### PR TITLE
Add IdP email to host vitals

### DIFF
--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -361,6 +361,7 @@ func testAndroidHostStorageData(t *testing.T, ds *Datastore) {
 }
 
 func testNewAndroidHostWithIdP(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
 	test.AddBuiltinLabels(t, ds)
 
 	// create IdP account... InsertMDMIdPAccount generates its own UUID
@@ -369,89 +370,59 @@ func testNewAndroidHostWithIdP(t *testing.T, ds *Datastore) {
 		Fullname: "John Doe",
 		Email:    "john.doe@example.com",
 	}
-	err := ds.InsertMDMIdPAccount(context.Background(), idpAccount)
+	err := ds.InsertMDMIdPAccount(ctx, idpAccount)
 	require.NoError(t, err)
 
 	// get the actual UUID that was generated
-	insertedAccount, err := ds.GetMDMIdPAccountByEmail(context.Background(), "john.doe@example.com")
+	insertedAccount, err := ds.GetMDMIdPAccountByEmail(ctx, "john.doe@example.com")
 	require.NoError(t, err)
 	require.NotNil(t, insertedAccount)
 	idpAccount.UUID = insertedAccount.UUID
 
 	// create Android host
 	const enterpriseSpecificID = "enterprise_with_idp"
-	host := &fleet.AndroidHost{
-		Host: &fleet.Host{
-			Hostname:       "hostname",
-			ComputerName:   "computer_name",
-			Platform:       "android",
-			OSVersion:      "Android 14",
-			Build:          "build",
-			Memory:         1024,
-			TeamID:         nil,
-			HardwareSerial: "hardware_serial",
-			CPUType:        "cpu_type",
-			HardwareModel:  "hardware_model",
-			HardwareVendor: "hardware_vendor",
-			UUID:           "test-host-uuid",
-		},
-		Device: &android.Device{
-			DeviceID:             "device_id",
-			EnterpriseSpecificID: ptr.String(enterpriseSpecificID),
-			AndroidPolicyID:      ptr.Uint(1),
-			LastPolicySyncTime:   ptr.Time(time.Now().UTC().Truncate(time.Millisecond)),
-		},
-	}
-	host.SetNodeKey(enterpriseSpecificID)
+	host := createAndroidHost(enterpriseSpecificID)
+	host.Host.UUID = "test-host-uuid" // Use a specific UUID for testing
 
-	result, err := ds.NewAndroidHost(context.Background(), host)
+	result, err := ds.NewAndroidHost(ctx, host)
 	require.NoError(t, err)
 	require.NotZero(t, result.Host.ID)
 
 	// associate host with IdP account, triggering reconciliation
-	err = ds.AssociateHostMDMIdPAccount(context.Background(), "test-host-uuid", idpAccount.UUID)
+	err = ds.AssociateHostMDMIdPAccount(ctx, "test-host-uuid", idpAccount.UUID)
 	require.NoError(t, err)
 
 	// host_emails table has IdP email
-	var emails []string
-	err = ds.writer(context.Background()).SelectContext(context.Background(), &emails,
-		`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
-		result.Host.ID, fleet.DeviceMappingMDMIdpAccounts)
+	emails, err := ds.GetHostEmails(ctx, "test-host-uuid", fleet.DeviceMappingMDMIdpAccounts)
 	require.NoError(t, err)
 	require.Len(t, emails, 1)
 	assert.Equal(t, "john.doe@example.com", emails[0])
 
 	// is reconciliation idempotent?
-	err = ds.AssociateHostMDMIdPAccount(context.Background(), "test-host-uuid", idpAccount.UUID)
+	err = ds.AssociateHostMDMIdPAccount(ctx, "test-host-uuid", idpAccount.UUID)
 	require.NoError(t, err)
 
 	// still only one email (no duplicates)
-	emails = nil
-	err = ds.writer(context.Background()).SelectContext(context.Background(), &emails,
-		`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
-		result.Host.ID, fleet.DeviceMappingMDMIdpAccounts)
+	emails, err = ds.GetHostEmails(ctx, "test-host-uuid", fleet.DeviceMappingMDMIdpAccounts)
 	require.NoError(t, err)
 	require.Len(t, emails, 1, "Should still have exactly one email after reassociation")
 	assert.Equal(t, "john.doe@example.com", emails[0])
 
 	// remove IdP account association and trigger reconciliation
-	_, err = ds.writer(context.Background()).ExecContext(context.Background(),
+	_, err = ds.writer(ctx).ExecContext(ctx,
 		`DELETE FROM host_mdm_idp_accounts WHERE host_uuid = ?`,
 		"test-host-uuid")
 	require.NoError(t, err)
 
 	// test cleanup (in production this would happen on re-enrollment)
-	err = ds.withRetryTxx(context.Background(), func(tx sqlx.ExtContext) error {
-		_, err := reconcileHostEmailsFromMdmIdpAccountsDB(context.Background(), tx, ds.logger, result.Host.ID)
+	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		_, err := reconcileHostEmailsFromMdmIdpAccountsDB(ctx, tx, ds.logger, result.Host.ID)
 		return err
 	})
 	require.NoError(t, err)
 
 	// host_emails table no longer has IdP email
-	emails = nil
-	err = ds.writer(context.Background()).SelectContext(context.Background(), &emails,
-		`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
-		result.Host.ID, fleet.DeviceMappingMDMIdpAccounts)
+	emails, err = ds.GetHostEmails(ctx, "test-host-uuid", fleet.DeviceMappingMDMIdpAccounts)
 	require.NoError(t, err)
 	require.Empty(t, emails, "IdP email should be removed when association is deleted")
 }

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7035,6 +7035,24 @@ func (ds *Datastore) AssociateHostMDMIdPAccount(ctx context.Context, hostUUID, i
 		if err := associateHostMDMIdPAccountDB(ctx, tx, hostUUID, idpAcctUUID); err != nil {
 			return ctxerr.Wrap(ctx, err, "associate host mdm idp account")
 		}
+
+		// get the host ID from the UUID to reconcile IdP accounts
+		var hostID uint
+		err := sqlx.GetContext(ctx, tx, &hostID, `SELECT id FROM hosts WHERE uuid = ?`, hostUUID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "get host ID for IdP reconciliation")
+		}
+
+		// reconcile IdP accounts after association is created
+		if hostID > 0 {
+			_, err = reconcileHostEmailsFromMdmIdpAccountsDB(ctx, tx, ds.logger, hostID)
+			if err != nil {
+				// log error but don't fail, matches Apple enrollment pattern
+				level.Error(ds.logger).Log("msg", "failed to reconcile IdP accounts after association",
+					"err", err, "host_id", hostID, "host_uuid", hostUUID)
+			}
+		}
+
 		return nil
 	})
 	return err
@@ -7098,140 +7116,6 @@ func getMDMAppleLegacyEnrollRefDB(ctx context.Context, tx sqlx.ExtContext, logge
 	}
 
 	return result, nil
-}
-
-func reconcileHostEmailsFromMdmIdpAccountsDB(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, hostID uint) (*fleet.MDMIdPAccount, error) {
-	idp, err := getMDMIdPAccountByHostID(ctx, tx, logger, hostID)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get host mdm idp account email")
-	}
-
-	var hostEmails []fleet.HostDeviceMapping
-	selectStmt := `SELECT id, host_id, email, source FROM host_emails WHERE host_id = ? AND source = ?`
-	if err := sqlx.SelectContext(ctx, tx, &hostEmails, selectStmt, hostID, fleet.DeviceMappingMDMIdpAccounts); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "get host_emails")
-	}
-
-	// TODO: discuss email vs. username with Victor
-	var idpEmail, idpAccountUUID string
-	if idp != nil {
-		idpEmail = idp.Email
-		idpAccountUUID = idp.UUID
-	}
-
-	// if we don't have idp info, we can just delete any prior host mdm idp account emails
-	if idpEmail == "" {
-		if len(hostEmails) == 0 {
-			// nothing to do
-			level.Info(logger).Log("msg", "reconcile host emails: no mdm idp account and no host emails", "host_id", hostID, "account_uuid", idpAccountUUID)
-			return nil, nil
-		}
-		// delete any prior host mdm idp account emails
-		delStmt := "DELETE FROM host_emails WHERE host_id = ? AND source = ?"
-		if _, err := tx.ExecContext(ctx, delStmt, hostID, fleet.DeviceMappingMDMIdpAccounts); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "delete host_emails")
-		}
-		return idp, nil
-	}
-
-	// analyze existing host emails to see if we have a match; we also want to handle potential
-	// duplicates because we don't have good constraints on the host_emails table
-	hits, misses := []fleet.HostDeviceMapping{}, []fleet.HostDeviceMapping{}
-	for _, he := range hostEmails {
-		if he.Email == idp.Email {
-			hits = append(hits, he)
-		} else {
-			misses = append(misses, he)
-		}
-	}
-
-	idsToDelete := []uint{}
-	if len(misses) > 0 {
-		// log the emails we'll be deleting
-		msg := "reconcile host emails: deleting emails"
-		for _, m := range misses {
-			idsToDelete = append(idsToDelete, m.ID)
-			msg += fmt.Sprintf(" %s", m.Email)
-		}
-		level.Info(logger).Log("msg", msg, "host_id", hostID)
-	}
-
-	var idToUpdate uint
-	if len(hits) > 0 {
-		// if we have more than one hit, we'll just update the first one
-		idToUpdate = hits[0].ID
-	}
-	if len(hits) > 1 {
-		// this should not happen, but if it does we want to know about it
-		level.Info(logger).Log("msg", "reconcile host emails: found duplicate mdm idp account host email", "host_id", hostID, "email", idp.Email, "account_uuid", idp.UUID)
-		for _, h := range hits[1:] {
-			idsToDelete = append(idsToDelete, h.ID) // we'll delete all but the first
-		}
-	}
-
-	if len(idsToDelete) > 0 {
-		// perform the delete
-		stmt, args, err := sqlx.In("DELETE FROM host_emails WHERE id IN (?)", idsToDelete)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "prepare delete host_emails arguments")
-		}
-		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "delete host_emails")
-		}
-	}
-
-	if idToUpdate != 0 {
-		// perform the update
-		level.Info(logger).Log("msg", "reconcile host emails: update host mdm idp account email", "host_id", hostID, "email", idpEmail)
-		updateStmt := "UPDATE host_emails SET email = ? WHERE id = ?"
-		if _, err := tx.ExecContext(ctx, updateStmt, idpEmail, idToUpdate); err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "update host_emails")
-		}
-		return idp, nil
-	}
-
-	// insert new email
-	level.Info(logger).Log("msg", "reconcile host emails: insert host mdm idp account email", "host_id", hostID, "email", idpEmail, "account_uuid", idp.UUID)
-	insStmt := "INSERT INTO host_emails (email, host_id, source) VALUES (?, ?, ?)"
-	if _, err := tx.ExecContext(ctx, insStmt, idpEmail, hostID, fleet.DeviceMappingMDMIdpAccounts); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "insert host_emails")
-	}
-
-	return idp, nil
-}
-
-func getMDMIdPAccountByHostID(ctx context.Context, q sqlx.QueryerContext, logger log.Logger, hostID uint) (*fleet.MDMIdPAccount, error) {
-	stmt := `SELECT account_uuid FROM host_mdm_idp_accounts WHERE host_uuid = (SELECT uuid FROM hosts WHERE id = ?)`
-	var dest []string
-	if err := sqlx.SelectContext(ctx, q, &dest, stmt, hostID); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "select host_mdm_idp_accounts")
-	}
-
-	var acctUUID string
-	switch {
-	case len(dest) == 0:
-		// TODO: consider falling back to the legacy enroll ref
-		level.Info(logger).Log("msg", "get host mdm idp accounts: no account found", "host_id", hostID)
-	default:
-		if len(dest) > 1 {
-			// this should not happen, but if it does we want to know about it
-			level.Info(logger).Log("msg", "get host mdm idp accounts: found multiple accounts", "host_id", hostID, "acct_uuids", fmt.Sprintf("%+v", dest))
-		}
-		acctUUID = dest[0]
-	}
-
-	var idp fleet.MDMIdPAccount
-	if acctUUID != "" {
-		stmt := `SELECT uuid, username, fullname, email FROM mdm_idp_accounts WHERE uuid = ?`
-		if err := sqlx.GetContext(ctx, q, &idp, stmt, acctUUID); err != nil {
-			if err == sql.ErrNoRows {
-				return nil, nil // TODO: maybe return a not found error?
-			}
-			return nil, ctxerr.Wrap(ctx, err, "get host mdm idp account")
-		}
-	}
-
-	return &idp, nil
 }
 
 func (ds *Datastore) GetMDMIdPAccountsByHostUUIDs(ctx context.Context, hostUUIDs []string) (map[string]*fleet.MDMIdPAccount, error) {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2227,7 +2227,11 @@ func reconcileHostEmailsFromMdmIdpAccountsDB(ctx context.Context, tx sqlx.ExtCon
 		}
 	}
 
-	idsToDelete := []uint{}
+	maxCapacity := len(misses)
+	if len(hits) > 1 {
+		maxCapacity += len(hits) - 1
+	}
+	idsToDelete := make([]uint, 0, maxCapacity)
 	if len(misses) > 0 {
 		// log the emails we'll be deleting
 		msg := "reconcile host emails: deleting emails"

--- a/server/datastore/mysql/mdm_idp_accounts_test.go
+++ b/server/datastore/mysql/mdm_idp_accounts_test.go
@@ -1,0 +1,178 @@
+package mysql
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMDMIdPAccountsReconciliation(t *testing.T) {
+	ds := CreateMySQLDS(t)
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"AssociateHostMDMIdPAccountTriggersReconciliation", testAssociateHostMDMIdPAccountTriggersReconciliation},
+		{"AndroidEnrollmentFlowWithIdP", testAndroidEnrollmentFlowWithIdP},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer TruncateTables(t, ds)
+			c.fn(t, ds)
+		})
+	}
+}
+
+// testAssociateHostMDMIdPAccountTriggersReconciliation verifies that calling AssociateHostMDMIdPAccount
+// triggers email reconciliation for ANY platform (our change that fixes Android IdP)
+func testAssociateHostMDMIdPAccountTriggersReconciliation(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	// Android and one Apple platform to verify cross-platform behavior
+	platforms := []struct {
+		name     string
+		platform string
+		uuid     string
+	}{
+		{"Android", "android", "android-host-uuid"},
+		{"macOS", "darwin", "macos-host-uuid"}, // Apple platforms
+	}
+
+	// create IdP account
+	idpAccount := &fleet.MDMIdPAccount{
+		Username: "test.user",
+		Fullname: "Test User",
+		Email:    "test.user@example.com",
+	}
+	err := ds.InsertMDMIdPAccount(ctx, idpAccount)
+	require.NoError(t, err)
+
+	// get the generated UUID
+	insertedAccount, err := ds.GetMDMIdPAccountByEmail(ctx, "test.user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, insertedAccount)
+	idpAccount.UUID = insertedAccount.UUID
+
+	for _, p := range platforms {
+		t.Run(p.name, func(t *testing.T) {
+			// Create host for this platform
+			host := &fleet.Host{
+				Hostname:      p.name + "-host",
+				UUID:          p.uuid,
+				Platform:      p.platform,
+				OSVersion:     "Test OS",
+				NodeKey:       ptr.String(p.uuid + "-key"),
+				OsqueryHostID: ptr.String(p.uuid + "-osquery"),
+			}
+
+			h, err := ds.NewHost(ctx, host)
+			require.NoError(t, err)
+			require.NotZero(t, h.ID)
+
+			// associate host with IdP account, should trigger reconciliation
+			err = ds.AssociateHostMDMIdPAccount(ctx, p.uuid, idpAccount.UUID)
+			require.NoError(t, err)
+
+			// host_emails table has IdP email
+			var emails []string
+			err = ds.writer(ctx).SelectContext(ctx, &emails,
+				`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
+				h.ID, fleet.DeviceMappingMDMIdpAccounts)
+			require.NoError(t, err)
+			require.Len(t, emails, 1, "Platform %s should have exactly one IdP email after association", p.name)
+			assert.Equal(t, "test.user@example.com", emails[0])
+
+			// calling again shouldn't create duplicates
+			err = ds.AssociateHostMDMIdPAccount(ctx, p.uuid, idpAccount.UUID)
+			require.NoError(t, err)
+
+			emails = nil
+			err = ds.writer(ctx).SelectContext(ctx, &emails,
+				`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
+				h.ID, fleet.DeviceMappingMDMIdpAccounts)
+			require.NoError(t, err)
+			require.Len(t, emails, 1, "Platform %s should still have exactly one IdP email after re-association", p.name)
+			assert.Equal(t, "test.user@example.com", emails[0])
+		})
+	}
+}
+
+// testAndroidEnrollmentFlowWithIdP tests the complete Android enrollment flow
+// as it happens in production: NewAndroidHost followed by AssociateHostMDMIdPAccount
+func testAndroidEnrollmentFlowWithIdP(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	// create IdP account (during SSO login)
+	idpAccount := &fleet.MDMIdPAccount{
+		Username: "android.user",
+		Fullname: "Android User",
+		Email:    "android.user@example.com",
+	}
+	err := ds.InsertMDMIdPAccount(ctx, idpAccount)
+	require.NoError(t, err)
+
+	insertedAccount, err := ds.GetMDMIdPAccountByEmail(ctx, "android.user@example.com")
+	require.NoError(t, err)
+	require.NotNil(t, insertedAccount)
+	idpAccount.UUID = insertedAccount.UUID
+
+	// simulate Android device enrollment
+	const enterpriseSpecificID = "android-device-001"
+	androidHost := &fleet.AndroidHost{
+		Host: &fleet.Host{
+			Hostname:       "Android Device",
+			ComputerName:   "Pixel 8",
+			Platform:       "android",
+			OSVersion:      "Android 14",
+			Build:          "UP1A.231005.007",
+			Memory:         8192,
+			HardwareSerial: "SERIAL123",
+			CPUType:        "arm64",
+			HardwareModel:  "Pixel 8",
+			HardwareVendor: "Google",
+			UUID:           "android-uuid-001",
+		},
+		Device: &android.Device{
+			DeviceID:             "device-001",
+			EnterpriseSpecificID: ptr.String(enterpriseSpecificID),
+		},
+	}
+	androidHost.SetNodeKey(enterpriseSpecificID)
+
+	// simulates enrollment call
+	result, err := ds.NewAndroidHost(ctx, androidHost)
+	require.NoError(t, err)
+	require.NotZero(t, result.Host.ID)
+
+	// no emails yet
+	var emails []string
+	err = ds.writer(ctx).SelectContext(ctx, &emails,
+		`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
+		result.Host.ID, fleet.DeviceMappingMDMIdpAccounts)
+	require.NoError(t, err)
+	require.Empty(t, emails, "No IdP emails should exist immediately after NewAndroidHost")
+
+	// associate with IdP account
+	err = ds.AssociateHostMDMIdPAccount(ctx, "android-uuid-001", idpAccount.UUID)
+	require.NoError(t, err)
+
+	// verify reconciliation happened
+	err = ds.writer(ctx).SelectContext(ctx, &emails,
+		`SELECT email FROM host_emails WHERE host_id = ? AND source = ?`,
+		result.Host.ID, fleet.DeviceMappingMDMIdpAccounts)
+	require.NoError(t, err)
+	require.Len(t, emails, 1)
+	assert.Equal(t, "android.user@example.com", emails[0])
+
+	// the host record (for username field in the future)
+	host, err := ds.Host(ctx, result.Host.ID)
+	require.NoError(t, err)
+	require.NotNil(t, host)
+	// N.b.: if/when username field is added to hosts table, verify it here
+}


### PR DESCRIPTION
Resolves #31464 (backend).

 ## Summary
 
 The reconciliation logic was consolidated and moved from Apple-specific code (`apple_mdm.go`) to shared MDM code (`mdm.go`), making it available to all platforms. The key insight here is that reconciliation should happen _after_ IdP association, not during host creation. This fixes Android and maintains backward compatibility for Apple devices.
  
  - Fixed Android IdP email reconciliation by moving it from `NewAndroidHost` to `AssociateHostMDMIdPAccount`
  - Resolved timing issue where reconciliation was attempted before IdP association existed
  - Made reconciliation consistent across all platforms (Android, iOS, iPadOS, macOS)
  - Added comprehensive tests for IdP email reconciliation flow

  ## Test plan
  - [x] Android IdP enrollment flow test passing
  - [x] Cross-platform IdP reconciliation test passing
  - [x] Existing Apple IdP tests still passing (no regressions)
  - [x] Android host enrollment with IdP verified
  - [x] Email deduplication (idempotency) confirmed
  - [x] Email cleanup on disassociation tested
  - [x] Builds passing
  
  ### Details

The PR makes these changes:

  #### Moves from apple_mdm.go to mdm.go:

  - The entire `reconcileHostEmailsFromMdmIdpAccountsDB` function
  - The helper function `getMDMIdPAccountByHostID`
  - Consolidation makes the function available to _all_ platforms, not just Apple

  #### Adds to `AssociateHostMDMIdPAccount`:

  - Adds reconciliation call here
  - Key fix... any platform that associates an IdP account gets reconciliation

 #### A problem:
 
  - Android tried to reconcile in `NewAndroidHost`, too early, I think, before IdP association existed
  - Apple had reconciliation in `MDMResetEnrollment`, which happens _after_ association
  - No reconciliation happened in `AssociateHostMDMIdPAccount`, which is the actual association point
