### PR TITLE
Add Android MDM profiles to host details API response

### DIFF
--- a/changes/25557-android-profiles
+++ b/changes/25557-android-profiles
@@ -1,0 +1,2 @@
+- Added Android MDM profiles to host details API response.
+- Added activity logging for Android profile creation, modification, and deletion.

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -685,9 +685,10 @@ host_uuid = ? AND NOT (operation_type = '%s' AND COALESCE(status, '%s') IN('%s',
 		fleet.MDMDeliveryVerifying,
 		fleet.MDMDeliveryVerified,
 	)
+	args := []interface{}{hostUUID}
 
 	var profiles []fleet.HostMDMAndroidProfile
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, args...); err != nil {
 		return nil, err
 	}
 	return profiles, nil

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -33,6 +33,7 @@ func TestAndroid(t *testing.T) {
 		{"GetMDMAndroidConfigProfile", testGetMDMAndroidConfigProfile},
 		{"DeleteMDMAndroidConfigProfile", testDeleteMDMAndroidConfigProfile},
 		{"GetMDMAndroidProfilesSummary", testMDMAndroidProfilesSummary},
+		{"GetHostMDMAndroidProfiles", testGetHostMDMAndroidProfiles},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -722,6 +723,86 @@ func testMDMAndroidProfilesSummary(t *testing.T, ds *Datastore) {
 
 		cleanupTables(t)
 	})
+}
+
+func testGetHostMDMAndroidProfiles(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	// Create a host
+	host := createAndroidHost("host-mdm-profiles-test")
+	newHost, err := ds.NewAndroidHost(ctx, host)
+	require.NoError(t, err)
+	require.NotNil(t, newHost)
+
+	// No profiles initially
+	profiles, err := ds.GetHostMDMAndroidProfiles(ctx, newHost.UUID)
+	require.NoError(t, err)
+	require.Empty(t, profiles)
+
+	// Create some profiles
+	profile1 := androidProfileForTest("profile1")
+	profile1, err = ds.NewMDMAndroidConfigProfile(ctx, *profile1)
+	require.NoError(t, err)
+	require.NotNil(t, profile1)
+
+	profile2 := androidProfileForTest("profile2")
+	profile2, err = ds.NewMDMAndroidConfigProfile(ctx, *profile2)
+	require.NoError(t, err)
+	require.NotNil(t, profile2)
+
+	profile3 := androidProfileForTest("profile3")
+	profile3, err = ds.NewMDMAndroidConfigProfile(ctx, *profile3)
+	require.NoError(t, err)
+	require.NotNil(t, profile3)
+
+	// Assign profiles to host with different statuses
+	upsertAndroidHostProfileStatus(t, ds, newHost.UUID, profile1.ProfileUUID, &fleet.MDMDeliveryVerified)
+	upsertAndroidHostProfileStatus(t, ds, newHost.UUID, profile2.ProfileUUID, &fleet.MDMDeliveryPending)
+	upsertAndroidHostProfileStatus(t, ds, newHost.UUID, profile3.ProfileUUID, nil)
+
+	// Retrieve host profiles
+	profiles, err = ds.GetHostMDMAndroidProfiles(ctx, newHost.UUID)
+	require.NoError(t, err)
+	require.Len(t, profiles, 3)
+	byProfileUUID := make(map[string]fleet.HostMDMAndroidProfile)
+	for _, p := range profiles {
+		require.NotNil(t, p.Status)
+		byProfileUUID[p.ProfileUUID] = p
+	}
+	require.Len(t, byProfileUUID, 3)
+	require.Equal(t, fleet.MDMDeliveryVerified, *byProfileUUID[profile1.ProfileUUID].Status)
+	require.Equal(t, fleet.MDMDeliveryPending, *byProfileUUID[profile2.ProfileUUID].Status)
+	require.Equal(t, fleet.MDMDeliveryPending, *byProfileUUID[profile3.ProfileUUID].Status)
+
+	// Change status of two profiles
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		// delivery failed
+		_, err := q.ExecContext(ctx, `UPDATE host_mdm_android_profiles SET status = ? WHERE host_uuid = ? AND profile_uuid = ?`,
+			fleet.MDMDeliveryFailed, newHost.UUID, profile2.ProfileUUID)
+		require.NoError(t, err)
+		// removal verifying
+		_, err = q.ExecContext(ctx, `UPDATE host_mdm_android_profiles SET operation_type = ?, status = ? WHERE host_uuid = ? AND profile_uuid = ?`,
+			fleet.MDMOperationTypeRemove, fleet.MDMDeliveryVerifying, newHost.UUID, profile3.ProfileUUID)
+		return err
+	})
+
+	// Retrieve host profiles
+	profiles, err = ds.GetHostMDMAndroidProfiles(ctx, newHost.UUID)
+	require.NoError(t, err)
+	require.Len(t, profiles, 2) // verifying removal profile not returned
+	byProfileUUID = make(map[string]fleet.HostMDMAndroidProfile)
+	for _, p := range profiles {
+		require.NotNil(t, p.Status)
+		byProfileUUID[p.ProfileUUID] = p
+	}
+	require.Len(t, byProfileUUID, 2)
+	require.Equal(t, fleet.MDMDeliveryVerified, *byProfileUUID[profile1.ProfileUUID].Status)
+	require.Equal(t, fleet.MDMDeliveryFailed, *byProfileUUID[profile2.ProfileUUID].Status)
+
+	// Non-existent host returns empty slice
+	profiles, err = ds.GetHostMDMAndroidProfiles(ctx, "non-existent-uuid")
+	require.NoError(t, err)
+	require.Empty(t, profiles)
 }
 
 // TODO Is there a better way to create an android profile for test(i.e. better keys to set)?

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -86,3 +86,27 @@ type MDMAndroidPolicyRequest struct {
 	AppliedPolicyVersion sql.Null[int64]  `db:"applied_policy_version"`
 	PolicyVersion        sql.Null[int64]  `db:"policy_version"`
 }
+
+// HostMDMAndroidProfile represents the status of an MDM profile for a Android host.
+type HostMDMAndroidProfile struct {
+	HostUUID      string             `db:"host_uuid" json:"host_uuid"`
+	RequestUUID   string             `db:"request_uuid" json:"request_uuid"`
+	ProfileUUID   string             `db:"profile_uuid" json:"profile_uuid"`
+	Name          string             `db:"name" json:"name"`
+	Status        *MDMDeliveryStatus `db:"status" json:"status"`
+	OperationType MDMOperationType   `db:"operation_type" json:"operation_type"`
+	Detail        string             `db:"detail" json:"detail"`
+}
+
+func (p HostMDMAndroidProfile) ToHostMDMProfile() HostMDMProfile {
+	return HostMDMProfile{
+		HostUUID:      p.HostUUID,
+		ProfileUUID:   p.ProfileUUID,
+		Name:          p.Name,
+		Identifier:    "",
+		Status:        p.Status,
+		OperationType: p.OperationType,
+		Detail:        p.Detail,
+		Platform:      "android",
+	}
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2229,6 +2229,9 @@ type Datastore interface {
 	// assigned to any team).
 	GetMDMAndroidProfilesSummary(ctx context.Context, teamID *uint) (*MDMProfilesSummary, error)
 
+	// GetHostMDMAndroidProfiles retrieves the Android MDM profiles for a specific host.
+	GetHostMDMAndroidProfiles(ctx context.Context, hostUUID string) ([]HostMDMAndroidProfile, error)
+
 	// NewAndroidPolicyRequest saves details about a new Android AMAPI request.
 	NewAndroidPolicyRequest(ctx context.Context, req *MDMAndroidPolicyRequest) error
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1425,6 +1425,8 @@ type DeleteMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID str
 
 type GetMDMAndroidProfilesSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error)
 
+type GetHostMDMAndroidProfilesFunc func(ctx context.Context, hostUUID string) ([]fleet.HostMDMAndroidProfile, error)
+
 type NewAndroidPolicyRequestFunc func(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error
 
 type CreateScimUserFunc func(ctx context.Context, user *fleet.ScimUser) (uint, error)
@@ -3592,6 +3594,9 @@ type DataStore struct {
 
 	GetMDMAndroidProfilesSummaryFunc        GetMDMAndroidProfilesSummaryFunc
 	GetMDMAndroidProfilesSummaryFuncInvoked bool
+
+	GetHostMDMAndroidProfilesFunc        GetHostMDMAndroidProfilesFunc
+	GetHostMDMAndroidProfilesFuncInvoked bool
 
 	NewAndroidPolicyRequestFunc        NewAndroidPolicyRequestFunc
 	NewAndroidPolicyRequestFuncInvoked bool
@@ -8597,6 +8602,13 @@ func (s *DataStore) GetMDMAndroidProfilesSummary(ctx context.Context, teamID *ui
 	s.GetMDMAndroidProfilesSummaryFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetMDMAndroidProfilesSummaryFunc(ctx, teamID)
+}
+
+func (s *DataStore) GetHostMDMAndroidProfiles(ctx context.Context, hostUUID string) ([]fleet.HostMDMAndroidProfile, error) {
+	s.mu.Lock()
+	s.GetHostMDMAndroidProfilesFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostMDMAndroidProfilesFunc(ctx, hostUUID)
 }
 
 func (s *DataStore) NewAndroidPolicyRequest(ctx context.Context, req *fleet.MDMAndroidPolicyRequest) error {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1299,8 +1299,6 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				profs = []fleet.HostMDMAndroidProfile{}
 			}
 			for _, p := range profs {
-				// TODO(AP): confirm whether we need to add special messages for Android here or if
-				// we can count on the detail being formatted for the API by the pub/sub handlers
 				p.Detail = fleet.HostMDMProfileDetail(p.Detail).Message()
 				profiles = append(profiles, p.ToHostMDMProfile())
 			}


### PR DESCRIPTION
Resolves #32039 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)


## Testing

- [ ] Added/updated automated tests -> TODO: Tests will be added after backend is updated to record host profile statuses for Android
- [ ] QA'd all new/changed functionality manually -> TODO: QA will be performed after backend is updated to record host profile statuses for Android

