### PR TITLE
Check for device token inactive error in refetcher and turn off MDM

### DIFF
--- a/changes/29650-turn-off-mdm-on-device-token-inactive-refetcher
+++ b/changes/29650-turn-off-mdm-on-device-token-inactive-refetcher
@@ -1,0 +1,1 @@
+- Turn off MDM for iOS and iPadOS devices when refetcher returns device token is inactive

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1414,7 +1414,6 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	}
 	if len(installedAppsUUIDs) > 0 {
 		err = commander.InstalledApplicationList(ctx, installedAppsUUIDs, fleet.RefetchAppsCommandUUIDPrefix+commandUUID, false)
-		fmt.Println(err)
 		turnedOff, turnedOffError := turnOffMDMIfAPNSFailed(ctx, ds, err)
 		if turnedOffError != nil {
 			return turnedOffError
@@ -1436,7 +1435,6 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	}
 	if len(certsListUUIDs) > 0 {
 		err = commander.CertificateList(ctx, certsListUUIDs, fleet.RefetchCertsCommandUUIDPrefix+commandUUID)
-		fmt.Println(err)
 		turnedOff, turnedOffError := turnOffMDMIfAPNSFailed(ctx, ds, err)
 		if turnedOffError != nil {
 			return turnedOffError
@@ -1459,7 +1457,6 @@ func IOSiPadOSRefetch(ctx context.Context, ds fleet.Datastore, commander *MDMApp
 	}
 	if len(deviceInfoUUIDs) > 0 {
 		err := commander.DeviceInformation(ctx, deviceInfoUUIDs, fleet.RefetchDeviceCommandUUIDPrefix+commandUUID)
-		fmt.Println(err)
 		turnedOff, turnedOffError := turnOffMDMIfAPNSFailed(ctx, ds, err)
 		if turnedOffError != nil {
 			return turnedOffError

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -17826,6 +17826,10 @@ func (s *integrationMDMTestSuite) TestIOSiPadOSRefetch() {
 	err = failedMdmDevice.Enroll()
 	require.NoError(s.T(), err)
 
+	originalPushFunc := s.pushProvider.PushFunc
+	s.T().Cleanup(func() {
+		s.pushProvider.PushFunc = originalPushFunc
+	})
 	s.pushProvider.PushFunc = func(_ context.Context, pushes []*mdm.Push) (map[string]*push.Response, error) {
 		require.Len(s.T(), pushes, 1)
 		pushObject := pushes[0]
@@ -17849,7 +17853,7 @@ func (s *integrationMDMTestSuite) TestIOSiPadOSRefetch() {
 	}
 
 	err = apple_mdm.IOSiPadOSRefetch(ctx, s.ds, s.mdmCommander, s.logger)
-	require.Contains(s.T(), err.Error(), "device token is inactive")
+	require.NoError(s.T(), err) // Verify it not longer throws an error
 
 	// Verify successful is still enrolled, and failed has been unenrolled
 	successfulHostMDM, err := s.ds.GetHostMDM(ctx, successfulHost.ID)


### PR DESCRIPTION
fixes: #29650

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually (Not possible for me to get it into the same state, I just never get a response from my device, but never the device token is inactive, I think that might be a very long time process?, but verified that if the error comes back it successfully turns off MDM)
