### PR TITLE
update my device page to allow resend of profiles

### DIFF
--- a/frontend/components/forms/validators/valid_password/valid_password.tests.js
+++ b/frontend/components/forms/validators/valid_password/valid_password.tests.js
@@ -56,7 +56,6 @@ describe("validPassword", () => {
     ];
 
     invalidPasswords.map((test) => {
-      console.log(test.password);
       return expect(validPassword(test.password)).toEqual(
         { isValid: false, error: test.error, error_code: test.error_code },
         `expected ${test.password} to not be valid`

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -669,7 +669,7 @@ const DeviceUserPage = ({
         )}
         {!!host && showOSSettingsModal && (
           <OSSettingsModal
-            canResendProfiles={false}
+            canResendProfiles={host.platform === "darwin"}
             hostId={host.id}
             platform={host.platform}
             hostMDMData={host.mdm}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -427,6 +427,13 @@ const DeviceUserPage = ({
     setSelectedCertificate(certificate);
   };
 
+  const resendProfile = (profileUUID: string): Promise<void> => {
+    if (!host) {
+      return new Promise(() => undefined);
+    }
+    return deviceUserAPI.resendProfile(deviceAuthToken, profileUUID);
+  };
+
   const renderDeviceUserPage = () => {
     const failingPoliciesCount = host?.issues?.failing_policies_count || 0;
 
@@ -672,9 +679,7 @@ const DeviceUserPage = ({
             canResendProfiles={host.platform === "darwin"}
             platform={host.platform}
             hostMDMData={host.mdm}
-            resendRequest={(profileUUID: string) =>
-              deviceUserAPI.resendProfile(deviceAuthToken, profileUUID)
-            }
+            resendRequest={resendProfile}
             onProfileResent={refetchHostDetails}
             onClose={toggleOSSettingsModal}
           />

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -670,9 +670,12 @@ const DeviceUserPage = ({
         {!!host && showOSSettingsModal && (
           <OSSettingsModal
             canResendProfiles={host.platform === "darwin"}
-            hostId={host.id}
             platform={host.platform}
             hostMDMData={host.mdm}
+            resendRequest={(profileUUID: string) =>
+              deviceUserAPI.resendProfile(deviceAuthToken, profileUUID)
+            }
+            onProfileResent={refetchHostDetails}
             onClose={toggleOSSettingsModal}
           />
         )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1338,10 +1338,12 @@ const HostDetailsPage = ({
           {showOSSettingsModal && (
             <OSSettingsModal
               canResendProfiles={host.platform === "darwin"}
-              hostId={host.id}
               platform={host.platform}
               hostMDMData={host.mdm}
               onClose={toggleOSSettingsModal}
+              resendRequest={(profileUUID: string) =>
+                hostAPI.resendProfile(host.id, profileUUID)
+              }
               onProfileResent={refetchHostDetails}
             />
           )}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -659,6 +659,13 @@ const HostDetailsPage = ({
     }
   };
 
+  const resendProfile = (profileUUID: string): Promise<void> => {
+    if (!host) {
+      return new Promise(() => undefined);
+    }
+    return hostAPI.resendProfile(host.id, profileUUID);
+  };
+
   const onChangeActivityTab = (tabIndex: number) => {
     setActiveActivityTab(tabIndex === 0 ? "past" : "upcoming");
     setActivityPage(0);
@@ -1341,9 +1348,7 @@ const HostDetailsPage = ({
               platform={host.platform}
               hostMDMData={host.mdm}
               onClose={toggleOSSettingsModal}
-              resendRequest={(profileUUID: string) =>
-                hostAPI.resendProfile(host.id, profileUUID)
-              }
+              resendRequest={resendProfile}
               onProfileResent={refetchHostDetails}
             />
           )}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
@@ -7,26 +7,29 @@ import OSSettingsTable from "./OSSettingsTable";
 import { generateTableData } from "./OSSettingsTable/OSSettingsTableConfig";
 
 interface IOSSettingsModalProps {
-  hostId: number;
   platform: string;
   hostMDMData: IHostMdmData;
   /** controls showing the action for a user to resend a profile. Defaults to `false` */
   canResendProfiles?: boolean;
+  /** This request method will be called when a user clicks on the resend button.
+   * This behaviour is dynamic based on the page this modal is rendered on
+   * so we allow the request function to be passed in */
+  resendRequest: (profileUUID: string) => Promise<void>;
   onClose: () => void;
   /** handler that fires when a profile was reset. Requires `canResendProfiles` prop
    * to be `true`, otherwise has no effect.
    */
-  onProfileResent?: () => void;
+  onProfileResent: () => void;
 }
 
 const baseClass = "os-settings-modal";
 
 const OSSettingsModal = ({
-  hostId,
   platform,
   hostMDMData,
   canResendProfiles = false,
   onClose,
+  resendRequest,
   onProfileResent,
 }: IOSSettingsModalProps) => {
   // the caller should ensure that hostMDMData is not undefined and that platform is supported otherwise we will allow an empty modal will be rendered.
@@ -47,8 +50,8 @@ const OSSettingsModal = ({
       <>
         <OSSettingsTable
           canResendProfiles={canResendProfiles}
-          hostId={hostId}
           tableData={memoizedTableData ?? []}
+          resendRequest={resendRequest}
           onProfileResent={onProfileResent}
         />
         <div className="modal-cta-wrap">

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tests.tsx
@@ -10,13 +10,13 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           platform: "windows",
           status: "failed",
           detail:
             "starting encryption: encrypt(C:): error code returned during encryption: -2147024809, error 2: This is another error",
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -51,8 +51,8 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({})}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -63,8 +63,8 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({ status: "failed" })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -75,8 +75,8 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({ status: "verified" })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -87,11 +87,11 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           status: "failed",
           detail: "There is no IdP email for this host.",
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -105,11 +105,11 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           status: "failed",
           detail: `Fleet couldn't populate $FLEET_VAR_CUSTOM_SCEP_URL_SCEP_WIFI because SCEP_WIFI certificate authority doesn't exist.`,
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -125,11 +125,11 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           status: "failed",
           detail: `Couldn't get certificate from DigiCert for WIFI_CERTIFICATE. unexpected DigiCert status code for POST request: 410, errors: Profile with id {test-id} was deleted`,
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -145,12 +145,12 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           status: "failed",
           detail: `Couldn't get certificate from DigiCert for WIFI_CERTIFICATE. unexpected DigiCert status code for POST request: 400, errors: Enrollment creation and Certificate issuance/renewal for deleted or suspended Profile are not supported.
           Please contact system Administrator.`,
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 
@@ -166,11 +166,11 @@ describe("OSSettingsErrorCell", () => {
     render(
       <OSSettingsErrorCell
         canResendProfiles
-        hostId={1}
         profile={createMockHostMdmProfile({
           status: "failed",
           detail: `Couldn’t get certificate from DigiCert. The API token configured in DIGICERT_TEST certificate authority is invalid.`,
         })}
+        resendRequest={() => new Promise(() => undefined)}
       />
     );
 

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
@@ -3,9 +3,7 @@ import classnames from "classnames";
 import { noop } from "lodash";
 
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
-import hostAPI from "services/entities/hosts";
 import { NotificationContext } from "context/notification";
-
 import { IHostMdmProfile } from "interfaces/mdm";
 
 import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
@@ -206,15 +204,15 @@ const generateErrorTooltip = (
 
 interface IOSSettingsErrorCellProps {
   canResendProfiles: boolean;
-  hostId: number;
   profile: IHostMdmProfileWithAddedStatus;
+  resendRequest: (profileUUID: string) => Promise<void>;
   onProfileResent?: () => void;
 }
 
 const OSSettingsErrorCell = ({
   canResendProfiles,
-  hostId,
   profile,
+  resendRequest,
   onProfileResent = noop,
 }: IOSSettingsErrorCellProps) => {
   const { renderFlash } = useContext(NotificationContext);
@@ -223,7 +221,7 @@ const OSSettingsErrorCell = ({
   const onResendProfile = async () => {
     setIsLoading(true);
     try {
-      await hostAPI.resendProfile(hostId, profile.profile_uuid);
+      await resendRequest(profile.profile_uuid);
       onProfileResent();
     } catch (e) {
       renderFlash("error", "Couldn't resend. Please try again.");

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTable.tsx
@@ -9,21 +9,22 @@ const baseClass = "os-settings-table";
 
 interface IOSSettingsTableProps {
   canResendProfiles: boolean;
-  hostId: number;
   tableData: IHostMdmProfileWithAddedStatus[];
-  onProfileResent?: () => void;
+  resendRequest: (profileUUID: string) => Promise<void>;
+  onProfileResent: () => void;
 }
 
 const OSSettingsTable = ({
   canResendProfiles,
-  hostId,
   tableData,
+  resendRequest,
   onProfileResent,
 }: IOSSettingsTableProps) => {
   // useMemo prevents tooltip flashing during host data refetch
   const tableConfig = useMemo(
-    () => generateTableHeaders(hostId, canResendProfiles, onProfileResent),
-    [hostId, canResendProfiles, onProfileResent]
+    () =>
+      generateTableHeaders(canResendProfiles, resendRequest, onProfileResent),
+    [canResendProfiles, resendRequest, onProfileResent]
   );
 
   return (

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -12,6 +12,8 @@ import {
   isLinuxDiskEncryptionStatus,
   isWindowsDiskEncryptionStatus,
 } from "interfaces/mdm";
+import { isAppleDevice } from "interfaces/platform";
+import { isDDMProfile } from "services/entities/mdm";
 
 import OSSettingsNameCell from "./OSSettingsNameCell";
 import OSSettingStatusCell from "./OSSettingStatusCell";
@@ -79,16 +81,13 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "detail",
       Cell: (cellProps: ITableStringCellProps) => {
-        const { name, platform, status } = cellProps.row.original;
-        const isFailedWindowsDiskEncryption =
-          platform === "windows" &&
-          name === "Disk encryption" &&
-          status === "failed";
+        const { platform } = cellProps.row.original;
+
+        const isMacOSMobileConfigProfile =
+          platform === "darwin" && !isDDMProfile(cellProps.row.original);
         return (
           <OSSettingsErrorCell
-            canResendProfiles={
-              canResendProfiles && !isFailedWindowsDiskEncryption
-            }
+            canResendProfiles={canResendProfiles && isMacOSMobileConfigProfile}
             hostId={hostId}
             profile={cellProps.row.original}
             onProfileResent={onProfileResent}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -5,14 +5,12 @@ import { IStringCellProps } from "interfaces/datatable_config";
 import { IHostMdmData } from "interfaces/host";
 import {
   FLEET_FILEVAULT_PROFILE_DISPLAY_NAME,
-  // FLEET_FILEVAULT_PROFILE_IDENTIFIER,
   IHostMdmProfile,
   MdmDDMProfileStatus,
   MdmProfileStatus,
   isLinuxDiskEncryptionStatus,
   isWindowsDiskEncryptionStatus,
 } from "interfaces/mdm";
-import { isAppleDevice } from "interfaces/platform";
 import { isDDMProfile } from "services/entities/mdm";
 
 import OSSettingsNameCell from "./OSSettingsNameCell";
@@ -42,9 +40,9 @@ export type OsSettingsTableStatusValue =
   | INonDDMProfileStatus;
 
 const generateTableConfig = (
-  hostId: number,
   canResendProfiles: boolean,
-  onProfileResent?: () => void
+  resendRequest: (profileUUID: string) => Promise<void>,
+  onProfileResent: () => void
 ): ITableColumnConfig[] => {
   return [
     {
@@ -88,8 +86,8 @@ const generateTableConfig = (
         return (
           <OSSettingsErrorCell
             canResendProfiles={canResendProfiles && isMacOSMobileConfigProfile}
-            hostId={hostId}
             profile={cellProps.row.original}
+            resendRequest={resendRequest}
             onProfileResent={onProfileResent}
           />
         );

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -11,8 +11,6 @@ import {
 
 import { IMdmCommandResult } from "interfaces/mdm";
 
-import { createMockSetupSoftwareStatusesResponse } from "__mocks__/deviceUserMock";
-
 import { IHostSoftwareQueryParams } from "./hosts";
 
 export type ILoadHostDetailsExtension = "macadmins";
@@ -180,6 +178,12 @@ export default {
   }: IGetSetupSoftwareStatusesParams): Promise<IGetSetupSoftwareStatusesResponse> => {
     const { DEVICE_SETUP_SOFTWARE_STATUSES } = endpoints;
     const path = DEVICE_SETUP_SOFTWARE_STATUSES(token);
+    return sendRequest("POST", path);
+  },
+
+  resendProfile: (deviceToken: string, profileUUID: string) => {
+    const { DEVICE_RESEND_PROFILE } = endpoints;
+    const path = DEVICE_RESEND_PROFILE(deviceToken, profileUUID);
     return sendRequest("POST", path);
   },
 };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -619,7 +619,7 @@ export default {
     return sendRequest("POST", HOST_WIPE(id));
   },
 
-  resendProfile: (hostId: number, profileUUID: string) => {
+  resendProfile: (hostId: number, profileUUID: string): Promise<void> => {
     const { HOST_RESEND_PROFILE } = endpoints;
 
     return sendRequest("POST", HOST_RESEND_PROFILE(hostId, profileUUID));

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -65,6 +65,8 @@ export default {
   DEVICE_SETUP_SOFTWARE_STATUSES: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/setup_experience/status`;
   },
+  DEVICE_RESEND_PROFILE: (token: string, profileUUID: string) =>
+    `/${API_VERSION}/fleet/device/${token}/configuration_profiles/${profileUUID}/resend`,
 
   // Host endpoints
   HOST_SUMMARY: `/${API_VERSION}/fleet/host_summary`,


### PR DESCRIPTION
resolves #32686

this adds the ability for users to resend profiles in the OS Settings modal on the my device page.
This also changes which profiles can resend. Now only macos hosts .mobileconfig profiles can be resent

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually

