### PR TITLE
Update fleetctl and log destinations guide

### DIFF
--- a/articles/fleetctl.md
+++ b/articles/fleetctl.md
@@ -1,8 +1,8 @@
-# fleetctl
+# Fleetctl
 
-fleetctl (pronounced "Fleet control") is a command line interface (CLI) tool for managing Fleet from the command line. fleetctl enables a GitOps workflow with Fleet.
+Fleetctl (pronounced "Fleet control") is a command line interface (CLI) tool for managing Fleet from the command line. Fleetctl enables a GitOps workflow with Fleet.
 
-fleetctl also provides a quick way to work with all the data exposed by Fleet without having to use the Fleet UI or work directly with the Fleet API.
+Fleetctl also provides a quick way to work with all the data exposed by Fleet without having to use the Fleet UI or work directly with the Fleet API.
 
 <div purpose="embedded-content">
    <iframe src="https://www.youtube.com/embed/ERbknt6w8eg" allowfullscreen></iframe>
@@ -22,24 +22,13 @@ Alternatively, and for Windows and Linux, you can download the fleectl binary fr
 
 Double-click the `tar.gz` or `zip` file to extract the binary. To run fleetctl commands, use the binary's path (`/path/to/fleetctl`). For convenience, copy or move the binary to a directory in your `$PATH` (ex: `/usr/local/bin`). This allows you to execute fleetctl without specifying its location.
 
-> To generate `fleetd` packages to enroll hosts, you may need [additional dependencies](https://fleetdm.com/guides/enroll-hosts#cli), depending on both your operating system and the OS you're packaging `fleetd` for.
-
 ### Upgrading fleetctl
 
 If you used npm to install fleetctl, fleetctl will update itself the next time you run it.
 
 You can also install the latest version of the binary from [GitHub](https://github.com/fleetdm/fleet/releases).
 
-
 ## Usage
-
-
-### Available commands
-
-
-Much of the functionality available in the Fleet UI is also available in fleetctl. You can run queries, add and remove users, generate Fleet's agent (fleetd) to add new hosts, get information about existing hosts, and more!
-
-> Unless a [log destination](https://fleetdm.com/guides/log-destinations) is configured, osquery logs will be stored locally on each device.
 
 To see the available commands you can run:
 
@@ -47,32 +36,10 @@ To see the available commands you can run:
 > fleetctl --help
 ```
 
-### Get more info about a command
-
 Each command has a help menu with additional information. To pull up the help menu, run `fleetctl <command> --help`, replacing `<command>` with the command you're looking up:
 
 ```sh
 > fleetctl setup --help
-```
-
-You will see more info about the command, including the usage and information about any additional commands and options (or 'flags'):
-
-```sh
-NAME:
-   fleetctl setup - Set up a Fleet instance
-
-USAGE:
-   fleetctl setup [options]
-
-OPTIONS:
-   --email value     Email of the admin user to create (required) [$EMAIL]
-   --name value      Name or nickname of the admin user to create (required) [$NAME]
-   --password value  Password for the admin user (recommended to use interactive entry) [$PASSWORD]
-   --org-name value  Name of the organization (required) [$ORG_NAME]
-   --config value    Path to the fleetctl config file (default: "/Users/ksatter/.fleet/config") [$CONFIG]
-   --context value   Name of fleetctl config context to use (default: "default") [$CONTEXT]
-   --debug           Enable debug http request logging (default: false) [$DEBUG]
-   --help, -h        show help (default: false)
 ```
 
 ## Authentication
@@ -104,7 +71,7 @@ Once your local context is configured, you can use fleetctl normally.
 
 #### Users with single sign-on (SSO) or email two-factor authentication (2FA)
 
-Users that log into Fleet with SSO or email 2FA can't log in with `fleetctl login`. Instead they can retrieve their API token from the UI and manually set it in their fleetctl configuration (instead of logging in via `fleetctl login`).
+Users that log into Fleet with SSO or email 2FA can't log in with `fleetctl login`. Instead, the best practice is to retrieve their API token from the UI and manually set it in their fleetctl configuration (instead of logging in via `fleetctl login`).
 
 **Fleet UI:**
 1. Go to the **My account** page (https://fleet.example.com/profile)
@@ -120,15 +87,15 @@ contexts:
 ```
 4. Now you're ready to run `fleetctl` commands!
 
-The token can also be set with `fleetctl config set --token`, but this may leak the token into a user's shell history.
+> The token can also be set with `fleetctl config set --token`, but this may leak the token into a user's shell history.
 
-## Using fleetctl with an API-only user
+### Using fleetctl with an API-only user
 
 When running automated workflows using the Fleet API, we recommend using an API-only user's API key rather than a regular user's API key. A regular user's API key expires frequently for security purposes, requiring routine updates. Meanwhile, an API-only user's key does not expire.   
 
 An API-only user does not have access to the Fleet UI. Instead, it's only purpose is to interact with the API programmatically or from fleetctl.
 
-### Create API-only user
+#### Create API-only user
 
 Before creating the API-only user, log in to fleetctl as an admin.  See [authentication](#authentication) above for details.
 
@@ -187,9 +154,11 @@ Password:
 
 Running a command with no context will use the default profile.
 
-## Debugging Fleet
+## Advanced
 
-fleetctl provides debugging capabilities about the running Fleet server via the `debug` command. To see a complete list of all the options, run:
+### Debugging Fleet
+
+Fleetctl provides debugging capabilities about the running Fleet server via the `debug` command. To see a complete list of all the options, run:
 
 ```sh
 fleetctl debug --help
@@ -211,5 +180,5 @@ This will generate a `tar.gz` file with:
 <meta name="authorGitHubUsername" value="noahtalerman">
 <meta name="authorFullName" value="Noah Talerman">
 <meta name="publishedOn" value="2024-07-04">
-<meta name="articleTitle" value="fleetctl">
+<meta name="articleTitle" value="Fleetctl">
 <meta name="description" value="Read about fleetctl, a CLI tool for managing Fleet and osquery configurations, running queries, generating Fleet's agent (fleetd), and more.">

--- a/articles/log-destinations.md
+++ b/articles/log-destinations.md
@@ -7,7 +7,7 @@ Log destinations can be used in Fleet to log:
 
 By default, logs are stored in the local filesystem on each host.
 
-To configure an external log destination, you must set the correct logging configuration options in Fleet. Currently, only self-managed users and customers can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
+To configure an external log destination, you must set the correct logging configuration options in Fleet. Currently, only self-hosted users can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
 
 ## Amazon Kinesis Data Firehose
 

--- a/articles/log-destinations.md
+++ b/articles/log-destinations.md
@@ -1,35 +1,13 @@
 # Log destinations
 
 Log destinations can be used in Fleet to log:
-- Osquery [status logs](https://osquery.readthedocs.io/en/stable/deployment/logging/#status-logs).
+- Schedule query result logs
+- Fleet [audit logs](https://fleetdm.com/docs/using-fleet/audit-logs)
+- Satus logs from [osquery](https://osquery.readthedocs.io/en/stable/deployment/logging/#status-logs)
 
-- Osquery [schedule query result logs](https://osquery.readthedocs.io/en/stable/deployment/logging/#results-logs).
+By default, logs are stored in the local filesystem on each host.
 
-- Fleet [audit logs](https://fleetdm.com/docs/using-fleet/audit-logs).
-
-
-To configure each log destination, you must set the correct logging configuration options in Fleet.
-
-Check out the reference documentation for:
-  - [Osquery status logging configuration options](https://fleetdm.com/docs/deploying/configuration#osquery-status-log-plugin).
-  - [Osquery result logging configuration options](https://fleetdm.com/docs/deploying/configuration#osquery-result-log-plugin).
-  - [Activity audit logging configuration options](https://fleetdm.com/docs/deploying/configuration#activity_audit_log_plugin).
-
-This guide provides a list of the supported log destinations in Fleet.
-
-### In this guide:
-
-  - [Amazon Kinesis Data Firehose](#amazon-kinesis-data-firehose)
-  - [Webhook](#webhook)
-  - [Snowflake](#snowflake)
-  - [Splunk](#splunk)
-  - [Amazon Kinesis Data Streams](#amazon-kinesis-data-streams)
-  - [AWS Lambda](#aws-lambda)
-  - [Google Cloud Pub/Sub](#google-cloud-pubsub)
-  - [Apache Kafka](#apache-kafka)
-  - [Stdout](#stdout)
-  - [Filesystem](#filesystem)
-  - [Sending logs outside of Fleet](#sending-logs-outside-of-fleet)
+To configure an external log destination, you must set the correct logging configuration options in Fleet. Currently, only self-managed users and customers can modify this configuration. If you're a managed-cloud customer, please reach out to Fleet about modifying the configuration.
 
 ## Amazon Kinesis Data Firehose
 


### PR DESCRIPTION
- Capital "Fleetctl" at the start of a sentence: https://fleetdm.com/handbook/company/communications#capitalization-and-proper-nouns
- Move note about `filesysten` being the default log destination
- Add note that only self-hosted users being able to configure log destinations on their own
- Cut content
