### PR TITLE
Fleet UI: Fix teams page link color to new styling (#33127)

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -98,7 +98,12 @@ const Agents = ({
             <InfoBanner>
               These options are not applied to hosts on a team. To update agent
               options for hosts on a team, head to the&nbsp;
-              <a href={ADMIN_TEAMS}>Teams page</a>&nbsp;and select a team.
+              <CustomLink
+                url={ADMIN_TEAMS}
+                text="Teams page"
+                variant="banner-link"
+              />
+              &nbsp;and select a team.
             </InfoBanner>
           ) : (
             <InfoBanner>


### PR DESCRIPTION
Merged into main with #33127 

This is a missed case to close out #31944


```
 1871  git checkout fleetdm/rc-minor-fleet-v4.74.0
 1872  git log main
 1873  git checkout -b link-teams-page-rc
 1874  git cherry-pick c23ff36e23511276d80bff15445ebdb861ef9a3e 
 1875  git push -u fleetdm link-teams-page-rc
```