### PR TITLE
[Activity design] Deliver SCEP certificates from Smallstep (certificate authority)

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -1717,6 +1717,51 @@ This activity contains the following fields:
 }
 ```
 
+## added_smallstep
+
+Generated when Smallstep certificate authority configuration is added in Fleet.
+
+This activity contains the following fields:
+- "name": Name of the certificate authority.
+
+#### Example
+
+```json
+{
+  "name": "SMALLSTEP_WIFI"
+}
+```
+
+## deleted_smallstep
+
+Generated when Smallstep certificate authority configuration is deleted in Fleet.
+
+This activity contains the following fields:
+- "name": Name of the certificate authority.
+
+#### Example
+
+```json
+{
+  "name": "SMALLSTEP_WIFI"
+}
+```
+
+## edited_smallstep
+
+Generated when Smallstep certificate authority configuration is edited in Fleet.
+
+This activity contains the following fields:
+- "name": Name of the certificate authority.
+
+#### Example
+
+```json
+{
+  "name": "SMALLSTEP_WIFI"
+}
+```
+
 ## enabled_activity_automations
 
 Generated when activity automations are enabled


### PR DESCRIPTION
UPDATE: @noahtalerman: Closed this PR because [Smallstep activities](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/audit-logs.md#added_smallstep) are live in 4.75.

---

DO NOT MERGE. Leaving this PR in draft but it's ready for review. When it's approved, we'll close it. Won't merge because the `audit-logs.md` is edited during development.

Activity changes for the following user story:
- #30880
