### PR TITLE
Docs: Fix invalid SQL join in VS Code extensions query

### DIFF
--- a/docs/queries.yml
+++ b/docs/queries.yml
@@ -2910,8 +2910,7 @@ spec:
   name: Get a list of Visual Studio Code extensions
   platform: darwin, linux, windows
   description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).
-  query: |
-    SELECT u.username, vs.* FROM users u CROSS JOIN vscode_extensions vs USING (uid);
+  query: SELECT u.username, vs.* FROM users u JOIN vscode_extensions vs ON u.uid = vs.uid;
   bash: echo "username,extension_name" && for u in /Users/*; do [ -d "$u/.vscode/extensions" ] && for ext in "$u/.vscode/extensions"/*; do [ -d "$ext" ] && echo "$(basename "$u"),$(basename "$ext")"; done; done
   powershell: >
     $users = @(


### PR DESCRIPTION
The existing query used a CROSS JOIN with USING(uid), which is not valid SQL in Fleet/osquery/SQLite and prevented the query from being saved.

This change replaces the CROSS JOIN with a standard JOIN ... ON ... clause. The explicit ON form was chosen for clarity:

- Makes the join condition (u.uid = vs.uid) explicit to readers
- Avoids the subtle column-merging behavior of USING

This preserves the intended behavior (joining users with their installed VS Code extensions) while ensuring the query runs correctly in Fleet.