### PR TITLE
Remove XDG_CURRENT_DESKTOP env var when opening URLs on KDE

### DIFF
--- a/pkg/open/open_linux.go
+++ b/pkg/open/open_linux.go
@@ -163,6 +163,15 @@ func newEnvironmentWithVariablesFromNamedProcesses(exePaths []string, envvars ..
 		delete(localEnv, k)
 	}
 
+	if _, ok := localEnv["XDG_CURRENT_DESKTOP"]; ok && localEnv["XDG_CURRENT_DESKTOP"] == "KDE" {
+		// xdg-open checks KDE_SESSION_VERSION to determine how to launch the browser, but it is
+		// not always up-to-date and may fail for newer versions of KDE Plasma. Unsetting here
+		// will cause xdg-open to fall back to "generic" behavior for launching the browser, which
+		// ends up being more reliable.
+		log.Debug().Msg("unsetting XDG_CURRENT_DESKTOP=KDE for better xdg-open compatibility")
+		delete(localEnv, "XDG_CURRENT_DESKTOP")
+	}
+
 	var out []string
 	for k, v := range localEnv {
 		out = append(out, fmt.Sprintf("%s=%s", k, v))

--- a/pkg/open/open_linux.go
+++ b/pkg/open/open_linux.go
@@ -163,11 +163,12 @@ func newEnvironmentWithVariablesFromNamedProcesses(exePaths []string, envvars ..
 		delete(localEnv, k)
 	}
 
+	// When KDE is detected, xdg-open checks the KDE_SESSION_VERSION to determine how to
+	// launch the browser, so we could set that here and try to let `xdg-open` do the right thing.
+	// However, xdg-open is not always up-to-date and may fail for newer versions of
+	// KDE Plasma. Unsetting XDG_CURRENT_DESKTOP here will cause xdg-open to fall back to
+	// "generic" behavior for launching the browser, which ends up being more reliable.
 	if _, ok := localEnv["XDG_CURRENT_DESKTOP"]; ok && localEnv["XDG_CURRENT_DESKTOP"] == "KDE" {
-		// xdg-open checks KDE_SESSION_VERSION to determine how to launch the browser, but it is
-		// not always up-to-date and may fail for newer versions of KDE Plasma. Unsetting here
-		// will cause xdg-open to fall back to "generic" behavior for launching the browser, which
-		// ends up being more reliable.
 		log.Debug().Msg("unsetting XDG_CURRENT_DESKTOP=KDE for better xdg-open compatibility")
 		delete(localEnv, "XDG_CURRENT_DESKTOP")
 	}


### PR DESCRIPTION
for #31087 
for #32863

# Details

The [community PR](https://github.com/fleetdm/fleet/pull/30608) for #31087 sets a number of new env vars to try and ensure that `xdg-open` can correctly open URLs when called from our `open` package on linux. However, it was discovered that the addition of the `XDG_CURRENT_DESKTOP` env var actually broke `xdg-open` use on environments using KDE Plasma (i.e. Kubuntu). After doing some testing I determined that the best path forward was to just clear this env var when KDE was detected, setting it back to the state that previous versions of `fleet-desktop` have been in: that is, allowing `xdg-open` to determine how to open links by other means. 

# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
