### PR TITLE
Website: Update sidebar on docs pages

### DIFF
--- a/website/assets/js/components/docs-nav-and-search.component.js
+++ b/website/assets/js/components/docs-nav-and-search.component.js
@@ -36,7 +36,7 @@ parasails.registerComponent('docsNavAndSearch', {
       <div purpose="nav-link-container" class="d-flex align-items-center">
         <div purpose="docs-links" class="d-flex flex-row">
           <a :class="[currentSection === 'docs' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/docs" style="text-decoration: none; text-decoration-line: none;">Get started</a>
-          <a :class="[currentSection === 'controls' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/os-settings" style="text-decoration: none; text-decoration-line: none;">Controls</a>
+          <a :class="[currentSection === 'controls' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/mdm-commands" style="text-decoration: none; text-decoration-line: none;">Controls</a>
           <a :class="[currentSection === 'vitals' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/vitals" style="text-decoration: none; text-decoration-line: none;">Vitals</a>
           <a :class="[currentSection === 'queries' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/queries" style="text-decoration: none; text-decoration-line: none;">Queries</a>
           <a :class="[currentSection === 'policies' ? 'active' : '']" purpose="docs-top-nav-menu-link" href="/policies" style="text-decoration: none; text-decoration-line: none;">Policies</a>

--- a/website/assets/styles/components/docs-nav-and-search.component.less
+++ b/website/assets/styles/components/docs-nav-and-search.component.less
@@ -61,7 +61,7 @@
       padding: 8px 15px;
       height: 36px;
       margin: 0;
-      width: 190px;
+      width: 220px;
     }
     .DocSearch-Button:hover {
       box-shadow: none;

--- a/website/assets/styles/pages/app-details.less
+++ b/website/assets/styles/pages/app-details.less
@@ -78,8 +78,8 @@
     }
     [purpose='app-details'] {
       padding-right: 64px;
-      max-width: 800px;
       width: 100%;
+      min-width: 0px;// Prevents long overflowing text from keeping this element from shrinking.
       p {
         margin-bottom: 24px;
         margin-top: 16px;
@@ -149,7 +149,7 @@
     }
 
     [purpose='right-sidebar'] {
-      width: 256px;
+      min-width: 220px;
       margin-left: 16px;
       font-size: 14px;
       transition-property: transform;

--- a/website/assets/styles/pages/command-details.less
+++ b/website/assets/styles/pages/command-details.less
@@ -127,8 +127,8 @@
   }
   [purpose='command-details'] {
     padding-right: 64px;
-    max-width: 800px;
     width: 100%;
+    min-width: 0px;// Prevents long overflowing nowrap text from keeping this element from shrinking.
   }
   [purpose='command-check'] {
     padding-top: 48px;
@@ -146,7 +146,7 @@
   }
 
   [purpose='right-sidebar'] {
-    width: 256px;
+    min-width: 220px;
     margin-left: 16px;
     font-size: 14px;
     transition-property: transform;

--- a/website/assets/styles/pages/docs/basic-documentation.less
+++ b/website/assets/styles/pages/docs/basic-documentation.less
@@ -1015,7 +1015,7 @@
         p {
           line-height: 21px;
         }
-        min-width: 190px;
+        min-width: 220px;
         position: sticky;
         top: 104px;
         margin-left: 24px;

--- a/website/assets/styles/pages/policy-details.less
+++ b/website/assets/styles/pages/policy-details.less
@@ -38,6 +38,7 @@
     font-size: 14px;
     font-weight: 400;
     line-height: 150%; /*  */
+    text-decoration: none;
     &:hover {
       color: #192147;
       text-decoration: none;
@@ -93,8 +94,8 @@
   }
   [purpose='policy-details'] {
     padding-right: 64px;
-    max-width: 800px;
     width: 100%;
+    min-width: 0px;// Prevents long overflowing nowrap text from keeping this element from shrinking.
   }
   [purpose='powershell-note'] {
     display: flex;
@@ -290,7 +291,7 @@
 
   }
   [purpose='right-sidebar'] {
-    width: 256px;
+    min-width: 220px;
     margin-left: 16px;
     font-size: 14px;
     transition-property: transform;
@@ -300,6 +301,7 @@
       margin-bottom: 8px;
       display: block;
       color: #515774;
+      text-decoration: none;
       &:hover {
         text-decoration: none;
         color: @core-fleet-black;

--- a/website/assets/styles/pages/query-detail.less
+++ b/website/assets/styles/pages/query-detail.less
@@ -95,15 +95,15 @@
   }
   [purpose='query-details'] {
     padding-right: 64px;
-    max-width: 800px;
     width: 100%;
+    min-width: 0px;// Prevents long overflowing text from keeping this element from shrinking.
   }
   [purpose='query-check'] {
     padding-bottom: 24px;
   }
 
   [purpose='right-sidebar'] {
-    width: 256px;
+    min-width: 220px;
     margin-left: 16px;
     font-size: 14px;
     transition-property: transform;

--- a/website/assets/styles/pages/script-details.less
+++ b/website/assets/styles/pages/script-details.less
@@ -50,7 +50,7 @@
     margin-left: 8px;
   }
 
-  [purpose='query-name'] {
+  [purpose='script-name'] {
     color: #192147;
     font-size: 32px;
     font-style: normal;
@@ -58,16 +58,16 @@
     line-height: 150%;
     margin-bottom: 0px;
   }
-  [purpose='query-description'] {
+  [purpose='script-description'] {
     color: #515774;
     font-size: 16px;
     font-style: normal;
     font-weight: 400;
     line-height: 150%;
     margin-bottom: 0px;
-    padding: 48px 0px 32px 0px;
+    padding: 16px 0px 0px 0px;
   }
-  [purpose='query-attribution'] {
+  [purpose='script-attribution'] {
     display: flex;
     flex-direction: row;
     align-items: center;
@@ -82,7 +82,7 @@
       font-size: 14px;
       line-height: 150%;
     }
-    [purpose='query-link'] {
+    [purpose='script-link'] {
       color: unset;
       text-decoration: none;
 
@@ -93,17 +93,16 @@
 
 
   }
-  [purpose='query-details'] {
+  [purpose='script-details'] {
     padding-right: 64px;
-    max-width: 800px;
     width: 100%;
   }
-  [purpose='query-check'] {
+  [purpose='script-check'] {
     padding-bottom: 24px;
   }
 
   [purpose='right-sidebar'] {
-    width: 256px;
+    min-width: 220px;
     margin-left: 16px;
     font-size: 14px;
     transition-property: transform;
@@ -164,7 +163,7 @@
       width: 20px;
     }
   }
-  [purpose='query-platform'] {
+  [purpose='script-platform'] {
     border-bottom: 1px solid #E2E4EA;
     padding-bottom: 24px;
     padding-top: 16px;
@@ -254,9 +253,9 @@
       text-underline-offset: 3px;
     }
   }
-  [purpose='query-check'] {
+  [purpose='script-check'] {
     [purpose='codeblock'] {
-      margin-top: 40px;
+      margin-top: 48px;
       [purpose='codeblock-tabs'] {
         background: var(--UI-Fleet-Black-5, #F4F4F6);
         border-top: 1px solid var(--UI-Fleet-Black-10, #E2E4EA);
@@ -437,7 +436,7 @@
     [purpose='page-container'] {
       padding: 32px;
     }
-    [purpose='query-details'] {
+    [purpose='script-details'] {
       padding-right: 0px;
       max-width: 100%;
     }
@@ -467,7 +466,7 @@
     [purpose='page-container'] {
       padding: 32px 24px;
     }
-    [purpose='query-check'] {
+    [purpose='script-check'] {
       [purpose='codeblock'] {
         [purpose='copy-button'] {
           top: 2px;

--- a/website/views/pages/command-details.ejs
+++ b/website/views/pages/command-details.ejs
@@ -32,12 +32,10 @@
             </div>
           </div>
         </div>
-        <div purpose="sidebar-container">
-          <div purpose="right-sidebar" class="d-flex flex-column">
-            <div purpose="docs-links" class="order-3">
-              <a purpose="sidebar-link" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/docs/mdm-commands.yml'+'#L'+thisCommand.lineNumberInYaml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Suggest an edit</a>
-              <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
-            </div>
+        <div purpose="right-sidebar" class="d-flex flex-column">
+          <div purpose="docs-links" class="order-3">
+            <a purpose="sidebar-link" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/docs/mdm-commands.yml'+'#L'+thisCommand.lineNumberInYaml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Suggest an edit</a>
+            <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
           </div>
         </div>
       </div>

--- a/website/views/pages/os-settings.ejs
+++ b/website/views/pages/os-settings.ejs
@@ -37,7 +37,7 @@
         <div purpose="content">
           <div purpose="page-headline">
             <h1>OS settings</h1>
-            <p>In Fleet, you can restrict or preset any OS setting that's supported by popular MDMs, like Jamf and Intune. Choose your platform for more information.</p>
+            <p>In Fleet, you can restrict or preset any OS setting that's supported by popular MDMs, like Jamf and Intune.</p>
           </div>
           <div purpose="platform-content" v-if="selectedPlatform === 'apple'">
             <ul>

--- a/website/views/pages/script-details.ejs
+++ b/website/views/pages/script-details.ejs
@@ -10,11 +10,11 @@
           <span><%- thisScript.name %></span>
         </div>
       </div>
-      <div purpose="query-details-and-sidebar" class="d-flex flex-lg-row flex-column">
-        <div purpose="query-details" class="d-flex flex-column">
-          <h2 purpose="query-name"><%- thisScript.name %></h2>
-          <p purpose="query-description"><%- thisScript.description %></p>
-          <div purpose="query-check">
+      <div purpose="script-details-and-sidebar" class="d-flex flex-lg-row flex-column">
+        <div purpose="script-details" class="d-flex flex-column">
+          <h2 purpose="script-name"><%- thisScript.name %></h2>
+          <p purpose="script-description"><%- thisScript.description %></p>
+          <div purpose="script-check">
             <div purpose="codeblock">
               <div purpose="codeblock-tabs" >
                 <a purpose="codeblock-tab" class="selected"><%= thisScript.platform === 'windows' ? 'PowerShell' : 'Bash'%></a>
@@ -30,12 +30,10 @@
             </div>
           </div>
         </div>
-        <div purpose="sidebar-container">
-          <div purpose="right-sidebar" class="d-flex flex-column">
-            <div purpose="docs-links" class="order-3">
-              <a purpose="sidebar-link" target="_blank" href="https://github.com/fleetdm/fleet/tree/main/docs/scripts.yml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Edit</a>
-              <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
-            </div>
+        <div purpose="right-sidebar" class="d-flex flex-column">
+          <div purpose="docs-links" class="order-3">
+            <a purpose="sidebar-link" target="_blank" href="https://github.com/fleetdm/fleet/tree/main/docs/scripts.yml"> <img src="/images/icon-edit-16x16@2x.png" alt="Suggest an edit">Edit</a>
+            <a purpose="sidebar-link" href="/contact"><img alt="Talk to an engineer" src="/images/icon-contact-16x16@2x.png">Get a demo</a>
           </div>
         </div>
       </div>

--- a/website/views/pages/scripts.ejs
+++ b/website/views/pages/scripts.ejs
@@ -37,7 +37,7 @@
         <div purpose="content">
           <div purpose="page-headline">
             <h1>Scripts</h1>
-            <p>A collection of scripts you can run on your devices Contributions welcome <a target="_blank" href="https://github.com/fleetdm/fleet/tree/main/docs/scripts.yml">over on GitHub</a>.</p>
+            <p>A collection of scripts you can run on your devices. Contributions welcome <a target="_blank" href="https://github.com/fleetdm/fleet/tree/main/docs/scripts.yml">over on GitHub</a>.</p>
           </div>
           <div purpose="platform-content" v-if="selectedPlatform === 'apple'">
             <% for(let script of macOsScripts){%>


### PR DESCRIPTION
Closes: #33450


Changes: 
- Updated the size of the right sidebar on documentation pages to be consistent
- Updated the space between sections on the script details page
- Fixed the incorrect styling on the policy details page's sidebar & breadcrumb links
- Fixed a styling bug where long overflowing hidden text in code blocks would reduce the size of the right sidebar on policy and query pages
- Added missing punctuation to text on the scripts page
- Updated the "Controls" link in the docs-nav-and-search component to go to the MDM commands page
- Updated the width of the search bar in the docs-nav-and-search component