### PR TITLE
Fleet UI: Fix self-service preview icon default FMA name match

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -115,7 +115,7 @@ interface IEditIconModalProps {
     versions?: number;
     source?: string;
     currentIconUrl: string | null;
-    /** Name used for FMA default icon matching */
+    /** Name used in preview UI but also for FMA default icon matching */
     name: string;
     countsUpdatedAt?: string;
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
-import { AxiosError } from "axios";
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs";
 import { IAppStoreApp, ISoftwarePackage } from "interfaces/software";
 
@@ -116,6 +115,7 @@ interface IEditIconModalProps {
     versions?: number;
     source?: string;
     currentIconUrl: string | null;
+    /** Name used for FMA default icon matching */
     name: string;
     countsUpdatedAt?: string;
   };
@@ -461,7 +461,7 @@ const EditIconModal = ({
             // Known limitation: we cannot see VPP app icons as the fallback when a custom icon
             // is set as VPP icon is not returned by the API if a custom icon is returned
             <SoftwareIcon
-              name={software.name}
+              name={previewInfo.name}
               source={previewInfo.source}
               url={isSoftwarePackage ? undefined : software.icon_url} // fallback PNG icons only exist for VPP apps
               uploadedAt={iconUploadedAt}


### PR DESCRIPTION
## Issue
Closes #32821  unreleased

## Description
- After digging the wrong way, realized name being passed was installer `.name` (e.g. `"Microsoft_Word_16.100.25090553_Installer.pkg"` instead of software `.name` (e.g. `"Microsoft Word"`) so it wasn't string matching FMA icons to default icons properly

> Side: Removed one unused import, added a code comment

## Screenshot of fix
<img width="1204" height="518" alt="Screenshot 2025-09-12 at 10 34 50 AM" src="https://github.com/user-attachments/assets/a00f9d9f-8ec1-4041-bccc-84265c6ef264" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] QA'd all new/changed functionality manually
