### PR TITLE
Add slack notification to TUF signature job when it fails

### DIFF
--- a/.github/workflows/check-tuf-timestamps.yml
+++ b/.github/workflows/check-tuf-timestamps.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  test-go:
+  check-signatures-old-tuf:
     strategy:
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/check-updates-timestamps.yml
+++ b/.github/workflows/check-updates-timestamps.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  test-go:
+  check-signatures:
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -164,7 +164,7 @@ jobs:
         with:
           payload: |
             {
-              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "text": "${{ job.status }},
               "blocks": [
                 {
                   "type": "section",

--- a/.github/workflows/update-tuf-timestamp-signature.yaml
+++ b/.github/workflows/update-tuf-timestamp-signature.yaml
@@ -88,3 +88,24 @@ jobs:
       - name: Smoke test production environment
         run: |
           fleetctl package --type deb --enroll-secret=foo --fleet-url=https://localhost:8080 --fleet-desktop
+
+      - name: Slack notification
+        if: failure()
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ Failed to update timestamp signature on https://updates.fleetdm.com/timestamp.json\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
We got the following warning today:

<img width="1311" height="200" alt="Screenshot 2025-08-29 at 9 51 52 AM" src="https://github.com/user-attachments/assets/a62ab52d-fe89-4b96-9082-f1a91d6e8b08" />

The process for updating the signature which happens every Tuesday failed, and nobody realized it failed because we missed adding a Slack notification to it.