### PR TITLE
Website: Update receive-from-clay webhook exits

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -54,6 +54,8 @@ module.exports = {
     duplicateContactOrAccountFound: {description: 'A contact or account could not be created because a duplicate record exists.', statusCode: 409 },
     couldNotCreateContactOrAccount: { description: 'A contact or account could not be created in the CRM using the provided information.' },
     couldNotCreateActivity: { description: 'An error occured when trying to create a historical event record in the CRM' },
+    invalidContactOrAccountCriteria: { description: 'A contact or account could not be created in the CRM using the provided information.', responseType: 'badRequest' },
+    invalidHistoricalEventCriteria: { description: 'A historical could not be created in the CRM using the provided information.', responseType: 'badRequest' },
   },
 
 
@@ -75,7 +77,9 @@ module.exports = {
       linkedinUrl,
       contactSource,
       jobTitle,
-    }).intercept((err)=>{
+    })
+    .intercept({name: 'UsageError'}, 'invalidContactOrAccountCriteria')
+    .intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a contact/account could not be created or updated. Full error: ${require('util').inspect(err)}`);
       if(typeof err.errorCode !== 'undefined' && err.errorCode === 'DUPLICATES_DETECTED') {
         return 'duplicateContactOrAccountFound';
@@ -100,7 +104,9 @@ module.exports = {
       eventContent: historicalContent,
       eventContentUrl: historicalContentUrl,
       linkedinUrl: trimmedLinkedinUrl,
-    }).intercept((err)=>{
+    })
+    .intercept({name: 'UsageError'}, 'invalidHistoricalEventCriteria')
+    .intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);
       return 'couldNotCreateActivity';
     });


### PR DESCRIPTION
Changes:
- Added two exits to the `receive-from-clay` webhook that are used if the webhook receives invalid inputs for the CRM helpers it uses.