### PR TITLE
Improving Building Fleet guide.

### DIFF
--- a/docs/Contributing/getting-started/building-fleet.md
+++ b/docs/Contributing/getting-started/building-fleet.md
@@ -57,6 +57,8 @@ If you plan to use [WSL](https://learn.microsoft.com/en-us/windows/wsl/install) 
 
 ### Clone and build
 
+The following commands will clone the repository and build the Fleet and fleetctl binaries. When running these commands for the first time, please review the [Details](#details) section below for additional required dependencies.
+
 ```sh
 git clone https://github.com/fleetdm/fleet.git
 cd fleet
@@ -69,13 +71,14 @@ The binaries are now available in `./build/`.
 
 ### Details
 
-To set up a working local development environment, you must install the following minimum toolset:
+To set up a working local development environment, you must have the following toolset:
 
 * [Go](https://golang.org/doc/install)
 * [Node.js v20.18.1](https://nodejs.org/en/blog/release/v20.18.1) and [Yarn](https://yarnpkg.com/en/docs/install)
+  * A specific version of Node.js can be installed using [nvm](https://github.com/nvm-sh/nvm#install--update-script)
 * [GNU Make](https://www.gnu.org/software/make/) (probably already installed if you're on macOS/Linux)
 
-Once you have those minimum requirements, check out this [Loom video](https://www.loom.com/share/e7439f058eb44c45af872abe8f8de4a1) that walks through starting up a local development environment for Fleet.
+Once you have those requirements, check out this [Loom video](https://www.loom.com/share/e7439f058eb44c45af872abe8f8de4a1) that walks through starting up a local development environment for Fleet.
 
 For a text-based walkthrough, continue through the following steps:
 
@@ -107,7 +110,7 @@ To generate all necessary code (bundling JavaScript into Go, etc.), run the foll
 make generate
 ```
 
-If you are using a Mac computer with Apple Silicon and have not installed Rosetta 2, you will need to do so before running `make generate`.
+If you are using a Mac computer with Apple Silicon and have not installed Rosetta 2, you will need to do so before running `make generate`. Otherwise, you may see the following error: `Unknown system error -86`
 
 ```sh
 /usr/sbin/softwareupdate --install-rosetta --agree-to-license


### PR DESCRIPTION
Slight improvements after recent experience trying to build fleet on livestream.

The main issue is that the `Clone and build` section comes before the contributor has installed all the required tools/dependencies on their system.