### PR TITLE
Fleet UI: New tab navs + storybook working again

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -50,9 +50,7 @@ const config: StorybookConfig = {
   addons: [
     "@storybook/addon-links",
     "@storybook/addon-essentials",
-    "@storybook/addon-mdx-gfm",
     "@storybook/addon-a11y",
-    "@storybook/test-runner",
     "@storybook/addon-designs",
     "@storybook/addon-webpack5-compiler-babel",
   ],

--- a/frontend/components/TabNav/TabNav.stories.tsx
+++ b/frontend/components/TabNav/TabNav.stories.tsx
@@ -91,3 +91,64 @@ export const Default: Story = {
     );
   },
 };
+
+export const Secondary: Story = {
+  render: () => {
+    const [selectedTabIndex, setSelectedTabIndex] = React.useState(0);
+
+    const platformSubNav = [
+      { name: <TabText>Basic tab</TabText>, type: "type1" },
+      { name: <TabText>Basic tab 2</TabText>, type: "type2" },
+      {
+        name: <TabText>Disabled tab</TabText>,
+        type: "type3",
+        disabled: true,
+      },
+      { name: <TabText count={3}>Tab with count</TabText>, type: "type4" },
+      {
+        name: (
+          <TabText count={20} countVariant="alert">
+            Tab with error count
+          </TabText>
+        ),
+        type: "type5",
+      },
+    ];
+
+    const renderPanel = (type: string) => {
+      switch (type) {
+        case "type1":
+          return <div>Content for Tab 1</div>;
+        case "type2":
+          return <div>Content for Tab 2</div>;
+        case "type3":
+          return <div>Content for Tab 3</div>;
+        case "type4":
+          return <div>Content for Tab 4</div>;
+        case "type5":
+          return <div>Content for Tab 5</div>;
+        default:
+          return null;
+      }
+    };
+
+    return (
+      <TabNav secondary>
+        <Tabs onSelect={setSelectedTabIndex} selectedIndex={selectedTabIndex}>
+          <TabList>
+            {platformSubNav.map((navItem) => (
+              <Tab disabled={navItem.disabled}>
+                <TabText>{navItem.name}</TabText>
+              </Tab>
+            ))}
+          </TabList>
+          {platformSubNav.map((navItem) => (
+            <TabPanel key={navItem.type}>
+              <div>{renderPanel(navItem.type)}</div>
+            </TabPanel>
+          ))}
+        </Tabs>
+      </TabNav>
+    );
+  },
+};

--- a/frontend/components/TabNav/TabNav.tsx
+++ b/frontend/components/TabNav/TabNav.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import classnames from "classnames";
 
 interface ITabNavProps {
-  children: React.ReactChild | React.ReactChild[];
+  children: React.ReactNode;
   className?: string;
   secondary?: boolean;
 }

--- a/frontend/components/TabNav/TabNav.tsx
+++ b/frontend/components/TabNav/TabNav.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 interface ITabNavProps {
   children: React.ReactChild | React.ReactChild[];
   className?: string;
-  sticky?: boolean;
+  secondary?: boolean;
 }
 
 /*
@@ -16,10 +16,10 @@ const baseClass = "tab-nav";
 const TabNav = ({
   children,
   className,
-  sticky = false,
+  secondary = false,
 }: ITabNavProps): JSX.Element => {
   const classNames = classnames(baseClass, className, {
-    [`${baseClass}--sticky`]: sticky,
+    [`${baseClass}--secondary`]: secondary,
   });
 
   return <div className={classNames}>{children}</div>;

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -16,12 +16,11 @@
       height: 43px;
       margin: 0; // Override react-tab 10px bottom margin
       position: relative; // Required for shift left
-      left: -8px; // Design request for text to justify left despite hover padding
     }
 
     &__tab {
       font-size: $x-small;
-      border-radius: $border-radius;
+      border-radius: $border-radius-large;
       border: none;
       padding: 6px $pad-small;
       display: inline-flex;
@@ -29,13 +28,10 @@
       align-items: center;
       line-height: 21px;
 
+      // Undoes blue native shadow
       &:focus {
         box-shadow: none;
         outline: 0;
-        &:after {
-          left: 0;
-          bottom: 0;
-        }
       }
 
       &:hover {
@@ -43,12 +39,10 @@
       }
 
       // focus-visible only highlights when tabbing not clicking
+      // outline instead of border prevents pixel shifts
       &:focus-visible {
-        .tab-text {
-          outline: 1px solid $core-focused-outline;
-          outline-offset: 5px;
-          border-radius: $border-radius-small;
-        }
+        outline: 1px solid $core-focused-outline;
+        outline-offset: -1px;
       }
 
       // // Bolding text when the button is active causes a layout shift
@@ -64,7 +58,6 @@
       }
 
       &--selected {
-        border-radius: $border-radius;
         font-weight: $bold;
         background-color: $ui-fleet-black-5;
       }
@@ -75,7 +68,7 @@
     }
 
     &__tab-panel--selected {
-      margin-top: $pad-large;
+      margin-top: $gap-page-component;
 
       .no-results-message {
         margin-top: $pad-xxlarge;
@@ -96,12 +89,10 @@
       align-items: center; /* Vertically align items */
 
       .tab-text__text {
-        display: relative;
-
         // Reserve space for bold text using a hidden pseudo-element
         &::before {
           content: attr(data-text); /* Same text as the visible one */
-          font-weight: 600; /* Mimic bold styling */
+          font-weight: $bold; /* Mimic bold styling */
           visibility: hidden; /* Keep it invisible */
           position: absolute; /* Prevent it from affecting layout */
         }
@@ -115,7 +106,6 @@
       &__tab-list {
         gap: $pad-xxlarge;
         border-bottom: 1px solid $ui-fleet-black-10;
-        left: 0; // Undo design request for text to justify left as there's no hover padding
       }
 
       &__tab {
@@ -123,6 +113,24 @@
 
         &:hover {
           background-color: transparent;
+        }
+
+        // Aligns underline correctly when focused
+        &:focus {
+          &:after {
+            left: 0;
+            bottom: 0;
+          }
+        }
+
+        &:focus-visible {
+          outline: none; // Undo primary tabbing through app styling as it runs into edges
+
+          .tab-text {
+            outline: 1px solid $core-focused-outline;
+            outline-offset: 3px;
+            border-radius: $border-radius;
+          }
         }
 
         &--selected {
@@ -167,12 +175,6 @@
 
         &.no-count:not(.errors-empty).react-tabs__tab--selected::after {
           bottom: -2px;
-        }
-
-        &:focus-visible {
-          .tab-text {
-            border-radius: $border-radius;
-          }
         }
       }
     }

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -3,9 +3,9 @@
   // No background color as TabNav is often over a background gradient
 
   .react-tabs {
-    // Remove 8px top margin react-tab adds causing buggy 8px gap in all uses
+    // Remove 12px top margin react-tab adds causing buggy 12px gap in all uses
     // TODO: Find upstream fix
-    margin-top: -8px;
+    margin-top: -12px;
 
     &__tab-list {
       display: inline-flex;
@@ -13,7 +13,7 @@
       gap: $pad-medium;
       border-bottom: none;
       width: 100%;
-      height: 43px;
+      height: 33px;
       margin: 0; // Override react-tab 10px bottom margin
       position: relative; // Required for shift left
     }
@@ -106,6 +106,7 @@
       &__tab-list {
         gap: $pad-xxlarge;
         border-bottom: 1px solid $ui-fleet-black-10;
+        padding-bottom: 10px;
       }
 
       &__tab {

--- a/frontend/components/TabNav/_styles.scss
+++ b/frontend/components/TabNav/_styles.scss
@@ -1,42 +1,29 @@
 .tab-nav {
   top: 0;
-  background-color: $core-fleet-white;
-
-  &--sticky {
-    position: sticky;
-    z-index: 2;
-  }
+  // No background color as TabNav is often over a background gradient
 
   .react-tabs {
+    // Remove 8px top margin react-tab adds causing buggy 8px gap in all uses
+    // TODO: Find upstream fix
+    margin-top: -8px;
+
     &__tab-list {
       display: inline-flex;
       align-items: flex-start;
-      gap: $pad-xxlarge;
-      border-bottom: 1px solid $ui-fleet-black-10;
+      gap: $pad-medium;
+      border-bottom: none;
       width: 100%;
       height: 43px;
-    }
-    .tab-text {
-      display: flex; /* Ensure text and count are aligned horizontally */
-      align-items: center; /* Vertically align items */
-
-      .tab-text__text {
-        display: relative;
-
-        // Reserve space for bold text using a hidden pseudo-element
-        &::before {
-          content: attr(data-text); /* Same text as the visible one */
-          font-weight: bold; /* Mimic bold styling */
-          visibility: hidden; /* Keep it invisible */
-          position: absolute; /* Prevent it from affecting layout */
-        }
-      }
+      margin: 0; // Override react-tab 10px bottom margin
+      position: relative; // Required for shift left
+      left: -8px; // Design request for text to justify left despite hover padding
     }
 
     &__tab {
-      padding: 5px 0 $pad-medium;
       font-size: $x-small;
+      border-radius: $border-radius;
       border: none;
+      padding: 6px $pad-small;
       display: inline-flex;
       flex-direction: column;
       align-items: center;
@@ -51,13 +38,16 @@
         }
       }
 
+      &:hover {
+        background-color: $ui-fleet-black-5;
+      }
+
       // focus-visible only highlights when tabbing not clicking
       &:focus-visible {
         .tab-text {
-          border-radius: $border-radius;
-          // Outline used instead of border not to shift component
-          outline: 1px solid $ui-vibrant-blue-25;
-          outline-offset: -1px;
+          outline: 1px solid $core-focused-outline;
+          outline-offset: 5px;
+          border-radius: $border-radius-small;
         }
       }
 
@@ -74,52 +64,19 @@
       }
 
       &--selected {
+        border-radius: $border-radius;
         font-weight: $bold;
-
-        &::after {
-          content: "";
-          width: 100%;
-          height: 0;
-          border-bottom: 2px solid $core-vibrant-blue;
-          position: absolute;
-          bottom: 0;
-          left: 0;
-        }
-      }
-
-      &:hover {
-        &::after {
-          content: "";
-          width: 100%;
-          height: 0;
-          border-bottom: 2px solid $core-vibrant-blue;
-          position: absolute;
-          bottom: 0;
-          left: 0;
-        }
+        background-color: $ui-fleet-black-5;
       }
 
       &--disabled {
         cursor: not-allowed;
-
-        &:hover {
-          &::after {
-            content: "";
-            width: 100%;
-            height: 0;
-            border-bottom: 0;
-            position: absolute;
-            bottom: 0;
-            left: 0;
-          }
-        }
-      }
-
-      &.no-count:not(.errors-empty).react-tabs__tab--selected::after {
-        bottom: -2px;
       }
     }
-    &__tab-panel {
+
+    &__tab-panel--selected {
+      margin-top: $pad-large;
+
       .no-results-message {
         margin-top: $pad-xxlarge;
         font-size: $small;
@@ -130,6 +87,92 @@
           font-size: $x-small;
           font-weight: $regular;
           display: block;
+        }
+      }
+    }
+
+    .tab-text {
+      display: flex; /* Ensure text and count are aligned horizontally */
+      align-items: center; /* Vertically align items */
+
+      .tab-text__text {
+        display: relative;
+
+        // Reserve space for bold text using a hidden pseudo-element
+        &::before {
+          content: attr(data-text); /* Same text as the visible one */
+          font-weight: 600; /* Mimic bold styling */
+          visibility: hidden; /* Keep it invisible */
+          position: absolute; /* Prevent it from affecting layout */
+        }
+      }
+    }
+  }
+
+  // All secondary tab styling
+  &--secondary {
+    .react-tabs {
+      &__tab-list {
+        gap: $pad-xxlarge;
+        border-bottom: 1px solid $ui-fleet-black-10;
+        left: 0; // Undo design request for text to justify left as there's no hover padding
+      }
+
+      &__tab {
+        padding: 5px 0 $pad-medium;
+
+        &:hover {
+          background-color: transparent;
+        }
+
+        &--selected {
+          background-color: transparent;
+
+          &::after {
+            content: "";
+            width: 100%;
+            height: 0;
+            border-bottom: 2px solid $core-fleet-black;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+          }
+        }
+
+        &:hover {
+          &::after {
+            content: "";
+            width: 100%;
+            height: 0;
+            border-bottom: 2px solid $core-fleet-black;
+            position: absolute;
+            bottom: 0;
+            left: 0;
+          }
+        }
+
+        &--disabled {
+          &:hover {
+            &::after {
+              content: "";
+              width: 100%;
+              height: 0;
+              border-bottom: 0;
+              position: absolute;
+              bottom: 0;
+              left: 0;
+            }
+          }
+        }
+
+        &.no-count:not(.errors-empty).react-tabs__tab--selected::after {
+          bottom: -2px;
+        }
+
+        &:focus-visible {
+          .tab-text {
+            border-radius: $border-radius;
+          }
         }
       }
     }

--- a/frontend/components/TabText/TabText.tsx
+++ b/frontend/components/TabText/TabText.tsx
@@ -37,7 +37,7 @@ const TabText = ({
 
   return (
     <div className={classNames}>
-      <div className={`${baseClass}__text}`} data-text={children}>
+      <div className={`${baseClass}__text`} data-text={children}>
         {children}
       </div>
       {renderCount()}

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -140,7 +140,7 @@ const Mdm = ({
         </div>
       )}
       <div style={opacity}>
-        <TabNav>
+        <TabNav secondary>
           <Tabs selectedIndex={navTabIndex} onSelect={onTabChange}>
             <TabList>
               <Tab>

--- a/frontend/pages/DashboardPage/cards/Munki/Munki.tsx
+++ b/frontend/pages/DashboardPage/cards/Munki/Munki.tsx
@@ -59,7 +59,7 @@ const Munki = ({
         </div>
       )}
       <div style={opacity}>
-        <TabNav>
+        <TabNav secondary>
           <Tabs selectedIndex={navTabIndex} onSelect={onTabChange}>
             <TabList>
               <Tab>

--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -78,7 +78,7 @@ const Software = ({
         </div>
       )}
       <div style={opacity}>
-        <TabNav>
+        <TabNav secondary>
           <Tabs selectedIndex={navTabIndex} onSelect={onTabChange}>
             <TabList>
               <Tab>

--- a/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/_styles.scss
@@ -1,6 +1,6 @@
 .os-settings {
-  font-size: $x-small;
-  margin-top: $pad-xxlarge;
+  font-size: $x-small; // Removed with status aggregate counts uses cards in future PR
+  margin-top: 22px; // 32 px total, 10 from react-tabs
   display: flex;
   flex-direction: column;
   gap: $pad-xxlarge;

--- a/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
@@ -8,15 +8,15 @@ import { getPathWithQueryParams } from "utilities/url";
 
 import { IConfig } from "interfaces/config";
 import { ITeamConfig } from "interfaces/team";
-import { ApplePlatform, isAndroid } from "interfaces/platform";
+import { ApplePlatform } from "interfaces/platform";
 
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
+import SectionHeader from "components/SectionHeader";
 import Spinner from "components/Spinner";
 
-import EndUserOSRequirementPreview from "./components/EndUserOSRequirementPreview";
 import TurnOnMdmMessage from "../../../components/TurnOnMdmMessage/TurnOnMdmMessage";
 import CurrentVersionSection from "./components/CurrentVersionSection";
 import TargetSection from "./components/TargetSection";
@@ -131,7 +131,7 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
         Remotely encourage the installation of software updates on hosts
         assigned to this team.
       </p>
-      <div className={`${baseClass}__content`}>
+      <>
         <div className={`${baseClass}__current-version-container`}>
           <CurrentVersionSection
             router={router}
@@ -140,6 +140,10 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
           />
         </div>
         <div className={`${baseClass}__target-container`}>
+          <SectionHeader
+            title="Target"
+            wrapperCustomClass={`${baseClass}__header`}
+          />
           <TargetSection
             key={teamIdForApi} // if the team changes, remount the target section
             appConfig={config}
@@ -152,12 +156,7 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
             refetchTeamConfig={refetchTeamConfig}
           />
         </div>
-        {!isAndroid(selectedPlatform) && (
-          <div className={`${baseClass}__nudge-preview`}>
-            <EndUserOSRequirementPreview platform={selectedPlatform} />
-          </div>
-        )}
-      </div>
+      </>
     </div>
   );
 };

--- a/frontend/pages/ManageControlsPage/OSUpdates/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/_styles.scss
@@ -1,8 +1,11 @@
 .os-updates {
-  font-size: $x-small;
+  margin-top: 22px; // 32 px total, 10 from react-tabs
+  display: flex;
+  flex-direction: column;
+  gap: $pad-xxlarge;
 
   &__description {
-    margin: $pad-xxlarge 0;
+    margin: 0;
   }
 
   &__content {

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/PlatformTabs.tsx
@@ -5,8 +5,12 @@ import TabText from "components/TabText";
 import CustomLink from "components/CustomLink";
 import { SUPPORT_LINK } from "utilities/constants";
 
+import EndUserOSRequirementPreview from "../EndUserOSRequirementPreview";
 import WindowsTargetForm from "../WindowsTargetForm";
-import { OSUpdatesTargetPlatform } from "../../OSUpdates";
+import {
+  OSUpdatesSupportedPlatform,
+  OSUpdatesTargetPlatform,
+} from "../../OSUpdates";
 import AppleOSTargetForm from "../AppleOSTargetForm";
 
 const baseClass = "platform-tabs";
@@ -63,7 +67,7 @@ const PlatformTabs = ({
 
   return (
     <div className={baseClass}>
-      <TabNav>
+      <TabNav secondary>
         <Tabs
           defaultIndex={platformByIndex.indexOf(selectedPlatform)}
           onSelect={onTabChange}
@@ -89,7 +93,7 @@ const PlatformTabs = ({
               </Tab>
             )}
           </TabList>
-          <TabPanel>
+          <TabPanel className={`${baseClass}__tab-panel`}>
             <AppleOSTargetForm
               currentTeamId={currentTeamId}
               applePlatform="darwin"
@@ -99,9 +103,14 @@ const PlatformTabs = ({
               refetchAppConfig={refetchAppConfig}
               refetchTeamConfig={refetchTeamConfig}
             />
+            <div className={`${baseClass}__nudge-preview`}>
+              <EndUserOSRequirementPreview
+                platform={selectedPlatform as OSUpdatesSupportedPlatform}
+              />
+            </div>
           </TabPanel>
           {isWindowsMdmEnabled && (
-            <TabPanel>
+            <TabPanel className={`${baseClass}__tab-panel`}>
               <WindowsTargetForm
                 currentTeamId={currentTeamId}
                 defaultDeadlineDays={defaultWindowsDeadlineDays}
@@ -110,9 +119,14 @@ const PlatformTabs = ({
                 refetchAppConfig={refetchAppConfig}
                 refetchTeamConfig={refetchTeamConfig}
               />
+              <div className={`${baseClass}__nudge-preview`}>
+                <EndUserOSRequirementPreview
+                  platform={selectedPlatform as OSUpdatesSupportedPlatform}
+                />
+              </div>
             </TabPanel>
           )}
-          <TabPanel>
+          <TabPanel className={`${baseClass}__tab-panel`}>
             <AppleOSTargetForm
               currentTeamId={currentTeamId}
               applePlatform="ios"
@@ -122,8 +136,13 @@ const PlatformTabs = ({
               refetchAppConfig={refetchAppConfig}
               refetchTeamConfig={refetchTeamConfig}
             />
+            <div className={`${baseClass}__nudge-preview`}>
+              <EndUserOSRequirementPreview
+                platform={selectedPlatform as OSUpdatesSupportedPlatform}
+              />
+            </div>
           </TabPanel>
-          <TabPanel>
+          <TabPanel className={`${baseClass}__tab-panel`}>
             <AppleOSTargetForm
               currentTeamId={currentTeamId}
               applePlatform="ipados"
@@ -133,9 +152,14 @@ const PlatformTabs = ({
               refetchAppConfig={refetchAppConfig}
               refetchTeamConfig={refetchTeamConfig}
             />
+            <div className={`${baseClass}__nudge-preview`}>
+              <EndUserOSRequirementPreview
+                platform={selectedPlatform as OSUpdatesSupportedPlatform}
+              />
+            </div>
           </TabPanel>
           {isAndroidMdmEnabled && (
-            <TabPanel>
+            <TabPanel className={`${baseClass}__tab-panel`}>
               <div className={`${baseClass}__coming-soon`}>
                 <p>
                   <b>Android updates are coming soon.</b>

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/PlatformTabs/_styles.scss
@@ -1,11 +1,35 @@
 .platform-tabs {
-  .react-tabs__tab-list {
-    margin-bottom: $pad-large;
-  }
-  &__coming-soon {
-    p {
-      margin: 0;
-      padding-bottom: $pad-small;
+  &__tab-panel {
+    display: grid;
+    gap: $pad-medium;
+    grid-template-columns: 1fr 1fr;
+    grid-template-areas: "target nudge-preview";
+
+    @media (max-width: $break-md) {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "target"
+        "nudge-preview";
     }
+  }
+
+  &__target-container {
+    grid-area: target;
+  }
+
+  &__nudge-preview-container {
+    grid-area: nudge-preview;
+
+    &__coming-soon {
+      p {
+        margin: 0;
+        padding-bottom: $pad-small;
+      }
+    }
+  }
+
+  .apple-os-target-form,
+  .windows-target-form {
+    padding-right: $pad-xlarge; // match figma
   }
 }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/TargetSection/TargetSection.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/TargetSection/TargetSection.tsx
@@ -4,7 +4,6 @@ import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
 import { IConfig } from "interfaces/config";
 import { ApplePlatform } from "interfaces/platform";
 
-import SectionHeader from "components/SectionHeader";
 import Spinner from "components/Spinner";
 
 import WindowsTargetForm from "../WindowsTargetForm";
@@ -195,15 +194,7 @@ const TargetSection = ({
     );
   };
 
-  return (
-    <div className={baseClass}>
-      <SectionHeader
-        title="Target"
-        wrapperCustomClass={`${baseClass}__header`}
-      />
-      {renderTargetForms()}
-    </div>
-  );
+  return <div className={baseClass}>{renderTargetForms()}</div>;
 };
 
 export default TargetSection;

--- a/frontend/pages/ManageControlsPage/Scripts/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Scripts/_styles.scss
@@ -1,8 +1,11 @@
 .scripts {
-  font-size: $x-small;
+  margin-top: 22px; // 32 px total, 10 from react-tabs
+  display: flex;
+  flex-direction: column;
+  gap: $pad-xxlarge;
 
   &__description {
-    margin: $pad-xxlarge 0;
+    margin: 0;
   }
 
   &__premium-feature-message {

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -224,7 +224,7 @@ const ScriptBatchProgress = ({
     <>
       <div className={baseClass}>
         <SectionHeader title="Batch progress" alignLeftHeaderVertically />
-        <TabNav>
+        <TabNav secondary>
           <Tabs
             selectedIndex={STATUS_BY_INDEX.indexOf(selectedStatus)}
             onSelect={handleTabChange}

--- a/frontend/pages/ManageControlsPage/Secrets/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Secrets/_styles.scss
@@ -1,108 +1,113 @@
 .secrets-batch-paginated-list {
-    &__description {
-            margin: $pad-xxlarge 0;
+  margin-top: 22px; // 32 px total, 10 from react-tabs
+  display: flex;
+  flex-direction: column;
+  gap: $pad-xxlarge;
+
+  &__description {
+    margin: 0;
+  }
+
+  &__copy-message {
+    @include copy-message;
+    vertical-align: bottom;
+    font-size: $xx-small;
+    margin-left: $pad-xsmall;
+  }
+
+  .paginated-list__row {
+    display: flex;
+    justify-content: space-between;
+    padding: $pad-small $pad-large;
+
+    .button > .children-wrapper {
+      opacity: 0;
+      transition: opacity 250ms;
+      pointer-events: none;
     }
 
-    &__copy-message {
-        @include copy-message;
-        vertical-align: bottom;
-        font-size: $xx-small;
-        margin-left: $pad-xsmall;
+    &.paginated-list__header {
+      .button > .children-wrapper {
+        opacity: 1;
+        pointer-events: auto;
+      }
     }
 
-    .paginated-list__row {
+    .secrets-batch-paginated-list__copy-secret-icon {
+      margin-left: 4px;
+      vertical-align: bottom;
+      .children-wrapper {
+        opacity: 1;
+      }
+    }
+
+    &:hover,
+    &:focus-within {
+      cursor: default;
+      .button > .children-wrapper {
+        opacity: 1;
+      }
+    }
+
+    .list-item__details {
+      color: $ui-fleet-black-75;
+      min-width: 0;
+      > span {
         display: flex;
-        justify-content: space-between;
-        padding: $pad-small $pad-large;
-        
-        .button>.children-wrapper {
-            opacity: 0;
-            transition: opacity 250ms;
-            pointer-events: none;
-        }
-
-        &.paginated-list__header {
-            .button>.children-wrapper {
-                    opacity: 1;
-                    pointer-events: auto;
-            }
-        }
-
-        .secrets-batch-paginated-list__copy-secret-icon {
-            margin-left: 4px;
-            vertical-align: bottom;
-            .children-wrapper {
-                opacity: 1;
-            }
-        }
-
-        &:hover,
-        &:focus-within {
-            cursor: default;
-            .button>.children-wrapper {
-                opacity: 1;
-            }
-        }
-
-        .list-item__details {
-            color: $ui-fleet-black-75;
-            min-width: 0;
-            > span {
-                display: flex;
-            }
-        }
-
-        /* Make the main content column actually able to shrink so truncation can happen */
-        .list-item {
-            display: flex;
-            flex: 1 1 auto;
-            min-width: 0;
-        }
-
-        .list-item__main-content {
-            flex: 1 1 auto;
-            min-width: 0; /* for truncation */
-        }
-
-        .list-item__info {
-            min-width: 0; /* for truncation */            
-        }
-
-        .list-item__title {
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            min-width: 0;
-        }
-
-        .secret-details__text {
-            flex: 1 1 auto;
-            min-width: 0;
-            white-space: nowrap;
-            overflow: hidden;
-            text-overflow: ellipsis;
-        }
+      }
     }
 
-    .loading-spinner.centered {
-        margin: auto;
+    /* Make the main content column actually able to shrink so truncation can happen */
+    .list-item {
+      display: flex;
+      flex: 1 1 auto;
+      min-width: 0;
     }
 
-    &__header {
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        width: 100%;
-        font-weight: $bold;
-        align-items: center;
+    .list-item__main-content {
+      flex: 1 1 auto;
+      min-width: 0; /* for truncation */
     }
+
+    .list-item__info {
+      min-width: 0; /* for truncation */
+    }
+
+    .list-item__title {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      min-width: 0;
+    }
+
+    .secret-details__text {
+      flex: 1 1 auto;
+      min-width: 0;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .loading-spinner.centered {
+    margin: auto;
+  }
+
+  &__header {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    font-weight: $bold;
+    align-items: center;
+  }
 }
 
 .fleet-add-secret-modal {
-    &__add-secret-form {
-        .form-field__help-text {
-            text-overflow: ellipsis;
-            overflow: hidden;
-        }
+  &__add-secret-form {
+    .form-field__help-text {
+      text-overflow: ellipsis;
+      overflow: hidden;
     }
+  }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
@@ -45,7 +45,9 @@ const SetupExperience = ({
 
   return (
     <div className={baseClass}>
-      <p>Customize the end user&apos;s setup experience.</p>
+      <p className={`${baseClass}__description`}>
+        Customize the end user&apos;s setup experience.
+      </p>
       <SideNav
         className={`${baseClass}__side-nav`}
         navItems={SETUP_EXPERIENCE_NAV_ITEMS.map((navItem) => ({

--- a/frontend/pages/ManageControlsPage/SetupExperience/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/_styles.scss
@@ -1,7 +1,11 @@
 .setup-experience {
-  > p {
-    font-size: $x-small;
-    margin: $pad-xxlarge 0;
+  margin-top: 22px; // 32 px total, 10 from react-tabs
+  display: flex;
+  flex-direction: column;
+  gap: $pad-xxlarge;
+
+  &__description {
+    margin: 0;
   }
 
   &__premium-feature-message {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserExperiencePreview/EndUserExperiencePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserExperiencePreview/EndUserExperiencePreview.tsx
@@ -22,7 +22,7 @@ const EndUserExperiencePreview = ({
   return (
     <div className={classes}>
       <h3>End user experience</h3>
-      <TabNav className={`${baseClass}__tab-nav`}>
+      <TabNav className={`${baseClass}__tab-nav`} secondary>
         <Tabs>
           <TabList>
             <Tab>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -162,7 +162,7 @@ const InstallSoftware = ({
   return (
     <section className={baseClass}>
       <SectionHeader title="Install software" />
-      <TabNav>
+      <TabNav secondary>
         <Tabs
           selectedIndex={PLATFORM_BY_INDEX.indexOf(selectedPlatform)}
           onSelect={handleTabChange}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
@@ -1,8 +1,0 @@
-.install-software {
-  .tab-nav {
-    margin-top: -20px;
-  }
-  .react-tabs__tab-list {
-    margin-bottom: $pad-xxlarge;
-  }
-}

--- a/frontend/pages/ManageControlsPage/_styles.scss
+++ b/frontend/pages/ManageControlsPage/_styles.scss
@@ -1,4 +1,8 @@
 .manage-controls-page {
+  &__wrapper {
+    @include page;
+  }
+
   &__header-wrap {
     @include normalize-team-header;
 

--- a/frontend/pages/admin/AdminWrapper.tsx
+++ b/frontend/pages/admin/AdminWrapper.tsx
@@ -70,6 +70,9 @@ const AdminWrapper = ({
     });
   };
 
+  // we add a conditional sandbox-mode class here as we will need to make some
+  // styling changes on the settings page to have the sticky elements work
+  // with the sandbox mode expiry message
   const classNames = classnames(baseClass, { "sandbox-mode": isSandboxMode });
 
   return (

--- a/frontend/pages/admin/AdminWrapper.tsx
+++ b/frontend/pages/admin/AdminWrapper.tsx
@@ -70,15 +70,12 @@ const AdminWrapper = ({
     });
   };
 
-  // we add a conditional sandbox-mode class here as we will need to make some
-  // styling changes on the settings page to have the sticky elements work
-  // with the sandbox mode expiry message
   const classNames = classnames(baseClass, { "sandbox-mode": isSandboxMode });
 
   return (
     <MainContent className={classNames}>
       <div className={`${baseClass}_wrapper`}>
-        <TabNav sticky>
+        <TabNav>
           <h1>Settings</h1>
           <Tabs
             selectedIndex={getTabIndex(pathname)}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1255,7 +1255,7 @@ const HostDetailsPage = ({
                 )}
               </TabPanel>
               <TabPanel>
-                <TabNav className={`${baseClass}__software-tab-nav`}>
+                <TabNav className={`${baseClass}__software-tab-nav`} secondary>
                   <Tabs
                     selectedIndex={getSoftwareTabIndex(location.pathname)}
                     onSelect={(i) => navigateToSoftwareTab(i)}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -984,8 +984,12 @@ const HostDetailsPage = ({
         {isSoftwareLibrarySupported ? (
           <>
             <TabList>
-              <Tab>Inventory</Tab>
-              <Tab>Library</Tab>
+              <Tab>
+                <TabText>Inventory</TabText>
+              </Tab>
+              <Tab>
+                <TabText>Library</TabText>
+              </Tab>
             </TabList>
             <TabPanel>
               <SoftwareInventoryCard

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -76,7 +76,7 @@ const Activity = ({
         </div>
       )}
       <CardHeader header="Activity" />
-      <TabNav>
+      <TabNav secondary>
         <Tabs
           selectedIndex={activeTab === "past" ? 0 : 1}
           onSelect={onChangeTab}

--- a/frontend/styles/var/padding.scss
+++ b/frontend/styles/var/padding.scss
@@ -9,3 +9,12 @@ $pad-large: px-to-rem(24);
 $pad-xlarge: px-to-rem(32);
 $pad-xxlarge: px-to-rem(40);
 $pad-xxxlarge: px-to-rem(80);
+
+// 2025 Stylesheet
+$pad-page: $pad-xlarge;
+$gap-page-component: $pad-large;
+$gap-page-component-responsiveness: $pad-medium;
+$gap-page-component-inner: $pad-medium;
+$gap-page-component-inner-responsiveness: $pad-smedium;
+$gap-form: $pad-medium;
+$gap-table-elements: $pad-smedium;


### PR DESCRIPTION
## Issue
Part of Conf 11765

## Description
- Styling for primary and `secondary` tabs match [Figma](https://www.figma.com/design/gxvU745LfOdkE9AuRg64wi/%F0%9F%A7%A9-Design-system--purge-the-purple-WIP-?node-id=1404-4721&t=PI7pUwTDkLWPe9ic-0)
- TabNav changes only
- Added secondary tab to storybook
- Had to remove two storybook dependencies causing issues with opening storybook locally
- Controls > OS Settings > Targets - Updated so the preview is WITHIN the tab now, see [figma](https://www.figma.com/design/gxvU745LfOdkE9AuRg64wi/%F0%9F%A7%A9-Design-system--purge-the-purple-WIP-?node-id=4738-20635&t=PI7pUwTDkLWPe9ic-0)

## Screenshots
- Secondary tab added to storybook
<img width="1209" height="853" alt="Screenshot 2025-09-17 at 11 19 29 AM" src="https://github.com/user-attachments/assets/5fe7cc1c-c082-44dd-a810-c4ef3f937a1e" />

- Issues with opening storybook locally before removing dependencies
(Sorry part of error was in white and my terminal is white)
<img width="1216" height="870" alt="Screenshot 2025-09-17 at 12 18 38 PM" src="https://github.com/user-attachments/assets/d90d3f7f-bf4d-4f31-a70c-bb185cb14a3c" />

- Video recording of some primary and secondary tabs in this PR

https://github.com/user-attachments/assets/d15d7061-c6d6-4b47-be9b-dac5ed6ae65f




## Testing

- [x] QA'd all new/changed functionality manually
