### PR TITLE
Support providing multiple packages per software package file in GitOps

### DIFF
--- a/changes/30849-multipkg-gitops
+++ b/changes/30849-multipkg-gitops
@@ -1,0 +1,1 @@
+- Added support for writing multiple packages in a single GitOps YAML file included under `software.packages`.

--- a/cmd/fleetctl/fleetctl/testdata/gitops/subdir/multi_missing_url.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/subdir/multi_missing_url.yml
@@ -1,0 +1,2 @@
+- slug: mozilla-firefox/darwin
+- url: https://example.com

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_no_url_multi.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_no_url_multi.yml
@@ -1,0 +1,17 @@
+name: "${TEST_TEAM_NAME}"
+team_settings:
+  secrets:
+    - secret: "ABC"
+  features:
+    enable_host_users: true
+    enable_software_inventory: true
+  host_expiry_settings:
+    host_expiry_enabled: true
+    host_expiry_window: 30
+agent_options:
+controls:
+policies:
+queries:
+software:
+  packages:
+    - path: subdir/multi_missing_url.yml

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -48,6 +48,7 @@ func TestGitOpsTeamSoftwareInstallers(t *testing.T) {
 		{"testdata/gitops/team_software_installer_uninstall_not_found.yml", "no such file or directory"},
 		{"testdata/gitops/team_software_installer_post_install_not_found.yml", "no such file or directory"},
 		{"testdata/gitops/team_software_installer_no_url.yml", "at least one of hash_sha256 or url is required for each software package"},
+		{"testdata/gitops/team_software_installer_no_url_multi.yml", "multi_missing_url.yml, list item #1"},
 		{"testdata/gitops/team_software_installer_invalid_self_service_value.yml",
 			"Couldn't edit \"../../fleetctl/testdata/gitops/team_software_installer_invalid_self_service_value.yml\" at \"software.packages.self_service\", expected type bool but got string"},
 		{"testdata/gitops/team_software_installer_invalid_both_include_exclude.yml",

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -165,7 +165,7 @@ const ViewYamlModal = ({
             readOnly
             name="filename"
             label="Filename"
-            value={`${hyphenatedSoftwareTitle}.yml`}
+            value={`${hyphenatedSoftwareTitle}.package.yml`}
           />
           <Editor label="Contents" value={packageYaml} enableCopy />
         </div>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
@@ -31,16 +31,16 @@ describe("createPackageYaml", () => {
 
     expect(yaml)
       .toBe(`# Falcon Sensor Test Package (TestPackage-1.2.3.pkg) version 1.2.3
-url: https://fakeurl.testpackageurlforfalconapp.fake/test/package
-hash_sha256: abcd1234
-pre_install_query:
-  path: ../queries/pre-install-query-falcon-sensor-test-package.yml
-install_script:
-  path: ../scripts/install-falcon-sensor-test-package.sh
-post_install_script:
-  path: ../scripts/post-install-falcon-sensor-test-package.sh
-uninstall_script:
-  path: ../scripts/uninstall-falcon-sensor-test-package.sh`);
+- url: https://fakeurl.testpackageurlforfalconapp.fake/test/package
+  hash_sha256: abcd1234
+  pre_install_query:
+    path: ../queries/pre-install-query-falcon-sensor-test-package.yml
+  install_script:
+    path: ../scripts/install-falcon-sensor-test-package.sh
+  post_install_script:
+    path: ../scripts/post-install-falcon-sensor-test-package.sh
+  uninstall_script:
+    path: ../scripts/uninstall-falcon-sensor-test-package.sh`);
   });
 
   it("omits optional fields when not provided", () => {
@@ -76,10 +76,10 @@ uninstall_script:
 
     expect(yaml)
       .toBe(`# Falcon Sensor Test Package (TestPackage-1.2.3.pkg) version 1.2.3
-pre_install_query:
-  path: ../queries/pre-install-query-falcon-sensor-test-package.yml
-post_install_script:
-  path: ../scripts/post-install-falcon-sensor-test-package.sh`);
+  pre_install_query:
+    path: ../queries/pre-install-query-falcon-sensor-test-package.yml
+  post_install_script:
+    path: ../scripts/post-install-falcon-sensor-test-package.sh`);
   });
 
   it("hyphenates name correctly for file paths", () => {
@@ -97,8 +97,8 @@ post_install_script:
 
     expect(yaml)
       .toBe(`# Falcon Sensor Test Package (TestPackage-1.2.3.pkg) version 1.2.3
-install_script:
-  path: ../scripts/install-falcon-sensor-test-package.sh`);
+  install_script:
+    path: ../scripts/install-falcon-sensor-test-package.sh`);
   });
 
   it("does not include hash_sha256 if sha256 is null or empty", () => {
@@ -127,11 +127,11 @@ install_script:
     });
 
     expect(yamlNull).toBe(`# Null Hash (TestPackage-1.2.3.pkg) version 1.2.3
-install_script:
-  path: ../scripts/install-null-hash.sh`);
+  install_script:
+    path: ../scripts/install-null-hash.sh`);
     expect(yamlEmpty).toBe(`# Empty Hash (TestPackage-1.2.3.pkg) version 1.2.3
-install_script:
-  path: ../scripts/install-empty-hash.sh`);
+  install_script:
+    path: ../scripts/install-empty-hash.sh`);
   });
 });
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -146,7 +146,8 @@ export const createPackageYaml = ({
   }
 
   if (sha256) {
-    yaml += `- hash_sha256: ${sha256}
+    yaml += url ? "  " : "- ";
+    yaml += `hash_sha256: ${sha256}
 `;
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -141,38 +141,38 @@ export const createPackageYaml = ({
 `;
 
   if (url) {
-    yaml += `url: ${url}
+    yaml += `- url: ${url}
 `;
   }
 
   if (sha256) {
-    yaml += `hash_sha256: ${sha256}
+    yaml += `- hash_sha256: ${sha256}
 `;
   }
 
   const hyphenatedSWTitle = hyphenateString(softwareTitle);
 
   if (preInstallQuery) {
-    yaml += `pre_install_query:
-  path: ../queries/pre-install-query-${hyphenatedSWTitle}.yml
+    yaml += `  pre_install_query:
+    path: ../queries/pre-install-query-${hyphenatedSWTitle}.yml
 `;
   }
 
   if (installScript) {
-    yaml += `install_script:
-  path: ../scripts/install-${hyphenatedSWTitle}.sh
+    yaml += `  install_script:
+    path: ../scripts/install-${hyphenatedSWTitle}.sh
 `;
   }
 
   if (postInstallScript) {
-    yaml += `post_install_script:
-  path: ../scripts/post-install-${hyphenatedSWTitle}.sh
+    yaml += `  post_install_script:
+    path: ../scripts/post-install-${hyphenatedSWTitle}.sh
 `;
   }
 
   if (uninstallScript) {
-    yaml += `uninstall_script:
-  path: ../scripts/uninstall-${hyphenatedSWTitle}.sh
+    yaml += `  uninstall_script:
+    path: ../scripts/uninstall-${hyphenatedSWTitle}.sh
 `;
   }
 

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1049,7 +1049,7 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 		var policyInstallSoftwareSpec fleet.SoftwarePackageSpec
 		if err := YamlUnmarshal(fileBytes, &policyInstallSoftwareSpec); err != nil {
 			// see if the issue is that a package path was passed in that references multiple packages
-			var multiplePackages []*fleet.SoftwarePackageSpec
+			var multiplePackages []fleet.SoftwarePackageSpec
 			if err := YamlUnmarshal(fileBytes, &multiplePackages); err != nil || len(multiplePackages) == 0 {
 				return fmt.Errorf("file %q does not contain a valid software package definition", policy.InstallSoftware.PackagePath)
 			}
@@ -1058,7 +1058,7 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 				return fmt.Errorf("file %q contains multiple packages, so cannot be used as a target for policy automation", policy.InstallSoftware.PackagePath)
 			}
 
-			policyInstallSoftwareSpec = *multiplePackages[0]
+			policyInstallSoftwareSpec = multiplePackages[0]
 		}
 		installerOnTeamFound := false
 		for _, pkg := range packages {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1301,6 +1301,14 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_exclude_any" or "labels_include_any" can be specified for software URL %q`, softwarePackageSpec.URL))
 				continue
 			}
+			if softwarePackageSpec.SHA256 != "" && !validSHA256Value.MatchString(softwarePackageSpec.SHA256) {
+				multiError = multierror.Append(multiError, fmt.Errorf("hash_sha256 value %q must be a valid lower-case hex-encoded (64-character) SHA-256 hash value", softwarePackageSpec.SHA256))
+				continue
+			}
+			if softwarePackageSpec.SHA256 == "" && softwarePackageSpec.URL == "" {
+				multiError = multierror.Append(multiError, errors.New("at least one of hash_sha256 or url is required for each software package"))
+				continue
+			}
 			if len(softwarePackageSpec.URL) > fleet.SoftwareInstallerURLMaxLength {
 				multiError = multierror.Append(multiError, fmt.Errorf("software URL %q is too long, must be %d characters or less", softwarePackageSpec.URL, fleet.SoftwareInstallerURLMaxLength))
 				continue
@@ -1320,15 +1328,6 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 					multiError = multierror.Append(multiError, fmt.Errorf("software URL %s refers to a .tar.gz archive, which requires both install_script and uninstall_script", softwarePackageSpec.URL))
 					continue
 				}
-			}
-
-			if softwarePackageSpec.SHA256 != "" && !validSHA256Value.MatchString(softwarePackageSpec.SHA256) {
-				multiError = multierror.Append(multiError, fmt.Errorf("hash_sha256 value %q must be a valid lower-case hex-encoded (64-character) SHA-256 hash value", softwarePackageSpec.SHA256))
-				continue
-			}
-			if softwarePackageSpec.SHA256 == "" && softwarePackageSpec.URL == "" {
-				multiError = multierror.Append(multiError, errors.New("at least one of hash_sha256 or url is required for each software package"))
-				continue
 			}
 
 			result.Software.Packages = append(result.Software.Packages, softwarePackageSpec)

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1051,7 +1051,7 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 			// see if the issue is that a package path was passed in that references multiple packages
 			var multiplePackages []*fleet.SoftwarePackageSpec
 			if err := YamlUnmarshal(fileBytes, &multiplePackages); err != nil || len(multiplePackages) == 0 {
-				return MaybeParseTypeError(policy.InstallSoftware.PackagePath, []string{"policy", "install_software", "package_path"}, err)
+				return fmt.Errorf("file %q does not contain a valid software package definition", policy.InstallSoftware.PackagePath)
 			}
 
 			if len(multiplePackages) > 1 {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1048,6 +1048,12 @@ func parsePolicyInstallSoftware(baseDir string, teamName *string, policy *Policy
 		}
 		var policyInstallSoftwareSpec fleet.SoftwarePackageSpec
 		if err := YamlUnmarshal(fileBytes, &policyInstallSoftwareSpec); err != nil {
+			// see if the issue is that a package path was passed in that references multiple packages
+			var multiplePackages []*fleet.SoftwarePackageSpec
+			if err := YamlUnmarshal(fileBytes, &multiplePackages); err == nil {
+				return fmt.Errorf("file %q contains multiple packages, so cannot be used as a target for policy automation", policy.InstallSoftware.PackagePath)
+			}
+
 			return MaybeParseTypeError(policy.InstallSoftware.PackagePath, []string{"policy", "install_software", "package_path"}, err)
 		}
 		installerOnTeamFound := false

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -1229,10 +1228,11 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		result.Software.FleetMaintainedApps = append(result.Software.FleetMaintainedApps, &maintainedAppSpec)
 	}
 	for _, teamLevelPackage := range software.Packages {
-		var softwarePackageSpec fleet.SoftwarePackageSpec
+		// A single item in Packages can result in multiple SoftwarePackageSpecs being generated
+		var softwarePackageSpecs []*fleet.SoftwarePackageSpec
 		if teamLevelPackage.Path != nil {
-			softwarePackageSpec.ReferencedYamlPath = resolveApplyRelativePath(baseDir, *teamLevelPackage.Path)
-			fileBytes, err := os.ReadFile(softwarePackageSpec.ReferencedYamlPath)
+			yamlPath := resolveApplyRelativePath(baseDir, *teamLevelPackage.Path)
+			fileBytes, err := os.ReadFile(yamlPath)
 			if err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to read software package file %s: %w", *teamLevelPackage.Path, err))
 				continue
@@ -1243,76 +1243,64 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to expand environment in file %s: %w", *teamLevelPackage.Path, err))
 				continue
 			}
-			if err := YamlUnmarshal(fileBytes, &softwarePackageSpec); err != nil {
+			var singlePackageSpec SoftwarePackage
+			singlePackageSpec.ReferencedYamlPath = yamlPath
+			if err := YamlUnmarshal(fileBytes, &singlePackageSpec); err == nil {
+				if singlePackageSpec.IncludesFieldsDisallowedInPackageFile() {
+					multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
+					continue
+				}
+				softwarePackageSpecs = append(softwarePackageSpecs, &singlePackageSpec.SoftwarePackageSpec)
+			} else if err = YamlUnmarshal(fileBytes, &softwarePackageSpecs); err == nil {
+				// Failing that, try to unmarshal as a list of SoftwarePackageSpecs
+				for i, spec := range softwarePackageSpecs {
+					if spec.IncludesFieldsDisallowedInPackageFile() {
+						multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
+						continue
+					}
+
+					softwarePackageSpecs[i].ReferencedYamlPath = yamlPath
+				}
+			} else {
+				// If we reached here, we couldn't unmarshal as either format.
 				multiError = multierror.Append(multiError, MaybeParseTypeError(*teamLevelPackage.Path, []string{"software", "packages"}, err))
 				continue
 			}
 
-			softwarePackageSpec = softwarePackageSpec.ResolveSoftwarePackagePaths(filepath.Dir(softwarePackageSpec.ReferencedYamlPath))
-
-			if softwarePackageSpec.IncludesFieldsDisallowedInPackageFile() {
-				multiError = multierror.Append(multiError, fmt.Errorf("labels, categories, setup_experience, and self_service values must be specified at the team level; package-level specified in %s", *teamLevelPackage.Path))
-				continue
+			for i, spec := range softwarePackageSpecs {
+				softwarePackageSpec := spec.ResolveSoftwarePackagePaths(filepath.Dir(spec.ReferencedYamlPath))
+				softwarePackageSpec = teamLevelPackage.HydrateToPackageLevel(softwarePackageSpec)
+				softwarePackageSpecs[i] = &softwarePackageSpec
 			}
-
-			softwarePackageSpec = teamLevelPackage.HydrateToPackageLevel(softwarePackageSpec)
 		} else {
-			softwarePackageSpec = teamLevelPackage.SoftwarePackageSpec.ResolveSoftwarePackagePaths(baseDir)
-		}
-		if softwarePackageSpec.InstallScript.Path != "" {
-			if err := gatherFileSecrets(result, softwarePackageSpec.InstallScript.Path); err != nil {
-				multiError = multierror.Append(multiError, err)
-				continue
-			}
-		}
-		if softwarePackageSpec.PostInstallScript.Path != "" {
-			if err := gatherFileSecrets(result, softwarePackageSpec.PostInstallScript.Path); err != nil {
-				multiError = multierror.Append(multiError, err)
-				continue
-			}
-		}
-		if softwarePackageSpec.SHA256 != "" && !validSHA256Value.MatchString(softwarePackageSpec.SHA256) {
-			multiError = multierror.Append(multiError, fmt.Errorf("hash_sha256 value %q must be a valid lower-case hex-encoded (64-character) SHA-256 hash value", softwarePackageSpec.SHA256))
-			continue
-		}
-		if softwarePackageSpec.SHA256 == "" && softwarePackageSpec.URL == "" {
-			multiError = multierror.Append(multiError, errors.New("at least one of hash_sha256 or url is required for each software package"))
-			continue
-		}
-		if softwarePackageSpec.UninstallScript.Path != "" {
-			if err := gatherFileSecrets(result, softwarePackageSpec.UninstallScript.Path); err != nil {
-				multiError = multierror.Append(multiError, err)
-				continue
-			}
-		}
-		if len(softwarePackageSpec.LabelsExcludeAny) > 0 && len(softwarePackageSpec.LabelsIncludeAny) > 0 {
-			multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_exclude_any" or "labels_include_any" can be specified for software URL %q`, softwarePackageSpec.URL))
-			continue
-		}
-		if len(softwarePackageSpec.URL) > fleet.SoftwareInstallerURLMaxLength {
-			multiError = multierror.Append(multiError, fmt.Errorf("software URL %q is too long, must be %d characters or less", softwarePackageSpec.URL, fleet.SoftwareInstallerURLMaxLength))
-			continue
-		}
-		parsedUrl, err := url.Parse(softwarePackageSpec.URL)
-		if err != nil {
-			multiError = multierror.Append(multiError, fmt.Errorf("software URL %s is not a valid URL", softwarePackageSpec.URL))
-			continue
+			softwarePackageSpec := teamLevelPackage.SoftwarePackageSpec.ResolveSoftwarePackagePaths(baseDir)
+			softwarePackageSpecs = append(softwarePackageSpecs, &softwarePackageSpec)
 		}
 
-		if softwarePackageSpec.InstallScript.Path == "" || softwarePackageSpec.UninstallScript.Path == "" {
-			// URL checks won't catch everything, but might as well include a lightweight check here to fail fast if it's
-			// certain that the package will fail later.
-			if strings.HasSuffix(parsedUrl.Path, ".exe") {
-				multiError = multierror.Append(multiError, fmt.Errorf("software URL %s refers to an .exe package, which requires both install_script and uninstall_script", softwarePackageSpec.URL))
+		for _, softwarePackageSpec := range softwarePackageSpecs {
+			if softwarePackageSpec.InstallScript.Path != "" {
+				if err := gatherFileSecrets(result, softwarePackageSpec.InstallScript.Path); err != nil {
+					multiError = multierror.Append(multiError, err)
+					continue
+				}
+			}
+			if softwarePackageSpec.PostInstallScript.Path != "" {
+				if err := gatherFileSecrets(result, softwarePackageSpec.PostInstallScript.Path); err != nil {
+					multiError = multierror.Append(multiError, err)
+					continue
+				}
+			}
+			if softwarePackageSpec.SHA256 != "" && !validSHA256Value.MatchString(softwarePackageSpec.SHA256) {
+				multiError = multierror.Append(multiError, fmt.Errorf("hash_sha256 value %q must be a valid lower-case hex-encoded (64-character) SHA-256 hash value", softwarePackageSpec.SHA256))
 				continue
 			}
-			if strings.HasSuffix(parsedUrl.Path, ".tar.gz") || strings.HasSuffix(parsedUrl.Path, ".tgz") {
-				multiError = multierror.Append(multiError, fmt.Errorf("software URL %s refers to a .tar.gz archive, which requires both install_script and uninstall_script", softwarePackageSpec.URL))
+			if softwarePackageSpec.SHA256 == "" && softwarePackageSpec.URL == "" {
+				multiError = multierror.Append(multiError, errors.New("at least one of hash_sha256 or url is required for each software package"))
 				continue
 			}
-		}
 
-		result.Software.Packages = append(result.Software.Packages, &softwarePackageSpec)
+			result.Software.Packages = append(result.Software.Packages, softwarePackageSpec)
+		}
 	}
 
 	return multiError

--- a/pkg/spec/testdata/multipkg.policies.yml
+++ b/pkg/spec/testdata/multipkg.policies.yml
@@ -1,0 +1,5 @@
+- name: Stuff needs installing
+  platform: darwin
+  query: SELECT 1 FROM apps WHERE name = 'Microsoft Teams.app' AND version_compare(bundle_short_version, '24193.1707.3028.4282') >= 0;
+  install_software:
+    package_path: ./multiple-packages.yml

--- a/pkg/spec/testdata/software/multiple-packages.yml
+++ b/pkg/spec/testdata/software/multiple-packages.yml
@@ -1,0 +1,2 @@
+- hash_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+- hash_sha256: bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb

--- a/pkg/spec/testdata/software/single-package.yml
+++ b/pkg/spec/testdata/software/single-package.yml
@@ -1,0 +1,1 @@
+hash_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa


### PR DESCRIPTION
For #30849.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [n/a] Verified that the setting is exported via `fleetctl generate-gitops`
- [x] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [x] Verified that any relevant UI is disabled when GitOps mode is enabled