### PR TITLE
[DO NOT MERGE] Bugfix: delete label and remove it from profile in same gitops op should not result in broken profile

### DIFF
--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl"
@@ -219,4 +220,140 @@ func (s *integrationGitopsTestSuite) TestFleetGitopsWithFleetSecrets() {
 	winProfile, err := s.DS.GetMDMWindowsConfigProfile(ctx, windowsProfileUUID)
 	require.NoError(t, err)
 	assert.Contains(t, string(winProfile.SyncML), "${FLEET_SECRET_"+secretName2+"}")
+}
+
+// for https://github.com/fleetdm/fleet/issues/28107
+func (s *integrationGitopsTestSuite) TestGitopsDeleteLabelAndRemoveFromProfile() {
+	t := s.T()
+	ctx := t.Context()
+	fleetctlConfig := s.createFleetctlConfig()
+
+	gitopsDir := t.TempDir()
+
+	// create the labels files
+	labelA := writeGitopsFile(t, gitopsDir, "labelA-*.yml", `
+- name: A
+  query: SELECT 1;
+  label_membership_type: dynamic
+`)
+
+	labelB := writeGitopsFile(t, gitopsDir, "labelB-*.yml", `
+- name: B
+  query: SELECT 2;
+  label_membership_type: dynamic
+`)
+
+	// create the profile file
+	profile := writeGitopsFile(t, gitopsDir, "profile-*.mobileconfig", `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadDescription</key><string>prof1</string>
+  <key>PayloadDisplayName</key><string>prof1</string>
+  <key>PayloadIdentifier</key><string>com.fleet.1</string>
+  <key>PayloadOrganization</key><string>Fleet</string>
+  <key>PayloadRemovalDisallowed</key><false/>
+  <key>PayloadScope</key><string>System</string>
+  <key>PayloadType</key><string>Configuration</string>
+  <key>PayloadUUID</key><string>D399FCFD-C68A-4939-BFA1-CD2814778D25</string>
+  <key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>
+`)
+
+	// create the gitops file
+	globalFile := writeGitopsFile(t, gitopsDir, "global-*.yml", fmt.Sprintf(`
+policies:
+queries:
+agent_options:
+controls:
+  macos_settings:
+    custom_settings:
+      - path: ./%s
+        labels_include_any: 
+        - A
+        - B
+labels:
+  - path: ./%s
+  - path: ./%s
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: "$FLEET_GLOBAL_ENROLL_SECRET"
+`, filepath.Base(profile), filepath.Base(labelA), filepath.Base(labelB)))
+
+	// Set the required environment variables
+	t.Setenv("FLEET_URL", s.Server.URL)
+	t.Setenv("FLEET_GLOBAL_ENROLL_SECRET", "global_enroll_secret")
+
+	// apply this config
+	fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile})
+
+	// at this point the profile is valid and has "include any" with labels A and B
+	profs, _, err := s.DS.ListMDMConfigProfiles(ctx, nil, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, profs, 1)
+	require.Equal(t, "prof1", profs[0].Name)
+	require.Len(t, profs[0].LabelsIncludeAny, 2)
+	// labels are sorted by name so this is deterministic
+	require.Equal(t, "A", profs[0].LabelsIncludeAny[0].LabelName)
+	require.False(t, profs[0].LabelsIncludeAny[0].Broken)
+	require.Equal(t, "B", profs[0].LabelsIncludeAny[1].LabelName)
+	require.False(t, profs[0].LabelsIncludeAny[1].Broken)
+
+	// update the gitops config to remove label A from the profile and delete it
+	// from Fleet at the same time (so it shouldn't be "broken" in the proflie as
+	// it is removed from it).
+	globalFile = writeGitopsFile(t, gitopsDir, "global-*.yml", fmt.Sprintf(`
+policies:
+queries:
+agent_options:
+controls:
+  macos_settings:
+    custom_settings:
+      - path: ./%s
+        labels_include_any: 
+        - B
+labels:
+  - path: ./%s
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: "$FLEET_GLOBAL_ENROLL_SECRET"
+`, filepath.Base(profile), filepath.Base(labelB)))
+
+	// apply this config
+	fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile})
+
+	profs, _, err = s.DS.ListMDMConfigProfiles(ctx, nil, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, profs, 1)
+	require.Equal(t, "prof1", profs[0].Name)
+	// TODO: the following line should fail, it should show as 2 labels and 1
+	// broken, but it doesn't... maybe it's a race?
+	require.Len(t, profs[0].LabelsIncludeAny, 1)
+	require.Equal(t, "B", profs[0].LabelsIncludeAny[0].LabelName)
+	require.False(t, profs[0].LabelsIncludeAny[0].Broken)
+}
+
+// if dir is empty, t.TempDir() is used. Returns the path to the file.
+func writeGitopsFile(t *testing.T, dir, pattern, content string) string {
+	t.Helper()
+
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	f, err := os.CreateTemp(dir, pattern)
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	err = f.Close()
+	require.NoError(t, err)
+	return f.Name()
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #28107 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
