### PR TITLE
to RC: Couple setup experience software with URL

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -215,3 +215,9 @@ export const SETUP_EXPERIENCE_PLATFORMS = [
 ] as const;
 
 export type SetupExperiencePlatform = typeof SETUP_EXPERIENCE_PLATFORMS[number];
+
+export const isSetupExperiencePlatform = (
+  s: string | undefined
+): s is SetupExperiencePlatform => {
+  return SETUP_EXPERIENCE_PLATFORMS.includes(s as SetupExperiencePlatform);
+};

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperience.tsx
@@ -23,7 +23,7 @@ const SetupExperience = ({
   router,
   teamIdForApi,
 }: ISetupExperienceProps) => {
-  const { section } = params;
+  const { section, platform: urlPlatformParam } = params;
   const { isPremiumTier } = useContext(AppContext);
 
   // Not premium shows premium message
@@ -41,6 +41,14 @@ const SetupExperience = ({
     SETUP_EXPERIENCE_NAV_ITEMS.find((item) => item.urlSection === section) ??
     DEFAULT_SETTINGS_SECTION;
 
+  if (
+    currentFormSection.urlSection !== "install-software" &&
+    urlPlatformParam
+  ) {
+    router.replace(
+      currentFormSection.path + queryString // current card doesn't support platforms yet
+    );
+  }
   const CurrentCard = currentFormSection.Card;
 
   return (
@@ -58,6 +66,7 @@ const SetupExperience = ({
             key={teamIdForApi}
             currentTeamId={teamIdForApi}
             router={router}
+            urlPlatformParam={urlPlatformParam}
           />
         }
       />

--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
@@ -13,6 +13,7 @@ import RunScript from "./cards/RunScript";
 export interface ISetupExperienceCardProps {
   currentTeamId: number;
   router: InjectedRouter;
+  urlPlatformParam?: string; // not yet guaranteed to be a valid platform
 }
 
 const SETUP_EXPERIENCE_NAV_ITEMS: ISideNavItem<ISetupExperienceCardProps>[] = [
@@ -31,7 +32,7 @@ const SETUP_EXPERIENCE_NAV_ITEMS: ISideNavItem<ISetupExperienceCardProps>[] = [
   {
     title: "3. Install software",
     urlSection: "install-software",
-    path: PATHS.CONTROLS_INSTALL_SOFTWARE,
+    path: PATHS.CONTROLS_INSTALL_SOFTWARE("macos"),
     Card: InstallSoftware,
   },
   {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -11,7 +11,7 @@ import mdmAPI, {
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { ISoftwareTitle } from "interfaces/software";
-import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { DEFAULT_USE_QUERY_OPTIONS, SUPPORT_LINK } from "utilities/constants";
 import { IConfig } from "interfaces/config";
 import { API_NO_TEAM_ID, ITeamConfig } from "interfaces/team";
 import {
@@ -83,10 +83,9 @@ const InstallSoftware = ({
         per_page: PER_PAGE_SIZE,
       }),
     {
-      enabled: selectedPlatform !== "windows", // remove next iteration
+      enabled: isValidPlatform && selectedPlatform !== "windows", // remove next iteration
       ...DEFAULT_USE_QUERY_OPTIONS,
       select: (res) => res.software_titles,
-      enabled: isValidPlatform,
     }
   );
 

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -286,16 +286,22 @@ const routes = (
                 <Route path="os-updates" component={OSUpdates} />
                 <Route path="os-settings" component={OSSettings} />
                 <Route path="os-settings/:section" component={OSSettings} />
+
                 <Route path="setup-experience" component={SetupExperience} />
+                <Route
+                  path="setup-experience/:section"
+                  component={SetupExperience}
+                />
+                <Route
+                  path="setup-experience/:section/:platform"
+                  component={SetupExperience}
+                />
+
                 <Route path="scripts">
                   <IndexRedirect to="library" />
                   <Route path=":section" component={Scripts} />
                 </Route>
                 <Route path="variables" component={Secrets} />
-                <Route
-                  path="setup-experience/:section"
-                  component={SetupExperience}
-                />
               </Route>
             </Route>
             <Route

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -1,3 +1,4 @@
+import { SetupExperiencePlatform } from "interfaces/platform";
 import URL_PREFIX from "./url_prefix";
 
 const INTEGRATIONS_PREFIX = `${URL_PREFIX}/settings/integrations`;
@@ -16,7 +17,8 @@ export default {
   CONTROLS_END_USER_AUTHENTICATION: `${URL_PREFIX}/controls/setup-experience/end-user-auth`,
   CONTROLS_BOOTSTRAP_PACKAGE: `${URL_PREFIX}/controls/setup-experience/bootstrap-package`,
   CONTROLS_SETUP_ASSITANT: `${URL_PREFIX}/controls/setup-experience/setup-assistant`,
-  CONTROLS_INSTALL_SOFTWARE: `${URL_PREFIX}/controls/setup-experience/install-software`,
+  CONTROLS_INSTALL_SOFTWARE: (platform: SetupExperiencePlatform) =>
+    `${URL_PREFIX}/controls/setup-experience/install-software/${platform}`,
   CONTROLS_RUN_SCRIPT: `${URL_PREFIX}/controls/setup-experience/run-script`,
   CONTROLS_SCRIPTS: `${URL_PREFIX}/controls/scripts`,
   CONTROLS_SCRIPTS_LIBRARY: `${URL_PREFIX}/controls/scripts/library`,


### PR DESCRIPTION
See https://github.com/fleetdm/fleet/pull/33327

Note: [this commit](https://github.com/fleetdm/fleet/pull/33358/commits/7470be1a02befac488582aba9525d26116d1c823) on this branch reconciles the cherry pick changes with the placeholder for Windows which exists in the RC but no longer in main. It accounts for the only diffs from the original PR to main