### PR TITLE
Website: Update compliance proxy admin consent webhook

### DIFF
--- a/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
+++ b/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
@@ -156,7 +156,7 @@ module.exports = {
       } catch(err){
         sails.log.warn(`An error occured when parsing the JSON response body from the PartnerCompliancePolicies endpoint for a microsoft compliance tenant. full error`, err);
         await MicrosoftComplianceTenant.updateOne({id: informationAboutThisTenant.id}).set({setupError:  `${require('util').inspect(err, {depth: null})}`});
-        return {redirect: fleetInstanceUrlToRedirectTo };
+        throw {redirect: fleetInstanceUrlToRedirectTo };
       }
       let createdPolicyId = parsedPoliciesResponse.value[0].Id;
 
@@ -184,14 +184,14 @@ module.exports = {
       } catch(err){
         sails.log.warn(`An error occured when parsing the JSON response body returned by the Microsoft graph API for a new Microsoft compliance tenant. full error`, err);
         await MicrosoftComplianceTenant.updateOne({id: informationAboutThisTenant.id}).set({setupError:  `${require('util').inspect(err, {depth: null})}`});
-        return {redirect: fleetInstanceUrlToRedirectTo };
+        throw {redirect: fleetInstanceUrlToRedirectTo };
       }
 
       // If the response from the Microsoft Graph API did not contain any groups, log a warning and save a setup error on the database record for this tenant.
       if(parsedGroupResponse.value.length === 0){
         sails.log.warn(`When an Entra tenant (${informationAboutThisTenant.fleetInstanceUrl}) tried setting up a conditional access integration, `);
         await MicrosoftComplianceTenant.updateOne({id: informationAboutThisTenant.id}).set({setupError:  `No "Fleet conditional access" Entra ID group was found on this Entra tenant.`});
-        return {redirect: fleetInstanceUrlToRedirectTo };
+        throw {redirect: fleetInstanceUrlToRedirectTo };
       }
 
       let groupId = parsedGroupResponse.value[0].id;

--- a/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
+++ b/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
@@ -201,7 +201,7 @@ module.exports = {
 
       // If the response from the Microsoft Graph API did not contain any groups, log a warning and save a setup error on the database record for this tenant.
       if(parsedGroupResponse.value.length === 0){
-        sails.log.warn(`When an Entra tenant (${informationAboutThisTenant.fleetInstanceUrl}) tried setting up a conditional access integration, `);
+        sails.log.warn(`When an Entra tenant (${informationAboutThisTenant.fleetInstanceUrl}) tried setting up a conditional access integration, no "Fleet conditional access" Entra ID group was found on this Entra tenant.`);
         await MicrosoftComplianceTenant.updateOne({id: informationAboutThisTenant.id}).set({setupError:  `No "Fleet conditional access" Entra ID group was found on this Entra tenant.`});
         throw {redirect: fleetInstanceUrlToRedirectTo };
       }

--- a/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
+++ b/website/api/controllers/microsoft-proxy/receive-redirect-from-microsoft.js
@@ -14,7 +14,8 @@ module.exports = {
     },
     state: {
       type: 'string',
-      description: 'A token used to authenticate this request for a provided entra tenant.'
+      description: 'A token used to authenticate this request for a provided entra tenant.',
+      required: true,
     },
     error: {
       type: 'string',


### PR DESCRIPTION
Changes:
- Updated the `receive-redirect-from-microsoft` endpoint to redirect users to their Fleet instance if an Entra admin did not consent to the permissions requested by Fleet's compliance partner integration.
- Fixed a bug that prevented users from being redirected to their Fleet instance if their Entra configuration is missing a required group
- Updated the `receive-redirect-from-microsoft` endpoint to require a `state` input