### PR TITLE
add new service method for device entry to resending profiles, and split into functions to reuse across both methods

### DIFF
--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1133,6 +1133,9 @@ type Service interface {
 	// ResendHostMDMProfile resends the MDM profile to the host.
 	ResendHostMDMProfile(ctx context.Context, hostID uint, profileUUID string) error
 
+	// ResendDeviceHostMDMProfile resends the MDM profile to the device host that requested it.
+	ResendDeviceHostMDMProfile(ctx context.Context, host *Host, profileUUID string) error
+
 	// BatchResendMDMProfileToHosts resends an MDM profile to the hosts that
 	// satisfy the specified filters.
 	BatchResendMDMProfileToHosts(ctx context.Context, profileUUID string, filters BatchResendMDMProfileFilters) error

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -396,7 +396,7 @@ func resendDeviceConfigurationProfileEndpoint(ctx context.Context, request inter
 	}
 
 	req := request.(*resendDeviceConfigurationProfileRequest)
-	err := svc.ResendHostMDMProfile(ctx, host.ID, req.ProfileUUID)
+	err := svc.ResendDeviceHostMDMProfile(ctx, host, req.ProfileUUID)
 	if err != nil {
 		return resendDeviceConfigurationProfileResponse{
 			Err: err,

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -466,7 +466,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 		return err
 	})
 	s.checkMDMProfilesSummaries(t, &tm.ID, fleet.MDMProfilesSummary{Failed: 1}, nil)
-	_ = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", token, mcUUID), nil, http.StatusAccepted)
+	_ = s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", token, mcUUID), nil, http.StatusAccepted)
 	s.awaitTriggerProfileSchedule(t)
 	installs, removes = checkNextPayloads(t, mdmDevice, false)
 	require.Len(t, installs, 1)
@@ -532,7 +532,7 @@ func (s *integrationMDMTestSuite) TestAppleProfileManagement() {
 	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/configuration_profiles/%s/resend", host.ID, declUUID), nil, http.StatusBadRequest)
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, fleet.CantResendAppleDeclarationProfilesMessage)
-	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", token, declUUID), nil, http.StatusBadRequest)
+	res = s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", token, declUUID), nil, http.StatusBadRequest)
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, fleet.CantResendAppleDeclarationProfilesMessage)
 
@@ -4065,7 +4065,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 	require.Contains(t, errMsg, fleet.CantResendWindowsProfilesMessage)
 	deviceToken := "windows-device-token"
 	createDeviceTokenForHost(t, s.ds, host.ID, deviceToken)
-	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", deviceToken, globalProfiles[0]), nil, http.StatusBadRequest)
+	res = s.DoRawNoAuth("POST", fmt.Sprintf("/api/latest/fleet/device/%s/configuration_profiles/%s/resend", deviceToken, globalProfiles[0]), nil, http.StatusBadRequest)
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, fleet.CantResendWindowsProfilesMessage)
 


### PR DESCRIPTION
A followup fix after failing to see it was called with an auth token, and therefore bypassing the device authentication completely.

# Checklist for submitter



## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

