### PR TITLE
Website: Update automatic issues created for rituals

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1179,7 +1179,7 @@ module.exports = {
         });
 
         let githubLabelsToCheck = {};
-        let KNOWN_AUTOMATABLE_FREQUENCIES = ['Daily', 'Weekly', 'Triweekly', 'Monthly', 'Annually'];
+        let KNOWN_AUTOMATABLE_FREQUENCIES = ['Daily', 'Weekly', 'Triweekly', 'Monthly', 'Annually', 'Quarterly'];
         // Process each rituals YAML file. These will be added to the builtStaticContent as JSON
         for(let ritualsYamlFilePath of ritualTablesYamlFiles){
           // Get this rituals.yml file's parent folder name, we'll use this as the key for this section's rituals in the ritualsTables dictionary
@@ -1229,6 +1229,9 @@ module.exports = {
               }
               if(!_.contains(['fleet', 'confidential'], ritual.autoIssue.repo)) {
                 throw new Error(`Could not built rituals from ${ritualsYamlFilePath}. The "autoIssue.repo" value of "${ritual.task}" contains an invalid GitHub repo (${ritual.autoIssue.repo}). Please change this value to be either "fleet" or "confidential" and try running this script again.`);
+              }
+              if(ritual.autoIssue.body && typeof ritual.autoIssue.body !== 'string') {
+                throw new Error(`Could not build rituals from ${ritualsYamlFilePath}. "${ritual.task}" has an 'autoIssue' value that has an invalid "body" value. Please change this value to be a string (currently ${typeof ritual.autoIssue.body}) that contains the issue description of this rituals GitHub issue and try running this script again.`);
               }
               // Check each label in the labels array
               for(let label of ritual.autoIssue.labels) {

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1230,8 +1230,8 @@ module.exports = {
               if(!_.contains(['fleet', 'confidential'], ritual.autoIssue.repo)) {
                 throw new Error(`Could not built rituals from ${ritualsYamlFilePath}. The "autoIssue.repo" value of "${ritual.task}" contains an invalid GitHub repo (${ritual.autoIssue.repo}). Please change this value to be either "fleet" or "confidential" and try running this script again.`);
               }
-              if(ritual.autoIssue.body && typeof ritual.autoIssue.body !== 'string') {
-                throw new Error(`Could not build rituals from ${ritualsYamlFilePath}. "${ritual.task}" has an 'autoIssue' value that has an invalid "body" value. Please change this value to be a string (currently ${typeof ritual.autoIssue.body}) that contains the issue description of this rituals GitHub issue and try running this script again.`);
+              if(ritual.autoIssue.issueDescription && typeof ritual.autoIssue.issueDescription !== 'string') {
+                throw new Error(`Could not build rituals from ${ritualsYamlFilePath}. "${ritual.task}" has an 'autoIssue' value that has an invalid "issueDescription" value. Please change this value to be a string (currently ${typeof ritual.autoIssue.issueDescription}) that contains the issue description of this rituals GitHub issue and try running this script again.`);
               }
               // Check each label in the labels array
               for(let label of ritual.autoIssue.labels) {

--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -117,8 +117,8 @@ module.exports = {
         if (!dry) {
           let owner = 'fleetdm';
           let bodyForThisAutoIssue;
-          if(ritual.autoIssue.body) {
-            bodyForThisAutoIssue = ritual.autoIssue.body + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : '');
+          if(ritual.autoIssue.issueDescription) {
+            bodyForThisAutoIssue = ritual.autoIssue.issueDescription + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : '');
           } else {
             bodyForThisAutoIssue = ritual.description + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : '');
           }

--- a/website/scripts/create-issues-for-todays-rituals.js
+++ b/website/scripts/create-issues-for-todays-rituals.js
@@ -48,6 +48,8 @@ module.exports = {
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * 7 * 3;
         } else if (ritual.frequency === 'Annually') {
           ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * 365;
+        } else if (ritual.frequency === 'Quarterly') {
+          ritualsFrequencyInMs = 1000 * 60 * 60 * 24 * 365 / 4;
         } else if (ritual.frequency === 'Monthly') {
           // For monthly rituals, we will create issues on the day of the month that the ritual was started on, or the last day of the month if the ritual was started on a day that doesn't exist in the current month
           // (e.g, the next issue for a monthly ritual started on 2024-01-31 would be created for on 2024-02-29)
@@ -106,17 +108,24 @@ module.exports = {
 
         // Skip to the next ritual if it isn't time yet.
         if(!isItTimeToCreateANewIssue) {
-          sails.log.verbose(`Next issue for ${ritual.task} (${ritual.autoIssue.labels.join(',')}) will be created on ${new Date(nextIssueShouldBeCreatedAt)} (Started on: ${ritual.startedOn}, frequency: ${ritual.frequency})`);
+          let lastIssueShouldHaveBeenCreatedAt = nextIssueShouldBeCreatedAt - ritualsFrequencyInMs;
+          sails.log(`Next issue for ${ritual.task} (${ritual.autoIssue.labels.join(',')}) will be created on ${new Date(nextIssueShouldBeCreatedAt)} (Started on: ${ritual.startedOn}, frequency: ${ritual.frequency}). Last issue for this ritual should have been created on ${new Date(lastIssueShouldHaveBeenCreatedAt)}`);
           continue;
         }
 
         // Create an issue with right labels and assignee, in the right repo.
         if (!dry) {
           let owner = 'fleetdm';
+          let bodyForThisAutoIssue;
+          if(ritual.autoIssue.body) {
+            bodyForThisAutoIssue = ritual.autoIssue.body + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : '');
+          } else {
+            bodyForThisAutoIssue = ritual.description + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : '');
+          }
           // [?] https://docs.github.com/en/rest/issues/issues#create-an-issue
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${ritual.autoIssue.repo}/issues`, {
             title: ritual.task,
-            body: ritual.description + (ritual.moreInfoUrl ? ('\n\n> Read more at '+ritual.moreInfoUrl) : ''),
+            body: bodyForThisAutoIssue,
             labels: ritual.autoIssue.labels,
             assignees: [ ritual.dri ]
           }, baseHeaders);


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/20792

Changes:
- Added support for the quarterly frequency for issues automatically created for rituals
- Added support for templated auto-issue issue descriptions. Rituals with an `issueDescription` value nested in the `autoIssue` object will now use that value as the issue description when an issue for the ritual is created. 