### PR TITLE
pass serverUrl, improve error handling

### DIFF
--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -23,7 +23,7 @@ type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseN
 
 type EnterpriseDeleteFunc func(ctx context.Context, enterpriseName string) error
 
-type EnterprisesListFunc func(ctx context.Context) ([]*androidmanagement.Enterprise, error)
+type EnterprisesListFunc func(ctx context.Context, serverURL string) ([]*androidmanagement.Enterprise, error)
 
 type SetAuthenticationSecretFunc func(secret string) error
 
@@ -87,11 +87,11 @@ func (p *Client) EnterpriseDelete(ctx context.Context, enterpriseName string) er
 	return p.EnterpriseDeleteFunc(ctx, enterpriseName)
 }
 
-func (p *Client) EnterprisesList(ctx context.Context) ([]*androidmanagement.Enterprise, error) {
+func (p *Client) EnterprisesList(ctx context.Context, serverURL string) ([]*androidmanagement.Enterprise, error) {
 	p.mu.Lock()
 	p.EnterprisesListFuncInvoked = true
 	p.mu.Unlock()
-	return p.EnterprisesListFunc(ctx)
+	return p.EnterprisesListFunc(ctx, serverURL)
 }
 
 func (p *Client) SetAuthenticationSecret(secret string) error {

--- a/server/mdm/android/mock/client_setup.go
+++ b/server/mdm/android/mock/client_setup.go
@@ -25,7 +25,7 @@ func (p *Client) InitCommonMocks() {
 	p.EnterprisesPoliciesPatchFunc = func(_ context.Context, policyName string, policy *androidmanagement.Policy) error {
 		return nil
 	}
-	p.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+	p.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 		// Default implementation returns a single enterprise with a standard name
 		return []*androidmanagement.Enterprise{
 			{

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -34,7 +34,7 @@ type Client interface {
 
 	// EnterprisesList lists all enterprises accessible to the calling user.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises/list
-	EnterprisesList(ctx context.Context) ([]*androidmanagement.Enterprise, error)
+	EnterprisesList(ctx context.Context, serverURL string) ([]*androidmanagement.Enterprise, error)
 
 	// SetAuthenticationSecret sets the secret used for authentication.
 	SetAuthenticationSecret(secret string) error

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -230,7 +230,7 @@ func (g *GoogleClient) EnterpriseDelete(ctx context.Context, enterpriseName stri
 	return nil
 }
 
-func (g *GoogleClient) EnterprisesList(ctx context.Context) ([]*androidmanagement.Enterprise, error) {
+func (g *GoogleClient) EnterprisesList(ctx context.Context, serverURL string) ([]*androidmanagement.Enterprise, error) {
 	if g == nil || g.mgmt == nil {
 		return nil, errors.New("android management service not initialized")
 	}

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -200,12 +200,13 @@ func (p *ProxyClient) EnterpriseDelete(ctx context.Context, enterpriseName strin
 	return nil
 }
 
-func (p *ProxyClient) EnterprisesList(ctx context.Context) ([]*androidmanagement.Enterprise, error) {
+func (p *ProxyClient) EnterprisesList(ctx context.Context, serverURL string) ([]*androidmanagement.Enterprise, error) {
 	if p == nil || p.mgmt == nil {
 		return nil, errors.New("android management service not initialized")
 	}
 	call := p.mgmt.Enterprises.List().Context(ctx)
 	call.Header().Set("Authorization", "Bearer "+p.fleetServerSecret)
+	call.Header().Set("Origin", serverURL)
 	resp, err := call.Do()
 	if err != nil {
 		// Convert proxy errors to proper googleapi.Error for service layer

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -273,7 +273,7 @@ func TestGetEnterprise(t *testing.T) {
 		}
 
 		// Override EnterprisesListFunc to return empty list (enterprise deleted)
-		androidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return []*androidmanagement.Enterprise{
 				{Name: "enterprises/some-other-enterprise"},
 			}, nil
@@ -322,7 +322,7 @@ func TestGetEnterprise(t *testing.T) {
 		}
 
 		// Override EnterprisesListFunc to return the enterprise
-		androidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return []*androidmanagement.Enterprise{
 				{Name: "enterprises/existing-enterprise-id"},
 				{Name: "enterprises/some-other-enterprise"},
@@ -364,7 +364,7 @@ func TestGetEnterprise(t *testing.T) {
 		}
 
 		// Override EnterprisesListFunc to fail
-		androidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return nil, &googleapi.Error{
 				Code:    http.StatusUnauthorized,
 				Message: "Invalid credentials for list operation.",
@@ -387,7 +387,7 @@ func TestGetEnterprise(t *testing.T) {
 
 		// Check that it returns the LIST error
 		assert.Contains(t, err.Error(), "verifying enterprise with Google")
-		assert.Contains(t, err.Error(), "Invalid credentials for list operation")
+		assert.Contains(t, err.Error(), "authentication error")
 	})
 
 	t.Run("SetAndroidEnabledAndConfigured fails - still return 404", func(t *testing.T) {
@@ -409,7 +409,7 @@ func TestGetEnterprise(t *testing.T) {
 		}
 
 		// Override EnterprisesListFunc to return empty list (enterprise deleted)
-		androidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return []*androidmanagement.Enterprise{}, nil
 		}
 
@@ -475,7 +475,7 @@ func TestGetEnterprise(t *testing.T) {
 					return nil
 				}
 
-				androidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+				androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 					return []*androidmanagement.Enterprise{
 						{Name: tc.enterpriseNameInList},
 					}, nil

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -717,7 +717,7 @@ func (svc *Service) verifyEnterpriseExistsWithGoogle(ctx context.Context, enterp
 			case http.StatusUnauthorized, http.StatusForbidden:
 				// Authentication/authorization issues - don't delete the enterprise
 				level.Error(svc.logger).Log("msg", "authentication/authorization error when verifying enterprise", "error", err)
-				return fmt.Errorf("verifying enterprise with Google: authentication error")
+				return fmt.Errorf("verifying enterprise with Google: authentication error: %w", err)
 			}
 		}
 		// LIST failed - this is likely a technical issue, not deletion

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -37,7 +37,7 @@ func (s *enterpriseTestSuite) SetupTest() {
 	s.AppConfig.MDM.AndroidEnabledAndConfigured = false
 	s.CreateCommonDSMocks()
 	// Override EnterprisesListFunc to return empty list initially (no enterprises exist)
-	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 		return []*androidmanagement.Enterprise{}, nil
 	}
 }
@@ -70,7 +70,7 @@ func (s *enterpriseTestSuite) TestEnterprise() {
 	assert.Contains(s.T(), string(body), "window.close()")
 
 	// Update the LIST mock to return the enterprise after "creation"
-	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 		return []*androidmanagement.Enterprise{
 			{Name: "enterprises/" + tests.EnterpriseID},
 		}, nil
@@ -87,7 +87,7 @@ func (s *enterpriseTestSuite) TestEnterprise() {
 	s.FleetSvc.AssertNumberOfCalls(s.T(), "NewActivity", 2)
 
 	// Reset LIST mock to empty after deletion
-	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 		return []*androidmanagement.Enterprise{}, nil
 	}
 
@@ -147,7 +147,7 @@ func (s *enterpriseTestSuite) TestEnterpriseDeletedDetection() {
 	s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
 
 	// Update LIST mock to return the enterprise after "creation"
-	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 		return []*androidmanagement.Enterprise{
 			{Name: "enterprises/" + tests.EnterpriseID},
 		}, nil
@@ -162,7 +162,7 @@ func (s *enterpriseTestSuite) TestEnterpriseDeletedDetection() {
 
 	t.Run("enterprise deleted detection - 403 from GET, empty LIST", func(t *testing.T) {
 		// Mock EnterprisesListFunc to return empty list (enterprise deleted)
-		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return []*androidmanagement.Enterprise{}, nil
 		}
 
@@ -185,7 +185,7 @@ func (s *enterpriseTestSuite) TestEnterpriseDeletedDetection() {
 		s.AndroidAPIClient.EnterprisesListFuncInvoked = false
 
 		// Mock EnterprisesListFunc to return the enterprise
-		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context) ([]*androidmanagement.Enterprise, error) {
+		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
 			return []*androidmanagement.Enterprise{
 				{Name: "enterprises/" + tests.EnterpriseID},
 			}, nil

--- a/website/api/controllers/android-proxy/get-android-enterprises.js
+++ b/website/api/controllers/android-proxy/get-android-enterprises.js
@@ -76,7 +76,9 @@ module.exports = {
             pageToken: tokenForNextPageOfEnterprises,
           });
           tokenForNextPageOfEnterprises = listEnterprisesResponse.data.nextPageToken;
-          allEnterprises = allEnterprises.concat(listEnterprisesResponse.data.enterprises);
+          if (listEnterprisesResponse.data.enterprises) {
+            allEnterprises = allEnterprises.concat(listEnterprisesResponse.data.enterprises);
+          }
 
           if(!listEnterprisesResponse.data.nextPageToken){
             return true;
@@ -90,8 +92,11 @@ module.exports = {
       });
 
       // Filter the results to only include enterprises belonging to this Fleet instance
-      let allEnterprises = (enterprisesList && enterprisesList.enterprises) || [];
+      let allEnterprises = enterprisesList || [];
       let filteredEnterprises = allEnterprises.filter(enterprise => {
+        if (!enterprise) {
+          return false;
+        }
         // Extract enterprise ID from the Google enterprise name (format: "enterprises/ENTERPRISE_ID")
         let enterpriseId = enterprise.name ? enterprise.name.split('/')[1] : null;
         return enterpriseId === thisAndroidEnterprise.androidEnterpriseId;


### PR DESCRIPTION
Fixes #32893. Adds `serverUrl` to client implementations for LIST. Improves error handling to prevent aggressive deletion of enterprises.