### PR TITLE
Update nudge-configuration.mobileconfig

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
@@ -46,7 +46,7 @@
 					<key>aboutUpdateURL</key>
 					<string>https://support.apple.com/en-us/120283</string>
 					<key>requiredMinimumOSVersion</key>
-					<string>latest-minor</string>
+					<string>15.6</string>
 					<key>targetedOSVersionsRule</key>
 					<string>15</string>
 				</dict>


### PR DESCRIPTION
- Changed to `15.6` from `latest-minor` to get Nudge deployed without alerting end users. 