### PR TITLE
Stop showing debug logs during fleetctl preview, slight reformat

### DIFF
--- a/changes/32208-fleetctl-preview-logging
+++ b/changes/32208-fleetctl-preview-logging
@@ -1,0 +1,1 @@
+- Disabled debug logging by default in `fleetctl preview` and reformatted login information


### PR DESCRIPTION
**Related issue:** #32208

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

Also added a spinner while waiting for docker compose to start and stop, added some spacing around the login information, and bolded the username and password.

<img width="724" height="409" alt="image" src="https://github.com/user-attachments/assets/b354b759-b87f-48a2-a8b7-5d8b89937b0f" />
