### PR TITLE
Software ingestion fixes

### DIFF
--- a/changes/29053-sw-names-on-ingest
+++ b/changes/29053-sw-names-on-ingest
@@ -1,0 +1,1 @@
+* Re-added and optimized fix for macos software ingestion to prevent duplicate software due to end user renaming software on host.

--- a/changes/33298-software-ingestion
+++ b/changes/33298-software-ingestion
@@ -1,0 +1,1 @@
+* Improved software ingestion DB lock times by pre-inserting software/titles in smaller batches when hosts check in.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -35,6 +35,10 @@ type softwareIDChecksum struct {
 	Source           string  `db:"source"`
 }
 
+// tracer is an OTEL tracer. It has no-op behavior when OTEL is not enabled.
+// If provider is set later (with otel.SetTracerProvider), the tracer will start using the new provider.
+var tracer = otel.Tracer("github.com/fleetdm/fleet/v4/server/datastore/mysql")
+
 // Since DB may have millions of software items, we need to batch the aggregation counts to avoid long SQL query times.
 // This is a variable so it can be adjusted during unit testing.
 var countHostSoftwareBatchSize = uint64(100000)
@@ -59,7 +63,6 @@ func softwareSliceToMap(softwareItems []fleet.Software) map[string]fleet.Softwar
 
 func (ds *Datastore) UpdateHostSoftware(ctx context.Context, hostID uint, software []fleet.Software) (*fleet.UpdateHostSoftwareDBResult, error) {
 	// OTEL instrumentation. It has no-op behavior when OTEL is not enabled.
-	tracer := otel.Tracer("github.com/fleetdm/fleet/v4/server/datastore/mysql")
 	ctx, span := tracer.Start(ctx, "mysql.UpdateHostSoftware",
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -605,6 +605,11 @@ func (ds *Datastore) getExistingSoftware(
 					swWithID := sw
 					swWithID.ID = s.ID
 					existingBundleIDsToUpdate[*s.BundleIdentifier] = swWithID
+
+					// Remove from incomingChecksumToSoftware to prevent it being treated as new software
+					if cs, ok := bundleIDsToChecksum[*s.BundleIdentifier]; ok {
+						delete(incomingChecksumToSoftware, cs)
+					}
 					continue
 				}
 			}
@@ -620,15 +625,6 @@ func (ds *Datastore) getExistingSoftware(
 	incomingChecksumToTitle, _, err = ds.getIncomingSoftwareChecksumsToExistingTitles(ctx, newSoftware, incomingChecksumToSoftware)
 	if err != nil {
 		return nil, nil, nil, nil, ctxerr.Wrap(ctx, err, "get incoming software checksums to existing titles")
-	}
-
-	for bid := range existingBundleIDsToUpdate {
-		if cs, ok := bundleIDsToChecksum[bid]; ok {
-			// we don't want this to be treated as a new software title, because then a new software
-			// entry will be created. Instead, we want to update the existing entries with the new
-			// names.
-			delete(incomingChecksumToSoftware, cs)
-		}
 	}
 
 	return currentSoftware, incomingChecksumToSoftware, incomingChecksumToTitle, existingBundleIDsToUpdate, nil

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"bytes"
 	"context"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -1865,6 +1866,7 @@ func testUpdateHostSoftwareSameBundleIDDifferentNames(t *testing.T, ds *Datastor
 	require.NoError(t, err)
 	require.Len(t, host.Software, 1)
 	require.Equal(t, "GoLand.app", host.Software[0].Name)
+	originalSoftwareID := host.Software[0].ID
 
 	// Now update with the same bundle ID but different name
 	// The behavior depends on how the system handles bundle ID matching
@@ -1881,6 +1883,7 @@ func testUpdateHostSoftwareSameBundleIDDifferentNames(t *testing.T, ds *Datastor
 	require.Len(t, host.Software, 1)
 	// The existing software entry is reused (matched by bundle ID)
 	require.Equal(t, "GoLand.app", host.Software[0].Name)
+	require.Equal(t, originalSoftwareID, host.Software[0].ID, "Should reuse the same software row")
 
 	// Verify only one software title exists
 	var titleCount int
@@ -8938,7 +8941,7 @@ func testPreInsertSoftwareInventory(t *testing.T, ds *Datastore) {
 	softwareChecksums := make(map[string]fleet.Software)
 	for i := 0; i < 10; i++ {
 		checksum := make([]byte, 32)
-		rand.Read(checksum)
+		_, _ = crand.Read(checksum)
 		checksumStr := hex.EncodeToString(checksum)
 		softwareChecksums[checksumStr] = fleet.Software{
 			Name:     fmt.Sprintf("idempotent-test-%d", i),

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1834,10 +1834,9 @@ func testUpdateHostSoftware(t *testing.T, ds *Datastore) {
 	ds.logger = oldLogger
 
 	// Test edge case: Software with same bundle identifier but different names
-	// SKIP: This test is skipped due to complex bundle ID matching behavior that needs
-	// further investigation. The refactored code maintains the same behavior as before.
+	// When software with the same bundle ID but different name is added, the system
+	// reuses the existing software entry (matched by bundle ID) and links it to the host
 	t.Run("SameBundleIDDifferentNames", func(t *testing.T) {
-		t.Skip("Skipping bundle ID matching test - needs investigation of matching logic")
 		host := test.NewHost(t, ds, "bundle-host", "", "bundlekey", "bundleuuid", time.Now())
 
 		// First, add software with a bundle ID


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:**
Resolves #29053
Resolves #33298

For reference, the diffs for merging Konstantin's changes into my original PR are here: https://github.com/fleetdm/fleet/pull/33390

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed duplicate macOS software entries caused by users renaming apps, ensuring accurate, consolidated inventory.

- Documentation
  - Documented improved software ingestion performance by pre-inserting data in smaller batches to reduce database lock times during host check-ins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->