### PR TITLE
Fix GCS for remaining features that use S3

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -104,14 +104,17 @@ func applyDevFlags(cfg *config.FleetConfig) {
 		cfg.Prometheus.BasicAuth.Password = "insecure"
 	}
 
-	cfg.S3.CarvesBucket = "carves-dev"
-	cfg.S3.CarvesRegion = "minio"
-	cfg.S3.CarvesPrefix = "dev-prefix"
-	cfg.S3.CarvesEndpointURL = "http://localhost:9000"
-	cfg.S3.CarvesAccessKeyID = "minio"
-	cfg.S3.CarvesSecretAccessKey = "minio123!"
-	cfg.S3.CarvesDisableSSL = true
-	cfg.S3.CarvesForceS3PathStyle = true
+	// Allow the carves bucket to be overridden in dev mode
+	if cfg.S3.CarvesBucket == "" {
+		cfg.S3.CarvesBucket = "carves-dev"
+		cfg.S3.CarvesRegion = "minio"
+		cfg.S3.CarvesPrefix = "dev-prefix"
+		cfg.S3.CarvesEndpointURL = "http://localhost:9000"
+		cfg.S3.CarvesAccessKeyID = "minio"
+		cfg.S3.CarvesSecretAccessKey = "minio123!"
+		cfg.S3.CarvesDisableSSL = true
+		cfg.S3.CarvesForceS3PathStyle = true
+	}
 
 	// Allow the software installers bucket to be overridden in dev mode
 	if cfg.S3.SoftwareInstallersBucket == "" {

--- a/server/datastore/s3/bootstrap_package.go
+++ b/server/datastore/s3/bootstrap_package.go
@@ -20,6 +20,8 @@ func NewBootstrapPackageStore(config config.S3Config) (*BootstrapPackageStore, e
 			s3store:    s3store,
 			pathPrefix: bootstrapPackagePrefix,
 			fileLabel:  "bootstrap package",
+
+			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }

--- a/server/datastore/s3/common_file_store.go
+++ b/server/datastore/s3/common_file_store.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"path"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -36,6 +37,12 @@ type commonFileStore struct {
 	*s3store
 	pathPrefix string
 	fileLabel  string // how to call the file in error messages
+
+	gcs bool
+}
+
+func isGCS(endpointURL string) bool {
+	return strings.Contains(endpointURL, "storage.googleapis.com")
 }
 
 // Get retrieves the requested file from S3.
@@ -76,19 +83,17 @@ func (s *commonFileStore) Put(ctx context.Context, fileID string, content io.Rea
 		u.Concurrency = runtime.NumCPU()
 	})
 
-	// TODO: The `UploadOutput` is discarded currently. However, it does include
-	// checksums of the uploaded content which are calculated _server-side_. We
-	// could do something like:
-	// - Wrap the `context.Context` with a cancellation.
-	// - Wrap the `content` `ReadSeeker` in a `TeeReader`.
-	// - Feed the `TeeReader` to a `hash.Hasher` (probably SHA1).
-	// - Compare the `hash.Hasher` result to the `manager.UploadOutput` hash to
-	//   verify upload integrity, cancelling the context if the hashes don't match.
+	var checksumAlgorithm types.ChecksumAlgorithm
+	if s.gcs {
+		checksumAlgorithm = types.ChecksumAlgorithmCrc32c // Required for GCS
+	}
+
 	_, err := uploader.Upload(ctx, &s3.PutObjectInput{
-		Bucket:            &s.bucket,
-		Body:              content,
-		Key:               &key,
-		ChecksumAlgorithm: types.ChecksumAlgorithmCrc32c, // Required for GCS
+		Bucket: &s.bucket,
+		Body:   content,
+		Key:    &key,
+
+		ChecksumAlgorithm: checksumAlgorithm,
 	})
 
 	return err

--- a/server/datastore/s3/s3.go
+++ b/server/datastore/s3/s3.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
 	"github.com/fleetdm/fleet/v4/server/aws_common"
@@ -114,7 +113,7 @@ func newS3Store(cfg config.S3ConfigInternal) (*s3store, error) {
 		// Apply workaround if using Google Cloud Storage (GCS) endpoint
 		// This fixes signature issues with AWS SDK v2 when using GCS
 		// See: https://github.com/aws/aws-sdk-go-v2/issues/1816#issuecomment-1927281540
-		if cfg.EndpointURL != "" && strings.Contains(cfg.EndpointURL, "storage.googleapis.com") {
+		if cfg.EndpointURL != "" && isGCS(cfg.EndpointURL) {
 			// GCS alters the Accept-Encoding header which breaks the request signature
 			ignoreSigningHeaders(o, []string{"Accept-Encoding"})
 			// GCS also has issues with trailing checksums in UploadPart and PutObject operations

--- a/server/datastore/s3/software_installer.go
+++ b/server/datastore/s3/software_installer.go
@@ -21,6 +21,8 @@ func NewSoftwareInstallerStore(config config.S3Config) (*SoftwareInstallerStore,
 			s3store:    s3store,
 			pathPrefix: softwareInstallersPrefix,
 			fileLabel:  "software installer",
+
+			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }
@@ -40,6 +42,8 @@ func NewTestSoftwareInstallerStore(conf config.S3Config) (*SoftwareInstallerStor
 			s3store:    store,
 			pathPrefix: softwareInstallersPrefix,
 			fileLabel:  "software installer",
+
+			gcs: isGCS(conf.EndpointURL),
 		},
 	}, nil
 }

--- a/server/datastore/s3/software_title_icon.go
+++ b/server/datastore/s3/software_title_icon.go
@@ -19,6 +19,8 @@ func NewSoftwareTitleIconStore(config config.S3Config) (*SoftwareTitleIconStore,
 			s3store:    s3store,
 			pathPrefix: "software-title-icons",
 			fileLabel:  "software title icon",
+
+			gcs: isGCS(config.EndpointURL),
 		},
 	}, nil
 }

--- a/server/service/carves.go
+++ b/server/service/carves.go
@@ -293,7 +293,7 @@ func (svc *Service) CarveBlock(ctx context.Context, payload fleet.CarveBlockPayl
 
 	if err := svc.validateCarveBlock(payload, carve); err != nil {
 		carve.Error = ptr.String(err.Error())
-		if errRecord := svc.carveStore.UpdateCarve(ctx, carve); err != nil {
+		if errRecord := svc.carveStore.UpdateCarve(ctx, carve); errRecord != nil {
 			logging.WithExtras(ctx, "validate_carve_error", errRecord, "carve_id", carve.ID)
 		}
 
@@ -302,7 +302,7 @@ func (svc *Service) CarveBlock(ctx context.Context, payload fleet.CarveBlockPayl
 
 	if err := svc.carveStore.NewBlock(ctx, carve, payload.BlockId, payload.Data); err != nil {
 		carve.Error = ptr.String(err.Error())
-		if errRecord := svc.carveStore.UpdateCarve(ctx, carve); err != nil {
+		if errRecord := svc.carveStore.UpdateCarve(ctx, carve); errRecord != nil {
 			logging.WithExtras(ctx, "record_carve_error", errRecord, "carve_id", carve.ID)
 		}
 


### PR DESCRIPTION
For #32571.

Original PR from the community: https://github.com/fleetdm/fleet/pull/32573.

Changes on this PR:
- Only setting the checksum algorithm when using GCS as backend (to not break other S3 backends).
- Changes for carves, bootstrap packages, and software icons which also use S3.

## Testing

- [X] QA'd all new/changed functionality manually

```sh
FLEET_S3_SOFTWARE_INSTALLERS_BUCKET=some-software-installers-bucket \
FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID=... \
FLEET_S3_SOFTWARE_INSTALLERS_SECRET_ACCESS_KEY=... \
FLEET_S3_SOFTWARE_INSTALLERS_ENDPOINT_URL=https://storage.googleapis.com \
FLEET_S3_SOFTWARE_INSTALLERS_REGION=us \
FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE=true \
FLEET_S3_CARVES_BUCKET=some-carves-bucket \
FLEET_S3_CARVES_ACCESS_KEY_ID=... \
FLEET_S3_CARVES_SECRET_ACCESS_KEY=... \
FLEET_S3_CARVES_ENDPOINT_URL=https://storage.googleapis.com \
FLEET_S3_CARVES_REGION=us \
FLEET_S3_CARVES_FORCE_S3_PATH_STYLE=true \
./build/fleet serve --dev --dev_license --logging_debug 2>&1 | tee ~/fleet.txt
```