### PR TITLE
Handbook - Writing guidelines reorg

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -943,6 +943,7 @@ Different types of writing at Fleet have slightly different expectations. Keep t
 - Keep calls to action direct and specific 
   - Example: _“Try Fleet”_ instead of _“Learn more about our amazing platform.”_
 
+
 ### Editing and publishing
 
 Follow these steps before merging a change:

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -888,6 +888,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 - [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
 - [Writing mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics)
 - [Writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown)
+
 Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
 
 We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -896,7 +896,7 @@ We avoid "[puffery](https://www.linkedin.com/pulse/puffery-adam-frankl%3Ftrackin
 
 When in doubt, simplify. Read your draft, cut unnecessary words, and make it shorter. If something feels confusing, rewrite until it feels obvious.
 
-Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say) (see the [Further inspiration](#further-inspiration) section, below).
+Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of Mister Rogers. To see how tone can shift from formal or negative to simple and optimistic, [the "Mister Rogersing" example](https://fleetdm.com/handbook/company/communication#what-would-mister-rogers-say) is a practical illustration of how reframing can make complex or difficult ideas more approachable.
 
 
 ### Writing types

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -877,7 +877,13 @@ When Fleeties relocate, there are vendors that need to be notified of the change
 
 ## Writing
 
-Learn how to communicate as Fleet with [guidelines for tone of voice](https://fleetdm.com/handbook/company/communication#writing-style), [our approach](https://fleetdm.com/handbook/company/communication#writing-types), [editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing), [grammar and mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics), [writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown), and the [tools we use](https://fleetdm.com/handbook/company/communication#writing-assistance).
+Learn how to write as Fleet: 
+- [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
+- [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
+- [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
+- [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance).
+- [Writing mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics)
+- [Writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown)
 
 
 ### Writing style
@@ -922,6 +928,9 @@ Different types of writing at Fleet have slightly different expectations. Keep t
 - Provide context or insight (the “why”), not just the “what.”
 - Avoid jargon unless you explain it.
 - Stay aligned with Fleet’s values and overall voice.
+
+> To propose an article for Fleet to publish, create an ["📝 Article" issue](https://github.com/fleetdm/fleet/issues/new?template=fleet-article.md) 
+ and follow the instructions in the template.
 
 
 #### Website copy
@@ -1032,8 +1041,6 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
   - "Does it use APNs (the Apple Push Notification service)?"
 
 > ***Struggling with this?*** It takes some adjustment, and you need repetitions of seeing things written this way and correcting yourself. Contributors have given feedback that this [opinionated solution](https://fleetdm.com/handbook/company/why-this-way#why-does-fleet-use-sentence-case) is a huge relief once you build the habit of sentence case capitalization. You don't have to think as hard, nor choose between flouting and diligently adhering to the style guide.
-
-<img width="384" alt="image" src="https://github.com/fleetdm/fleet/assets/618009/cca980db-24e1-4303-a120-ecdb7419aac4">
 
 
 #### Capitalization and proper nouns
@@ -1281,7 +1288,7 @@ Writing in Fleet-flavored Markdown ensures that content on fleetdm.com, the docs
 Markdown itself is a simple formatting syntax used to write content on the web. In order to publish content like [docs](https://fleetdm.com/docs), [handbook entries](https://fleetdm.com/handbook), and [articles](https://fleetdm.com/articles), you must format your content in Markdown. 
 
 
-### Headings
+#### Headings
 
 Each heading needs two lines of empty space separating it from the previous section and one line of empty space between the heading and related content. This helps break up blocks of text and is especially important on larger, more detailed pages. Here's an example:
 
@@ -1525,109 +1532,6 @@ This is a large blockquote.
 
 You can use a large quote blockquote to reduce the font size and line height of the rendered text.
 </blockquote>
-
-
-#### Mermaid diagrams
-
-The Fleet Docs support diagrams that are written in mermaid.js syntax. Take a look at the [Mermaid docs](https://mermaid-js.github.io/mermaid/#/README) to learn about the syntax language and what types of diagrams you can display.
-
-To add a mermaid diagram to the docs, you need to add a code block and specify that it is written in the mermaid language by adding `mermaid` to the opening backticks (i.e., ` ```mermaid`).
-
-For example, the following code block is a mermaid diagram that has **not** been specified as a mermaid code block:
-
-```
-graph TD;
-    A-->D
-    B-->D
-    C-->D
-    D-->E
-```
-
-Once we specify the `mermaid` as the language in the code block, it will render as a mermaid diagram on fleetdm.com and GitHub.
-
-```mermaid
-graph TD;
-    A-->D
-    B-->D
-    C-->D
-    D-->E
-```
-
-If the mermaid syntax is incorrect, the diagram will be replaced with an image displaying an error, as shown in the following example where the code block was written with **intentional** syntax errors:
-
-```mermaid
-graph TD;
-    A--D
-```
-
-## Contributing to articles
-To propose an article for Fleet to publish, create an ["📝 Article" issue](https://github.com/fleetdm/fleet/issues/new?template=fleet-article.md) 
- and follow the instructions in the template.
-
-## Commonly used terms
-
-This glossary provides definitions to commonly used terms within our space.
-
-| Term | Meaning | 
-|:------ |:-----------------|
-| **antivirus** | A class of programs designed to detect, block, and clear away malware from devices, networks, and IT systems. |
-| **API** | (Application Programming Interface) a software go-between that allows applications to communicate.  |
-| **automation** | A system that operates without needing intervention from a human to do so. |
-| **AWS** | (Amazon Web Services) An ever-evolving cloud computing platform designed to allow application providers, ISVs, and vendors to host applications. |
-| **CI/CD** | (Continuous Integration and Continuous Delivery/Continuous Deployment) A software development practice where cumulative code changes are made regularly and accurately. |
-| **CLI** | (Command Line Interface) A tool for managing Fleet from the command line. |
-| **Client Platform Engineer (CPE)** | See: CPE. |
-| **cloud** | Data storage, networking, servers, databases, software, intelligence, and analytics through the internet instead of a device's hard drive. |
-| **command line** | A horizontal row on an interface for text to allow you to type in a variety of commands. Also, see "CLI." |
-| **compliance** | The act of being in line with the established risk-based expectations to preserve the strength and confidentiality of data stored, used, and transmitted. |
-| **CPE** | (Client Platform Engineer) A person who constructs, evaluates, and deploys solutions to administrate a fleet of "clients" or end-users and does so in a scalable manner. |
-| **CVE** | (Common Vulnerabilities and Exposures) A system that provides a technique for sharing information publicly. |
-| **data leaks** | When crucial and confidential data is unwittingly exposed physically, on the Internet, or any other way. This includes misplaced hard drives or devices. |
-| **device management** | The process of overseeing the execution, process, and upkeep of a device, be it physical or virtual. |
-| **DevOps** | Practices that incorporate both software development (Dev) and IT operations (Ops). |
-| **Docker** | An open source platform that allows one to manage containerized applications. |
-| **DRI** | The person who is singularly responsible for a given aspect of the open source project, the product, or the company. |
-| **EDR** | (Endpoint Detection and Response) Security software that continually audits end-user devices to identify and respond to threats such as malware and ransomware. Also, see EDTR. |
-| **EDTR** | (Endpoint Detection and Threat Response) Security software that continually audits end-user devices to identify and respond to threats such as malware and ransomware. Also, see EDR. |
-| **encryption** | The act of converting data into a cipher that requires a key to be deciphered. |
-| **end-users** | Someone using a distributed device or service. This could be a computer or a mobile device. |
-| **FileVault** | The macOS feature to encrypt entire drives. |
-| **Firewall** | A device or software that is used to block unwanted network traffic. |
-| **fleetctl** | A CLI tool for managing Fleet from the command line. It can be used to accomplish many tasks you would typically need to do through the UI (User Interface). Also, fleetctl enables a GitOps workflow with Fleet and osquery. |
-| **GitHub** | Cloud-based service for software development and version control using Git. |
-| **historical compliance** | The ability to view past behavior around established risk-based controls to safeguard the integrity, confidentiality, and access of data storage, processing, or transfers. |
-| **IETF** | (Internet Engineering Task Force) An organization that defines standardizing operations of internet protocols |
-| **Internet Engineering Task Force (IETF)** | See: IETF |
-| **IR** | (Incident Response) The actions one takes in response to a security breach or cyberattack. |
-| **Linux** | An open source operating system. |
-| **macOS** | The operating system used in all of Apple's Mac computers. |
-| **Munki** | Open-source software deployment tool for macOS. |
-| **open core** | Is the business model where a company has a core version of a product with some of the features as (FOSS) Free Open Source Software in addition to a paid commercial version that is proprietary software. |
-| **open source** | Software with intentionally public code for the sake of transparency. |
-| **OS** | (Operating System) Software that provides the groundwork and instructions for a device's basic functions, including application use and controlling peripherals. |
-| **osquery**  | A tool that assembles low-level operating system analytics and monitoring. |
-| **out-of-policy device** | A device that fails any security or vulnerability policy created in Fleet. |
-| **permissions** | Users have different abilities depending on the access level they have. |
-| **platform** | Any software or hardware for hosting an application, data, or service. |
-| **policies** | Yes or no questions you can ask using Fleet about your host devices. |
-| **policy compliance** | The state of whether a device is passing or failing policies created in Fleet. |
-| **queries** | Questions you can ask an end-user device's operating system via Fleet. |
-| **SAML** | (Security Assertion Markup Language) A standard that allows identity providers (IdP) to authorize credentials for service providers, enabling SSO (Single Sign-On). |
-| **security audits** | An assessment of an organization's security posture. |
-| **security engineer** | Individuals in charge of managing and implementing security systems in an organization. |
-| **SIEM** | (Security Information and Event Management) Technology that assembles data, security warnings, and events into one platform and provides almost real-time analyzed data to help you better monitor your organization's security. |
-| **Site Reliability Engineers (SREs)** | Individuals who apply site reliability principles to improve reliability and scalability of systems in a systematic manner. |
-| **SQL** | (Structured Query Language) A language used to manage databases and complete a variety of operations tasks within said databases. |
-| **SRE** | See "Site Reliability Engineers." |
-| **SSO authentication** | (Single Sign-On authentication) Allows identity providers (IdP) to authorize credentials for service providers once and use that as the authentication for multiple outside accounts. |
-| **TLS** | (Transport Layer Security) An Internet Engineering Task Force (IETF) standardized protocol that authenticates and provides privacy and data protection over computer networks. |
-| **token** | A physical Two-Factor Authentication (2FA) login security device to prove one's identity. |
-| **Transport Layer Security (TLS)** | See: TLS |
-| **UI** | (User Interface) An interactive space in a program that concentrates on style and intuitive use. |
-| **URL** | Uniform resource locator. Specifies where a web resource is located (ex: https://fleetdm.com/articles/) |
-| **vulnerabilities** | An exploitable weakness that can lead to unauthorized access or other negative consequences to a computer system. |
-| **Windows** | Microsoft's graphical operating system. |
-| **YAML** | A data serialized language that has features derived from Perl, C, HTML, and other languages and is often used to write configuration files. |
 
 
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -882,7 +882,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 
 ### Writing style
 
-- [Writing style](#writing-style)
+- [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
 - [Writing types](#writing-types)
 - [Editing and publishing](#editing-and-publishing)
 - [Further inspiration](#further-inspiration)

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -886,7 +886,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 - [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
 - [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
 - [Further inspiration](#further-inspiration)
-- [Writing assistance](#writing-assistance)
+- [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
 - [Writing mechanics](#writing-mechanics)
 - [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown)
 Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -953,9 +953,6 @@ Follow these steps before merging a change:
 - Check preview mode in GitHub to make sure formatting renders correctly.
 - Look for and remove any unintentional changes in your diff.
 
-### Further inspiration
-
-To see how tone can shift from formal or negative to simple and optimistic, The "The Mister Rogersing" example below is a practical illustration of how reframing can make complex or difficult ideas more approachable.
 
 #### What would Mister Rogers say?
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -886,7 +886,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 - [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
 - [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
 - [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
-- [Writing mechanics](#writing-mechanics)
+- [Writing mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics)
 - [Writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown)
 Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -904,6 +904,7 @@ Our approach is informed by [Paul Graham's essays on writing simply](http://www.
 
 Different types of writing at Fleet have slightly different expectations. Keep the shared principles in mind (plain English, brevity, clarity), but adjust for the format.
 
+
 #### Guides and tutorials
 
 - Write in short sentences, imperative mood, and active voice.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -932,6 +932,7 @@ Different types of writing at Fleet have slightly different expectations. Keep t
 - Avoid jargon unless you explain it.
 - Stay aligned with Fleet’s values and overall voice.
 
+
 #### Website copy
 
 - Keep it simple: short sentences, plain English, imperative mood.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -883,7 +883,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 ### Writing style
 
 - [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
-- [Writing types](#writing-types)
+- [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
 - [Editing and publishing](#editing-and-publishing)
 - [Further inspiration](#further-inspiration)
 - [Writing assistance](#writing-assistance)

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -993,7 +993,7 @@ Collaborating with AI can be helpful for outlines, rewrites, and drafts. But it�
 - Don’t paste sensitive data.
 - Always fact-check names, versions, dates, and links.
 - Question everything you don't understand and strip out anything fabricated.
-- Make sure the tone sounds like Fleet (plain English, short sentences, active voice) and watch for common AI habits like em dashes, over-bolding, clichés, or passive voice.
+- Make sure the tone sounds like Fleet (plain English, short sentences, active voice) and watch for common AI habits like the overuse of em dashes, over-bolding, or passive voice.
 
 Finally, check the format that you are writing for. [Guides](https://fleetdm.com/handbook/company/communication#guides-and-tutorials) should be step-by-step instructions, [announcements](https://fleetdm.com/handbook/company/communication#announcements) should be short and factual, and [articles](https://fleetdm.com/handbook/company/communication#articles) can be more conversational but still simple and professional.
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -924,6 +924,7 @@ Different types of writing at Fleet have slightly different expectations. Keep t
 - Use plain, factual language without fluff.
 - Include a clear link or call to action if readers need to follow up.
 
+
 #### Articles
 
 - Keep the tone conversational and approachable, while still representing Fleet.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -884,7 +884,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 
 - [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
 - [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
-- [Editing and publishing](#editing-and-publishing)
+- [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
 - [Further inspiration](#further-inspiration)
 - [Writing assistance](#writing-assistance)
 - [Writing mechanics](#writing-mechanics)

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -887,7 +887,7 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 - [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
 - [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
 - [Writing mechanics](#writing-mechanics)
-- [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown)
+- [Writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown)
 Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
 
 We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -885,7 +885,6 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 - [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
 - [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
 - [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
-- [Further inspiration](#further-inspiration)
 - [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
 - [Writing mechanics](#writing-mechanics)
 - [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown)

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -900,7 +900,6 @@ When in doubt, simplify. Read your draft, cut unnecessary words, and make it sho
 Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say) (see the [Further inspiration](#further-inspiration) section, below).
 
 
-
 ### Writing types
 
 Different types of writing at Fleet have slightly different expectations. Keep the shared principles in mind (plain English, brevity, clarity), but adjust for the format.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -877,27 +877,18 @@ When Fleeties relocate, there are vendors that need to be notified of the change
 
 ## Writing
 
-Learn how to communicate as Fleet with guidelines for tone of voice, our approach, grammar and mechanics, and more.
+Learn how to communicate as Fleet with [guidelines for tone of voice](https://fleetdm.com/handbook/company/communication#writing-style), [our approach](https://fleetdm.com/handbook/company/communication#writing-types), [editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing), [grammar and mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics), [writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown), and the [tools we use](https://fleetdm.com/handbook/company/communication#writing-assistance).
 
 
 ### Writing style
 
-- [Writing style](https://fleetdm.com/handbook/company/communication#writing-style)
-- [Writing types](https://fleetdm.com/handbook/company/communication#writing-types)
-- [Editing and publishing](https://fleetdm.com/handbook/company/communication#editing-and-publishing)
-- [Writing assistance](https://fleetdm.com/handbook/company/communication#writing-assistance)
-- [Writing mechanics](https://fleetdm.com/handbook/company/communication#writing-mechanics)
-- [Writing in Fleet-flavored Markdown](https://fleetdm.com/handbook/company/communication#writing-in-fleet-flavored-markdown)
-
-Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
-
-We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.
+Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read. We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.
 
 We avoid "[puffery](https://www.linkedin.com/pulse/puffery-adam-frankl%3FtrackingId=SBVWxzqXTBm9qlO7Rw3ddw%253D%253D/?trackingId=SBVWxzqXTBm9qlO7Rw3ddw%3D%3D)". For engineers, replace hype with real data. For business readers, translate it into clear outcomes such as time saved or return on investment. Links are better than long explanations, since they keep content short and point people to more detail when they need it.
 
-When in doubt, simplify. Read your draft, cut unnecessary words, and make it shorter. If something feels confusing, rewrite until it feels obvious.
-
 Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of Mister Rogers. To see how tone can shift from formal or negative to simple and optimistic, [the "Mister Rogersing" example](https://fleetdm.com/handbook/company/communication#what-would-mister-rogers-say) is a practical illustration of how reframing can make complex or difficult ideas more approachable.
+
+When in doubt, simplify. Read your draft, cut unnecessary words, and make it shorter. If something feels confusing, rewrite until it feels obvious.
 
 
 ### Writing types
@@ -957,9 +948,7 @@ Follow these steps before merging a change:
 
 #### What would Mister Rogers say?
 
-[*Mister Rogers’ Neighborhood*](https://en.wikipedia.org/wiki/Mister_Rogers%27_Neighborhood) was one of the longest-running children’s T.V. series. That’s thanks to [Fred Rogers](https://en.wikipedia.org/wiki/Fred_Rogers)’ communication skills. He knew kids heard things differently than adults. So, he checked every line to avoid confusion and encourage positivity.
-
-Our audience is a little older. But just like the show, Mister Rogers’ method is appropriate for all ages. Here are some steps you can take to communicate like Mister Rogers:
+[*Mister Rogers’ Neighborhood*](https://en.wikipedia.org/wiki/Mister_Rogers%27_Neighborhood) was one of the longest-running children’s T.V. series. That’s thanks to [Fred Rogers](https://en.wikipedia.org/wiki/Fred_Rogers)’ communication skills. He knew kids heard things differently than adults. So, he checked every line to avoid confusion and encourage positivity. Our audience is a little older. But just like the show, Mister Rogers’ method is appropriate for all ages. Here are some steps you can take to communicate like Mister Rogers:
 
 - State the idea you want to express as clearly as possible.
 - Rephrase the idea in a positive manner.
@@ -978,6 +967,7 @@ What would Mister Rogers say? The tweet could look something like this...
 
 By Mister Rogersing our writing, we can encourage our readers to succeed by emphasizing optimism. You might not be able to apply all of these steps every time. That’s fine. Think of these as guidelines to help you simplify complex topics.
 
+
 ### Writing assistance
 
 #### Grammarly
@@ -987,15 +977,17 @@ All of our writers and editors have access to Grammarly, which comes with a hand
 - **Brand tones** to keep the tone of our messaging consistent with just the right amount of confidence, optimism, and joy.
 - **Snippets** to turn commonly used phrases, sentences, and paragraphs (such as calls to action, thank you messages, etc.) into consistent, reusable snippets to save time.
 
+
 #### Generative AI
 
-Collaborating with AI can be helpful for outlines, rewrites, and drafts. But it’s not a substitute for judgment. You (a human) are responsible for accuracy, tone, and format.
+Collaborating with AI can be helpful for outlines, rewrites, and drafts. But it’s not a substitute for judgment. You (a human) are responsible for accuracy, tone, and format. 
+- Don’t paste sensitive data.
+- Always fact-check names, versions, dates, and links.
+- Question everything you don't understand and strip out anything fabricated.
+- Make sure the tone sounds like Fleet (plain English, short sentences, active voice) and watch for common AI habits like em dashes, over-bolding, clichés, or passive voice.
 
-Don’t paste sensitive data. Always fact-check names, versions, dates, and links. Question everything you don't understand and strip out anything fabricated.
+Finally, check the format that you are writing for. [Guides](https://fleetdm.com/handbook/company/communication#guides-and-tutorials) should be step-by-step instructions, [announcements](https://fleetdm.com/handbook/company/communication#announcements) should be short and factual, and [articles](https://fleetdm.com/handbook/company/communication#articles) can be more conversational but still simple and professional.
 
-Make sure the tone sounds like Fleet (plain English, short sentences, active voice) and watch for common AI habits like em dashes, over-bolding, clichés, or passive voice.
-
-Finally, check the format that you are writing for. Guides should be step-by-step instructions, announcements should be short and factual, and articles can be more conversational but still simple and professional.
 
 #### Prompt template
 
@@ -1011,22 +1003,17 @@ Constraints:
 - Bold UI elements only (e.g., **Hosts**, **Add a host**).
 - Prefer commas over em dashes; use colons sparingly.
 Output: valid Markdown.
-
 ```
+
 
 ### Writing mechanics
 
-Writing mechanics cover everything from capitalization and punctuation to list formatting and SQL examples. Following them keeps our content consistent and easy to read.
+Writing mechanics cover everything from capitalization and punctuation to list formatting and SQL examples. Following them keeps our content consistent and easy to read. For Markdown-specific rules, see [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown).
 
-For Markdown-specific rules, see [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown).
 
-#### Sentence case and capitalization
+#### Sentence case
 
-##### Sentence case
-
-Fleet uses sentence case capitalization for all headings, subheadings, button text in the Fleet product, fleetdm.com, the documentation, the handbook, marketing material, direct emails, in Slack, and in every other conceivable situation.
-
-In sentence case, we write and capitalize words as if they were in sentences:
+Fleet uses sentence case capitalization for all headings, subheadings, button text in the Fleet product, fleetdm.com, the documentation, the handbook, marketing material, direct emails, in Slack, and in every other conceivable situation. In sentence case, we write and capitalize words as if they were in sentences:
 
 <blockquote purpose= "large-quote"> Ask questions about your servers, containers, and laptops running Linux, Windows, and macOS.</blockquote>
 
@@ -1044,11 +1031,12 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
   - "Does it work with MySQL?"
   - "Does it use APNs (the Apple Push Notification service)?"
 
-- ***Struggling with this?*** It takes some adjustment, and you need repetitions of seeing things written this way and correcting yourself. Contributors have given feedback that this [opinionated solution](https://fleetdm.com/handbook/company/why-this-way#why-does-fleet-use-sentence-case) is a huge relief once you build the habit of sentence case capitalization. You don't have to think as hard, nor choose between flouting and diligently adhering to the style guide.
+> ***Struggling with this?*** It takes some adjustment, and you need repetitions of seeing things written this way and correcting yourself. Contributors have given feedback that this [opinionated solution](https://fleetdm.com/handbook/company/why-this-way#why-does-fleet-use-sentence-case) is a huge relief once you build the habit of sentence case capitalization. You don't have to think as hard, nor choose between flouting and diligently adhering to the style guide.
+
 <img width="384" alt="image" src="https://github.com/fleetdm/fleet/assets/618009/cca980db-24e1-4303-a120-ecdb7419aac4">
 
 
-##### Capitalization and proper nouns
+#### Capitalization and proper nouns
 
 - **Fleet:** When talking about Fleet the company, we stylize our name as either "Fleet" or "Fleet Device Management".
 - **Fleet the product:** We always say “Fleet”.  We _NEVER_ say "fleetDM" or "FleetDM" or "fleetdm".
@@ -1058,7 +1046,9 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 - **Fleetd:** Fleetd should always be written in lowercase unless used to start a sentence or heading.
 - **Fleetctl:** Fleetctl should always be written in lowercase unless used to start a sentence or heading. Fleetctl should always be in plain text and not inside codeblocks text unless used in a command (ex. `fleetctl -help`).
 
-##### Links and anchors
+
+#### Links and anchors
+
 - Make links meaningful (avoid “here” / “click here”); link descriptive words.
 - Link to existing pages instead of duplicating content.
 - Favor permalinks and headings that make good anchors (people link to sections).
@@ -1066,7 +1056,7 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 > > **Note:** We run grep -Eir --exclude-dir=node_modules --include=\*.md '\[(click )?here\]' . in CI to make sure those link anchors don't slip in.
 
 
-##### Device vs endpoint
+#### Device vs endpoint
 
 - When talking about a users' computer, we prefer to use "device" over _endpoint._ Devices in this context can be a physical device or virtual instance that connect to and exchange information with a computer network. Examples of devices include mobile devices, desktop computers, laptop computers, virtual machines, and servers.
 
@@ -1074,18 +1064,20 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 #### Headings and titles
 
 Headings and titles should:
-
 - Give an accurate idea of a topic's content.
 - Help guide readers through your writing so they can quickly find what they need.
 - [Make good permalinks](https://fleetdm.com/handbook/company/communications#use-links-in-your-writing).
+
 
 ##### Static headings
 
 Use static headings (a `noun` or `noun phrase`) e.g., “Log destinations,” for concept or reference topics. Be as short and specific as possible.
 
+
 ##### Task-based headings
 
 Use task-based headings (`verb` + `topic`) e.g., _“Configure a log destination”_ for guides and tutorials where the heading should reveal the task that the reader is trying to achieve. 
+
 
 ##### Avoid _-ing_ verb forms in headings
 
@@ -1097,9 +1089,10 @@ _-ing_ verb forms are more difficult for non-native English readers to understan
 | ---------------- | -------------------- |
 | “Configure a log destination” | “Configuring a log destination” |
 
+
 ##### Avoid vague verbs in headings
 
-Were possible, avoid starting a heading with a vague verb, like “understand,” “learn,” or “Use.” Headings that start with a vague verb can mislead readers by making a topic appear to be task-oriented (a guide) when it is actually reference or conceptual information. 
+Where possible, avoid starting a heading with a vague verb, like “understand,” “learn,” or “Use.” Headings that start with a vague verb can mislead readers by making a topic appear to be task-oriented (a guide) when it is actually reference or conceptual information. 
 
 | ✅ Recommended | ❌ Not recommended | 
 | ---------------- | -------------------- |
@@ -1110,6 +1103,7 @@ Were possible, avoid starting a heading with a vague verb, like “understand,�
 
 While our readers are more tech-savvy than most, we can’t expect them to recognize queries by SQL alone.  Avoid using code for headings. Instead, say what the code does and include code examples in the body of your document. That aside, it doesn't render well on the website.
 
+
 ##### Heading hierarchy 
 
 Use heading tags to structure your content hierarchically. Try to stay within three or four heading levels. Detailed documents may use more, but pages with a simpler structure are easier to read.
@@ -1119,6 +1113,7 @@ Use heading tags to structure your content hierarchically. Try to stay within th
 - H3: Subheadings
 - H4: Sub-subheadings
 
+
 ##### Punctuation in headings
 
 Fleet headings do not use end punctuation unless the heading is a question:
@@ -1127,13 +1122,16 @@ Fleet headings do not use end punctuation unless the heading is a question:
 
 If the heading is a question, end the heading with a question mark.
 
+
 #### Contractions 
 
-They’re great! Don’t be afraid to use them. They’ll help your writing sound more approachable
+They’re great! Don’t be afraid to use them. They’ll help your writing sound more approachable.
+
 
 #### Ampersands 
 
 (&) Only use ampersands if they appear in a brand name, or if you’re quoting the title of an article from another source. Otherwise, write out “and”.
+
 
 #### Commas 
 
@@ -1144,6 +1142,7 @@ When listing three or more things, use commas to separate the words. This is cal
 ❌ **Don’t:** Fleet is for IT professionals, client platform engineers and security practitioners.
 
 Aside from the serial comma, use commas, as usual, to break up your sentences. If you’re unsure whether you need a comma, saying the sentence aloud can give you a clue. If you pause or take a breath, that’s when you probably need a comma.
+
 
 #### Hyphens
 
@@ -1158,6 +1157,7 @@ Aside from the serial comma, use commas, as usual, to break up your sentences. I
 - Fleet is released every three weeks.
 - Osquery is open source.
 
+
 #### Colons 
 
 Colons introduce one or more elements that add detail to the idea before the colon. 
@@ -1168,9 +1168,11 @@ Colons introduce one or more elements that add detail to the idea before the col
 ✅ **Do** use a colon to introduce a phrase (Only capitalize the first word following a colon if it’s a proper noun):
 - Introducing Sandbox: the fastest way to play with Fleet.
 
+
 #### Exclamation points 
 
 They’re fun! But too many can undermine your credibility!!!1! Please use them sparingly. Take context into consideration. And only use one at a time.
+
 
 #### Abbreviations and acronyms
 
@@ -1181,9 +1183,8 @@ Then use the short version for all other references.
 - The Fleet CLI is called fleetctl.
 If the abbreviation or acronym is well known, like API or HTML, use it instead (and don’t worry about spelling it out).
 
-#### Numbers and times
 
-##### Numbers
+#### Numbers
 
 Spell out a number when it begins a sentence. Otherwise, use the numeral. 
 
@@ -1197,7 +1198,8 @@ Numbers over 3 digits get commas:
 - 1,000
 - 150,000
 
-##### Times
+
+#### Times
 
 Use numerals and am or pm without a space in between:
 - 7am
@@ -1218,6 +1220,7 @@ Spell out international time zones:
 - Central European Time
 - Japan Standard Time
 
+
 #### Emphasis
 
 - **Bold:** Use bold text to emphasize words or phrases. Just don’t overdo it. Too much bold text may make it hard to see what’s really important.
@@ -1225,11 +1228,13 @@ Spell out international time zones:
 - _Italics:_ Use italics when referencing UI elements (e.g., buttons and navigation labels):
   - On the settings page, go to *Organization Settings* and select *Fleet Desktop*.
 
+
 #### Lists
 
 Lists help readers scan content for essential information. They should be as concise and symmetrical as possible.
 If you find your list running long, or if each item contains several sentences, you may want to reconsider whether a list is the best approach.
 Use a numbered list if it follows a specific order or includes a set number of items. Otherwise, use bullet points.
+
 
 ##### How to introduce a list 
 
@@ -1261,6 +1266,7 @@ End punctuation refers to punctuation marks that are used to end sentences, such
 
 ✅ **Do** use a capital letter at the beginning of every bullet point. The only exceptions are words that follow specific style guides (e.g., macOS).
 
+
 #### SQL statements
 
 When adding SQL statements, all SQL reserved words should be uppercase, and all identifiers (such as tables and columns) should be lowercase. Here’s an example:
@@ -1275,7 +1281,7 @@ Writing in Fleet-flavored Markdown ensures that content on fleetdm.com, the docs
 Markdown itself is a simple formatting syntax used to write content on the web. In order to publish content like [docs](https://fleetdm.com/docs), [handbook entries](https://fleetdm.com/handbook), and [articles](https://fleetdm.com/articles), you must format your content in Markdown. 
 
 
-#### Headings
+### Headings
 
 Each heading needs two lines of empty space separating it from the previous section and one line of empty space between the heading and related content. This helps break up blocks of text and is especially important on larger, more detailed pages. Here's an example:
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -890,7 +890,7 @@ We avoid "[puffery](https://www.linkedin.com/pulse/puffery-adam-frankl%3Ftrackin
 
 When in doubt, simplify. Read your draft, cut unnecessary words, and make it shorter. If something feels confusing, rewrite until it feels obvious.
 
-Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say).
+Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say) (see the [Further inspiration](#further-inspiration) section, below).
 
 
 
@@ -905,6 +905,8 @@ Different types of writing at Fleet have slightly different expectations. Keep t
 - Format as directional, step-by-step instructions, not narrative prose.
 - Use **bold** text when referencing UI elements.
   - Example: “Navigate to **Hosts** and click **Add a host**.”
+- Surface the simple, high-level steps first.
+- Place advanced or technical details, including troubleshooting, in a separate section at the bottom.
 - Keep it practical, avoid marketing fluff, superlatives, and unnecessary adjectives.
 
 

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -892,7 +892,6 @@ When in doubt, simplify. Read your draft, cut unnecessary words, and make it sho
 
 Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say).
 
-Link instead of repeating. If something’s already covered elsewhere in the handbook, point to it to keep pages short and accurate.
 
 
 ### Writing types

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -882,6 +882,13 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 
 ### Writing style
 
+- [Writing style](#writing-style)
+- [Writing types](#writing-types)
+- [Editing and publishing](#editing-and-publishing)
+- [Further inspiration](#further-inspiration)
+- [Writing assistance](#writing-assistance)
+- [Writing mechanics](#writing-mechanics)
+- [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown)
 Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
 
 We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -882,24 +882,72 @@ Learn how to communicate as Fleet with guidelines for tone of voice, our approac
 
 ### Writing style
 
-  - Infuse the core [values](https://fleetdm.com/handbook/company#values) into everything you write. 
-  - Read and reread, then rewrite to make it shorter. Use links rather than explanations, and favor short sentences. 
-  - Get to where you feel like it’s really good, short, simple, and clear, hack away at any word that’s too confusing. 
-  - Don’t sound formal, sound welcoming so that anyone can understand. Translate "[puffery](https://www.linkedin.com/pulse/puffery-adam-frankl%3FtrackingId=SBVWxzqXTBm9qlO7Rw3ddw%253D%253D/?trackingId=SBVWxzqXTBm9qlO7Rw3ddw%3D%3D)" into "ease of use" or "readability".
-    - Disarm puffery for engineers by replacing puffery with real data.
-    - Disarm puffery for the business by replacing puffery with ROI/RTO  (how much time and/or money is it going save the business?  Forget the details.  When will it pay itself back?)
-  - Apply the advice about writing linked from the company values (the [Paul Graham](http://www.paulgraham.com/simply.html) essays). 
-  - Avoid unnecessary changes, and don’t change headings lightly (it breaks handbook links people might have put in an external article or have in their email inbox somewhere). 
-  - Read your PRs, check it carefully with each change and edit until the diff looks good.
-  - Check preview mode in GitHub to make sure the format renders correctly. If you look at your diff and notice unintentional changes, remove them.
+Fleet’s writing style is clear, simple, and welcoming. We use short sentences, plain English, and an active voice so anyone can follow along. Instead of sounding formal, we aim for approachable and easy to read.
 
-#### Use links in your writing
+We infuse the company’s [values](https://fleetdm.com/handbook/company#values) into everything we write. That means being transparent, straightforward, and respectful of the reader’s time.
 
-Don’t duplicate content. Link to existing places like the [values](https://fleetdm.com/handbook/company#values) or [“why this way”](https://fleetdm.com/handbook/company/why-this-way#why-this-way), but don’t make it awkward. Linking to existing material when something comes up is a gentle way to remind and train using the foundation we've already built.
+We avoid "[puffery](https://www.linkedin.com/pulse/puffery-adam-frankl%3FtrackingId=SBVWxzqXTBm9qlO7Rw3ddw%253D%253D/?trackingId=SBVWxzqXTBm9qlO7Rw3ddw%3D%3D)". For engineers, replace hype with real data. For business readers, translate it into clear outcomes such as time saved or return on investment. Links are better than long explanations, since they keep content short and point people to more detail when they need it.
 
-Create headings that make good permalinks, use links and add missing links. Don't anchor links with "here" or "click here"; [linking relevant words is better for accessibility](https://granicus.com/blog/why-click-here-links-are-bad/) and better for SEO. We run `grep -Eir --exclude-dir=node_modules --include=\*.md '\[(click )?here\]' .` in CI to make sure those link anchors don't slip in.
+When in doubt, simplify. Read your draft, cut unnecessary words, and make it shorter. If something feels confusing, rewrite until it feels obvious.
 
-### What would Mister Rogers say?
+Our approach is informed by [Paul Graham's essays on writing simply](http://www.paulgraham.com/simply.html) and the clarity and optimism of [Mister Rogers](#what-would-mister-rogers-say).
+
+Link instead of repeating. If something’s already covered elsewhere in the handbook, point to it to keep pages short and accurate.
+
+
+### Writing types
+
+Different types of writing at Fleet have slightly different expectations. Keep the shared principles in mind (plain English, brevity, clarity), but adjust for the format.
+
+#### Guides and tutorials
+
+- Write in short sentences, imperative mood, and active voice.
+  - Example: “Click Save.” not “The button should then be clicked.”
+- Format as directional, step-by-step instructions, not narrative prose.
+- Use **bold** text when referencing UI elements.
+  - Example: “Navigate to **Hosts** and click **Add a host**.”
+- Keep it practical, avoid marketing fluff, superlatives, and unnecessary adjectives.
+
+
+#### Announcements
+
+- Lead with the news. Put the key point in the first sentence.
+- Keep it brief (two to four sentences).
+- Use plain, factual language without fluff.
+- Include a clear link or call to action if readers need to follow up.
+
+#### Articles
+
+- Keep the tone conversational and approachable, while still representing Fleet.
+- Provide context or insight (the “why”), not just the “what.”
+- Avoid jargon unless you explain it.
+- Stay aligned with Fleet’s values and overall voice.
+
+#### Website copy
+
+- Keep it simple: short sentences, plain English, imperative mood.
+- Avoid fluff, filler, or jargon.
+- Emphasize reader outcomes. Show what someone can do with Fleet, not just what Fleet is.
+  - Example: _“Manage all your devices in one place”_ instead of _“Fleet is the leading platform for device management.”_
+- Use headings and subheadings to make scanning easy.
+- Keep calls to action direct and specific 
+  - Example: _“Try Fleet”_ instead of _“Learn more about our amazing platform.”_
+
+### Editing and publishing
+
+Follow these steps before merging a change:
+
+- Avoid unnecessary changes to headings, since this can break handbook links shared in other places.
+- Link instead of duplicating content. If a concept exists elsewhere, link to it rather than restating it.
+- Review your pull request carefully. Read the diff line by line until it looks intentional.
+- Check preview mode in GitHub to make sure formatting renders correctly.
+- Look for and remove any unintentional changes in your diff.
+
+### Further inspiration
+
+To see how tone can shift from formal or negative to simple and optimistic, The "The Mister Rogersing" example below is a practical illustration of how reframing can make complex or difficult ideas more approachable.
+
+#### What would Mister Rogers say?
 
 [*Mister Rogers’ Neighborhood*](https://en.wikipedia.org/wiki/Mister_Rogers%27_Neighborhood) was one of the longest-running children’s T.V. series. That’s thanks to [Fred Rogers](https://en.wikipedia.org/wiki/Fred_Rogers)’ communication skills. He knew kids heard things differently than adults. So, he checked every line to avoid confusion and encourage positivity.
 
@@ -922,19 +970,51 @@ What would Mister Rogers say? The tweet could look something like this...
 
 By Mister Rogersing our writing, we can encourage our readers to succeed by emphasizing optimism. You might not be able to apply all of these steps every time. That’s fine. Think of these as guidelines to help you simplify complex topics.
 
+### Writing assistance
 
-### Grammarly
+#### Grammarly
 
 All of our writers and editors have access to Grammarly, which comes with a handy set of tools, including:
 - **Style guide**, which helps us write consistently in the style of Fleet.
 - **Brand tones** to keep the tone of our messaging consistent with just the right amount of confidence, optimism, and joy.
 - **Snippets** to turn commonly used phrases, sentences, and paragraphs (such as calls to action, thank you messages, etc.) into consistent, reusable snippets to save time.
 
+#### Generative AI
 
-### Using sentence case and capitalization
+Collaborating with AI can be helpful for outlines, rewrites, and drafts. But it’s not a substitute for judgment. You (a human) are responsible for accuracy, tone, and format.
 
+Don’t paste sensitive data. Always fact-check names, versions, dates, and links. Question everything you don't understand and strip out anything fabricated.
 
-#### Sentence case
+Make sure the tone sounds like Fleet (plain English, short sentences, active voice) and watch for common AI habits like em dashes, over-bolding, clichés, or passive voice.
+
+Finally, check the format that you are writing for. Guides should be step-by-step instructions, announcements should be short and factual, and articles can be more conversational but still simple and professional.
+
+#### Prompt template
+
+```
+Act as a Fleet editor. Audience: IT and security practitioners.
+Goal: <what you need>.
+Tone: simple, plain English; short sentences; imperative mood; active voice.
+Format: <guide | announcement | article>.
+Constraints:
+- No marketing fluff, superlatives, or filler adjectives.
+- Use sentence case for headings.
+- For guides: numbered, step-by-step instructions; no narrative prose.
+- Bold UI elements only (e.g., **Hosts**, **Add a host**).
+- Prefer commas over em dashes; use colons sparingly.
+Output: valid Markdown.
+
+```
+
+### Writing mechanics
+
+Writing mechanics cover everything from capitalization and punctuation to list formatting and SQL examples. Following them keeps our content consistent and easy to read.
+
+For Markdown-specific rules, see [Writing in Fleet-flavored Markdown](#writing-in-fleet-flavored-markdown).
+
+#### Sentence case and capitalization
+
+##### Sentence case
 
 Fleet uses sentence case capitalization for all headings, subheadings, button text in the Fleet product, fleetdm.com, the documentation, the handbook, marketing material, direct emails, in Slack, and in every other conceivable situation.
 
@@ -946,7 +1026,7 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 
 - Proper nouns _("Nudge", "Skimbleshanks", "Kleenex")_
   - "Yeah, we use Nudge."
-  - "Introducing our friend Skimbleshanks."
+  - "Introducing our friend, Skimbleshanks."
   - "Please, can I have a Kleenex?"
 - Acronyms _("MDM", "REST", "API", "JSON")_
   - "MDM commands in Fleet are available over a REST API that returns JSON."
@@ -960,7 +1040,7 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 <img width="384" alt="image" src="https://github.com/fleetdm/fleet/assets/618009/cca980db-24e1-4303-a120-ecdb7419aac4">
 
 
-#### Capitalization and proper nouns
+##### Capitalization and proper nouns
 
 - **Fleet:** When talking about Fleet the company, we stylize our name as either "Fleet" or "Fleet Device Management".
 - **Fleet the product:** We always say “Fleet”.  We _NEVER_ say "fleetDM" or "FleetDM" or "fleetdm".
@@ -970,13 +1050,20 @@ As we use sentence case, only the first word is capitalized. But, if a word woul
 - **Fleetd:** Fleetd should always be written in lowercase unless used to start a sentence or heading.
 - **Fleetctl:** Fleetctl should always be written in lowercase unless used to start a sentence or heading. Fleetctl should always be in plain text and not inside codeblocks text unless used in a command (ex. `fleetctl -help`).
 
+##### Links and anchors
+- Make links meaningful (avoid “here” / “click here”); link descriptive words.
+- Link to existing pages instead of duplicating content.
+- Favor permalinks and headings that make good anchors (people link to sections).
 
-#### Device vs endpoint
+> > **Note:** We run grep -Eir --exclude-dir=node_modules --include=\*.md '\[(click )?here\]' . in CI to make sure those link anchors don't slip in.
+
+
+##### Device vs endpoint
 
 - When talking about a users' computer, we prefer to use "device" over _endpoint._ Devices in this context can be a physical device or virtual instance that connect to and exchange information with a computer network. Examples of devices include mobile devices, desktop computers, laptop computers, virtual machines, and servers.
 
 
-### Headings and titles
+#### Headings and titles
 
 Headings and titles should:
 
@@ -984,15 +1071,15 @@ Headings and titles should:
 - Help guide readers through your writing so they can quickly find what they need.
 - [Make good permalinks](https://fleetdm.com/handbook/company/communications#use-links-in-your-writing).
 
-#### Static headings
+##### Static headings
 
 Use static headings (a `noun` or `noun phrase`) e.g., “Log destinations,” for concept or reference topics. Be as short and specific as possible.
 
-#### Task-based headings
+##### Task-based headings
 
 Use task-based headings (`verb` + `topic`) e.g., _“Configure a log destination”_ for guides and tutorials where the heading should reveal the task that the reader is trying to achieve. 
 
-#### Avoid _-ing_ verb forms in headings
+##### Avoid _-ing_ verb forms in headings
 
 Avoid starting a heading with _-ing_ verb form, if possible.
 
@@ -1002,7 +1089,7 @@ _-ing_ verb forms are more difficult for non-native English readers to understan
 | ---------------- | -------------------- |
 | “Configure a log destination” | “Configuring a log destination” |
 
-#### Avoid vague verbs in headings
+##### Avoid vague verbs in headings
 
 Were possible, avoid starting a heading with a vague verb, like “understand,” “learn,” or “Use.” Headings that start with a vague verb can mislead readers by making a topic appear to be task-oriented (a guide) when it is actually reference or conceptual information. 
 
@@ -1011,11 +1098,11 @@ Were possible, avoid starting a heading with a vague verb, like “understand,�
 | “Log destinations” | “Understand log destinations.” |
 
 
-#### Avoid code in headings
+##### Avoid code in headings
 
 While our readers are more tech-savvy than most, we can’t expect them to recognize queries by SQL alone.  Avoid using code for headings. Instead, say what the code does and include code examples in the body of your document. That aside, it doesn't render well on the website.
 
-#### Heading hierarchy 
+##### Heading hierarchy 
 
 Use heading tags to structure your content hierarchically. Try to stay within three or four heading levels. Detailed documents may use more, but pages with a simpler structure are easier to read.
 
@@ -1024,7 +1111,7 @@ Use heading tags to structure your content hierarchically. Try to stay within th
 - H3: Subheadings
 - H4: Sub-subheadings
 
-#### Punctuation in headings
+##### Punctuation in headings
 
 Fleet headings do not use end punctuation unless the heading is a question:
 
@@ -1032,19 +1119,13 @@ Fleet headings do not use end punctuation unless the heading is a question:
 
 If the heading is a question, end the heading with a question mark.
 
-
-### Grammar mechanics
-
-
 #### Contractions 
 
 They’re great! Don’t be afraid to use them. They’ll help your writing sound more approachable
 
-
 #### Ampersands 
 
 (&) Only use ampersands if they appear in a brand name, or if you’re quoting the title of an article from another source. Otherwise, write out “and”.
-
 
 #### Commas 
 
@@ -1055,7 +1136,6 @@ When listing three or more things, use commas to separate the words. This is cal
 ❌ **Don’t:** Fleet is for IT professionals, client platform engineers and security practitioners.
 
 Aside from the serial comma, use commas, as usual, to break up your sentences. If you’re unsure whether you need a comma, saying the sentence aloud can give you a clue. If you pause or take a breath, that’s when you probably need a comma.
-
 
 #### Hyphens
 
@@ -1070,7 +1150,6 @@ Aside from the serial comma, use commas, as usual, to break up your sentences. I
 - Fleet is released every three weeks.
 - Osquery is open source.
 
-
 #### Colons 
 
 Colons introduce one or more elements that add detail to the idea before the colon. 
@@ -1081,11 +1160,9 @@ Colons introduce one or more elements that add detail to the idea before the col
 ✅ **Do** use a colon to introduce a phrase (Only capitalize the first word following a colon if it’s a proper noun):
 - Introducing Sandbox: the fastest way to play with Fleet.
 
-
 #### Exclamation points 
 
 They’re fun! But too many can undermine your credibility!!!1! Please use them sparingly. Take context into consideration. And only use one at a time.
-
 
 #### Abbreviations and acronyms
 
@@ -1096,11 +1173,9 @@ Then use the short version for all other references.
 - The Fleet CLI is called fleetctl.
 If the abbreviation or acronym is well known, like API or HTML, use it instead (and don’t worry about spelling it out).
 
+#### Numbers and times
 
-### Numbers and times
-
-
-#### Numbers
+##### Numbers
 
 Spell out a number when it begins a sentence. Otherwise, use the numeral. 
 
@@ -1114,8 +1189,7 @@ Numbers over 3 digits get commas:
 - 1,000
 - 150,000
 
-
-#### Times
+##### Times
 
 Use numerals and am or pm without a space in between:
 - 7am
@@ -1136,30 +1210,27 @@ Spell out international time zones:
 - Central European Time
 - Japan Standard Time
 
-
-### Emphasis
+#### Emphasis
 
 - **Bold:** Use bold text to emphasize words or phrases. Just don’t overdo it. Too much bold text may make it hard to see what’s really important.
 
 - _Italics:_ Use italics when referencing UI elements (e.g., buttons and navigation labels):
   - On the settings page, go to *Organization Settings* and select *Fleet Desktop*.
 
-
-### Lists
+#### Lists
 
 Lists help readers scan content for essential information. They should be as concise and symmetrical as possible.
 If you find your list running long, or if each item contains several sentences, you may want to reconsider whether a list is the best approach.
 Use a numbered list if it follows a specific order or includes a set number of items. Otherwise, use bullet points.
 
-
-#### How to introduce a list 
+##### How to introduce a list 
 
 ✅ **Do** use a colon if you introduce a list with a complete sentence.
 
 ❌ **Don’t** use a colon if you start a list right after a heading.
 
 
-#### How to use end punctuation with list items
+##### How to use end punctuation with list items
 
 End punctuation refers to punctuation marks that are used to end sentences, such as periods, question marks, and exclamation points.
 
@@ -1178,13 +1249,9 @@ End punctuation refers to punctuation marks that are used to end sentences, such
 ❌ **Don’t** use commas or semicolons to end bullet points.
 
 
-#### How to capitalize list items
+##### How to capitalize list items
 
 ✅ **Do** use a capital letter at the beginning of every bullet point. The only exceptions are words that follow specific style guides (e.g., macOS).
-
-
-### Web elements
-
 
 #### SQL statements
 
@@ -1195,7 +1262,9 @@ When adding SQL statements, all SQL reserved words should be uppercase, and all 
 
 ### Writing in Fleet-flavored Markdown
 
-Markdown is a simple formatting syntax used to write content on the web. In order to publish content like [docs](https://fleetdm.com/docs), [handbook entries](https://fleetdm.com/handbook), and [articles](https://fleetdm.com/articles), you must format your content in Markdown. 
+Writing in Fleet-flavored Markdown ensures that content on fleetdm.com, the docs, and the handbook looks consistent. These rules are specific to publishing on the website.
+
+Markdown itself is a simple formatting syntax used to write content on the web. In order to publish content like [docs](https://fleetdm.com/docs), [handbook entries](https://fleetdm.com/handbook), and [articles](https://fleetdm.com/articles), you must format your content in Markdown. 
 
 
 #### Headings
@@ -1342,7 +1411,7 @@ Add angle brackets "< >" around a URL to turn it into a link.
 - **Rendered output:** <https://fleetdm.com>
 
 
-#### Emails
+##### Emails
 
 To create a mailto link... oh wait, I'm not going to tell you.
 - ***Important: To avoid spam, we **NEVER** use mailto links.***
@@ -1444,7 +1513,7 @@ You can use a large quote blockquote to reduce the font size and line height of 
 </blockquote>
 
 
-##### Mermaid diagrams
+#### Mermaid diagrams
 
 The Fleet Docs support diagrams that are written in mermaid.js syntax. Take a look at the [Mermaid docs](https://mermaid-js.github.io/mermaid/#/README) to learn about the syntax language and what types of diagrams you can display.
 


### PR DESCRIPTION
Closes https://github.com/fleetdm/fleet/issues/18969

@Sampfluger88, here's the PR you secretly wanted, but I'm sorry to throw the review in your lap!

I planned to add clear guidance on writing types (guides vs. articles vs. website copy), but I couldn't comfortably do that because the entire Writing section needed attention before that could fit in properly.

I reorganized the section to make it easier to follow and maintain, grouping existing content into clearer buckets:

- Style & values
- Types (examples of different writing formats at Fleet; can expand later to include social media)
- Process (editing, publishing, PR review)
- Inspiration (Mister Rogers / Paul Graham)
- Assistance (tools like Grammarly and generative AI)
- Mechanics (rules across all mediums)
- Markdown (website-specific rules)

These now live under the following headings:

- Writing (top-level intro)
- Writing style
- Writing types
- Editing and publishing
- Further inspiration (Mister Rogers)
- Writing assistance (Grammarly and generative AI)
- Writing mechanics (Fleet-specific conventions across all writing)
- Writing in Fleet-flavored Markdown (rules specific to the website)

The old structure mixed values, style, rules, and process, which made it hard to scan. This new hierarchy separates high-level principles from detailed rules and tool guidance, so contributors can find what they need more quickly.

### Next steps

I plan to circle back to optimize the Mechanics section:

- Trim redundant content
- Make examples consistent in style
- Improve the order of rules

✊
