### PR TITLE
Bugfix: make EULA path in gitops relative to the YAML file (like other settings)

### DIFF
--- a/changes/32016-make-eula-gitops-path-relative-to-yaml
+++ b/changes/32016-make-eula-gitops-path-relative-to-yaml
@@ -1,0 +1,1 @@
+* Bugfix: fixed EULA path to be relative to the YAML file in `fleetctl gitops`, as it is for other settings.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3378,14 +3378,63 @@ org_settings:
 	cases := []struct {
 		name             string
 		cfg              string
-		mockSetup        func(t *testing.T, ds *mock.Store)
+		mockSetup        func(t *testing.T, ds *mock.Store, gitopsDir string)
 		dryRunAssertion  func(t *testing.T, ds *mock.Store, out string, err error)
 		realRunAssertion func(t *testing.T, ds *mock.Store, out string, err error)
 	}{
 		{
 			name: "valid pdf file (no existing EULA uploaded)",
 			cfg:  createGlobalGitOpsConfig(fmt.Sprintf(`end_user_license_agreement: "%s"`, pdfPath)),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
+				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
+					return nil, &notFoundError{} // No existing EULA
+				}
+			},
+			dryRunAssertion: func(t *testing.T, ds *mock.Store, out string, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, out, "[+] would've applied EULA")
+				assert.False(t, ds.MDMInsertEULAFuncInvoked)
+			},
+			realRunAssertion: func(t *testing.T, ds *mock.Store, out string, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, out, "[+] applied EULA")
+				assert.True(t, ds.MDMInsertEULAFuncInvoked)
+			},
+		},
+		{
+			name: "relative path to working dir to pdf file (no existing EULA uploaded)",
+			cfg:  createGlobalGitOpsConfig(`end_user_license_agreement: "./testdata/gitops/tiny_eula.pdf"`),
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
+				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
+					return nil, &notFoundError{} // No existing EULA
+				}
+			},
+			dryRunAssertion: func(t *testing.T, ds *mock.Store, out string, err error) {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, "error uploading EULA: reading eula file:")
+				assert.ErrorContains(t, err, "no such file or directory")
+				assert.False(t, ds.MDMInsertEULAFuncInvoked)
+			},
+			realRunAssertion: func(t *testing.T, ds *mock.Store, out string, err error) {
+				assert.Error(t, err)
+				assert.ErrorContains(t, err, "error uploading EULA: reading eula file:")
+				assert.ErrorContains(t, err, "no such file or directory")
+				assert.False(t, ds.MDMInsertEULAFuncInvoked)
+			},
+		},
+		{
+			name: "relative path to yaml file to pdf file (no existing EULA uploaded)",
+			cfg:  createGlobalGitOpsConfig(`end_user_license_agreement: "./lib/eula.pdf"`),
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
+				err := os.Mkdir(filepath.Join(dir, "lib"), 0o755)
+				require.NoError(t, err)
+				tmpPDF, err := os.Create(filepath.Join(dir, "lib", "eula.pdf"))
+				require.NoError(t, err)
+				_, err = tmpPDF.Write(pdfContent)
+				require.NoError(t, err)
+				err = tmpPDF.Close()
+				require.NoError(t, err)
+
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					return nil, &notFoundError{} // No existing EULA
 				}
@@ -3404,7 +3453,7 @@ org_settings:
 		{
 			name: "valid new pdf file (different EULA already uploaded)",
 			cfg:  createGlobalGitOpsConfig(fmt.Sprintf(`end_user_license_agreement: "%s"`, pdfPath)),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					return &fleet.MDMEULA{
 						Name:  pdfPath,
@@ -3428,7 +3477,7 @@ org_settings:
 		{
 			name: "no EULA specified (no existing EULA uploaded)",
 			cfg:  createGlobalGitOpsConfig(""),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					return nil, &notFoundError{} // No existing EULA
 				}
@@ -3449,7 +3498,7 @@ org_settings:
 		{
 			name: "deleting existing EULA",
 			cfg:  createGlobalGitOpsConfig(""),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					return &fleet.MDMEULA{
 						Name:  pdfPath,
@@ -3471,7 +3520,7 @@ org_settings:
 		{
 			name: "not a PDF file",
 			cfg:  createGlobalGitOpsConfig(fmt.Sprintf(`end_user_license_agreement: "%s"`, invalidPDFPath)),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					return nil, &notFoundError{} // No existing EULA
 				}
@@ -3486,7 +3535,7 @@ org_settings:
 		{
 			name: "uploading the same EULA again",
 			cfg:  createGlobalGitOpsConfig(""),
-			mockSetup: func(t *testing.T, ds *mock.Store) {
+			mockSetup: func(t *testing.T, ds *mock.Store, dir string) {
 				ds.MDMGetEULAMetadataFunc = func(ctx context.Context) (*fleet.MDMEULA, error) {
 					hash := sha256.Sum256(pdfContent) // Simulate same EULA
 					return &fleet.MDMEULA{
@@ -3521,13 +3570,13 @@ org_settings:
 				return nil
 			}
 
-			// these mocks are defined in the individual test cases
-			tt.mockSetup(t, ds)
-
 			tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 			require.NoError(t, err)
 			_, err = tmpFile.WriteString(tt.cfg)
 			require.NoError(t, err)
+
+			// these mocks are defined in the individual test cases
+			tt.mockSetup(t, ds, filepath.Dir(tmpFile.Name()))
 
 			// Dry run
 			out, err := RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name(), "--dry-run"})

--- a/cmd/fleetctl/fleetctl/testdata/gitops/tiny_eula.pdf
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/tiny_eula.pdf
@@ -1,0 +1,14 @@
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/Resources<<>>/MediaBox[0 0 9 9]>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000052 00000 n 
+0000000101 00000 n 
+trailer<</Root 1 0 R/Size 4>>
+startxref
+174
+%%EOF

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1902,6 +1902,9 @@ func (c *Client) DoGitOps(
 
 		// we want to apply the EULA only for the global settings
 		if appConfig.License.IsPremium() && appConfig.MDM.EnabledAndConfigured {
+			if eulaPath != "" {
+				eulaPath = resolveApplyRelativePath(baseDir, eulaPath)
+			}
 			err = c.doGitOpsEULA(eulaPath, logFn, dryRun)
 			if err != nil {
 				return nil, nil, err


### PR DESCRIPTION
For #32016 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

