### PR TITLE
Fixed error when updating a script to exactly match the contents of another script.

### DIFF
--- a/changes/31580-duplicate-scripts
+++ b/changes/31580-duplicate-scripts
@@ -1,0 +1,1 @@
+* Fixed error when updating a script to exactly match the contents of another script.


### PR DESCRIPTION
Fixes #31580 

Fixes issues
- When updating a script to exactly match the content of another script, we fail
- When updating one script which happens to match content of another script, both get updated and not just the one being edited

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved error when updating a script to exactly match another script’s contents.
  * Improved handling of script content updates: identical contents are deduplicated and unused versions are cleaned up.
  * Scheduled/pending runs are canceled on content updates with clearer cancellation messaging.

* **Documentation**
  * Added changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->