### PR TITLE
UI: Couple Setup experience > Install software selected platform with URL

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -215,3 +215,9 @@ export const SETUP_EXPERIENCE_PLATFORMS = [
 ] as const;
 
 export type SetupExperiencePlatform = typeof SETUP_EXPERIENCE_PLATFORMS[number];
+
+export const isSetupExperiencePlatform = (
+  s: string | undefined
+): s is SetupExperiencePlatform => {
+  return SETUP_EXPERIENCE_PLATFORMS.includes(s as SetupExperiencePlatform);
+};

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
@@ -41,6 +41,14 @@ const SetupExperience = ({
     SETUP_EXPERIENCE_NAV_ITEMS.find((item) => item.urlSection === section) ??
     DEFAULT_SETTINGS_SECTION;
 
+  if (
+    currentFormSection.urlSection !== "install-software" &&
+    urlPlatformParam
+  ) {
+    router.replace(
+      currentFormSection.path + queryString // current card doesn't support platforms yet
+    );
+  }
   const CurrentCard = currentFormSection.Card;
 
   return (

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
@@ -23,7 +23,7 @@ const SetupExperience = ({
   router,
   teamIdForApi,
 }: ISetupExperienceProps) => {
-  const { section } = params;
+  const { section, platform: urlPlatformParam } = params;
   const { isPremiumTier } = useContext(AppContext);
 
   // Not premium shows premium message
@@ -58,6 +58,7 @@ const SetupExperience = ({
             key={teamIdForApi}
             currentTeamId={teamIdForApi}
             router={router}
+            urlPlatformParam={urlPlatformParam}
           />
         }
       />

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
@@ -31,7 +31,7 @@ const SETUP_EXPERIENCE_NAV_ITEMS: ISideNavItem<ISetupExperienceCardProps>[] = [
   {
     title: "3. Install software",
     urlSection: "install-software",
-    path: PATHS.CONTROLS_INSTALL_SOFTWARE,
+    path: PATHS.CONTROLS_INSTALL_SOFTWARE("macos"),
     Card: InstallSoftware,
   },
   {

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
@@ -13,6 +13,7 @@ import RunScript from "./cards/RunScript";
 export interface ISetupExperienceCardProps {
   currentTeamId: number;
   router: InjectedRouter;
+  urlPlatformParam?: string; // not yet guaranteed to be a valid platform
 }
 
 const SETUP_EXPERIENCE_NAV_ITEMS: ISideNavItem<ISetupExperienceCardProps>[] = [

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -294,6 +294,13 @@ const routes = (
                   <Route path=":section" component={Scripts} />
                 </Route>
                 <Route path="variables" component={Secrets} />
+                <Route path="setup-experience/install-software">
+                  <IndexRedirect to="macos" />
+                  <Route
+                    path="setup-experience/install-software/:platform"
+                    component={SetupExperience}
+                  />
+                </Route>
                 <Route
                   path="setup-experience/:section"
                   component={SetupExperience}

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -288,23 +288,22 @@ const routes = (
                 <Route path="os-updates" component={OSUpdates} />
                 <Route path="os-settings" component={OSSettings} />
                 <Route path="os-settings/:section" component={OSSettings} />
+
                 <Route path="setup-experience" component={SetupExperience} />
+                <Route
+                  path="setup-experience/:section"
+                  component={SetupExperience}
+                />
+                <Route
+                  path="setup-experience/:section/:platform"
+                  component={SetupExperience}
+                />
+
                 <Route path="scripts">
                   <IndexRedirect to="library" />
                   <Route path=":section" component={Scripts} />
                 </Route>
                 <Route path="variables" component={Secrets} />
-                <Route path="setup-experience/install-software">
-                  <IndexRedirect to="macos" />
-                  <Route
-                    path="setup-experience/install-software/:platform"
-                    component={SetupExperience}
-                  />
-                </Route>
-                <Route
-                  path="setup-experience/:section"
-                  component={SetupExperience}
-                />
               </Route>
             </Route>
             <Route

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -1,3 +1,4 @@
+import { SetupExperiencePlatform } from "interfaces/platform";
 import URL_PREFIX from "./url_prefix";
 
 const INTEGRATIONS_PREFIX = `${URL_PREFIX}/settings/integrations`;
@@ -16,7 +17,8 @@ export default {
   CONTROLS_END_USER_AUTHENTICATION: `${URL_PREFIX}/controls/setup-experience/end-user-auth`,
   CONTROLS_BOOTSTRAP_PACKAGE: `${URL_PREFIX}/controls/setup-experience/bootstrap-package`,
   CONTROLS_SETUP_ASSITANT: `${URL_PREFIX}/controls/setup-experience/setup-assistant`,
-  CONTROLS_INSTALL_SOFTWARE: `${URL_PREFIX}/controls/setup-experience/install-software`,
+  CONTROLS_INSTALL_SOFTWARE: (platform: SetupExperiencePlatform) =>
+    `${URL_PREFIX}/controls/setup-experience/install-software/${platform}`,
   CONTROLS_RUN_SCRIPT: `${URL_PREFIX}/controls/setup-experience/run-script`,
   CONTROLS_SCRIPTS: `${URL_PREFIX}/controls/scripts`,
   CONTROLS_SCRIPTS_LIBRARY: `${URL_PREFIX}/controls/scripts/library`,


### PR DESCRIPTION
## For #33299 

- Couple card logic to URL param
- Validate param, push to default macos if invalid or missing
- Validate that other setup experience cards don't have a platform param, push to no param if present

![ezgif-7ab225faff3840](https://github.com/user-attachments/assets/ea1c0382-a928-4855-a083-c8c52ec2ab4f)


- [x] QA'd all new/changed functionality manually
