### PR TITLE
Add manual translation for com.sentinelone.SentinelAgent

### DIFF
--- a/changes/31318-sentinelone-pkg
+++ b/changes/31318-sentinelone-pkg
@@ -1,0 +1,1 @@
+* Fixed SentinelOne pkg generating wrong bundle identifier for auto-install policy.

--- a/pkg/file/xar.go
+++ b/pkg/file/xar.go
@@ -327,6 +327,10 @@ var knownBadNames = map[string]struct{}{
 	"SU_TITLE":           {},
 }
 
+var idTranslations = map[string]string{
+	"com.sentinelone.sentinel-agent": "com.sentinelone.SentinelAgent",
+}
+
 // getDistributionInfo gets the name, bundle identifier and version of a PKG distribution file
 func getDistributionInfo(d *distributionXML) (name string, identifier string, version string, packageIDs []string) {
 	var appVersion string
@@ -456,6 +460,10 @@ func getDistributionInfo(d *distributionXML) (name string, identifier string, ve
 				break
 			}
 		}
+	}
+
+	if newID, ok := idTranslations[identifier]; ok {
+		identifier = newID
 	}
 
 	// if package IDs are still empty, use the identifier as the package ID

--- a/pkg/file/xar_test.go
+++ b/pkg/file/xar_test.go
@@ -211,7 +211,7 @@ func TestParseRealDistributionFiles(t *testing.T) {
 			file:               "distribution-sentinelone.xml",
 			expectedName:       "SentinelOne",
 			expectedVersion:    "24.3.2.7753",
-			expectedBundleID:   "com.sentinelone.sentinel-agent",
+			expectedBundleID:   "com.sentinelone.SentinelAgent",
 			expectedPackageIDs: []string{"com.sentinelone.pkg.sentinel-agent", "com.sentinelone.sentinel-agent"},
 		},
 		{


### PR DESCRIPTION
Fixes: #31318 
Worth noting that SentinelOne [bundles its content](https://developer.apple.com/documentation/bundleresources/placing-content-in-a-bundle) under `./Library/Sentinel/sentinel-agent.bundle` in an embedded pkg file. It could be worth adding parsing logic for that case if more apps in the future are bundled this way.
# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
