### PR TITLE
dont close delete modal if deletion fails

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DeleteCertificateAuthorityModal/DeleteCertificateAuthorityModal.tsx
@@ -29,14 +29,15 @@ const DeleteCertificateAuthorityModal = ({
         "success",
         "Successfully deleted your certificate authority."
       );
+      setIsUpdating(false);
+      onExit();
     } catch (e) {
+      setIsUpdating(false);
       renderFlash(
         "error",
         "Couldn't delete certificate authority. Please try again."
       );
     }
-    setIsUpdating(false);
-    onExit();
   };
 
   return (


### PR DESCRIPTION
fixes #32614

quick fix to keep showing the delete certificate authority modal if there is an error when deleting 

- [x] QA'd all new/changed functionality manually

