### PR TITLE
Fix conditional access deletion

### DIFF
--- a/changes/32419-fix-conditional-access-delete
+++ b/changes/32419-fix-conditional-access-delete
@@ -1,0 +1,1 @@
+* Fixed deletion of conditional access integration by adding a spinner and clearing the tenant ID after the deletion.


### PR DESCRIPTION
Resolves #32419.

I took a stab at it while fixing #32420.

Sorry, missed to record with audio:
- I test with the proxy being down (to simulate failure when deleting) and that the delete modal is not closed.
- Spinner during the delete API request.
- Cancel button disabled during the delete API request/.
- Tenant ID is cleared after successful deletion.

https://github.com/user-attachments/assets/dbad0613-a8bd-455d-8741-83c626328437

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually