### PR TITLE
Removing `minimum_version` to fix enrollment issues

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -129,8 +129,8 @@ controls:
     enable_end_user_authentication: false
     macos_setup_assistant: null
   macos_updates:
-    deadline: "2025-08-31"
-    minimum_version: "15.6"
+    deadline: 
+    minimum_version: 
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/Enable firewall.xml

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -82,8 +82,8 @@ controls:
       - package_path: ../lib/macos/software/1password.yml # 1Password for macOS
       - app_store_id: '803453959' # Slack Desktop
   macos_updates:
-    deadline: "2025-08-31"
-    minimum_version: "15.6"
+    deadline: 
+    minimum_version: 
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/Enable firewall.xml


### PR DESCRIPTION
- Newly enrolled devices are running into issues installing macOS 26. Removing `minimum_version` requirements in favor of Nudge enforcing OS updates. 