### PR TITLE
Fixed duplicate enrolled macOS UUIDs/SNs

### DIFF
--- a/orbit/changes/32695-duplicate-macOS-hosts
+++ b/orbit/changes/32695-duplicate-macOS-hosts
@@ -1,1 +1,1 @@
-Fixed duplicate enrolled macOS UUID/SNs: for macOS, orbit saves hardware UUID to a file and forces a re-enrollment if the hardware UUID has changed.
+Fixed duplicate enrolled macOS UUIDs/SNs: for macOS, orbit saves hardware UUID to a file and forces a re-enrollment if the hardware UUID has changed. Existing duplicate hosts on the server are unaffected by this agent change.

--- a/orbit/changes/32695-duplicate-macOS-hosts
+++ b/orbit/changes/32695-duplicate-macOS-hosts
@@ -1,0 +1,1 @@
+Fixed duplicate enrolled macOS UUID/SNs: for macOS, orbit saves hardware UUID to a file and forces a re-enrollment if the hardware UUID has changed.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -796,7 +796,7 @@ func main() {
 				storedUUID = strings.TrimSpace(string(fileContent))
 			}
 
-			if oi.HardwareUUID != storedUUID {
+			if !strings.EqualFold(oi.HardwareUUID, storedUUID) {
 				// Then we have moved to a new physical machine, so we should restart!
 				log.Info().Str("stored_uuid", storedUUID).Str("current_uuid", oi.HardwareUUID).Msg("detected hardware migration")
 

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -762,7 +762,8 @@ func main() {
 			// Get the hardware UUID. We use a temporary osquery DB location in order to guarantee that
 			// we're getting true UUID, not a cached UUID. See
 			// https://github.com/fleetdm/fleet/issues/17934 and
-			// https://github.com/osquery/osquery/issues/7509 for more details.
+			// https://github.com/osquery/osquery/issues/7509 and
+			// https://github.com/fleetdm/fleet/issues/31934 for more details.
 
 			tmpDBPath := filepath.Join(os.TempDir(), strings.Join([]string{uuid.NewString(), "tmp-db"}, "-"))
 			oi, err := getHostInfo(osquerydPath, tmpDBPath)
@@ -774,8 +775,36 @@ func main() {
 				log.Info().Err(err).Msg("failed to remove temporary osquery db")
 			}
 
-			if oi.HardwareUUID != orbitHostInfo.HardwareUUID {
+			// Read the stored hardware UUID from file (if it exists)
+			hardwareUUIDFile := filepath.Join(c.String("root-dir"), constant.HardwareUUIDFileName)
+			var storedUUID string
+
+			fileContent, err := os.ReadFile(hardwareUUIDFile)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					// If there's an error other than file not existing, log it
+					log.Warn().Err(err).Msg("failed to read hardware UUID file")
+				}
+				// If file doesn't exist or can't be read, create it with the current UUID
+				if err := os.WriteFile(hardwareUUIDFile, []byte(oi.HardwareUUID), constant.DefaultFileMode); err != nil {
+					log.Error().Err(err).Msg("failed to write hardware UUID file")
+				} else {
+					log.Debug().Str("uuid", oi.HardwareUUID).Msg("created hardware UUID file")
+				}
+				storedUUID = oi.HardwareUUID
+			} else {
+				storedUUID = strings.TrimSpace(string(fileContent))
+			}
+
+			if oi.HardwareUUID != storedUUID {
 				// Then we have moved to a new physical machine, so we should restart!
+				log.Info().Str("stored_uuid", storedUUID).Str("current_uuid", oi.HardwareUUID).Msg("detected hardware migration")
+
+				// Remove the hardware UUID file so it gets recreated with the new UUID on restart
+				if err := os.RemoveAll(hardwareUUIDFile); err != nil {
+					return fmt.Errorf("removing old hardware UUID file: %w", err)
+				}
+
 				// Removing the osquery DB should trigger a re-enrollment when fleetd is restarted.
 				if err := os.RemoveAll(osqueryDB); err != nil {
 					return fmt.Errorf("removing old osquery.db: %w", err)

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -21,6 +21,8 @@ const (
 	DesktopTokenFileName = "identifier"
 	// OrbitNodeKeyFileName is the filename on disk where we write the orbit node key to
 	OrbitNodeKeyFileName = "secret-orbit-node-key.txt"
+	// HardwareUUIDFileName is the filename on disk where we store the hardware UUID for migration detection
+	HardwareUUIDFileName = "hardware-uuid.txt"
 	// OrbitEnrollMaxRetries is the max number of retries when doing an enroll request.
 	// We set it to 6 to allow the retry backoff to take effect.
 	OrbitEnrollMaxRetries = 6


### PR DESCRIPTION
Fixes #31934 

Manually QA'd using a Migration Assistant flow from one macOS VM to another.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * macOS: Prevents duplicate hosts by persisting the hardware UUID and triggering re-enrollment when it changes (e.g., after hardware migration or system restore). Improves reliability across restarts and cleans up legacy data during migration.

* **Documentation**
  * Added changelog entry noting the macOS-specific fix for duplicate enrolled hosts (UUID/SN).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->