### PR TITLE
Added missing OpenTelemetry instrumentation to several API endpoints.

### DIFF
--- a/changes/32331-otel-instrumentation
+++ b/changes/32331-otel-instrumentation
@@ -1,0 +1,1 @@
+* Added missing OpenTelemetry instrumentation to several API endpoints.

--- a/cmd/fleet/otel.go
+++ b/cmd/fleet/otel.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+)
+
+// wrapWithOTEL wraps an HTTP handler with OpenTelemetry instrumentation for a fixed route.
+// It creates spans named as "{method} {route}" (e.g., "GET /healthz").
+func wrapWithOTEL(handler http.Handler, route string, config config.FleetConfig) http.Handler {
+	if config.Logging.TracingEnabled && config.Logging.TracingType == "opentelemetry" {
+		// Wrap with OTEL handler to create properly named spans: "{method} {route}"
+		return otelhttp.NewHandler(
+			otelhttp.WithRouteTag(route, handler),
+			"", // Empty operation name - will be set by span name formatter
+			otelhttp.WithSpanNameFormatter(func(operation string, r *http.Request) string {
+				return r.Method + " " + route
+			}),
+		)
+	}
+	return handler
+}
+
+// wrapWithOTELDynamic wraps an HTTP handler with OpenTelemetry instrumentation using dynamic routes.
+// It creates spans based on the actual request path (e.g., "GET /assets/app.js").
+func wrapWithOTELDynamic(handler http.Handler, config config.FleetConfig) http.Handler {
+	if config.Logging.TracingEnabled && config.Logging.TracingType == "opentelemetry" {
+		// Create a wrapper that instruments each request with its actual path
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Use the actual request path as the route
+			route := r.URL.Path
+			instrumentedHandler := otelhttp.NewHandler(
+				otelhttp.WithRouteTag(route, handler),
+				"", // Empty operation name - will be set by span name formatter
+				otelhttp.WithSpanNameFormatter(func(operation string, req *http.Request) string {
+					return req.Method + " " + route
+				}),
+			)
+			instrumentedHandler.ServeHTTP(w, r)
+		})
+	}
+	return handler
+}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1311,7 +1311,6 @@ the way that the Fleet server works.
 			}
 
 			if config.Prometheus.BasicAuth.Username != "" && config.Prometheus.BasicAuth.Password != "" {
-				level.Info(logger).Log("msg", "metrics endpoint enabled with http basic auth enabled", "username", config.Prometheus.BasicAuth.Username, "password", config.Prometheus.BasicAuth.Password)
 				rootMux.Handle("/metrics", basicAuthHandler(
 					config.Prometheus.BasicAuth.Username,
 					config.Prometheus.BasicAuth.Password,

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1290,10 +1290,10 @@ the way that the Fleet server works.
 
 			if license.IsPremium() {
 				// SCEP proxy (for NDES, etc.)
-				if err = service.RegisterSCEPProxy(rootMux, ds, logger, nil); err != nil {
+				if err = service.RegisterSCEPProxy(rootMux, ds, logger, nil, &config); err != nil {
 					initFatal(err, "setup SCEP proxy")
 				}
-				if err = scim.RegisterSCIM(rootMux, ds, svc, logger); err != nil {
+				if err = scim.RegisterSCIM(rootMux, ds, svc, logger, &config); err != nil {
 					initFatal(err, "setup SCIM")
 				}
 				// Host identify SCEP feature only works if a private key has been set up
@@ -1302,7 +1302,7 @@ the way that the Fleet server works.
 					if err != nil {
 						initFatal(err, "setup host identity SCEP depot")
 					}
-					if err = hostidentity.RegisterSCEP(rootMux, hostIdentitySCEPDepot, ds, logger); err != nil {
+					if err = hostidentity.RegisterSCEP(rootMux, hostIdentitySCEPDepot, ds, logger, &config); err != nil {
 						initFatal(err, "setup host identity SCEP")
 					}
 				} else {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1438,7 +1438,7 @@ the way that the Fleet server works.
 			rootMux.Handle("/api/latest/fleet/scim/details", apiHandler)
 
 			rootMux.Handle("/enroll", otelmw.WrapHandler(endUserEnrollOTAHandler, "/enroll", config))
-			rootMux.Handle("/", otelmw.WrapHandlerDynamic(frontendHandler, config))
+			rootMux.Handle("/", otelmw.WrapHandler(frontendHandler, "/", config))
 
 			debugHandler := &debugMux{
 				fleetAuthenticatedHandler: service.MakeDebugHandler(svc, config, logger, eh, ds),

--- a/ee/server/scim/scim.go
+++ b/ee/server/scim/scim.go
@@ -224,7 +224,9 @@ func RegisterSCIM(
 		handler = LastRequestMiddleware(ds, scimLogger, handler)
 		handler = log.LogResponseEndMiddleware(scimLogger, handler)
 		handler = auth.SetRequestsContextMiddleware(svc, handler)
-		handler = otel.WrapHandlerDynamic(handler, *fleetConfig)
+		// Not using the dynamic OTEL wrapper to avoid exposing identifiers in the span name.
+		// We can improve the OTEL instrumentation in the future if we need additional visibility into specific SCIM endpoints.
+		handler = otel.WrapHandler(handler, prefix, *fleetConfig)
 		return handler
 	}
 

--- a/ee/server/scim/scim_otel_test.go
+++ b/ee/server/scim/scim_otel_test.go
@@ -1,0 +1,211 @@
+package scim
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestSCIMOTELMiddleware(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name         string
+		path         string
+		method       string
+		expectedSpan string
+	}{
+		{
+			name:         "Users list",
+			path:         "Users",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Users",
+		},
+		{
+			name:         "Users list with trailing slash",
+			path:         "Users/",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Users",
+		},
+		{
+			name:         "Individual user - hides ID",
+			path:         "Users/12345",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Users/{id}",
+		},
+		{
+			name:         "Update user - hides ID",
+			path:         "Users/67890",
+			method:       "PATCH",
+			expectedSpan: "PATCH /api/v1/fleet/scim/Users/{id}",
+		},
+		{
+			name:         "Groups list",
+			path:         "Groups",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Groups",
+		},
+		{
+			name:         "Individual group - hides ID",
+			path:         "Groups/abc-def-123",
+			method:       "PUT",
+			expectedSpan: "PUT /api/v1/fleet/scim/Groups/{id}",
+		},
+		{
+			name:         "Schemas",
+			path:         "Schemas",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Schemas",
+		},
+		{
+			name:         "Individual schema",
+			path:         "Schemas/urn:ietf:params:scim:schemas:core:2.0:User",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/Schemas/{id}",
+		},
+		{
+			name:         "Service provider config",
+			path:         "ServiceProviderConfig",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/ServiceProviderConfig",
+		},
+		{
+			name:         "Resource types",
+			path:         "ResourceTypes",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/ResourceTypes",
+		},
+		{
+			name:         "Unknown path - uses full path",
+			path:         "SomethingElse",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/SomethingElse",
+		},
+		{
+			name:         "Bulk operations endpoint",
+			path:         "Bulk",
+			method:       "POST",
+			expectedSpan: "POST /api/v1/fleet/scim/Bulk",
+		},
+		{
+			name:         "Search endpoint",
+			path:         ".search",
+			method:       "POST",
+			expectedSpan: "POST /api/v1/fleet/scim/.search",
+		},
+		{
+			name:         "Unknown resource with ID - hides ID",
+			path:         "CustomResource/abc123",
+			method:       "GET",
+			expectedSpan: "GET /api/v1/fleet/scim/CustomResource/{id}",
+		},
+		{
+			name:         "Unknown nested path with ID - hides ID",
+			path:         "Custom/Resource/123",
+			method:       "DELETE",
+			expectedSpan: "DELETE /api/v1/fleet/scim/Custom/{id}",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test span recorder
+			sr := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+			// Create test configuration with OTEL enabled
+			cfg := config.FleetConfig{
+				Logging: config.LoggingConfig{
+					TracingEnabled: true,
+					TracingType:    "opentelemetry",
+				},
+			}
+
+			// Create a test handler that just returns 200 OK
+			testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			// Wrap with SCIM OTEL middleware
+			tracer := tp.Tracer("test")
+			wrappedHandler := scimOTELMiddleware(testHandler, "/api/v1/fleet/scim", cfg)
+
+			// Create request - now OTEL runs before StripPrefix so it sees the full path
+			req := httptest.NewRequest(tc.method, "/api/v1/fleet/scim/"+tc.path, nil)
+
+			// Add span to context
+			ctx, span := tracer.Start(req.Context(), "test-parent-span")
+			defer span.End()
+			req = req.WithContext(ctx)
+
+			// Execute request
+			w := httptest.NewRecorder()
+			wrappedHandler.ServeHTTP(w, req)
+
+			// Force span to end
+			span.End()
+
+			// Check spans
+			spans := sr.Ended()
+			require.GreaterOrEqual(t, len(spans), 2, "Should have at least parent and child spans")
+
+			// Find the SCIM span (should be the second one, after the parent)
+			var scimSpan trace.ReadOnlySpan
+			for _, s := range spans {
+				if s.Name() == tc.expectedSpan {
+					scimSpan = s
+					break
+				}
+			}
+
+			require.NotNil(t, scimSpan, "Should find SCIM span with name: %s", tc.expectedSpan)
+			assert.Equal(t, tc.expectedSpan, scimSpan.Name())
+
+			// Check that the route tag is set correctly (without exposing IDs)
+			attrs := scimSpan.Attributes()
+			for _, attr := range attrs {
+				if string(attr.Key) == "http.route" {
+					// The route should match the pattern, not the actual path
+					assert.NotContains(t, attr.Value.AsString(), "123", "Should not expose user ID")
+					assert.NotContains(t, attr.Value.AsString(), "67890", "Should not expose user ID")
+				}
+			}
+		})
+	}
+}
+
+func TestSCIMOTELMiddleware_Disabled(t *testing.T) {
+	t.Parallel()
+	// Create test configuration with OTEL disabled
+	cfg := config.FleetConfig{
+		Logging: config.LoggingConfig{
+			TracingEnabled: false,
+		},
+	}
+
+	// Create a test handler
+	called := false
+	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Wrap with SCIM OTEL middleware
+	wrappedHandler := scimOTELMiddleware(testHandler, "/api/v1/fleet/scim", cfg)
+
+	// Create request - OTEL sees the full path now
+	req := httptest.NewRequest("GET", "/api/v1/fleet/scim/Users", nil)
+	w := httptest.NewRecorder()
+
+	// Execute request
+	wrappedHandler.ServeHTTP(w, req)
+
+	// Should have called the handler without any OTEL instrumentation
+	assert.True(t, called, "Handler should have been called")
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -338,7 +338,7 @@ func Handle(ctx context.Context, err error) {
 
 		if v.User != nil {
 			attrs = append(attrs,
-				attribute.String("user.email", v.User.Email),
+				// Not sending the email here as it may contain sensitive information (PII).
 				attribute.Int64("user.id", int64(v.User.ID)), //nolint:gosec
 			)
 		} else if h != nil {
@@ -382,7 +382,7 @@ func Handle(ctx context.Context, err error) {
 	}
 
 	if eh := FromContext(ctx); eh != nil {
-		eh.Store(err)
+		eh.Store(ferr)
 	}
 }
 

--- a/server/contexts/ctxerr/ctxerr_otel_test.go
+++ b/server/contexts/ctxerr/ctxerr_otel_test.go
@@ -33,8 +33,7 @@ func TestHandleSendsContextToOTEL(t *testing.T) {
 			},
 			errorMessage: "test error with user context",
 			expectedAttrs: map[string]any{
-				"user.email": "test@example.com",
-				"user.id":    int64(123),
+				"user.id": int64(123),
 			},
 		},
 		{

--- a/server/contexts/ctxerr/ctxerr_otel_test.go
+++ b/server/contexts/ctxerr/ctxerr_otel_test.go
@@ -1,0 +1,130 @@
+package ctxerr
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/host"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestHandleSendsContextToOTEL(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		name          string
+		setupContext  func(context.Context) context.Context
+		errorMessage  string
+		expectedAttrs map[string]any // expected attributes in the exception event
+	}{
+		{
+			name: "with user context",
+			setupContext: func(ctx context.Context) context.Context {
+				testUser := &fleet.User{
+					ID:    123,
+					Email: "test@example.com",
+				}
+				return viewer.NewContext(ctx, viewer.Viewer{User: testUser})
+			},
+			errorMessage: "test error with user context",
+			expectedAttrs: map[string]any{
+				"user.email": "test@example.com",
+				"user.id":    int64(123),
+			},
+		},
+		{
+			name: "with host context",
+			setupContext: func(ctx context.Context) context.Context {
+				testHost := &fleet.Host{
+					ID:       456,
+					Hostname: "test-host.example.com",
+				}
+				return host.NewContext(ctx, testHost)
+			},
+			errorMessage: "test error with host context",
+			expectedAttrs: map[string]any{
+				"host.hostname": "test-host.example.com",
+				"host.id":       int64(456),
+			},
+		},
+		{
+			name: "without additional context",
+			setupContext: func(ctx context.Context) context.Context {
+				return ctx // no additional context
+			},
+			errorMessage:  "test error without context",
+			expectedAttrs: map[string]any{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a test span recorder and tracer provider
+			sr := tracetest.NewSpanRecorder()
+			tp := trace.NewTracerProvider(trace.WithSpanProcessor(sr))
+
+			// Create a context with an active span using the test tracer
+			tracer := tp.Tracer("test")
+			ctx, span := tracer.Start(t.Context(), "test-span")
+			defer span.End()
+
+			// Setup context with test-specific data
+			ctx = tc.setupContext(ctx)
+
+			// Create and handle an error
+			err := New(ctx, tc.errorMessage)
+			Handle(ctx, err)
+
+			// Force span to end so we can check recorded data
+			span.End()
+
+			// Check that the exception event was created
+			spans := sr.Ended()
+			require.Len(t, spans, 1)
+
+			// Find the exception event
+			events := spans[0].Events()
+			var exceptionEvent *trace.Event
+			for i := range events {
+				if events[i].Name == "exception" {
+					exceptionEvent = &events[i]
+					break
+				}
+			}
+			require.NotNil(t, exceptionEvent, "Expected to find an exception event")
+
+			// Check all expected attributes are present
+			attributes := make(map[string]any)
+			for _, attr := range exceptionEvent.Attributes {
+				switch attr.Key {
+				case "user.id", "host.id":
+					attributes[string(attr.Key)] = attr.Value.AsInt64()
+				default:
+					attributes[string(attr.Key)] = attr.Value.AsString()
+				}
+			}
+
+			// Always check for stack trace
+			stackTrace, ok := attributes["exception.stacktrace"].(string)
+			assert.True(t, ok, "Expected exception.stacktrace attribute")
+			assert.Contains(t, stackTrace, "TestHandleSendsContextToOTEL", "Stack trace should contain test function name")
+			assert.True(t, strings.Contains(stackTrace, "\n"), "Stack trace should be formatted with newlines")
+
+			// Check for exception message and type
+			assert.Equal(t, tc.errorMessage, attributes["exception.message"])
+			assert.Equal(t, "*ctxerr.FleetError", attributes["exception.type"])
+
+			// Check test-specific expected attributes
+			for expectedKey, expectedValue := range tc.expectedAttrs {
+				actualValue, found := attributes[expectedKey]
+				assert.True(t, found, "Expected to find attribute %s", expectedKey)
+				assert.Equal(t, expectedValue, actualValue, "Attribute %s should match", expectedKey)
+			}
+		})
+	}
+}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1266,7 +1266,8 @@ func RegisterSCEPProxy(
 	e.GetEndpoint = scepserver.EndpointLoggingMiddleware(scepLogger)(e.GetEndpoint)
 	e.PostEndpoint = scepserver.EndpointLoggingMiddleware(scepLogger)(e.PostEndpoint)
 	scepHandler := scepserver.MakeHTTPHandlerWithIdentifier(e, apple_mdm.SCEPProxyPath, scepLogger)
-	scepHandler = otel.WrapHandlerDynamic(scepHandler, *fleetConfig)
+	// Not using OTEL dynamic wrapper so as not to expose {identifier} in the span name
+	scepHandler = otel.WrapHandler(scepHandler, apple_mdm.SCEPProxyPath, *fleetConfig)
 	rootMux.Handle(apple_mdm.SCEPProxyPath, scepHandler)
 	return nil
 }

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/mdmconfigured"
+	"github.com/fleetdm/fleet/v4/server/service/middleware/otel"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/ratelimit"
 	kithttp "github.com/go-kit/kit/transport/http"
 	kitlog "github.com/go-kit/log"
@@ -1171,14 +1172,15 @@ func RegisterAppleMDMProtocolServices(
 	ddmService nanomdm_service.DeclarativeManagement,
 	profileService nanomdm_service.ProfileService,
 	serverURLPrefix string,
+	fleetConfig config.FleetConfig,
 ) error {
-	if err := registerSCEP(mux, scepConfig, scepStorage, mdmStorage, logger); err != nil {
+	if err := registerSCEP(mux, scepConfig, scepStorage, mdmStorage, logger, fleetConfig); err != nil {
 		return fmt.Errorf("scep: %w", err)
 	}
-	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger); err != nil {
+	if err := registerMDM(mux, mdmStorage, checkinAndCommandService, ddmService, profileService, logger, fleetConfig); err != nil {
 		return fmt.Errorf("mdm: %w", err)
 	}
-	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix); err != nil {
+	if err := registerMDMServiceDiscovery(mux, logger, serverURLPrefix, fleetConfig); err != nil {
 		return fmt.Errorf("service discovery: %w", err)
 	}
 	return nil
@@ -1188,6 +1190,7 @@ func registerMDMServiceDiscovery(
 	mux *http.ServeMux,
 	logger kitlog.Logger,
 	serverURLPrefix string,
+	fleetConfig config.FleetConfig,
 ) error {
 	serviceDiscoveryLogger := kitlog.With(logger, "component", "mdm-apple-service-discovery")
 	fullMDMEnrollmentURL := fmt.Sprintf("%s%s", serverURLPrefix, apple_mdm.AccountDrivenEnrollPath)
@@ -1201,7 +1204,7 @@ func registerMDMServiceDiscovery(
 			http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 		}
 	})
-	mux.Handle(apple_mdm.ServiceDiscoveryPath, serviceDiscoveryHandler)
+	mux.Handle(apple_mdm.ServiceDiscoveryPath, otel.WrapHandler(serviceDiscoveryHandler, apple_mdm.ServiceDiscoveryPath, fleetConfig))
 	return nil
 }
 
@@ -1213,6 +1216,7 @@ func registerSCEP(
 	scepStorage scep_depot.Depot,
 	mdmStorage fleet.MDMAppleStore,
 	logger kitlog.Logger,
+	fleetConfig config.FleetConfig,
 ) error {
 	var signer scepserver.CSRSignerContext = scepserver.SignCSRAdapter(scep_depot.NewSigner(
 		scepStorage,
@@ -1237,7 +1241,7 @@ func registerSCEP(
 	e.GetEndpoint = scepserver.EndpointLoggingMiddleware(scepLogger)(e.GetEndpoint)
 	e.PostEndpoint = scepserver.EndpointLoggingMiddleware(scepLogger)(e.PostEndpoint)
 	scepHandler := scepserver.MakeHTTPHandler(e, scepService, scepLogger)
-	mux.Handle(apple_mdm.SCEPPath, scepHandler)
+	mux.Handle(apple_mdm.SCEPPath, otel.WrapHandler(scepHandler, apple_mdm.SCEPPath, fleetConfig))
 	return nil
 }
 
@@ -1295,6 +1299,7 @@ func registerMDM(
 	ddmService nanomdm_service.DeclarativeManagement,
 	profileService nanomdm_service.ProfileService,
 	logger kitlog.Logger,
+	fleetConfig config.FleetConfig,
 ) error {
 	certVerifier := mdmcrypto.NewSCEPVerifier(mdmStorage)
 	mdmLogger := NewNanoMDMLogger(kitlog.With(logger, "component", "http-mdm-apple-mdm"))
@@ -1326,7 +1331,7 @@ func registerMDM(
 	}
 	mdmHandler = httpmdm.CertExtractMdmSignatureMiddleware(mdmHandler, httpmdm.MdmSignatureVerifierFunc(cryptoutil.VerifyMdmSignature),
 		httpmdm.SigLogWithLogger(mdmLogger.With("handler", "cert-extract")))
-	mux.Handle(apple_mdm.MDMPath, mdmHandler)
+	mux.Handle(apple_mdm.MDMPath, otel.WrapHandler(mdmHandler, apple_mdm.MDMPath, fleetConfig))
 	return nil
 }
 

--- a/server/service/middleware/otel/otel.go
+++ b/server/service/middleware/otel/otel.go
@@ -1,4 +1,4 @@
-package main
+package otel
 
 import (
 	"net/http"
@@ -7,9 +7,9 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 )
 
-// wrapWithOTEL wraps an HTTP handler with OpenTelemetry instrumentation for a fixed route.
+// WrapHandler wraps an HTTP handler with OpenTelemetry instrumentation for a fixed route.
 // It creates spans named as "{method} {route}" (e.g., "GET /healthz").
-func wrapWithOTEL(handler http.Handler, route string, config config.FleetConfig) http.Handler {
+func WrapHandler(handler http.Handler, route string, config config.FleetConfig) http.Handler {
 	if config.Logging.TracingEnabled && config.Logging.TracingType == "opentelemetry" {
 		// Wrap with OTEL handler to create properly named spans: "{method} {route}"
 		return otelhttp.NewHandler(
@@ -23,9 +23,9 @@ func wrapWithOTEL(handler http.Handler, route string, config config.FleetConfig)
 	return handler
 }
 
-// wrapWithOTELDynamic wraps an HTTP handler with OpenTelemetry instrumentation using dynamic routes.
+// WrapHandlerDynamic wraps an HTTP handler with OpenTelemetry instrumentation using dynamic routes.
 // It creates spans based on the actual request path (e.g., "GET /assets/app.js").
-func wrapWithOTELDynamic(handler http.Handler, config config.FleetConfig) http.Handler {
+func WrapHandlerDynamic(handler http.Handler, config config.FleetConfig) http.Handler {
 	if config.Logging.TracingEnabled && config.Logging.TracingType == "opentelemetry" {
 		// Create a wrapper that instruments each request with its actual path
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -441,6 +441,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 				},
 				commander,
 				"https://test-url.com",
+				cfg,
 			)
 			require.NoError(t, err)
 		}

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -459,6 +459,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 				ds,
 				logger,
 				timeout,
+				&cfg,
 			)
 			require.NoError(t, err)
 		}
@@ -480,7 +481,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	extra = append(extra, WithLoginRateLimit(throttled.PerMin(1000)))
 
 	if len(opts) > 0 && opts[0].HostIdentity != nil {
-		require.NoError(t, hostidentity.RegisterSCEP(rootMux, opts[0].HostIdentity.SCEPStorage, ds, logger))
+		require.NoError(t, hostidentity.RegisterSCEP(rootMux, opts[0].HostIdentity.SCEPStorage, ds, logger, &cfg))
 		var httpSigVerifier func(http.Handler) http.Handler
 		httpSigVerifier, err := httpsig.Middleware(ds, opts[0].HostIdentity.RequireHTTPMessageSignature, kitlog.With(logger, "component", "http-sig-verifier"))
 		require.NoError(t, err)
@@ -498,7 +499,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	rootMux.Handle("/enroll", ServeEndUserEnrollOTA(svc, "", ds, logger))
 
 	if len(opts) > 0 && opts[0].EnableSCIM {
-		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger))
+		require.NoError(t, scim.RegisterSCIM(rootMux, ds, svc, logger, &cfg))
 		rootMux.Handle("/api/v1/fleet/scim/details", apiHandler)
 		rootMux.Handle("/api/latest/fleet/scim/details", apiHandler)
 	}


### PR DESCRIPTION
Fixes #32331 

Manually tested all paths. `/test` path removed in https://github.com/fleetdm/fleet/pull/32962

Also added support for sending errors to OpenTelemetry, like we do for APM/Sentry.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenTelemetry tracing across core HTTP endpoints (health, version, assets, metrics, enroll/root, debug, Apple MDM, SCEP, SCIM) with dynamic per-request route instrumentation.
  * Enhanced error reporting to include OpenTelemetry spans/events with contextual user/host attributes.

* **Tests**
  * Added unit tests validating SCIM and error-handling telemetry, span naming, and sensitive-data redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->