### PR TITLE
HCA: fix generate GitOps missing todo comment and include secrets parsing

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -789,6 +789,7 @@ func (cmd *GenerateGitopsCommand) generateCertificateAuthorities(filePath string
 	includeSecrets := cmd.CLI.Bool("insecure")
 
 	// Get the certificate authorities spec
+	fmt.Println("Is insecure", includeSecrets)
 	cas, err := cmd.Client.GetCertificateAuthoritiesSpec(includeSecrets)
 	if err != nil {
 		return nil, err
@@ -830,6 +831,15 @@ func (cmd *GenerateGitopsCommand) generateCertificateAuthorities(filePath string
 				cmd.Messages.SecretWarnings = append(cmd.Messages.SecretWarnings, SecretWarning{
 					Filename: "default.yml",
 					Key:      "integrations.custom_scep_proxy.challenge",
+				})
+			}
+		}
+		if hydrant, ok := result["hydrant"]; ok && hydrant != nil {
+			for _, intg := range hydrant.([]interface{}) {
+				intg.(map[string]interface{})["client_secret"] = cmd.AddComment(filePath, "TODO: Add your Hydrant client secret here")
+				cmd.Messages.SecretWarnings = append(cmd.Messages.SecretWarnings, SecretWarning{
+					Filename: "default.yml",
+					Key:      "integrations.hydrant.client_secret",
 				})
 			}
 		}

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -789,7 +789,6 @@ func (cmd *GenerateGitopsCommand) generateCertificateAuthorities(filePath string
 	includeSecrets := cmd.CLI.Bool("insecure")
 
 	// Get the certificate authorities spec
-	fmt.Println("Is insecure", includeSecrets)
 	cas, err := cmd.Client.GetCertificateAuthoritiesSpec(includeSecrets)
 	if err != nil {
 		return nil, err

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -502,7 +502,7 @@ func (MockClient) GetCertificateAuthoritiesSpec(includeSecrets bool) (*fleet.Gro
 			{
 				Name:                  "some-digicert-name",
 				URL:                   "https://some-digicert-url.com",
-				APIToken:              "some-digicert-api-token",
+				APIToken:              maskSecret("some-digicert-api-token", includeSecrets),
 				ProfileID:             "some-digicert-profile-id",
 				CertificateCommonName: "some-digicert-certificate-common-name",
 				CertificateUserPrincipalNames: []string{
@@ -516,18 +516,33 @@ func (MockClient) GetCertificateAuthoritiesSpec(includeSecrets bool) (*fleet.Gro
 			URL:      "https://some-ndes-scep-proxy-url.com",
 			AdminURL: "https://some-ndes-admin-url.com",
 			Username: "some-ndes-username",
-			Password: "some-ndes-password",
+			Password: maskSecret("some-ndes-password", includeSecrets),
 		},
 		CustomScepProxy: []fleet.CustomSCEPProxyCA{
 			{
 				Name:      "some-custom-scep-proxy-name",
 				URL:       "https://some-custom-scep-proxy-url.com",
-				Challenge: "some-custom-scep-proxy-challenge",
+				Challenge: maskSecret("some-custom-scep-proxy-challenge", includeSecrets),
+			},
+		},
+		Hydrant: []fleet.HydrantCA{
+			{
+				Name:         "some-hydrant-name",
+				URL:          "https://some-hydrant-url.com",
+				ClientID:     "some-hydrant-client-id",
+				ClientSecret: maskSecret("some-hydrant-client-secret", includeSecrets),
 			},
 		},
 	}
 
 	return &res, nil
+}
+
+func maskSecret(value string, shouldShowSecret bool) string {
+	if shouldShowSecret {
+		return value
+	}
+	return "********"
 }
 
 func compareDirs(t *testing.T, sourceDir, targetDir string) {

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
@@ -1,19 +1,23 @@
 certificate_authorities:
   custom_scep_proxy:
-  - challenge: some-custom-scep-proxy-challenge
-    name: some-custom-scep-proxy-name
-    url: https://some-custom-scep-proxy-url.com
+    - challenge: some-custom-scep-proxy-challenge
+      name: some-custom-scep-proxy-name
+      url: https://some-custom-scep-proxy-url.com
   digicert:
-  - api_token: some-digicert-api-token
-    certificate_common_name: some-digicert-certificate-common-name
-    certificate_seat_id: some-digicert-certificate-seat-id
-    certificate_user_principal_names:
-    - some-digicert-certificate-user-principal-name
-    - some-other-digicert-certificate-user-principal-name
-    name: some-digicert-name
-    profile_id: some-digicert-profile-id
-    url: https://some-digicert-url.com
+    - api_token: some-digicert-api-token
+      certificate_common_name: some-digicert-certificate-common-name
+      certificate_seat_id: some-digicert-certificate-seat-id
+      certificate_user_principal_names:
+        - some-digicert-certificate-user-principal-name
+        - some-other-digicert-certificate-user-principal-name
+      name: some-digicert-name
+      profile_id: some-digicert-profile-id
+      url: https://some-digicert-url.com
   hydrant:
+    - name: some-hydrant-name
+      url: https://some-hydrant-url.com
+      client_id: some-hydrant-client-id
+      client_secret: some-hydrant-client-secret
   ndes_scep_proxy:
     admin_url: https://some-ndes-admin-url.com
     password: some-ndes-password
@@ -23,11 +27,11 @@ features:
   enable_host_users: true
   enable_software_inventory: true
   additional_queries:
-      time: "SELECT * FROM time"
-      macs: "SELECT mac FROM interface_details"
+    time: "SELECT * FROM time"
+    macs: "SELECT mac FROM interface_details"
   detail_query_overrides:
-      users:
-      mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
+    users:
+    mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
 fleet_desktop:
   transparency_url: https://fleetdm.com/transparency
 host_expiry_settings:
@@ -36,29 +40,29 @@ host_expiry_settings:
 integrations:
   conditional_access_enabled: true
   google_calendar:
-  - api_key_json:
-      owl: hoot
-    domain: fleetdm.com
+    - api_key_json:
+        owl: hoot
+      domain: fleetdm.com
   jira:
-  - api_token: some-jira-api-token
-    enable_failing_policies: false
-    enable_software_vulnerabilities: false
-    project_key: some-jira-project-key
-    url: https://some-jira-url.com
-    username: some-jira-username
+    - api_token: some-jira-api-token
+      enable_failing_policies: false
+      enable_software_vulnerabilities: false
+      project_key: some-jira-project-key
+      url: https://some-jira-url.com
+      username: some-jira-username
   zendesk:
-  - api_token: some-zendesk-api-token
-    email: some-zendesk-email@example.com
-    enable_failing_policies: false
-    enable_software_vulnerabilities: false
-    group_id: 123456789
-    url: https://some-zendesk-url.com
+    - api_token: some-zendesk-api-token
+      email: some-zendesk-email@example.com
+      enable_failing_policies: false
+      enable_software_vulnerabilities: false
+      group_id: 123456789
+      url: https://some-zendesk-url.com
 mdm:
   apple_business_manager:
-  - ios_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    ipados_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    macos_team: "\U0001F4BB Workstations"
-    organization_name: Fleet Device Management Inc.
+    - ios_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+      ipados_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+      macos_team: "\U0001F4BB Workstations"
+      organization_name: Fleet Device Management Inc.
   apple_server_url: http://some-apple-server-url.com
   end_user_authentication:
     entity_id: some-mdm-entity-id.com
@@ -68,25 +72,25 @@ mdm:
     metadata_url: http://some-mdm-metadata-url.com
   end_user_license_agreement: ./lib/eula/test.pdf
   volume_purchasing_program:
-  - location: Fleet Device Management Inc.
-    teams:
-    - "\U0001F4BB Workstations"
-    - "\U0001F4BB\U0001F423 Workstations (canary)"
-    - "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    - "\U0001F4F1\U0001F510 Personal mobile devices"
+    - location: Fleet Device Management Inc.
+      teams:
+        - "\U0001F4BB Workstations"
+        - "\U0001F4BB\U0001F423 Workstations (canary)"
+        - "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+        - "\U0001F4F1\U0001F510 Personal mobile devices"
 org_info:
   contact_url: https://fleetdm.com/company/contact
   org_logo_url: http://some-org-logo-url.com
   org_logo_url_light_background: http://some-org-logo-url-light-background.com
   org_name: Fleet
 secrets:
-- secret: some-secret-number-one
-- secret: some-secret-number-two
+  - secret: some-secret-number-one
+  - secret: some-secret-number-two
 server_settings:
   ai_features_disabled: false
   debug_host_ids:
-  - 1
-  - 3
+    - 1
+    - 3
   deferred_save_host: false
   enable_analytics: true
   live_query_disabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
@@ -1,19 +1,23 @@
 certificate_authorities:
   custom_scep_proxy:
-  - challenge: ___GITOPS_COMMENT_5___
-    name: some-custom-scep-proxy-name
-    url: https://some-custom-scep-proxy-url.com
+    - challenge: ___GITOPS_COMMENT_5___
+      name: some-custom-scep-proxy-name
+      url: https://some-custom-scep-proxy-url.com
   digicert:
-  - api_token: ___GITOPS_COMMENT_3___
-    certificate_common_name: some-digicert-certificate-common-name
-    certificate_seat_id: some-digicert-certificate-seat-id
-    certificate_user_principal_names:
-    - some-digicert-certificate-user-principal-name
-    - some-other-digicert-certificate-user-principal-name
-    name: some-digicert-name
-    profile_id: some-digicert-profile-id
-    url: https://some-digicert-url.com
+    - api_token: ___GITOPS_COMMENT_3___
+      certificate_common_name: some-digicert-certificate-common-name
+      certificate_seat_id: some-digicert-certificate-seat-id
+      certificate_user_principal_names:
+        - some-digicert-certificate-user-principal-name
+        - some-other-digicert-certificate-user-principal-name
+      name: some-digicert-name
+      profile_id: some-digicert-profile-id
+      url: https://some-digicert-url.com
   hydrant:
+    - name: some-hydrant-name
+      url: https://some-hydrant-url.com
+      client_id: some-hydrant-client-id
+      client_secret: ___GITOPS_COMMENT_6___
   ndes_scep_proxy:
     admin_url: https://some-ndes-admin-url.com
     password: ___GITOPS_COMMENT_4___
@@ -23,11 +27,11 @@ features:
   enable_host_users: true
   enable_software_inventory: true
   additional_queries:
-      time: "SELECT * FROM time"
-      macs: "SELECT mac FROM interface_details"
+    time: "SELECT * FROM time"
+    macs: "SELECT mac FROM interface_details"
   detail_query_overrides:
-      users:
-      mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
+    users:
+    mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
 fleet_desktop:
   transparency_url: https://fleetdm.com/transparency
 host_expiry_settings:
@@ -36,57 +40,57 @@ host_expiry_settings:
 integrations:
   conditional_access_enabled: true
   google_calendar:
-  - api_key_json:
-      owl: hoot
-      private_key: ___GITOPS_COMMENT_0___
-    domain: fleetdm.com
+    - api_key_json:
+        owl: hoot
+        private_key: ___GITOPS_COMMENT_0___
+      domain: fleetdm.com
   jira:
-  - api_token: ___GITOPS_COMMENT_1___
-    enable_failing_policies: false
-    enable_software_vulnerabilities: false
-    project_key: some-jira-project-key
-    url: https://some-jira-url.com
-    username: some-jira-username
+    - api_token: ___GITOPS_COMMENT_1___
+      enable_failing_policies: false
+      enable_software_vulnerabilities: false
+      project_key: some-jira-project-key
+      url: https://some-jira-url.com
+      username: some-jira-username
   zendesk:
-  - api_token: ___GITOPS_COMMENT_2___
-    email: some-zendesk-email@example.com
-    enable_failing_policies: false
-    enable_software_vulnerabilities: false
-    group_id: 123456789
-    url: https://some-zendesk-url.com
+    - api_token: ___GITOPS_COMMENT_2___
+      email: some-zendesk-email@example.com
+      enable_failing_policies: false
+      enable_software_vulnerabilities: false
+      group_id: 123456789
+      url: https://some-zendesk-url.com
 mdm:
   apple_business_manager:
-  - ios_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    ipados_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    macos_team: "\U0001F4BB Workstations"
-    organization_name: Fleet Device Management Inc.
+    - ios_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+      ipados_team: "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+      macos_team: "\U0001F4BB Workstations"
+      organization_name: Fleet Device Management Inc.
   apple_server_url: http://some-apple-server-url.com
   end_user_authentication:
     entity_id: some-mdm-entity-id.com
     idp_name: some-other-idp-name
     issuer_uri: https://some-mdm-issuer-uri.com
-    metadata: ___GITOPS_COMMENT_6___
-    metadata_url: ___GITOPS_COMMENT_7___
+    metadata: ___GITOPS_COMMENT_7___
+    metadata_url: ___GITOPS_COMMENT_8___
   end_user_license_agreement: ./lib/eula/test.pdf
   volume_purchasing_program:
-  - location: Fleet Device Management Inc.
-    teams:
-    - "\U0001F4BB Workstations"
-    - "\U0001F4BB\U0001F423 Workstations (canary)"
-    - "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
-    - "\U0001F4F1\U0001F510 Personal mobile devices"
+    - location: Fleet Device Management Inc.
+      teams:
+        - "\U0001F4BB Workstations"
+        - "\U0001F4BB\U0001F423 Workstations (canary)"
+        - "\U0001F4F1\U0001F3E2 Company-owned mobile devices"
+        - "\U0001F4F1\U0001F510 Personal mobile devices"
 org_info:
   contact_url: https://fleetdm.com/company/contact
   org_logo_url: http://some-org-logo-url.com
   org_logo_url_light_background: http://some-org-logo-url-light-background.com
   org_name: Fleet
 secrets:
-- secret: ___GITOPS_COMMENT_8___
+  - secret: ___GITOPS_COMMENT_9___
 server_settings:
   ai_features_disabled: false
   debug_host_ids:
-  - 1
-  - 3
+    - 1
+    - 3
   deferred_save_host: false
   enable_analytics: true
   live_query_disabled: false
@@ -101,8 +105,8 @@ sso_settings:
   entity_id: dogfood.fleetdm.com
   idp_image_url: http://some-sso-idp-image-url.com
   idp_name: some-idp-name
-  metadata: ___GITOPS_COMMENT_9___
-  metadata_url: ___GITOPS_COMMENT_10___
+  metadata: ___GITOPS_COMMENT_10___
+  metadata_url: ___GITOPS_COMMENT_11___
   sso_server_url: https://sso.fleetdm.com
 webhook_settings:
   activities_webhook:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -62,6 +62,10 @@ org_settings:
       profile_id: some-digicert-profile-id
       url: https://some-digicert-url.com
     hydrant:
+    - client_id: some-hydrant-client-id
+      client_secret: # TODO: Add your Hydrant client secret here
+      name: some-hydrant-name
+      url: https://some-hydrant-url.com
     ndes_scep_proxy:
       admin_url: https://some-ndes-admin-url.com
       password: # TODO: Add your NDES SCEP proxy password here
@@ -165,7 +169,7 @@ policies:
   critical: false
   description: This is a global policy
   install_software:
-    hash_sha256: ___GITOPS_COMMENT_11___
+    hash_sha256: ___GITOPS_COMMENT_12___
   labels_include_any:
   - Label A
   - Label B

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -47,6 +47,10 @@ org_settings:
       profile_id: some-digicert-profile-id
       url: https://some-digicert-url.com
     hydrant:
+    - client_id: some-hydrant-client-id
+      client_secret: # TODO: Add your Hydrant client secret here
+      name: some-hydrant-name
+      url: https://some-hydrant-url.com
     ndes_scep_proxy:
       admin_url: https://some-ndes-admin-url.com
       password: # TODO: Add your NDES SCEP proxy password here

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -211,7 +211,7 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 }
 
 type getCertificateAuthoritiesSpecRequest struct {
-	IncludeSecrets bool `json:"-" query:"include_secrets,optional"`
+	IncludeSecrets bool `query:"include_secrets,optional"`
 }
 
 type getCertificateAuthoritiesSpecResponse struct {


### PR DESCRIPTION
fixes: #32609 

Fixed the adding of TODO comment instead of masked secret `********`, but also saw the insecure flag was not working correctly to generate the actual secret values for CA's, which was due to wrongly formatted request struct parsing string.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
