### PR TITLE
fix: standardize team_id handling in policy activities (#32151)

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -69,8 +69,8 @@ Generated when creating policies.
 This activity contains the following fields:
 - "policy_id": the ID of the created policy.
 - "policy_name": the name of the created policy.
-- "team_id": the ID of the team the policy belongs to.
-- "team_name": the name of the team the policy belongs to.
+- "team_id": the ID of the team the policy belongs to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belongs to. null for global policies and "No Team" policies.
 
 #### Example
 
@@ -90,8 +90,8 @@ Generated when editing policies.
 This activity contains the following fields:
 - "policy_id": the ID of the edited policy.
 - "policy_name": the name of the edited policy.
-- "team_id": the ID of the team the policy belongs to.
-- "team_name": the name of the team the policy belongs to.
+- "team_id": the ID of the team the policy belongs to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belongs to. null for global policies and "No Team" policies.
 
 #### Example
 
@@ -111,8 +111,8 @@ Generated when deleting policies.
 This activity contains the following fields:
 - "policy_id": the ID of the deleted policy.
 - "policy_name": the name of the deleted policy.
-- "team_id": the ID of the team the policy belonged to.
-- "team_name": the name of the team the policy belonged to.
+- "team_id": the ID of the team the policy belonged to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belonged to. null for global policies and "No Team" policies.
 
 #### Example
 

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1365,6 +1365,7 @@ const TAGGED_TEMPLATES = {
     } else if (activity.details?.team_id === 0) {
       teamText = (
         <>
+          {" "}
           for <b>No Team</b>
         </>
       );

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -363,7 +363,7 @@ func (a ActivityTypeAppliedSpecPack) Documentation() (activity string, details s
 type ActivityTypeCreatedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   int64   `json:"team_id,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty"`
 	TeamName *string `json:"team_name,omitempty"`
 }
 
@@ -376,8 +376,8 @@ func (a ActivityTypeCreatedPolicy) Documentation() (activity string, details str
 		`This activity contains the following fields:
 - "policy_id": the ID of the created policy.
 - "policy_name": the name of the created policy.
-- "team_id": the ID of the team the policy belongs to.
-- "team_name": the name of the team the policy belongs to.`, `{
+- "team_id": the ID of the team the policy belongs to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belongs to. null for global policies and "No Team" policies.`, `{
 	"policy_id": 123,
 	"policy_name": "foo",
 	"team_id": 1,
@@ -388,7 +388,7 @@ func (a ActivityTypeCreatedPolicy) Documentation() (activity string, details str
 type ActivityTypeEditedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   *uint   `json:"team_id,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty"`
 	TeamName *string `json:"team_name,omitempty"`
 }
 
@@ -401,8 +401,8 @@ func (a ActivityTypeEditedPolicy) Documentation() (activity string, details stri
 		`This activity contains the following fields:
 - "policy_id": the ID of the edited policy.
 - "policy_name": the name of the edited policy.
-- "team_id": the ID of the team the policy belongs to.
-- "team_name": the name of the team the policy belongs to.`, `{
+- "team_id": the ID of the team the policy belongs to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belongs to. null for global policies and "No Team" policies.`, `{
 	"policy_id": 123,
 	"policy_name": "foo",
 	"team_id": 1,
@@ -413,7 +413,7 @@ func (a ActivityTypeEditedPolicy) Documentation() (activity string, details stri
 type ActivityTypeDeletedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   int64   `json:"team_id,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty"`
 	TeamName *string `json:"team_name,omitempty"`
 }
 
@@ -426,8 +426,8 @@ func (a ActivityTypeDeletedPolicy) Documentation() (activity string, details str
 		`This activity contains the following fields:
 - "policy_id": the ID of the deleted policy.
 - "policy_name": the name of the deleted policy.
-- "team_id": the ID of the team the policy belonged to.
-- "team_name": the name of the team the policy belonged to.`, `{
+- "team_id": the ID of the team the policy belonged to. Use -1 for global policies, 0 for "No Team" policies.
+- "team_name": the name of the team the policy belonged to. null for global policies and "No Team" policies.`, `{
 	"policy_id": 123,
 	"policy_name": "foo",
 	"team_id": 1,

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -81,13 +81,14 @@ func (svc Service) NewGlobalPolicy(ctx context.Context, p fleet.PolicyPayload) (
 	}
 	// Note: Issue #4191 proposes that we move to SQL transactions for actions so that we can
 	// rollback an action in the event of an error writing the associated activity
+	globalTeamID := int64(-1)
 	if err := svc.NewActivity(
 		ctx,
 		authz.UserFromContext(ctx),
 		fleet.ActivityTypeCreatedPolicy{
 			ID:       policy.ID,
 			Name:     policy.Name,
-			TeamID:   -1,
+			TeamID:   &globalTeamID,
 			TeamName: nil,
 		},
 	); err != nil {
@@ -265,13 +266,14 @@ func (svc Service) DeleteGlobalPolicies(ctx context.Context, ids []uint) ([]uint
 	// Note: Issue #4191 proposes that we move to SQL transactions for actions so that we can
 	// rollback an action in the event of an error writing the associated activity
 	for _, id := range deletedIDs {
+		globalTeamID := int64(-1)
 		if err := svc.NewActivity(
 			ctx,
 			authz.UserFromContext(ctx),
 			fleet.ActivityTypeDeletedPolicy{
 				ID:       id,
 				Name:     policiesByID[id].Name,
-				TeamID:   -1,
+				TeamID:   &globalTeamID,
 				TeamName: nil,
 			},
 		); err != nil {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -6772,7 +6772,6 @@ func (s *integrationEnterpriseTestSuite) TestRunBatchScript() {
 		fmt.Sprintf(`{"batch_execution_id":"%s", "host_count":2, "script_name":"%s", "team_id":null, "not_before": "%s"}`, batchRes.BatchExecutionID, script.Name, scheduledTime.UTC().Format(time.RFC3339Nano)),
 		0,
 	)
-
 }
 
 func (s *integrationEnterpriseTestSuite) TestCancelBatchScripts() {
@@ -17282,11 +17281,12 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 	require.Equal(t, tpResp.Policy.ID, gotPolicy.ID)
 
 	// check that we created an activity for the policy creation
+	noTeamID := int64(0)
 	wantAct := fleet.ActivityTypeCreatedPolicy{
 		ID:       gotPolicy.ID,
 		Name:     gotPolicy.Name,
-		TeamID:   0,
-		TeamName: ptr.String("No Team"),
+		TeamID:   &noTeamID,
+		TeamName: nil,
 	}
 	s.lastActivityMatches(wantAct.ActivityName(), string(jsonMustMarshal(t, wantAct)), 0)
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -103,15 +103,15 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 	}
 
 	if teamID == 0 {
-		teamName := "No Team"
+		noTeamID := int64(0)
 		if err := svc.NewActivity(
 			ctx,
 			authz.UserFromContext(ctx),
 			fleet.ActivityTypeCreatedPolicy{
 				ID:       policy.ID,
 				Name:     policy.Name,
-				TeamID:   int64(teamID),
-				TeamName: &teamName,
+				TeamID:   &noTeamID,
+				TeamName: nil,
 			},
 		); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for no-team policy creation")
@@ -133,13 +133,14 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		}
 	}
 
+	teamIDPtr := int64(teamID)
 	if err := svc.NewActivity(
 		ctx,
 		authz.UserFromContext(ctx),
 		fleet.ActivityTypeCreatedPolicy{
 			ID:       policy.ID,
 			Name:     policy.Name,
-			TeamID:   int64(teamID),
+			TeamID:   &teamIDPtr,
 			TeamName: teamName,
 		},
 	); err != nil {
@@ -451,7 +452,7 @@ func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []ui
 	}
 
 	if teamID == 0 {
-		teamName := "No Team"
+		noTeamID := int64(0)
 		for _, id := range deletedIDs {
 			if err := svc.NewActivity(
 				ctx,
@@ -459,8 +460,8 @@ func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []ui
 				fleet.ActivityTypeDeletedPolicy{
 					ID:       id,
 					Name:     policiesByID[id].Name,
-					TeamID:   int64(teamID),
-					TeamName: &teamName,
+					TeamID:   &noTeamID,
+					TeamName: nil,
 				},
 			); err != nil {
 				return nil, ctxerr.Wrap(ctx, err, "create activity for no-team policy deletion")
@@ -484,13 +485,14 @@ func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []ui
 	}
 
 	for _, id := range deletedIDs {
+		teamIDPtr := int64(teamID)
 		if err := svc.NewActivity(
 			ctx,
 			authz.UserFromContext(ctx),
 			fleet.ActivityTypeDeletedPolicy{
 				ID:       id,
 				Name:     policiesByID[id].Name,
-				TeamID:   int64(teamID),
+				TeamID:   &teamIDPtr,
 				TeamName: teamName,
 			},
 		); err != nil {
@@ -657,17 +659,34 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
 	}
 
-	// Add a special case for handling "No Team" (teamID = 0) in ModifyTeamPolicy
-	if teamID != nil && *teamID == 0 {
-		teamName := "No Team"
+	if teamID == nil {
+		globalTeamID := int64(-1)
 		if err := svc.NewActivity(
 			ctx,
 			authz.UserFromContext(ctx),
 			fleet.ActivityTypeEditedPolicy{
 				ID:       policy.ID,
 				Name:     policy.Name,
-				TeamID:   teamID,
-				TeamName: &teamName,
+				TeamID:   &globalTeamID,
+				TeamName: nil,
+			},
+		); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "create activity for global policy modification")
+		}
+		return policy, nil
+	}
+
+	// Add a special case for handling "No Team" (teamID = 0) in ModifyTeamPolicy
+	if teamID != nil && *teamID == 0 {
+		noTeamID := int64(0)
+		if err := svc.NewActivity(
+			ctx,
+			authz.UserFromContext(ctx),
+			fleet.ActivityTypeEditedPolicy{
+				ID:       policy.ID,
+				Name:     policy.Name,
+				TeamID:   &noTeamID,
+				TeamName: nil,
 			},
 		); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "create activity for no-team policy modification")
@@ -689,13 +708,20 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		}
 	}
 
+	// Convert *uint to *int64 for the activity
+	var activityTeamID *int64
+	if teamID != nil {
+		teamIDInt64 := int64(*teamID)
+		activityTeamID = &teamIDInt64
+	}
+
 	if err := svc.NewActivity(
 		ctx,
 		authz.UserFromContext(ctx),
 		fleet.ActivityTypeEditedPolicy{
 			ID:       policy.ID,
 			Name:     policy.Name,
-			TeamID:   teamID,
+			TeamID:   activityTeamID,
 			TeamName: teamName,
 		},
 	); err != nil {


### PR DESCRIPTION
> # Cherry pick of #32151 from main to 4.73.0 RC

handles the edge case mentioned in QA Notes #27689 and
- Use consistent *int64 for TeamID across all policy activity types 
- Fix JSON omitempty issue causing team_id: 0 to be omitted(to fix a small copy test bug in Frontend)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

Current Output
<img width="639" height="166" alt="image"
src="https://github.com/user-attachments/assets/ee17b3ee-65c9-430f-ae3b-3c350f7e20f9" />
<img width="647" height="524" alt="image"
src="https://github.com/user-attachments/assets/9bc01988-ccca-4ea4-84bf-3a15f35ba428" />

---------

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
