### PR TITLE
Cherry-Pick: Hide GitOps export info for icons in UI

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -103,7 +103,7 @@ export const renderDownloadFilesText = ({
       ),
     });
   }
-  if (iconUrl) {
+  /* if (iconUrl) {
     items.push({
       key: "icon-url",
       element: (
@@ -112,7 +112,7 @@ export const renderDownloadFilesText = ({
         </Button>
       ),
     });
-  }
+  } */
 
   if (items.length === 0) return <></>;
 
@@ -193,11 +193,12 @@ export const createPackageYaml = ({
 `;
   }
 
-  if (iconUrl) {
-    yaml += `icon_url:
-  path: ./icons/${hyphenatedSWTitle}-icon.png
+  // skipping pending GitOps support
+  /*  if (iconUrl) {
+    yaml += `  icon_url:
+    path: ./icons/${hyphenatedSWTitle}-icon.png
 `;
-  }
+  } */
 
   return yaml.trim();
 };


### PR DESCRIPTION
Fixes #32832.
Merged into `main` in #32839.