### PR TITLE
Fleet UI: Setup pages only

### DIFF
--- a/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.tsx
+++ b/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.tsx
@@ -11,6 +11,8 @@ interface IAuthenticationFormWrapperProps {
   children: React.ReactNode;
   header?: string;
   headerCta?: React.ReactNode;
+  /** Only used on the registration page */
+  breadcrumbs?: React.ReactNode;
   className?: string;
 }
 
@@ -20,6 +22,7 @@ const AuthenticationFormWrapper = ({
   children,
   header,
   headerCta,
+  breadcrumbs,
   className,
 }: IAuthenticationFormWrapperProps) => {
   const classNames = classnames(baseClass, className);
@@ -39,6 +42,7 @@ const AuthenticationFormWrapper = ({
           </ul>
         </div>
       </nav>
+      {breadcrumbs}
       <div className={classNames}>
         <Card className={`${baseClass}__card`} paddingSize="xxlarge">
           {(header || headerCta) && (

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -70,9 +70,11 @@ class AdminDetails extends Component {
           tabIndex={tabIndex}
           label="Confirm password"
         />
-        <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
-          Next
-        </Button>
+        <div className="button-wrap">
+          <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
+            Next
+          </Button>
+        </div>
       </form>
     );
   }

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
@@ -99,7 +99,7 @@ const ConfirmationPage = ({
 
         {importOsqueryConfig()}
       </div>
-      <p className="help-text">
+      <p className={`${baseClass}__help-text`}>
         Fleet Device Management Inc. periodically collects information about
         your instance. Sending usage statistics from your Fleet instance is
         optional and can be disabled in settings.

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/ConfirmationPage.tsx
@@ -104,14 +104,16 @@ const ConfirmationPage = ({
         your instance. Sending usage statistics from your Fleet instance is
         optional and can be disabled in settings.
       </p>
-      <Button
-        type="submit"
-        tabIndex={tabIndex}
-        disabled={!currentPage}
-        isLoading={isLoading}
-      >
-        Confirm
-      </Button>
+      <div className="button-wrap">
+        <Button
+          type="submit"
+          tabIndex={tabIndex}
+          disabled={!currentPage}
+          isLoading={isLoading}
+        >
+          Confirm
+        </Button>
+      </div>
     </form>
   );
 };

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
@@ -3,8 +3,9 @@
   flex-direction: column;
   align-items: center;
 
-  .help-text {
+  &__help-text {
     @include help-text;
+    color: $ui-fleet-black-75; // Undo grey in help text
   }
 
   &__icon {
@@ -29,9 +30,11 @@
 
   &__table {
     width: 100%;
+    border-collapse: separate;
+    border-spacing: 0 $gap-form; /* 0px horizontal, 16px vertical gap between rows */
 
     caption {
-      font-size: $small;
+      font-size: $x-small;
       font-weight: $bold;
       margin-bottom: $pad-large;
       text-align: left;
@@ -42,14 +45,14 @@
     }
 
     th {
-      font-size: $small;
+      font-size: $x-small;
       font-weight: $bold;
       text-align: left;
       padding-right: 20px;
     }
 
     td {
-      font-size: $small;
+      font-size: $x-small;
       font-weight: $regular;
     }
   }
@@ -99,6 +102,5 @@
 
   .button {
     width: 160px;
-    margin-top: $pad-xxlarge;
   }
 }

--- a/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/ConfirmationPage/_styles.scss
@@ -3,15 +3,8 @@
   flex-direction: column;
   align-items: center;
 
-  h2 {
-    text-align: center;
-  }
   .help-text {
     @include help-text;
-  }
-
-  &__wrapper {
-    width: auto;
   }
 
   &__icon {

--- a/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/FleetDetails/FleetDetails.jsx
@@ -52,10 +52,12 @@ class FleetDetails extends Component {
           ref={(input) => {
             this.firstInput = input;
           }}
-        />
-        <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
-          Next
-        </Button>
+        />{" "}
+        <div className="button-wrap">
+          <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
+            Next
+          </Button>
+        </div>
       </form>
     );
   }

--- a/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/OrgDetails/OrgDetails.jsx
@@ -55,9 +55,11 @@ class OrgDetails extends Component {
           tabIndex={tabIndex}
           helpText="Personalize Fleet with your brand.  For best results, use a square image at least 150px wide, like https://fleetdm.com/logo.png."
         />
-        <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
-          Next
-        </Button>
+        <div className="button-wrap">
+          <Button type="submit" tabIndex={tabIndex} disabled={!currentPage}>
+            Next
+          </Button>
+        </div>
       </form>
     );
   }

--- a/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
+++ b/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
@@ -6,7 +6,6 @@ import AdminDetails from "components/forms/RegistrationForm/AdminDetails";
 import ConfirmationPage from "components/forms/RegistrationForm/ConfirmationPage";
 import FleetDetails from "components/forms/RegistrationForm/FleetDetails";
 import OrgDetails from "components/forms/RegistrationForm/OrgDetails";
-import { Decipheriv } from "crypto";
 
 const baseClass = "user-registration";
 
@@ -130,7 +129,7 @@ class RegistrationForm extends Component {
         </div>
       ),
       2: (
-        <div paddingSize="xxlarge" className={orgDetailsContainerClass}>
+        <div className={orgDetailsContainerClass}>
           <OrgDetails
             formData={formData}
             handleSubmit={onPageFormSubmit}
@@ -140,7 +139,7 @@ class RegistrationForm extends Component {
         </div>
       ),
       3: (
-        <div paddingSize="xxlarge" className={fleetDetailsContainerClass}>
+        <div className={fleetDetailsContainerClass}>
           <FleetDetails
             formData={formData}
             handleSubmit={onPageFormSubmit}
@@ -150,7 +149,7 @@ class RegistrationForm extends Component {
         </div>
       ),
       4: (
-        <div paddingSize="xxlarge" className={confirmationContainerClass}>
+        <div className={confirmationContainerClass}>
           <ConfirmationPage
             formData={formData}
             handleSubmit={onSubmitConfirmation}

--- a/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
+++ b/frontend/components/forms/RegistrationForm/RegistrationForm.jsx
@@ -2,11 +2,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import classnames from "classnames";
 
-import Card from "components/Card";
 import AdminDetails from "components/forms/RegistrationForm/AdminDetails";
 import ConfirmationPage from "components/forms/RegistrationForm/ConfirmationPage";
 import FleetDetails from "components/forms/RegistrationForm/FleetDetails";
 import OrgDetails from "components/forms/RegistrationForm/OrgDetails";
+import { Decipheriv } from "crypto";
 
 const baseClass = "user-registration";
 
@@ -118,47 +118,57 @@ class RegistrationForm extends Component {
       [`${baseClass}__form--step4-active`]: page === 4,
     });
 
+    const REGISTRATION_FORM = {
+      1: (
+        <div className={adminDetailsContainerClass}>
+          <AdminDetails
+            formData={formData}
+            handleSubmit={onPageFormSubmit}
+            className={adminDetailsClass}
+            currentPage={isCurrentPage(1)}
+          />
+        </div>
+      ),
+      2: (
+        <div paddingSize="xxlarge" className={orgDetailsContainerClass}>
+          <OrgDetails
+            formData={formData}
+            handleSubmit={onPageFormSubmit}
+            className={orgDetailsClass}
+            currentPage={isCurrentPage(2)}
+          />
+        </div>
+      ),
+      3: (
+        <div paddingSize="xxlarge" className={fleetDetailsContainerClass}>
+          <FleetDetails
+            formData={formData}
+            handleSubmit={onPageFormSubmit}
+            className={fleetDetailsClass}
+            currentPage={isCurrentPage(3)}
+          />
+        </div>
+      ),
+      4: (
+        <div paddingSize="xxlarge" className={confirmationContainerClass}>
+          <ConfirmationPage
+            formData={formData}
+            handleSubmit={onSubmitConfirmation}
+            className={confirmationClass}
+            currentPage={isCurrentPage(4)}
+            isLoading={isLoading}
+          />
+        </div>
+      ),
+    };
+
+    const renderRegistrationForm = () => {
+      return REGISTRATION_FORM[page];
+    };
+
     return (
       <div className={baseClass}>
-        <div className={formSectionClasses}>
-          <Card paddingSize="xxlarge" className={adminDetailsContainerClass}>
-            <h2>Set up user</h2>
-            <AdminDetails
-              formData={formData}
-              handleSubmit={onPageFormSubmit}
-              className={adminDetailsClass}
-              currentPage={isCurrentPage(1)}
-            />
-          </Card>
-          <Card paddingSize="xxlarge" className={orgDetailsContainerClass}>
-            <h2>Organization details</h2>
-            <OrgDetails
-              formData={formData}
-              handleSubmit={onPageFormSubmit}
-              className={orgDetailsClass}
-              currentPage={isCurrentPage(2)}
-            />
-          </Card>
-          <Card paddingSize="xxlarge" className={fleetDetailsContainerClass}>
-            <h2>Set Fleet URL</h2>
-            <FleetDetails
-              formData={formData}
-              handleSubmit={onPageFormSubmit}
-              className={fleetDetailsClass}
-              currentPage={isCurrentPage(3)}
-            />
-          </Card>
-          <Card paddingSize="xxlarge" className={confirmationContainerClass}>
-            <h2>Confirm configuration</h2>
-            <ConfirmationPage
-              formData={formData}
-              handleSubmit={onSubmitConfirmation}
-              className={confirmationClass}
-              currentPage={isCurrentPage(4)}
-              isLoading={isLoading}
-            />
-          </Card>
-        </div>
+        <div className={formSectionClasses}>{renderRegistrationForm()}</div>
       </div>
     );
   }

--- a/frontend/components/forms/RegistrationForm/_styles.scss
+++ b/frontend/components/forms/RegistrationForm/_styles.scss
@@ -1,40 +1,13 @@
 .user-registration {
-  display: flex;
-  justify-content: center;
-  align-items: stretch;
-  margin-top: $pad-large;
-  min-height: 950px;
+  @include card;
 
   &__container {
-    @include size(500px auto);
-    @include position(absolute, 49% 0 null null);
     transition: left 300ms ease, opacity 300ms ease;
-    border-radius: 10px;
-    background-color: $ui-off-white;
-    box-sizing: border-box;
-    padding: $pad-xxlarge;
     z-index: 1;
-    transform: translateY(-50%);
-
-    h2 {
-      font-size: $large;
-      font-weight: $regular;
-      text-align: center;
-      padding: 0 0 $pad-medium;
-      margin: 0;
-      margin-bottom: $pad-xxlarge;
-      border-bottom: 1px solid $ui-fleet-black-10;
-    }
-
-    p {
-      font-size: $small;
-      margin: 0;
-    }
 
     &--admin {
       left: 0;
       top: unquote("max(60%, 625px)");
-      margin: auto;
     }
 
     &--org {
@@ -68,12 +41,7 @@
   }
 
   &__form {
-    display: flex;
-    width: 100%;
-    box-sizing: border-box;
-
     @include breakpoint(tablet) {
-      transform: translateY(-100px);
     }
 
     &--step1-complete {
@@ -84,7 +52,6 @@
 
       .user-registration__container--org {
         left: 0;
-        margin: auto;
         display: block;
       }
 
@@ -112,7 +79,6 @@
 
       .user-registration__container--fleet {
         left: 0;
-        margin: auto;
         display: block;
       }
 
@@ -140,7 +106,6 @@
 
       .user-registration__container--confirmation {
         left: 0;
-        margin: auto;
         display: block;
       }
     }
@@ -172,16 +137,12 @@
   }
 
   &__field-wrapper {
-    background-color: $ui-off-white;
-    box-sizing: border-box;
-    z-index: 2;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+    .button-wrap {
+      justify-content: center;
+    }
 
     .button {
       width: 160px;
-      margin-top: $pad-medium; // 40px total (24px gap + 16px more)
     }
   }
 }

--- a/frontend/pages/RegistrationPage/Breadcrumbs/Breadcrumbs.tsx
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/Breadcrumbs.tsx
@@ -34,29 +34,31 @@ const Breadcrumbs = ({
 
   return (
     <div className={baseClass}>
-      <Button
-        className={page1ClassName}
-        onClick={() => onSetPage(1)}
-        variant="unstyled"
-      >
-        Set up user
-      </Button>
-      <Button
-        className={page2ClassName}
-        onClick={() => onSetPage(2)}
-        tabIndex={page2TabIndex}
-        variant="unstyled"
-      >
-        Organization details
-      </Button>
-      <Button
-        className={page3ClassName}
-        onClick={() => onSetPage(3)}
-        tabIndex={page3TabIndex}
-        variant="unstyled"
-      >
-        Set Fleet URL
-      </Button>
+      <div className={`${baseClass}__wrapper`}>
+        <Button
+          className={page1ClassName}
+          onClick={() => onSetPage(1)}
+          variant="unstyled"
+        >
+          Set up user
+        </Button>
+        <Button
+          className={page2ClassName}
+          onClick={() => onSetPage(2)}
+          tabIndex={page2TabIndex}
+          variant="unstyled"
+        >
+          Organization details
+        </Button>
+        <Button
+          className={page3ClassName}
+          onClick={() => onSetPage(3)}
+          tabIndex={page3TabIndex}
+          variant="unstyled"
+        >
+          Set Fleet URL
+        </Button>
+      </div>
     </div>
   );
 };

--- a/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
+++ b/frontend/pages/RegistrationPage/Breadcrumbs/_styles.scss
@@ -1,12 +1,19 @@
 .registration-breadcrumbs {
+  background-color: $gradient-background; // Solid color, gradient starts below it
   display: flex;
-  justify-content: space-between;
-  width: 652px;
+  justify-content: center;
+  width: 100%;
   height: 125px;
-  margin: 38px auto 0;
 
-  @include breakpoint(tablet) {
-    height: 75px;
+  &__wrapper {
+    display: flex;
+    justify-content: center;
+    height: 125px;
+    padding-top: $pad-medium;
+
+    @include breakpoint(tablet) {
+      height: 75px;
+    }
   }
 
   &__page {
@@ -14,7 +21,7 @@
     min-width: 156px;
     font-size: $small;
     font-weight: $regular;
-    color: $core-fleet-white;
+    color: $ui-fleet-black-75;
     position: relative;
     display: flex;
     flex-direction: column;
@@ -26,11 +33,11 @@
     &::before {
       content: "";
       position: absolute;
-      width: 88.5%;
+      width: 84.5%;
       height: 2px;
-      background-color: $core-vibrant-blue;
+      background-color: $ui-fleet-black-25;
       bottom: 36%;
-      left: 121px;
+      left: 90px;
 
       // Firefox-specific
       @-moz-document url-prefix() {
@@ -65,7 +72,7 @@
     }
 
     &:focus {
-      outline: 1px dashed $core-fleet-white;
+      outline: 1px dashed $ui-fleet-black-75;
       border-radius: $border-radius;
     }
 
@@ -75,7 +82,7 @@
 
     &--1 {
       &::after {
-        border: 2px solid $core-fleet-white;
+        border: 2px solid $ui-fleet-black-75;
         margin-top: 11px;
       }
 
@@ -83,20 +90,20 @@
         &::before {
           background: linear-gradient(
             to right,
-            $core-fleet-white 50%,
-            $core-vibrant-blue 50%
+            $ui-fleet-black-75 50%,
+            $ui-fleet-black-25 50%
           );
         }
 
         &::after {
           background-color: transparent;
-          border: 2px solid $core-fleet-white;
+          border: 2px solid $ui-fleet-black-75;
         }
       }
 
       &.registration-breadcrumbs__page--complete {
         &::before {
-          background: $core-fleet-white;
+          background: $ui-fleet-black-75;
           background-size: auto;
           z-index: 2;
         }
@@ -104,7 +111,7 @@
         &::after {
           @include size(28px);
           content: "\f035";
-          color: $core-fleet-white;
+          color: $ui-fleet-black-75;
           border: 0;
         }
       }
@@ -112,7 +119,7 @@
 
     &--2 {
       &::after {
-        border: solid 1px $core-vibrant-blue;
+        border: solid 1px $ui-fleet-black-25;
         margin-top: 11px;
       }
 
@@ -120,27 +127,27 @@
         &::before {
           background: linear-gradient(
             to right,
-            $core-fleet-white 50%,
-            $core-vibrant-blue 50%
+            $ui-fleet-black-75 50%,
+            $ui-fleet-black-25 50%
           );
         }
 
         &::after {
           background-color: transparent;
-          border: 2px solid $core-fleet-white;
+          border: 2px solid $ui-fleet-black-75;
         }
       }
 
       &.registration-breadcrumbs__page--complete {
         &::before {
-          background: $core-fleet-white;
+          background: $ui-fleet-black-75;
           z-index: 2;
         }
 
         &::after {
           @include size(28px);
           content: "\f035";
-          color: $core-fleet-white;
+          color: $ui-fleet-black-75;
           border: 0;
         }
       }
@@ -152,7 +159,7 @@
       }
 
       &::after {
-        border: solid 1px $core-vibrant-blue;
+        border: solid 1px $ui-fleet-black-25;
         margin-top: 11px;
       }
 
@@ -160,14 +167,14 @@
         &::before {
           background: linear-gradient(
             to right,
-            $core-fleet-white 50%,
-            $core-vibrant-blue 50%
+            $ui-fleet-black-75 50%,
+            $ui-fleet-black-25 50%
           );
         }
 
         &::after {
           background-color: transparent;
-          border: 2px solid $core-fleet-white;
+          border: 2px solid $ui-fleet-black-75;
         }
       }
 
@@ -175,7 +182,7 @@
         &::after {
           @include size(28px);
           content: "\f035";
-          color: $core-fleet-white;
+          color: $ui-fleet-black-75;
           border: 0;
         }
       }

--- a/frontend/pages/RegistrationPage/RegistrationPage.tsx
+++ b/frontend/pages/RegistrationPage/RegistrationPage.tsx
@@ -9,12 +9,12 @@ import local from "utilities/local";
 
 import FlashMessage from "components/FlashMessage";
 import { INotification } from "interfaces/notification";
+
+import AuthenticationFormWrapper from "components/AuthenticationFormWrapper";
 // @ts-ignore
 import RegistrationForm from "components/forms/RegistrationForm";
 // @ts-ignore
 import Breadcrumbs from "./Breadcrumbs";
-// @ts-ignore
-import fleetLogoText from "../../../assets/images/fleet-logo-text-white.svg";
 
 const ERROR_NOTIFICATION: INotification = {
   alertType: "error",
@@ -85,18 +85,26 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
     setPage(pageNum);
   };
 
+  const REGISTRATION_HEADERS: Record<number, string> = {
+    1: "Set up user",
+    2: "Organization details",
+    3: "Set Fleet URL",
+    4: "Confirm Configuration",
+  };
+  const header = REGISTRATION_HEADERS[page];
+
   return (
-    <div className={baseClass}>
-      <img
-        alt="Fleet logo"
-        src={fleetLogoText}
-        className={`${baseClass}__logo`}
-      />
-      <Breadcrumbs
-        currentPage={page}
-        onSetPage={onSetPage}
-        pageProgress={pageProgress}
-      />
+    <AuthenticationFormWrapper
+      className={baseClass}
+      header={header}
+      breadcrumbs={
+        <Breadcrumbs
+          currentPage={page}
+          onSetPage={onSetPage}
+          pageProgress={pageProgress}
+        />
+      }
+    >
       <RegistrationForm
         page={page}
         onNextPage={onNextPage}
@@ -111,7 +119,7 @@ const RegistrationPage = ({ router }: IRegistrationPageProps) => {
           onRemoveFlash={() => setShowSetupError(false)}
         />
       )}
-    </div>
+    </AuthenticationFormWrapper>
   );
 };
 

--- a/frontend/pages/RegistrationPage/_styles.scss
+++ b/frontend/pages/RegistrationPage/_styles.scss
@@ -1,8 +1,11 @@
 .registration-page {
   display: flex;
-  justify-content: center;
   flex-direction: column;
-  margin-top: 24px;
+  height: 100%;
+
+  .registration-breadcrumbs {
+    flex-shrink: 0; // Keeps it at top—no vertical stretching
+  }
 
   &__logo {
     width: 120px;

--- a/frontend/styles/var/colors.scss
+++ b/frontend/styles/var/colors.scss
@@ -52,6 +52,7 @@ $rainbow-green: #63c740;
 $rainbow-blue: #5cabdf;
 
 // Gradients
+$gradient-background: #eff6fa; // 2025 gradient start color
 $gradients-dark-gradient: linear-gradient(270deg, #201e43 0%, #353d62 100%);
 $gradients-dark-gradient-vertical: linear-gradient(
   360deg,


### PR DESCRIPTION
## Issue
Conf 11765 https://github.com/fleetdm/confidential/issues/11765

## Description
- Just setup pages
- I made it so the bread crumbs stay at the top while the setup cards are still vertically centered on the rest of the page (see screen recording)
- Note: These can probably be refactored to typescript and cleaned up a lot more added to the long running list of [future iterations](https://docs.google.com/document/d/1TzLviitXV1QIHIAFpPejQTro5ZThHKEim3yENUfUi1Q/edit?tab=t.0)
- Button changes are not a part of this PR as it's it's own giant story

## Code breakdown
1. `ui-reskin` has ALL UI updates 
  - If you checkout this branch, you can view all UI updates
2. `11765conf-ui-reskin-feature-branch` has reviewed and approved changes only
  - If you checkout this branch, you can view all approved code thus far for UI updates
3. Slowly breaking out parts of `ui-reskin` into PRs to review, approve, and merge into `11765conf-ui-reskin-feature-branch`
4. This is the `ui-reskin-setup-page` PR up for review
  - If you checkout this branch you will only see all approved code thus far + these changes
 

## Screen recording
https://github.com/user-attachments/assets/8be05c93-464d-4d5c-bd38-a1f1679a8b88




## Testing

- [x] QA'd all new/changed functionality manually
