### PR TITLE
Update how deleted hosts show in batch scripts (#32290)

### DIFF
--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -2310,13 +2310,13 @@ FROM (
 
   -- If batch is not finished, calculate the host result counts live.
   SELECT
-    COUNT(*)                                AS num_targeted,
+    COUNT(bahr.host_id)                     AS num_targeted,
     COUNT(bahr.error)                       AS num_incompatible,
     COUNT(IF(hsr.exit_code = 0, 1, NULL))   AS num_ran,
     COUNT(IF(hsr.exit_code > 0, 1, NULL))   AS num_errored,
     COUNT(IF(hsr.canceled = 1 AND hsr.exit_code IS NULL, 1, NULL)) AS num_canceled,
     (
-      COUNT(*)
+      COUNT(bahr.host_id)
       - COUNT(bahr.error)
       - COUNT(IF(hsr.exit_code = 0, 1, NULL))
       - COUNT(IF(hsr.exit_code > 0, 1, NULL))
@@ -2333,11 +2333,11 @@ FROM (
     ba.created_at                           AS created_at,
     j.not_before                            AS not_before,
     ba.id                                   AS id
-  FROM batch_activity_host_results bahr
+  FROM batch_activities ba 
+  LEFT JOIN batch_activity_host_results bahr
+         ON ba.execution_id = bahr.batch_execution_id
   LEFT JOIN host_script_results hsr
          ON bahr.host_execution_id = hsr.execution_id
-  JOIN batch_activities ba
-         ON ba.execution_id = bahr.batch_execution_id
   JOIN scripts s
          ON ba.script_id = s.id
   LEFT JOIN jobs j


### PR DESCRIPTION
> # Cherry pick from main to rc 4.73.0

for #32231

# Details

This PR adjusts the queries for listing batch scripts slightly to count _every_ row in `batch_activities` matching the filters, regardless of whether any `batch_activity_host_results` rows exist for it. This handles the edge case of a batch script where all the hosts have been deleted.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [ ] Added/updated automated tests I didn't add tests for this because these tests have already changed quite a bit in https://github.com/fleetdm/fleet/pull/32174. I can add tests in there when this merges.

- [X] QA'd all new/changed functionality manually

* Select a host in Manage Hosts, click Run Script, select a script and do Run Now
* Delete that host
* Go to the batch scripts list (Controls -> Scripts -> Batch Progress)
* Verify that the batch script is still listed.

We don't have clear expectations for what numbers should be displayed for the progress of a batch like this, but this PR at least ensures the batch doesn't disappear.

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
