### PR TITLE
macOS setup experience: End user auth before BYOD Android enrollment

### DIFF
--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -30,7 +30,7 @@ Using Fleet, you can require end users to authenticate with your identity provid
 
 ### End user authentication
 
-You can enforce end user authentication during automatic enrollment (ADE) for Apple (macOS, iOS, iPadOS) hosts and manual enrollment for personal (BYOD) iOS and iPadOS hosts (Android coming soon).
+You can enforce end user authentication during automatic enrollment (ADE) for Apple (macOS, iOS, iPadOS) hosts and manual enrollment for personal (BYOD) iOS, iPadOS, and Android hosts.
 
 1. Create a new SAML app in your IdP. In your new app, use `https://<your_fleet_url>/api/v1/fleet/mdm/sso/callback` for the SSO URL. If this URL is set incorrectly, end users won't be able to enroll. On iOS hosts, they'll see a "This screen size is not supported yet" error message.
 


### PR DESCRIPTION
- @noahtalerman: It looks like end user auth before BYOD Android enrollment is supported. Added in this story:
  - https://github.com/fleetdm/fleet/issues/29222
