### PR TITLE
dont allow cert to have same name if the same cert type in the UI

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -151,7 +151,6 @@ const CertificateAuthorities = () => {
         selectedCertAuthority &&
         certAuthorities && (
           <EditCertAuthorityModal
-            certAuthorities={certAuthorities}
             certAuthority={selectedCertAuthority}
             onExit={onEditedCertAuthority}
           />

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/CertificateAuthorities.tsx
@@ -147,12 +147,15 @@ const CertificateAuthorities = () => {
           onExit={onAddedNewCertAuthority}
         />
       )}
-      {showEditCertAuthorityModal && selectedCertAuthority && (
-        <EditCertAuthorityModal
-          certAuthority={selectedCertAuthority}
-          onExit={onEditedCertAuthority}
-        />
-      )}
+      {showEditCertAuthorityModal &&
+        selectedCertAuthority &&
+        certAuthorities && (
+          <EditCertAuthorityModal
+            certAuthorities={certAuthorities}
+            certAuthority={selectedCertAuthority}
+            onExit={onEditedCertAuthority}
+          />
+        )}
       {showDeleteCertAuthorityModal && selectedCertAuthority && (
         <DeleteCertificateAuthorityModal
           certAuthority={selectedCertAuthority}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tsx
@@ -165,6 +165,7 @@ const AddCertAuthorityModal = ({
         return (
           <DigicertForm
             formData={digicertFormData}
+            certAuthorities={certAuthorities}
             submitBtnText={submitBtnText}
             isSubmitting={isAdding}
             onChange={onChangeForm}
@@ -176,6 +177,7 @@ const AddCertAuthorityModal = ({
         return (
           <HydrantForm
             formData={hydrantFormData}
+            certAuthorities={certAuthorities}
             submitBtnText={submitBtnText}
             isSubmitting={isAdding}
             onChange={onChangeForm}
@@ -198,6 +200,7 @@ const AddCertAuthorityModal = ({
         return (
           <CustomSCEPForm
             formData={customSCEPFormData}
+            certAuthorities={certAuthorities}
             submitBtnText={submitBtnText}
             isSubmitting={isAdding}
             onChange={onChangeForm}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CustomSCEPForm/helpers.ts
@@ -29,7 +29,7 @@ type IFormValidations = Record<
 >;
 
 export const generateFormValidations = (
-  customSCEPIntegrations: ICertificateAuthorityPartial[],
+  certAuthorities: ICertificateAuthorityPartial[],
   isEditing: boolean
 ) => {
   const FORM_VALIDATIONS: IFormValidations = {
@@ -54,8 +54,10 @@ export const generateFormValidations = (
           isValid: (formData: ICustomSCEPFormData) => {
             return (
               isEditing ||
-              customSCEPIntegrations.find(
-                (cert) => cert.name === formData.name
+              certAuthorities.find(
+                (cert) =>
+                  cert.type === "custom_scep_proxy" &&
+                  cert.name === formData.name
               ) === undefined
             );
           },

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/DigicertForm/helpers.ts
@@ -57,8 +57,10 @@ export const generateFormValidations = (
           isValid: (formData: IDigicertFormData) => {
             return (
               isEditing ||
-              certAuthorities.find((cert) => cert.name === formData.name) ===
-                undefined
+              certAuthorities.find(
+                (cert) =>
+                  cert.type === "digicert" && cert.name === formData.name
+              ) === undefined
             );
           },
           message: "Name is already used by another DigiCert CA.",

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/HydrantForm/helpers.ts
@@ -59,8 +59,9 @@ export const generateFormValidations = (
           isValid: (formData: IHydrantFormData) => {
             return (
               isEditing ||
-              certAuthorities.find((cert) => cert.name === formData.name) ===
-                undefined
+              certAuthorities.find(
+                (cert) => cert.type === "hydrant" && cert.name === formData.name
+              ) === undefined
             );
           },
           message: "Name is already used by another Hydrant CA.",

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -31,7 +31,6 @@ const NDESForm = ({
   formData,
   submitBtnText,
   isSubmitting,
-  isEditing = false,
   isDirty = true,
   onChange,
   onSubmit,


### PR DESCRIPTION
fixes #33246

This adds logic on the UI to show an error if a cert with the same types tries to create a new cert with an existing name
