### PR TITLE
fix host cancelation reporting on canceled future batches

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1066,7 +1066,6 @@ func (ds *Datastore) ListHosts(ctx context.Context, filter fleet.TeamFilter, opt
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hosts, sql, params...); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "list hosts")
 	}
-	fmt.Println(sql, params)
 	return hosts, nil
 }
 

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1208,7 +1208,7 @@ func (ds *Datastore) applyHostFilters(
 	batchScriptExecutionJoin := ""
 	batchScriptExecutionIDFilter := "TRUE"
 	if opt.BatchScriptExecutionIDFilter != nil {
-		batchScriptExecutionJoin = `LEFT JOIN batch_activity_host_results bsehr ON h.id = bsehr.host_id`
+		batchScriptExecutionJoin = `LEFT JOIN batch_activity_host_results bsehr ON h.id = bsehr.host_id JOIN batch_activities ba ON bsehr.batch_execution_id = ba.execution_id`
 		batchScriptExecutionIDFilter = `bsehr.batch_execution_id = ?`
 		whereParams = append(whereParams, *opt.BatchScriptExecutionIDFilter)
 		if opt.BatchScriptExecutionStatusFilter.IsValid() {
@@ -1223,13 +1223,16 @@ func (ds *Datastore) applyHostFilters(
 				//                      but either way we haven't canceled it.
 				// bsehr.error IS NULL <- this means the batch script framework didn't mark this host as incompatible
 				//                        with this script run.
-				batchScriptExecutionIDFilter += ` AND (hsr.exit_code IS NULL AND (hsr.canceled IS NULL OR hsr.canceled = 0) AND bsehr.error IS NULL)`
+				batchScriptExecutionIDFilter += ` AND (hsr.host_id AND (hsr.exit_code IS NULL AND (hsr.canceled IS NULL OR hsr.canceled = 0) AND bsehr.error IS NULL)) OR (hsr.host_id is NULL AND ba.canceled = 0 AND bsehr.error IS NULL)`
 			case fleet.BatchScriptExecutionErrored:
 				batchScriptExecutionIDFilter += ` AND hsr.exit_code > 0 AND hsr.canceled = 0`
 			case fleet.BatchScriptExecutionIncompatible:
 				batchScriptExecutionIDFilter += ` AND bsehr.error IS NOT NULL`
 			case fleet.BatchScriptExecutionCanceled:
-				batchScriptExecutionIDFilter += ` AND hsr.exit_code IS NULL AND hsr.canceled = 1`
+				// A host may have a host_script_results record if the batch started, in which case canceling will set that record's `canceled` field.
+				// Or it may not have one, if it's a scheduled batch, in which case if the batch is marked as canceled then we'll count
+				// the host as canceled as well.
+				batchScriptExecutionIDFilter += ` AND ((hsr.exit_code IS NULL AND hsr.canceled = 1) OR (hsr.host_id IS NULL AND bsehr.error IS NULL AND ba.canceled = 1))`
 			}
 		}
 	}

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3542,6 +3542,17 @@ func testHostsListByBatchScriptExecutionStatus(t *testing.T, ds *Datastore) {
 
 	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{BatchScriptExecutionIDFilter: &execID, BatchScriptExecutionStatusFilter: fleet.BatchScriptExecutionCanceled}, 1)
 	require.Equal(t, host3.ID, hosts[0].ID)
+
+	// Schedule script that we will subsequently cancel.
+	execID, err = ds.BatchScheduleScript(ctx, &user.ID, script.ID, []uint{hostNoScripts.ID, hostWindows.ID, host1.ID, host2.ID, host3.ID}, time.Now().Add(10*time.Hour).UTC())
+	require.NoError(t, err)
+	require.NotEmpty(t, execID)
+
+	err = ds.CancelBatchScript(ctx, execID)
+	require.NoError(t, err)
+
+	// Get the batch summary.
+	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{BatchScriptExecutionIDFilter: &execID, BatchScriptExecutionStatusFilter: fleet.BatchScriptExecutionCanceled}, 5)
 }
 
 func testHostsListMacOSSettingsDiskEncryptionStatus(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -3553,6 +3553,12 @@ func testHostsListByBatchScriptExecutionStatus(t *testing.T, ds *Datastore) {
 
 	// Get the batch summary.
 	hosts = listHostsCheckCount(t, ds, fleet.TeamFilter{User: test.UserAdmin}, fleet.HostListOptions{BatchScriptExecutionIDFilter: &execID, BatchScriptExecutionStatusFilter: fleet.BatchScriptExecutionCanceled}, 5)
+	expectedHostIds = []uint{hostNoScripts.ID, hostWindows.ID, host1.ID, host2.ID, host3.ID}
+	require.Contains(t, expectedHostIds, hosts[0].ID)
+	require.Contains(t, expectedHostIds, hosts[1].ID)
+	require.Contains(t, expectedHostIds, hosts[2].ID)
+	require.Contains(t, expectedHostIds, hosts[3].ID)
+	require.Contains(t, expectedHostIds, hosts[4].ID)
 }
 
 func testHostsListMacOSSettingsDiskEncryptionStatus(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -2219,7 +2219,7 @@ SELECT
 	COUNT(bsehr.error) as num_did_not_run,
 	COUNT(CASE WHEN hsr.exit_code = 0 THEN 1 END) as num_succeeded,
 	COUNT(CASE WHEN hsr.exit_code > 0 THEN 1 END) as num_failed,
-	COUNT(CASE WHEN hsr.canceled = 1 AND hsr.exit_code IS NULL THEN 1 END) as num_cancelled
+	COUNT(CASE WHEN ((hsr.canceled = 1 AND hsr.exit_code IS NULL) OR (hsr.host_id IS NULL AND bsehr.error is NULL AND ba.canceled = 1)) THEN 1 END) as num_cancelled
 FROM
   batch_activities ba
 LEFT JOIN batch_activity_host_results bsehr

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2353,8 +2353,7 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 	// Get the batch summary.
 	summary, err := ds.BatchExecuteSummary(ctx, execID)
 	require.NoError(t, err)
-	// The summary should have two pending hosts and two errored ones, because
-	// the script is not compatible with the hostNoScripts and hostWindows.
+	// The summary should have all hosts marked as canceled.
 	require.Equal(t, *summary.NumPending, uint(0))
 	require.Equal(t, *summary.NumIncompatible, uint(0))
 	require.Equal(t, *summary.NumErrored, uint(0))

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -1988,7 +1988,7 @@ func testBatchExecuteWithStatus(t *testing.T, ds *Datastore) {
 	// Update the batch to have a pending status
 	// TODO -- remove this when status is set automatically
 	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
-		_, err := tx.ExecContext(ctx, "UPDATE batch_activities SET status = 'scheduled' WHERE execution_id = ?", execID)
+		_, err := tx.ExecContext(ctx, "UPDATE batch_activities SET status = 'started' WHERE execution_id = ?", execID)
 		return err
 	})
 
@@ -2119,7 +2119,7 @@ func testBatchExecuteWithStatus(t *testing.T, ds *Datastore) {
 
 	// The summary should be returned when filtering by status "scheduled".
 	summaryList, err = ds.ListBatchScriptExecutions(ctx, fleet.BatchExecutionStatusFilter{
-		Status: ptr.String("scheduled"),
+		Status: ptr.String("started"),
 	})
 	require.NoError(t, err)
 	require.Len(t, summaryList, 1)
@@ -2341,6 +2341,25 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 			require.Failf(t, "forgot to check a host", "host_id: %d", hostResult.HostID)
 		}
 	}
+
+	// Schedule script that we will subsequently cancel.
+	execID, err = ds.BatchScheduleScript(ctx, &user.ID, script.ID, []uint{host4.ID, hostWindows.ID, hostTeam1.ID, hostNoScripts.ID, 0xbeef}, scheduledTime)
+	require.NoError(t, err)
+	require.NotEmpty(t, execID)
+
+	err = ds.CancelBatchScript(ctx, execID)
+	require.NoError(t, err)
+
+	// Get the batch summary.
+	summary, err := ds.BatchExecuteSummary(ctx, execID)
+	require.NoError(t, err)
+	// The summary should have two pending hosts and two errored ones, because
+	// the script is not compatible with the hostNoScripts and hostWindows.
+	require.Equal(t, *summary.NumPending, uint(0))
+	require.Equal(t, *summary.NumIncompatible, uint(0))
+	require.Equal(t, *summary.NumErrored, uint(0))
+	require.Equal(t, *summary.NumRan, uint(0))
+	require.Equal(t, *summary.NumCanceled, uint(5))
 }
 
 func testMarkActivitiesAsCompleted(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
for #32468

# Details

Previously, if you canceled a script that was scheduled for the future, the hosts in that script were shown as "pending" in the batch summary and in the filtered hosts list. This PR fixes the displays so that those hosts are correctly shown as "canceled".

# Checklist for submitter

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually

**Scheduled script**
1. Created a new batch script run scheduled for a future date
2. Canceled that batch run
3. Clicked on the batch run in the "finished" tab of the batch scripts list
4. Verified that the number of canceled hosts = the number of targeted hosts for that batch, and all other numbers were 0.
5. Verified that clicking the canceled hosts number navigated to the correct list of canceled hosts

**"Run now" script**
1. Created a new batch script run with "run now"
2. Waited for at least one host to run.
3. Canceled that batch
4. Clicked on the batch run in the "finished" tab of the batch scripts list
5. Verified that the number of canceled hosts = the number that were still pending when I canceled the script, and that the # of pending hosts was 0
5. Verified that clicking the canceled hosts number navigated to the correct list of canceled hosts

**One more batch**
1. Created another batch script with the same hosts, scheduled for the future
2. Verified that the "pending" host list is correct


For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
