### PR TITLE
Website: fix search on announcements category page

### DIFF
--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -58,7 +58,7 @@ parasails.registerPage('articles', {
   },
 
   mounted: async function() {
-    if(['Articles', 'Announcements', 'Guides', 'Releases'].includes(this.articleCategory)) {
+    if(['Articles', 'News', 'Guides', 'Releases'].includes(this.articleCategory)) {
       if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
         docsearch({
           appId: 'NZXAYZXDGH',


### PR DESCRIPTION
Closes: [#32378](https://github.com/fleetdm/fleet/issues/32378)

Changes:
- Fixed the broken search widget on the /announcements page