### PR TITLE
Add prompt to releaser.sh for fleetd release to edge

### DIFF
--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -327,6 +327,18 @@ print_reminder () {
     if [[ $ACTION == "release-to-edge" ]]; then
         if [[ $COMPONENT == "fleetd" ]]; then
             prompt "To smoke test the release make sure to generate and install fleetd with 'fleetctl package [...] --update-url=https://updates-staging.fleetdm.com --update-interval=1m --orbit-channel=edge --desktop-channel=edge' on Linux amd64, Linux arm64, Windows, and macOS."
+            milestone_url=$(curl -s 'https://api.github.com/repos/fleetdm/fleet/milestones?per_page=100' | jq -r ".[]|select(.title | contains(\"$VERSION\")).html_url")
+            echo "Milestone checks:"
+            if [[ -n $milestone_url ]]; then
+                prompt "1. It seems fleetd version $VERSION milestone is: $milestone_url"
+            else
+                prompt "1. fleetd $VERSION has a milestone in https://github.com/fleetdm/fleet/milestones"
+            fi
+            echo "Orbit changes:"
+            cat orbit/changes/*
+            echo 
+            prompt "2. All items above under orbit/changes/ correspond to a Github issue"
+            prompt "3. All items in the $VERSION milestone are in 'Ready for release'"
         elif [[ $COMPONENT == "osqueryd" ]]; then
             prompt "To smoke test the release make sure to generate and install fleetd with 'fleetctl package [...] --update-url=https://updates-staging.fleetdm.com --osqueryd-channel=edge --update-interval=1m' on Linux amd64, Linux arm64, Windows, and macOS."
         fi


### PR DESCRIPTION
Adding this check to avoid pushing a version to `edge` before all Github issues are in 'Ready for release'.