### PR TITLE
Refactor `DiskSpaceIndicator` to use `ProgressBar`

### DIFF
--- a/frontend/components/ProgressBar/ProgressBar.tsx
+++ b/frontend/components/ProgressBar/ProgressBar.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { COLORS } from "styles/var/colors";
 
+import classnames from "classnames";
+
 const baseClass = "progress-bar";
 
 export interface IProgressBarSection {
@@ -11,18 +13,20 @@ export interface IProgressBarSection {
 export interface IProgressBar {
   sections: IProgressBarSection[];
   backgroundColor?: string;
+  width?: "small" | "large";
 }
 
 const ProgressBar = ({
   sections,
   backgroundColor = COLORS["ui-fleet-black-10"],
+  width = "large",
 }: IProgressBar) => {
+  const classes = classnames(baseClass, {
+    [`${baseClass}__small`]: width === "small",
+    [`${baseClass}__large`]: width === "large",
+  });
   return (
-    <div
-      className={`${baseClass}`}
-      style={{ backgroundColor }}
-      role="progressbar"
-    >
+    <div className={classes} style={{ backgroundColor }} role="progressbar">
       {sections.map((section, index) => (
         <div
           key={`${section.color}-${section.portion}`}

--- a/frontend/components/ProgressBar/_styles.scss
+++ b/frontend/components/ProgressBar/_styles.scss
@@ -1,9 +1,15 @@
 .progress-bar {
   display: flex;
   height: 4px;
-  width: 100px;
   border-radius: 8px;
   overflow: hidden;
+
+  &__small {
+    width: px-to-rem(50);
+  }
+  &__large {
+    width: px-to-rem(100);
+  }
 
   &__section {
     height: 100%;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -291,7 +291,7 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
       }
       return (
         <DiskSpaceIndicator
-          baseClass="gigs_disk_space_available__cell"
+          inTableCell
           gigsDiskSpaceAvailable={cellProps.cell.value}
           percentDiskSpaceAvailable={percent_disk_space_available}
           platform={platform}

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -285,11 +285,7 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
     accessor: "gigs_disk_space_available",
     id: "gigs_disk_space_available",
     Cell: (cellProps: IHostTableNumberCellProps) => {
-      const {
-        id,
-        platform,
-        percent_disk_space_available,
-      } = cellProps.row.original;
+      const { platform, percent_disk_space_available } = cellProps.row.original;
       if (platform === "chrome") {
         return NotSupported;
       }
@@ -298,7 +294,6 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
           baseClass="gigs_disk_space_available__cell"
           gigsDiskSpaceAvailable={cellProps.cell.value}
           percentDiskSpaceAvailable={percent_disk_space_available}
-          id={`disk-space__${id}`}
           platform={platform}
         />
       );

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.stories.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.stories.tsx
@@ -6,7 +6,6 @@ const meta: Meta<typeof DiskSpaceIndicator> = {
   title: "Components/DiskSpaceIndicator",
   component: DiskSpaceIndicator,
   args: {
-    baseClass: "disk-space-indicator",
     gigsDiskSpaceAvailable: 100,
     percentDiskSpaceAvailable: 75,
     platform: "darwin",

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.stories.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.stories.tsx
@@ -9,7 +9,6 @@ const meta: Meta<typeof DiskSpaceIndicator> = {
     baseClass: "disk-space-indicator",
     gigsDiskSpaceAvailable: 100,
     percentDiskSpaceAvailable: 75,
-    id: "disk-space-indicator",
     platform: "darwin",
   },
 };

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
@@ -1,11 +1,18 @@
 import React from "react";
 
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
+
+import { COLORS } from "styles/var/colors";
 
 import DiskSpaceIndicator from "./DiskSpaceIndicator";
 
 describe("Disk space Indicator", () => {
+  const [errStyle, warningStyle, okayStyle] = [
+    `background-color: ${COLORS["ui-error"]}`,
+    `background-color: ${COLORS["ui-warning"]}`,
+    `background-color: ${COLORS["status-success"]}`,
+  ];
   it("renders warning tooltip for <32gB when hovering over the yellow disk space indicator for darwin or windows", async () => {
     const { user } = renderWithSetup(
       <DiskSpaceIndicator
@@ -17,16 +24,16 @@ describe("Disk space Indicator", () => {
       />
     );
 
-    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 10%");
-    expect(screen.getByTitle("disk space indicator")).toHaveClass(
-      "data-set__disk-space--yellow"
-    );
+    const section = screen.getByTestId("section-0");
+    expect(section).toHaveStyle(warningStyle);
 
-    await user.hover(screen.getByTitle("disk space indicator"));
-    const tooltip = screen.getByText(
-      "Not enough disk space available to install most large operating systems updates."
-    );
-    expect(tooltip).toBeInTheDocument();
+    await user.hover(section);
+    await waitFor(() => {
+      const tooltip = screen.getByText(
+        "Not enough disk space available to install most large operating systems updates."
+      );
+      expect(tooltip).toBeInTheDocument();
+    });
   });
 
   it("renders severe warning tooltip for <16 gBwhen hovering over the red disk space indicator for darwin or windows", async () => {
@@ -40,16 +47,17 @@ describe("Disk space Indicator", () => {
       />
     );
 
-    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 2%");
-    expect(screen.getByTitle("disk space indicator")).toHaveClass(
-      "data-set__disk-space--red"
-    );
+    const section = screen.getByTestId("section-0");
+    expect(section).toHaveStyle(errStyle);
 
-    await user.hover(screen.getByTitle("disk space indicator"));
-    const tooltip = screen.getByText(
-      "Not enough disk space available to install most small operating systems updates."
-    );
-    expect(tooltip).toBeInTheDocument();
+    await user.hover(section);
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(
+        "Not enough disk space available to install most small operating systems updates."
+      );
+      expect(tooltip).toBeInTheDocument();
+    });
   });
 
   it("renders tooltip when hovering over the green disk space indicator for darwin or windows", async () => {
@@ -63,15 +71,16 @@ describe("Disk space Indicator", () => {
       />
     );
 
-    expect(screen.getByTitle("disk space indicator")).toHaveStyle("width: 15%");
-    expect(screen.getByTitle("disk space indicator")).toHaveClass(
-      "data-set__disk-space--green"
-    );
+    const section = screen.getByTestId("section-0");
+    expect(section).toHaveStyle(okayStyle);
 
-    await user.hover(screen.getByTitle("disk space indicator"));
-    const tooltip = screen.getByText(
-      "Enough disk space available to install most operating systems updates."
-    );
-    expect(tooltip).toBeInTheDocument();
+    await user.hover(section);
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(
+        "Enough disk space available to install most operating systems updates."
+      );
+      expect(tooltip).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
@@ -12,7 +12,6 @@ describe("Disk space Indicator", () => {
         baseClass="data-set"
         gigsDiskSpaceAvailable={17}
         percentDiskSpaceAvailable={10}
-        id="disk-space-indicator"
         platform="darwin"
         tooltipPosition="bottom"
       />
@@ -36,7 +35,6 @@ describe("Disk space Indicator", () => {
         baseClass="data-set"
         gigsDiskSpaceAvailable={5}
         percentDiskSpaceAvailable={2}
-        id="disk-space-indicator"
         platform="windows"
         tooltipPosition="bottom"
       />
@@ -60,7 +58,6 @@ describe("Disk space Indicator", () => {
         baseClass="data-set"
         gigsDiskSpaceAvailable={33}
         percentDiskSpaceAvailable={15}
-        id="disk-space-indicator"
         platform="windows"
         tooltipPosition="bottom"
       />

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tests.tsx
@@ -16,7 +16,6 @@ describe("Disk space Indicator", () => {
   it("renders warning tooltip for <32gB when hovering over the yellow disk space indicator for darwin or windows", async () => {
     const { user } = renderWithSetup(
       <DiskSpaceIndicator
-        baseClass="data-set"
         gigsDiskSpaceAvailable={17}
         percentDiskSpaceAvailable={10}
         platform="darwin"
@@ -39,7 +38,6 @@ describe("Disk space Indicator", () => {
   it("renders severe warning tooltip for <16 gBwhen hovering over the red disk space indicator for darwin or windows", async () => {
     const { user } = renderWithSetup(
       <DiskSpaceIndicator
-        baseClass="data-set"
         gigsDiskSpaceAvailable={5}
         percentDiskSpaceAvailable={2}
         platform="windows"
@@ -63,7 +61,6 @@ describe("Disk space Indicator", () => {
   it("renders tooltip when hovering over the green disk space indicator for darwin or windows", async () => {
     const { user } = renderWithSetup(
       <DiskSpaceIndicator
-        baseClass="data-set"
         gigsDiskSpaceAvailable={33}
         percentDiskSpaceAvailable={15}
         platform="windows"

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
@@ -1,7 +1,11 @@
 import React from "react";
 
-import ReactTooltip from "react-tooltip";
+import { PlacesType } from "react-tooltip-5";
+
 import { COLORS } from "styles/var/colors";
+
+import ProgressBar from "components/ProgressBar";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface IDiskSpaceIndicatorProps {
   baseClass: string;
@@ -9,7 +13,7 @@ interface IDiskSpaceIndicatorProps {
   percentDiskSpaceAvailable: number;
   id: string;
   platform: string;
-  tooltipPosition?: "top" | "bottom";
+  tooltipPosition?: PlacesType;
 }
 
 const DiskSpaceIndicator = ({
@@ -28,12 +32,12 @@ const DiskSpaceIndicator = ({
     // return space-dependent indicator colors for mac and windows hosts, green for linux
     if (platform === "darwin" || platform === "windows") {
       if (gigsDiskSpaceAvailable < 16) {
-        return "red";
+        return COLORS["ui-error"];
       } else if (gigsDiskSpaceAvailable < 32) {
-        return "yellow";
+        return COLORS["ui-warning"];
       }
     }
-    return "green";
+    return COLORS["status-success"];
   };
 
   const diskSpaceTooltipText = ((): string | undefined => {
@@ -48,39 +52,32 @@ const DiskSpaceIndicator = ({
     return undefined;
   })();
 
+  const renderBar = () => (
+    <ProgressBar
+      sections={[
+        {
+          color: getDiskSpaceIndicatorColor(),
+          portion: percentDiskSpaceAvailable / 100,
+        },
+      ]}
+      width="small"
+    />
+  );
+
   return (
-    <span className={`${baseClass}__data`}>
-      <div
-        className={`${baseClass}__disk-space-wrapper tooltip`}
-        data-tip
-        data-for={`tooltip-${id}`}
-      >
-        <div className={`${baseClass}__disk-space`}>
-          <div
-            className={`${baseClass}__disk-space--${getDiskSpaceIndicatorColor()}`}
-            style={{
-              width: `${percentDiskSpaceAvailable}%`,
-            }}
-            title="disk space indicator"
-          />
-        </div>
-      </div>
-      {diskSpaceTooltipText && (
-        <ReactTooltip
-          className="disk-space-tooltip"
-          place={tooltipPosition}
-          type="dark"
-          effect="solid"
-          id={`tooltip-${id}`}
-          backgroundColor={COLORS["tooltip-bg"]}
+    <span className="disk-space-indicator">
+      {diskSpaceTooltipText ? (
+        <TooltipWrapper
+          position={tooltipPosition}
+          tipOffset={10}
+          showArrow
+          underline={false}
+          tipContent={diskSpaceTooltipText}
         >
-          <span
-            className={`${baseClass}__tooltip-text`}
-            title="disk space tooltip"
-          >
-            {diskSpaceTooltipText}
-          </span>
-        </ReactTooltip>
+          {renderBar()}
+        </TooltipWrapper>
+      ) : (
+        renderBar()
       )}
       {gigsDiskSpaceAvailable} GB{baseClass === "info-flex" && " available"}
     </span>

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
@@ -11,7 +11,6 @@ interface IDiskSpaceIndicatorProps {
   baseClass: string;
   gigsDiskSpaceAvailable: number | "---";
   percentDiskSpaceAvailable: number;
-  id: string;
   platform: string;
   tooltipPosition?: PlacesType;
 }
@@ -20,7 +19,6 @@ const DiskSpaceIndicator = ({
   baseClass,
   gigsDiskSpaceAvailable,
   percentDiskSpaceAvailable,
-  id,
   platform,
   tooltipPosition = "top",
 }: IDiskSpaceIndicatorProps): JSX.Element => {

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
@@ -7,23 +7,24 @@ import { COLORS } from "styles/var/colors";
 import ProgressBar from "components/ProgressBar";
 import TooltipWrapper from "components/TooltipWrapper";
 
+const baseClass = "disk-space-indicator";
 interface IDiskSpaceIndicatorProps {
-  baseClass: string;
   gigsDiskSpaceAvailable: number | "---";
   percentDiskSpaceAvailable: number;
   platform: string;
+  inTableCell?: boolean;
   tooltipPosition?: PlacesType;
 }
 
 const DiskSpaceIndicator = ({
-  baseClass,
   gigsDiskSpaceAvailable,
   percentDiskSpaceAvailable,
   platform,
+  inTableCell = false,
   tooltipPosition = "top",
 }: IDiskSpaceIndicatorProps): JSX.Element => {
   if (gigsDiskSpaceAvailable === 0 || gigsDiskSpaceAvailable === "---") {
-    return <span className={`${baseClass}__data`}>No data available</span>;
+    return <span className={`${baseClass}__empty`}>No data available</span>;
   }
 
   const getDiskSpaceIndicatorColor = (): string => {
@@ -63,7 +64,7 @@ const DiskSpaceIndicator = ({
   );
 
   return (
-    <span className="disk-space-indicator">
+    <span className={baseClass}>
       {diskSpaceTooltipText ? (
         <TooltipWrapper
           position={tooltipPosition}
@@ -77,7 +78,7 @@ const DiskSpaceIndicator = ({
       ) : (
         renderBar()
       )}
-      {gigsDiskSpaceAvailable} GB{baseClass === "info-flex" && " available"}
+      {gigsDiskSpaceAvailable} GB{!inTableCell && " available"}
     </span>
   );
 };

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/_styles.scss
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/_styles.scss
@@ -2,15 +2,11 @@
   display: flex;
   align-items: center;
   gap: $pad-small;
+  white-space: nowrap;
 
   .react-tooltip {
     max-width: px-to-rem(160);
     text-align: center;
     font-size: px-to-rem(13);
   }
-}
-
-.info-flex,
-.gigs_disk_space_available__cell {
-  white-space: nowrap;
 }

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/_styles.scss
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/_styles.scss
@@ -1,42 +1,16 @@
+.disk-space-indicator {
+  display: flex;
+  align-items: center;
+  gap: $pad-small;
+
+  .react-tooltip {
+    max-width: px-to-rem(160);
+    text-align: center;
+    font-size: px-to-rem(13);
+  }
+}
+
 .info-flex,
 .gigs_disk_space_available__cell {
   white-space: nowrap;
-
-  &__disk-space {
-    display: inline-block;
-    height: 4px;
-    width: 50px;
-    background-color: $ui-fleet-black-10;
-    border-radius: 2px;
-    margin-right: $pad-small;
-    overflow: hidden;
-    margin-bottom: 2px;
-
-    &-wrapper {
-      display: inline-block;
-    }
-
-    &--green {
-      background-color: $ui-success;
-      height: 100%;
-    }
-
-    &--yellow {
-      background-color: $ui-warning;
-      height: 100%;
-    }
-
-    &--red {
-      background-color: $ui-error;
-      height: 100%;
-    }
-  }
-
-  &__data {
-    .disk-space-tooltip {
-      display: block;
-      white-space: normal;
-      max-width: 160px;
-    }
-  }
 }

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -184,7 +184,6 @@ const HostSummary = ({
             baseClass="info-flex"
             gigsDiskSpaceAvailable={summaryData.gigs_disk_space_available}
             percentDiskSpaceAvailable={summaryData.percent_disk_space_available}
-            id={`disk-space-tooltip-${summaryData.id}`}
             platform={platform}
             tooltipPosition="bottom"
           />

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -181,7 +181,6 @@ const HostSummary = ({
         title={title}
         value={
           <DiskSpaceIndicator
-            baseClass="info-flex"
             gigsDiskSpaceAvailable={summaryData.gigs_disk_space_available}
             percentDiskSpaceAvailable={summaryData.percent_disk_space_available}
             platform={platform}

--- a/frontend/styles/var/colors.ts
+++ b/frontend/styles/var/colors.ts
@@ -23,6 +23,8 @@ export const COLORS = {
   "ui-blue-10": "#F1F0FF",
   "tooltip-bg": "#3E4771",
   "ui-light-grey": "#FAFAFA",
+  "ui-error": "#d66c7b",
+  "ui-warning": "#ebbc43",
 
   // Notifications & status
   "status-success": "#3DB67B",


### PR DESCRIPTION
## Precursor for #31671 

- Add width option to `ProgressBar`
- Refactor `DiskSpaceIndicator`
  - Use `ProgressBar` with new `width` option
  - Replace raw react tooltip with `TooltipWrapper`
  - Clean up confusing styles
- Update tests, ensure consistent style with previous implementation on hosts table, hosts details page, my device page

<img width="1020" height="546" alt="Screenshot 2025-09-18 at 4 49 28 PM" src="https://github.com/user-attachments/assets/a0c958d0-8b2b-466c-b169-a91dc8fb984c" />
<img width="1020" height="546" alt="Screenshot 2025-09-18 at 4 49 35 PM" src="https://github.com/user-attachments/assets/f60f1e0a-573d-438b-9ded-ec45825599c1" />


- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually