### PR TITLE
Fix Orbit-canceled script runs being counted as "pending"

### DIFF
--- a/pkg/scripts/scripts.go
+++ b/pkg/scripts/scripts.go
@@ -7,7 +7,8 @@ import "time"
 const (
 	// MaxHostExecutionTime is the maximum time allowed for a script to run in a
 	// host before is terminated.
-	MaxHostExecutionTime = 5 * time.Minute
+	// MaxHostExecutionTime = 5 * time.Minute
+	MaxHostExecutionTime = 1 * time.Second
 	// MaxServerWaitTime is the maximum time allowed for the server to wait for
 	// hosts to run a script during syncronous execution. We add an extra buffer
 	// to account for the notification system used to deliver scripts to the

--- a/pkg/scripts/scripts.go
+++ b/pkg/scripts/scripts.go
@@ -7,8 +7,7 @@ import "time"
 const (
 	// MaxHostExecutionTime is the maximum time allowed for a script to run in a
 	// host before is terminated.
-	// MaxHostExecutionTime = 5 * time.Minute
-	MaxHostExecutionTime = 1 * time.Second
+	MaxHostExecutionTime = 5 * time.Minute
 	// MaxServerWaitTime is the maximum time allowed for the server to wait for
 	// hosts to run a script during syncronous execution. We add an extra buffer
 	// to account for the notification system used to deliver scripts to the

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1395,7 +1395,7 @@ func (*Datastore) getBatchExecutionFilters(whereParams []interface{}, opt fleet.
 			//                        with this script run.
 			batchScriptExecutionFilter += ` AND ((hsr.host_id AND (hsr.exit_code IS NULL AND (hsr.canceled IS NULL OR hsr.canceled = 0) AND bsehr.error IS NULL)) OR (hsr.host_id is NULL AND ba.canceled = 0 AND bsehr.error IS NULL))`
 		case fleet.BatchScriptExecutionErrored:
-			batchScriptExecutionFilter += ` AND hsr.exit_code > 0 AND hsr.canceled = 0`
+			batchScriptExecutionFilter += ` AND hsr.exit_code <> 0 AND hsr.canceled = 0`
 		case fleet.BatchScriptExecutionIncompatible:
 			batchScriptExecutionFilter += ` AND bsehr.error IS NOT NULL`
 		case fleet.BatchScriptExecutionCanceled:

--- a/server/datastore/mysql/scripts.go
+++ b/server/datastore/mysql/scripts.go
@@ -2277,7 +2277,7 @@ SELECT
 	COUNT(*) as num_targeted,
 	COUNT(bsehr.error) as num_did_not_run,
 	COUNT(CASE WHEN hsr.exit_code = 0 THEN 1 END) as num_succeeded,
-	COUNT(CASE WHEN hsr.exit_code > 0 THEN 1 END) as num_failed,
+	COUNT(CASE WHEN hsr.exit_code <> 0 THEN 1 END) as num_failed,
 	COUNT(CASE WHEN hsr.canceled = 1 AND hsr.exit_code IS NULL THEN 1 END) as num_cancelled
 FROM
 	batch_activity_host_results bsehr
@@ -2372,13 +2372,13 @@ FROM (
     COUNT(bahr.host_id)                     AS num_targeted,
     COUNT(bahr.error)                       AS num_incompatible,
     COUNT(IF(hsr.exit_code = 0, 1, NULL))   AS num_ran,
-    COUNT(IF(hsr.exit_code > 0, 1, NULL))   AS num_errored,
+    COUNT(IF(hsr.exit_code <> 0, 1, NULL))   AS num_errored,
     COUNT(IF((hsr.canceled = 1 AND hsr.exit_code IS NULL) OR (hsr.host_id IS NULL AND bahr.error is NULL AND ba.canceled = 1), 1, NULL)) AS num_cancelled,
     (
       COUNT(bahr.host_id)
       - COUNT(bahr.error)
       - COUNT(IF(hsr.exit_code = 0, 1, NULL))
-      - COUNT(IF(hsr.exit_code > 0, 1, NULL))
+      - COUNT(IF(hsr.exit_code <> 0, 1, NULL))
       - COUNT(IF((hsr.canceled = 1 AND hsr.exit_code IS NULL) OR (hsr.host_id IS NULL AND bahr.error is NULL AND ba.canceled = 1), 1, NULL))
     ) AS num_pending,
     ba.execution_id,
@@ -2501,7 +2501,7 @@ JOIN (
     COUNT(bahr.host_id)                                        AS num_targeted,
     COUNT(bahr.error)                                          AS num_incompatible,
     COUNT(IF(hsr.exit_code = 0, 1, NULL))                      AS num_ran,
-    COUNT(IF(hsr.exit_code > 0, 1, NULL))                      AS num_errored,
+    COUNT(IF(hsr.exit_code <> 0, 1, NULL))                     AS num_errored,
 	COUNT(IF((hsr.canceled = 1 AND hsr.exit_code IS NULL) OR (hsr.host_id IS NULL AND bahr.error is NULL AND ba2.canceled = 1), 1, NULL)) AS num_canceled
   FROM batch_activities AS ba2
   LEFT JOIN batch_activity_host_results AS bahr

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -2083,7 +2083,7 @@ func testBatchExecuteWithStatus(t *testing.T, ds *Datastore) {
 		HostID:      host2.ID,
 		ExecutionID: host2Upcoming[0].ExecutionID,
 		Output:      "bar",
-		ExitCode:    1,
+		ExitCode:    -1,
 	})
 	require.NoError(t, err)
 
@@ -2425,7 +2425,7 @@ func testMarkActivitiesAsCompleted(t *testing.T, ds *Datastore) {
 		HostID:      host2.ID,
 		ExecutionID: host2Upcoming[0].ExecutionID,
 		Output:      "bar",
-		ExitCode:    1,
+		ExitCode:    -1,
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32220

# Details

This PR fixes an issue where hosts whose running scripts were canceled by Orbit (e.g. due to timing out) were reported as being still "pending" on the batch script details view. This was due to our only counting runs as errored if the error code was > 0, and ignoring negative error codes (which is what Orbit uses for this case).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests
Changed a couple of places where we were using `1` for an error code to `-1`
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [X] Alerted the release DRI if additional load testing is needed
