### PR TITLE
Do not allow positional arguments when running gitops

### DIFF
--- a/changes/32478-fleetctl-gitops-globs-ignore-dry-run
+++ b/changes/32478-fleetctl-gitops-globs-ignore-dry-run
@@ -1,1 +1,1 @@
-* Made sure gitops also looks for dry-run flag when passed as a positional argument.
+* Added check to gitops command to throw error if positional arguments are detected.

--- a/changes/32478-fleetctl-gitops-globs-ignore-dry-run
+++ b/changes/32478-fleetctl-gitops-globs-ignore-dry-run
@@ -1,0 +1,1 @@
+* Made sure gitops also looks for dry-run flag when passed as a positional argument.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -65,7 +65,7 @@ func gitopsCommand() *cli.Command {
 			}
 
 			if len(c.Args().Slice()) != 0 {
-				return errors.New("no positional arguments are allowed")
+				return errors.New("No positional arguments are allowed. To load multiple config files, use one -f flag per file.")
 			}
 
 			totalFilenames := len(flFilenames.Value())

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -64,13 +64,8 @@ func gitopsCommand() *cli.Command {
 				_, _ = fmt.Fprintf(c.App.Writer, format, a...)
 			}
 
-			// Make sure to capture the --dry-run flag in case it's passed as a positional argument
-			// which can happen when using glob patterns (e.g. -f my_dir/* --dry-run).
-			// We only want to do this for --dry-run due to its importance in preventing unwanted side effects.
-			for _, arg := range c.Args().Slice() {
-				if arg == "--dry-run" {
-					flDryRun = true
-				}
+			if len(c.Args().Slice()) != 0 {
+				return errors.New("no positional arguments are allowed")
 			}
 
 			totalFilenames := len(flFilenames.Value())


### PR DESCRIPTION
For #32478

Added check to gitops command to throw error if positional arguments are detected.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually