### PR TITLE
Hide GitOps export info for icons in UI

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -103,7 +103,7 @@ export const renderDownloadFilesText = ({
       ),
     });
   }
-  if (iconUrl) {
+  /*if (iconUrl) {
     items.push({
       key: "icon-url",
       element: (
@@ -112,7 +112,7 @@ export const renderDownloadFilesText = ({
         </Button>
       ),
     });
-  }
+  }*/
 
   if (items.length === 0) return <></>;
 
@@ -193,11 +193,12 @@ export const createPackageYaml = ({
 `;
   }
 
-  if (iconUrl) {
-    yaml += `icon_url:
-  path: ./icons/${hyphenatedSWTitle}-icon.png
+  // skipping pending GitOps support
+/*  if (iconUrl) {
+    yaml += `  icon_url:
+    path: ./icons/${hyphenatedSWTitle}-icon.png
 `;
-  }
+  }*/
 
   return yaml.trim();
 };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -103,7 +103,7 @@ export const renderDownloadFilesText = ({
       ),
     });
   }
-  /*if (iconUrl) {
+  /* if (iconUrl) {
     items.push({
       key: "icon-url",
       element: (
@@ -112,7 +112,7 @@ export const renderDownloadFilesText = ({
         </Button>
       ),
     });
-  }*/
+  } */
 
   if (items.length === 0) return <></>;
 
@@ -194,11 +194,11 @@ export const createPackageYaml = ({
   }
 
   // skipping pending GitOps support
-/*  if (iconUrl) {
+  /*  if (iconUrl) {
     yaml += `  icon_url:
     path: ./icons/${hyphenatedSWTitle}-icon.png
 `;
-  }*/
+  } */
 
   return yaml.trim();
 };


### PR DESCRIPTION
Also fixes a spacing issue once GitOps lands and we can un-comment this

Fixes #32832.

# Checklist for submitter
## Testing

- [x] QA'd all new/changed functionality manually

- [x] Confirmed that the fix is not expected to adversely impact load test results