### PR TITLE
AP: backend logic to call AMAPI endpoints to apply profiles (Android policy)

### DIFF
--- a/changes/32029-reconcile-android-profiles
+++ b/changes/32029-reconcile-android-profiles
@@ -1,0 +1,1 @@
+* Added a cron job to support applying Android profiles to the devices.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1297,6 +1297,7 @@ func newAndroidMDMProfileManagerSchedule(
 	instanceID string,
 	ds fleet.Datastore,
 	logger kitlog.Logger,
+	licenseKey string,
 ) (*schedule.Schedule, error) {
 	const (
 		name            = string(fleet.CronMDMAndroidProfileManager)
@@ -1308,7 +1309,7 @@ func newAndroidMDMProfileManagerSchedule(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
 		schedule.WithJob("manage_android_profiles", func(ctx context.Context) error {
-			return android_svc.ReconcileProfiles(ctx, ds, logger)
+			return android_svc.ReconcileProfiles(ctx, ds, logger, licenseKey)
 		}),
 	)
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -20,6 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm"
+	android_svc "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
@@ -1307,8 +1308,7 @@ func newAndroidMDMProfileManagerSchedule(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
 		schedule.WithJob("manage_android_profiles", func(ctx context.Context) error {
-			// TODO: return service.ReconcileWindowsProfiles(ctx, ds, logger)
-			panic("unimplemented")
+			return android_svc.ReconcileProfiles(ctx, ds, logger)
 		}),
 	)
 

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1291,6 +1291,30 @@ func newWindowsMDMProfileManagerSchedule(
 	return s, nil
 }
 
+func newAndroidMDMProfileManagerSchedule(
+	ctx context.Context,
+	instanceID string,
+	ds fleet.Datastore,
+	logger kitlog.Logger,
+) (*schedule.Schedule, error) {
+	const (
+		name            = string(fleet.CronMDMAndroidProfileManager)
+		defaultInterval = 30 * time.Second
+	)
+
+	logger = kitlog.With(logger, "cron", name)
+	s := schedule.New(
+		ctx, name, instanceID, defaultInterval, ds, ds,
+		schedule.WithLogger(logger),
+		schedule.WithJob("manage_android_profiles", func(ctx context.Context) error {
+			// TODO: return service.ReconcileWindowsProfiles(ctx, ds, logger)
+			panic("unimplemented")
+		}),
+	)
+
+	return s, nil
+}
+
 func newMDMAppleServiceDiscoverySchedule(
 	ctx context.Context,
 	instanceID string,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -984,6 +984,17 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return newAndroidMDMProfileManagerSchedule(
+					ctx,
+					instanceID,
+					ds,
+					logger,
+				)
+			}); err != nil {
+				initFatal(err, "failed to register mdm_android_profile_manager schedule")
+			}
+
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 				return newMDMAPNsPusher(
 					ctx,
 					instanceID,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -989,6 +989,7 @@ the way that the Fleet server works.
 					instanceID,
 					ds,
 					logger,
+					config.License.Key, // NOTE: this requires the license key, not the parsed *LicenseInfo available in the ctx
 				)
 			}); err != nil {
 				initFatal(err, "failed to register mdm_android_profile_manager schedule")

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -524,5 +524,25 @@ func (ds *Datastore) DeleteMDMAndroidConfigProfile(ctx context.Context, profileU
 }
 
 func (ds *Datastore) NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error {
-	panic("unimplemented")
+	const stmt = `
+	INSERT INTO android_policy_requests
+		(request_uuid, request_name, policy_id, payload, status_code, error_details, applied_policy_version, policy_version)
+	VALUES
+		(?, ?, ?, ?, ?, ?, ?, ?)
+`
+	if req.RequestUUID == "" {
+		req.RequestUUID = uuid.NewString()
+	}
+
+	_, err := ds.writer(ctx).ExecContext(ctx, stmt,
+		req.RequestUUID,
+		req.RequestName,
+		req.PolicyID,
+		req.Payload,
+		req.StatusCode,
+		req.ErrorDetails,
+		req.AppliedPolicyVersion,
+		req.PolicyVersion,
+	)
+	return ctxerr.Wrap(ctx, err, "inserting android policy request")
 }

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -236,8 +236,9 @@ func (ds *Datastore) AndroidHostLite(ctx context.Context, enterpriseSpecificID s
 		ad.host_id,
 		ad.device_id,
 		ad.enterprise_specific_id,
-		ad.android_policy_id,
-		ad.last_policy_sync_time
+		ad.last_policy_sync_time,
+		ad.applied_policy_id,
+		ad.applied_policy_version
 		FROM android_devices ad
 		JOIN hosts h ON ad.host_id = h.id
 		WHERE ad.enterprise_specific_id = ?`
@@ -271,8 +272,9 @@ func (ds *Datastore) AndroidHostLiteByHostID(ctx context.Context, hostID uint) (
 		ad.host_id,
 		ad.device_id,
 		ad.enterprise_specific_id,
-		ad.android_policy_id,
-		ad.last_policy_sync_time
+		ad.last_policy_sync_time,
+		ad.applied_policy_id,
+		ad.applied_policy_version
 		FROM android_devices ad
 		JOIN hosts h ON ad.host_id = h.id
 		WHERE ad.host_id = ?`

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -522,3 +522,7 @@ func (ds *Datastore) DeleteMDMAndroidConfigProfile(ctx context.Context, profileU
 
 	return nil
 }
+
+func (ds *Datastore) NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error {
+	panic("unimplemented")
+}

--- a/server/datastore/mysql/android_hosts.go
+++ b/server/datastore/mysql/android_hosts.go
@@ -56,10 +56,25 @@ func (ds *AndroidDatastore) deleteDevice(ctx context.Context, tx sqlx.ExtContext
 }
 
 func (ds *AndroidDatastore) insertDevice(ctx context.Context, device *android.Device, tx sqlx.ExtContext) (*android.Device, error) {
-	stmt := `INSERT INTO android_devices (host_id, device_id, enterprise_specific_id, android_policy_id, last_policy_sync_time) VALUES (?, ?, ?, ?,
-?)`
-	result, err := tx.ExecContext(ctx, stmt, device.HostID, device.DeviceID, device.EnterpriseSpecificID, device.AndroidPolicyID,
-		device.LastPolicySyncTime)
+	stmt := `INSERT INTO
+		android_devices
+		(
+			host_id,
+			device_id,
+			enterprise_specific_id,
+			last_policy_sync_time,
+			applied_policy_id,
+			applied_policy_version
+		)
+		VALUES (?, ?, ?, ?, ?, ?)`
+	result, err := tx.ExecContext(ctx, stmt,
+		device.HostID,
+		device.DeviceID,
+		device.EnterpriseSpecificID,
+		device.LastPolicySyncTime,
+		device.AppliedPolicyID,
+		device.AppliedPolicyVersion,
+	)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "inserting device")
 	}
@@ -77,8 +92,9 @@ func (ds *AndroidDatastore) updateDevice(ctx context.Context, device *android.De
 		host_id = :host_id,
 		device_id = :device_id,
 		enterprise_specific_id = :enterprise_specific_id,
-		android_policy_id = :android_policy_id,
-		last_policy_sync_time = :last_policy_sync_time
+		last_policy_sync_time = :last_policy_sync_time,
+		applied_policy_id = :applied_policy_id,
+		applied_policy_version = :applied_policy_version
 	WHERE id = :id`
 	stmt, args, err := sqlx.Named(stmt, device)
 	if err != nil {

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -113,7 +113,8 @@ func createAndroidHost(enterpriseSpecificID string) *fleet.AndroidHost {
 		Device: &android.Device{
 			DeviceID:             "device_id",
 			EnterpriseSpecificID: ptr.String(enterpriseSpecificID),
-			AndroidPolicyID:      ptr.Uint(1),
+			AppliedPolicyID:      ptr.String("1"),
+			AppliedPolicyVersion: ptr.Int64(1),
 			LastPolicySyncTime:   ptr.Time(time.Now().UTC().Truncate(time.Millisecond)),
 		},
 	}
@@ -151,7 +152,7 @@ func testUpdateAndroidHost(t *testing.T, ds *Datastore) {
 	host.Host.CPUType = "cpu_type_updated"
 	host.Host.HardwareModel = "hardware_model_updated"
 	host.Host.HardwareVendor = "hardware_vendor_updated"
-	host.Device.AndroidPolicyID = ptr.Uint(2)
+	host.Device.AppliedPolicyID = ptr.String("2")
 	err = ds.UpdateAndroidHost(testCtx(), host, false)
 	require.NoError(t, err)
 
@@ -327,7 +328,7 @@ func testAndroidHostStorageData(t *testing.T, ds *Datastore) {
 		Device: &android.Device{
 			DeviceID:             "storage-test-device-id",
 			EnterpriseSpecificID: ptr.String(enterpriseSpecificID),
-			AndroidPolicyID:      ptr.Uint(1),
+			AppliedPolicyID:      ptr.String("1"),
 			LastPolicySyncTime:   ptr.Time(time.Now().UTC().Truncate(time.Millisecond)),
 		},
 	}

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -61,6 +61,16 @@ func testNewAndroidHost(t *testing.T, ds *Datastore) {
 	assert.Equal(t, result.Host.ID, resultLite.Host.ID)
 	assert.Equal(t, result.Device.ID, resultLite.Device.ID)
 
+	resultLite, err = ds.AndroidHostLiteByHostID(testCtx(), result.Host.ID)
+	require.NoError(t, err)
+	assert.Equal(t, result.Host.ID, resultLite.Host.ID)
+	assert.Equal(t, result.Device.ID, resultLite.Device.ID)
+
+	_, err = ds.AndroidHostLite(testCtx(), "non-existent")
+	require.Error(t, err)
+	_, err = ds.AndroidHostLiteByHostID(testCtx(), result.Host.ID+1000)
+	require.Error(t, err)
+
 	// Inserting the same host again should be fine.
 	// This may occur when 2 Fleet servers received the same host information via pubsub.
 	resultCopy, err := ds.NewAndroidHost(testCtx(), host)

--- a/server/datastore/mysql/migrations/tables/20250825165154_AddTableMDMAndroidProfiles.go
+++ b/server/datastore/mysql/migrations/tables/20250825165154_AddTableMDMAndroidProfiles.go
@@ -47,24 +47,31 @@ CREATE TABLE mdm_android_configuration_profiles (
 		return fmt.Errorf("create mdm_android_configuration_profiles table: %w", err)
 	}
 
+	// TODO(ap): not sure how to handle the 3 retries before marking a profile as
+	// failed, does that mean that after 3 failures we stop merging any proflies
+	// that were part of those failures, and send only other (newer) profiles? Or
+	// do we stop sending any policy for that host from that point on?
+
 	// The table android_policy_requests tracks the API requests made to create
 	// or update the policy to apply to a given host.
 	createRequestsTable := `
 CREATE TABLE android_policy_requests (
   request_uuid      VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  android_policy_id INT UNSIGNED NOT NULL,
-  policy_version    INT UNSIGNED NOT NULL,
+  -- request_name is the policy_name (for patch policy) or device_name (for patch device)
+  request_name      VARCHAR(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  -- the policy_id for which this request was made
+  policy_id         VARCHAR(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   payload           JSON NOT NULL,
 
   -- track if API request was successful or not
   status_code       INT NOT NULL,
-  -- in case of error, store (part of) the returned body
-  error_body				TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  -- in case of error, store details here
+  error_details	    TEXT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
 
-  -- from figma, retry up to 3 times before marking profile as failed
-  -- (since the policy is a merge of all profiles, all profiles
-  -- associated with this request would be failed)
-  retries           TINYINT UNSIGNED NOT NULL DEFAULT '0',
+  -- on success, the currently applied policy version for the device (only for patch device)
+  applied_policy_version INT DEFAULT NULL,
+  -- on success, the new version of the policy (only for patch policy)
+  policy_version    INT DEFAULT NULL,
 
   created_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   updated_at        TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
@@ -75,12 +82,6 @@ CREATE TABLE android_policy_requests (
 	if _, err := tx.Exec(createRequestsTable); err != nil {
 		return fmt.Errorf("create android_policy_requests table: %w", err)
 	}
-
-	// TODO: do we get to define the policyId? Could it simply be the host's
-	// uuid? TBD if we have to store this info, and where. I see that we already
-	// have android_policy_id in the android_devices table, my guess is that this
-	// is where we'll store that info (AFAIK it is a 1:1 relationship with devices).
-	// See https://github.com/fleetdm/fleet/blob/49369c43b090f2bdf3c4de200046214e99252e1e/server/datastore/mysql/migrations/tables/20250219142401_UpdateAndroidTables.go#L31-L32
 
 	// Note that the policy version ID seems to be managed by Google and AFAICT we only
 	// receive it, we don't define it:
@@ -105,16 +106,17 @@ CREATE TABLE host_mdm_android_profiles (
 
   -- uuid of the corresponding android_policy_requests, supports NULL because
   -- we won't have the request uuid until the request is ready to be sent
-  request_uuid   VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
+  policy_request_uuid   VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
+  device_request_uuid   VARCHAR(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NULL,
 
   created_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   updated_at TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
 
-
   PRIMARY KEY (host_uuid, profile_uuid),
   FOREIGN KEY (status) REFERENCES mdm_delivery_status (status) ON UPDATE CASCADE,
   FOREIGN KEY (operation_type) REFERENCES mdm_operation_types (operation_type) ON UPDATE CASCADE,
-  FOREIGN KEY (request_uuid) REFERENCES android_policy_requests (request_uuid) ON DELETE SET NULL
+  FOREIGN KEY (policy_request_uuid) REFERENCES android_policy_requests (request_uuid) ON DELETE SET NULL,
+  FOREIGN KEY (device_request_uuid) REFERENCES android_policy_requests (request_uuid) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
 `
 	if _, err := tx.Exec(createHostProfilesTable); err != nil {
@@ -147,7 +149,7 @@ ALTER TABLE android_devices
 	// migrate android_policy_id to applied_policy_id, before removing the column
 	migratePolicyID := `
 UPDATE android_devices
-	SET applied_policy_id = CAST(android_policy_id AS CHAR(100)) 
+	SET applied_policy_id = CAST(android_policy_id AS CHAR(100))
 	WHERE android_policy_id IS NOT NULL
 `
 	if _, err := tx.Exec(migratePolicyID); err != nil {

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -92,12 +92,13 @@ CREATE TABLE `android_enterprises` (
 /*!50503 SET character_set_client = utf8mb4 */;
 CREATE TABLE `android_policy_requests` (
   `request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
-  `android_policy_id` int unsigned NOT NULL,
-  `policy_version` int unsigned NOT NULL,
+  `request_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
+  `policy_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `payload` json NOT NULL,
   `status_code` int NOT NULL,
-  `error_body` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
-  `retries` tinyint unsigned NOT NULL DEFAULT '0',
+  `error_details` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `applied_policy_version` int DEFAULT NULL,
+  `policy_version` int DEFAULT NULL,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`request_uuid`)
@@ -609,16 +610,19 @@ CREATE TABLE `host_mdm_android_profiles` (
   `detail` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
   `profile_uuid` varchar(37) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
   `profile_name` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT '',
-  `request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `policy_request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `device_request_uuid` varchar(36) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `created_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
   PRIMARY KEY (`host_uuid`,`profile_uuid`),
   KEY `status` (`status`),
   KEY `operation_type` (`operation_type`),
-  KEY `request_uuid` (`request_uuid`),
+  KEY `policy_request_uuid` (`policy_request_uuid`),
+  KEY `device_request_uuid` (`device_request_uuid`),
   CONSTRAINT `host_mdm_android_profiles_ibfk_1` FOREIGN KEY (`status`) REFERENCES `mdm_delivery_status` (`status`) ON UPDATE CASCADE,
   CONSTRAINT `host_mdm_android_profiles_ibfk_2` FOREIGN KEY (`operation_type`) REFERENCES `mdm_operation_types` (`operation_type`) ON UPDATE CASCADE,
-  CONSTRAINT `host_mdm_android_profiles_ibfk_3` FOREIGN KEY (`request_uuid`) REFERENCES `android_policy_requests` (`request_uuid`) ON DELETE SET NULL
+  CONSTRAINT `host_mdm_android_profiles_ibfk_3` FOREIGN KEY (`policy_request_uuid`) REFERENCES `android_policy_requests` (`request_uuid`) ON DELETE SET NULL,
+  CONSTRAINT `host_mdm_android_profiles_ibfk_4` FOREIGN KEY (`device_request_uuid`) REFERENCES `android_policy_requests` (`request_uuid`) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -63,15 +63,16 @@ CREATE TABLE `android_devices` (
   `host_id` int unsigned NOT NULL,
   `device_id` varchar(32) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci NOT NULL,
   `enterprise_specific_id` varchar(64) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  `android_policy_id` int unsigned DEFAULT NULL,
   `last_policy_sync_time` datetime(3) DEFAULT NULL,
   `created_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
   `updated_at` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+  `applied_policy_id` varchar(100) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `applied_policy_version` int DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `idx_android_devices_host_id` (`host_id`),
   UNIQUE KEY `idx_android_devices_device_id` (`device_id`),
   UNIQUE KEY `idx_android_devices_enterprise_specific_id` (`enterprise_specific_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) /*!50100 TABLESPACE `innodb_system` */ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!50503 SET character_set_client = utf8mb4 */;

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -70,4 +71,18 @@ func (m *MDMAndroidConfigProfile) ValidateUserProvided() error {
 	}
 
 	return nil
+}
+
+// MDMAndroidPolicyRequest represents a request made to the Android Management
+// API (AMAPI) to patch the policy or the device (as made by
+// androidsvc.ReconcileProfiles).
+type MDMAndroidPolicyRequest struct {
+	RequestUUID          string           `db:"request_uuid"`
+	RequestName          string           `db:"request_name"`
+	PolicyID             string           `db:"policy_id"`
+	Payload              []byte           `db:"payload"`
+	StatusCode           int              `db:"status_code"`
+	ErrorDetails         sql.Null[string] `db:"error_details"`
+	AppliedPolicyVersion sql.Null[int]    `db:"applied_policy_version"`
+	PolicyVersion        sql.Null[int]    `db:"policy_version"`
 }

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -83,6 +83,6 @@ type MDMAndroidPolicyRequest struct {
 	Payload              []byte           `db:"payload"`
 	StatusCode           int              `db:"status_code"`
 	ErrorDetails         sql.Null[string] `db:"error_details"`
-	AppliedPolicyVersion sql.Null[int]    `db:"applied_policy_version"`
-	PolicyVersion        sql.Null[int]    `db:"policy_version"`
+	AppliedPolicyVersion sql.Null[int64]  `db:"applied_policy_version"`
+	PolicyVersion        sql.Null[int64]  `db:"policy_version"`
 }

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -23,6 +23,7 @@ const (
 	CronActivitiesStreaming          CronScheduleName = "activities_streaming"
 	CronMDMAppleProfileManager       CronScheduleName = "mdm_apple_profile_manager"
 	CronMDMWindowsProfileManager     CronScheduleName = "mdm_windows_profile_manager"
+	CronMDMAndroidProfileManager     CronScheduleName = "mdm_android_profile_manager"
 	CronAppleMDMIPhoneIPadRefetcher  CronScheduleName = "apple_mdm_iphone_ipad_refetcher"
 	CronAppleMDMAPNsPusher           CronScheduleName = "apple_mdm_apns_pusher"
 	CronCalendar                     CronScheduleName = "calendar"

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/types"
 	"github.com/fleetdm/fleet/v4/server/config"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/health"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -2209,7 +2208,7 @@ type Datastore interface {
 	DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error
 
 	// NewAndroidPolicyRequest saves details about a new Android AMAPI request.
-	NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error
+	NewAndroidPolicyRequest(ctx context.Context, req *MDMAndroidPolicyRequest) error
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// SCIM

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/types"
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/health"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -2206,6 +2207,9 @@ type Datastore interface {
 	// DeleteMDMAndroidConfigProfile deletes the Android MDM profile corresponding to
 	// the specified profile uuid.
 	DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error
+
+	// NewAndroidPolicyRequest saves details about a new Android AMAPI request.
+	NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// SCIM

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2306,6 +2306,7 @@ type Datastore interface {
 type AndroidDatastore interface {
 	android.Datastore
 	AndroidHostLite(ctx context.Context, enterpriseSpecificID string) (*AndroidHost, error)
+	AndroidHostLiteByHostID(ctx context.Context, hostID uint) (*AndroidHost, error)
 	AppConfig(ctx context.Context) (*AppConfig, error)
 	BulkSetAndroidHostsUnenrolled(ctx context.Context) error
 	DeleteMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName) error

--- a/server/mdm/android/android.go
+++ b/server/mdm/android/android.go
@@ -44,6 +44,7 @@ type Device struct {
 	HostID               uint       `db:"host_id"`
 	DeviceID             string     `db:"device_id"`
 	EnterpriseSpecificID *string    `db:"enterprise_specific_id"`
-	AndroidPolicyID      *uint      `db:"android_policy_id"`
 	LastPolicySyncTime   *time.Time `db:"last_policy_sync_time"`
+	AppliedPolicyID      *string    `db:"applied_policy_id"`
+	AppliedPolicyVersion *int64     `db:"applied_policy_version"`
 }

--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -19,6 +19,8 @@ type EnterprisesCreateFunc func(ctx context.Context, req androidmgmt.Enterprises
 
 type EnterprisesPoliciesPatchFunc func(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error)
 
+type EnterprisesDevicesPatchFunc func(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
+
 type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
 
 type EnterpriseDeleteFunc func(ctx context.Context, enterpriseName string) error
@@ -34,6 +36,9 @@ type Client struct {
 
 	EnterprisesPoliciesPatchFunc        EnterprisesPoliciesPatchFunc
 	EnterprisesPoliciesPatchFuncInvoked bool
+
+	EnterprisesDevicesPatchFunc        EnterprisesDevicesPatchFunc
+	EnterprisesDevicesPatchFuncInvoked bool
 
 	EnterprisesEnrollmentTokensCreateFunc        EnterprisesEnrollmentTokensCreateFunc
 	EnterprisesEnrollmentTokensCreateFuncInvoked bool
@@ -66,6 +71,13 @@ func (p *Client) EnterprisesPoliciesPatch(ctx context.Context, policyName string
 	p.EnterprisesPoliciesPatchFuncInvoked = true
 	p.mu.Unlock()
 	return p.EnterprisesPoliciesPatchFunc(ctx, policyName, policy)
+}
+
+func (p *Client) EnterprisesDevicesPatch(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error) {
+	p.mu.Lock()
+	p.EnterprisesDevicesPatchFuncInvoked = true
+	p.mu.Unlock()
+	return p.EnterprisesDevicesPatchFunc(ctx, deviceName, device)
 }
 
 func (p *Client) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {

--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -17,7 +17,7 @@ type SignupURLsCreateFunc func(ctx context.Context, serverURL string, callbackUR
 
 type EnterprisesCreateFunc func(ctx context.Context, req androidmgmt.EnterprisesCreateRequest) (androidmgmt.EnterprisesCreateResponse, error)
 
-type EnterprisesPoliciesPatchFunc func(ctx context.Context, policyName string, policy *androidmanagement.Policy) error
+type EnterprisesPoliciesPatchFunc func(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error)
 
 type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
 
@@ -61,7 +61,7 @@ func (p *Client) EnterprisesCreate(ctx context.Context, req androidmgmt.Enterpri
 	return p.EnterprisesCreateFunc(ctx, req)
 }
 
-func (p *Client) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) error {
+func (p *Client) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error) {
 	p.mu.Lock()
 	p.EnterprisesPoliciesPatchFuncInvoked = true
 	p.mu.Unlock()

--- a/server/mdm/android/mock/client_setup.go
+++ b/server/mdm/android/mock/client_setup.go
@@ -22,8 +22,8 @@ func (p *Client) InitCommonMocks() {
 			FleetServerSecret: "fleetServerSecret",
 		}, nil
 	}
-	p.EnterprisesPoliciesPatchFunc = func(_ context.Context, policyName string, policy *androidmanagement.Policy) error {
-		return nil
+	p.EnterprisesPoliciesPatchFunc = func(_ context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error) {
+		return &androidmanagement.Policy{}, nil
 	}
 	p.SetAuthenticationSecretFunc = func(secret string) error { return nil }
 }

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"google.golang.org/api/androidmanagement/v1"
+	"google.golang.org/api/googleapi"
 )
 
 // Client is used to interact with the Android Management API.
@@ -58,4 +59,10 @@ type EnterprisesCreateResponse struct {
 	// TopicName is the Google PubSub topic name, like: projects/project_id/topics/topic_id. It is only present Google API client is used
 	// directly (no proxy). We save it for debugging purposes.
 	TopicName string
+}
+
+// IsNotModifiedError reports whether the AMAPI error indicates that the
+// resource has not been modified.
+func IsNotModifiedError(err error) bool {
+	return googleapi.IsNotModified(err)
 }

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -25,6 +25,11 @@ type Client interface {
 	// On success it returns the applied policy, with its version number set.
 	EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error)
 
+	// EnterprisesDevicesPatch updates a device.
+	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/patch
+	// On success it returns the updated device with latest applied policy information.
+	EnterprisesDevicesPatch(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
+
 	// EnterprisesEnrollmentTokensCreate creates an enrollment token for a given enterprise. It is used to enroll an Android device.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens/create
 	EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -21,7 +21,8 @@ type Client interface {
 
 	// EnterprisesPoliciesPatch updates or creates a policy.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.policies/patch
-	EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) error
+	// On success it returns the applied policy, with its version number set.
+	EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error)
 
 	// EnterprisesEnrollmentTokensCreate creates an enrollment token for a given enterprise. It is used to enroll an Android device.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens/create

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -156,15 +156,15 @@ func (g *GoogleClient) createPubSub(ctx context.Context, pushURL string) (string
 	return topic.String(), nil
 }
 
-func (g *GoogleClient) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) error {
-	_, err := g.mgmt.Enterprises.Policies.Patch(policyName, policy).Context(ctx).Do()
+func (g *GoogleClient) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error) {
+	ret, err := g.mgmt.Enterprises.Policies.Patch(policyName, policy).Context(ctx).Do()
 	switch {
 	case googleapi.IsNotModified(err):
 		g.logger.Log("msg", "Android policy not modified", "policy_name", policyName)
 	case err != nil:
-		return fmt.Errorf("patching policy %s: %w", policyName, err)
+		return nil, fmt.Errorf("patching policy %s: %w", policyName, err)
 	}
-	return nil
+	return ret, nil
 }
 
 func (g *GoogleClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken,

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -50,7 +50,7 @@ func NewGoogleClient(ctx context.Context, logger kitlog.Logger, getenv func(stri
 		return nil
 	}
 
-	slogLogger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	slogLogger := slog.New(slog.NewTextHandler(os.Stdout, nil))
 	mgmt, err := androidmanagement.NewService(ctx,
 		option.WithCredentialsJSON([]byte(androidServiceCredentials)),
 		option.WithLogger(slogLogger),

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -161,6 +161,7 @@ func (g *GoogleClient) EnterprisesPoliciesPatch(ctx context.Context, policyName 
 	switch {
 	case googleapi.IsNotModified(err):
 		g.logger.Log("msg", "Android policy not modified", "policy_name", policyName)
+		return nil, err
 	case err != nil:
 		return nil, fmt.Errorf("patching policy %s: %w", policyName, err)
 	}

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -154,17 +154,17 @@ func (p *ProxyClient) EnterprisesCreate(ctx context.Context, req EnterprisesCrea
 	}, nil
 }
 
-func (p *ProxyClient) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) error {
+func (p *ProxyClient) EnterprisesPoliciesPatch(ctx context.Context, policyName string, policy *androidmanagement.Policy) (*androidmanagement.Policy, error) {
 	call := p.mgmt.Enterprises.Policies.Patch(policyName, policy).Context(ctx)
 	call.Header().Set("Authorization", "Bearer "+p.fleetServerSecret)
-	_, err := call.Do()
+	ret, err := call.Do()
 	switch {
 	case googleapi.IsNotModified(err):
 		p.logger.Log("msg", "Android policy not modified", "policy_name", policyName)
 	case err != nil:
-		return fmt.Errorf("patching policy %s: %w", policyName, err)
+		return nil, fmt.Errorf("patching policy %s: %w", policyName, err)
 	}
-	return nil
+	return ret, nil
 }
 
 func (p *ProxyClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -161,6 +161,7 @@ func (p *ProxyClient) EnterprisesPoliciesPatch(ctx context.Context, policyName s
 	switch {
 	case googleapi.IsNotModified(err):
 		p.logger.Log("msg", "Android policy not modified", "policy_name", policyName)
+		return nil, err
 	case err != nil:
 		return nil, fmt.Errorf("patching policy %s: %w", policyName, err)
 	}

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -168,6 +168,20 @@ func (p *ProxyClient) EnterprisesPoliciesPatch(ctx context.Context, policyName s
 	return ret, nil
 }
 
+func (p *ProxyClient) EnterprisesDevicesPatch(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error) {
+	call := p.mgmt.Enterprises.Devices.Patch(deviceName, device).Context(ctx)
+	call.Header().Set("Authorization", "Bearer "+p.fleetServerSecret)
+	ret, err := call.Do()
+	switch {
+	case googleapi.IsNotModified(err):
+		p.logger.Log("msg", "Android device not modified", "device_name", deviceName)
+		return nil, err
+	case err != nil:
+		return nil, fmt.Errorf("patching device %s: %w", deviceName, err)
+	}
+	return ret, nil
+}
+
 func (p *ProxyClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,
 	token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {
 	if p == nil || p.mgmt == nil {

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -1,0 +1,12 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	kitlog "github.com/go-kit/log"
+)
+
+func ReconcileProfiles(ctx context.Context, ds fleet.AndroidDatastore, logger kitlog.Logger) error {
+	panic("unimplemented")
+}

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
@@ -32,7 +31,6 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 	// configured.
 	enterprise, err := ds.GetEnterprise(ctx)
 	if err != nil {
-		fmt.Println(">>>>> NO ANDROID ENTERPRISE!")
 		return ctxerr.Wrap(ctx, err, "get android enterprise")
 	}
 
@@ -83,7 +81,6 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 	}
 
 	if len(hosts) == 0 {
-		fmt.Println(">>>>> NO ANDROID HOST!")
 		return nil
 	}
 
@@ -92,7 +89,7 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 		// for now.
 		policy := &androidmanagement.Policy{
 			CameraDisabled: true,
-			FunDisabled:    true,
+			FunDisabled:    false,
 		}
 
 		// for every policy, we want to enforce some settings
@@ -116,7 +113,7 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 		}
 		if androidHost.AppliedPolicyID != nil && *androidHost.AppliedPolicyID == h.UUID {
 			// that policy name is already applied to this host, it will pick up the new version
-			// TODO(ap): confirm in tests
+			// (confirmed in tests)
 			continue
 		}
 
@@ -149,8 +146,6 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 		// expected version. Note that with "funDisabled: true", I did get a
 		// NonComplianceDetails for it with reason "MANAGEMENT_MODE", but the field
 		// PolicyCompliant was still true.
-		fmt.Println(">>>>> APPLIED POLICY TO DEVICE:", err)
-		spew.Dump(device)
 	}
 
 	return nil

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -255,7 +255,7 @@ func applyFleetEnforcedSettings(policy *androidmanagement.Policy) {
 		SystemPropertiesEnabled:      true,
 		SoftwareInfoEnabled:          true,
 		CommonCriteriaModeEnabled:    true,
-		ApplicationReportsEnabled:    false, // TODO(ap): SET THIS TO TRUE! Just switching for manual tests as apps are too noisy
-		ApplicationReportingSettings: nil,   // only option is "includeRemovedApps", which I opted not to enable (we can diff apps to see removals)
+		ApplicationReportsEnabled:    true,
+		ApplicationReportingSettings: nil, // only option is "includeRemovedApps", which I opted not to enable (we can diff apps to see removals)
 	}
 }

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -130,12 +130,9 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 			// > DISABLED are the only allowable values.
 			State: "ACTIVE",
 		}
-		skip, err = patchDevice(ctx, client, ds, h.UUID, deviceName, device)
+		_, err = patchDevice(ctx, client, ds, h.UUID, deviceName, device)
 		if err != nil {
 			return ctxerr.Wrapf(ctx, err, "patch device for host %d", h.ID)
-		}
-		if skip {
-			continue
 		}
 
 		// From what I can see in tests, after the PATCH /devices, the device

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -3,10 +3,45 @@ package service
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	kitlog "github.com/go-kit/log"
 )
 
 func ReconcileProfiles(ctx context.Context, ds fleet.AndroidDatastore, logger kitlog.Logger) error {
+	appConfig, err := ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get app config")
+	}
+	if !appConfig.MDM.AndroidEnabledAndConfigured {
+		return nil
+	}
+
+	// TODO(ap): here would come the queries to identify the profiles to add and
+	// remove from the host, and merge the final payload. This will all be part
+	// of the upcoming https://github.com/fleetdm/fleet/issues/32032 work, not of
+	// the current work. For the current ticket, I'll just assume we have the
+	// final payload.
+	//
+	// Would probably be a good idea to generate the canonical JSON form of the
+	// payload and keep track of the hash of the last applied payload, to avoid
+	// re-applying if there are no changes. Also, I'm not sure how _removing_ a
+	// setting/profile would work, does it get "removed" just by the fact that
+	// the settings are not present in the new profile applied?
+	//
+	// We also need to agree on a determined order to merge the profiles. I'd go
+	// by name, alphabetically ascending, as it's simple and the order
+	// information can be viewed by the user in the UI, but we had discussed
+	// upload time of the profile (which may not be deterministic for batch-set
+	// profiles).
+	//
+	// Due to the logic needed to merge the "profiles" to form a final "policy"
+	// payload, I don't think we can use SQL queries to find out what hosts need
+	// to be updated or not, I think that at best we can generate a minimal
+	// subset of affected hosts via queries by using things like last policy
+	// timestamp vs timestamps of the profiles involved, and if it looks like a
+	// host may need an update, compute the final payload and use the checksum to
+	// see if it has actually changed or not.
+
 	panic("unimplemented")
 }

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -3,10 +3,12 @@ package service
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
@@ -110,6 +112,10 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal Android status report message")
 	}
+
+	fmt.Println(">>>>> ANDROID STATUS REPORT:")
+	spew.Dump(device)
+
 	if device.AppliedState == string(android.DeviceStateDeleted) {
 		level.Debug(svc.logger).Log("msg", "Android device deleted from MDM", "device.name", device.Name,
 			"device.enterpriseSpecificId", device.HardwareInfo.EnterpriseSpecificId)
@@ -359,6 +365,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 		},
 	}
 	if device.AppliedPolicyName != "" {
+		// TODO(ap): change type of policy ID to string and store the applied policy version too.
 		policy, err := svc.getPolicyID(ctx, device)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "getting Android policy ID")

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -3,11 +3,9 @@ package service
 import (
 	"context"
 	"encoding/base64"
-	"fmt"
 	"strings"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
@@ -111,9 +109,6 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal Android status report message")
 	}
-
-	fmt.Println(">>>>> ANDROID STATUS REPORT:")
-	spew.Dump(device)
 
 	if device.AppliedState == string(android.DeviceStateDeleted) {
 		level.Debug(svc.logger).Log("msg", "Android device deleted from MDM", "device.name", device.Name,

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -57,12 +57,7 @@ func NewService(
 	licenseKey string,
 	serverPrivateKey string,
 ) (android.Service, error) {
-	var client androidmgmt.Client
-	if os.Getenv("FLEET_DEV_ANDROID_GOOGLE_CLIENT") == "1" || strings.ToUpper(os.Getenv("FLEET_DEV_ANDROID_GOOGLE_CLIENT")) == "ON" {
-		client = androidmgmt.NewGoogleClient(ctx, logger, os.Getenv)
-	} else {
-		client = androidmgmt.NewProxyClient(ctx, logger, licenseKey, os.Getenv)
-	}
+	client := newAMAPIClient(ctx, logger, licenseKey)
 	return NewServiceWithClient(logger, ds, client, fleetSvc, serverPrivateKey)
 }
 
@@ -87,6 +82,16 @@ func NewServiceWithClient(
 		serverPrivateKey:  serverPrivateKey,
 		SignupSSEInterval: DefaultSignupSSEInterval,
 	}, nil
+}
+
+func newAMAPIClient(ctx context.Context, logger kitlog.Logger, licenseKey string) androidmgmt.Client {
+	var client androidmgmt.Client
+	if os.Getenv("FLEET_DEV_ANDROID_GOOGLE_CLIENT") == "1" || strings.ToUpper(os.Getenv("FLEET_DEV_ANDROID_GOOGLE_CLIENT")) == "ON" {
+		client = androidmgmt.NewGoogleClient(ctx, logger, os.Getenv)
+	} else {
+		client = androidmgmt.NewProxyClient(ctx, logger, licenseKey, os.Getenv)
+	}
+	return client
 }
 
 func newErrResponse(err error) android.DefaultResponse {

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -323,7 +323,7 @@ func (svc *Service) EnterpriseSignupCallback(ctx context.Context, signupToken st
 			ApplicationReportingSettings: nil,
 		},
 	})
-	if err != nil {
+	if err != nil && !androidmgmt.IsNotModifiedError(err) {
 		return ctxerr.Wrapf(ctx, err, "patching %d policy", defaultAndroidPolicyID)
 	}
 

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -303,7 +303,7 @@ func (svc *Service) EnterpriseSignupCallback(ctx context.Context, signupToken st
 	}
 
 	policyName := fmt.Sprintf("%s/policies/%s", enterprise.Name(), fmt.Sprintf("%d", defaultAndroidPolicyID))
-	err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{
+	_, err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{
 		StatusReportingSettings: &androidmanagement.StatusReportingSettings{
 			DeviceSettingsEnabled:        true,
 			MemoryInfoEnabled:            true,

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -163,9 +163,9 @@ func (ts *WithServer) createCommonProxyMocks(t *testing.T) {
 			TopicName:      "projects/android/topics/ae98ed130-5ce2-4ddb-a90a-191ec76976d5",
 		}, nil
 	}
-	ts.AndroidAPIClient.EnterprisesPoliciesPatchFunc = func(_ context.Context, policyName string, _ *androidmanagement.Policy) error {
+	ts.AndroidAPIClient.EnterprisesPoliciesPatchFunc = func(_ context.Context, policyName string, _ *androidmanagement.Policy) (*androidmanagement.Policy, error) {
 		assert.Contains(t, policyName, EnterpriseID)
-		return nil
+		return &androidmanagement.Policy{}, nil
 	}
 	ts.AndroidAPIClient.EnterpriseDeleteFunc = func(_ context.Context, enterpriseName string) error {
 		assert.Equal(t, "enterprises/"+EnterpriseID, enterpriseName)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1397,6 +1397,8 @@ type UpdateDeviceTxFunc func(ctx context.Context, tx sqlx.ExtContext, device *an
 
 type AndroidHostLiteFunc func(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error)
 
+type AndroidHostLiteByHostIDFunc func(ctx context.Context, hostID uint) (*fleet.AndroidHost, error)
+
 type BulkSetAndroidHostsUnenrolledFunc func(ctx context.Context) error
 
 type NewAndroidHostFunc func(ctx context.Context, host *fleet.AndroidHost) (*fleet.AndroidHost, error)
@@ -1410,6 +1412,8 @@ type NewMDMAndroidConfigProfileFunc func(ctx context.Context, cp fleet.MDMAndroi
 type GetMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string) (*fleet.MDMAndroidConfigProfile, error)
 
 type DeleteMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string) error
+
+type NewAndroidPolicyRequestFunc func(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error
 
 type CreateScimUserFunc func(ctx context.Context, user *fleet.ScimUser) (uint, error)
 
@@ -3535,6 +3539,9 @@ type DataStore struct {
 	AndroidHostLiteFunc        AndroidHostLiteFunc
 	AndroidHostLiteFuncInvoked bool
 
+	AndroidHostLiteByHostIDFunc        AndroidHostLiteByHostIDFunc
+	AndroidHostLiteByHostIDFuncInvoked bool
+
 	BulkSetAndroidHostsUnenrolledFunc        BulkSetAndroidHostsUnenrolledFunc
 	BulkSetAndroidHostsUnenrolledFuncInvoked bool
 
@@ -3555,6 +3562,9 @@ type DataStore struct {
 
 	DeleteMDMAndroidConfigProfileFunc        DeleteMDMAndroidConfigProfileFunc
 	DeleteMDMAndroidConfigProfileFuncInvoked bool
+
+	NewAndroidPolicyRequestFunc        NewAndroidPolicyRequestFunc
+	NewAndroidPolicyRequestFuncInvoked bool
 
 	CreateScimUserFunc        CreateScimUserFunc
 	CreateScimUserFuncInvoked bool
@@ -8461,6 +8471,13 @@ func (s *DataStore) AndroidHostLite(ctx context.Context, enterpriseSpecificID st
 	return s.AndroidHostLiteFunc(ctx, enterpriseSpecificID)
 }
 
+func (s *DataStore) AndroidHostLiteByHostID(ctx context.Context, hostID uint) (*fleet.AndroidHost, error) {
+	s.mu.Lock()
+	s.AndroidHostLiteByHostIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.AndroidHostLiteByHostIDFunc(ctx, hostID)
+}
+
 func (s *DataStore) BulkSetAndroidHostsUnenrolled(ctx context.Context) error {
 	s.mu.Lock()
 	s.BulkSetAndroidHostsUnenrolledFuncInvoked = true
@@ -8508,6 +8525,13 @@ func (s *DataStore) DeleteMDMAndroidConfigProfile(ctx context.Context, profileUU
 	s.DeleteMDMAndroidConfigProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteMDMAndroidConfigProfileFunc(ctx, profileUUID)
+}
+
+func (s *DataStore) NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error {
+	s.mu.Lock()
+	s.NewAndroidPolicyRequestFuncInvoked = true
+	s.mu.Unlock()
+	return s.NewAndroidPolicyRequestFunc(ctx, req)
 }
 
 func (s *DataStore) CreateScimUser(ctx context.Context, user *fleet.ScimUser) (uint, error) {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -13774,7 +13774,7 @@ func createAndroidHosts(t *testing.T, ds *mysql.Datastore, count int, teamID *ui
 			Device: &android.Device{
 				DeviceID:             strings.ReplaceAll(uuid.NewString(), "-", ""), // Remove dashes to fit in VARCHAR(37)
 				EnterpriseSpecificID: ptr.String(uuid.NewString()),
-				AndroidPolicyID:      ptr.Uint(1),
+				AppliedPolicyID:      ptr.String("1"),
 				LastPolicySyncTime:   ptr.Time(time.Now().Add(-time.Hour)), // 1 hour ago
 			},
 		}
@@ -13804,7 +13804,7 @@ func createAndroidHostWithStorage(t *testing.T, ds *mysql.Datastore, teamID *uin
 		Device: &android.Device{
 			DeviceID:             strings.ReplaceAll(uuid.NewString(), "-", ""),
 			EnterpriseSpecificID: ptr.String(uuid.NewString()),
-			AndroidPolicyID:      ptr.Uint(1),
+			AppliedPolicyID:      ptr.String("1"),
 			LastPolicySyncTime:   ptr.Time(time.Now().Add(-time.Hour)),
 		},
 	}


### PR DESCRIPTION
For #32029 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests (more to come after #32032)

- [x] QA'd all new/changed functionality manually

## Database migrations

- [x] Checked table schema to confirm autoupdate
- [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [x] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

