### PR TITLE
Fleet UI: Fix cut off long filepaths/hash

### DIFF
--- a/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
+++ b/frontend/pages/hosts/details/components/InventoryVersions/_styles.scss
@@ -30,5 +30,12 @@
     dt {
       min-width: 40px;
     }
+
+    // Show entire hash and file path, easier to read/compare not hidden in tooltip
+    dd {
+      width: 100%;
+      text-wrap: wrap;
+      overflow-wrap: anywhere;
+    }
   }
 }


### PR DESCRIPTION
## Issue
Closes #32885 

## Description
- Wraps > tooltip for easier readability and comparison of multiple paths/hashes
- Previously [implemented](https://github.com/fleetdm/fleet/pull/31420/files#r2341042254) with wrap and not tooltip and was accidentally removed

## Screenshot of fix
<img width="1003" height="549" alt="Screenshot 2025-09-11 at 10 14 14 AM" src="https://github.com/user-attachments/assets/e0dccc8d-916a-4ad5-a9c9-c27647b067b7" />


- [x] QA'd all new/changed functionality manually
