### PR TITLE
Cherry-pick: Custom Variables UI updates (#32304)

### DIFF
--- a/frontend/pages/ManageControlsPage/Secrets/Secrets.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/Secrets.tests.tsx
@@ -303,6 +303,18 @@ describe("Custom variables", () => {
           expect(saveButton).toBeDisabled();
         });
       });
+      it("does not allow saving very long name", async () => {
+        const { nameInput, valueInput, saveButton } = await getAddSecretUI();
+        await user.type(nameInput, new Array(300).fill("A").join("")); // Invalid name
+        await user.type(valueInput, "a value");
+        await user.click(saveButton);
+        await waitFor(() => {
+          expect(
+            screen.getByText("Name may not exceed 256 characters")
+          ).toBeInTheDocument();
+          expect(saveButton).toBeDisabled();
+        });
+      });
     });
 
     it("deleting a secret is successful", async () => {

--- a/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
@@ -14,6 +14,7 @@ import { ISecret } from "interfaces/secrets";
 import { AppContext } from "context/app";
 
 import { stringToClipboard } from "utilities/copy_text";
+import { FLEET_WEBSITE_URL } from "utilities/constants";
 import CustomLink from "components/CustomLink";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 import ListItem from "components/ListItem/ListItem";
@@ -46,15 +47,9 @@ const Secrets = () => {
 
   const queryClient = useQueryClient();
 
-  const {
-    isGlobalAdmin,
-    isTeamAdmin,
-    isGlobalMaintainer,
-    isTeamMaintainer,
-  } = useContext(AppContext);
+  const { isGlobalAdmin, isGlobalMaintainer } = useContext(AppContext);
 
-  const canEdit =
-    isGlobalAdmin || isTeamAdmin || isGlobalMaintainer || isTeamMaintainer;
+  const canEdit = isGlobalAdmin || isGlobalMaintainer;
 
   // Fetch a single page of secrets.
   const fetchPage = useCallback(
@@ -155,8 +150,11 @@ const Secrets = () => {
         title={secret.name.toUpperCase()}
         details={
           <span>
-            Updated <HumanTimeDiffWithDateTip timeString={secret.updated_at} />{" "}
-            &bull; {getTokenFromSecretName(secret.name)}
+            <span className="secret-details__text">
+              Updated{" "}
+              <HumanTimeDiffWithDateTip timeString={secret.updated_at} /> &bull;{" "}
+              {getTokenFromSecretName(secret.name)}
+            </span>
             <Button
               variant="unstyled"
               className={`${baseClass}__copy-secret-icon`}
@@ -223,8 +221,13 @@ const Secrets = () => {
   }
   return (
     <div className={baseClass}>
-      <p>
-        Manage custom variables that will be available in scripts and profiles.
+      <p className={`${baseClass}__description`}>
+        Manage custom variables that will be available in scripts and profiles.{" "}
+        <CustomLink
+          text="Learn more"
+          url={`${FLEET_WEBSITE_URL}/guides/secrets-in-scripts-and-configuration-profiles`}
+          newTab
+        />
       </p>
       <PaginatedList<ISecret>
         ref={paginatedListRef}

--- a/frontend/pages/ManageControlsPage/Secrets/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Secrets/_styles.scss
@@ -1,4 +1,7 @@
 .secrets-batch-paginated-list {
+    &__description {
+            margin: $pad-xxlarge 0;
+    }
 
     &__copy-message {
         @include copy-message;
@@ -43,6 +46,41 @@
 
         .list-item__details {
             color: $ui-fleet-black-75;
+            min-width: 0;
+            > span {
+                display: flex;
+            }
+        }
+
+        /* Make the main content column actually able to shrink so truncation can happen */
+        .list-item {
+            display: flex;
+            flex: 1 1 auto;
+            min-width: 0;
+        }
+
+        .list-item__main-content {
+            flex: 1 1 auto;
+            min-width: 0; /* for truncation */
+        }
+
+        .list-item__info {
+            min-width: 0; /* for truncation */            
+        }
+
+        .list-item__title {
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            min-width: 0;
+        }
+
+        .secret-details__text {
+            flex: 1 1 auto;
+            min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
     }
 
@@ -57,5 +95,14 @@
         width: 100%;
         font-weight: $bold;
         align-items: center;
+    }
+}
+
+.fleet-add-secret-modal {
+    &__add-secret-form {
+        .form-field__help-text {
+            text-overflow: ellipsis;
+            overflow: hidden;
+        }
     }
 }

--- a/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/AddSecretModal.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/AddSecretModal.tsx
@@ -41,7 +41,6 @@ const AddSecretModal = ({ onCancel, onSave }: AddSecretModalProps) => {
       value = value.trimRight().toUpperCase();
       setSecretName(value);
     } else if (name === "value") {
-      value = value.trimRight();
       setSecretValue(value);
     }
     setFormValidation(

--- a/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/helpers.ts
@@ -51,6 +51,13 @@ const FORM_VALIDATIONS: IFormValidations = {
           "Name may only include uppercase letters, numbers, and underscores",
       },
       {
+        name: "notTooLong",
+        isValid: (formData: IAddSecretModalScheduleFormData) => {
+          return formData.name.length <= 256;
+        },
+        message: "Name may not exceed 256 characters",
+      },
+      {
         name: "doesNotIncludePrefix",
         isValid: (formData: IAddSecretModalScheduleFormData) => {
           return !formData.name.match(/^FLEET_SECRET_/);


### PR DESCRIPTION
> # Cherry pick from main to v4.73.0 rc

for #32269 
for #32271 
for #32285

# Details

This PR addresses some front-end issues found during QA testing of the new Custom Variables UI

# Checklist for submitter

## Testing

- [X] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

* Spaces allowed in custom variable values: <img width="659" height="399" alt="image"
src="https://github.com/user-attachments/assets/e849636f-d91c-4649-a6f1-82bc2397cbbe" />

* Overflow in add var modal <img width="657" height="412" alt="image"
src="https://github.com/user-attachments/assets/d04563e1-df29-457d-976a-b6b05b3aa623" />

* If it's too long, show error <img width="664" height="414" alt="image"
src="https://github.com/user-attachments/assets/91100d0c-35b5-4cd2-a779-6a34bfdc9fc3" />

* Overflow in table too <img width="1031" height="178" alt="image"
src="https://github.com/user-attachments/assets/4833bd64-2f3f-4de7-9392-1955341a5a96" />

* Added "Learn More" button and correct margin between tabs and description
<img width="1053" height="224" alt="image"
src="https://github.com/user-attachments/assets/4db5116c-0a77-4427-ad61-9bde6e94679b" />

* Team admins / maintainers can no longer see "Add" or "Delete" var buttons
<img width="1031" height="374" alt="image"
src="https://github.com/user-attachments/assets/a15ab358-a6de-4d0b-9df9-aa2e7ed5c0cb" />

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
