### PR TITLE
Fix formatting for clarity

### DIFF
--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -229,10 +229,10 @@ To map users from Google Workspace to hosts in Fleet, we'll do the following ste
 10. For the **Group Property Mappings**, remove all selected properties by clicking the "X" icon, and select all group properties that we created in the left box and select the ">" icon between boxes.
 ![authentik LDAP user property mappings](../website/assets/images/articles/authentik-group-ldap-attributes-custom-mappings-960x270@2x.png)
 11. Under **Additional settings**, enter values below:
-- **User object filter** > `(objectClass=person)`
-- **Group object filter** > `(objectClass= groupOfNames)`
-- **Group membership field** > `member`
-- **Object uniqueness field** > `objectSid`  
+    - **User object filter** > `(objectClass=person)`
+    - **Group object filter** > `(objectClass= groupOfNames)`
+    - **Group membership field** > `member`
+    - **Object uniqueness field** > `objectSid`  
 12. Select **Finish** to save your configuration. 
 13. After a few minutes, on the **Directory > Users** page, you should see users from your Google Workspace.
 

--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -229,7 +229,10 @@ To map users from Google Workspace to hosts in Fleet, we'll do the following ste
 10. For the **Group Property Mappings**, remove all selected properties by clicking the "X" icon, and select all group properties that we created in the left box and select the ">" icon between boxes.
 ![authentik LDAP user property mappings](../website/assets/images/articles/authentik-group-ldap-attributes-custom-mappings-960x270@2x.png)
 11. Under **Additional settings**, enter values below:
-**User object filter** > `(objectClass=person)`,  **Group object filter** > `(objectClass= groupOfNames)`, **Group membership field** > `member`, **Object uniqueness field** > `objectSid`
+- **User object filter** > `(objectClass=person)`
+- **Group object filter** > `(objectClass= groupOfNames)`
+- **Group membership field** > `member`
+- **Object uniqueness field** > `objectSid`  
 12. Select **Finish** to save your configuration. 
 13. After a few minutes, on the **Directory > Users** page, you should see users from your Google Workspace.
 


### PR DESCRIPTION
Trying to get lines 12 and 13 to appear on their own lines, instead of as a continuation of the previous paragraph as show in the screen shot. For bonus points, putting each value in step 11 on its own line for clarity.

<img width="762" height="196" alt="Screenshot 2025-09-05 at 11 24 29 AM" src="https://github.com/user-attachments/assets/dd357130-b996-480e-9a58-b594c30c5049" />
