### PR TITLE
update UI to support unenrolling android and ios and ipados devices

### DIFF
--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -207,12 +207,12 @@ export interface IActivityDetails {
   labels_exclude_any?: ILabelSoftwareTitle[];
   labels_include_any?: ILabelSoftwareTitle[];
   location?: string; // name of location associated with VPP token
-  mdm_platform?: "microsoft" | "apple";
+  mdm_platform?: "microsoft" | "apple" | "android" | "ios" | "ipados";
   minimum_version?: string;
   name?: string;
   pack_id?: number;
   pack_name?: string;
-  platform?: Platform; // software platform
+  platform?: Platform; // OS platform
   policy_id?: number;
   policy_name?: string;
   profile_identifier?: string;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1036,10 +1036,11 @@ describe("Activity Feed", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a 'mdm_enrolled' type for android or apple personal devices with enrollment ID provided", () => {
+  it("renders a 'mdm_enrolled' type for android or apple personal devices with actor full name provided", () => {
     const activity = createMockActivity({
       type: ActivityType.MdmEnrolled,
       details: {
+        host_display_name: "Test Host",
         enrollment_id: "test-enrollment-id",
         platform: "android",
       },
@@ -1048,25 +1049,7 @@ describe("Activity Feed", () => {
 
     expect(
       screen.getByText((content, node) => {
-        return (
-          node?.innerHTML === "<b>test-enrollment-id</b> enrolled to Fleet"
-        );
-      })
-    ).toBeInTheDocument();
-  });
-
-  it("renders a 'mdm_enrolled' type for android or apple personal devices without enrollment ID provided", () => {
-    const activity = createMockActivity({
-      type: ActivityType.MdmEnrolled,
-      details: {
-        platform: "ios",
-      },
-    });
-    render(<GlobalActivityItem activity={activity} isPremiumTier />);
-
-    expect(
-      screen.getByText((content, node) => {
-        return node?.innerHTML === "A device enrolled to Fleet";
+        return node?.innerHTML === "<b>Test Host</b> enrolled to Fleet.";
       })
     ).toBeInTheDocument();
   });
@@ -1604,14 +1587,14 @@ describe("Activity Feed", () => {
       actor_full_name: "Test User",
       details: {
         platform: "ios",
-        enrollment_id: "Test Enrollment ID",
+        host_display_name: "Test Host",
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
 
     expect(screen.getByText(/Test User/)).toBeInTheDocument();
     expect(screen.getByText(/told Fleet to unenroll/)).toBeInTheDocument();
-    expect(screen.getByText(/Test Enrollment ID/)).toBeInTheDocument();
+    expect(screen.getByText(/Test Host/)).toBeInTheDocument();
   });
 
   it("renders an mdm unenroll activity with no actor name for ios, ipados, and android devices", () => {
@@ -1620,12 +1603,12 @@ describe("Activity Feed", () => {
       actor_full_name: undefined,
       details: {
         platform: "ios",
-        enrollment_id: "Test Enrollment ID",
+        host_display_name: "Test Host",
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
 
-    expect(screen.getByText(/Test Enrollment ID/)).toBeInTheDocument();
+    expect(screen.getByText(/Test Host/)).toBeInTheDocument();
     expect(screen.getByText(/is unenrolled from Fleet/)).toBeInTheDocument();
   });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1036,13 +1036,12 @@ describe("Activity Feed", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders a 'mdm_enrolled' type for apple with host display name and personal enrollment provided", () => {
+  it("renders a 'mdm_enrolled' type for android or apple personal devices with enrollment ID provided", () => {
     const activity = createMockActivity({
       type: ActivityType.MdmEnrolled,
       details: {
-        host_display_name: "Test Host",
         enrollment_id: "test-enrollment-id",
-        mdm_platform: "apple",
+        platform: "android",
       },
     });
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
@@ -1050,9 +1049,24 @@ describe("Activity Feed", () => {
     expect(
       screen.getByText((content, node) => {
         return (
-          node?.innerHTML ===
-          "<b>Test User </b>An end user turned on MDM features for <b>Test Host (personal)</b>."
+          node?.innerHTML === "<b>test-enrollment-id</b> enrolled to Fleet"
         );
+      })
+    ).toBeInTheDocument();
+  });
+
+  it("renders a 'mdm_enrolled' type for android or apple personal devices without enrollment ID provided", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmEnrolled,
+      details: {
+        platform: "ios",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(
+      screen.getByText((content, node) => {
+        return node?.innerHTML === "A device enrolled to Fleet";
       })
     ).toBeInTheDocument();
   });
@@ -1582,5 +1596,36 @@ describe("Activity Feed", () => {
       screen.getByText(/deleted a certificate authority/)
     ).toBeInTheDocument();
     expect(screen.getByText(/HYDRANT_TEST/)).toBeInTheDocument();
+  });
+
+  it("renders an mdm unenroll activity with an actor name for ios, ipados, and android devices", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmUnenrolled,
+      actor_full_name: "Test User",
+      details: {
+        platform: "ios",
+        enrollment_id: "Test Enrollment ID",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(screen.getByText(/Test User/)).toBeInTheDocument();
+    expect(screen.getByText(/told Fleet to unenroll/)).toBeInTheDocument();
+    expect(screen.getByText(/Test Enrollment ID/)).toBeInTheDocument();
+  });
+
+  it("renders an mdm unenroll activity with no actor name for ios, ipados, and android devices", () => {
+    const activity = createMockActivity({
+      type: ActivityType.MdmUnenrolled,
+      actor_full_name: undefined,
+      details: {
+        platform: "ios",
+        enrollment_id: "Test Enrollment ID",
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+
+    expect(screen.getByText(/Test Enrollment ID/)).toBeInTheDocument();
+    expect(screen.getByText(/is unenrolled from Fleet/)).toBeInTheDocument();
   });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -289,7 +289,11 @@ const TAGGED_TEMPLATES = {
     }
 
     if (isAndroid(platform) || isIPadOrIPhone(platform)) {
-      return <>{host_display_name} enrolled to Fleet.</>;
+      return (
+        <>
+          <b>{host_display_name}</b> enrolled to Fleet.
+        </>
+      );
     }
 
     // note: if mdm_platform is missing, we assume this is Apple MDM for backwards

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -274,8 +274,12 @@ const TAGGED_TEMPLATES = {
     );
     return <>{hostDisplayName} enrolled in Fleet.</>;
   },
+
   mdmEnrolled: (activity: IActivity) => {
-    if (activity.details?.mdm_platform === "microsoft") {
+    const { mdm_platform, platform = "", host_display_name, host_serial } =
+      activity.details || {};
+
+    if (mdm_platform === "microsoft") {
       return (
         <>
           <b>{activity.actor_full_name} </b>Mobile device management (MDM) was
@@ -284,15 +288,8 @@ const TAGGED_TEMPLATES = {
       );
     }
 
-    const { platform = "", enrollment_id } = activity.details || {};
-
     if (isAndroid(platform) || isIPadOrIPhone(platform)) {
-      return (
-        <>
-          {enrollment_id ? <b>{enrollment_id}</b> : "A device"} enrolled to
-          Fleet
-        </>
-      );
+      return <>{host_display_name} enrolled to Fleet.</>;
     }
 
     // note: if mdm_platform is missing, we assume this is Apple MDM for backwards
@@ -304,10 +301,8 @@ const TAGGED_TEMPLATES = {
       enrollmentTypeText = "manual";
     }
 
-    const hostDisplayText =
-      activity.details?.host_display_name || activity.details?.host_serial;
-
-    const hostDisplayPrefixText = activity.details?.host_display_name
+    const hostDisplayText = host_display_name || host_serial;
+    const hostDisplayPrefixText = host_display_name
       ? ""
       : "a host with serial number ";
 
@@ -322,39 +317,39 @@ const TAGGED_TEMPLATES = {
       </>
     );
   },
+
   mdmUnenrolled: (activity: IActivity) => {
     const { actor_full_name } = activity;
-    const { platform = "", enrollment_id } = activity.details || {};
+    const { platform = "", host_display_name } = activity.details || {};
 
     if (isAndroid(platform) || isIPadOrIPhone(platform)) {
       return actor_full_name ? (
         <>
           <b>{actor_full_name}</b> told Fleet to unenroll{" "}
-          {enrollment_id ? <b>{enrollment_id}</b> : "a device"}.
+          <b>{host_display_name}.</b>
         </>
       ) : (
         <>
-          {enrollment_id ? (
-            <>
-              <b>{enrollment_id}</b> is
-            </>
-          ) : (
-            "A device"
-          )}{" "}
-          unenrolled from Fleet.
+          <b>{host_display_name}</b> is unenrolled from Fleet.
         </>
       );
     }
 
     return (
       <>
-        {activity.actor_full_name
-          ? " told Fleet to turn off mobile device management (MDM) for"
-          : "Mobile device management (MDM) was turned off for"}{" "}
-        <b>{activity.details?.host_display_name}</b>.
+        {actor_full_name ? (
+          <>
+            <b>{actor_full_name}</b> told Fleet to turn off mobile device
+            management (MDM) for
+          </>
+        ) : (
+          "Mobile device management (MDM) was turned off for"
+        )}{" "}
+        <b>{host_display_name}</b>.
       </>
     );
   },
+
   editedAppleosMinVersion: (
     applePlatform: AppleDisplayPlatform,
     activity: IActivity

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -41,6 +41,7 @@ const HostActionsDropdown = ({
     isGlobalMaintainer = false,
     isMacMdmEnabledAndConfigured = false,
     isWindowsMdmEnabledAndConfigured = false,
+    isAndroidMdmEnabledAndConfigured = false,
     currentUser,
     config: globalConfig,
   } = useContext(AppContext);
@@ -69,6 +70,7 @@ const HostActionsDropdown = ({
     isConnectedToFleetMdm,
     isMacMdmEnabledAndConfigured,
     isWindowsMdmEnabledAndConfigured,
+    isAndroidMdmEnabledAndConfigured,
     doesStoreEncryptionKey: doesStoreEncryptionKey ?? false,
     hostMdmDeviceStatus,
     hostScriptsEnabled,

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/_styles.scss
@@ -8,4 +8,8 @@
     right: 0;
     min-width: max-content;
   }
+
+  .actions-dropdown-select__menu {
+    min-width: 200px;
+  }
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1350,6 +1350,9 @@ const HostDetailsPage = ({
               hostId={host.id}
               hostPlatform={host.platform}
               hostName={host.display_name}
+              isBYODEnrollment={isPersonalEnrollmentInMdm(
+                host.mdm.enrollment_status
+              )}
               onClose={toggleUnenrollMdmModal}
             />
           )}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -6,8 +6,7 @@ import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
 
 import mdmAPI from "services/entities/mdm";
-import { isIPadOrIPhone } from "interfaces/platform";
-import CustomLink from "components/CustomLink";
+import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
 interface IUnenrollMdmModalProps {
   hostId: number;
@@ -52,35 +51,55 @@ const UnenrollMdmModal = ({
     onClose();
   };
 
+  const generateDescription = () => {
+    if (isIPadOrIPhone(hostPlatform)) {
+      return (
+        <>
+          <p>Settings configured by Fleet will be removed.</p>
+          <p>
+            To re-enroll, go to <b>Hosts &gt; Add hosts &gt; iOS/iPadOS</b> and
+            share the link with end user.
+          </p>
+        </>
+      );
+    }
+    if (isAndroid(hostPlatform)) {
+      return (
+        <>
+          <p>Company data and OS settings (work profile) will be deleted.</p>
+          <p>
+            To re-enroll, go to <b>Hosts &gt; Add hosts &gt; Android</b> and
+            share the link with end user.
+          </p>
+        </>
+      );
+    }
+    return (
+      <>
+        <p>Settings configured by Fleet will be removed.</p>
+        <p>
+          To turn on MDM again, ask the device user to follow the{" "}
+          <b>Turn on MDM</b> instructions on their <b>My device</b> page.
+        </p>
+      </>
+    );
+  };
+
   const renderModalContent = () => {
     if (requestState === "error") {
       return <DataError />;
     }
 
-    const turnOnMDMInstructions = isIPadOrIPhone(hostPlatform) ? (
-      <>
-        invite the end user to{" "}
-        <CustomLink
-          text="enroll a BYOD iPhone or iPad"
-          url="https://fleetdm.com/guides/enroll-byod-ios-ipados-hosts"
-          newTab
-        />
-      </>
-    ) : (
-      <>
-        ask the device user to follow the <b>Turn on MDM</b> instructions on
-        their <b>My device</b> page.
-      </>
-    );
+    const buttonText =
+      isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform)
+        ? "Unenroll"
+        : "Turn off";
 
     return (
       <>
-        <p className={`${baseClass}__description`}>
-          Settings configured by Fleet will be removed.
-          <br />
-          <br />
-          To turn on MDM again, {turnOnMDMInstructions}
-        </p>
+        <div className={`${baseClass}__description`}>
+          {generateDescription()}
+        </div>
         <div className="modal-cta-wrap">
           <Button
             type="submit"
@@ -88,7 +107,7 @@ const UnenrollMdmModal = ({
             onClick={submitUnenrollMdm}
             isLoading={requestState === "unenrolling"}
           >
-            Turn off
+            {buttonText}
           </Button>
           <Button onClick={onClose} variant="inverse-alert">
             Cancel
@@ -98,13 +117,13 @@ const UnenrollMdmModal = ({
     );
   };
 
+  const title =
+    isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform)
+      ? "Unenroll"
+      : "Turn off MDM";
+
   return (
-    <Modal
-      title="Turn off MDM"
-      onExit={onClose}
-      className={baseClass}
-      width="medium"
-    >
+    <Modal title={title} onExit={onClose} className={baseClass} width="medium">
       {renderModalContent()}
     </Modal>
   );


### PR DESCRIPTION
resolves #31821, resolves #32120

this updates the UI to support unenrolling android and ios and ipad devices. This includes:

**updating the host details page to include and unenroll action in the host actions dropdown**

**Updating the unenroll modal to have dynamic content depending on the device we are unenrolling**

**updating the global activities to have different messages for mdm enroll and mdm unenroll actions**

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

