### PR TITLE
Website: update page IDs for /scripts, /mdm-commands, and /os-settings.

### DIFF
--- a/website/assets/js/pages/mdm-commands.page.js
+++ b/website/assets/js/pages/mdm-commands.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('mdm-commands', {
+parasails.registerPage('mdm-commands-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/js/pages/os-settings.page.js
+++ b/website/assets/js/pages/os-settings.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('os-settings', {
+parasails.registerPage('os-settings-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/js/pages/scripts.page.js
+++ b/website/assets/js/pages/scripts.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('scripts', {
+parasails.registerPage('scripts-page', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/styles/pages/mdm-commands.less
+++ b/website/assets/styles/pages/mdm-commands.less
@@ -1,4 +1,4 @@
-#mdm-commands {
+#mdm-commands-page {
   min-height: 800px;
   p, strong {
     color: #515774;

--- a/website/assets/styles/pages/os-settings.less
+++ b/website/assets/styles/pages/os-settings.less
@@ -1,4 +1,4 @@
-#os-settings {
+#os-settings-page {
   min-height: 800px;
   p, strong {
     color: #515774;

--- a/website/assets/styles/pages/scripts.less
+++ b/website/assets/styles/pages/scripts.less
@@ -1,4 +1,4 @@
-#scripts {
+#scripts-page {
   min-height: 800px;
   p, strong {
     color: #515774;

--- a/website/views/pages/mdm-commands.ejs
+++ b/website/views/pages/mdm-commands.ejs
@@ -1,4 +1,4 @@
-<div id="mdm-commands" v-cloak>
+<div id="mdm-commands-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
       <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>

--- a/website/views/pages/os-settings.ejs
+++ b/website/views/pages/os-settings.ejs
@@ -1,4 +1,4 @@
-<div id="os-settings" v-cloak>
+<div id="os-settings-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
       <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>

--- a/website/views/pages/scripts.ejs
+++ b/website/views/pages/scripts.ejs
@@ -1,4 +1,4 @@
-<div id="scripts" v-cloak>
+<div id="scripts-page" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
       <docs-nav-and-search  current-section="controls" :algolia-public-key="algoliaPublicKey" ></docs-nav-and-search>


### PR DESCRIPTION
Closes #33354

Changes:
- Updated the page IDs of the /scripts, /os-settings, and /mdm-commands pages to prevent the styles from being applied to headings on documentation pages.