### PR TITLE
RC only: Fix Setup experience software install Windows empty state

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/_styles.scss
@@ -2,7 +2,7 @@
   &__windows {
     @include tab-empty-state;
     max-width: none;
-    padding: 64px 170px;
+    text-align: center;
   }
   .tab-nav {
     margin-top: -20px;


### PR DESCRIPTION
## For #33276 

This updates the styling of the Windows placeholder UI that no longer exists on main since its full functionality has been implemented for the next release, so this is only an update to the RC and has no corresponding PR to `main`

<img width="918" height="819" alt="Screenshot 2025-09-22 at 11 13 09 AM" src="https://github.com/user-attachments/assets/b694f46e-97a0-495f-b21b-6efbf680a4b9" />

<img width="966" height="820" alt="Screenshot 2025-09-22 at 11 13 16 AM" src="https://github.com/user-attachments/assets/3d05c2e2-1198-451c-9ccc-189c749e4413" />
