### PR TITLE
Added frontend support for No team automations

### DIFF
--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -139,7 +139,6 @@ const ManagePolicyPage = ({
     currentTeamName,
     currentTeamSummary,
     isAllTeamsSelected,
-    isAnyTeamSelected,
     isTeamAdmin,
     isTeamMaintainer,
     isRouteOk,
@@ -393,8 +392,9 @@ const ManagePolicyPage = ({
     ["teams", teamIdForApi],
     () => teamsAPI.load(teamIdForApi),
     {
-      // no call for no team (teamIdForApi === 0)
-      enabled: isRouteOk && !!teamIdForApi && canAddOrDeletePolicies,
+      // Enable for all teams including "No team" (teamIdForApi === 0)
+      enabled:
+        isRouteOk && teamIdForApi !== undefined && canAddOrDeletePolicies,
       select: (data) => data.team,
     }
   );
@@ -522,10 +522,10 @@ const ManagePolicyPage = ({
   }) => {
     setIsUpdatingPolicies(true);
     try {
-      if (isAllTeamsSelected || isPrimoMode) {
-        // primo mode updates as global, though sources available policies from No team
+      if (isAllTeamsSelected) {
         await configAPI.update(requestBody);
       } else {
+        // For any team including "No team" (team ID 0), use the teams API
         await teamsAPI.update(requestBody, teamIdForApi);
       }
       renderFlash("success", DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG);
@@ -534,9 +534,7 @@ const ManagePolicyPage = ({
     } finally {
       toggleOtherWorkflowsModal();
       setIsUpdatingPolicies(false);
-      isAllTeamsSelected || isPrimoMode
-        ? refetchGlobalConfig()
-        : refetchTeamConfig();
+      isAllTeamsSelected ? refetchGlobalConfig() : refetchTeamConfig();
     }
   };
 
@@ -957,21 +955,15 @@ const ManagePolicyPage = ({
   const showCtaButtons = !policiesErrors;
 
   /**
-  all teams? -> global
-  no team?
-    primo? -> global
-    not primo? -> undefined
-  other teams -> teamConfig
+  all teams? -> globalConfig
+  any team (including "No team")? -> teamConfig
    */
 
   let automationsConfig;
   if (isAllTeamsSelected) {
     automationsConfig = globalConfig;
-  } else if (teamIdForApi === API_NO_TEAM_ID) {
-    if (isPrimoMode) {
-      automationsConfig = globalConfig;
-    }
   } else {
+    // For any team including "No team" (team ID 0), use the team config
     automationsConfig = teamConfig;
   }
 
@@ -1132,7 +1124,7 @@ const ManagePolicyPage = ({
       ? globalConfig?.integrations.conditional_access_enabled
       : teamConfig?.integrations.conditional_access_enabled) ?? false;
 
-  const getAutomationsDropdownOptions = (includeOtherWorkflows: boolean) => {
+  const getAutomationsDropdownOptions = () => {
     let disabledInstallTooltipContent: TooltipContent;
     let disabledCalendarTooltipContent: TooltipContent;
     let disabledRunScriptTooltipContent: TooltipContent;
@@ -1219,7 +1211,7 @@ const ManagePolicyPage = ({
     }
 
     // Maintainers do not have access to other workflows
-    if (includeOtherWorkflows && !isGlobalMaintainer && !isTeamMaintainer) {
+    if (!isGlobalMaintainer && !isTeamMaintainer) {
       options.push({
         label: "Other",
         value: "other_workflows",
@@ -1241,13 +1233,7 @@ const ManagePolicyPage = ({
           name="policy-automations"
           onChange={onSelectAutomationOption}
           placeholder="Manage automations"
-          options={
-            hasPoliciesToAutomate
-              ? getAutomationsDropdownOptions(
-                  isAllTeamsSelected || isAnyTeamSelected || isPrimoMode
-                ) // include "Other workflows" when all teams is selected, when a team other than No team is selected, and when in Primo mode (No team will be selected)
-              : []
-          }
+          options={hasPoliciesToAutomate ? getAutomationsDropdownOptions() : []}
           variant="button"
           nowrapMenu
         />

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -81,10 +81,10 @@ export default {
     return sendRequest("DELETE", path);
   },
   load: (teamId: number | undefined): Promise<ILoadTeamResponse> => {
-    if (!teamId || teamId <= API_NO_TEAM_ID) {
+    if (teamId === undefined || teamId < API_NO_TEAM_ID) {
       return Promise.reject(
         new Error(
-          `Invalid team id: ${teamId} must be greater than ${API_NO_TEAM_ID}`
+          `Invalid team id: ${teamId} must be greater than or equal to ${API_NO_TEAM_ID}`
         )
       );
     }


### PR DESCRIPTION
Fixes #32061 

- Depends on the backend changes in #32387 for full functionality
- Removed special case for primo mode

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Team-level configuration now supports the “No Team” selection (team 0).
  * Expanded availability of the “Other” option in the Automations dropdown for non-maintainers.

* **Bug Fixes**
  * Team 0 loads correctly in Policies management.
  * Automations configuration correctly switches between global (All Teams) and team contexts, including No Team.
  * Post-update refresh behavior is consistent: global refresh for All Teams, team refresh otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->