### PR TITLE
Website: Update homepage logo carousel margin

### DIFF
--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -193,7 +193,7 @@
     padding-left: 60px;
     padding-right: 60px;
     margin-top: 24px;
-    margin-bottom: 64px;
+    margin-bottom: 48px;
     [parasails-component='logo-carousel'] {
       margin-bottom: 0px;
     }

--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -192,8 +192,8 @@
     max-width: 1200px;
     padding-left: 60px;
     padding-right: 60px;
-    margin-top: 24px;
-    margin-bottom: 48px;
+    margin-top: 64px;
+    margin-bottom: 64px;
     [parasails-component='logo-carousel'] {
       margin-bottom: 0px;
     }


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/12106

Changes:
- Updated the top margin on the homepage logo carousel (24px » 64px)