### PR TITLE
UI: DUP only check for setup experience software on Fleet Premium

### DIFF
--- a/frontend/__mocks__/licenseMock.ts
+++ b/frontend/__mocks__/licenseMock.ts
@@ -4,6 +4,8 @@ const DEFAULT_LICENSE_MOCK = {
   expiration: "2050-01-01T00:00:00Z",
   note: "test license",
   organization: "test org",
+  managed_cloud: false,
+  allow_disable_telemetry: false,
 };
 
 type License = typeof DEFAULT_LICENSE_MOCK;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -1,15 +1,20 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import { IDeviceUserResponse, IHostDevice } from "interfaces/host";
 import createMockHost from "__mocks__/hostMock";
 import mockServer from "test/mock-server";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
+import createMockLicense from "__mocks__/licenseMock";
+
+import { IGetSetupSoftwareStatusesResponse } from "services/entities/device_user";
+
 import {
   customDeviceHandler,
   defaultDeviceCertificatesHandler,
   defaultDeviceHandler,
-  defaultSetupSoftwareStatusesHandler,
+  deviceSetupExperienceHandler,
+  emptySetupExperienceHandler,
 } from "test/handlers/device-handler";
 import DeviceUserPage from "./DeviceUserPage";
 
@@ -31,7 +36,7 @@ describe("Device User Page", () => {
   it("hides the software tab if the device has no software", async () => {
     mockServer.use(defaultDeviceHandler);
     mockServer.use(defaultDeviceCertificatesHandler);
-    mockServer.use(defaultSetupSoftwareStatusesHandler);
+    mockServer.use(emptySetupExperienceHandler);
 
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -54,7 +59,7 @@ describe("Device User Page", () => {
   it("hides the certificates card if the device has no certificates", async () => {
     mockServer.use(defaultDeviceHandler);
     mockServer.use(defaultDeviceCertificatesHandler);
-    mockServer.use(defaultSetupSoftwareStatusesHandler);
+    mockServer.use(emptySetupExperienceHandler);
 
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -82,7 +87,7 @@ describe("Device User Page", () => {
 
     mockServer.use(customDeviceHandler({ host }));
     mockServer.use(defaultDeviceCertificatesHandler);
-    mockServer.use(defaultSetupSoftwareStatusesHandler);
+    mockServer.use(emptySetupExperienceHandler);
 
     const render = createCustomRenderer({
       withBackendMock: true,
@@ -101,12 +106,79 @@ describe("Device User Page", () => {
 
     expect(screen.queryByText(/Certificates/)).not.toBeInTheDocument();
   });
+  describe("Setup experience software installation", () => {
+    const REGULAR_DUP_MATCHER = /Last fetched/;
+    const SETTING_UP_YOUR_DEVICE_MATCHER = /Setting up your device/;
+
+    const setupTest = async (
+      deviceUserResponseOverrides?: Partial<IDeviceUserResponse>,
+      setupExperienceOverrides?: Partial<IGetSetupSoftwareStatusesResponse>
+    ) => {
+      mockServer.use(customDeviceHandler(deviceUserResponseOverrides));
+      mockServer.use(defaultDeviceCertificatesHandler);
+      mockServer.use(deviceSetupExperienceHandler(setupExperienceOverrides));
+
+      const render = createCustomRenderer({
+        withBackendMock: true,
+      });
+
+      const { user } = render(
+        <DeviceUserPage
+          router={mockRouter}
+          params={{ device_auth_token: "testToken" }}
+          location={mockLocation}
+        />
+      );
+
+      await screen.findByText(/My device/);
+
+      return user;
+    };
+
+    it("does not check for setup experience software on Fleet Free", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "linux";
+
+      await setupTest({ host, license: createMockLicense({ tier: "free" }) });
+
+      await waitFor(() => {
+        expect(screen.getByText(REGULAR_DUP_MATCHER)).toBeInTheDocument();
+      });
+    });
+
+    it("checks for setup experience software on Fleet Premium, and renders Setting Up Your Device if there is such software", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "linux";
+
+      await setupTest({ host });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(SETTING_UP_YOUR_DEVICE_MATCHER)
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();
+    });
+    it("checks for setup experience software on Fleet Premium, and renders the normal device user page if there is no such software", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "linux";
+
+      await setupTest({ host }, { setup_experience_results: {} });
+
+      await waitFor(() => {
+        expect(screen.getByText(REGULAR_DUP_MATCHER)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(SETTING_UP_YOUR_DEVICE_MATCHER)).toBeNull();
+    });
+  });
 
   describe("MDM enrollment", () => {
     const setupTest = async (overrides: Partial<IDeviceUserResponse>) => {
       mockServer.use(customDeviceHandler(overrides));
       mockServer.use(defaultDeviceCertificatesHandler);
-      mockServer.use(defaultSetupSoftwareStatusesHandler);
+      mockServer.use(emptySetupExperienceHandler);
 
       const render = createCustomRenderer({
         withBackendMock: true,

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -315,7 +315,11 @@ const DeviceUserPage = ({
   } = dupResponse || {};
   const isPremiumTier = license?.tier === "premium";
   const isAppleHost = isAppleDevice(host?.platform);
-  const isSetupExperienceSoftwareHost = isLinuxLike(host?.platform || "");
+  const isSetupExperienceSoftwareEnabledPlatform = isLinuxLike(
+    host?.platform || ""
+  ); // TODO - add windows with next iteration
+  const checkForSetupExperienceSoftware =
+    isSetupExperienceSoftwareEnabledPlatform && isPremiumTier;
 
   const summaryData = normalizeEmptyValues(pick(host, HOST_SUMMARY_DATA));
 
@@ -335,7 +339,7 @@ const DeviceUserPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       select: (res) => res.setup_experience_results.software,
-      enabled: isSetupExperienceSoftwareHost, // TODO - add windows with next iteration
+      enabled: checkForSetupExperienceSoftware, // this can only become true once the above `dupResponse` is defined by its associated API call response, ensuring this call only fires once the frontend knows if this is a Fleet Premium instance
       refetchInterval: (data) => (getIsSettingUpSoftware(data) ? 5000 : false), // refetch every 5s until finished
       refetchIntervalInBackground: true,
     }
@@ -480,7 +484,7 @@ const DeviceUserPage = ({
       return <DataError description="Could not get software setup status." />;
     }
     if (
-      isSetupExperienceSoftwareHost &&
+      checkForSetupExperienceSoftware &&
       getIsSettingUpSoftware(softwareSetupStatuses)
     ) {
       // at this point, softwareSetupStatuses will be non-empty

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -53,7 +53,7 @@ export interface IGetVppInstallCommandResultsResponse {
   results: IMdmCommandResult[];
 }
 export interface IGetSetupSoftwareStatusesResponse {
-  setup_experience_results: { software: ISetupSoftwareStatus[] };
+  setup_experience_results: { software?: ISetupSoftwareStatus[] };
 }
 
 export interface IGetSetupSoftwareStatusesParams {

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -27,7 +27,7 @@ export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () => {
   });
 });
 
-export const customDeviceHandler = (overrides: Partial<IDeviceUserResponse>) =>
+export const customDeviceHandler = (overrides?: Partial<IDeviceUserResponse>) =>
   http.get(baseUrl("/device/:token"), () => {
     return HttpResponse.json(
       Object.assign(
@@ -83,13 +83,15 @@ export const defaultDeviceCertificatesHandler = http.get(
   }
 );
 
-export const defaultSetupSoftwareStatusesHandler = http.post(
-  baseUrl("/device/:token/setup_experience/status"),
-  () => {
-    return HttpResponse.json<IGetSetupSoftwareStatusesResponse>(
-      createMockSetupSoftwareStatusesResponse({
-        setup_experience_results: { software: [] },
-      })
+export const deviceSetupExperienceHandler = (
+  overrides?: Partial<IGetSetupSoftwareStatusesResponse>
+) =>
+  http.post(baseUrl("/device/:token/setup_experience/status"), () => {
+    return HttpResponse.json(
+      createMockSetupSoftwareStatusesResponse(overrides)
     );
-  }
-);
+  });
+
+export const emptySetupExperienceHandler = deviceSetupExperienceHandler({
+  setup_experience_results: { software: [] },
+});

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -1,5 +1,3 @@
-import { SetupExperiencePlatform } from "interfaces/platform";
-
 const API_VERSION = "latest";
 
 export default {


### PR DESCRIPTION
## For #32967

- Only check for setup experience software to install if Fleet is a Premium instance
- Test 3 states for Linux hosts (Free, Premium with setup software, Premium without setup software)

### Free –> forwards directly to regular DUP:
![ezgif-65398dddc88294](https://github.com/user-attachments/assets/e92ee339-3bb8-40bc-a1e2-f18a80801f89)

### Premium –> checks for setup software, renders "Setting up your device" page if present:
![ezgif-6dff84cf13facb](https://github.com/user-attachments/assets/03e8c994-e5e1-4fa7-9ad1-93c5e6171fe6)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
- [x] Confirmed that the fix is not expected to adversely impact load test results