### PR TITLE
 Update Makefile swift dialog versions and add github workflow (#32511)

### DIFF
--- a/.github/workflows/generate-swift-dialog-targets.yml
+++ b/.github/workflows/generate-swift-dialog-targets.yml
@@ -1,0 +1,53 @@
+name: Generate Swift Dialog targets for Fleetd
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      # The workflow can be triggered by modifying SWIFT_DIALOG_VERSION EV.
+      - '.github/workflows/generate-swift-dialog-targets.yml'
+  pull_request:
+    paths:
+      # The workflow can be triggered by modifying SWIFT_DIALOG_VERSION EV.
+      - '.github/workflows/generate-swift-dialog-targets.yml'
+  workflow_dispatch:
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+env:
+  # NB: Makefile is locked to these versions so updating requires changing this + makefile
+  SWIFT_DIALOG_VERSION: 2.5.6
+  SWIFT_DIALOG_BUILD: 4805
+
+permissions:
+  contents: read
+
+jobs:
+  generate-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Generate swiftDialog.app.tar.gz
+        run: make swift-dialog-app-tar-gz version=${SWIFT_DIALOG_VERSION} build=${SWIFT_DIALOG_BUILD} out-path=.
+
+      - name: Upload swiftDialog.app.tar.gz
+        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5.0
+        with:
+          name: swiftDialog.app.tar.gz
+          path: swiftDialog.app.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -673,21 +673,21 @@ endif
 # Generate swiftDialog.app.tar.gz bundle from the swiftDialog repo.
 #
 # Usage:
-# make swift-dialog-app-tar-gz version=2.2.1 build=4591 out-path=.
+# make swift-dialog-app-tar-gz version=2.5.6 build=4805 out-path=.
 swift-dialog-app-tar-gz:
 ifneq ($(shell uname), Darwin)
 	@echo "Makefile target swift-dialog-app-tar-gz is only supported on macOS"
 	@exit 1
 endif
-	# locking the version of swiftDialog to 2.2.1-4591 as newer versions
+	# locking the version of swiftDialog to 2.5.6-4805 as newer versions
 	# might have layout issues.
-ifneq ($(version), 2.2.1)
-	@echo "Version is locked at 2.1.0, see comments in Makefile target for details"
+ifneq ($(version), 2.5.6)
+	@echo "Version is locked at 2.5.6, see comments in Makefile target for details"
 	@exit 1
 endif
 
-ifneq ($(build), 4591)
-	@echo "Build version is locked at 4591, see comments in Makefile target for details"
+ifneq ($(build), 4805)
+	@echo "Build version is locked at 4805, see comments in Makefile target for details"
 	@exit 1
 endif
 	$(eval TMP_DIR := $(shell mktemp -d))
@@ -695,6 +695,8 @@ endif
 	pkgutil --expand $(TMP_DIR)/swiftDialog-$(version).pkg $(TMP_DIR)/swiftDialog_pkg_expanded
 	mkdir -p $(TMP_DIR)/swiftDialog_pkg_payload_expanded
 	tar xvf $(TMP_DIR)/swiftDialog_pkg_expanded/tmp-package.pkg/Payload --directory $(TMP_DIR)/swiftDialog_pkg_payload_expanded
+	# Remove xattrs which are included in the .pkg(erroneously?) in some versions
+	xattr -cr $(TMP_DIR)/swiftDialog_pkg_payload_expanded
 	$(TMP_DIR)/swiftDialog_pkg_payload_expanded/Library/Application\ Support/Dialog/Dialog.app/Contents/MacOS/Dialog --version
 	tar czf $(out-path)/swiftDialog.app.tar.gz -C $(TMP_DIR)/swiftDialog_pkg_payload_expanded/Library/Application\ Support/Dialog/ Dialog.app
 	rm -rf $(TMP_DIR)

--- a/orbit/changes/31675-update-swift-dialog
+++ b/orbit/changes/31675-update-swift-dialog
@@ -1,0 +1,1 @@
+* Updated Swift Dialog in Fleet's TUF repo to 2.5.6 and modified Migration dialog layout to display properly with 2.5.6

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -58,7 +58,7 @@ const mdmUnenrollmentTotalWaitTime = 90 * time.Second
 const defaultUnenrollmentRetryInterval = 5 * time.Second
 
 var mdmMigrationTemplatePreSonoma = template.Must(template.New("mdmMigrationTemplate").Parse(`
-## Migrate to Fleet
+### Migrate to Fleet
 
 Select **Start** and look for this notification in your notification center:` +
 	"\n\n![Image showing MDM migration notification](https://fleetdm.com/images/permanent/mdm-migration-screenshot-notification-2048x480.png)\n\n" +
@@ -66,7 +66,7 @@ Select **Start** and look for this notification in your notification center:` +
 ))
 
 var mdmManualMigrationTemplate = template.Must(template.New("").Parse(`
-## Migrate to Fleet
+### Migrate to Fleet
 
 Select **Start** and My device page will appear soon:` +
 	"\n\n![Image showing MDM migration notification](https://fleetdm.com/images/permanent/mdm-manual-migration-1024x500.png)\n\n" +
@@ -74,7 +74,7 @@ Select **Start** and My device page will appear soon:` +
 ))
 
 var mdmADEMigrationTemplate = template.Must(template.New("").Parse(`
-## Migrate to Fleet
+### Migrate to Fleet
 
 Select **Start** and Remote Management window will appear soon:` +
 	"\n\n![Image showing MDM migration notification](https://fleetdm.com/images/permanent/mdm-ade-migration-1024x500.png)\n\n" +
@@ -87,10 +87,10 @@ var errorTemplate = template.Must(template.New("").Parse(`
 Please [contact your IT admin]({{ .ContactURL }}).
 `))
 
-var unenrollBody = "## Migrate to Fleet\nUnenrolling you from your old MDM. This could take 90 seconds...\n\n%s"
+var unenrollBody = "### Migrate to Fleet\nUnenrolling you from your old MDM. This could take 90 seconds...\n\n%s"
 
 var mdmMigrationTemplateOffline = template.Must(template.New("").Parse(`
-## Migrate to Fleet
+### Migrate to Fleet
 
 🛜🚫 No internet connection. Please connect to internet to continue.`,
 ))


### PR DESCRIPTION
Merging fix into fleetd 1.47.4 patch branch

Fixes #31675
Fixes #32099 


Adds a Github workflow to generate our packaged build of Swift Dialog(following existing Nudge packager), updates the version to 2.5.6 and modifies the Migration dialog to render properly with the new Swift Dialog version(it previously rendered it just didn't format as expected due to changes in the markdown formatter)

Makefile changes are necessary not only because of the version bump but because the latest package includes xattrs for some strange reason. Extracting it verbatim on a system(at least with our Go implementation) creates files that cause Gatekeeper to stop execution of swift dialog.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must
rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
