### PR TITLE
Use writer node when returning App config

### DIFF
--- a/changes/28713-gitops-checkbox-status-replica-env
+++ b/changes/28713-gitops-checkbox-status-replica-env
@@ -1,1 +1,2 @@
 * Refactored PATH fleet/config end-point to use the primary DB node for both persisting changes and fetching modified App Config.
+* Refactored GET fleet/config end-point to use the primary DB node for fetching the App Config.

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -36,7 +36,7 @@ func (ds *Datastore) GetCurrentTime(ctx context.Context) (time.Time, error) {
 }
 
 func (ds *Datastore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
-	return appConfigDB(ctx, ds.reader(ctx))
+	return appConfigDB(ctx, ds.writer(ctx))
 }
 
 func appConfigDB(ctx context.Context, q sqlx.QueryerContext) (*fleet.AppConfig, error) {

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -36,7 +36,10 @@ func (ds *Datastore) GetCurrentTime(ctx context.Context) (time.Time, error) {
 }
 
 func (ds *Datastore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
-	return appConfigDB(ctx, ds.writer(ctx))
+	if ctxdb.IsPrimaryRequired(ctx) {
+		return appConfigDB(ctx, ds.writer(ctx))
+	}
+	return appConfigDB(ctx, ds.reader(ctx))
 }
 
 func appConfigDB(ctx context.Context, q sqlx.QueryerContext) (*fleet.AppConfig, error) {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -230,7 +230,7 @@ func (svc *Service) AppConfigObfuscated(ctx context.Context) (*fleet.AppConfig, 
 		}
 	}
 
-	ac, err := svc.ds.AppConfig(ctx)
+	ac, err := svc.ds.AppConfig(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return nil, err
 	}

--- a/tools/mysql-replica-testing/docker-compose.yml
+++ b/tools/mysql-replica-testing/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       [
         "mysqld",
         "--datadir=/tmp/mysqldata-replica-main",
+        "--default-authentication-plugin=mysql_native_password",
         # These 3 keys run MySQL with GTID consistency enforced to avoid issues with production deployments that use it.
         "--enforce-gtid-consistency=ON",
         "--log-bin=bin.log",
@@ -51,6 +52,24 @@ services:
     ports:
       - "3309:3306"
 
+  minio:
+    image: quay.io/minio/minio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123!
+    volumes:
+      - data-minio:/data
+
+  redis:
+    image: redis:5
+    ports:
+      - "6379:6379"
+
 volumes:
   mysql-persistent-volume-replica-main:
   mysql-persistent-volume-replica-read:
+  data-minio:


### PR DESCRIPTION
Resolves #28713

Use writer node when returning App config to avoid UI issues when refreshing the page right after performing a mutation.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually