### PR TITLE
HCA: add dirty state to CA forms and backend validation for empty update payload

### DIFF
--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -866,6 +866,10 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 	var caActivityName string
 
 	if p.DigiCertCAUpdatePayload != nil {
+		if p.DigiCertCAUpdatePayload.IsEmpty() {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%sDigiCert CA update payload is empty", errPrefix)}
+		}
+
 		if err := p.DigiCertCAUpdatePayload.ValidateRelatedFields(errPrefix, *oldCA.Name); err != nil {
 			return err
 		}
@@ -890,6 +894,10 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 		activity = fleet.ActivityEditedDigiCert{Name: caActivityName}
 	}
 	if p.HydrantCAUpdatePayload != nil {
+		if p.HydrantCAUpdatePayload.IsEmpty() {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%sHydrant CA update payload is empty", errPrefix)}
+		}
+
 		if err := p.HydrantCAUpdatePayload.ValidateRelatedFields(errPrefix, *oldCA.Name); err != nil {
 			return err
 		}
@@ -910,6 +918,10 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 		activity = fleet.ActivityEditedHydrant{Name: caActivityName}
 	}
 	if p.NDESSCEPProxyCAUpdatePayload != nil {
+		if p.NDESSCEPProxyCAUpdatePayload.IsEmpty() {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%sNDES SCEP Proxy CA update payload is empty", errPrefix)}
+		}
+
 		if err := p.NDESSCEPProxyCAUpdatePayload.ValidateRelatedFields(errPrefix, *oldCA.Name); err != nil {
 			return err
 		}
@@ -930,6 +942,10 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 		activity = fleet.ActivityEditedNDESSCEPProxy{}
 	}
 	if p.CustomSCEPProxyCAUpdatePayload != nil {
+		if p.CustomSCEPProxyCAUpdatePayload.IsEmpty() {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%sCustom SCEP Proxy CA update payload is empty", errPrefix)}
+		}
+
 		if err := p.CustomSCEPProxyCAUpdatePayload.ValidateRelatedFields(errPrefix, *oldCA.Name); err != nil {
 			return err
 		}

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1009,6 +1009,17 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 		require.EqualError(t, err, "Couldn't edit certificate authority. Certificate authority with ID 999 does not exist.")
 	})
 
+	t.Run("Errors on empty inner update payload", func(t *testing.T) {
+		svc, ctx := baseSetupForCATests()
+
+		payload := fleet.CertificateAuthorityUpdatePayload{
+			DigiCertCAUpdatePayload: &fleet.DigiCertCAUpdatePayload{},
+		}
+
+		err := svc.UpdateCertificateAuthority(ctx, digicertID, payload)
+		require.EqualError(t, err, "Couldn't edit certificate authority. DigiCert CA update payload is empty")
+	})
+
 	t.Run("Errors on wrong existing CA type", func(t *testing.T) {
 		svc, ctx := baseSetupForCATests()
 

--- a/ee/server/service/certificate_authorities_test.go
+++ b/ee/server/service/certificate_authorities_test.go
@@ -1011,13 +1011,26 @@ func TestUpdatingCertificateAuthorities(t *testing.T) {
 
 	t.Run("Errors on empty inner update payload", func(t *testing.T) {
 		svc, ctx := baseSetupForCATests()
-
-		payload := fleet.CertificateAuthorityUpdatePayload{
-			DigiCertCAUpdatePayload: &fleet.DigiCertCAUpdatePayload{},
+		payloadMap := map[uint]fleet.CertificateAuthorityUpdatePayload{
+			digicertID: {
+				DigiCertCAUpdatePayload: &fleet.DigiCertCAUpdatePayload{},
+			},
+			hydrantID: {
+				HydrantCAUpdatePayload: &fleet.HydrantCAUpdatePayload{},
+			},
+			scepID: {
+				CustomSCEPProxyCAUpdatePayload: &fleet.CustomSCEPProxyCAUpdatePayload{},
+			},
+			ndesID: {
+				NDESSCEPProxyCAUpdatePayload: &fleet.NDESSCEPProxyCAUpdatePayload{},
+			},
 		}
 
-		err := svc.UpdateCertificateAuthority(ctx, digicertID, payload)
-		require.EqualError(t, err, "Couldn't edit certificate authority. DigiCert CA update payload is empty")
+		for id, payload := range payloadMap {
+
+			err := svc.UpdateCertificateAuthority(ctx, id, payload)
+			require.Contains(t, err.Error(), "update payload is empty")
+		}
 	})
 
 	t.Run("Errors on wrong existing CA type", func(t *testing.T) {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
@@ -40,7 +40,11 @@ describe("CustomSCEPForm", () => {
       />
     );
 
-    // data is valid, submit should be enabled
+    // data is valid, but no changes have been made so submit should be disabled
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Name is valid and now changed so submit should be enabled
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -61,5 +65,24 @@ describe("CustomSCEPForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("has submit disabled when no changes have been made", async () => {
+    const { user } = renderWithSetup(
+      <CustomSCEPForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Update a field
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
@@ -40,11 +40,7 @@ describe("CustomSCEPForm", () => {
       />
     );
 
-    // data is valid, but no changes have been made so submit should be disabled
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-
-    // Name is valid and now changed so submit should be enabled
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    // data is valid, so submit should be enabled
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -67,12 +63,13 @@ describe("CustomSCEPForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("has submit disabled when no changes have been made", async () => {
-    const { user } = renderWithSetup(
+  it("submit button is disabled if isDirty is false", async () => {
+    render(
       <CustomSCEPForm
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
+        isDirty={false}
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}
@@ -80,9 +77,21 @@ describe("CustomSCEPForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
 
-    // Update a field
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+  it("submit button is enabled if isDirty", async () => {
+    render(
+      <CustomSCEPForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        isDirty={true}
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
@@ -63,7 +63,7 @@ describe("CustomSCEPForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is disabled if isDirty is false", async () => {
+  it("submit button is disabled if isDirty is false", () => {
     render(
       <CustomSCEPForm
         formData={createTestFormData()}
@@ -79,7 +79,7 @@ describe("CustomSCEPForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is enabled if isDirty", async () => {
+  it("submit button is enabled if isDirty", () => {
     render(
       <CustomSCEPForm
         formData={createTestFormData()}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tests.tsx
@@ -85,7 +85,7 @@ describe("CustomSCEPForm", () => {
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
-        isDirty={true}
+        isDirty
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
@@ -27,6 +27,7 @@ interface ICustomSCEPFormProps {
   submitBtnText: string;
   isSubmitting: boolean;
   isEditing?: boolean;
+  isDirty?: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -38,11 +39,11 @@ const CustomSCEPForm = ({
   submitBtnText,
   isSubmitting,
   isEditing = false,
+  isDirty = true,
   onChange,
   onSubmit,
   onCancel,
 }: ICustomSCEPFormProps) => {
-  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -69,7 +70,6 @@ const CustomSCEPForm = ({
       )
     );
     onChange(update);
-    setIsDirty(true);
   };
 
   return (

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/CustomSCEPForm.tsx
@@ -42,6 +42,7 @@ const CustomSCEPForm = ({
   onSubmit,
   onCancel,
 }: ICustomSCEPFormProps) => {
+  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -68,6 +69,7 @@ const CustomSCEPForm = ({
       )
     );
     onChange(update);
+    setIsDirty(true);
   };
 
   return (
@@ -113,7 +115,7 @@ const CustomSCEPForm = ({
           <Button
             type="submit"
             isLoading={isSubmitting}
-            disabled={!formValidation.isValid || isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting || !isDirty}
           >
             {submitBtnText}
           </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
@@ -89,7 +89,7 @@ describe("DigicertForm", () => {
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
-        isDirty={true}
+        isDirty
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
@@ -44,7 +44,11 @@ describe("DigicertForm", () => {
       />
     );
 
-    // data is valid, submit should be enabled
+    // data is valid, but no changes have been made so submit should be disabled
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Name is valid and now changed so submit should be enabled
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -65,5 +69,24 @@ describe("DigicertForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("has submit disabled when no changes have been made", async () => {
+    const { user } = renderWithSetup(
+      <DigicertForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Update a field
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
@@ -67,7 +67,7 @@ describe("DigicertForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is disabled if isDirty is false", async () => {
+  it("submit button is disabled if isDirty is false", () => {
     render(
       <DigicertForm
         formData={createTestFormData()}
@@ -83,7 +83,7 @@ describe("DigicertForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is enabled if isDirty", async () => {
+  it("submit button is enabled if isDirty", () => {
     render(
       <DigicertForm
         formData={createTestFormData()}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tests.tsx
@@ -44,11 +44,7 @@ describe("DigicertForm", () => {
       />
     );
 
-    // data is valid, but no changes have been made so submit should be disabled
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-
-    // Name is valid and now changed so submit should be enabled
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    // data is valid, so submit should be enabled
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -71,12 +67,13 @@ describe("DigicertForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("has submit disabled when no changes have been made", async () => {
-    const { user } = renderWithSetup(
+  it("submit button is disabled if isDirty is false", async () => {
+    render(
       <DigicertForm
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
+        isDirty={false}
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}
@@ -84,9 +81,21 @@ describe("DigicertForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
 
-    // Update a field
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+  it("submit button is enabled if isDirty", async () => {
+    render(
+      <DigicertForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        isDirty={true}
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -46,6 +46,7 @@ const DigicertForm = ({
   onSubmit,
   onCancel,
 }: IDigicertFormProps) => {
+  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -78,6 +79,7 @@ const DigicertForm = ({
       )
     );
     onChange(update);
+    setIsDirty(true);
   };
 
   return (
@@ -166,7 +168,7 @@ const DigicertForm = ({
         >
           <Button
             isLoading={isSubmitting}
-            disabled={!formValidation.isValid || isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting || !isDirty}
             type="submit"
           >
             {submitBtnText}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/DigicertForm.tsx
@@ -31,6 +31,7 @@ interface IDigicertFormProps {
   submitBtnText: string;
   isSubmitting: boolean;
   isEditing?: boolean;
+  isDirty?: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -42,11 +43,11 @@ const DigicertForm = ({
   submitBtnText,
   isSubmitting,
   isEditing = false,
+  isDirty = true,
   onChange,
   onSubmit,
   onCancel,
 }: IDigicertFormProps) => {
-  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -79,7 +80,6 @@ const DigicertForm = ({
       )
     );
     onChange(update);
-    setIsDirty(true);
   };
 
   return (

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
@@ -36,6 +36,7 @@ const EditCertAuthorityModal = ({
 }: IEditCertAuthorityModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const [isUpdating, setIsUpdating] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
   const [formData, setFormData] = useState<ICertFormData | undefined>();
 
   const { data: fullCertAuthority, isLoading, isError } = useQuery(
@@ -55,6 +56,8 @@ const EditCertAuthorityModal = ({
       if (!prevFormData) return prevFormData;
       return updateFormData(fullCertAuthority, prevFormData, update);
     });
+
+    setIsDirty(true);
   };
 
   const onEditCertAuthority = async () => {
@@ -111,6 +114,7 @@ const EditCertAuthorityModal = ({
         submitBtnText="Save"
         isSubmitting={isUpdating}
         isEditing
+        isDirty={isDirty}
         onChange={onChangeForm}
         onSubmit={onEditCertAuthority}
         onCancel={onExit}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
@@ -86,7 +86,7 @@ describe("HydrantForm", () => {
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
-        isDirty={true}
+        isDirty
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
@@ -64,7 +64,7 @@ describe("HydrantForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is disabled if isDirty is false", async () => {
+  it("submit button is disabled if isDirty is false", () => {
     render(
       <HydrantForm
         formData={createTestFormData()}
@@ -80,7 +80,7 @@ describe("HydrantForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is enabled if isDirty", async () => {
+  it("submit button is enabled if isDirty", () => {
     render(
       <HydrantForm
         formData={createTestFormData()}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
@@ -41,7 +41,11 @@ describe("HydrantForm", () => {
       />
     );
 
-    // data is valid, submit should be enabled
+    // data is valid, but no changes have been made so submit should be disabled
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // name is valid and now changed so submit should be enabled
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -62,5 +66,24 @@ describe("HydrantForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("has submit disabled when no changes have been made", async () => {
+    const { user } = renderWithSetup(
+      <HydrantForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Update a field
+    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tests.tsx
@@ -41,11 +41,7 @@ describe("HydrantForm", () => {
       />
     );
 
-    // data is valid, but no changes have been made so submit should be disabled
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-
-    // name is valid and now changed so submit should be enabled
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+    // data is valid, so submit should be enabled
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // name input is invalidated, submit should be disabled
@@ -68,12 +64,13 @@ describe("HydrantForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("has submit disabled when no changes have been made", async () => {
-    const { user } = renderWithSetup(
+  it("submit button is disabled if isDirty is false", async () => {
+    render(
       <HydrantForm
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
+        isDirty={false}
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}
@@ -81,9 +78,21 @@ describe("HydrantForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
 
-    // Update a field
-    await user.type(screen.getByLabelText("Name"), "Updated_Name");
+  it("submit button is enabled if isDirty", async () => {
+    render(
+      <HydrantForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        isDirty={true}
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
@@ -42,6 +42,7 @@ const HydrantForm = ({
   onSubmit,
   onCancel,
 }: IHydrantFormProps) => {
+  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -66,6 +67,7 @@ const HydrantForm = ({
       )
     );
     onChange(update);
+    setIsDirty(true);
   };
 
   return (
@@ -118,7 +120,7 @@ const HydrantForm = ({
         >
           <Button
             isLoading={isSubmitting}
-            disabled={!formValidation.isValid || isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting || !isDirty}
             type="submit"
           >
             {submitBtnText}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/HydrantForm.tsx
@@ -27,6 +27,7 @@ interface IHydrantFormProps {
   submitBtnText: string;
   isSubmitting: boolean;
   isEditing?: boolean;
+  isDirty?: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -38,11 +39,11 @@ const HydrantForm = ({
   submitBtnText,
   isSubmitting,
   isEditing = false,
+  isDirty = true,
   onChange,
   onSubmit,
   onCancel,
 }: IHydrantFormProps) => {
-  const [isDirty, setIsDirty] = useState(false);
   const validations = useMemo(
     () => generateFormValidations(certAuthorities ?? [], isEditing),
     [certAuthorities, isEditing]
@@ -67,7 +68,6 @@ const HydrantForm = ({
       )
     );
     onChange(update);
-    setIsDirty(true);
   };
 
   return (

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
@@ -41,11 +41,7 @@ describe("NDESForm", () => {
       />
     );
 
-    // data is valid, but no changes have been made so submit should be disabled
-    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
-
-    // scepURL is valid and now changed so submit should be enabled
-    await user.type(screen.getByLabelText("SCEP URL"), "https://updated.com");
+    // data is valid, so submit should be enabled
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
     // scepURL input is invalidated, submit should be disabled
@@ -68,12 +64,13 @@ describe("NDESForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("has submit disabled when no changes have been made", async () => {
-    const { user } = renderWithSetup(
+  it("submit button is disabled if isDirty is false", async () => {
+    render(
       <NDESForm
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
+        isDirty={false}
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}
@@ -81,9 +78,21 @@ describe("NDESForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
 
-    // Update a field
-    await user.type(screen.getByLabelText("SCEP URL"), "https://updated.com");
+  it("submit button is enabled if isDirty", async () => {
+    render(
+      <NDESForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        isDirty={true}
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
@@ -64,7 +64,7 @@ describe("NDESForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is disabled if isDirty is false", async () => {
+  it("submit button is disabled if isDirty is false", () => {
     render(
       <NDESForm
         formData={createTestFormData()}
@@ -80,7 +80,7 @@ describe("NDESForm", () => {
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
 
-  it("submit button is enabled if isDirty", async () => {
+  it("submit button is enabled if isDirty", () => {
     render(
       <NDESForm
         formData={createTestFormData()}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
@@ -86,7 +86,7 @@ describe("NDESForm", () => {
         formData={createTestFormData()}
         isSubmitting={false}
         submitBtnText="Submit"
-        isDirty={true}
+        isDirty
         onChange={noop}
         onSubmit={noop}
         onCancel={noop}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tests.tsx
@@ -41,10 +41,14 @@ describe("NDESForm", () => {
       />
     );
 
-    // data is valid, submit should be enabled
+    // data is valid, but no changes have been made so submit should be disabled
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // scepURL is valid and now changed so submit should be enabled
+    await user.type(screen.getByLabelText("SCEP URL"), "https://updated.com");
     expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
 
-    // name input is invalidated, submit should be disabled
+    // scepURL input is invalidated, submit should be disabled
     await user.clear(screen.getByLabelText("SCEP URL"));
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
   });
@@ -62,5 +66,24 @@ describe("NDESForm", () => {
     );
 
     expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+  });
+
+  it("has submit disabled when no changes have been made", async () => {
+    const { user } = renderWithSetup(
+      <NDESForm
+        formData={createTestFormData()}
+        isSubmitting={false}
+        submitBtnText="Submit"
+        onChange={noop}
+        onSubmit={noop}
+        onCancel={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Submit" })).toBeDisabled();
+
+    // Update a field
+    await user.type(screen.getByLabelText("SCEP URL"), "https://updated.com");
+    expect(screen.getByRole("button", { name: "Submit" })).toBeEnabled();
   });
 });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -35,6 +35,7 @@ const NDESForm = ({
   onSubmit,
   onCancel,
 }: INDESFormProps) => {
+  const [isDirty, setIsDirty] = useState(false);
   const [formValidation, setFormValidation] = useState<INDESFormValidation>(
     () => validateFormData(formData)
   );
@@ -51,6 +52,7 @@ const NDESForm = ({
       validateFormData({ ...formData, [update.name]: update.value })
     );
     onChange(update);
+    setIsDirty(true);
   };
 
   return (
@@ -107,7 +109,7 @@ const NDESForm = ({
           <Button
             type="submit"
             isLoading={isSubmitting}
-            disabled={!formValidation.isValid || isSubmitting}
+            disabled={!formValidation.isValid || isSubmitting || !isDirty}
           >
             {submitBtnText}
           </Button>

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -21,6 +21,7 @@ interface INDESFormProps {
   submitBtnText: string;
   isSubmitting: boolean;
   isEditing?: boolean;
+  isDirty?: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;
   onCancel: () => void;
@@ -31,11 +32,11 @@ const NDESForm = ({
   submitBtnText,
   isSubmitting,
   isEditing = false,
+  isDirty = true,
   onChange,
   onSubmit,
   onCancel,
 }: INDESFormProps) => {
-  const [isDirty, setIsDirty] = useState(false);
   const [formValidation, setFormValidation] = useState<INDESFormValidation>(
     () => validateFormData(formData)
   );
@@ -52,7 +53,6 @@ const NDESForm = ({
       validateFormData({ ...formData, [update.name]: update.value })
     );
     onChange(update);
-    setIsDirty(true);
   };
 
   return (

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -207,6 +207,13 @@ type DigiCertCAUpdatePayload struct {
 	CertificateSeatID             *string   `json:"certificate_seat_id"`
 }
 
+// IsEmpty checks if the struct only has all empty values
+func (dcp DigiCertCAUpdatePayload) IsEmpty() bool {
+	return dcp.Name == nil && dcp.URL == nil && dcp.APIToken == nil &&
+		dcp.ProfileID == nil && dcp.CertificateCommonName == nil &&
+		dcp.CertificateUserPrincipalNames == nil && dcp.CertificateSeatID == nil
+}
+
 // ValidateRelatedFields verifies that fields that are related to each other are set correctly.
 // For example if the URL is provided then the API token must also be provided.
 func (dcp *DigiCertCAUpdatePayload) ValidateRelatedFields(errPrefix string, certName string) error {
@@ -234,6 +241,11 @@ type NDESSCEPProxyCAUpdatePayload struct {
 	AdminURL *string `json:"admin_url"`
 	Username *string `json:"username"`
 	Password *string `json:"password"`
+}
+
+// IsEmpty checks if the struct only has all empty values
+func (ndesp *NDESSCEPProxyCAUpdatePayload) IsEmpty() bool {
+	return ndesp.URL == nil && ndesp.AdminURL == nil && ndesp.Username == nil && ndesp.Password == nil
 }
 
 // ValidateRelatedFields verifies that fields that are related to each other are set correctly.
@@ -264,6 +276,11 @@ type CustomSCEPProxyCAUpdatePayload struct {
 	Challenge *string `json:"challenge"`
 }
 
+// IsEmpty checks if the struct only has all empty values
+func (cscepp CustomSCEPProxyCAUpdatePayload) IsEmpty() bool {
+	return cscepp.Name == nil && cscepp.URL == nil && cscepp.Challenge == nil
+}
+
 // ValidateRelatedFields verifies that fields that are related to each other are set correctly.
 // For example if the Name is provided then the Challenge must also be provided.
 func (cscepp *CustomSCEPProxyCAUpdatePayload) ValidateRelatedFields(errPrefix string, certName string) error {
@@ -288,6 +305,11 @@ type HydrantCAUpdatePayload struct {
 	URL          *string `json:"url"`
 	ClientID     *string `json:"client_id"`
 	ClientSecret *string `json:"client_secret"`
+}
+
+// IsEmpty checks if the struct only has all empty values
+func (hp HydrantCAUpdatePayload) IsEmpty() bool {
+	return hp.Name == nil && hp.URL == nil && hp.ClientID == nil && hp.ClientSecret == nil
 }
 
 // ValidateRelatedFields verifies that fields that are related to each other are set correctly.


### PR DESCRIPTION
fixes: #32608 

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
