### PR TITLE
Make policy pass/fail icons and copy consistent across host details, my device, and manage policies tables

### DIFF
--- a/changes/32924-align-policy-pass-fail-text-and-icons
+++ b/changes/32924-align-policy-pass-fail-text-and-icons
@@ -1,0 +1,2 @@
+* Make policy pass/fail icons and copy consistent across host details, my device, and manage
+policies tables.

--- a/frontend/components/policies/helpers.ts
+++ b/frontend/components/policies/helpers.ts
@@ -1,0 +1,13 @@
+import { IndicatorStatus } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
+import { PolicyStatus } from "pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig";
+
+const POLICY_STATUS_TO_INDICATOR_PARAMS: Record<
+  PolicyStatus,
+  [IndicatorStatus, string]
+> = {
+  pass: ["success", "Pass"],
+  fail: ["failure", "Fail"],
+  actionRequired: ["actionRequired", "Action required"],
+};
+
+export default POLICY_STATUS_TO_INDICATOR_PARAMS;

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -5,10 +5,10 @@ import { PolicyResponse, DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 import { noop } from "lodash";
 
 import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
-import { IndicatorStatus } from "components/StatusIndicatorWithIcon/StatusIndicatorWithIcon";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
+import POLICY_STATUS_TO_INDICATOR_PARAMS from "components/policies/helpers";
 
 interface IEnhancedHostPolicy extends IHostPolicy {
   status: PolicyStatus | null;
@@ -52,15 +52,6 @@ const getPolicyStatus = (policy: IHostPolicy): PolicyStatus | null => {
   }
   // can occur when response === ""
   return null;
-};
-
-export const POLICY_STATUS_TO_INDICATOR_PARAMS: Record<
-  PolicyStatus,
-  [IndicatorStatus, string]
-> = {
-  pass: ["success", "Pass"],
-  fail: ["failure", "Fail"],
-  actionRequired: ["actionRequired", "Action required"],
 };
 
 // NOTE: cellProps come from react-table

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig.tsx
@@ -54,7 +54,7 @@ const getPolicyStatus = (policy: IHostPolicy): PolicyStatus | null => {
   return null;
 };
 
-const POLICY_STATUS_TO_INDICATOR_PARAMS: Record<
+export const POLICY_STATUS_TO_INDICATOR_PARAMS: Record<
   PolicyStatus,
   [IndicatorStatus, string]
 > = {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
@@ -1,21 +1,17 @@
-import Icon from "components/Icon";
+import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
+import { POLICY_STATUS_TO_INDICATOR_PARAMS } from "pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig";
 import React from "react";
 
 interface IPassingColumnHeaderProps {
   isPassing: boolean;
 }
 
-const baseClass = "passing-column-header";
-
 const PassingColumnHeader = ({ isPassing }: IPassingColumnHeaderProps) => {
-  const iconName = isPassing ? "success" : "error";
-  const columnText = isPassing ? "Pass" : "Fail";
-
+  const [indicatorStatus, displayText] = POLICY_STATUS_TO_INDICATOR_PARAMS[
+    isPassing ? "pass" : "fail"
+  ];
   return (
-    <div className={baseClass}>
-      <Icon name={iconName} />
-      <span className="status-header-text">{columnText}</span>
-    </div>
+    <StatusIndicatorWithIcon value={displayText} status={indicatorStatus} />
   );
 };
 

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
@@ -1,5 +1,5 @@
+import POLICY_STATUS_TO_INDICATOR_PARAMS from "components/policies/helpers";
 import StatusIndicatorWithIcon from "components/StatusIndicatorWithIcon";
-import { POLICY_STATUS_TO_INDICATOR_PARAMS } from "pages/hosts/details/cards/Policies/HostPoliciesTable/HostPoliciesTableConfig";
 import React from "react";
 
 interface IPassingColumnHeaderProps {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/PassingColumnHeader.tsx
@@ -9,7 +9,7 @@ const baseClass = "passing-column-header";
 
 const PassingColumnHeader = ({ isPassing }: IPassingColumnHeaderProps) => {
   const iconName = isPassing ? "success" : "error";
-  const columnText = isPassing ? "Yes" : "No";
+  const columnText = isPassing ? "Pass" : "Fail";
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/_styles.scss
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PassingColumnHeader/_styles.scss
@@ -1,4 +1,0 @@
-.passing-column-header {
-  display: flex;
-  align-items: center;
-}


### PR DESCRIPTION
## For #32924 

<img width="1793" height="894" alt="Screenshot 2025-09-12 at 9 39 35 AM" src="https://github.com/user-attachments/assets/cb576e6d-296f-4f03-acc5-c02265dc6ec7" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] QA'd all new/changed functionality manually