### PR TITLE
update copy and cleanup profile graphic on custom settings page

### DIFF
--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -137,7 +137,13 @@ export interface IMdmSummaryResponse {
   mobile_device_management_solution: IMdmSummaryMdmSolution[] | null;
 }
 
-export type ProfilePlatform = "darwin" | "windows" | "ios" | "ipados" | "linux";
+export type ProfilePlatform =
+  | "darwin"
+  | "windows"
+  | "ios"
+  | "ipados"
+  | "linux"
+  | "android";
 
 export interface IProfileLabel {
   name: string;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileListItem/ProfileListItem.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileListItem/ProfileListItem.tsx
@@ -3,7 +3,7 @@ import { format, formatDistanceToNow } from "date-fns";
 import FileSaver from "file-saver";
 import classnames from "classnames";
 
-import { IMdmProfile } from "interfaces/mdm";
+import { IMdmProfile, ProfilePlatform } from "interfaces/mdm";
 import { isAppleDevice } from "interfaces/platform";
 import mdmAPI, { isDDMProfile } from "services/entities/mdm";
 
@@ -29,7 +29,7 @@ const LabelCount = ({
 );
 
 interface IProfileDetailsProps {
-  platform: string;
+  platform: ProfilePlatform;
   createdAt: string;
   isDDM?: boolean;
 }
@@ -40,8 +40,18 @@ const ProfileDetails = ({
   isDDM,
 }: IProfileDetailsProps) => {
   const getPlatformName = () => {
-    if (platform === "windows") return "Windows";
-    return isDDM ? "macOS, iOS, iPadOS (declaration)" : "macOS, iOS, iPadOS";
+    switch (platform) {
+      case "windows":
+        return "Windows";
+      case "android":
+        return "Android";
+      case "linux":
+        return "Linux";
+      default:
+        return isDDM
+          ? "macOS, iOS, iPadOS (declaration)"
+          : "macOS, iOS, iPadOS";
+    }
   };
 
   return (

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileCard/AddProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileCard/AddProfileCard.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Card from "components/Card";
 import Button from "components/buttons/Button";
-import ProfileGraphic from "../AddProfileGraphic";
+import ProfileGraphic from "../ProfileGraphic";
 
 const baseClass = "add-profile-card";
 
@@ -14,7 +14,16 @@ interface IAddProfileCardProps {
 const AddProfileCard = ({ setShowModal }: IAddProfileCardProps) => (
   <Card color="grey" className={baseClass}>
     <div className={`${baseClass}__card--content-wrap`}>
-      <ProfileGraphic baseClass={baseClass} showMessage />
+      <ProfileGraphic
+        baseClass={baseClass}
+        message={
+          <>
+            <b>Upload configuration profile</b>
+            <br />
+            For Apple (macOS, iOS, iPadOS), Windows, or Android hosts.
+          </>
+        }
+      />
       <GitOpsModeTooltipWrapper
         tipOffset={8}
         renderChildren={(disableChildren) => (

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
@@ -18,7 +18,7 @@ import Icon from "components/Icon";
 import Modal from "components/Modal";
 import Spinner from "components/Spinner";
 import TargetLabelSelector from "components/TargetLabelSelector";
-import ProfileGraphic from "../AddProfileGraphic";
+import ProfileGraphic from "../ProfileGraphic";
 
 import {
   DEFAULT_ERROR_MESSAGE,
@@ -40,7 +40,18 @@ interface IFileChooserProps {
 
 const FileChooser = ({ isLoading, onFileOpen }: IFileChooserProps) => (
   <div className={`${baseClass}__file-chooser`}>
-    <ProfileGraphic baseClass={baseClass} showMessage />
+    <ProfileGraphic
+      baseClass={baseClass}
+      message={
+        <>
+          <b>Upload configuration profile</b>
+          <br />
+          .mobileconfig and .json for Apple (macOS/iOS,iPadOS),
+          <br />
+          .xml for Windows, .json for Android.
+        </>
+      }
+    />
     <Button
       className={`${baseClass}__upload-button`}
       variant="text-icon"

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/ProfileGraphic.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/ProfileGraphic.tsx
@@ -2,26 +2,22 @@ import React from "react";
 
 import Graphic from "components/Graphic";
 
-const ProfileGraphic = ({
-  baseClass,
-  showMessage,
-}: {
+interface IProfileGraphicProps {
   baseClass: string;
-  showMessage?: boolean;
-}) => (
+  /** Provide an optional message to be displayed below the graphic */
+  message?: React.ReactNode;
+}
+
+const ProfileGraphic = ({ baseClass, message }: IProfileGraphicProps) => (
   <div className={`${baseClass}__profile-graphic`}>
     <Graphic
       key="file-configuration-profile-graphic"
       className={`${baseClass}__graphic`}
       name="file-configuration-profile"
     />
-    {showMessage && (
+    {message && (
       <span className={`${baseClass}__profile-graphic--message`}>
-        <b>Upload configuration profile</b>
-        <br />
-        .mobileconfig and .json for macOS, iOS, and iPadOS.
-        <br />
-        .xml for Windows.
+        {message}
       </span>
     )}
   </div>


### PR DESCRIPTION
resolves #32034

This is a quick update to the custom settings page for the add profiles copy.

We updated the copy for the list item platform name, the add profile card, and the add profile modal


- [x] QA'd all new/changed functionality manually

