### PR TITLE
docs(conditional-access): clarify missing UI note for Fleet Cloud users

### DIFF
--- a/articles/entra-conditional-access-integration.md
+++ b/articles/entra-conditional-access-integration.md
@@ -38,6 +38,7 @@ To connect Fleet to your Entra account you need your "Microsoft Entra tenant ID"
 Once you have your tenant ID, in Fleet, head to **Settings > Integrations > Conditional access** and enter the tenant ID.
 
 ![Conditional access setup](../website/assets/images/articles/conditional-access-setup-554x250@2x.png)
+> **Note:** If you’re on **Fleet Cloud** and the **Conditional access** integration is missing, please [reach out to support](https://fleetdm.com/support).
 
 After clicking **Save** you will be redirected to https://login.microsoftonline.com to consent to the permissions for Fleet's multi-tenant application. 
 


### PR DESCRIPTION
- Added a note under Step 3 (Connect Fleet to Entra) to clarify what to do if the  "Conditional access" integration link is not visible.
- Explicitly instructs Fleet Cloud users to contact Fleet support if they don’t  see Settings → Integrations → Conditional access.