### PR TITLE
fix inconsistent header spacing by using section header

### DIFF
--- a/changes/30166-inconsistent-spacing-os-settings-cards-headers
+++ b/changes/30166-inconsistent-spacing-os-settings-cards-headers
@@ -1,0 +1,1 @@
+* Fixed inconsistent spacing in Controls OS settings headers

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -202,17 +202,25 @@ const CustomSettings = ({
     !!profileLabelsModalData?.labels_include_any?.length ||
     !!profileLabelsModalData?.labels_exclude_any?.length;
 
+  const subTitle = (
+    <>
+      Create and upload configuration profiles to apply custom settings.{" "}
+      <CustomLink
+        newTab
+        text="Learn how"
+        url="https://fleetdm.com/learn-more-about/custom-os-settings"
+      />
+    </>
+  );
+
   return (
     <div className={baseClass}>
-      <SectionHeader title="Custom settings" />
-      <p className={`${baseClass}__description`}>
-        Create and upload configuration profiles to apply custom settings.{" "}
-        <CustomLink
-          newTab
-          text="Learn how"
-          url="https://fleetdm.com/learn-more-about/custom-os-settings"
-        />
-      </p>
+      <SectionHeader
+        title="Custom settings"
+        subTitle={subTitle}
+        alignLeftHeaderVertically
+        greySubtitle
+      />
       {!mdmEnabled ? (
         <TurnOnMdmMessage
           router={router}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
@@ -1,10 +1,4 @@
 .custom-settings {
-  &__description {
-    font-size: $x-small;
-    margin-bottom: $pad-large;
-    @include grey-text;
-  }
-
   .upload-list {
     &__list {
       .list-item__label-count {


### PR DESCRIPTION
fixes: #30166 

Opted to use the already existing `SectionHeader` component, and it's subtitle prop, that way we stay consistent across all pages in the entire product.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## Media:

<img width="538" height="170" alt="image" src="https://github.com/user-attachments/assets/d54b6b1c-d864-43ab-ac3b-5308267d4610" />

<img width="685" height="116" alt="image" src="https://github.com/user-attachments/assets/872bd916-59cf-4e50-b1c8-6e3647008fc0" />
