### PR TITLE
HCA: lowercase error reason to avoid case sensitive string matching

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -171,22 +171,22 @@ const INVALID_CHALLENGE_ERROR =
  */
 export const getDisplayErrMessage = (err: unknown) => {
   let message: string | JSX.Element = DEFAULT_ERROR;
-  const reason = getErrorReason(err);
+  const reason = getErrorReason(err).toLowerCase();
 
-  if (reason.includes("invalid API token")) {
+  if (reason.includes("invalid api token")) {
     message = INVALID_API_TOKEN_ERROR;
-  } else if (reason.includes("invalid profile GUID")) {
+  } else if (reason.includes("invalid profile guid")) {
     message = INVALID_PROFILE_GUID_ERROR;
   } else if (
-    reason.includes("invalid URL") ||
+    reason.includes("invalid url") ||
     reason.includes("no such host")
   ) {
     message = INVALID_URL_ERROR;
   } else if (reason.includes("private key")) {
     message = PRIVATE_KEY_NOT_CONFIGURED_ERROR;
-  } else if (reason.includes("invalid SCEP URL")) {
+  } else if (reason.includes("invalid scep url")) {
     message = INVALID_SCEP_URL_ERROR;
-  } else if (reason.includes("invalid admin URL or credentials")) {
+  } else if (reason.includes("invalid admin url or credentials")) {
     message = INVALID_ADMIN_URL_OR_CREDENTIALS_ERROR;
   } else if (reason.includes("password cache is full")) {
     message = NDES_PASSWORD_CACHE_FULL_ERROR;


### PR DESCRIPTION
fixes: #32612 

It was due to case sensitive matching, and it might have changed, so decided to lowercase the reason coming in and only user lowercase for `.includes` checks.

<img width="820" height="593" alt="image" src="https://github.com/user-attachments/assets/df7eae54-9d3c-4b4c-bd9a-7b8297482158" />

- [x] QA'd all new/changed functionality manually