### PR TITLE
Use new pacman table to ingest software from arch linux

### DIFF
--- a/changes/32862-arch-linux-software-ingestion
+++ b/changes/32862-arch-linux-software-ingestion
@@ -1,0 +1,1 @@
+- Add software ingestion from Arch Linux

--- a/changes/32862-arch-linux-software-ingestion
+++ b/changes/32862-arch-linux-software-ingestion
@@ -1,1 +1,1 @@
-- Add software ingestion from Arch Linux
+* Added software ingestion from Arch Linux hosts.

--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -585,8 +585,8 @@ SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND na
 - Query:
 ```sql
 SELECT package, MAX(atime) AS last_opened_at
-		FROM deb_package_files 
-		CROSS JOIN file USING (path) 
+		FROM deb_package_files
+		CROSS JOIN file USING (path)
 		WHERE type = 'regular' AND regex_match(file.mode, '[1357]', 0)
 		GROUP BY package
 ```
@@ -673,6 +673,30 @@ SELECT
   '' AS arch,
   path AS installed_path
 FROM cached_users CROSS JOIN firefox_addons USING (uid);
+```
+
+## software_linux_fleetd_pacman
+
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo, neon, archarm
+
+- Discovery query:
+```sql
+SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'fleetd_pacman_packages'
+```
+
+- Query:
+```sql
+SELECT
+  name AS name,
+  version AS version,
+  '' AS extension_id,
+  '' AS browser,
+  'pacman_packages' AS source,
+  '' AS release,
+  '' AS vendor,
+  arch AS arch,
+  '' AS installed_path
+FROM fleetd_pacman_packages
 ```
 
 ## software_macos

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -198,7 +198,7 @@ export const SOURCE_TYPE_CONVERSION = {
   portage_packages: "Package (Portage)",
   rpm_packages: "Package (RPM)",
   yum_sources: "Package (YUM)",
-  fleetd_pacman_packages: "Package (pacman)",
+  pacman_packages: "Package (pacman)",
   npm_packages: "Package (NPM)",
   atom_packages: "Package (Atom)", // Atom packages were removed from software inventory. Mapping is maintained for backwards compatibility. (2023-12-04)
   python_packages: "Package (Python)",
@@ -226,7 +226,7 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   portage_packages: "linux",
   rpm_packages: "linux",
   yum_sources: "linux",
-  fleetd_pacman_packages: "linux",
+  pacman_packages: "linux",
   tgz_packages: "linux",
   npm_packages: null,
   atom_packages: null,

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -198,6 +198,7 @@ export const SOURCE_TYPE_CONVERSION = {
   portage_packages: "Package (Portage)",
   rpm_packages: "Package (RPM)",
   yum_sources: "Package (YUM)",
+  fleetd_pacman_packages: "Package (pacman)",
   npm_packages: "Package (NPM)",
   atom_packages: "Package (Atom)", // Atom packages were removed from software inventory. Mapping is maintained for backwards compatibility. (2023-12-04)
   python_packages: "Package (Python)",
@@ -225,6 +226,7 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   portage_packages: "linux",
   rpm_packages: "linux",
   yum_sources: "linux",
+  fleetd_pacman_packages: "linux",
   tgz_packages: "linux",
   npm_packages: null,
   atom_packages: null,

--- a/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
+++ b/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
@@ -43,7 +43,20 @@ func Columns() []table.ColumnDefinition {
 //
 // Constraints for generating can be retrieved from the queryContext.
 func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	out, err := exec.Command("/usr/bin/pacman", "-Qi").Output()
+	var softwareTitles []string
+
+	if software, ok := queryContext.Constraints["name"]; ok {
+		for _, c := range software.Constraints {
+			if c.Operator == table.OperatorEquals {
+				softwareTitles = append(softwareTitles, c.Expression)
+			}
+		}
+	}
+
+	args := []string{"-Qi"}
+	args = append(args, softwareTitles...)
+
+	out, err := exec.Command("/usr/bin/pacman", args...).Output()
 	if os.IsNotExist(err) {
 		// If no package manager, return nothing but don't fail
 		return nil, nil

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1384,6 +1384,9 @@ func preProcessSoftwareResults(
 	pythonPackagesWithUsersExtraQuery := hostDetailQueryPrefix + "software_python_packages_with_users_dir"
 	preProcessSoftwareExtraResults(pythonPackagesWithUsersExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
 
+	fleetdPacmanPackagesExtraQuery := hostDetailQueryPrefix + "software_linux_fleetd_pacman"
+	preProcessSoftwareExtraResults(fleetdPacmanPackagesExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
+
 	for name, query := range overrides {
 		fullQueryName := hostDetailQueryPrefix + "software_" + name
 		preProcessSoftwareExtraResults(fullQueryName, host.ID, results, statuses, messages, query, logger)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1110,6 +1110,7 @@ func verifyDiscovery(t *testing.T, queries, discovery map[string]string) {
 		hostDetailQueryPrefix + "kubequery_info":                          {},
 		hostDetailQueryPrefix + "orbit_info":                              {},
 		hostDetailQueryPrefix + "software_vscode_extensions":              {},
+		hostDetailQueryPrefix + "software_linux_fleetd_pacman":            {},
 		hostDetailQueryPrefix + "software_python_packages":                {},
 		hostDetailQueryPrefix + "software_python_packages_with_users_dir": {},
 		hostDetailQueryPrefix + "software_macos_firefox":                  {},

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1001,6 +1001,25 @@ var scheduledQueryStats = DetailQuery{
 	Platforms:            append(fleet.HostLinuxOSs, "darwin", "windows"), // not chrome
 }
 
+var softwareLinuxPacman = DetailQuery{
+	Query: `
+SELECT
+  name AS name,
+  version AS version,
+  '' AS extension_id,
+  '' AS browser,
+  'pacman_packages' AS source,
+  '' AS release,
+  '' AS vendor,
+  arch AS arch,
+  '' AS installed_path
+FROM fleetd_pacman_packages`,
+	Platforms: fleet.HostLinuxOSs,
+	Discovery: discoveryTable("fleetd_pacman_packages"),
+	// Has no IngestFunc, DirectIngestFunc or DirectTaskIngestFunc because
+	// the results of this query are appended to the results of the other software queries.
+}
+
 var softwareLinux = DetailQuery{
 	Query: withCachedUsers(`WITH cached_users AS (%s)
 SELECT
@@ -1039,18 +1058,6 @@ SELECT
   arch AS arch,
   '' AS installed_path
 FROM rpm_packages
-UNION
-SELECT
-  name AS name,
-  version AS version,
-  '' AS extension_id,
-  '' AS browser,
-  'fleetd_pacman_packages' AS source,
-  '' AS release,
-  '' AS vendor,
-  arch AS arch,
-  '' AS installed_path
-FROM fleetd_pacman_packages
 UNION
 SELECT
   name AS name,
@@ -2699,6 +2706,7 @@ func GetDetailQueries(
 		generatedMap["software_python_packages"] = softwarePythonPackages
 		generatedMap["software_python_packages_with_users_dir"] = softwarePythonPackagesWithUsersDir
 		generatedMap["software_vscode_extensions"] = softwareVSCodeExtensions
+		generatedMap["software_linux_pacman"] = softwareLinuxPacman
 
 		for key, query := range SoftwareOverrideQueries {
 			generatedMap["software_"+key] = query

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2706,7 +2706,7 @@ func GetDetailQueries(
 		generatedMap["software_python_packages"] = softwarePythonPackages
 		generatedMap["software_python_packages_with_users_dir"] = softwarePythonPackagesWithUsersDir
 		generatedMap["software_vscode_extensions"] = softwareVSCodeExtensions
-		generatedMap["software_linux_pacman"] = softwareLinuxPacman
+		generatedMap["software_linux_fleetd_pacman"] = softwareLinuxPacman
 
 		for key, query := range SoftwareOverrideQueries {
 			generatedMap["software_"+key] = query

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1045,6 +1045,18 @@ SELECT
   version AS version,
   '' AS extension_id,
   '' AS browser,
+  'fleetd_pacman_packages' AS source,
+  '' AS release,
+  '' AS vendor,
+  arch AS arch,
+  '' AS installed_path
+FROM fleetd_pacman_packages
+UNION
+SELECT
+  name AS name,
+  version AS version,
+  '' AS extension_id,
+  '' AS browser,
   'npm_packages' AS source,
   '' AS release,
   '' AS vendor,
@@ -1360,8 +1372,8 @@ var SoftwareOverrideQueries = map[string]DetailQuery{
 		// deb_package_files does not have a mode column, so we need to join to the file table and filter there
 		Query: `
 		SELECT package, MAX(atime) AS last_opened_at
-		FROM deb_package_files 
-		CROSS JOIN file USING (path) 
+		FROM deb_package_files
+		CROSS JOIN file USING (path)
 		WHERE type = 'regular' AND regex_match(file.mode, '[1357]', 0)
 		GROUP BY package
 	`,
@@ -1793,9 +1805,11 @@ const (
 	linuxImageRegex       = `^linux-image-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-[[:digit:]]+-[[:alnum:]]+`
 	amazonLinuxKernelName = "kernel"
 	rhelKernelName        = "kernel-core"
+	archKernelName        = `^linux(?:-(?:lts|zen|hardened))?$`
 )
 
 var kernelRegex = regexp.MustCompile(linuxImageRegex)
+var archKernelRegex = regexp.MustCompile(archKernelName)
 
 func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var software []fleet.Software
@@ -1834,7 +1848,7 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 			continue
 		}
 
-		if fleet.IsLinux(host.Platform) && (kernelRegex.MatchString(s.Name) || s.Name == amazonLinuxKernelName || s.Name == rhelKernelName) {
+		if fleet.IsLinux(host.Platform) && (kernelRegex.MatchString(s.Name) || s.Name == amazonLinuxKernelName || s.Name == rhelKernelName || archKernelRegex.MatchString(s.Name)) {
 			s.IsKernel = true
 		}
 
@@ -2555,7 +2569,7 @@ var tpmPINQueries = map[string]DetailQuery{
 					-- BitLocker is an optional feature but enabled
 					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
 					-- BitLocker is built in, so it won't appear as an optional feature
-					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker')
 				)
 				-- PIN is already set, so regardless of the current config, we don't need to enforce it:
 				-- 4: TPM And PIN.
@@ -2622,14 +2636,14 @@ var tpmPINQueries = map[string]DetailQuery{
 					-- BitLocker is an optional feature but enabled
 					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
 					-- BitLocker is built in, so it won't appear as an optional feature
-					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker')
 				)
 			)
 			SELECT 1 FROM should_run WHERE yes = 1`,
 		Query: `
 			SELECT EXISTS(
-				SELECT 1 
-				FROM bitlocker_key_protectors 
+				SELECT 1
+				FROM bitlocker_key_protectors
 				-- 4: TPM And PIN.
 				-- 6: TPM And PIN And Startup key.
 				WHERE drive_letter = 'C:' AND key_protector_type IN (4,6)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -343,7 +343,7 @@ func TestGetDetailQueries(t *testing.T) {
 
 	queriesWithUsersAndSoftware := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true}, Integrations{}, nil)
 	qs = baseQueries
-	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions",
+	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_linux_fleetd_pacman",
 		"software_chrome", "software_python_packages", "software_python_packages_with_users_dir", "scheduled_query_stats", "software_macos_firefox", "software_macos_codesign", "software_windows_last_opened_at", "software_deb_last_opened_at", "software_rpm_last_opened_at")
 	require.Len(t, queriesWithUsersAndSoftware, len(qs))
 	sortedKeysCompare(t, queriesWithUsersAndSoftware, qs)


### PR DESCRIPTION
#32862

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))

Made a small addition to the `fleetd_pacman_packages` table to let users query for specific packages instead of getting the full list and filtering.

Kernels are detected properly
<img width="2908" height="292" alt="image" src="https://github.com/user-attachments/assets/84188d10-5b1a-4be1-a30d-354f18651362" />

Software inventory is updated
<img width="2908" height="2280" alt="image" src="https://github.com/user-attachments/assets/488331d9-c80f-4ef4-9d96-4d954e17dbd3" />

Vulnerabilities seem to be getting tagged properly
<img width="2908" height="2172" alt="image" src="https://github.com/user-attachments/assets/57e776ab-79f3-45e6-bf5c-1713c1414a42" />

