### PR TITLE
add android profiles and changes selected profile details to file extension

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
@@ -23,6 +23,7 @@ import ProfileGraphic from "../ProfileGraphic";
 import {
   DEFAULT_ERROR_MESSAGE,
   getErrorMessage,
+  IParseFileResult,
   parseFile,
 } from "../../helpers";
 import {
@@ -76,22 +77,19 @@ const FileChooser = ({ isLoading, onFileOpen }: IFileChooserProps) => (
 );
 
 interface IFileDetailsProps {
-  details: {
-    name: string;
-    platform: string;
-  };
+  details: IParseFileResult;
 }
 
 // TODO: if we reuse this one more time, we should consider moving this
 // into FileUploader as a default preview. Currently we have this in
 // AddPackageForm.tsx and here.
-const FileDetails = ({ details: { name, platform } }: IFileDetailsProps) => (
+const FileDetails = ({ details: { name, ext } }: IFileDetailsProps) => (
   <div className={`${baseClass}__selected-file`}>
     <ProfileGraphic baseClass={baseClass} />
     <div className={`${baseClass}__selected-file--details`}>
       <div className={`${baseClass}__selected-file--details--name`}>{name}</div>
       <div className={`${baseClass}__selected-file--details--platform`}>
-        {platform}
+        .{ext}
       </div>
     </div>
   </div>
@@ -113,10 +111,7 @@ const AddProfileModal = ({
   const { renderFlash } = useContext(NotificationContext);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [fileDetails, setFileDetails] = useState<{
-    name: string;
-    platform: string;
-  } | null>(null);
+  const [fileDetails, setFileDetails] = useState<IParseFileResult | null>(null);
   const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
   const [selectedLabels, setSelectedLabels] = useState<Record<string, boolean>>(
     {}
@@ -190,8 +185,8 @@ const AddProfileModal = ({
     fileRef.current = file;
 
     try {
-      const [name, platform] = await parseFile(file);
-      setFileDetails({ name, platform });
+      const details = await parseFile(file);
+      setFileDetails(details);
     } catch (e) {
       renderFlash("error", "Invalid file type");
     } finally {

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/_styles.scss
@@ -46,7 +46,7 @@
       }
 
       &--platform {
-        font-size: $xx-small;
+        font-size: $x-small;
         color: $ui-fleet-black-75;
       }
     }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/helpers.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/helpers.tsx
@@ -6,7 +6,13 @@ import { generateSecretErrMsg } from "pages/SoftwarePage/helpers";
 
 import CustomLink from "components/CustomLink";
 
-export const parseFile = async (file: File): Promise<[string, string]> => {
+export interface IParseFileResult {
+  name: string;
+  platform: string;
+  ext: string;
+}
+
+export const parseFile = async (file: File): Promise<IParseFileResult> => {
   // get the file name and extension
   const nameParts = file.name.split(".");
   const name = nameParts.slice(0, -1).join(".");
@@ -14,13 +20,17 @@ export const parseFile = async (file: File): Promise<[string, string]> => {
 
   switch (ext) {
     case "xml": {
-      return [name, "Windows"];
+      return {
+        name,
+        platform: "Windows",
+        ext,
+      };
     }
     case "mobileconfig": {
-      return [name, "macOS, iOS, iPadOS"];
+      return { name, platform: "macOS, iOS, iPadOS", ext };
     }
     case "json": {
-      return [name, "macOS, iOS, iPadOS"];
+      return { name, platform: "Android or macOS(DDM)", ext };
     }
     default: {
       throw new Error(`Invalid file type: ${ext}`);

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -186,8 +186,8 @@ export const generateTableData = (
     case "rhel":
       return makeLinuxRows(hostMDMData);
     case "ios":
-      return hostMDMData.profiles;
     case "ipados":
+    case "android":
       return hostMDMData.profiles;
     default:
       return null;


### PR DESCRIPTION
fixes #33041, fixes #33038

added the android profiles to the OS Settings modal table

also changes the file desctiption to the file extension instead of the platform

<img width="651" height="409" alt="image" src="https://github.com/user-attachments/assets/70ff04b9-7463-450c-810f-86d7d054248a" />


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
