### PR TITLE
Website: Update scripts-details and command-details view actions

### DIFF
--- a/website/api/controllers/view-command-details.js
+++ b/website/api/controllers/view-command-details.js
@@ -26,7 +26,7 @@ module.exports = {
     }
     let thisCommand = _.find(sails.config.builtStaticContent.mdmCommands, { slug: slug });
     if(!thisCommand) {
-      return 'notFound';
+      throw 'notFound';
     }
     let pageTitleForMeta = ` ${thisCommand.name} command | Fleet controls library`;
     let pageDescriptionForMeta = `${thisCommand.description}`;

--- a/website/api/controllers/view-script-details.js
+++ b/website/api/controllers/view-script-details.js
@@ -29,7 +29,7 @@ module.exports = {
 
     let thisScript = _.find(sails.config.builtStaticContent.scripts, { slug: slug });
     if(!thisScript){
-      return 'notFound';
+      throw 'notFound';
     }
 
     let pageTitleForMeta = `${thisScript.name} | Fleet controls library`;


### PR DESCRIPTION
Changes:
- Updated view-script-details and view-command-details to throw a `notFound` response instead of returning it.