### PR TITLE
Fix ace editor cursor issues on chromeos

### DIFF
--- a/changes/30691-fix-ace-editor-cursor
+++ b/changes/30691-fix-ace-editor-cursor
@@ -1,0 +1,1 @@
+- Fixes an issue on ChromeOS and Windows where the cursor in the SQL editor is misaligned.

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -28,7 +28,7 @@
     }
   }
 
-  .ace_content {
+  .ace_scroller {
     padding-left: 4px;
   }
 

--- a/frontend/components/SQLEditor/theme.css
+++ b/frontend/components/SQLEditor/theme.css
@@ -89,7 +89,7 @@
 
 .ace-fleet .ace_keyword {
   color: #ae6ddf;
-  font-weight: 600;
+  font-weight: 700;
 }
 
 .ace-fleet .ace_osquery-token {

--- a/frontend/components/SQLEditor/theme.css
+++ b/frontend/components/SQLEditor/theme.css
@@ -89,7 +89,7 @@
 
 .ace-fleet .ace_keyword {
   color: #ae6ddf;
-  font-weight: $bold;
+  font-weight: 600;
 }
 
 .ace-fleet .ace_osquery-token {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #30691

# Details

This PR fixes an issue where the cursor in the SQL editor is positioned incorrectly on ChromeOS and Windows. 

Also fixed an incorrect style declaration that was preventing keywords from being bolded.

Before:
<img width="364" height="103" alt="image" src="https://github.com/user-attachments/assets/19d9632b-b57b-4a0f-b019-99a7c145da8d" />

After:
<img width="363" height="108" alt="image" src="https://github.com/user-attachments/assets/cbe9aefe-1920-41e5-9212-eb0f8cb51e4b" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

Tested on Chrome, Firefox, Safari and Microsoft Edge (where appropriate) on MacOS, Linux and Windows.

Note that the specified padding does not render on ChromeOS or Windows (it doesn't in production right now either).