### PR TITLE
add card for consistancy on the os versions empty table

### DIFF
--- a/changes/issue-31688-ui-consistant-empty-table
+++ b/changes/issue-31688-ui-consistant-empty-table
@@ -1,0 +1,2 @@
+- update the os updates current versions empty state to match consistancy with other empty states
+

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionsEmptyState/OSVersionsEmptyState.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionsEmptyState/OSVersionsEmptyState.tsx
@@ -1,21 +1,24 @@
 import React from "react";
 
 import EmptyTable from "components/EmptyTable";
+import Card from "components/Card";
 
 const baseClass = "os-versions-empty-state";
 
 const OSVersionsEmptyState = () => {
   return (
-    <EmptyTable
-      className={`${baseClass}__empty-table`}
-      header="No OS versions detected"
-      info={
-        <span>
-          This report is updated every hour to protect
-          <br /> the performance of your devices.
-        </span>
-      }
-    />
+    <Card>
+      <EmptyTable
+        className={`${baseClass}__empty-table`}
+        header="No OS versions detected"
+        info={
+          <span>
+            This report is updated every hour to protect
+            <br /> the performance of your devices.
+          </span>
+        }
+      />
+    </Card>
   );
 };
 

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionsEmptyState/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionsEmptyState/_styles.scss
@@ -1,3 +1,7 @@
 .os-versions-empty-state {
   margin: 0 auto $pad-xxlarge;
+
+  &__empty-table {
+    margin: $pad-xxxlarge auto;
+  }
 }


### PR DESCRIPTION
**Related issue:** Fixes #31688

updates the empty table state on os versions table to be consistant with other empty states

**before**

<img width="1032" height="339" alt="image" src="https://github.com/user-attachments/assets/bf5e353e-fc0e-4d40-b864-c9a47e8f93c1" />

**after**

<img width="1086" height="366" alt="image" src="https://github.com/user-attachments/assets/2d2c7800-bbb7-4721-949b-bdfbb9adfb24" />


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
