### PR TITLE
Updating App config should use primary

### DIFF
--- a/changes/28713-gitops-checkbox-status-replica-env
+++ b/changes/28713-gitops-checkbox-status-replica-env
@@ -1,0 +1,1 @@
+* Refactored PATH fleet/config end-point to use the primary DB node for both persisting changes and fetching modified App Config.

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -648,7 +648,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.FleetDesktop.TransparencyURL = ""
 	}
 
-	if err := svc.ds.SaveAppConfig(ctx, appConfig); err != nil {
+	if err := svc.ds.SaveAppConfig(ctxdb.RequirePrimary(ctx, true), appConfig); err != nil {
 		return nil, err
 	}
 
@@ -825,7 +825,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	// retrieve new app config with obfuscated secrets
-	obfuscatedAppConfig, err := svc.ds.AppConfig(ctx)
+	obfuscatedAppConfig, err := svc.ds.AppConfig(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -648,7 +648,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.FleetDesktop.TransparencyURL = ""
 	}
 
-	if err := svc.ds.SaveAppConfig(ctxdb.RequirePrimary(ctx, true), appConfig); err != nil {
+	if err := svc.ds.SaveAppConfig(ctx, appConfig); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
For #28713

Refactored the PATH fleet/config end-point to use the primary DB node for both persisting changes and fetching modified App Config to avoid stale UI due to read replica delay.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually