### PR TITLE
Fleet UI: Fix teams page link color to new styling

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -98,7 +98,12 @@ const Agents = ({
             <InfoBanner>
               These options are not applied to hosts on a team. To update agent
               options for hosts on a team, head to the&nbsp;
-              <a href={ADMIN_TEAMS}>Teams page</a>&nbsp;and select a team.
+              <CustomLink
+                url={ADMIN_TEAMS}
+                text="Teams page"
+                variant="banner-link"
+              />
+              &nbsp;and select a team.
             </InfoBanner>
           ) : (
             <InfoBanner>


### PR DESCRIPTION
## Issue
Missed from #31944 

## Screenshot
- Correct black instead of purple link
<img width="962" height="482" alt="Screenshot 2025-09-17 at 1 53 12 PM" src="https://github.com/user-attachments/assets/a0eb4391-0935-4bc7-b9eb-107c845bec56" />


- [x] QA'd all new/changed functionality manually
