### PR TITLE
Fleet UI: Remove inaccurate updated never timestamp

### DIFF
--- a/changes/31601-remove-inaccurate-timestamp
+++ b/changes/31601-remove-inaccurate-timestamp
@@ -1,0 +1,1 @@
+- Fleet UI: Removes inaccurate host count time stamp on the software version details page

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
 
 import LastUpdatedHostCount from ".";
 
@@ -17,19 +18,22 @@ describe("Last updated host count", () => {
     expect(hostCount).toBeInTheDocument();
     expect(updateText).toBeInTheDocument();
   });
-  it("renders never if missing timestamp", () => {
-    render(<LastUpdatedHostCount />);
 
-    const text = screen.getByText("Updated never");
-
-    expect(text).toBeInTheDocument();
+  it("renders 'Updated never' if lastUpdatedAt is explicitly null", () => {
+    render(<LastUpdatedHostCount lastUpdatedAt={null} />);
+    expect(screen.getByText("Updated never")).toBeInTheDocument();
   });
 
-  it("renders tooltip on hover", async () => {
-    render(<LastUpdatedHostCount hostCount={0} />);
+  it("does not render updated text if lastUpdatedAt is undefined", () => {
+    render(<LastUpdatedHostCount />);
+    expect(screen.queryByText(/Updated/i)).not.toBeInTheDocument();
+  });
 
-    await fireEvent.mouseEnter(screen.getByText("Updated never"));
-
+  it("renders tooltip on hover when 'Updated never'", async () => {
+    const { user } = renderWithSetup(
+      <LastUpdatedHostCount hostCount={0} lastUpdatedAt={null} />
+    );
+    await user.hover(screen.getByText("Updated never"));
     expect(
       screen.getByText(/last time host data was updated/i)
     ).toBeInTheDocument();

--- a/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
+++ b/frontend/components/LastUpdatedHostCount/LastUpdatedHostCount.tsx
@@ -5,7 +5,7 @@ const baseClass = "last-updated-host-count";
 
 interface ILastUpdatedHostCount {
   hostCount?: string | number | JSX.Element;
-  lastUpdatedAt?: string;
+  lastUpdatedAt?: string | null;
 }
 
 const LastUpdatedHostCount = ({
@@ -23,10 +23,12 @@ const LastUpdatedHostCount = ({
   return (
     <div className={baseClass}>
       <>{hostCount}</>
-      <LastUpdatedText
-        lastUpdatedAt={lastUpdatedAt}
-        customTooltipText={tooltipContent}
-      />
+      {lastUpdatedAt !== undefined && (
+        <LastUpdatedText
+          lastUpdatedAt={lastUpdatedAt}
+          customTooltipText={tooltipContent}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/components/LastUpdatedText/LastUpdatedText.tsx
+++ b/frontend/components/LastUpdatedText/LastUpdatedText.tsx
@@ -7,7 +7,7 @@ import TooltipWrapper from "components/TooltipWrapper";
 const baseClass = "component__last-updated-text";
 
 interface ILastUpdatedTextBase {
-  lastUpdatedAt?: string;
+  lastUpdatedAt?: string | null;
 }
 
 interface ILastUpdatedTextWithCustomTooltip extends ILastUpdatedTextBase {


### PR DESCRIPTION
## Issues
Closes #31601

## Description
- Update component to remove timestamp if it is undefined, still keeping "Updated never" if countsUpdatedAt is set as null
- Component is only used on this page and the vuln details page and confirmed component change didn't cause any regressions

## Screenshot of fix
<img width="773" height="420" alt="Screenshot 2025-08-28 at 2 16 10 PM" src="https://github.com/user-attachments/assets/219a2890-04aa-48d9-aef3-1205f8a21d68" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
