### PR TITLE
Cherry-pick fleetd v1.48.1: Changes to not rely on Fleet Desktop for Linux setup experience (#33018)

### DIFF
--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -264,6 +264,10 @@ func (svc *Service) GetDeviceSetupExperienceStatus(ctx context.Context) (*fleet.
 		return nil, ctxerr.New(ctx, "internal error: missing host from request context")
 	}
 
+	return svc.getHostSetupExperienceStatus(ctx, host)
+}
+
+func (svc *Service) getHostSetupExperienceStatus(ctx context.Context, host *fleet.Host) (*fleet.DeviceSetupExperienceStatusPayload, error) {
 	hostUUID, err := fleet.HostUUIDForSetupExperience(host)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "failed to get host's UUID for the setup experience")

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -15,9 +15,21 @@ import (
 func (svc *Service) GetOrbitSetupExperienceStatus(ctx context.Context, orbitNodeKey string, forceRelease bool) (*fleet.SetupExperienceStatusPayload, error) {
 	// this is not a user-authenticated endpoint
 	svc.authz.SkipAuthorization(ctx)
-	host, err := svc.ds.LoadHostByOrbitNodeKey(ctx, orbitNodeKey)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "loading host by orbit node key")
+
+	host, ok := hostctx.FromContext(ctx)
+	if !ok {
+		err := ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+		return nil, err
+	}
+
+	if fleet.IsLinux(host.Platform) {
+		status, err := svc.getHostSetupExperienceStatus(ctx, host)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "get host setup experience status")
+		}
+		return &fleet.SetupExperienceStatusPayload{
+			Software: status.Software,
+		}, nil
 	}
 
 	appCfg, err := svc.ds.AppConfig(ctx)

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1551,16 +1551,19 @@ func main() {
 		go sigusrListener(c.String("root-dir"))
 
 		isLinux := runtime.GOOS == "linux"
-		serverHasWebSetup := orbitClient.GetServerCapabilities().Has(fleet.CapabilityWebSetupExperience)
 		setupExperienceNotDisabled := !c.Bool("disable-setup-experience")
-		runSetupExperience := isLinux && serverHasWebSetup && setupExperienceNotDisabled
+		runSetupExperience := isLinux && setupExperienceNotDisabled
 		log.Debug().
 			Bool("isLinux", isLinux).
-			Bool("serverHasSetup", serverHasWebSetup).
 			Bool("notDisabled", setupExperienceNotDisabled).
 			Msg("checking setup experience preflight values")
 
 		openMyDevicePage := func() error {
+			if !c.Bool("fleet-desktop") {
+				log.Debug().Msg("fleet desktop disabled, not launching my device page")
+				return nil
+			}
+
 			log.Debug().Msg("launching browser for my device page")
 			token, err := trw.Read()
 			if err != nil {
@@ -1603,8 +1606,7 @@ func main() {
 
 		if runSetupExperience {
 			log.Debug().Msg("web setup experience enabled")
-			setupExpPath := path.Join(c.String("root-dir"), constant.SetupExperienceFilename)
-			if err := processSetupExperience(orbitClient, setupExpPath, openMyDevicePage); err != nil {
+			if err := processSetupExperience(orbitClient, c.String("root-dir"), openMyDevicePage); err != nil {
 				log.Error().Err(err).Msg("initiating setup experience")
 			}
 		} else {
@@ -1628,75 +1630,75 @@ func main() {
 	}
 }
 
-func processSetupExperience(oc *service.OrbitClient, setupExperienceStatusPath string, openMyDevicePage func() error) error {
+func processSetupExperience(orbitClient *service.OrbitClient, rootDir string, openMyDevicePage func() error) error {
 	log.Debug().Msg("checking setup experience file")
-	exp, err := readSetupExperienceStatusFile(setupExperienceStatusPath)
+	exp, err := setupexperience.ReadSetupExperienceStatusFile(rootDir)
 	if err != nil {
 		return fmt.Errorf("read setup experience file: %w", err)
 	}
 
-	// Setup experience has been completed
-	if exp != nil && exp.TimeInitiated != nil {
+	switch {
+	case exp == nil:
+		// If communicating with an old Fleet server, write setup experience file and not run setup experience.
+		if !orbitClient.GetServerCapabilities().Has(fleet.CapabilityWebSetupExperience) {
+			log.Debug().Msg("server does not support setup experience, writing setup experience file, and continuing")
+			initTime := time.Now()
+			if err := setupexperience.WriteSetupExperienceStatusFile(rootDir, &setupexperience.SetupExperienceInfo{
+				TimeInitiated: initTime,
+				Enabled:       false,
+			}); err != nil {
+				return fmt.Errorf("writing setup experience file: %w", err)
+			}
+			return nil
+		}
+
+		// Setup experience wasn't checked yet, we start it.
+		log.Info().Msg("initiating setup experience")
+		initSetupExperienceResponse, err := orbitClient.InitiateSetupExperience()
+		switch {
+		case err == nil:
+			// OK, continue
+		case errors.Is(err, service.ErrMissingLicense):
+			// Setup experience is a premium feature.
+			log.Debug().Msg("setup experience is a premium feature, writing setup experience file, and continuing")
+			initSetupExperienceResponse = fleet.SetupExperienceInitResult{
+				Enabled: false,
+			}
+		default:
+			return fmt.Errorf("initializing server-side setup experience: %w", err)
+		}
+		if initSetupExperienceResponse.Enabled {
+			// Setup experience enabled for us and is now kicked off, open a browser
+			if err := openMyDevicePage(); err != nil {
+				log.Error().Err(err).Msg("opening setup experience my device page using")
+			}
+		}
+		// Even if it wasn't enabled, mark it as complete so we don't start it again later
+		initTime := time.Now()
+		log.Info().
+			Time("time", initTime).
+			Bool("enabled", initSetupExperienceResponse.Enabled).
+			Msg("writing setup experience file")
+		if err := setupexperience.WriteSetupExperienceStatusFile(rootDir, &setupexperience.SetupExperienceInfo{
+			TimeInitiated: initTime,
+			Enabled:       initSetupExperienceResponse.Enabled,
+		}); err != nil {
+			return fmt.Errorf("writing setup experience file: %w", err)
+		}
+
+		setupExperiencer := setupexperience.NewLinuxSetupExperiencer(orbitClient, rootDir)
+		orbitClient.RegisterConfigReceiver(setupExperiencer)
+	case !exp.Enabled:
+		// Setup experience was checked, but was disabled at the time, nothing else to do.
+		log.Debug().Msg("setup experience already checked and disabled at the time")
+	case exp.TimeFinished == nil:
+		// Setup experience started but not finished.
+		log.Debug().Msg("setup experience started but not finished")
+		setupExperiencer := setupexperience.NewLinuxSetupExperiencer(orbitClient, rootDir)
+		orbitClient.RegisterConfigReceiver(setupExperiencer)
+	case exp.TimeFinished != nil:
+		// Setup experience is complete, nothing else to do.
 		log.Debug().Msg("setup experience already completed")
-		return nil
-	}
-
-	log.Debug().Msg("initiating setup experience")
-	resp, err := oc.InitiateSetupExperience()
-	if err != nil {
-		return fmt.Errorf("initializing server-side setup experience: %w", err)
-	}
-
-	// Setup experience enabled for us and is now kicked off, open a browser
-	if resp.Enabled {
-		if err := openMyDevicePage(); err != nil {
-			log.Err(err).Msg("opening setup experience my device page using")
-		}
-	} else {
-		log.Debug().Msg("setup experience not enabled on team")
-	}
-
-	// Even if it wasn't enabled, mark it as complete so we don't start it again later
-	log.Debug().Msg("writing setup experience file")
-	initTime := time.Now()
-	if err := writeSetupExperienceStatusFile(setupExperienceStatusPath, &SetupExperienceInfo{
-		TimeInitiated: &initTime,
-	}); err != nil {
-		return fmt.Errorf("writing setup experience file: %w", err)
-	}
-
-	return nil
-}
-
-type SetupExperienceInfo struct {
-	TimeInitiated *time.Time `json:"time_initiated,omitempty"`
-}
-
-// Returns the time setup experience was completed, or nil if it hasn't
-func readSetupExperienceStatusFile(experienceCompletedPath string) (*SetupExperienceInfo, error) {
-	f, err := os.Open(experienceCompletedPath)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("read setup experience file: %w", err)
-	}
-	var exp *SetupExperienceInfo
-	if err := json.NewDecoder(f).Decode(exp); err != nil {
-		return nil, fmt.Errorf("decoding setup experience file: %w", err)
-	}
-
-	return exp, nil
-}
-
-func writeSetupExperienceStatusFile(experienceCompletedPath string, exp *SetupExperienceInfo) error {
-	f, err := os.Create(experienceCompletedPath)
-	if err != nil {
-		return fmt.Errorf("create setup experience completed file: %w", err)
-	}
-
-	if err := json.NewEncoder(f).Encode(exp); err != nil {
-		return fmt.Errorf("write setup experience completed file: %w", err)
 	}
 
 	return nil

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -77,6 +77,7 @@ const (
 	DesktopTUFTargetName = "desktop"
 	// FleetURLFileName is the file where Fleet URL is stored after being read from Apple config profile.
 	FleetURLFileName = "fleet_url.txt"
+
 	// SetupExperienceComplete is a file created when Linux (and soon Windows) completes setup experience
 	SetupExperienceFilename = "setup_experience.json"
 

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -129,7 +129,7 @@ func connectOsquery(r *Runner) error {
 	if r.OsqueryClient == nil {
 		osqueryClient, err := osquery.NewClient(r.osquerySocketPath, 10*time.Second)
 		if err != nil {
-			log.Err(err).Msg("establishing osquery connection for software install runner")
+			log.Error().Err(err).Msg("establishing osquery connection for software install runner")
 			return err
 		}
 
@@ -266,7 +266,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 		}
 		err := removeAllFn(tmpDir)
 		if err != nil {
-			log.Err(err)
+			log.Error().Err(err).Msg("failed to remove tmp dir")
 		}
 	}()
 
@@ -322,7 +322,7 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 	if strings.HasSuffix(installerPath, ".tgz") || strings.HasSuffix(installerPath, ".tar.gz") {
 		logger.Info().Msg("detected tar.gz archive, extracting to subdirectory")
 		extractDestination := filepath.Join(tmpDir, extractionDirectoryName)
-		err := os.Mkdir(extractDestination, 0700)
+		err := os.Mkdir(extractDestination, 0o700)
 		if err != nil {
 			logger.Err(err).Msg("failed to create directory for .tar.gz extraction")
 			// Using download failed exit code here to indicate that installer extraction failed

--- a/orbit/pkg/setup_experience/setup_experience_test.go
+++ b/orbit/pkg/setup_experience/setup_experience_test.go
@@ -1,0 +1,44 @@
+package setupexperience
+
+import (
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSetupExperienceStatusFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Test first execution of reading the setup experience file.
+	s, err := ReadSetupExperienceStatusFile(tmpDir)
+	require.NoError(t, err)
+	require.Nil(t, s)
+
+	err = WriteSetupExperienceStatusFile(tmpDir, &SetupExperienceInfo{
+		TimeInitiated: time.Now(),
+		Enabled:       true,
+	})
+	require.NoError(t, err)
+
+	s, err = ReadSetupExperienceStatusFile(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.NotZero(t, s.TimeInitiated)
+	timeInitiated := s.TimeInitiated
+	require.True(t, s.Enabled)
+	require.Nil(t, s.TimeFinished)
+
+	s.TimeFinished = ptr.Time(time.Now())
+	err = WriteSetupExperienceStatusFile(tmpDir, s)
+	require.NoError(t, err)
+
+	s, err = ReadSetupExperienceStatusFile(tmpDir)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	require.Equal(t, timeInitiated, s.TimeInitiated)
+	require.True(t, s.Enabled)
+	require.NotNil(t, s.TimeFinished)
+	require.NotZero(t, *s.TimeFinished)
+}

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1024,6 +1024,10 @@ func IsLinux(hostPlatform string) bool {
 	return slices.Contains(HostLinuxOSs, hostPlatform)
 }
 
+func IsApplePlatform(hostPlatform string) bool {
+	return hostPlatform == "darwin" || hostPlatform == "ios" || hostPlatform == "ipados"
+}
+
 func IsUnixLike(hostPlatform string) bool {
 	unixLikeOSs := HostLinuxOSs
 	unixLikeOSs = append(unixLikeOSs, "darwin")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -941,7 +941,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	oe.POST("/api/fleet/orbit/software_install/details", getOrbitSoftwareInstallDetails, orbitGetSoftwareInstallRequest{})
 	oe.POST("/api/fleet/orbit/setup_experience/init", orbitSetupExperienceInitEndpoint, orbitSetupExperienceInitRequest{})
 
-	oeAppleMDM := oe.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyAppleMDM())
+	// POST /api/fleet/orbit/setup_experience/status is used by macOS and Linux hosts.
+	// For macOS hosts we verify Apple MDM is enabled and configured.
+	oeAppleMDM := oe.WithCustomMiddlewareAfterAuth(mdmConfiguredMiddleware.VerifyAppleMDMOnMacOSHosts())
 	oeAppleMDM.POST("/api/fleet/orbit/setup_experience/status", getOrbitSetupExperienceStatusEndpoint, getOrbitSetupExperienceStatusRequest{})
 
 	oeWindowsMDM := oe.WithCustomMiddleware(mdmConfiguredMiddleware.VerifyWindowsMDM())

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -10033,7 +10033,9 @@ func (s *integrationTestSuite) TestMDMNotConfiguredEndpoints() {
 
 	// create a host with device token to test device authenticated routes
 	tkn := "D3V1C370K3N"
-	createHostAndDeviceToken(t, s.ds, tkn)
+	h := createHostAndDeviceToken(t, s.ds, tkn)
+	orbitKey := setOrbitEnrollment(t, h, s.ds)
+	h.OrbitNodeKey = &orbitKey
 
 	windowsOnly := windowsMDMConfigurationRequiredEndpoints()
 
@@ -10051,7 +10053,13 @@ func (s *integrationTestSuite) TestMDMNotConfiguredEndpoints() {
 		if route.deviceAuthenticated {
 			path = fmt.Sprintf(path, tkn)
 		}
-		res := s.Do(route.method, path, nil, expectedErr.StatusCode())
+		var params interface{}
+		if route.method == "POST" && route.path == "/api/fleet/orbit/setup_experience/status" {
+			params = getOrbitSetupExperienceStatusRequest{
+				OrbitNodeKey: *h.OrbitNodeKey,
+			}
+		}
+		res := s.Do(route.method, path, params, expectedErr.StatusCode())
 		errMsg := extractServerErrorText(res.Body)
 		assert.Contains(t, errMsg, expectedErr.Error(), fmt.Sprintf("%s %s", route.method, path))
 	}

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -511,15 +511,19 @@ type HandlerFunc func(ctx context.Context, request interface{}, svc fleet.Servic
 type AndroidFunc func(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer
 
 type CommonEndpointer[H HandlerFunc | AndroidFunc] struct {
-	EP               Endpointer[H]
-	MakeDecoderFn    func(iface interface{}) kithttp.DecodeRequestFunc
-	EncodeFn         kithttp.EncodeResponseFunc
-	Opts             []kithttp.ServerOption
-	AuthFunc         func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint
-	FleetService     fleet.Service
-	Router           *mux.Router
+	EP            Endpointer[H]
+	MakeDecoderFn func(iface interface{}) kithttp.DecodeRequestFunc
+	EncodeFn      kithttp.EncodeResponseFunc
+	Opts          []kithttp.ServerOption
+	AuthFunc      func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint
+	FleetService  fleet.Service
+	Router        *mux.Router
+	Versions      []string
+
+	// CustomMiddleware are middlewares that run before AuthFunc.
 	CustomMiddleware []endpoint.Middleware
-	Versions         []string
+	// CustomMiddlewareAfterAuth are middlewares that run after AuthFunc.
+	CustomMiddlewareAfterAuth []endpoint.Middleware
 
 	startingAtVersion string
 	endingAtVersion   string
@@ -565,10 +569,20 @@ func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
 	next := func(ctx context.Context, request interface{}) (interface{}, error) {
 		return e.EP.CallHandlerFunc(f, ctx, request, e.EP.Service())
 	}
-	endp := e.AuthFunc(e.FleetService, next)
 
-	// apply middleware in reverse order so that the first wraps the second
-	// wraps the third etc.
+	// Apply "after auth" middleware (in reverse order so that the first wraps
+	// the second wraps the third etc.)
+	endp := next
+	if len(e.CustomMiddlewareAfterAuth) > 0 {
+		for i := len(e.CustomMiddlewareAfterAuth) - 1; i >= 0; i-- {
+			mw := e.CustomMiddlewareAfterAuth[i]
+			endp = mw(endp)
+		}
+	}
+	endp = e.AuthFunc(e.FleetService, endp)
+
+	// Apply "before auth" middleware (in reverse order so that the first wraps
+	// the second wraps the third etc.)
 	for i := len(e.CustomMiddleware) - 1; i >= 0; i-- {
 		mw := e.CustomMiddleware[i]
 		endp = mw(endp)
@@ -609,6 +623,12 @@ func (e *CommonEndpointer[H]) WithAltPaths(paths ...string) *CommonEndpointer[H]
 func (e *CommonEndpointer[H]) WithCustomMiddleware(mws ...endpoint.Middleware) *CommonEndpointer[H] {
 	ae := *e
 	ae.CustomMiddleware = mws
+	return &ae
+}
+
+func (e *CommonEndpointer[H]) WithCustomMiddlewareAfterAuth(mws ...endpoint.Middleware) *CommonEndpointer[H] {
+	ae := *e
+	ae.CustomMiddlewareAfterAuth = mws
 	return &ae
 }
 

--- a/server/service/middleware/endpoint_utils/endpoint_utils_test.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils_test.go
@@ -1,0 +1,122 @@
+package endpoint_utils
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomMiddlewareAfterAuth(t *testing.T) {
+	var (
+		i                = 0
+		beforeIndex      = 0
+		authIndex        = 0
+		afterFirstIndex  = 0
+		afterSecondIndex = 0
+	)
+	beforeAuthMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			i++
+			beforeIndex = i
+			return next(ctx, req)
+		}
+	}
+
+	authFunc := func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			i++
+			authIndex = i
+			if authctx, ok := authz_ctx.FromContext(ctx); ok {
+				authctx.SetChecked()
+			}
+			return next(ctx, req)
+		}
+	}
+
+	afterAuthMiddlewareFirst := func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			i++
+			afterFirstIndex = i
+			return next(ctx, req)
+		}
+	}
+	afterAuthMiddlewareSecond := func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			i++
+			afterSecondIndex = i
+			return next(ctx, req)
+		}
+	}
+
+	r := mux.NewRouter()
+	ce := &CommonEndpointer[HandlerFunc]{
+		EP: nopEP{},
+		MakeDecoderFn: func(iface interface{}) kithttp.DecodeRequestFunc {
+			return func(ctx context.Context, r *http.Request) (request interface{}, err error) {
+				return nopRequest{}, nil
+			}
+		},
+		EncodeFn: func(ctx context.Context, w http.ResponseWriter, i interface{}) error {
+			w.WriteHeader(http.StatusOK)
+			return nil
+		},
+		AuthFunc: authFunc,
+		CustomMiddleware: []endpoint.Middleware{
+			beforeAuthMiddleware,
+		},
+		CustomMiddlewareAfterAuth: []endpoint.Middleware{
+			afterAuthMiddlewareFirst,
+			afterAuthMiddlewareSecond,
+		},
+		Router: r,
+	}
+	ce.handleEndpoint("/", func(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+		fmt.Printf("handler\n")
+		return nopResponse{}, nil
+	}, nil, "GET")
+
+	s := httptest.NewServer(r)
+	t.Cleanup(func() {
+		s.Close()
+	})
+
+	req, err := http.NewRequest("GET", s.URL+"/", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		resp.Body.Close()
+	})
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, 1, beforeIndex)
+	require.Equal(t, 2, authIndex)
+	require.Equal(t, 3, afterFirstIndex)
+	require.Equal(t, 4, afterSecondIndex)
+}
+
+type nopRequest struct{}
+
+type nopResponse struct{}
+
+func (n nopResponse) Error() error {
+	return nil
+}
+
+type nopEP struct{}
+
+func (n nopEP) CallHandlerFunc(f HandlerFunc, ctx context.Context, request interface{}, svc interface{}) (fleet.Errorer, error) {
+	return nopResponse{}, nil
+}
+
+func (n nopEP) Service() interface{} {
+	return nil
+}

--- a/server/service/middleware/mdmconfigured/mdmconfigured.go
+++ b/server/service/middleware/mdmconfigured/mdmconfigured.go
@@ -5,6 +5,8 @@ package mdmconfigured
 import (
 	"context"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/go-kit/kit/endpoint"
 )
@@ -34,6 +36,26 @@ func (m *Middleware) VerifyAppleMDM() endpoint.Middleware {
 		return func(ctx context.Context, req interface{}) (interface{}, error) {
 			if err := m.svc.VerifyMDMAppleConfigured(ctx); err != nil {
 				return nil, err
+			}
+
+			return next(ctx, req)
+		}
+	}
+}
+
+// VerifyAppleMDMOnMacOSHosts verifies that MDM is enabled and configured when it's an Apple host making the request.
+// This is used on API endpoints that are reused on Linux hosts (which don't require Apple MDM to be configured).
+func (m *Middleware) VerifyAppleMDMOnMacOSHosts() endpoint.Middleware {
+	return func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req interface{}) (interface{}, error) {
+			host, ok := hostctx.FromContext(ctx)
+			if !ok {
+				return nil, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("internal error: missing host from request context"))
+			}
+			if fleet.IsApplePlatform(host.Platform) {
+				if err := m.svc.VerifyMDMAppleConfigured(ctx); err != nil {
+					return nil, err
+				}
 			}
 
 			return next(ctx, req)


### PR DESCRIPTION
Cherry-pick for #32788 (unreleased bug in 1.48.0).

Server side code changes don't matter because this patch branch will be used to release fleetd.