### PR TITLE
Website: re-order sidebar links on controls pages.

### DIFF
--- a/website/assets/styles/pages/os-settings.less
+++ b/website/assets/styles/pages/os-settings.less
@@ -83,6 +83,7 @@
     margin-right: 64px;
     display: flex;
     flex-direction: column;
+    min-width: 220px;
     width: 220px;
     [purpose='sidebar-link'] {
       display: flex;

--- a/website/views/pages/mdm-commands.ejs
+++ b/website/views/pages/mdm-commands.ejs
@@ -24,9 +24,9 @@
       </div>
       <div purpose="sidebar-and-content">
         <div purpose="sidebar" class="d-lg-flex d-none">
-          <a purpose="sidebar-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
-          <a purpose="sidebar-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
           <a purpose="sidebar-link" class="active" :href="'/mdm-commands#'+selectedPlatform">MDM commands</a>
+          <a purpose="sidebar-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
+          <a purpose="sidebar-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
         </div>
         <div class="d-flex d-lg-none">
           <div purpose="mobile-custom-select" class="d-flex flex-row justify-content-between align-items-center" @click="clickOpenTableOfContents()">
@@ -89,9 +89,9 @@
       <p purpose="mobile-table-of-contents-header"><strong>Controls</strong></p>
         <div purpose="table-of-contents" class="w-100">
           <div purpose="modal-links">
-            <a class="d-block" purpose="modal-nav-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
-            <a class="d-block" purpose="modal-nav-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
             <a class="d-block active" purpose="modal-nav-link" :href="'/mdm-commands#'+selectedPlatform">MDM commands</a>
+            <a class="d-block" purpose="modal-nav-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
+            <a class="d-block" purpose="modal-nav-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
           </div>
         </div>
     </modal>

--- a/website/views/pages/os-settings.ejs
+++ b/website/views/pages/os-settings.ejs
@@ -24,9 +24,9 @@
       </div>
       <div purpose="sidebar-and-content">
         <div purpose="sidebar" class="d-lg-flex d-none">
-          <a purpose="sidebar-link" class="active" :href="'/os-settings#'+selectedPlatform">OS settings</a>
-          <a purpose="sidebar-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
           <a purpose="sidebar-link" :href="'/mdm-commands#'+selectedPlatform">MDM commands</a>
+          <a purpose="sidebar-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
+          <a purpose="sidebar-link" class="active" :href="'/os-settings#'+selectedPlatform">OS settings</a>
         </div>
         <div class="d-flex d-lg-none">
           <div purpose="mobile-custom-select" class="d-flex flex-row justify-content-between align-items-center" @click="clickOpenTableOfContents()">
@@ -70,9 +70,9 @@
       <p purpose="mobile-table-of-contents-header"><strong>Controls</strong></p>
         <div purpose="table-of-contents" class="w-100">
           <div purpose="modal-links">
-            <a class="d-block" purpose="modal-nav-link" href="/os-settings">OS settings</a>
-            <a class="d-block active" purpose="modal-nav-link" href="/scripts">Scripts</a>
             <a class="d-block" purpose="modal-nav-link" href="/mdm-commands">MDM commands</a>
+            <a class="d-block active" purpose="modal-nav-link" href="/scripts">Scripts</a>
+            <a class="d-block" purpose="modal-nav-link" href="/os-settings">OS settings</a>
           </div>
         </div>
     </modal>

--- a/website/views/pages/scripts.ejs
+++ b/website/views/pages/scripts.ejs
@@ -24,9 +24,9 @@
       </div>
       <div purpose="sidebar-and-content">
         <div purpose="sidebar" class="d-lg-flex d-none">
-          <a purpose="sidebar-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
-          <a purpose="sidebar-link" class="active" :href="'/scripts#'+selectedPlatform">Scripts</a>
           <a purpose="sidebar-link" :href="'/mdm-commands#'+selectedPlatform">MDM commands</a>
+          <a purpose="sidebar-link" class="active" :href="'/scripts#'+selectedPlatform">Scripts</a>
+          <a purpose="sidebar-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
         </div>
         <div class="d-flex d-lg-none">
           <div purpose="mobile-custom-select" class="d-flex flex-row justify-content-between align-items-center" @click="clickOpenTableOfContents()">
@@ -87,9 +87,9 @@
       <p purpose="mobile-table-of-contents-header"><strong>Controls</strong></p>
         <div purpose="table-of-contents" class="w-100">
           <div purpose="modal-links">
-            <a class="d-block" purpose="modal-nav-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
-            <a class="d-block active" purpose="modal-nav-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
             <a class="d-block" purpose="modal-nav-link" :href="'/mdm-commands#'+selectedPlatform">MDM commands</a>
+            <a class="d-block active" purpose="modal-nav-link" :href="'/scripts#'+selectedPlatform">Scripts</a>
+            <a class="d-block" purpose="modal-nav-link" :href="'/os-settings#'+selectedPlatform">OS settings</a>
           </div>
         </div>
     </modal>


### PR DESCRIPTION
Changes:
- Updated the sidebar links on /mdm-commands, /scripts, and /os-settings
- Updated the width of the sidebar on the os-settings page to be consistent with /mdm-commands and /scripts