### PR TITLE
AP: Android profiles status counts

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -523,7 +523,6 @@ func (ds *Datastore) DeleteMDMAndroidConfigProfile(ctx context.Context, profileU
 	return nil
 }
 
-<<<<<<< HEAD
 func (ds *Datastore) GetMDMAndroidProfilesSummary(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error) {
 	stmt := `
 SELECT

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -546,8 +546,7 @@ GROUP BY
 // sqlJoinMDMAndroidProfilesStatus returns a SQL snippet that can be used to join a table derived from
 // host_mdm_android_profiles (grouped by host_uuid and status) and the hosts table. For each host_uuid,
 // it derives a boolean value for each status category. The value will be 1 if the host has any
-// profile in the given status category. Separate columns are used for status of the filevault profile
-// vs. all other profiles. The snippet assumes the hosts table to be aliased as 'h'.
+// profile in the given status category. The snippet assumes the hosts table to be aliased as 'h'.
 func sqlJoinMDMAndroidProfilesStatus() string {
 	// NOTE: To make this snippet reusable, we're not using sqlx.Named here because it would
 	// complicate usage in other queries (e.g., list hosts).

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -495,7 +495,7 @@ FROM
 	%s
 WHERE
 	platform = 'android' AND
-	hmdm.enrolled = 1 AND -- TODO AP Do we need this check? Windows does it, Apple does not
+	hmdm.enrolled = 1 AND
 	 %s
 GROUP BY
 	status HAVING status IS NOT NULL`

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -617,13 +617,11 @@ func testMDMAndroidProfilesSummary(t *testing.T, ds *Datastore) {
 		checkExpected(t, nil, expected)
 
 		// add some other android hosts that won't be be assigned any profiles
-		otherHosts := make([]*fleet.Host, 0, 5)
 		for i := 0; i < 5; i++ {
 			androidHost := createAndroidHost(fmt.Sprintf("enterprise-id-other-%d", i))
 			newHost, err := ds.NewAndroidHost(ctx, androidHost)
 			require.NoError(t, err)
 			require.NotNil(t, newHost)
-			otherHosts = append(otherHosts, newHost.Host)
 		}
 
 		checkExpected(t, nil, expected)

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -89,6 +89,8 @@ func testNewAndroidHost(t *testing.T, ds *Datastore) {
 }
 
 func createAndroidHost(enterpriseSpecificID string) *fleet.AndroidHost {
+	// Device ID needs to be unique per device
+	deviceID := md5ChecksumBytes([]byte(enterpriseSpecificID))[:16]
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			Hostname:       "hostname",
@@ -105,7 +107,7 @@ func createAndroidHost(enterpriseSpecificID string) *fleet.AndroidHost {
 			UUID:           enterpriseSpecificID,
 		},
 		Device: &android.Device{
-			DeviceID:             "device_id",
+			DeviceID:             deviceID,
 			EnterpriseSpecificID: ptr.String(enterpriseSpecificID),
 			AndroidPolicyID:      ptr.Uint(1),
 			LastPolicySyncTime:   ptr.Time(time.Now().UTC().Truncate(time.Millisecond)),

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -1956,6 +1956,7 @@ func (ds *Datastore) deleteMDMOSCustomSettingsForHost(ctx context.Context, tx sq
 		"ios":     {"host_mdm_apple_profiles", "host_mdm_apple_declarations"},
 		"ipados":  {"host_mdm_apple_profiles", "host_mdm_apple_declarations"},
 		"windows": {"host_mdm_windows_profiles"},
+		"android": {"host_mdm_android_profiles"},
 	}
 
 	tables, ok := tableMap[platform]

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1795,6 +1795,16 @@ func filterHostsByProfileStatus(sqlstmt string, opt fleet.HostListOptions, param
 			hwap.host_uuid = h.uuid
 			AND hwap.profile_uuid = ?
 			AND hwap.status = ?)`
+		case strings.HasPrefix(*opt.ProfileUUIDFilter, fleet.MDMAndroidProfileUUIDPrefix):
+			sqlstmt += ` AND EXISTS (
+		SELECT
+			1
+		FROM
+			host_mdm_android_profiles hmap
+		WHERE
+			hmap.host_uuid = h.uuid
+			AND hmap.profile_uuid = ?
+			AND hmap.status = ?)`
 		default:
 			return sqlstmt, params
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1192,7 +1192,8 @@ func (ds *Datastore) applyHostFilters(
 		opt.OSSettingsDiskEncryptionFilter.IsValid() {
 		connectedToFleetJoin = `
 				LEFT JOIN nano_enrollments ne ON ne.id = h.uuid AND ne.enabled = 1 AND ne.type IN ('Device', 'User Enrollment (Device)')
-				LEFT JOIN mdm_windows_enrollments mwe ON mwe.host_uuid = h.uuid AND mwe.device_state = ?`
+				LEFT JOIN mdm_windows_enrollments mwe ON mwe.host_uuid = h.uuid AND mwe.device_state = ?
+				LEFT JOIN android_devices ad ON ad.host_id = h.id`
 		whereParams = append(whereParams, microsoft_mdm.MDMDeviceStateEnrolled)
 	}
 
@@ -1493,7 +1494,7 @@ func (ds *Datastore) filterHostsByOSSettingsStatus(sql string, opt fleet.HostLis
 	sqlFmt := ` AND (
 		(h.platform = 'windows' AND mwe.host_uuid IS NOT NULL AND hmdm.enrolled = 1) -- windows
 		OR (h.platform IN ('darwin', 'ios', 'ipados') AND ne.id IS NOT NULL AND hmdm.enrolled = 1) -- apple
-		OR (h.platform = 'android' AND hmdm.enrolled = 1) -- android
+		OR (h.platform = 'android' AND hmdm.enrolled = 1 AND ad.host_id IS NOT NULL) -- android
 		OR ` + includeLinuxCond + `
 	)`
 

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1203,7 +1203,9 @@ func (ds *Datastore) applyHostFilters(
 		opt.MacOSSettingsFilter.IsValid() {
 		mdmAppleProfilesStatusJoin = sqlJoinMDMAppleProfilesStatus()
 		mdmAppleDeclarationsStatusJoin = sqlJoinMDMAppleDeclarationsStatus()
-		// TODO Do we need an android settings filter?
+	}
+
+	if opt.OSSettingsFilter.IsValid() {
 		mdmAndroidProfilesStatusJoin = sqlJoinMDMAndroidProfilesStatus()
 	}
 

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -81,6 +81,7 @@ func TestHosts(t *testing.T) {
 		{"WithTeamPackStats", testHostsWithTeamPackStats},
 		{"Delete", testHostsDelete},
 		{"HostListOptionsTeamFilter", testHostListOptionsTeamFilter},
+		{"HostListOptionsAndroidOSSettings", testHostListAndroidHostsOSSettings},
 		{"ListFilterAdditional", testHostsListFilterAdditional},
 		{"ListStatus", testHostsListStatus},
 		{"ListQuery", testHostsListQuery},
@@ -834,6 +835,23 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 		nanoEnrollAndSetHostMDMData(t, ds, h, false)
 	}
 
+	upsertAndroidHostProfileStatus := func(t *testing.T, hostUUID string, profUUID string, status *fleet.MDMDeliveryStatus) {
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := `INSERT INTO host_mdm_android_profiles (host_uuid, profile_uuid, status, operation_type) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE status = ?`
+			_, err := q.ExecContext(context.Background(), stmt, hostUUID, profUUID, status, fleet.MDMOperationTypeInstall, status)
+			return err
+		})
+	}
+
+	// Add a couple of Android hosts(creation path is slightly different)
+	for i := 0; i < 2; i++ {
+		androidHost := createAndroidHost(fmt.Sprintf("enterprise-id-%d", i))
+		newHost, err := ds.NewAndroidHost(context.Background(), androidHost)
+		require.NoError(t, err)
+		require.NotNil(t, newHost)
+		hosts = append(hosts, newHost.Host)
+	}
+
 	userFilter := fleet.TeamFilter{User: test.UserAdmin}
 
 	// confirm initial state
@@ -851,13 +869,13 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team1.ID}, 3)
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID}, 0)
 
-	// assign four hosts to team 2
-	require.NoError(t, ds.AddHostsToTeam(context.Background(), fleet.NewAddHostsToTeamParams(&team2.ID, []uint{hosts[13].ID, hosts[14].ID, hosts[15].ID, hosts[16].ID})))
+	// assign five hosts, including one Android, to team 2
+	require.NoError(t, ds.AddHostsToTeam(context.Background(), fleet.NewAddHostsToTeamParams(&team2.ID, []uint{hosts[13].ID, hosts[14].ID, hosts[15].ID, hosts[16].ID, hosts[20].ID})))
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{}, len(hosts))
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterNil}, len(hosts))
-	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero}, len(hosts)-7)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero}, len(hosts)-8)
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team1.ID}, 3)
-	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID}, 4)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID}, 5)
 
 	// test team filter in combination with macos settings filter
 	profUUID := "a" + uuid.NewString()
@@ -873,18 +891,24 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 			Scope:             fleet.PayloadScopeSystem,
 		},
 	}))
+
+	// Insert a "verifying" profile for Android host 20(team 2) and a failed profile for Android host 21(no team)
+	upsertAndroidHostProfileStatus(t, hosts[20].UUID, "g"+uuid.NewString(), &fleet.MDMDeliveryVerifying)
+	upsertAndroidHostProfileStatus(t, hosts[21].UUID, "g"+uuid.NewString(), &fleet.MDMDeliveryFailed)
+
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team1.ID, MacOSSettingsFilter: fleet.OSSettingsVerifying}, 1) // hosts[0]
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID, MacOSSettingsFilter: fleet.OSSettingsVerifying}, 0) // wrong team
 	// macos settings filter does not support "all teams" so teamIDFilterNil acts the same as teamIDFilterZero
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, MacOSSettingsFilter: fleet.OSSettingsVerifying}, 0) // no team
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterNil, MacOSSettingsFilter: fleet.OSSettingsVerifying}, 0)  // no team
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{MacOSSettingsFilter: fleet.OSSettingsVerifying}, 0)                               // no team
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{MacOSSettingsFilter: fleet.OSSettingsFailed}, 0)                                  // 0 because the failed host is Android
 
 	require.NoError(t, ds.BulkUpsertMDMAppleHostProfiles(context.Background(), []*fleet.MDMAppleBulkUpsertHostProfilePayload{
 		{
 			ProfileUUID:       profUUID,
 			ProfileIdentifier: "identifier",
-			HostUUID:          hosts[19].UUID, // hosts[19] is assgined to no team
+			HostUUID:          hosts[19].UUID, // hosts[19] is assigned to no team
 			CommandUUID:       "command-uuid-2",
 			OperationType:     fleet.MDMOperationTypeInstall,
 			Status:            &fleet.MDMDeliveryVerifying,
@@ -905,12 +929,13 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team1.ID, OSSettingsFilter: fleet.OSSettingsVerifying}, 1) // hosts[10]
 
 	// team 2
-	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID, OSSettingsFilter: fleet.OSSettingsVerifying}, 0) // wrong team
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: &team2.ID, OSSettingsFilter: fleet.OSSettingsVerifying}, 1) // Android hosts[20]
 
 	// os settings filter does not support "all teams" so teamIDFilterNil acts the same as teamIDFilterZero
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsFilter: fleet.OSSettingsVerifying}, 1) // hosts[19]
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterNil, OSSettingsFilter: fleet.OSSettingsVerifying}, 1)  // hosts[19]
-	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsVerifying}, 1)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsVerifying}, 1)                               // hosts[19]
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsFailed}, 1)                                  // hosts[21]
 
 	// disk encryption for linux, must enable disk encryption for no team first
 	ac, err := ds.AppConfig(context.Background())
@@ -926,7 +951,7 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 	require.NoError(t, ds.ReportEscrowError(context.Background(), hosts[2].ID, "error")) // set host 2 to failed
 
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsFilter: fleet.OSSettingsVerified}, 1) // hosts[1]
-	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsFilter: fleet.OSSettingsFailed}, 1)   // hosts[2]
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsFilter: fleet.OSSettingsFailed}, 2)   // hosts[2], hosts[21]
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsFilter: fleet.OSSettingsPending}, 3)  // still-pending supported linux hosts
 
 	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterZero, OSSettingsDiskEncryptionFilter: fleet.DiskEncryptionVerified}, 1)
@@ -979,6 +1004,56 @@ func testHostListOptionsTeamFilter(t *testing.T, ds *Datastore) {
 	_, err = ds.ListHosts(context.Background(), userFilter, fleet.HostListOptions{TeamFilter: teamIDFilterBad})
 	require.Error(t, err)
 	require.True(t, strings.Contains(err.Error(), "team is invalid"), err)
+}
+
+func testHostListAndroidHostsOSSettings(t *testing.T, ds *Datastore) {
+	// Add a couple of Android hosts. One we will create profiles on, another as a control
+	hosts := []*fleet.Host{}
+	upsertAndroidHostProfileStatus := func(t *testing.T, hostUUID string, profUUID string, status *fleet.MDMDeliveryStatus) {
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := `INSERT INTO host_mdm_android_profiles (host_uuid, profile_uuid, status, operation_type) VALUES (?, ?, ?, ?) ON DUPLICATE KEY UPDATE status = ?`
+			_, err := q.ExecContext(context.Background(), stmt, hostUUID, profUUID, status, fleet.MDMOperationTypeInstall, status)
+			return err
+		})
+	}
+	for i := 0; i < 2; i++ {
+		androidHost := createAndroidHost(fmt.Sprintf("enterprise-id-%d", i))
+		newHost, err := ds.NewAndroidHost(context.Background(), androidHost)
+		require.NoError(t, err)
+		require.NotNil(t, newHost)
+		hosts = append(hosts, newHost.Host)
+	}
+
+	profUUID := "gfleetie-was-here"
+	statuses := []*fleet.MDMDeliveryStatus{nil, &fleet.MDMDeliveryFailed, &fleet.MDMDeliveryPending, &fleet.MDMDeliveryVerified, &fleet.MDMDeliveryVerifying}
+
+	userFilter := fleet.TeamFilter{User: test.UserAdmin}
+	// confirm initial state
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{}, len(hosts))
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(fleet.MDMDeliveryFailed)}, 0)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(fleet.MDMDeliveryPending)}, 0)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(fleet.MDMDeliveryVerifying)}, 0)
+	listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(fleet.MDMDeliveryVerified)}, 0)
+
+	for _, v := range statuses {
+		upsertAndroidHostProfileStatus(t, hosts[0].UUID, profUUID, v)
+		expectedStatus := fleet.MDMDeliveryPending
+		if v != nil {
+			expectedStatus = *v
+		}
+		fmt.Printf("upserted host UUID %s prof status %v %s\n", hosts[0].UUID, v, expectedStatus)
+		for _, checkStatus := range statuses {
+			if checkStatus == nil {
+				continue
+			}
+			expected := 0
+			if *checkStatus == expectedStatus {
+				expected = 1
+			}
+			fmt.Printf("Checking check %s expectedStatus %s expected %d", *checkStatus, expectedStatus, expected)
+			listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(*checkStatus)}, expected)
+		}
+	}
 }
 
 func testHostsListFilterAdditional(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -1026,7 +1026,6 @@ func testHostListAndroidHostsOSSettings(t *testing.T, ds *Datastore) {
 		if v != nil {
 			expectedStatus = *v
 		}
-		fmt.Printf("upserted host UUID %s prof status %v %s\n", hosts[0].UUID, v, expectedStatus)
 		for _, checkStatus := range statuses {
 			if checkStatus == nil {
 				continue
@@ -1035,7 +1034,6 @@ func testHostListAndroidHostsOSSettings(t *testing.T, ds *Datastore) {
 			if *checkStatus == expectedStatus {
 				expected = 1
 			}
-			fmt.Printf("Checking check %s expectedStatus %s expected %d", *checkStatus, expectedStatus, expected)
 			listHostsCheckCount(t, ds, userFilter, fleet.HostListOptions{OSSettingsFilter: fleet.OSSettingsStatus(*checkStatus)}, expected)
 		}
 	}

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -838,7 +838,8 @@ func (ds *Datastore) applyHostLabelFilters(ctx context.Context, filter fleet.Tea
 		opt.OSSettingsDiskEncryptionFilter.IsValid() {
 		query += `
 		  LEFT JOIN nano_enrollments ne ON ne.id = h.uuid AND ne.enabled = 1 AND ne.type IN ('Device', 'User Enrollment (Device)')
-		  LEFT JOIN mdm_windows_enrollments mwe ON mwe.host_uuid = h.uuid AND mwe.device_state = ?`
+		  LEFT JOIN mdm_windows_enrollments mwe ON mwe.host_uuid = h.uuid AND mwe.device_state = ?
+		  LEFT JOIN android_devices ad ON ad.host_id = h.id`
 		joinParams = append(joinParams, microsoft_mdm.MDMDeviceStateEnrolled)
 	}
 

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -848,6 +848,10 @@ func (ds *Datastore) applyHostLabelFilters(ctx context.Context, filter fleet.Tea
 		query += sqlJoinMDMAppleDeclarationsStatus()
 	}
 
+	if opt.OSSettingsFilter.IsValid() {
+		query += sqlJoinMDMAndroidProfilesStatus()
+	}
+
 	query += fmt.Sprintf(` WHERE lm.label_id = ? AND %s `, ds.whereFilterHostsByTeams(filter, "h"))
 	whereParams = append(whereParams, lid)
 

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1992,6 +1992,7 @@ SELECT
 FROM
 	hosts h
 	JOIN host_mdm hmdm ON h.id = hmdm.host_id
+	JOIN android_devices ad ON h.id=ad.host_id
 	JOIN host_mdm_android_profiles hmap ON hmap.host_uuid = h.uuid
 WHERE
 	h.platform = 'android' AND

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1729,6 +1729,8 @@ func getTableAndColumnNameForHostMDMProfileUUID(profUUID string) (table, column 
 		return "host_mdm_apple_profiles", "profile_uuid", nil
 	case strings.HasPrefix(profUUID, fleet.MDMWindowsProfileUUIDPrefix):
 		return "host_mdm_windows_profiles", "profile_uuid", nil
+	case strings.HasPrefix(profUUID, fleet.MDMAndroidProfileUUIDPrefix):
+		return "host_mdm_android_profiles", "profile_uuid", nil
 	default:
 		return "", "", fmt.Errorf("invalid profile UUID prefix %s", profUUID)
 	}
@@ -1962,9 +1964,77 @@ func (ds *Datastore) GetMDMConfigProfileStatus(ctx context.Context, profileUUID 
 		return ds.getAppleMDMDeclarationStatus(ctx, profileUUID)
 	case strings.HasPrefix(profileUUID, fleet.MDMWindowsProfileUUIDPrefix):
 		return ds.getWindowsMDMConfigProfileStatus(ctx, profileUUID)
+	case strings.HasPrefix(profileUUID, fleet.MDMAndroidProfileUUIDPrefix):
+		return ds.getAndroidMDMConfigProfileStatus(ctx, profileUUID)
 	default:
 		return fleet.MDMConfigProfileStatus{}, ctxerr.Wrap(ctx, notFound("ConfigurationProfile").WithName(profileUUID))
 	}
+}
+
+func (ds *Datastore) getAndroidMDMConfigProfileStatus(ctx context.Context, profileUUID string) (fleet.MDMConfigProfileStatus, error) {
+	var counts fleet.MDMConfigProfileStatus
+
+	stmt := `
+SELECT
+	CASE
+		WHEN hmap.status = :status_failed THEN
+			'failed'
+		WHEN COALESCE(hmap.status, :status_pending) = :status_pending THEN
+			'pending'
+		WHEN hmap.status = :status_verifying THEN
+			'verifying'
+		WHEN hmap.status = :status_verified THEN
+			'verified'
+		ELSE
+			''
+	END AS final_status,
+	SUM(1) AS count
+FROM
+	hosts h
+	JOIN host_mdm hmdm ON h.id = hmdm.host_id
+	JOIN host_mdm_android_profiles hmap ON hmap.host_uuid = h.uuid
+WHERE
+	h.platform = 'android' AND
+	hmdm.enrolled = 1 AND
+	hmap.profile_uuid = :profile_uuid
+GROUP BY
+	final_status`
+
+	stmt, args, err := sqlx.Named(stmt, map[string]any{
+		"status_failed":    fleet.MDMDeliveryFailed,
+		"status_pending":   fleet.MDMDeliveryPending,
+		"status_verifying": fleet.MDMDeliveryVerifying,
+		"status_verified":  fleet.MDMDeliveryVerified,
+		"profile_uuid":     profileUUID,
+	})
+	if err != nil {
+		return counts, ctxerr.Wrap(ctx, err, "prepare arguments with sqlx.Named")
+	}
+
+	var rows []statusCounts
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, args...)
+	if err != nil {
+		return counts, err
+	}
+
+	// Note that hosts with "BitLocker action required" are counted as pending.
+	for _, row := range rows {
+		switch row.Status {
+		case "failed":
+			counts.Failed = row.Count
+		case "pending":
+			counts.Pending += row.Count
+		case "verifying":
+			counts.Verifying = row.Count
+		case "verified":
+			counts.Verified = row.Count
+		case "":
+			level.Debug(ds.logger).Log("msg", fmt.Sprintf("counted %d android hosts for profile %s with mdm turned on but no profiles", row.Count, profileUUID))
+		default:
+			return counts, ctxerr.New(ctx, fmt.Sprintf("unexpected mdm android status count: status=%s, count=%d", row.Status, row.Count))
+		}
+	}
+	return counts, nil
 }
 
 func (ds *Datastore) getWindowsMDMConfigProfileStatus(ctx context.Context, profileUUID string) (fleet.MDMConfigProfileStatus, error) {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2017,16 +2017,15 @@ GROUP BY
 		return counts, err
 	}
 
-	// Note that hosts with "BitLocker action required" are counted as pending.
 	for _, row := range rows {
 		switch row.Status {
-		case "failed":
+		case string(fleet.MDMDeliveryFailed):
 			counts.Failed = row.Count
-		case "pending":
+		case string(fleet.MDMDeliveryPending):
 			counts.Pending += row.Count
-		case "verifying":
+		case string(fleet.MDMDeliveryVerifying):
 			counts.Verifying = row.Count
-		case "verified":
+		case string(fleet.MDMDeliveryVerified):
 			counts.Verified = row.Count
 		case "":
 			level.Debug(ds.logger).Log("msg", fmt.Sprintf("counted %d android hosts for profile %s with mdm turned on but no profiles", row.Count, profileUUID))

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2207,6 +2207,11 @@ type Datastore interface {
 	// the specified profile uuid.
 	DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error
 
+	// GetMDMWindowsProfilesSummary summarizes the current state of Android profiles on each
+	// Android host in the specified team (or, if no team is specified, each host that is not
+	// assigned to any team).
+	GetMDMAndroidProfilesSummary(ctx context.Context, teamID *uint) (*MDMProfilesSummary, error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// SCIM
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1129,10 +1129,16 @@ type Service interface {
 
 	// NewMDMAndroidConfigProfile creates a new Android configuration profile
 	NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode MDMLabelsMode) (*MDMAndroidConfigProfile, error)
+
 	// DeleteMDMAndroidConfigProfile deletes the specified Android profile.
 	DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error
+
 	// GetMDMAndroidConfigProfile returns the specified Android profile.
 	GetMDMAndroidConfigProfile(ctx context.Context, profileUUID string) (*MDMAndroidConfigProfile, error)
+
+	// GetMDMAndroidProfilesSummary summarizes the current state of MDM configuration profiles on each Android
+	// host in the specified team (or, if no team is specified, each host that is not assigned to any team).
+	GetMDMAndroidProfilesSummary(ctx context.Context, teamID *uint) (*MDMProfilesSummary, error)
 
 	///////////////////////////////////////////////////////////////////////////////
 	// Common MDM

--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -205,5 +205,5 @@ func ListFleetReservedMacOSDeclarationNames() []string {
 // are reserved by Fleet for Android
 // TODO AP Add default Android settings reporting profile name once determined
 func ListFleetReservedAndroidProfileNames() []string {
-	return []string{}
+	return []string{"fleet-android-status-reporting"}
 }

--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -200,10 +200,3 @@ func ListFleetReservedMacOSDeclarationNames() []string {
 		FleetIPadOSUpdatesProfileName,
 	}
 }
-
-// ListFleetReservedAndroidProfileNames returns a list of Profile name strings that
-// are reserved by Fleet for Android
-// TODO AP Add default Android settings reporting profile name once determined
-func ListFleetReservedAndroidProfileNames() []string {
-	return []string{"fleet-android-status-reporting"}
-}

--- a/server/mdm/mdm.go
+++ b/server/mdm/mdm.go
@@ -200,3 +200,10 @@ func ListFleetReservedMacOSDeclarationNames() []string {
 		FleetIPadOSUpdatesProfileName,
 	}
 }
+
+// ListFleetReservedAndroidProfileNames returns a list of Profile name strings that
+// are reserved by Fleet for Android
+// TODO AP Add default Android settings reporting profile name once determined
+func ListFleetReservedAndroidProfileNames() []string {
+	return []string{}
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1411,6 +1411,8 @@ type GetMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string
 
 type DeleteMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string) error
 
+type GetMDMAndroidProfilesSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error)
+
 type CreateScimUserFunc func(ctx context.Context, user *fleet.ScimUser) (uint, error)
 
 type ScimUserByIDFunc func(ctx context.Context, id uint) (*fleet.ScimUser, error)
@@ -3555,6 +3557,9 @@ type DataStore struct {
 
 	DeleteMDMAndroidConfigProfileFunc        DeleteMDMAndroidConfigProfileFunc
 	DeleteMDMAndroidConfigProfileFuncInvoked bool
+
+	GetMDMAndroidProfilesSummaryFunc        GetMDMAndroidProfilesSummaryFunc
+	GetMDMAndroidProfilesSummaryFuncInvoked bool
 
 	CreateScimUserFunc        CreateScimUserFunc
 	CreateScimUserFuncInvoked bool
@@ -8508,6 +8513,13 @@ func (s *DataStore) DeleteMDMAndroidConfigProfile(ctx context.Context, profileUU
 	s.DeleteMDMAndroidConfigProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteMDMAndroidConfigProfileFunc(ctx, profileUUID)
+}
+
+func (s *DataStore) GetMDMAndroidProfilesSummary(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error) {
+	s.mu.Lock()
+	s.GetMDMAndroidProfilesSummaryFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMAndroidProfilesSummaryFunc(ctx, teamID)
 }
 
 func (s *DataStore) CreateScimUser(ctx context.Context, user *fleet.ScimUser) (uint, error) {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -3348,11 +3348,6 @@ func (svc *Service) GetMDMConfigProfileStatus(ctx context.Context, profileUUID s
 		if err != nil {
 			return fleet.MDMConfigProfileStatus{}, err
 		}
-		if ok := slices.Contains(mdm.ListFleetReservedAndroidProfileNames(), prof.Name); ok {
-			// this endpoint is for custom settings, not fleet-controlled profiles,
-			// return not found if such a profile is requested here.
-			return fleet.MDMConfigProfileStatus{}, fleet.NewInvalidArgumentError("profile_uuid", "unknown profile").WithStatus(http.StatusNotFound)
-		}
 		teamID = prof.TeamID
 	default:
 		return fleet.MDMConfigProfileStatus{}, fleet.NewInvalidArgumentError("profile_uuid", "unknown profile").WithStatus(http.StatusNotFound)


### PR DESCRIPTION
Fixes #32031

Adds status counts + filtering by status for android profiles. So far testing has just involved manual DB inserts and automated testing since right now we don't have a way to fully test this end to end

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

