### PR TITLE
Website: Update CTAs & header navigation menu

### DIFF
--- a/website/assets/js/components/call-to-action.component.js
+++ b/website/assets/js/components/call-to-action.component.js
@@ -63,7 +63,7 @@ parasails.registerComponent('callToAction', {
       </div>
     </div>
     <div purpose="default-cta" v-else>
-      <a purpose="cta-button" href="/contact">Talk to an engineer</a>
+      <a purpose="cta-button" href="/contact">Get a demo</a>
       <animated-arrow-button  href="/register">Try it yourself</animated-arrow-button>
     </div>
   </div>

--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -58,10 +58,12 @@ b, strong, .font-weight-bold {
 
 a[href] {
   color: @core-fleet-black-75;
-  text-decoration: underline;
-  text-underline-offset: 4px;
-  text-decoration-color: #C5C7D1;
   cursor: pointer;
+  &:not([no-underline]) {
+    text-decoration: underline;
+    text-underline-offset: 4px;
+    text-decoration-color: #C5C7D1;
+  }
   &:hover {
     color: @core-fleet-black;
     text-decoration-color: @core-fleet-black;;

--- a/website/assets/styles/bootstrap-overrides.less
+++ b/website/assets/styles/bootstrap-overrides.less
@@ -59,10 +59,11 @@ b, strong, .font-weight-bold {
 a[href] {
   color: @core-fleet-black-75;
   cursor: pointer;
-  &:not([no-underline]) {
-    text-decoration: underline;
-    text-underline-offset: 4px;
-    text-decoration-color: #C5C7D1;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-color: #C5C7D1;
+  &[no-underline] {
+    text-decoration: none;
   }
   &:hover {
     color: @core-fleet-black;

--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -280,16 +280,16 @@ html, body {
 
   [purpose='glass-header-btn'] {
     color: #FFFFFF;
-    height: 32px;
+    height: 36px;
     position: relative;
     font-size: 14px;
     font-weight: 700;
     line-height: 1;
-    padding: 16px;
-    box-shadow: 1px 1px 2px rgba(25, 33, 71, 0.24);
-    border-radius: 4px;
+    padding: 16px 12px;
+    border-radius: 8px;
     background-color: @core-vibrant-red;
-    overflow: hidden;
+    text-decoration: none;
+    white-space: nowrap;
     &:hover {
       color: #FFF;
     }
@@ -311,6 +311,53 @@ html, body {
     opacity: 0;
     left: 160px;
     width: 110%;
+  }
+
+  [purpose='layout-animated-arrow-button'] {
+    width: fit-content;
+    display: flex;
+    align-items: center;
+    padding: 6px 0px;
+    text-align: center;
+    font-family: Inter;
+    font-size: 15px;
+    line-height: 24px; /* 160% */
+    color: @core-fleet-black;
+    font-weight: 600;
+    text-decoration: none;
+    margin-right: 16px;
+    margin-left: 8px;
+    [purpose='button-text'] {
+      color: @core-fleet-black;
+    }
+    [purpose='animated-arrow'] {
+      margin-left: 8px;
+      stroke-width: 2px;
+      height: 12px;
+      width: 12px;
+      fill: none;
+      stroke: #FF5C83;
+    }
+    [purpose='arrow-line'] {
+      opacity: 0;
+      transition: opacity 10ms ease-out;
+    }
+    [purpose='chevron'] {
+      transition: transform 100ms ease-out;
+    }
+    &:hover {
+      text-decoration: none;
+      [purpose='button-text'] {
+        color: @core-fleet-black;
+      }
+      [purpose='arrow-line'] {
+        opacity: 1;
+        transition: opacity 150ms ease-out;
+      }
+      [purpose='chevron'] {
+        transform: translateX(5px);
+      }
+    }
   }
 
   [purpose='mobile-nav-toggle-btn'] {
@@ -346,8 +393,12 @@ html, body {
       padding: 19px 32px;
       height: 80px;
     }
+    [purpose='mobile-dropdown-menus'] {
+      margin-top: 16px;
+      margin-bottom: 32px;
+    }
     [purpose='mobile-nav-container'] {
-      padding: 8px 40px 0px 40px;
+      padding: 0px 24px;
     }
     [purpose='mobile-header-logo'] {
       img {
@@ -365,7 +416,9 @@ html, body {
         width: 16px;
       }
     }
-
+    [purpose='layout-animated-arrow-button'] {
+      margin-left: 16px;
+    }
     [purpose='mobile-dropdown-link'] {
       width: 100%;
       padding: 8px 24px 8px 0px;
@@ -445,19 +498,7 @@ html, body {
   }
   [purpose='header-nav'] {
 
-    [purpose='glass-header-btn'] {
-      color: #FFFFFF;
-      height: 36px;
-      position: relative;
-      font-size: 14px;
-      font-weight: 700;
-      line-height: 1;
-      padding: 16px 12px;
-      border-radius: 8px;
-      background-color: @core-vibrant-red;
-      text-decoration: none;
-      white-space: nowrap;
-    }
+
     [purpose='header-nav-btn'][aria-expanded='true'] {
       // font-weight: 700;
       outline: none;
@@ -799,7 +840,7 @@ body.detected-mobile {
         padding: 19px 32px;
       }
       [purpose='mobile-nav-container'] {
-        padding: 8px 32px 0px 32px;
+        padding: 0px 32px 0px 32px;
       }
     }
   }
@@ -836,7 +877,7 @@ body.detected-mobile {
         padding: 19px 20px;
       }
       [purpose='mobile-nav-container'] {
-        padding: 8px 24px 24px 24px;
+        padding: 0px 24px 24px 24px;
       }
     }
   }
@@ -871,7 +912,7 @@ body.detected-mobile {
         padding: 19px 16px;
       }
       [purpose='mobile-nav-container'] {
-        padding: 8px 16px 24px 16px;
+        padding: 0px 16px 0px 16px;
       }
     }
   }

--- a/website/assets/styles/pages/observability.less
+++ b/website/assets/styles/pages/observability.less
@@ -82,6 +82,7 @@
   }
 
  [purpose='button-row'] {
+    white-space: nowrap;
     a {
       font-weight: 700;
       font-size: 16px;

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -237,7 +237,6 @@
                     <hr>
                     <a class="dropdown-item" data-dropdown-option="handbook" href="/handbook">The handbook</a>
                     <a class="dropdown-item" data-dropdown-option="handbook" href="/new-license">Get your license</a>
-                    <a class="dropdown-item" data-dropdown-option="contact" href="/contact">Schedule a demo</a><!-- «« included here in the desktop hover nav because unlike the mobile nav (which has 'Take a tour' as a primary CTA), there is no option to do that on desktop from other pages otherwise -->
                   </div>
                 </div>
                 <%if(!hideGetStartedButton){%>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -214,7 +214,7 @@
                 <a purpose="header-nav-btn" button-text="Docs" class="<%= typeof currentSection !== 'undefined' && currentSection === 'documentation' ? 'current-section' : '' %>" style="width: 55px;" href="/docs">Docs</a>
                 <a purpose="header-nav-btn" button-text="Pricing" href="/pricing" class=" align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'pricing' ? 'current-section' : '' %>" style="width: 72px; text-decoration: none; line-height: 23px;">Pricing</a>
                 <div purpose="dropdown-button" class="btn-group" >
-                  <a purpose="header-nav-btn" button-text="More" href="/testimonials" class="dropdown-toggle align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'community' ? 'current-section' : '' %>" >More</a>
+                  <span purpose="header-nav-btn" button-text="More" class="dropdown-toggle align-items-center <%= typeof currentSection !== 'undefined' && currentSection === 'community' ? 'current-section' : '' %>" >More</span>
                   <div purpose="header-dropdown" class="dropdown-menu">
                     <a class="dropdown-item" data-dropdown-option="announcements" href="/announcements">News</a>
                     <a class="dropdown-item" data-dropdown-option="testimonials" href="/testimonials">Case studies</a>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -159,33 +159,35 @@
                   </a>
                 </div>
                 <div purpose="mobile-nav-container" id="mobileDropdowns">
-                  <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleUseCases" aria-haspopup="true" aria-expanded="false">Multi platform</a>
-                  <div id="mobileNavbarToggleUseCases" purpose="mobile-dropdown" class="collapse align-items-start" data-parent="#mobileDropdowns">
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="device-management" href="/device-management">Device management &nbsp; <small>(+ MDM)</small></a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="orchestration" href="/orchestration">Orchestration &nbsp; <small>(+ monitoring)</small></a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="software-management" href="/software-management">Software management &nbsp; <small>(+ CVEs)</small></a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="integrations" href="/integrations">Integrations</a>
-                  </div>
-                  <hr>
-                  <a purpose="mobile-dropdown-link" class="d-flex align-items-center" href="/docs">Docs</a>
-                  <hr>
-                  <a purpose="mobile-dropdown-link" href="/pricing" class="d-flex align-items-center">Pricing</a>
-                  <hr>
-                  <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center mr-4 collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleCommunity">More</a>
-                  <div id="mobileNavbarToggleCommunity" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="announcements" href="/announcements">News</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="testimonials" href="/testimonials">Case studies</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="support" href="/support">Ask around</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="meetups" href="/meetups">Meetups</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="share-your-story" target="_blank" href="https://github.com/fleetdm/fleet/blob/main/handbook/company/testimonials.yml">Share your story</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/handbook">The handbook</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/new-license">Get your license</a>
-                    <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/contact">Schedule a demo</a>
-                  </div>
-                  <% if(_.has(me, 'id')) {%>
+                  <div purpose="mobile-dropdown-menus">
+                    <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleUseCases" aria-haspopup="true" aria-expanded="false">Multi platform</a>
+                    <div id="mobileNavbarToggleUseCases" purpose="mobile-dropdown" class="collapse align-items-start" data-parent="#mobileDropdowns">
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="device-management" href="/device-management">Device management &nbsp; <small>(+ MDM)</small></a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="orchestration" href="/orchestration">Orchestration &nbsp; <small>(+ monitoring)</small></a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="software-management" href="/software-management">Software management &nbsp; <small>(+ CVEs)</small></a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="integrations" href="/integrations">Integrations</a>
+                    </div>
                     <hr>
-                    <a purpose="mobile-dropdown-link" href="/logout" class="d-flex mt-2 text-decoration-none">Log out</a>
-                  <% }%>
+                    <a purpose="mobile-dropdown-link" class="d-flex align-items-center" href="/docs">Docs</a>
+                    <hr>
+                    <a purpose="mobile-dropdown-link" href="/pricing" class="d-flex align-items-center">Pricing</a>
+                    <hr>
+                    <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center mr-4 collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleCommunity">More</a>
+                    <div id="mobileNavbarToggleCommunity" purpose="mobile-dropdown" class="collapse" data-parent="#mobileDropdowns">
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="announcements" href="/announcements">News</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="testimonials" href="/testimonials">Case studies</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="support" href="/support">Ask around</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="meetups" href="/meetups">Meetups</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="share-your-story" target="_blank" href="https://github.com/fleetdm/fleet/blob/main/handbook/company/testimonials.yml">Share your story</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/handbook">The handbook</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/new-license">Get your license</a>
+                      <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/contact">Get a demo</a>
+                    </div>
+                    <% if(_.has(me, 'id')) {%>
+                      <hr>
+                      <a purpose="mobile-dropdown-link" href="/logout" class="d-flex mt-2 text-decoration-none">Log out</a>
+                    <% }%>
+                  </div>
                   <%if(me && me.isSuperAdmin && showAdminLinks) {%>
                     <hr>
                     <a purpose="mobile-dropdown-toggle" class="d-flex align-items-center mr-4 collapsed" data-toggle="collapse" data-target="#mobileNavbarToggleAdmin">Admin</a>
@@ -196,7 +198,18 @@
                     </div>
                   <%}%>
                   <%if(!hideGetStartedButton){%>
-                  <a purpose="glass-header-btn" style="padding: 4px 16px; line-height: 24px; width: 152px" class="btn btn-sm btn-primary align-items-center d-flex mt-4" href="/contact" no-underline>Schedule a demo</a>
+                  <div class="d-flex flex-row align-items-center">
+
+                    <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact" no-underline>Get a demo</a>
+
+                    <a purpose="layout-animated-arrow-button" class="start-cta-continue-button" href="/register" no-underline>
+                      Try it yourself
+                      <svg purpose="animated-arrow" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+                        <path purpose="arrow-line" d="M1 6H9" stroke-width="2" stroke-linecap="round"/>
+                        <path purpose="chevron" d="M1.35712 1L5.64283 6L1.35712 11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                      </svg>
+                    </a>
+                  </div>
                   <% }%>
                 </div>
               </div>
@@ -227,12 +240,15 @@
                     <a class="dropdown-item" data-dropdown-option="contact" href="/contact">Schedule a demo</a><!-- «« included here in the desktop hover nav because unlike the mobile nav (which has 'Take a tour' as a primary CTA), there is no option to do that on desktop from other pages otherwise -->
                   </div>
                 </div>
-                <span purpose="gh-button" class="d-flex align-items-center">
-                  <iframe src="//ghbtns.com/github-btn.html?user=fleetdm&amp;repo=fleet&amp;type=watch&amp;count=true"
-                  allowtransparency="true" frameborder="0" scrolling="0" width="140" height="20"></iframe>
-                </span>
                 <%if(!hideGetStartedButton){%>
-                  <a purpose="glass-header-btn" class="align-items-center d-flex" href="/register" no-underline>Try it yourself</a>
+                  <a purpose="layout-animated-arrow-button" class="start-cta-continue-button" href="/register" no-underline>
+                    Try it yourself
+                    <svg purpose="animated-arrow" xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12">
+                      <path purpose="arrow-line" d="M1 6H9" stroke-width="2" stroke-linecap="round"/>
+                      <path purpose="chevron" d="M1.35712 1L5.64283 6L1.35712 11" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                  </a>
+                  <a purpose="glass-header-btn" class="align-items-center d-flex" href="/contact" no-underline>Get a demo</a>
                 <% }%>
                 <% if(_.has(me, 'id')) {%>
                 <a purpose="log-out-button" href="/logout" class="justify-content-end text-decoration-none">Log out</a>

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -181,7 +181,6 @@
                       <a purpose="mobile-dropdown-link" data-dropdown-option="share-your-story" target="_blank" href="https://github.com/fleetdm/fleet/blob/main/handbook/company/testimonials.yml">Share your story</a>
                       <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/handbook">The handbook</a>
                       <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/new-license">Get your license</a>
-                      <a purpose="mobile-dropdown-link" data-dropdown-option="handbook" href="/contact">Get a demo</a>
                     </div>
                     <% if(_.has(me, 'id')) {%>
                       <hr>

--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -62,7 +62,7 @@
             <a purpose="sidebar-link" href="/docs"><img alt="Docs" src="/images/icon-docs-16x16@2x.png"> Docs</a>
             <a purpose="sidebar-link" href="/docs/rest-api"><img alt="REST API" src="/images/icon-api-16x16@2x.png"> REST API</a>
             <a purpose="sidebar-link" href="/guides"><img alt="Guides" src="/images/icon-guides-16x16@2x.png"> Guides</a>
-            <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png"> Talk to an engineer</a>
+            <a purpose="sidebar-link" href="/contact"><img alt="Get a demo" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
             <div purpose="edit-link">
               <a purpose="sidebar-link" :href="'https://github.com/fleetdm/fleet/edit/main/articles/'+thisPage.sectionRelativeRepoPath"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Suggest an edit</a>
             </div>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -8,7 +8,7 @@
       <p v-else-if="psychologicalStage === '5 - Personally confident'">Schedule a personalized demo for your team and get support or training.</p>
       <p v-else>Schedule a personalized demo, or ask us anything. We’d love to chat.</p>
       <div purpose="contact-form-switch" class="d-flex flex-sm-row flex-column justify-content-center mx-auto" v-if="!userHasPremiumSubscription">
-        <div purpose="switch-option" :class="[formToDisplay === 'talk-to-us' ? 'selected' : '']" @click="clickSwitchForms('talk-to-us')">Talk to an engineer</div>
+        <div purpose="switch-option" :class="[formToDisplay === 'talk-to-us' ? 'selected' : '']" @click="clickSwitchForms('talk-to-us')">Get a demo</div>
         <div purpose="switch-option" :class="[formToDisplay === 'contact' ? 'selected' : '']" @click="clickSwitchForms('contact')">Send a message</div>
         <div purpose="switch" :class="formToDisplay+'-selected'"></div>
       </div>

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -823,8 +823,8 @@
         </div>
 
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/register">Try it yourself</a>
-          <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+          <a purpose="cta-button" href="/contact">Get a demo</a>
+        <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>
       <%/* Shorten the feedback loop section */%>

--- a/website/views/pages/device-management.ejs
+++ b/website/views/pages/device-management.ejs
@@ -45,8 +45,8 @@
 
         </div>
         <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-              <a purpose="cta-button" href="/contact">Talk to an engineer</a>
-              <a purpose="video-button"  @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png"> Watch demo <span>3 mins</span></a>
+              <a purpose="cta-button" href="/contact">Get a demo</a>
+              <a purpose="video-button"  @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png">See Fleet in action <span>3 mins</span></a>
             </div>
       </div>
       <logo-carousel></logo-carousel>
@@ -913,7 +913,7 @@
         <h4>Open device management</h4>
         <h1>Your last MDM migration</h1>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/contact">Talk to an engineer</a>
+          <a purpose="cta-button" href="/contact">Get a demo</a>
           <animated-arrow-button  href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/docs/basic-documentation.ejs
+++ b/website/views/pages/docs/basic-documentation.ejs
@@ -32,7 +32,7 @@
           <a purpose="subpage-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
           <a purpose="subpage-link" href="/releases" no-icon>Release notes</a>
           <a purpose="subpage-link" href="/support" no-icon>Support</a>
-          <a purpose="subpage-link" href="/contact">Take a tour</a>
+          <a purpose="subpage-link" href="/contact">Get a demo</a>
           <a purpose="subpage-link" href="/better">“Why is Fleet on my computer?”</a>
         </div>
         <div class="d-none d-lg-block left-cta" purpose="swag-cta" v-if="showSwagForm && ['REST API', 'Fleet server configuration'].includes(thisPage.title)">
@@ -141,7 +141,7 @@
       <a purpose="modal-nav-link" href="/docs/contributing" target="_blank" no-icon>Contribute</a>
       <a purpose="modal-nav-link" href="/releases" no-icon>Release notes</a>
       <a purpose="modal-nav-link" href="/support" no-icon>Support</a>
-      <a purpose="modal-nav-link" href="/contact">Take a tour</a>
+      <a purpose="modal-nav-link" href="/contact">Get a demo</a>
       <a purpose="modal-nav-link" href="/better">“Why is Fleet on my computer?”</a>
     </div>
   </modal>

--- a/website/views/pages/entrance/login.ejs
+++ b/website/views/pages/entrance/login.ejs
@@ -1,7 +1,4 @@
 <div id="login" v-cloak>
-  <div purpose="announcement-banner">
-    <animated-arrow-button arrow-color="white" text-color="white" href="/funding-announcement" target="_blank">🎉 Fleet raises $27M for<br> open device management </animated-arrow-button>
-  </div>
   <div purpose="page-container" class="container">
     <div purpose="page-heading">
       <h1>Welcome to Fleet</h1>

--- a/website/views/pages/entrance/signup.ejs
+++ b/website/views/pages/entrance/signup.ejs
@@ -1,7 +1,4 @@
 <div id="signup" v-cloak>
-  <div purpose="announcement-banner">
-    <animated-arrow-button arrow-color="white" text-color="white" href="/funding-announcement" target="_blank">🎉 Fleet raises $27M for<br> open device management </animated-arrow-button>
-  </div>
   <div purpose="page-container" class="container">
     <div purpose="page-heading">
       <h1>Welcome to Fleet</h1>

--- a/website/views/pages/fleetctl-preview.ejs
+++ b/website/views/pages/fleetctl-preview.ejs
@@ -1,7 +1,4 @@
 <div id="fleetctl-preview" v-cloak>
-  <div purpose="announcement-banner">
-    <animated-arrow-button arrow-color="white" text-color="white" href="/funding-announcement" target="_blank">🎉 Fleet raises $27M for<br> open device management </animated-arrow-button>
-  </div>
   <div purpose="page-container" class="d-flex flex-column container">
     <div purpose="page-title">
       <h1>Try Fleet</h1>

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -1,7 +1,4 @@
 <div id="homepage" v-cloak>
-  <div purpose="announcement-banner">
-    <animated-arrow-button arrow-color="white" text-color="white" href="/funding-announcement" target="_blank">🎉 Fleet raises $27M for<br> open device management </animated-arrow-button>
-  </div>
   <%/* Hero container */%>
   <div purpose="hero-container">
     <div purpose="hero-background-image">

--- a/website/views/pages/homepage.ejs
+++ b/website/views/pages/homepage.ejs
@@ -38,8 +38,8 @@
             </h1>
             <p>Replace the sprawl with lightning fast device management that puts you back in control.</p>
             <div purpose="button-row" class="d-flex justify-content-start align-items-center">
-              <a purpose="cta-button" href="/contact">Talk to an engineer</a>
-              <a purpose="video-button"  @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png"> Watch demo <span>3 mins</span></a>
+              <a purpose="cta-button" href="/contact">Get a demo</a>
+              <a purpose="video-button"  @click="clickOpenVideoModal('fleet-in-three-minutes')"><img alt="Play" class="d-inline" src="/images/icon-play-video-32x32@2x.png">See Fleet in action<span>3 mins</span></a>
             </div>
           </div>
         </div>
@@ -1473,7 +1473,7 @@
 
         <div purpose="button-row">
           <a purpose="cta-button" href="/pricing">Compare all features</a>
-          <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+          <animated-arrow-button href="/contact">Get a demo</animated-arrow-button>
         </div>
       </div>
 
@@ -1544,8 +1544,8 @@
           </div>
         </h1>
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/register">Try it yourself</a>
-          <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>
     </div>

--- a/website/views/pages/observability.ejs
+++ b/website/views/pages/observability.ejs
@@ -27,7 +27,7 @@
             <p>Ship data to any platform like Splunk, Snowflake, or <a href="/docs/using-fleet/log-destinations">any streaming infrastructure</a> like AWS Kinesis and Apache Kafka.</p>
           <% }%>
           <div purpose="button-row" class="d-flex flex-sm-row flex-column justify-content-start align-items-center">
-            <a purpose="cta-button" href="/contact">Take a tour</a>
+            <a purpose="cta-button" href="/contact">Get a demo</a>
             <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
           </div>
         </div>
@@ -271,8 +271,8 @@
         <h4>Open orchestration</h4>
         <h3><%= pagePersonalization==='eo-security'? 'Instrument your endpoints' : 'Talk to your computers'%></h3>
         <div purpose="button-row" style="margin-top: 32px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/register">Start now</a>
-          <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+          <a purpose="cta-button" href="/contact">Get a demo</a>
+          <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>
     </div>

--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -71,7 +71,7 @@
                 </div>
               </div>
               <div>
-                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact">Talk to an engineer</a>
+                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact">Get a demo</a>
               </div>
             </div>
           </div>

--- a/website/views/pages/query-detail.ejs
+++ b/website/views/pages/query-detail.ejs
@@ -61,7 +61,7 @@
             </div>
             <div purpose="docs-links" class="order-3">
               <a purpose="sidebar-link" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath+'#L'+query.lineNumberInYaml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Edit</a>
-              <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Talk to us</a>
+              <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
             </div>
           </div>
         </div>

--- a/website/views/pages/reports/state-of-device-management.ejs
+++ b/website/views/pages/reports/state-of-device-management.ejs
@@ -331,7 +331,7 @@
           <p>Get up and running with a test environment of Fleet within minutes</p>
         </div>
         <div purpose="cta-btns" class="mx-auto d-flex flex-sm-row flex-column justify-content-center">
-          <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Talk to us</a>
+          <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Get a demo</a>
           <a purpose="animated-arrow-btn-red" style="max-width: 220px;" class="btn btn-lg btn-white mr-2 pl-0 mx-auto mx-sm-0 mt-2 mt-sm-0" href="/register">Try it out
           </a>
         </div>
@@ -543,7 +543,7 @@
               <p>Fortune 1,000 companies use Fleet to keep their<br class="d-none d-sm-block"> MacOS, Windows, and Linux devices secure and compliant.</p>
             </div>
             <div purpose="cta-btns" class="mx-auto d-flex flex-sm-row flex-column justify-content-center">
-              <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Talk to us</a>
+              <a purpose="get-started-btn" class="d-sm-flex align-items-center justify-content-center btn btn-primary mx-auto mr-sm-4 ml-sm-0" href="/contact">Get a demo</a>
               <a purpose="animated-arrow-btn-red" style="max-width: 220px;" class="btn btn-lg mr-2 pl-0 mx-auto mx-sm-0 mt-2 mt-sm-0" href="/register">Try it out
               </a>
             </div>

--- a/website/views/pages/software-management.ejs
+++ b/website/views/pages/software-management.ejs
@@ -6,7 +6,7 @@
         <h1>Manage software consistently</h1>
         <p purpose="hero-text">Pick from a curated software catalog or upload your own custom packages. Configure custom installation scripts if you need or let Fleet do it for you.</p>
         <div purpose="button-row" class="d-flex justify-content-start">
-          <a class="btn btn-primary" purpose="contact-button" href="/contact">Talk to an engineer</a>
+          <a class="btn btn-primary" purpose="contact-button" href="/contact">Get a demo</a>
           <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>
@@ -219,7 +219,7 @@
       <h4>Software management</h4>
       <h2>Manage software consistently</h2>
       <div purpose="button-row" style="margin-top: 32px;" class="d-flex justify-content-center align-items-center mx-auto">
-        <a class="btn btn-primary" purpose="contact-button" href="/contact">Show me</a>
+        <a class="btn btn-primary" purpose="contact-button" href="/contact">Get a demo</a>
         <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
       </div>
     </div>

--- a/website/views/pages/testimonials.ejs
+++ b/website/views/pages/testimonials.ejs
@@ -163,7 +163,7 @@
         <h2 class="mx-auto" v-if="selectedContent === 'it'">Talk to your computers</h2>
         <h2 class="mx-auto" v-if="selectedContent === 'security'">Easily get security data</h2>
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" purpose="contact-button" href="/contact">Get a demo</a>
+          <a purpose="cta-button" href="/contact">Get a demo</a>
           <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>

--- a/website/views/pages/testimonials.ejs
+++ b/website/views/pages/testimonials.ejs
@@ -163,8 +163,8 @@
         <h2 class="mx-auto" v-if="selectedContent === 'it'">Talk to your computers</h2>
         <h2 class="mx-auto" v-if="selectedContent === 'security'">Easily get security data</h2>
         <div purpose="button-row" style="margin-top: 40px;" class="d-flex flex-sm-row flex-column justify-content-center align-items-center mx-auto">
-          <a purpose="cta-button" href="/register">Try it yourself</a>
-          <animated-arrow-button href="/contact">Talk to an engineer</animated-arrow-button>
+          <a purpose="cta-button" purpose="contact-button" href="/contact">Get a demo</a>
+          <animated-arrow-button href="/register">Try it yourself</animated-arrow-button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes https://github.com/fleetdm/confidential/issues/12017
Closes https://github.com/fleetdm/fleet/issues/32440
Closes https://github.com/fleetdm/fleet/issues/32441


Changes:
- Updated CTAs across the website ("Talk to an engineer" » "Get a demo")
- Removed the clickable link on the "More" dropdown menu
- Removed the funding announcement banner