### PR TITLE
Extend error detection for cached statements

### DIFF
--- a/changes/30779-extend-error-detection-cached-stms
+++ b/changes/30779-extend-error-detection-cached-stms
@@ -1,0 +1,1 @@
+* Extended the number of errors we look for when determining whether we should invalidate the prepared statements cache.

--- a/server/datastore/mysql/errors.go
+++ b/server/datastore/mysql/errors.go
@@ -4,6 +4,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"strconv"
@@ -147,7 +148,18 @@ func isMySQLAccessDenied(err error) bool {
 // isBadConnection checks if the error is a connection-level error that
 // justifies retrying the operation on a new connection.
 func isBadConnection(err error) bool {
-	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, mysql.ErrInvalidConn) {
+	if err == nil {
+		return false
+	}
+
+	if errors.Is(err, driver.ErrBadConn) ||
+		errors.Is(err, mysql.ErrInvalidConn) ||
+		errors.Is(err, io.ErrUnexpectedEOF) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ENETUNREACH) ||
+		errors.Is(err, syscall.ETIMEDOUT) {
 		return true
 	}
 

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -133,11 +133,11 @@ func (ds *Datastore) writer(ctx context.Context) *sqlx.DB {
 	return ds.primary
 }
 
-// loadOrPrepareStmt will load a statement from the statements cache.
+// loadOrPrepareStmt will load a statement from the statement cache.
 // If not available, it will attempt to prepare (create) it.
 // Returns nil if it failed to prepare a statement.
 //
-// IMPORTANT: Adding prepare statements consumes MySQL server resources, and is limited by MySQL max_prepared_stmt_count
+// IMPORTANT: Adding prepare statements consumes MySQL server resources and is limited by the MySQL max_prepared_stmt_count
 // system variable. This method may create 1 prepare statement for EACH database connection. Customers must be notified
 // to update their MySQL configurations when additional prepare statements are added.
 // For more detail, see: https://github.com/fleetdm/fleet/issues/15476


### PR DESCRIPTION
For #30779

Extend the number of errors we look for when determining whether we should invalidate the prepared statements cache.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.