### PR TITLE
Fix testBatchScriptSchedule() flakiness in server/datastore/mysql/scripts_test.go

### DIFF
--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2195,7 +2195,7 @@ func testBatchScriptSchedule(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	scheduledTime := time.Now().Add(10 * time.Hour).UTC()
+	scheduledTime := time.Now().Add(10 * time.Hour).Truncate(time.Second).UTC()
 	execID, err := ds.BatchScheduleScript(ctx, &user.ID, script.ID, []uint{host1.ID, host2.ID, host3.ID}, scheduledTime)
 	require.NoError(t, err)
 	require.NotEmpty(t, execID)


### PR DESCRIPTION
Fixes #32648 

It looks like we don't specify a precision for the jobs table so mysql does us the un-favor of rounding the timestamp in such a way that if it's 59 and some change it might get rounded to the next minute after the roundtrip and truncation to minute. Fixed the test's expectations by rounding to second before DB insertion

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
