### PR TITLE
Add VEX rule to remove CVE-2025-27509 false positive on fleetctl

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -141,6 +141,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-09 13:24:20
 
+### [CVE-2025-27509](https://nvd.nist.gov/vuln/detail/CVE-2025-27509)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** This vulnerability affected fleet, not fleetctl, adding it here to avoid false positives.
+- **Products:**: `fleetctl`,`pkg:github.com/fleetdm/fleet/v4`
+- **Justification:** `component_not_present`
+- **Timestamp:** 2025-09-12 09:25:41
+
 ### [CVE-2024-7254](https://nvd.nist.gov/vuln/detail/CVE-2024-7254)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleetctl/CVE-2025-27509.vex.json
+++ b/security/vex/fleetctl/CVE-2025-27509.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-e5b8cb393718e7eb8f0704667730322e37f63e71182c255e69d57937633fce58",
+  "author": "@lucasmrod",
+  "timestamp": "2025-09-12T09:25:41.833734-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-27509"
+      },
+      "timestamp": "2025-09-12T09:25:41.833734-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:github.com/fleetdm/fleet/v4"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "This vulnerability affected fleet, not fleetctl, adding it here to avoid false positives.",
+      "justification": "component_not_present"
+    }
+  ]
+}


### PR DESCRIPTION
This is to fix: 
- https://github.com/fleetdm/fleet/actions/runs/17666094872/job/50207923143
- https://github.com/fleetdm/fleet/actions/runs/17664167078/job/50202855532