### PR TITLE
Added missing nil check for menuManager.SetConnected to avoid crash loops in Fleet Free

### DIFF
--- a/orbit/changes/32796-nil
+++ b/orbit/changes/32796-nil
@@ -1,0 +1,1 @@
+* Fixed a crash loop on Fleet Free when Fleet Desktop is enabled

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -268,7 +268,11 @@ func main() {
 					if err == nil || errors.Is(err, service.ErrMissingLicense) {
 						log.Debug().Msg("enabling tray items")
 						isFreeTier := errors.Is(err, service.ErrMissingLicense)
-						menuManager.SetConnected(&summary.DesktopSummary, isFreeTier)
+						var desktopSummary *fleet.DesktopSummary
+						if summary != nil {
+							desktopSummary = &summary.DesktopSummary
+						}
+						menuManager.SetConnected(desktopSummary, isFreeTier)
 
 						return
 					}


### PR DESCRIPTION
Fixes #32796.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [n/a] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
