### PR TITLE
Fix Linux software install tooltip

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -65,7 +65,7 @@ const AddInstallSoftware = ({
       <>
         {installSoftwareDuringSetupCount} software item
         {installSoftwareDuringSetupCount > 1 && "s"} will be{" "}
-        <TooltipWrapper tipContent="Software order will vary.">
+        <TooltipWrapper tipContent="Software will install in alphabetical order.">
           installed during setup.
         </TooltipWrapper>
       </>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33429

# Details

Updates tooltip when viewing Linux software to be installed during setup:

<img width="468" height="383" alt="image" src="https://github.com/user-attachments/assets/04d77a42-81b0-4cdd-b5b7-351dc6e63611" />

## Testing

- [X] QA'd all new/changed functionality manually


