### PR TITLE
Fleet UI: Display UI after osVersions loads only

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -505,7 +505,7 @@ const ManageHostsPage = ({
     }
   );
 
-  const { data: osVersions } = useQuery<
+  const { data: osVersions, isLoading: isLoadingOsVersions } = useQuery<
     IOSVersionsResponse,
     Error,
     IOperatingSystemVersion[],
@@ -1832,6 +1832,7 @@ const ManageHostsPage = ({
           isLoadingHosts ||
           isLoadingHostsCount ||
           isLoadingPolicy ||
+          isLoadingOsVersions ||
           isLoadingConfigProfile ||
           isLoadingScriptBatchSummary
         }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1685,6 +1685,15 @@ const ManageHostsPage = ({
       filter in queryParams // TODO: replace this with `Object.hasOwn(queryParams, filter)` when we upgrade to es2022
   );
 
+  // Ensures rendering table/pills simultaneously when all API calls are done
+  const isLoading =
+    isLoadingHosts ||
+    isLoadingHostsCount ||
+    isLoadingPolicy ||
+    isLoadingOsVersions ||
+    isLoadingConfigProfile ||
+    isLoadingScriptBatchSummary;
+
   const renderTable = () => {
     if (!config || !currentUser || !isRouteOk) {
       return <Spinner />;
@@ -1828,14 +1837,7 @@ const ManageHostsPage = ({
         resultsTitle="hosts"
         columnConfigs={tableColumns}
         data={hostsData?.hosts || []}
-        isLoading={
-          isLoadingHosts ||
-          isLoadingHostsCount ||
-          isLoadingPolicy ||
-          isLoadingOsVersions ||
-          isLoadingConfigProfile ||
-          isLoadingScriptBatchSummary
-        }
+        isLoading={isLoading}
         manualSortBy
         defaultSortHeader={(sortBy[0] && sortBy[0].key) || DEFAULT_SORT_HEADER}
         defaultSortDirection={
@@ -2001,6 +2003,7 @@ const ManageHostsPage = ({
             }
             onClickEditLabel={onEditLabelClick}
             onClickDeleteLabel={toggleDeleteLabelModal}
+            isLoading={isLoading}
           />
           {renderNoEnrollSecretBanner()}
           {renderTable()}

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -109,6 +109,7 @@ interface IHostsFilterBlockProps {
   onChangeScriptBatchStatusFilter: (newStatus: ScriptBatchHostCountV1) => void;
   onClickEditLabel: (evt: React.MouseEvent<HTMLButtonElement>) => void;
   onClickDeleteLabel: () => void;
+  isLoading?: boolean;
 }
 
 /**
@@ -162,8 +163,13 @@ const HostsFilterBlock = ({
   onChangeScriptBatchStatusFilter,
   onClickEditLabel,
   onClickDeleteLabel,
+  isLoading = false,
 }: IHostsFilterBlockProps) => {
   const { currentUser, isOnGlobalTeam } = useContext(AppContext);
+
+  if (isLoading) {
+    return <></>;
+  }
 
   const renderLabelFilterPill = () => {
     if (selectedLabel) {


### PR DESCRIPTION
## Issue
Closes #32584 

## Description
- The UI would show before the osVersions API was finished calling, which caused a significant delay in the pill showing
- Update the UI not to show until the API request was completed, the only delay is the FE matches the os version to that API so it's only milliseconds delayed while that happens vs. how ever slow someone's connection is

> Note: Solution taken from policy filter block that also calls the API for the policy name

## Screenrecording of fix



https://github.com/user-attachments/assets/f26485e7-3c14-46f6-a75a-676fa2daa5b4



## Testing

- [x] QA'd all new/changed functionality manually
