### PR TITLE
In 4.74, remove experimental from certificate authorities (CAs) YAML and API

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -772,8 +772,6 @@ Can only be configured for all teams (`org_settings`). Use API to configure Jira
 
 ### certificate_authorities
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 This section lets you configure your certificate authorities (CA) to help your end users connect to Wi-Fi and VPN.
 
 #### Example
@@ -812,8 +810,6 @@ Can only be configured for all teams (`org_settings`). Use API to configure Zend
 
 #### digicert
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 - `name` is the name of certificate authority that will be used in variables in configuration profiles. Only letters, numbers, and underscores are allowed.
 - `url` is the URL to DigiCert One instance (default: `https://one.digicert.com`).
 - `api_token` is the token used to authenticate requests to DigiCert.
@@ -826,8 +822,6 @@ Can only be configured for all teams (`org_settings`).
 
 #### ndes_scep_proxy
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 - `url` is the URL of the NDES SCEP endpoint (default: `""`).
 - `admin_url` is the URL of the NDES admin endpoint (default: `""`).
 - `username` is the username of the NDES admin endpoint (default: `""`).
@@ -837,15 +831,11 @@ Can only be configured for all teams (`org_settings`).
 
 #### custom_scep_proxy
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 - `name` is the name of certificate authority that will be used in variables in configuration profiles. Only letters, numbers, and underscores are allowed.
 - `url` is the URL of the Simple Certificate Enrollment Protocol (SCEP) server.
 - `challenge` is the static challenge password used to authenticate requests to SCEP server.
 
 #### hydrant
-
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 - `name` is the name of the certificate authority. Only letters, numbers, and underscores are allowed.
 - `url` is the EST (Enrollment Over Secure Transport) endpoint provided by Hydrant.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -591,8 +591,6 @@ Returns a list of the activities that have been performed in Fleet. For a compre
 
 ### Add certificate authority (CA)
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 Connect Fleet to the certificate authority. Fleet currently supports [DigiCert](https://www.digicert.com/digicert-one), [Microsoft NDES](https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/network-device-enrollment-service-overview), [Hydrant](https://www.hidglobal.com/), and custom [SCEP](https://en.wikipedia.org/wiki/Simple_Certificate_Enrollment_Protocol) server.
 
 `POST /api/v1/fleet/certificate_authorities`
@@ -690,11 +688,9 @@ Object with the following structure:
 
 ### Edit certificate authority (CA)
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 `PATCH /api/v1/fleet/certificate_authorities/:id`
 
-> **Note:** When editing a CA, specify one object and only its fields that you want to update.
+When editing a CA, specify one object and only its fields that you want to update.
 
 #### Parameters
 
@@ -727,8 +723,6 @@ See [Add certificate authority](#add-certificate-authority-ca) above for the str
 `Status: 200`
 
 ### List certificate authorities (CAs)
-
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 `GET /api/v1/fleet/certificate_authorities`
 
@@ -774,8 +768,6 @@ See [Add certificate authority](#add-certificate-authority-ca) above for the str
 
 ### Get certificate authority (CA)
 
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
-
 Get details of the certificate authority.
 
 `GET /api/v1/fleet/certificate_authorities/:id`
@@ -811,8 +803,6 @@ Get details of the certificate authority.
 ```
 
 ### Delete certificate authority (CA)
-
-> **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 When the CA is deleted, the issued certificates will remain on existing hosts.
 


### PR DESCRIPTION
Why? We want customers to build on top of YAML / API. After we [break them in 4.74](https://github.com/fleetdm/confidential/issues/12133), let's commit to never breaking them outside of a major version.
