### PR TITLE
Fleet UI: Add last opened tooltip

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -258,6 +258,7 @@ const HostSoftware = ({
           router,
           teamId: hostTeamId,
           onShowInventoryVersions,
+          platform,
         });
   }, [isMyDevicePage, router, hostTeamId, onShowInventoryVersions]);
 

--- a/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftware.tsx
@@ -260,7 +260,7 @@ const HostSoftware = ({
           onShowInventoryVersions,
           platform,
         });
-  }, [isMyDevicePage, router, hostTeamId, onShowInventoryVersions]);
+  }, [isMyDevicePage, router, hostTeamId, onShowInventoryVersions, platform]);
 
   const isLoading = isMyDevicePage
     ? deviceSoftwareLoading

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -8,6 +8,7 @@ import {
   isIpadOrIphoneSoftwareSource,
   SoftwareSource,
 } from "interfaces/software";
+import { isLinuxLike } from "interfaces/platform";
 import { IHeaderProps, IStringCellProps } from "interfaces/datatable_config";
 
 import PATHS from "router/paths";
@@ -18,6 +19,7 @@ import TextCell from "components/TableContainer/DataTable/TextCell";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 import InstalledPathCell from "pages/SoftwarePage/components/tables/InstalledPathCell";
 import HashCell from "pages/SoftwarePage/components/tables/HashCell/HashCell";
+import TooltipWrapper from "components/TooltipWrapper";
 import { HumanTimeDiffWithDateTip } from "components/HumanTimeDiffWithDateTip";
 
 import VulnerabilitiesCell from "pages/SoftwarePage/components/tables/VulnerabilitiesCell";
@@ -40,6 +42,7 @@ interface ISoftwareTableHeadersProps {
   router: InjectedRouter;
   teamId: number;
   onShowInventoryVersions: (software: IHostSoftware) => void;
+  platform: HostPlatform;
 }
 
 // NOTE: cellProps come from react-table
@@ -48,6 +51,7 @@ export const generateSoftwareTableHeaders = ({
   router,
   teamId,
   onShowInventoryVersions,
+  platform,
 }: ISoftwareTableHeadersProps): ISoftwareTableConfig[] => {
   const tableHeaders: ISoftwareTableConfig[] = [
     {
@@ -121,7 +125,21 @@ export const generateSoftwareTableHeaders = ({
     },
     {
       Header: (): JSX.Element => {
-        return <HeaderCell value="Last opened" disableSortBy />;
+        const lastOpenedHeader = isLinuxLike(platform) ? (
+          <TooltipWrapper
+            tipContent={
+              <>
+                The last time the package was opened by the end user <br />
+                or accessed by any process on the host.
+              </>
+            }
+          >
+            Last opened
+          </TooltipWrapper>
+        ) : (
+          "Last opened"
+        );
+        return <HeaderCell value={lastOpenedHeader} disableSortBy />;
       },
       id: "Last opened",
       disableSortBy: true,

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -8,7 +8,7 @@ import {
   isIpadOrIphoneSoftwareSource,
   SoftwareSource,
 } from "interfaces/software";
-import { isLinuxLike } from "interfaces/platform";
+import { HostPlatform, isLinuxLike } from "interfaces/platform";
 import { IHeaderProps, IStringCellProps } from "interfaces/datatable_config";
 
 import PATHS from "router/paths";

--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -4,6 +4,7 @@ import { dateAgo } from "utilities/date_format";
 
 import {
   formatSoftwareType,
+  INSTALLABLE_SOURCE_PLATFORM_CONVERSION,
   IHostSoftware,
   ISoftwareInstallVersion,
   SoftwareSource,
@@ -53,6 +54,22 @@ const InventoryVersion = ({
     signature_information: signatureInformation,
   } = version;
 
+  const lastOpenedTitle =
+    INSTALLABLE_SOURCE_PLATFORM_CONVERSION[source] === "linux" ? (
+      <TooltipWrapper
+        tipContent={
+          <>
+            The last time the package was opened by the end user <br />
+            or accessed by any process on the host.
+          </>
+        }
+      >
+        Last opened
+      </TooltipWrapper>
+    ) : (
+      "Last opened"
+    );
+
   return (
     <Card
       className={`${baseClass}__version`}
@@ -67,18 +84,7 @@ const InventoryVersion = ({
         )}
         {version.last_opened_at || sourcesWithLastOpenedTime.has(source) ? (
           <DataSet
-            title={
-              <TooltipWrapper
-                tipContent={
-                  <>
-                    The last time the package was opened by the end user <br />
-                    or accessed by any process on the host.
-                  </>
-                }
-              >
-                Last opened
-              </TooltipWrapper>
-            }
+            title={lastOpenedTitle}
             value={
               version.last_opened_at ? dateAgo(version.last_opened_at) : "Never"
             }

--- a/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
+++ b/frontend/pages/hosts/details/components/InventoryVersions/InventoryVersions.tsx
@@ -11,6 +11,7 @@ import {
 
 import Card from "components/Card";
 import DataSet from "components/DataSet";
+import TooltipWrapper from "components/TooltipWrapper";
 
 export const sourcesWithLastOpenedTime = new Set([
   "programs",
@@ -66,7 +67,18 @@ const InventoryVersion = ({
         )}
         {version.last_opened_at || sourcesWithLastOpenedTime.has(source) ? (
           <DataSet
-            title="Last opened"
+            title={
+              <TooltipWrapper
+                tipContent={
+                  <>
+                    The last time the package was opened by the end user <br />
+                    or accessed by any process on the host.
+                  </>
+                }
+              >
+                Last opened
+              </TooltipWrapper>
+            }
             value={
               version.last_opened_at ? dateAgo(version.last_opened_at) : "Never"
             }


### PR DESCRIPTION
## Issue
Closes #32583

## Description
- Add tooltip to last opened headers
- These are the only places in the code with "last opened"

## Screenshots of fixes

<img width="1683" height="532" alt="Screenshot 2025-09-04 at 12 29 32 PM" src="https://github.com/user-attachments/assets/508a47cc-c6ae-4698-9683-ffb64e3fb31a" />
<img width="1682" height="456" alt="Screenshot 2025-09-04 at 12 29 56 PM" src="https://github.com/user-attachments/assets/ec9cefbf-80c8-45b7-b781-406177794bda" />


- [x] QA'd all new/changed functionality manually
