### PR TITLE
Orbit shell no longer ignores disable-updates

### DIFF
--- a/orbit/changes/32514-orbit-shell-ignores-updates-disabled
+++ b/orbit/changes/32514-orbit-shell-ignores-updates-disabled
@@ -1,0 +1,1 @@
+* Fixed issue with `orbit shell` ignoring disable updates flag.


### PR DESCRIPTION
For #32514

Fixed issue that caused orbit shell to ignore the 'disable-updates' flag.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] Verified that fleetd runs on macOS, Linux and Windows
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
