### PR TITLE
Supported host operating systems

### DIFF
--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -78,8 +78,8 @@ Fleet supports the following operating system versions on hosts.
 | macOS      | 14+ (Sonoma)                            |
 | iOS/iPadOS | 17+                                     |
 | Windows    | Pro and Enterprise 10+, Server 2012+    |
-| Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Amazon Linux 2+, Debian 11+ |
-| ChromeOS   | 112.0.5615.134+                        |
+| Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Amazon Linux 2+, Debian 11+, RHEL 7+ |
+| ChromeOS   | 112.0.5615.134+                         |
 | Android    | 13+                                     |
 
 While Fleet may still function partially or fully with OS versions older than those above, Fleet does not actively test against unsupported versions and does not pursue bugs on them.

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -78,7 +78,7 @@ Fleet supports the following operating system versions on hosts.
 | macOS      | 14+ (Sonoma)                            |
 | iOS/iPadOS | 17+                                     |
 | Windows    | Pro and Enterprise 10+, Server 2012+    |
-| Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Amazon Linux 2+, Debian 11+, RHEL 7+ |
+| Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Amazon Linux 2+, Debian 11+, Red Hat Enterprise Linux (RHEL) 7+ |
 | ChromeOS   | 112.0.5615.134+                         |
 | Android    | 13+                                     |
 


### PR DESCRIPTION
Add RHEL. Fleet supports RHEL today. We have users/customers with RHEL hosts enrolled.
