### PR TITLE
Updated golangci config to work in JetBrains IDE.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,7 +42,7 @@ linters-settings:
       - ruleguard
     settings:
       ruleguard:
-        rules: "./tools/ci/rules.go"
+        rules: "${configDir}/tools/ci/rules.go"
         failOn: all
 
   gofmt:


### PR DESCRIPTION
The special variable `configDir` is the directory of .golangci.yml

We are using v1 right now. When we upgrade to v2, `configDir` changes to `base-path`