### PR TITLE
fix issues with batch script summary

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchStatusTable/ScriptBatchStatusTableConfig.tsx
@@ -16,7 +16,7 @@ interface IRowData {
   hosts: number;
 }
 
-const STATUS_ORDER = ["ran", "pending", "errored", "canceled"];
+const STATUS_ORDER = ["ran", "pending", "errored", "incompatible", "canceled"];
 
 export interface IStatusCellValue {
   displayName: string;
@@ -35,6 +35,10 @@ const STATUS_DISPLAY_OPTIONS = {
   },
   errored: {
     displayName: "Error",
+    indicatorStatus: "error",
+  },
+  incompatible: {
+    displayName: "Incompatible",
     indicatorStatus: "error",
   },
   canceled: {

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -129,6 +129,7 @@ export interface IScriptBatchHostCountsV1 {
   ran: number;
   pending: number;
   errored: number;
+  incompatible: number;
   canceled: number;
 }
 export type ScriptBatchHostCountV1 = keyof IScriptBatchHostCountsV1;

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -1853,7 +1853,8 @@ func testBatchExecute(t *testing.T, ds *Datastore) {
 	// The summary should have two pending hosts and two errored ones, because
 	// the script is not compatible with the hostNoScripts and hostWindows.
 	require.Equal(t, *summary.NumPending, uint(3))
-	require.Equal(t, *summary.NumErrored, uint(2))
+	require.Equal(t, *summary.NumIncompatible, uint(2))
+	require.Equal(t, *summary.NumErrored, uint(0))
 	require.Equal(t, *summary.NumRan, uint(0))
 	require.Equal(t, *summary.NumCanceled, uint(0))
 	// Host 1 should have an upcoming execution
@@ -1910,7 +1911,8 @@ func testBatchExecute(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	// The summary should have one pending host, one run host and two errored ones.
 	require.Equal(t, *summary.NumPending, uint(2))
-	require.Equal(t, *summary.NumErrored, uint(2))
+	require.Equal(t, *summary.NumErrored, uint(0))
+	require.Equal(t, *summary.NumIncompatible, uint(2))
 	require.Equal(t, *summary.NumRan, uint(1))
 	require.Equal(t, *summary.NumCanceled, uint(0))
 
@@ -1928,7 +1930,8 @@ func testBatchExecute(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	// The summary should have one pending host, one run host and two errored ones.
 	require.Equal(t, *summary.NumPending, uint(1))
-	require.Equal(t, *summary.NumErrored, uint(3))
+	require.Equal(t, *summary.NumErrored, uint(1))
+	require.Equal(t, *summary.NumIncompatible, uint(2))
 	require.Equal(t, *summary.NumRan, uint(1))
 	require.Equal(t, *summary.NumCanceled, uint(0))
 
@@ -1940,7 +1943,8 @@ func testBatchExecute(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	// The summary should have no pending hosts, one run host, three errored ones and one canceled.
 	require.Equal(t, *summary.NumPending, uint(0))
-	require.Equal(t, *summary.NumErrored, uint(3))
+	require.Equal(t, *summary.NumErrored, uint(1))
+	require.Equal(t, *summary.NumIncompatible, uint(2))
 	require.Equal(t, *summary.NumRan, uint(1))
 	require.Equal(t, *summary.NumCanceled, uint(1))
 }

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -971,16 +971,17 @@ type batchScriptExecutionStatusResponse struct {
 type (
 	batchScriptExecutionSummaryRequest  batchScriptExecutionStatusRequest
 	batchScriptExecutionSummaryResponse struct {
-		ScriptID    uint      `json:"script_id" db:"script_id"`
-		ScriptName  string    `json:"script_name" db:"script_name"`
-		TeamID      *uint     `json:"team_id" db:"team_id"`
-		CreatedAt   time.Time `json:"created_at" db:"created_at"`
-		NumTargeted *uint     `json:"targeted" db:"num_targeted"`
-		NumPending  *uint     `json:"pending" db:"num_pending"`
-		NumRan      *uint     `json:"ran" db:"num_ran"`
-		NumErrored  *uint     `json:"errored" db:"num_errored"`
-		NumCanceled *uint     `json:"canceled" db:"num_canceled"`
-		Err         error     `json:"error,omitempty"`
+		ScriptID        uint      `json:"script_id" db:"script_id"`
+		ScriptName      string    `json:"script_name" db:"script_name"`
+		TeamID          *uint     `json:"team_id" db:"team_id"`
+		CreatedAt       time.Time `json:"created_at" db:"created_at"`
+		NumTargeted     *uint     `json:"targeted" db:"num_targeted"`
+		NumPending      *uint     `json:"pending" db:"num_pending"`
+		NumRan          *uint     `json:"ran" db:"num_ran"`
+		NumErrored      *uint     `json:"errored" db:"num_errored"`
+		NumIncompatible *uint     `json:"incompatible" db:"num_incompatible"`
+		NumCanceled     *uint     `json:"canceled" db:"num_canceled"`
+		Err             error     `json:"error,omitempty"`
 	}
 )
 
@@ -1091,15 +1092,16 @@ func batchScriptExecutionSummaryEndpoint(ctx context.Context, request interface{
 		return batchScriptExecutionSummaryResponse{Err: err}, nil
 	}
 	return batchScriptExecutionSummaryResponse{
-		ScriptID:    *summary.ScriptID,
-		ScriptName:  summary.ScriptName,
-		TeamID:      summary.TeamID,
-		CreatedAt:   summary.CreatedAt,
-		NumTargeted: summary.NumTargeted,
-		NumPending:  summary.NumPending,
-		NumRan:      summary.NumRan,
-		NumErrored:  summary.NumErrored,
-		NumCanceled: summary.NumCanceled,
+		ScriptID:        *summary.ScriptID,
+		ScriptName:      summary.ScriptName,
+		TeamID:          summary.TeamID,
+		CreatedAt:       summary.CreatedAt,
+		NumTargeted:     summary.NumTargeted,
+		NumPending:      summary.NumPending,
+		NumRan:          summary.NumRan,
+		NumErrored:      summary.NumErrored,
+		NumIncompatible: summary.NumIncompatible,
+		NumCanceled:     summary.NumCanceled,
 	}, nil
 }
 


### PR DESCRIPTION
for #32468 
for #32466

# Details

This PR fixes the following issues:

1. When viewing the summary for a batch script scheduled for the future, clicking the "Pending" hosts number now shows the correct hosts targeted by the batch, rather than an empty list.
2. When viewing the summary for a batch script that has been canceled, the number of canceled hosts will correctly be displayed in the "canceled" row rather than the "pending row".
3. When viewing the summary for any batch script, the table now splits up Error and Incompatible states and clicking on either goes to the correct list of hosts in that state.
4. When a batch script run has all of its targeted hosts deleted, it will now be cleaned up and marked as "finished".

The first three issues are already fixed on the main branch, hence the PR directly to the 4.73 release candidate.  The last issue will be patched on main in a separate PR (with tests) immediately following this once.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually
  - [X] Started a new batch script to run "now" using osquery-perf, and quit the agent halfway through the run so I could test the summary modal with hosts in different states. Verified that the host list had the correct # of hosts for each state.
  - [X] Canceled that batch and verified that the # of hosts formerly shown as "pending" in the summary modal now appeared as "canceled", and verified that clicking that number showed the correct list of hosts.
  - [X] Started a new batch script to run in the future, and verified that clicking the "pending" hosts number showed the correct hosts in the list
  - [X] Started a new batch script run with one host, deleted that host, and triggered the `batch_activity_completion_checker` schedule, and verified that the batch was moved to "finished".

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
