### PR TITLE
Fleet UI: Surface timestamp VPP device user page, remove vpp acknowledged tooltip

### DIFF
--- a/changes/31297-installer-status-improvements
+++ b/changes/31297-installer-status-improvements
@@ -1,0 +1,1 @@
+* Fleet UI: Improved install action tooltips and modals including timestamps to VPP successful installs.

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -84,10 +84,9 @@ export const getStatusMessage = ({
             {" "}
             on {formattedHost} but couldn&apos;t because the host was locked or
             was running on battery power while in Power Nap
-            {displayTimeStamp && <> {displayTimeStamp}</>}
           </>
         )}
-        . Fleet will try again.
+        {displayTimeStamp && <> {displayTimeStamp}</>}. Fleet will try again.
       </>
     );
   }
@@ -121,15 +120,15 @@ export const getStatusMessage = ({
       <>
         The MDM command (request) to install <b>{appName}</b>
         {!isDUP && <> on {formattedHost}</>} failed
-        {!isDUP && displayTimeStamp && <> {displayTimeStamp}</>}. Please
-        re-attempt this installation.
+        {displayTimeStamp && <> {displayTimeStamp}</>}. Please re-attempt this
+        installation.
       </>
     );
   }
 
   const renderSuffix = () => {
     if (isDUP) {
-      return null;
+      return <> {displayTimeStamp && <> {displayTimeStamp}</>}</>;
     }
     return (
       <>

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -79,16 +79,12 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
         return undefined;
       }
 
-      return isAppStoreApp ? (
-        <>
-          The host acknowledged the MDM
-          <br />
-          command to install the app.
-        </>
-      ) : (
+      return (
         <>
           Software was installed{" "}
-          {!isSelfService && "(install script finished with exit code 0) "}
+          {!isSelfService &&
+            !isAppStoreApp &&
+            "(install script finished with exit code 0) "}
           {dateAgo(lastInstalledAt)}.
         </>
       );
@@ -497,6 +493,7 @@ const InstallStatusCell = ({
         position="top"
         className={`${baseClass}__tooltip-wrapper`}
         disableTooltip={!tooltipContent}
+        tipOffset={8}
       >
         {(isSelfService || isHostOnline) &&
         displayConfig.iconName === "pending-outline" ? (

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
@@ -1,6 +1,11 @@
 .install-status-cell {
   width: 142px; // Prevent status change from installer action from changing cell width while maintaining tooltip centering
 
+  .react-tooltip {
+    /* Move every tooltip 12px right to center over text only but tooltip still shows on both icon + text hover */
+    transform: translateX(12px);
+  }
+
   &__tooltip-wrapper {
     .component__tooltip-wrapper__element {
       display: flex;

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfServiceTableConfig.tsx
@@ -14,7 +14,7 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCel
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 import { ISWUninstallDetailsParentState } from "components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal";
 
-import InstallerStatusCell from "../InstallStatusCell/InstallStatusCell";
+import InstallStatusCell from "../InstallStatusCell/InstallStatusCell";
 import { installStatusSortType } from "../helpers";
 import HostInstallerActionCell from "../../HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell";
 
@@ -95,7 +95,7 @@ export const generateSoftwareTableHeaders = ({
       disableGlobalFilter: true,
       accessor: "ui_status",
       Cell: (cellProps: IStatusCellProps) => (
-        <InstallerStatusCell
+        <InstallStatusCell
           software={cellProps.row.original}
           onShowUpdateDetails={onShowUpdateDetails}
           onShowInstallDetails={onShowInstallDetails}


### PR DESCRIPTION
## Issue
Closes #31297 

## Description
- Removes installation acknowledge tooltip for installed by Fleet VPP apps
- Fix alignment of install status cell tooltip (8 px up to match other table tooltips, 12 px right to align tooltip over text and not over icon + text)
  - Note: I tried to use react-tooltip-5 built in to do horizontal alignment, but it was buggy and putting the tooltip to the top of the column, gave it a good 30 minutes trying to get it to work before settling on local fix of just CSS translation
- timestamp will display as long as BE provides vpp command result `.updated_at`
  
## Screenshot
Alignment screenrecording:
https://github.com/user-attachments/assets/a936a0b3-9547-41d4-9833-43ba492cccb3

Show timestamp on tooltip
<img width="697" height="359" alt="Screenshot 2025-09-08 at 1 11 51 PM" src="https://github.com/user-attachments/assets/04348270-4428-4b4c-9489-ef53b05e1aa1" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually
Everything QAed except I don't have a macOS connected to VPP so I can't confirm Device user page x install modal, but if updated_at is returned, it should show like host details page
