### PR TITLE
Handle multiple software entries with the same bundle ID during renames.

### DIFF
--- a/changes/33468-multiple-versions-bundle-ID
+++ b/changes/33468-multiple-versions-bundle-ID
@@ -1,0 +1,1 @@
+* Fixed edge case when renaming macOS software mapped to multiple checksums.


### PR DESCRIPTION
- Adjusted logic to support multiple software versions sharing a bundle ID.
- Extended tests to validate scenarios involving renamed software across versions.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33468

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] Manually QA'd using osquery `--common_software_name_suffix` switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Improves handling of apps that share the same bundle ID, ensuring all versions are correctly linked and consistently renamed across hosts.
  - Reduces duplicate software entries and keeps host associations intact during rename operations.
  - Delivers more reliable software inventory views with accurate app names derived from bundle IDs.

- Tests
  - Adds comprehensive coverage for scenarios with multiple versions per bundle ID to validate linking and renaming behavior across hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->