### PR TITLE
Fix panic on some tools that use service.NewClient

### DIFF
--- a/server/service/client.go
+++ b/server/service/client.go
@@ -62,6 +62,10 @@ func NewClient(addr string, insecureSkipVerify bool, rootCA, urlPrefix string, o
 		}
 	}
 
+	if client.errWriter == nil {
+		client.errWriter = os.Stderr
+	}
+
 	return client, nil
 }
 


### PR DESCRIPTION
Fixes the following panic found by @AndreyKizimenko while doing loadtesting using the `./tools/loadtest/scripts_and_profiles/` tool.

```
2025-08-29T15:57:56Z: Creating 7 teams... (press enter to proceed) 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x1047fd598]

goroutine 1 [running]:
fmt.Fprint({0x0, 0x0}, {0x140001fb378, 0x1, 0x1})
	/Users/andrey/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.24.6.darwin-arm64/src/fmt/print.go:263 +0x48
github.com/fatih/color.(*Color).SetWriter(0x140005141a0, {0x0, 0x0})
	/Users/andrey/go/pkg/mod/github.com/fatih/color@v1.16.0/color.go:197 +0x88
github.com/fatih/color.(*Color).Fprintf(0x140005141a0, {0x0, 0x0}, {0x10515a87a, 0xf9}, {0x0, 0x0, 0x0})
	/Users/andrey/go/pkg/mod/github.com/fatih/color@v1.16.0/color.go:251 +0x50
github.com/fleetdm/fleet/v4/server/fleet.WriteExpiredLicenseBanner({0x0, 0x0})
	/Users/andrey/repositories/fleet/server/fleet/utils.go:17 +0x70
github.com/fleetdm/fleet/v4/server/service.(*Client).doContextWithBodyAndHeaders(0x140001fd810, {0x10599fde8, 0x1062ae040}, {0x1050ea452, 0x4}, {0x1051043a7?, 0x140000c61a0?}, {0x0, 0x0}, {0x140001aaf30, ...}, ...)
	/Users/andrey/repositories/fleet/server/service/client.go:134 +0x408
github.com/fleetdm/fleet/v4/server/service.(*Client).doContextWithHeaders(0x140001fd810?, {0x10599fde8?, 0x1062ae040?}, {0x1050ea452?, 0x4?}, {0x1051043a7?, 0x17?}, {0x0?, 0x0?}, {0x10580b160?, ...}, ...)
	/Users/andrey/repositories/fleet/server/service/client.go:156 +0x1a0
github.com/fleetdm/fleet/v4/server/service.(*Client).AuthenticatedDo(0x140001fd810, {0x1050ea452, 0x4}, {0x1051043a7, 0x17}, {0x0, 0x0}, {0x10580b160, 0x140001fd860})
	/Users/andrey/repositories/fleet/server/service/client.go:183 +0x204
github.com/fleetdm/fleet/v4/server/service.(*Client).authenticatedRequestWithQuery(0x140001fd810, {0x10580b160?, 0x140001fd860?}, {0x1050ea452, 0x4}, {0x1051043a7, 0x17}, {0x1057a8e80, 0x1400000ea20}, {0x0?, ...})
	/Users/andrey/repositories/fleet/server/service/client.go:263 +0x74
github.com/fleetdm/fleet/v4/server/service.(*Client).authenticatedRequest(...)
	/Users/andrey/repositories/fleet/server/service/client.go:273
github.com/fleetdm/fleet/v4/server/service.(*Client).CreateTeam(0x140001fd810, {0x140003584e0, 0x0, {0x0, 0x0, 0x0}, 0x0, 0x0, 0x0, 0x0})
	/Users/andrey/repositories/fleet/server/service/client_teams.go:30 +0xe0
main.main()
	/Users/andrey/repositories/fleet/tools/loadtest/scripts_and_profiles/main.go:74 +0x530
exit status 2
```