### PR TITLE
add user scope icon to os profiles

### DIFF
--- a/changes/issue-31166-add-user-icon-to-profiles
+++ b/changes/issue-31166-add-user-icon-to-profiles
@@ -1,0 +1,2 @@
+- add user icon to os settings custom profiles on host details page if they are user scoped
+

--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -18,6 +18,8 @@ const DEFAULT_HOST_PROFILE_MOCK: IHostMdmProfile = {
   platform: "darwin",
   status: "verified",
   detail: "This is verified",
+  scope: "device",
+  managed_local_account: "",
 };
 
 export const createMockHostMdmProfile = (

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
@@ -59,4 +59,8 @@
     align-items: center;
     flex-shrink: 0; /* Prevent suffix from shrinking */
   }
+
+  .__react_component_tooltip {
+    font-size: $xx-small;
+  }
 }

--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -167,6 +167,7 @@ export type MdmDDMProfileStatus =
   | "acknowledged";
 
 export type ProfileOperationType = "remove" | "install";
+export type ProfileScope = "device" | "user";
 
 export interface IHostMdmProfile {
   profile_uuid: string;
@@ -175,6 +176,8 @@ export interface IHostMdmProfile {
   platform: ProfilePlatform;
   status: MdmProfileStatus | MdmDDMProfileStatus | LinuxDiskEncryptionStatus;
   detail: string;
+  scope: ProfileScope | null;
+  managed_local_account: string | null;
 }
 
 // TODO - move disk encryption related types to dedicated file

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/_styles.scss
@@ -14,6 +14,7 @@
 
   .__react_component_tooltip {
     white-space: normal;
+    font-size: $xx-small;
   }
 
   &__status-text {

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/OSSettingsNameCell.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+import { ProfileScope } from "interfaces/mdm";
+
+import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
+import Icon from "components/Icon";
+import TooltipWrapper from "components/TooltipWrapper";
+
+const baseClass = "os-settings-name-cell";
+
+interface IOSSettingsNameCellProps {
+  profileName: string;
+  scope: ProfileScope | null;
+  managedAccount: string | null;
+}
+
+const OSSettingsNameCell = ({
+  profileName,
+  scope,
+  managedAccount,
+}: IOSSettingsNameCellProps) => {
+  return (
+    <div className={baseClass}>
+      <TooltipTruncatedTextCell
+        value={profileName}
+        className={`${baseClass}__name-tooltip`}
+      />
+      {scope === "user" && (
+        <TooltipWrapper
+          className={`${baseClass}__scope-tooltip`}
+          tipContent={
+            <>
+              Scoped to local user account:
+              <br />
+              <b>{managedAccount}</b>
+            </>
+          }
+          position="top"
+          underline={false}
+          showArrow
+        >
+          <Icon name="user" />
+        </TooltipWrapper>
+      )}
+    </div>
+  );
+};
+
+export default OSSettingsNameCell;

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/_styles.scss
@@ -1,0 +1,14 @@
+.os-settings-name-cell {
+  display: flex;
+  gap: $pad-small;
+
+  &__scope-tooltip {
+    text-align: center;
+  }
+}
+
+// need to do some overrides here to get the tooltip to be the right size
+.data-table-block .data-table tbody td .os-settings-name-cell__name-tooltip {
+  max-width: 142px;
+  min-width: auto;
+}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/_styles.scss
@@ -7,7 +7,7 @@
   }
 }
 
-// need to do some overrides here to get the tooltip to be the right size
+// need to do some overrides here to get the name text content to be the right size
 .data-table-block .data-table tbody td .os-settings-name-cell__name-tooltip {
   max-width: 142px;
   min-width: auto;

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/index.ts
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsNameCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./OSSettingsNameCell";

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -13,13 +13,14 @@ import {
   isWindowsDiskEncryptionStatus,
 } from "interfaces/mdm";
 
-import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
+import OSSettingsNameCell from "./OSSettingsNameCell";
 import OSSettingStatusCell from "./OSSettingStatusCell";
+import OSSettingsErrorCell from "./OSSettingsErrorCell";
+
 import {
   generateLinuxDiskEncryptionSetting,
   generateWinDiskEncryptionSetting,
 } from "../../helpers";
-import OSSettingsErrorCell from "./OSSettingsErrorCell";
 
 export interface IHostMdmProfileWithAddedStatus
   extends Omit<IHostMdmProfile, "status"> {
@@ -50,9 +51,10 @@ const generateTableConfig = (
       accessor: "name",
       Cell: (cellProps: ITableStringCellProps) => {
         return (
-          <TooltipTruncatedTextCell
-            value={cellProps.cell.value}
-            className="os-settings-name-cell"
+          <OSSettingsNameCell
+            profileName={cellProps.cell.value}
+            scope={cellProps.row.original.scope}
+            managedAccount={cellProps.row.original.managed_local_account}
           />
         );
       },

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -8,8 +8,7 @@
     }
     tbody td {
       .os-settings-name-cell {
-        width: 135px;
-        max-width: none;
+        max-width: 166px;
       }
       .os-settings-status-cell {
         width: 200px;

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -41,6 +41,8 @@ export const generateWinDiskEncryptionSetting = (
     status: convertWinDiskEncryptionStatusToSettingStatus(diskEncryptionStatus),
     detail: generateWindowsDiskEncryptionMessage(diskEncryptionStatus, detail),
     operation_type: null,
+    scope: null,
+    managed_local_account: null,
   };
 };
 
@@ -61,6 +63,8 @@ export const generateLinuxDiskEncryptionSetting = (
     status: diskEncryptionStatus,
     detail,
     operation_type: null,
+    scope: null,
+    managed_local_account: null,
   };
 };
 


### PR DESCRIPTION
resolves #31166

This adds a user icon and tooltip if the custom profile is user scoped

<img width="236" height="114" alt="image" src="https://github.com/user-attachments/assets/be8e241d-6f70-40dc-808d-625245eb771f" />


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually

