### PR TITLE
Allow fleet host ID when specifying Gitops manual label hosts

### DIFF
--- a/changes/32014-allow-fleet-host-ids-in-gitops-labels
+++ b/changes/32014-allow-fleet-host-ids-in-gitops-labels
@@ -1,0 +1,1 @@
+- Added ability to specify a Fleet host ID when declaring a manual label in a Gitops YAML file

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -272,7 +272,7 @@ func TestValidGitOpsYaml(t *testing.T) {
 					assert.Equal(t, "SELECT 1 FROM osquery_info", gitops.Labels[0].Query)
 					require.Len(t, gitops.Labels[1].Hosts, 2)
 					assert.Equal(t, "host1", gitops.Labels[1].Hosts[0])
-					assert.Equal(t, "host2", gitops.Labels[1].Hosts[1])
+					assert.Equal(t, "2", gitops.Labels[1].Hosts[1])
 
 				}
 

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -697,6 +697,12 @@ func TestInvalidGitOpsYaml(t *testing.T) {
 					config += "org_settings:\n"
 					_, err = gitOpsFromString(t, config)
 					assert.ErrorContains(t, err, "'org_settings.secrets' is required")
+
+					// Bad label spec (float instead of string in hosts)
+					config = getConfig([]string{"labels"})
+					config += "labels:\n  - name: TestLabel\n    description: Label for testing\n    hosts:\n    - 2.5\n    label_membership_type: manual\n"
+					_, err = gitOpsFromString(t, config)
+					assert.ErrorContains(t, err, "hosts must be strings or integers, got float 2.5")
 				}
 
 				// Invalid agent_options

--- a/pkg/spec/testdata/global_config_no_paths.yml
+++ b/pkg/spec/testdata/global_config_no_paths.yml
@@ -202,5 +202,5 @@ labels:
     description: A fly global label
     hosts: 
       - host1
-      - host2
+      - 2
     label_membership_type: manual

--- a/pkg/spec/testdata/top.labels.yml
+++ b/pkg/spec/testdata/top.labels.yml
@@ -6,5 +6,5 @@
     description: A fly global label
     hosts: 
       - host1
-      - host2
+      - 2
     label_membership_type: manual

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -148,9 +148,9 @@ DELETE FROM label_membership WHERE label_id = ?
 				// Use ignore because duplicate hostnames could appear in
 				// different batches and would result in duplicate key errors.
 				sql = `
-INSERT IGNORE INTO label_membership (label_id, host_id) (SELECT DISTINCT ?, id FROM hosts where hostname IN (?) OR hardware_serial IN (?) OR uuid IN (?))
+INSERT IGNORE INTO label_membership (label_id, host_id) (SELECT DISTINCT ?, id FROM hosts where hostname IN (?) OR hardware_serial IN (?) OR uuid IN (?) OR ID in (?))
 `
-				sql, args, err := sqlx.In(sql, labelID, hostIdentifiers, hostIdentifiers, hostIdentifiers)
+				sql, args, err := sqlx.In(sql, labelID, hostIdentifiers, hostIdentifiers, hostIdentifiers, hostIdentifiers)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "build membership IN statement")
 				}

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -174,10 +174,10 @@ func batchHostnames(hostnames []string) [][]string {
 	// https://github.com/golang/go/wiki/SliceTricks#batching-with-minimal-allocation
 	//
 	// WARNING: This is used in ApplyLabelSpecsWithAuthor and the batch sizes have to be small
-	// enough to allow for three copies each hostname list in the query. The batch size is 20_000
+	// enough to allow for three copies each hostname list in the query. The batch size is 15_000
 	// because 60_001 binding arguments is less than the maximum of 65,535.
 
-	const batchSize = 20_000 // Large, but well under the undocumented limit
+	const batchSize = 15_000 // Large, but well under the undocumented limit
 	batches := make([][]string, 0, (len(hostnames)+batchSize-1)/batchSize)
 
 	for batchSize < len(hostnames) {

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -148,7 +148,7 @@ DELETE FROM label_membership WHERE label_id = ?
 				// Use ignore because duplicate hostnames could appear in
 				// different batches and would result in duplicate key errors.
 				sql = `
-INSERT IGNORE INTO label_membership (label_id, host_id) (SELECT DISTINCT ?, id FROM hosts where hostname IN (?) OR hardware_serial IN (?) OR uuid IN (?) OR ID in (?))
+INSERT IGNORE INTO label_membership (label_id, host_id) (SELECT DISTINCT ?, id FROM hosts where hostname IN (?) OR hardware_serial IN (?) OR uuid IN (?) OR id IN (?))
 `
 				sql, args, err := sqlx.In(sql, labelID, hostIdentifiers, hostIdentifiers, hostIdentifiers, hostIdentifiers)
 				if err != nil {

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -34,13 +34,15 @@ func TestBatchHostnamesLarge(t *testing.T) {
 		large = append(large, strconv.Itoa(i))
 	}
 	batched := batchHostnames(large)
-	require.Equal(t, 6, len(batched))
-	assert.Equal(t, large[:20_000], batched[0])
-	assert.Equal(t, large[20_000:40_000], batched[1])
-	assert.Equal(t, large[40_000:60_000], batched[2])
-	assert.Equal(t, large[60_000:80_000], batched[3])
-	assert.Equal(t, large[80_000:100_000], batched[4])
-	assert.Equal(t, large[100_000:110_000], batched[5])
+	require.Equal(t, 8, len(batched))
+	assert.Equal(t, large[:15_000], batched[0])
+	assert.Equal(t, large[15_000:30_000], batched[1])
+	assert.Equal(t, large[30_000:45_000], batched[2])
+	assert.Equal(t, large[45_000:60_000], batched[3])
+	assert.Equal(t, large[60_000:75_000], batched[4])
+	assert.Equal(t, large[75_000:90_000], batched[5])
+	assert.Equal(t, large[90_000:105_000], batched[6])
+	assert.Equal(t, large[105_000:110_000], batched[7])
 }
 
 func TestBatchHostIdsSmall(t *testing.T) {
@@ -2005,6 +2007,7 @@ func testApplyLabelSpecsForSerialUUID(t *testing.T, ds *Datastore) {
 		HardwareSerial: "hwd3",
 		Platform:       "windows",
 	})
+	require.NoError(t, err)
 	host4, err := ds.NewHost(ctx, &fleet.Host{
 		OsqueryHostID:  ptr.String("4"),
 		NodeKey:        ptr.String("4"),
@@ -2023,7 +2026,7 @@ func testApplyLabelSpecsForSerialUUID(t *testing.T, ds *Datastore) {
 				"foo.local",
 				"hwd2",
 				"uuid3",
-				strconv.Itoa(int(host4.ID)),
+				strconv.Itoa(int(host4.ID)), //nolint:gosec // dismiss G115
 			},
 		},
 	})

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -790,6 +790,10 @@ func setupLabelSpecsTest(t *testing.T, ds fleet.Datastore) []*fleet.LabelSpec {
 	err := ds.ApplyLabelSpecs(context.Background(), expectedSpecs)
 	require.Nil(t, err)
 
+	// Because `Hosts` for manual labels matches both host name AND host ID,
+	// specifying "1" will match both host with ID 1 (whose name is "0")
+	// and host with name "1".
+	expectedSpecs[4].Hosts = []string{"0", "1", "2", "3", "4"}
 	return expectedSpecs
 }
 

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -2005,6 +2005,14 @@ func testApplyLabelSpecsForSerialUUID(t *testing.T, ds *Datastore) {
 		HardwareSerial: "hwd3",
 		Platform:       "windows",
 	})
+	host4, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:  ptr.String("4"),
+		NodeKey:        ptr.String("4"),
+		UUID:           "uuid4",
+		Hostname:       "boop.local",
+		HardwareSerial: "hwd4",
+		Platform:       "linux",
+	})
 	require.NoError(t, err)
 
 	err = ds.ApplyLabelSpecs(ctx, []*fleet.LabelSpec{
@@ -2015,6 +2023,7 @@ func testApplyLabelSpecsForSerialUUID(t *testing.T, ds *Datastore) {
 				"foo.local",
 				"hwd2",
 				"uuid3",
+				strconv.Itoa(int(host4.ID)),
 			},
 		},
 	})
@@ -2022,10 +2031,11 @@ func testApplyLabelSpecsForSerialUUID(t *testing.T, ds *Datastore) {
 
 	hosts, err := ds.ListHostsInLabel(ctx, fleet.TeamFilter{User: test.UserAdmin}, 1, fleet.HostListOptions{})
 	require.NoError(t, err)
-	require.Len(t, hosts, 3)
+	require.Len(t, hosts, 4)
 	require.Equal(t, host1.ID, hosts[0].ID)
 	require.Equal(t, host2.ID, hosts[1].ID)
 	require.Equal(t, host3.ID, hosts[2].ID)
+	require.Equal(t, host4.ID, hosts[3].ID)
 }
 
 func testApplyLabelSpecsWithPlatformChange(t *testing.T, ds *Datastore) {

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -181,6 +181,29 @@ type LabelQueryExecution struct {
 	HostID    uint
 }
 
+type HostsSlice []string
+
+func (s *HostsSlice) UnmarshalJSON(data []byte) error {
+	var raw []interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	var result []string
+	for _, v := range raw {
+		switch val := v.(type) {
+		case string:
+			result = append(result, val)
+		case float64:
+			// JSON numbers are float64, convert to int if needed
+			result = append(result, fmt.Sprintf("%.0f", val))
+		default:
+			return fmt.Errorf("hosts must be strings or integers, got %T", v)
+		}
+	}
+	*s = result
+	return nil
+}
+
 type LabelSpec struct {
 	ID                  uint                `json:"id"`
 	Name                string              `json:"name"`
@@ -189,7 +212,7 @@ type LabelSpec struct {
 	Platform            string              `json:"platform,omitempty"`
 	LabelType           LabelType           `json:"label_type,omitempty" db:"label_type"`
 	LabelMembershipType LabelMembershipType `json:"label_membership_type" db:"label_membership_type"`
-	Hosts               []string            `json:"hosts"`
+	Hosts               HostsSlice          `json:"hosts"`
 	HostVitalsCriteria  *json.RawMessage    `json:"criteria,omitempty" db:"criteria"`
 }
 

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -196,7 +196,7 @@ func (s *HostsSlice) UnmarshalJSON(data []byte) error {
 		case float64:
 			// Check if the float64 is actually an integer
 			if val != float64(int64(val)) {
-				return fmt.Errorf("hosts must be strings or integers, got float %f", val)
+				return fmt.Errorf("hosts must be strings or integers, got float %g", val)
 			}
 			// Convert to string
 			result = append(result, fmt.Sprintf("%.0f", val))

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -188,7 +188,11 @@ func (s *HostsSlice) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
-	var result []string
+	if raw == nil {
+		// nil slice, nothing to do
+		return nil
+	}
+	result := make([]string, 0, len(raw))
 	for _, v := range raw {
 		switch val := v.(type) {
 		case string:

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -183,13 +183,14 @@ type LabelQueryExecution struct {
 
 type HostsSlice []string
 
+// Custom unmarshaler to handle both string and integer host identifiers.
 func (s *HostsSlice) UnmarshalJSON(data []byte) error {
 	var raw []interface{}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return err
 	}
 	if raw == nil {
-		// nil slice, nothing to do
+		// Differentiate between nil and empty array.
 		return nil
 	}
 	result := make([]string, 0, len(raw))
@@ -198,11 +199,11 @@ func (s *HostsSlice) UnmarshalJSON(data []byte) error {
 		case string:
 			result = append(result, val)
 		case float64:
-			// Check if the float64 is actually an integer
+			// Check if the float64 is actually an integer.
 			if val != float64(int64(val)) {
 				return fmt.Errorf("hosts must be strings or integers, got float %g", val)
 			}
-			// Convert to string
+			// Convert to string.
 			result = append(result, fmt.Sprintf("%.0f", val))
 		default:
 			return fmt.Errorf("hosts must be strings or integers, got %T", v)

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -194,7 +194,11 @@ func (s *HostsSlice) UnmarshalJSON(data []byte) error {
 		case string:
 			result = append(result, val)
 		case float64:
-			// JSON numbers are float64, convert to int if needed
+			// Check if the float64 is actually an integer
+			if val != float64(int64(val)) {
+				return fmt.Errorf("hosts must be strings or integers, got float %f", val)
+			}
+			// Convert to string
 			result = append(result, fmt.Sprintf("%.0f", val))
 		default:
 			return fmt.Errorf("hosts must be strings or integers, got %T", v)


### PR DESCRIPTION
for #32014

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - GitOps manual labels can now reference hosts by Fleet host ID in addition to hostname, hardware serial, or UUID.
  - GitOps YAML/JSON accepts integers for host IDs; numeric IDs are handled seamlessly alongside strings.

- Validation
  - Stronger input validation for label hosts: only strings or integers are allowed.
  - Clear error returned for invalid types (e.g., floats) in hosts lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->