### PR TITLE
UI: Fix browser history issues navigating between batch progress and batch details pages

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/components/ScriptBatchHostsTable/ScriptBatchHostsTable.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/components/ScriptBatchHostsTable/ScriptBatchHostsTable.tsx
@@ -108,7 +108,8 @@ const ScriptBatchHostsTable = ({
         queryParams: newQueryParams,
       });
 
-      router.push(path);
+      // replace instead of push here keeps browser history clear and allows cleaner forward/back navigation
+      router.replace(path);
     },
     [selectedHostStatus, orderKey, orderDirection, batchExecutionId, router]
   );

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -119,8 +119,13 @@ const ScriptBatchProgress = ({
   );
 
   const onClickRow = (r: IScriptBatchSummaryV2) => {
-    router.push(PATHS.CONTROLS_SCRIPTS_BATCH_DETAILS(r.batch_execution_id));
-    // return satisfies caller expectations, not used in this case
+    // explicitly including the status param here avoids triggering the script details page's effect
+    // which would add it automatically, muddying browser history and preventing smooth forward/back navigation
+    router.push(
+      PATHS.CONTROLS_SCRIPTS_BATCH_DETAILS(r.batch_execution_id).concat(
+        "?status=ran"
+      )
+    );
     return r;
   };
 


### PR DESCRIPTION
## For #33285 

- Push to details page with `status` param included to avoid that page's effect that muddies browser history. Since tab nav on that page is controlled by URL query params, this effect is important - there _must_ always be a status param.
- Update the details page table query change handler to replace instead of push to the URL

https://github.com/user-attachments/assets/b15b4eda-df24-4d01-a7f4-a60a63282e63


- [x] QA'd all new/changed functionality manually