### PR TITLE
Deploying Fleet on AWS with Terraform guide updates

### DIFF
--- a/articles/deploy-fleet-on-aws-with-terraform.md
+++ b/articles/deploy-fleet-on-aws-with-terraform.md
@@ -40,48 +40,22 @@ vpc_name = "fleet-vpc"
 4. Run a command like the following in Terminal:
     
 ```
-% terraform init ~/Downloads/main.tf
+terraform init
 ```
 
 > If the file was not downloaded to the downloads folder, ensure that you adjust the file path in the command.
 
-> This step will take around 15 minutes.
+> This step will take around 30 minutes.
 
 5. Run the following command in Terminal:
 
 ```
-terraform apply -target module.fleet.module.vpc
-```
-
-6. Run the following command in Terminal:
-    
-```
-terraform apply -target module.osquery-carve -target module.firehose-logging
-```
-
-7. Log in to your AWS Route 53 instance
-
-8. Run the following command in Terminal:
-
-```
-terraform apply -target aws_route53_zone.main
-```
-
-9. From the Terminal output, obtain the NS records created for the zone and add them to the parent DNS zone in the AWS Route 53 GUI. Ensure you're *adding* the subdomain and its NS records to the parent DNS, not changing the NS records for the parent. For example: if the subdomain is `fleet.acme.com` and the NS record is `ns-420.awsdns-52.com`, *add* this record to the parent domain. 
-
-10. Run the following command in Terminal:
-    
-```
-terraform apply -target module.fleet
-```
-
-11. Run the following command in Terminal:
-    
-```
 terraform apply
 ```
 
-12. That’s it! You should now be able to log in to Fleet and [enroll a host](https://fleetdm.com/docs/using-fleet/enroll-hosts).
+6. From the Terminal output, obtain the NS records created for the zone and add them to the parent DNS zone in the AWS Route 53 GUI. Ensure you're *adding* the subdomain and its NS records to the parent DNS, not changing the NS records for the parent. For example: if the subdomain is `fleet.acme.com` and the NS record is `ns-420.awsdns-52.com`, *add* this record to the parent domain. 
+
+7. That’s it! You should now be able to log in to Fleet and [enroll a host](https://fleetdm.com/docs/using-fleet/enroll-hosts).
 
 ## Advanced
 


### PR DESCRIPTION
**Related issue:** Resolves https://github.com/fleetdm/fleet-terraform/issues/59

**Updated Deploy Fleet on AWS with Terraform guide**
- Consolidated steps to reflect recent updates to [Fleet-terraform modules](https://github.com/fleetdm/fleet-terraform) and [Fleet-terraform example](https://github.com/fleetdm/fleet-terraform/tree/main/example)