### PR TITLE
Website: Update "Talk to us" form

### DIFF
--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -106,7 +106,7 @@ module.exports = {
         lastName,
         organization,
       }).tolerate((err)=>{
-        sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`)
+        sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`);
         return {};
       });
 

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -135,8 +135,6 @@ module.exports = {
         // FUTURE: create POV here
       }
     }
-
-    return;
   }
 
 

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -105,7 +105,7 @@ module.exports = {
             sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
           }
         });
-        return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
+        return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
       } else {
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Number of hosts: ${numberOfHosts}`;
         sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
@@ -113,7 +113,7 @@ module.exports = {
             sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
           }
         });
-        return `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
+        return `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
       }
     } else {// If the enrichment helper didn't return a  employer.numberOfEmployees value, use the submitted number of hosts.
       if(numberOfHosts >= 700){
@@ -123,7 +123,7 @@ module.exports = {
             sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
           }
         });
-        return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`
+        return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
       } else {
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Number of hosts: ${numberOfHosts}`;
         sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -77,13 +77,6 @@ module.exports = {
     if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
       throw 'invalidEmailDomain';
     }
-    // Use the getEnriched helper to see if we can find out how many employees this user's company has.
-    let enrichmentInformation = await sails.helpers.iq.getEnriched.with({
-      emailAddress,
-      firstName,
-      lastName,
-      organization,
-    });
 
     let contactInformation = {
       emailAddress: emailAddress,
@@ -96,9 +89,29 @@ module.exports = {
       psychologicalStageChangeReason: 'Website - Contact forms'
     };
 
-    // If we got a employer.numberOfEmployees value from the getEnriched helper, use that to determine which Calendly event to send them to (if it is more than the provided numberOfHosts).
-    if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees && enrichmentInformation.employer.numberOfEmployees > numberOfHosts) {
-      if(enrichmentInformation.employer.numberOfEmployees >= 700){
+    // If the user said they have 700+ hosts, Update/create a contact and account, and send them to the "Talk to us" Calendly event.
+    if(numberOfHosts >= 700){
+      contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event. Number of hosts: ${numberOfHosts}`;
+      sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
+        if(err) {
+          sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
+        }
+      });
+      return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
+    } else {
+      // If the user has <700 hosts, use the get-enriched helper to try to find the number of employees at their organization.
+      let enrichmentInformation = await sails.helpers.iq.getEnriched.with({
+        emailAddress,
+        firstName,
+        lastName,
+        organization,
+      }).tolerate((err)=>{
+        sails.log.warn(`When a user (${emailAddress}) submitted the "Talk to us form", an error occured while getting enrichment information for this user. Error from get-enriched helper: ${require('util').inspect(err)}`)
+        return {};
+      });
+
+      // If we got a employer.numberOfEmployees value from the getEnriched helper, send the user to the "talk to us" calendly event if it is 700+.
+      if(enrichmentInformation.employer && enrichmentInformation.employer.numberOfEmployees && enrichmentInformation.employer.numberOfEmployees >= 700) {
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event because of the number of employees (${enrichmentInformation.employer.numberOfEmployees}) returned by Coresignal. Number of hosts: ${numberOfHosts}`;
         sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
           if(err) {
@@ -107,24 +120,7 @@ module.exports = {
         });
         return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
       } else {
-        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Number of hosts: ${numberOfHosts}`;
-        sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
-          if(err) {
-            sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
-          }
-        });
-        return `https://calendly.com/fleetdm/chat?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
-      }
-    } else {// If the enrichment helper didn't return a  employer.numberOfEmployees value, use the submitted number of hosts.
-      if(numberOfHosts >= 700){
-        contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Talk to us" event. Number of hosts: ${numberOfHosts}`;
-        sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
-          if(err) {
-            sails.log.warn(`Background task failed: When a user submitted the "Talk to us" form, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
-          }
-        });
-        return `https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(emailAddress)}&name=${encodeURIComponent(firstName+' '+lastName)}`;
-      } else {
+      // If the enrichment helper didn't return a employer.numberOfEmployees value and this user has <700 hosts, send them to the "Let's get you set up!" Calendly event
         contactInformation.description = `Submitted the "Talk to us" form and was taken to the Calendly page for the "Let\'s get you set up!" event. Number of hosts: ${numberOfHosts}`;
         sails.helpers.salesforce.updateOrCreateContactAndAccount.with(contactInformation).exec((err)=>{
           if(err) {

--- a/website/assets/js/pages/contact.page.js
+++ b/website/assets/js/pages/contact.page.js
@@ -98,7 +98,7 @@ parasails.registerPage('contact', {
       this.cloudSuccess = true;
 
     },
-    submittedTalkToUsForm: async function() {
+    handleSubmittingTalkToUsForm: async function(argins) {
       this.syncing = true;
       if(typeof gtag !== 'undefined'){
         gtag('event','fleet_website__contact_forms');
@@ -109,11 +109,9 @@ parasails.registerPage('contact', {
       if(typeof analytics !== 'undefined'){
         analytics.track('fleet_website__contact_forms');
       }
-      if(this.formData.numberOfHosts >= 700){
-        this.goto(`https://calendly.com/fleetdm/talk-to-us?email=${encodeURIComponent(this.formData.emailAddress)}&name=${encodeURIComponent(this.formData.firstName+' '+this.formData.lastName)}`);
-      } else {
-        this.goto(`https://calendly.com/fleetdm/chat?email=${encodeURIComponent(this.formData.emailAddress)}&name=${encodeURIComponent(this.formData.firstName+' '+this.formData.lastName)}`);
-      }
+      let eventUrl = await Cloud.deliverTalkToUsFormSubmission.with(argins);
+
+      this.goto(eventUrl);
     },
 
     clickSwitchForms: function(form) {

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -66,7 +66,7 @@
         </ajax-form>
       </div>
       <div v-else>
-        <ajax-form :handle-submitting="handleSubmittingTalkToUsForm" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules" :syncing.sync="syncing" :cloud-error.sync="cloudError">
+        <ajax-form :handle-submitting="handleSubmittingTalkToUsForm" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules"  :cloud-error.sync="cloudError">
           <div class="form-group">
             <label for="email-address">Work email *</label>
             <input class="form-control" id="email-address" name="email-address" type="email" :class="[formErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" autocomplete="email" focus-first>

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -66,7 +66,7 @@
         </ajax-form>
       </div>
       <div v-else>
-        <ajax-form action="deliverTalkToUsFormSubmission" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules" :syncing.sync="syncing" :cloud-error.sync="cloudError" @submitted="submittedTalkToUsForm()">
+        <ajax-form :handle-submitting="handleSubmittingTalkToUsForm" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules" :syncing.sync="syncing" :cloud-error.sync="cloudError">
           <div class="form-group">
             <label for="email-address">Work email *</label>
             <input class="form-control" id="email-address" name="email-address" type="email" :class="[formErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" autocomplete="email" focus-first>


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/11779

Changes:
- Updated the `deliver-talk-to-us-form-submission` to use information returned by the getEnriched helper to determine the Calendly event users are taken to when they submit the form.