### PR TITLE
Cherry pick fleetd v1.48.1:  fleetd pacman packages table

### DIFF
--- a/changes/32862-arch-linux-software-ingestion
+++ b/changes/32862-arch-linux-software-ingestion
@@ -1,0 +1,1 @@
+* Added software ingestion from Arch Linux hosts.

--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -585,8 +585,8 @@ SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND na
 - Query:
 ```sql
 SELECT package, MAX(atime) AS last_opened_at
-		FROM deb_package_files 
-		CROSS JOIN file USING (path) 
+		FROM deb_package_files
+		CROSS JOIN file USING (path)
 		WHERE type = 'regular' AND regex_match(file.mode, '[1357]', 0)
 		GROUP BY package
 ```
@@ -673,6 +673,30 @@ SELECT
   '' AS arch,
   path AS installed_path
 FROM cached_users CROSS JOIN firefox_addons USING (uid);
+```
+
+## software_linux_fleetd_pacman
+
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo, neon, archarm
+
+- Discovery query:
+```sql
+SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'fleetd_pacman_packages'
+```
+
+- Query:
+```sql
+SELECT
+  name AS name,
+  version AS version,
+  '' AS extension_id,
+  '' AS browser,
+  'pacman_packages' AS source,
+  '' AS release,
+  '' AS vendor,
+  arch AS arch,
+  '' AS installed_path
+FROM fleetd_pacman_packages
 ```
 
 ## software_macos

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -198,6 +198,7 @@ export const SOURCE_TYPE_CONVERSION = {
   portage_packages: "Package (Portage)",
   rpm_packages: "Package (RPM)",
   yum_sources: "Package (YUM)",
+  pacman_packages: "Package (pacman)",
   npm_packages: "Package (NPM)",
   atom_packages: "Package (Atom)", // Atom packages were removed from software inventory. Mapping is maintained for backwards compatibility. (2023-12-04)
   python_packages: "Package (Python)",
@@ -225,6 +226,7 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   portage_packages: "linux",
   rpm_packages: "linux",
   yum_sources: "linux",
+  pacman_packages: "linux",
   tgz_packages: "linux",
   npm_packages: null,
   atom_packages: null,

--- a/orbit/changes/32860-arch-linux-pacman-osquery-table
+++ b/orbit/changes/32860-arch-linux-pacman-osquery-table
@@ -1,0 +1,1 @@
+- Add `fleetd_pacman_packages` table for `pacman` package manager

--- a/orbit/pkg/table/extension_linux.go
+++ b/orbit/pkg/table/extension_linux.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/cryptsetup_luks_salt"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dconf_read"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/fleetd_pacman_packages"
 	"github.com/osquery/osquery-go"
 	"github.com/osquery/osquery-go/plugin/table"
 	"github.com/rs/zerolog/log"
@@ -23,6 +24,7 @@ func PlatformTables(_ PluginOpts) ([]osquery.OsqueryPlugin, error) {
 		dataflattentable.TablePluginExec(log.Logger, "nftables", dataflattentable.JsonType, []string{"nft", "-jat", "list", "ruleset"}, dataflattentable.WithBinDirs("/usr/bin", "/usr/sbin")), // -j (json) -a (show object handles) -t (terse, omit set contents)
 		table.NewPlugin("dconf_read", dconf_read.Columns(), dconf_read.Generate),
 		table.NewPlugin("containerd_containers", containerd_containers.Columns(), containerd_containers.Generate),
+		table.NewPlugin(fleetd_pacman_packages.TableName, fleetd_pacman_packages.Columns(), fleetd_pacman_packages.Generate),
 
 		dataflattentable.TablePluginExec(
 			log.Logger,

--- a/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
+++ b/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
@@ -43,7 +43,20 @@ func Columns() []table.ColumnDefinition {
 //
 // Constraints for generating can be retrieved from the queryContext.
 func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
-	out, err := exec.Command("/usr/bin/pacman", "-Qi").Output()
+	var softwareTitles []string
+
+	if software, ok := queryContext.Constraints["name"]; ok {
+		for _, c := range software.Constraints {
+			if c.Operator == table.OperatorEquals {
+				softwareTitles = append(softwareTitles, c.Expression)
+			}
+		}
+	}
+
+	args := []string{"-Qi"}
+	args = append(args, softwareTitles...)
+
+	out, err := exec.Command("/usr/bin/pacman", args...).Output()
 	if os.IsNotExist(err) {
 		// If no package manager, return nothing but don't fail
 		return nil, nil

--- a/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
+++ b/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages.go
@@ -1,0 +1,128 @@
+package fleetd_pacman_packages
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+const TableName = "fleetd_pacman_packages"
+
+// Columns is the schema of the table.
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("name"),
+		table.TextColumn("version"),
+		table.TextColumn("description"),
+		table.TextColumn("arch"),
+		table.TextColumn("url"),
+		table.TextColumn("licenses"),
+		table.TextColumn("groups"),
+		table.TextColumn("provides"),
+		table.TextColumn("depends_on"),
+		table.TextColumn("optional_deps"),
+		table.TextColumn("required_by"),
+		table.TextColumn("optional_for"),
+		table.TextColumn("conflicts_with"),
+		table.TextColumn("replaces"),
+		table.TextColumn("installed_size"),
+		table.TextColumn("packager"),
+		table.TextColumn("build_date"),
+		table.TextColumn("install_date"),
+		table.TextColumn("install_reason"),
+		table.TextColumn("install_script"),
+		table.TextColumn("validated_by"),
+	}
+}
+
+// Generate is called to return the results for the table at query time.
+//
+// Constraints for generating can be retrieved from the queryContext.
+func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	out, err := exec.Command("/usr/bin/pacman", "-Qi").Output()
+	if os.IsNotExist(err) {
+		// If no package manager, return nothing but don't fail
+		return nil, nil
+	} else if err != nil {
+		// Some other error
+		return nil, fmt.Errorf("command failed: %w", err)
+	}
+	return parsePacmanQiOutput(string(out)), nil
+}
+
+func parsePacmanQiOutput(output string) []map[string]string {
+	groups := strings.Split(output, "\n\n")
+	packages := make([]map[string]string, 0, len(groups))
+
+	for _, group := range groups {
+		trimmed := strings.TrimSpace(group)
+		if trimmed == "" {
+			continue
+		}
+
+		pkg := map[string]string{}
+		lines := strings.SplitSeq(trimmed, "\n")
+		for line := range lines {
+			colon := strings.Index(line, ":")
+			if colon == -1 || colon == len(line) {
+				continue
+			}
+			key := strings.TrimSpace(line[:colon])
+			value := strings.TrimSpace(line[colon+1:])
+			if value == "None" {
+				value = ""
+			}
+			switch key {
+			case "Name":
+				pkg["name"] = value
+			case "Version":
+				pkg["version"] = value
+			case "Description":
+				pkg["description"] = value
+			case "Architecture":
+				pkg["arch"] = value
+			case "URL":
+				pkg["url"] = value
+			case "Licenses":
+				pkg["licenses"] = value
+			case "Groups":
+				pkg["groups"] = value
+			case "Provides":
+				pkg["provides"] = value
+			case "Depends On":
+				pkg["depends_on"] = value
+			case "Optional Deps":
+				pkg["optional_deps"] = value
+			case "Required By":
+				pkg["required_by"] = value
+			case "Optional For":
+				pkg["optional_for"] = value
+			case "Conflicts With":
+				pkg["conflicts_with"] = value
+			case "Replaces":
+				pkg["replaces"] = value
+			case "Installed Size":
+				pkg["installed_size"] = value
+			case "Packager":
+				pkg["packager"] = value
+			case "Build Date":
+				pkg["build_date"] = value
+			case "Install Date":
+				pkg["install_date"] = value
+			case "Install Reason":
+				pkg["install_reason"] = value
+			case "Install Script":
+				pkg["install_script"] = value
+			case "Validated By":
+				pkg["validated_by"] = value
+			}
+		}
+		packages = append(packages, pkg)
+	}
+
+	return packages
+}

--- a/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages_test.go
+++ b/orbit/pkg/table/fleetd_pacman_packages/fleetd_pacman_packages_test.go
@@ -1,0 +1,109 @@
+package fleetd_pacman_packages
+
+import (
+	_ "embed"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//go:embed test_data.txt
+var data string
+
+func TestParsePacmanQiOutput(t *testing.T) {
+	packages := parsePacmanQiOutput(data)
+
+	require.Len(t, packages, 4)
+
+	pkg := packages[0]
+	require.Equal(t, "xxhash", pkg["name"])
+	require.Equal(t, "0.8.3-1", pkg["version"])
+	require.Equal(t, "Extremely fast non-cryptographic hash algorithm", pkg["description"])
+	require.Equal(t, "x86_64", pkg["arch"])
+	require.Equal(t, "https://cyan4973.github.io/xxHash/", pkg["url"])
+	require.Equal(t, "GPL2  BSD", pkg["licenses"])
+	require.Equal(t, "", pkg["groups"])
+	require.Equal(t, "libxxhash.so=0-64", pkg["provides"])
+	require.Equal(t, "glibc", pkg["depends_on"])
+	require.Equal(t, "", pkg["optional_deps"])
+	require.Equal(t, "debugedit  libplacebo", pkg["required_by"])
+	require.Equal(t, "limine-snapper-sync", pkg["optional_for"])
+	require.Equal(t, "", pkg["conflicts_with"])
+	require.Equal(t, "", pkg["replaces"])
+	require.Equal(t, "400.10 KiB", pkg["installed_size"])
+	require.Equal(t, "Christian Hesse <eworm@archlinux.org>", pkg["packager"])
+	require.Equal(t, "Mon 06 Jan 2025 02:26:25 AM EST", pkg["build_date"])
+	require.Equal(t, "Tue 16 Sep 2025 01:55:37 PM EDT", pkg["install_date"])
+	require.Equal(t, "Installed as a dependency for another package", pkg["install_reason"])
+	require.Equal(t, "Yes", pkg["install_script"])
+	require.Equal(t, "Signature", pkg["validated_by"])
+
+	pkg = packages[1]
+	require.Equal(t, "xz", pkg["name"])
+	require.Equal(t, "5.8.1-1", pkg["version"])
+	require.Equal(t, "Library and command line tools for XZ and LZMA compressed files", pkg["description"])
+	require.Equal(t, "x86_64", pkg["arch"])
+	require.Equal(t, "https://tukaani.org/xz/", pkg["url"])
+	require.Equal(t, "GPL  LGPL  custom", pkg["licenses"])
+	require.Equal(t, "", pkg["groups"])
+	require.Equal(t, "liblzma.so=5-64", pkg["provides"])
+	require.Equal(t, "sh", pkg["depends_on"])
+	require.Equal(t, "", pkg["optional_deps"])
+	require.Equal(t, "base  ffmpeg  file  imagemagick  karchive  kmod  libarchive  libelf  libtiff  libunwind  libxml2  libxmlb  libxslt  systemd  systemd-libs  zstd", pkg["required_by"])
+	require.Equal(t, "mkinitcpio  python", pkg["optional_for"])
+	require.Equal(t, "", pkg["conflicts_with"])
+	require.Equal(t, "", pkg["replaces"])
+	require.Equal(t, "2.92 MiB", pkg["installed_size"])
+	require.Equal(t, "Levente Polyak <anthraxx@archlinux.org>", pkg["packager"])
+	require.Equal(t, "Thu 03 Apr 2025 12:43:12 PM EDT", pkg["build_date"])
+	require.Equal(t, "Tue 16 Sep 2025 01:55:31 PM EDT", pkg["install_date"])
+	require.Equal(t, "Installed as a dependency for another package", pkg["install_reason"])
+	require.Equal(t, "No", pkg["install_script"])
+	require.Equal(t, "Signature", pkg["validated_by"])
+
+	pkg = packages[2]
+	require.Equal(t, "zeromq", pkg["name"])
+	require.Equal(t, "4.3.5-2", pkg["version"])
+	require.Equal(t, "Fast messaging system built on sockets. C and C++ bindings. aka 0MQ, ZMQ.", pkg["description"])
+	require.Equal(t, "x86_64", pkg["arch"])
+	require.Equal(t, "http://www.zeromq.org", pkg["url"])
+	require.Equal(t, "MPL2", pkg["licenses"])
+	require.Equal(t, "", pkg["groups"])
+	require.Equal(t, "libzmq.so=5-64", pkg["provides"])
+	require.Equal(t, "glibc  gnutls  gcc-libs  util-linux  libsodium  libpgm", pkg["depends_on"])
+	require.Equal(t, "cppzmq: C++ binding for libzmq", pkg["optional_deps"])
+	require.Equal(t, "ffmpeg", pkg["required_by"])
+	require.Equal(t, "", pkg["optional_for"])
+	require.Equal(t, "", pkg["conflicts_with"])
+	require.Equal(t, "", pkg["replaces"])
+	require.Equal(t, "3.05 MiB", pkg["installed_size"])
+	require.Equal(t, "George Rawlinson <grawlinson@archlinux.org>", pkg["packager"])
+	require.Equal(t, "Mon 23 Oct 2023 07:48:59 PM EDT", pkg["build_date"])
+	require.Equal(t, "Tue 16 Sep 2025 01:57:33 PM EDT", pkg["install_date"])
+	require.Equal(t, "Explicitly installed", pkg["install_reason"])
+	require.Equal(t, "No", pkg["install_script"])
+	require.Equal(t, "Signature", pkg["validated_by"])
+
+	pkg = packages[3]
+	require.Equal(t, "incomplete", pkg["name"])
+	require.Equal(t, "3", pkg["version"])
+	require.Equal(t, "", pkg["description"])
+	require.Equal(t, "any", pkg["arch"])
+	require.Equal(t, "", pkg["url"])
+	require.Equal(t, "", pkg["licenses"])
+	require.Equal(t, "", pkg["groups"])
+	require.Equal(t, "", pkg["provides"])
+	require.Equal(t, "", pkg["depends_on"])
+	require.Equal(t, "", pkg["optional_deps"])
+	require.Equal(t, "", pkg["required_by"])
+	require.Equal(t, "", pkg["optional_for"])
+	require.Equal(t, "", pkg["conflicts_with"])
+	require.Equal(t, "", pkg["replaces"])
+	require.Equal(t, "", pkg["installed_size"])
+	require.Equal(t, "", pkg["packager"])
+	require.Equal(t, "", pkg["build_date"])
+	require.Equal(t, "", pkg["install_date"])
+	require.Equal(t, "", pkg["install_reason"])
+	require.Equal(t, "", pkg["install_script"])
+	require.Equal(t, "", pkg["validated_by"])
+}

--- a/orbit/pkg/table/fleetd_pacman_packages/test_data.txt
+++ b/orbit/pkg/table/fleetd_pacman_packages/test_data.txt
@@ -1,0 +1,70 @@
+Name            : xxhash
+Version         : 0.8.3-1
+Description     : Extremely fast non-cryptographic hash algorithm
+Architecture    : x86_64
+URL             : https://cyan4973.github.io/xxHash/
+Licenses        : GPL2  BSD
+Groups          : None
+Provides        : libxxhash.so=0-64
+Depends On      : glibc
+Optional Deps   : None
+Required By     : debugedit  libplacebo
+Optional For    : limine-snapper-sync
+Conflicts With  : None
+Replaces        : None
+Installed Size  : 400.10 KiB
+Packager        : Christian Hesse <eworm@archlinux.org>
+Build Date      : Mon 06 Jan 2025 02:26:25 AM EST
+Install Date    : Tue 16 Sep 2025 01:55:37 PM EDT
+Install Reason  : Installed as a dependency for another package
+Install Script  : Yes
+Validated By    : Signature
+
+Name            : xz
+Version         : 5.8.1-1
+Description     : Library and command line tools for XZ and LZMA compressed files
+Architecture    : x86_64
+URL             : https://tukaani.org/xz/
+Licenses        : GPL  LGPL  custom
+Groups          : None
+Provides        : liblzma.so=5-64
+Depends On      : sh
+Optional Deps   : None
+Required By     : base  ffmpeg  file  imagemagick  karchive  kmod  libarchive  libelf  libtiff  libunwind  libxml2  libxmlb  libxslt  systemd  systemd-libs  zstd
+Optional For    : mkinitcpio  python
+Conflicts With  : None
+Replaces        : None
+Installed Size  : 2.92 MiB
+Packager        : Levente Polyak <anthraxx@archlinux.org>
+Build Date      : Thu 03 Apr 2025 12:43:12 PM EDT
+Install Date    : Tue 16 Sep 2025 01:55:31 PM EDT
+Install Reason  : Installed as a dependency for another package
+Install Script  : No
+Validated By    : Signature
+
+Name            : zeromq
+Version         : 4.3.5-2
+Description     : Fast messaging system built on sockets. C and C++ bindings. aka 0MQ, ZMQ.
+Architecture    : x86_64
+URL             : http://www.zeromq.org
+Licenses        : MPL2
+Groups          : None
+Provides        : libzmq.so=5-64
+Depends On      : glibc  gnutls  gcc-libs  util-linux  libsodium  libpgm
+Optional Deps   : cppzmq: C++ binding for libzmq
+Required By     : ffmpeg
+Optional For    : None
+Conflicts With  : None
+Replaces        : None
+Installed Size  : 3.05 MiB
+Packager        : George Rawlinson <grawlinson@archlinux.org>
+Build Date      : Mon 23 Oct 2023 07:48:59 PM EDT
+Install Date    : Tue 16 Sep 2025 01:57:33 PM EDT
+Install Reason  : Explicitly installed
+Install Script  : No
+Validated By    : Signature
+
+
+Name            : incomplete
+Version         : 3
+Architecture    : any

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -11655,6 +11655,145 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/fleetd_logs.yml"
   },
   {
+    "name": "fleetd_pacman_packages",
+    "platforms": [
+      "linux"
+    ],
+    "description": "List the packages installed using the `pacman` package manager.",
+    "columns": [
+      {
+        "name": "name",
+        "type": "text",
+        "required": false,
+        "description": "Name of the package"
+      },
+      {
+        "name": "version",
+        "type": "text",
+        "required": false,
+        "description": "Version of the package"
+      },
+      {
+        "name": "description",
+        "type": "text",
+        "required": false,
+        "description": "The description of the package"
+      },
+      {
+        "name": "arch",
+        "type": "text",
+        "required": false,
+        "description": "The CPU architecture of the package"
+      },
+      {
+        "name": "url",
+        "type": "text",
+        "required": false,
+        "description": "The upstream URL of the package"
+      },
+      {
+        "name": "licenses",
+        "type": "text",
+        "required": false,
+        "description": "The software license of the package"
+      },
+      {
+        "name": "groups",
+        "type": "text",
+        "required": false,
+        "description": "The package groups that the package is part of"
+      },
+      {
+        "name": "provides",
+        "type": "text",
+        "required": false,
+        "description": "An array of “virtual provisions” this package provides"
+      },
+      {
+        "name": "depends_on",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages this package depends on to run"
+      },
+      {
+        "name": "optional_deps",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages (and accompanying reasons) that are not essential for base functionality, but may be necessary to make full use of the contents of this package"
+      },
+      {
+        "name": "required_by",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages that depend on this package"
+      },
+      {
+        "name": "optional_for",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages that list this package an an optional dependency"
+      },
+      {
+        "name": "conflicts_with",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages that will conflict with this package"
+      },
+      {
+        "name": "replaces",
+        "type": "text",
+        "required": false,
+        "description": "An array of packages this package should replace"
+      },
+      {
+        "name": "installed_size",
+        "type": "text",
+        "required": false,
+        "description": "The size of the package once installed"
+      },
+      {
+        "name": "packager",
+        "type": "text",
+        "required": false,
+        "description": "The maintainer of the package"
+      },
+      {
+        "name": "build_date",
+        "type": "text",
+        "required": false,
+        "description": "The date the package was built"
+      },
+      {
+        "name": "install_date",
+        "type": "text",
+        "required": false,
+        "description": "The date the package was installed"
+      },
+      {
+        "name": "install_reason",
+        "type": "text",
+        "required": false,
+        "description": "The reason the package was installed"
+      },
+      {
+        "name": "install_script",
+        "type": "text",
+        "required": false,
+        "description": "Whether or not the package uses an install script"
+      },
+      {
+        "name": "validated_by",
+        "type": "text",
+        "required": false,
+        "description": "How the package was validated"
+      }
+    ],
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).",
+    "evented": false,
+    "url": "https://fleetdm.com/tables/fleetd_pacman_packages",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/fleetd_pacman_packages.yml"
+  },
+  {
     "name": "gatekeeper",
     "description": "macOS Gatekeeper Details.",
     "url": "https://fleetdm.com/tables/gatekeeper",

--- a/schema/tables/fleetd_pacman_packages.yml
+++ b/schema/tables/fleetd_pacman_packages.yml
@@ -1,0 +1,91 @@
+name: fleetd_pacman_packages
+platforms:
+  - linux
+description: List the packages installed using the `pacman` package manager.
+columns:
+  - name: name
+    type: text
+    required: false
+    description: Name of the package
+  - name: version
+    type: text
+    required: false
+    description: Version of the package
+  - name: description
+    type: text
+    required: false
+    description: The description of the package
+  - name: arch
+    type: text
+    required: false
+    description: The CPU architecture of the package
+  - name: url
+    type: text
+    required: false
+    description: The upstream URL of the package
+  - name: licenses
+    type: text
+    required: false
+    description: The software license of the package
+  - name: groups
+    type: text
+    required: false
+    description: The package groups that the package is part of
+  - name: provides
+    type: text
+    required: false
+    description: An array of “virtual provisions” this package provides
+  - name: depends_on
+    type: text
+    required: false
+    description: An array of packages this package depends on to run
+  - name: optional_deps
+    type: text
+    required: false
+    description: An array of packages (and accompanying reasons) that are not essential for base functionality, but may be necessary to make full use of the contents of this package
+  - name: required_by
+    type: text
+    required: false
+    description: An array of packages that depend on this package
+  - name: optional_for
+    type: text
+    required: false
+    description: An array of packages that list this package an an optional dependency
+  - name: conflicts_with
+    type: text
+    required: false
+    description: An array of packages that will conflict with this package
+  - name: replaces
+    type: text
+    required: false
+    description: An array of packages this package should replace
+  - name: installed_size
+    type: text
+    required: false
+    description: The size of the package once installed
+  - name: packager
+    type: text
+    required: false
+    description: The maintainer of the package
+  - name: build_date
+    type: text
+    required: false
+    description: The date the package was built
+  - name: install_date
+    type: text
+    required: false
+    description: The date the package was installed
+  - name: install_reason
+    type: text
+    required: false
+    description: The reason the package was installed
+  - name: install_script
+    type: text
+    required: false
+    description: Whether or not the package uses an install script
+  - name: validated_by
+    type: text
+    required: false
+    description: How the package was validated
+notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+evented: false

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1384,6 +1384,9 @@ func preProcessSoftwareResults(
 	pythonPackagesWithUsersExtraQuery := hostDetailQueryPrefix + "software_python_packages_with_users_dir"
 	preProcessSoftwareExtraResults(pythonPackagesWithUsersExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
 
+	fleetdPacmanPackagesExtraQuery := hostDetailQueryPrefix + "software_linux_fleetd_pacman"
+	preProcessSoftwareExtraResults(fleetdPacmanPackagesExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
+
 	for name, query := range overrides {
 		fullQueryName := hostDetailQueryPrefix + "software_" + name
 		preProcessSoftwareExtraResults(fullQueryName, host.ID, results, statuses, messages, query, logger)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1110,6 +1110,7 @@ func verifyDiscovery(t *testing.T, queries, discovery map[string]string) {
 		hostDetailQueryPrefix + "kubequery_info":                          {},
 		hostDetailQueryPrefix + "orbit_info":                              {},
 		hostDetailQueryPrefix + "software_vscode_extensions":              {},
+		hostDetailQueryPrefix + "software_linux_fleetd_pacman":            {},
 		hostDetailQueryPrefix + "software_python_packages":                {},
 		hostDetailQueryPrefix + "software_python_packages_with_users_dir": {},
 		hostDetailQueryPrefix + "software_macos_firefox":                  {},

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1001,6 +1001,25 @@ var scheduledQueryStats = DetailQuery{
 	Platforms:            append(fleet.HostLinuxOSs, "darwin", "windows"), // not chrome
 }
 
+var softwareLinuxPacman = DetailQuery{
+	Query: `
+SELECT
+  name AS name,
+  version AS version,
+  '' AS extension_id,
+  '' AS browser,
+  'pacman_packages' AS source,
+  '' AS release,
+  '' AS vendor,
+  arch AS arch,
+  '' AS installed_path
+FROM fleetd_pacman_packages`,
+	Platforms: fleet.HostLinuxOSs,
+	Discovery: discoveryTable("fleetd_pacman_packages"),
+	// Has no IngestFunc, DirectIngestFunc or DirectTaskIngestFunc because
+	// the results of this query are appended to the results of the other software queries.
+}
+
 var softwareLinux = DetailQuery{
 	Query: withCachedUsers(`WITH cached_users AS (%s)
 SELECT
@@ -1360,8 +1379,8 @@ var SoftwareOverrideQueries = map[string]DetailQuery{
 		// deb_package_files does not have a mode column, so we need to join to the file table and filter there
 		Query: `
 		SELECT package, MAX(atime) AS last_opened_at
-		FROM deb_package_files 
-		CROSS JOIN file USING (path) 
+		FROM deb_package_files
+		CROSS JOIN file USING (path)
 		WHERE type = 'regular' AND regex_match(file.mode, '[1357]', 0)
 		GROUP BY package
 	`,
@@ -1793,9 +1812,11 @@ const (
 	linuxImageRegex       = `^linux-image-[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+-[[:digit:]]+-[[:alnum:]]+`
 	amazonLinuxKernelName = "kernel"
 	rhelKernelName        = "kernel-core"
+	archKernelName        = `^linux(?:-(?:lts|zen|hardened))?$`
 )
 
 var kernelRegex = regexp.MustCompile(linuxImageRegex)
+var archKernelRegex = regexp.MustCompile(archKernelName)
 
 func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var software []fleet.Software
@@ -1834,7 +1855,7 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 			continue
 		}
 
-		if fleet.IsLinux(host.Platform) && (kernelRegex.MatchString(s.Name) || s.Name == amazonLinuxKernelName || s.Name == rhelKernelName) {
+		if fleet.IsLinux(host.Platform) && (kernelRegex.MatchString(s.Name) || s.Name == amazonLinuxKernelName || s.Name == rhelKernelName || archKernelRegex.MatchString(s.Name)) {
 			s.IsKernel = true
 		}
 
@@ -2555,7 +2576,7 @@ var tpmPINQueries = map[string]DetailQuery{
 					-- BitLocker is an optional feature but enabled
 					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
 					-- BitLocker is built in, so it won't appear as an optional feature
-					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker')
 				)
 				-- PIN is already set, so regardless of the current config, we don't need to enforce it:
 				-- 4: TPM And PIN.
@@ -2622,14 +2643,14 @@ var tpmPINQueries = map[string]DetailQuery{
 					-- BitLocker is an optional feature but enabled
 					EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker' AND state = 1)
 					-- BitLocker is built in, so it won't appear as an optional feature
-					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker') 
+					OR NOT EXISTS(SELECT 1 FROM windows_optional_features WHERE name = 'BitLocker')
 				)
 			)
 			SELECT 1 FROM should_run WHERE yes = 1`,
 		Query: `
 			SELECT EXISTS(
-				SELECT 1 
-				FROM bitlocker_key_protectors 
+				SELECT 1
+				FROM bitlocker_key_protectors
 				-- 4: TPM And PIN.
 				-- 6: TPM And PIN And Startup key.
 				WHERE drive_letter = 'C:' AND key_protector_type IN (4,6)
@@ -2685,6 +2706,7 @@ func GetDetailQueries(
 		generatedMap["software_python_packages"] = softwarePythonPackages
 		generatedMap["software_python_packages_with_users_dir"] = softwarePythonPackagesWithUsersDir
 		generatedMap["software_vscode_extensions"] = softwareVSCodeExtensions
+		generatedMap["software_linux_fleetd_pacman"] = softwareLinuxPacman
 
 		for key, query := range SoftwareOverrideQueries {
 			generatedMap["software_"+key] = query

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -343,7 +343,7 @@ func TestGetDetailQueries(t *testing.T) {
 
 	queriesWithUsersAndSoftware := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true}, Integrations{}, nil)
 	qs = baseQueries
-	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions",
+	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_linux_fleetd_pacman",
 		"software_chrome", "software_python_packages", "software_python_packages_with_users_dir", "scheduled_query_stats", "software_macos_firefox", "software_macos_codesign", "software_windows_last_opened_at", "software_deb_last_opened_at", "software_rpm_last_opened_at")
 	require.Len(t, queriesWithUsersAndSoftware, len(qs))
 	sortedKeysCompare(t, queriesWithUsersAndSoftware, qs)


### PR DESCRIPTION
Cherry-pick of https://github.com/fleetdm/fleet/pull/33139 (that adds the table) and https://github.com/fleetdm/fleet/pull/33238 (which contains a small fix on the table to allow filtering by name).

Server side code changes don't matter because this patch branch will be used to release fleetd.