### PR TITLE
Fleet UI: Consistent banner link colors

### DIFF
--- a/changes/31944-consistent-banner-link-colors
+++ b/changes/31944-consistent-banner-link-colors
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed banner link colors

--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -307,6 +307,7 @@ const PlatformWrapper = ({
                 text="adding hosts"
                 newTab
                 multiline
+                variant="banner-link"
               />
             </InfoBanner>
           </div>

--- a/frontend/pages/AccountPage/AccountPage.tsx
+++ b/frontend/pages/AccountPage/AccountPage.tsx
@@ -185,6 +185,7 @@ const AccountPage = ({ router }: IAccountPageProps): JSX.Element | null => {
                 url="https://fleetdm.com/docs/using-fleet/fleetctl-cli?utm_medium=fleetui&utm_campaign=get-api-token#using-fleetctl-with-an-api-only-user"
                 text="API-only user"
                 newTab
+                variant="banner-link"
               />
               &nbsp;instead.
             </p>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -148,6 +148,7 @@ const ViewYamlModal = ({
               text="How to use YAML"
               newTab
               multiline
+              variant="banner-link"
             />
           </p>
         </InfoBanner>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -174,6 +174,7 @@ const SoftwareOptionsSelector = ({
             url={`${LEARN_MORE_ABOUT_BASE_LINK}/query-templates-for-automatic-software-install`}
             text="Learn more"
             newTab
+            variant="banner-link"
           />
         </InfoBanner>
       )}

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -107,6 +107,7 @@ const Agents = ({
                 url="https://fleetdm.com/docs/using-fleet/teams"
                 text="Learn more about teams"
                 newTab
+                variant="banner-link"
               />
             </InfoBanner>
           )}

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -391,6 +391,7 @@ const UserForm = ({
               url="https://fleetdm.com/docs/using-fleet/permissions#user-permissions"
               text="Learn more about user permissions"
               newTab
+              variant="banner-link"
             />
           </InfoBanner>
         )}
@@ -448,6 +449,7 @@ const UserForm = ({
                   url="https://fleetdm.com/docs/using-fleet/permissions#team-member-permissions"
                   text="Learn more about user permissions"
                   newTab
+                  variant="banner-link"
                 />
               </InfoBanner>
               <SelectedTeamsForm

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -361,6 +361,7 @@ const EditQueryPage = ({
           url="https://github.com/fleetdm/fleet/issues/new/choose"
           text="file an issue"
           newTab
+          variant="banner-link"
         />
       </InfoBanner>
     );


### PR DESCRIPTION
## Issues
Closes #31944 

## Description
- Fixes 8 cases of banners that had purple links to match new (<1 year) fleet style guide that changed them to black (see PR for locations to QA)

## Screenshots
Several screenshots of fixes, not all

<img width="864" height="682" alt="Screenshot 2025-08-28 at 2 34 17 PM" src="https://github.com/user-attachments/assets/19a276e5-8b0b-4d4d-83f9-b019fbf567b9" />
<img width="938" height="553" alt="Screenshot 2025-08-28 at 2 36 07 PM" src="https://github.com/user-attachments/assets/df863c80-6834-449e-a23c-d3b3752077f3" />
<img width="1161" height="531" alt="Screenshot 2025-08-28 at 2 37 08 PM" src="https://github.com/user-attachments/assets/96b4c3bb-cb23-408c-9694-fcfb8b64e189" />
<img width="780" height="943" alt="Screenshot 2025-08-28 at 2 39 14 PM" src="https://github.com/user-attachments/assets/daff71a8-9fcc-4df2-b94b-347396ee04c7" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
