### PR TITLE
Device User Page: Fix unreleased modal margins bug

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import Button from "components/buttons/Button";
+import Modal from "components/Modal";
+
+import ModalFooter from "components/ModalFooter";
+
+interface IBitLockerPinModalProps {
+  onCancel: () => void;
+}
+
+const baseClass = "bit-locker-pin-modal";
+
+const BitLockerPinModal = ({
+  onCancel,
+}: IBitLockerPinModalProps): JSX.Element => {
+  return (
+    <Modal
+      title="Create PIN"
+      onExit={onCancel}
+      onEnter={onCancel}
+      className={baseClass}
+      width="large"
+    >
+      <>
+        <div>
+          <p>
+            <ol>
+              <li>
+                <p>
+                  Open the <b>Start menu</b>.
+                </p>
+              </li>
+              <li>
+                <p>Type &ldquo;Manage BitLocker&rdquo; and launch.</p>
+              </li>
+              <li>
+                <p>
+                  Choose <b>Enter a PIN (recommended)</b> and follow the prompts
+                  to create a PIN. If you don&apos;t see this option, wait 1
+                  minute and refresh the <b>BitLocker Drive Encryption</b>{" "}
+                  window.
+                </p>
+              </li>
+              <li>
+                <p>
+                  Close this window and select <b>Refetch</b> on your{" "}
+                  <b>My device</b> page. This informs your organization that you
+                  have set a BitLocker PIN.
+                </p>
+              </li>
+            </ol>
+          </p>
+        </div>
+        <ModalFooter
+          primaryButtons={<Button onClick={onCancel}>Done</Button>}
+        />
+      </>
+    </Modal>
+  );
+};
+
+export default BitLockerPinModal;

--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/index.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./BitLockerPinModal";

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -60,6 +60,7 @@ import FleetIcon from "../../../../../assets/images/fleet-avatar-24x24@2x.png";
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
 import AutoEnrollMdmModal from "./AutoEnrollMdmModal";
 import ManualEnrollMdmModal from "./ManualEnrollMdmModal";
+import BitLockerPinModal from "./BitLockerPinModal";
 import CreateLinuxKeyModal from "./CreateLinuxKeyModal";
 import OSSettingsModal from "../OSSettingsModal";
 import BootstrapPackageModal from "../HostDetailsPage/modals/BootstrapPackageModal";
@@ -620,53 +621,9 @@ const DeviceUserPage = ({
                 />
               ))}
             {showBitLockerPINModal && (
-              <Modal
-                title="Create PIN"
-                onExit={() => setShowBitLockerPINModal(false)}
-                onEnter={() => setShowBitLockerPINModal(false)}
-                className={baseClass}
-                width="large"
-              >
-                <>
-                  <div>
-                    <p>
-                      <ol>
-                        <li>
-                          <p>
-                            Open the <b>Start menu</b>.
-                          </p>
-                        </li>
-                        <li>
-                          <p>Type &ldquo;Manage BitLocker&rdquo; and launch.</p>
-                        </li>
-                        <li>
-                          <p>
-                            Choose <b>Enter a PIN (recommended)</b> and follow
-                            the prompts to create a PIN. If you don&apos;t see
-                            this option, wait 1 minute and refresh the{" "}
-                            <b>BitLocker Drive Encryption</b> window.
-                          </p>
-                        </li>
-                        <li>
-                          <p>
-                            Close this window and select <b>Refetch</b> on your{" "}
-                            <b>My device</b> page. This informs your
-                            organization that you have set a BitLocker PIN.
-                          </p>
-                        </li>
-                      </ol>
-                    </p>
-                  </div>
-                  <div className="modal-cta-wrap">
-                    <Button
-                      type="button"
-                      onClick={() => setShowBitLockerPINModal(false)}
-                    >
-                      Done
-                    </Button>
-                  </div>
-                </>
-              </Modal>
+              <BitLockerPinModal
+                onCancel={() => setShowBitLockerPINModal(false)}
+              />
             )}
           </div>
         )}

--- a/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/_styles.scss
@@ -67,10 +67,6 @@
   .policies-card .data-table-block .data-table__table thead .response__header {
     width: $col-md;
   }
-
-  .modal__content-wrapper {
-    margin-top: 0;
-  }
 }
 
 .dup-org-logo {


### PR DESCRIPTION
## Issue
Closes #32474

## Description
- Styling bug from #32217 which looks like that PR was trying to override incorrect classname pushed to BitLockerModal
- Moved modal to its own file to follow FE patterns

## Screenshots of fixes
<img width="1043" height="520" alt="Screenshot 2025-09-02 at 12 05 13 PM" src="https://github.com/user-attachments/assets/8d9c3ff9-7344-4354-8168-09a1f2e5e87d" />
<img width="839" height="589" alt="Screenshot 2025-09-02 at 12 05 43 PM" src="https://github.com/user-attachments/assets/95cd940e-670c-48a5-a9c5-c8cc9dd14833" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually
