### PR TITLE
22463 jetbrains plugins

### DIFF
--- a/changes/22463-jetbrains
+++ b/changes/22463-jetbrains
@@ -1,0 +1,1 @@
+- added Jetbrains plugins to software inventory

--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -591,6 +591,34 @@ SELECT package, MAX(atime) AS last_opened_at
 		GROUP BY package
 ```
 
+## software_jetbrains_plugins
+
+- Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo, neon, archarm, darwin, windows
+
+- Discovery query:
+```sql
+SELECT 1 FROM osquery_registry WHERE active = true AND registry = 'table' AND name = 'jetbrains_plugins'
+```
+
+- Query:
+```sql
+WITH cached_users AS (WITH cached_groups AS (select * from groups)
+ SELECT uid, uuid, username, type, groupname, shell
+ FROM users LEFT JOIN cached_groups USING (gid)
+ WHERE type <> 'special' AND shell NOT LIKE '%/false' AND shell NOT LIKE '%/nologin' AND shell NOT LIKE '%/shutdown' AND shell NOT LIKE '%/halt' AND username NOT LIKE '%$' AND username NOT LIKE '\_%' ESCAPE '\' AND NOT (username = 'sync' AND shell ='/bin/sync' AND directory <> ''))
+SELECT
+  name,
+  version,
+  '' AS bundle_identifier,
+  '' AS extension_id,
+  product_type AS browser,
+  'jetbrains_plugins' AS source,
+  vendor,
+  '' AS last_opened_at,
+  path AS installed_path
+FROM cached_users CROSS JOIN jetbrains_plugins USING (uid)
+```
+
 ## software_linux
 
 - Platforms: linux, ubuntu, debian, rhel, centos, sles, kali, gentoo, amzn, pop, arch, linuxmint, void, nixos, endeavouros, manjaro, opensuse-leap, opensuse-tumbleweed, tuxedo, neon, archarm

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -466,6 +466,7 @@ export interface IHostSoftware {
   bundle_identifier?: string;
   status: Exclude<SoftwareInstallStatus, "uninstalled"> | null;
   installed_versions: ISoftwareInstallVersion[] | null;
+  extension_for?: string; // only for jetbrains_plugins, indicates the IDE (e.g., "goland")
 }
 
 /**

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -43,6 +43,7 @@ export interface ISoftware {
   last_opened_at?: string | null; // e.g., "2021-08-18T15:11:35Z”
   installed_paths?: string[];
   browser?: string;
+  extension_for?: string; // only for jetbrains_plugins, indicates the IDE (e.g., "goland")
   vendor?: string;
   icon_url: string | null; // Only available on team view if an admin uploaded an icon to a team's software
 }
@@ -148,6 +149,7 @@ export interface ISoftwareTitle {
   software_package: ISoftwarePackage | null;
   app_store_app: IAppStoreApp | null;
   browser?: BrowserType;
+  extension_for?: string; // only for jetbrains_plugins, indicates the IDE (e.g., "goland")
 }
 
 export interface ISoftwareTitleDetails {
@@ -162,6 +164,7 @@ export interface ISoftwareTitleDetails {
   counts_updated_at?: string;
   bundle_identifier?: string;
   browser?: BrowserType;
+  extension_for?: string; // only for jetbrains_plugins, indicates the IDE (e.g., "goland")
   versions_count?: number;
 }
 
@@ -184,6 +187,7 @@ export interface ISoftwareVersion {
   bundle_identifier?: string; // e.g., "com.figma.Desktop"
   source: SoftwareSource;
   browser: BrowserType;
+  extension_for?: string; // only for jetbrains_plugins, indicates the IDE (e.g., "goland")
   release: string; // TODO: on software/verions/:id?
   vendor: string;
   arch: string; // e.g., "x86_64" // TODO: on software/verions/:id?
@@ -200,6 +204,7 @@ export const SOURCE_TYPE_CONVERSION = {
   yum_sources: "Package (YUM)",
   pacman_packages: "Package (pacman)",
   npm_packages: "Package (NPM)",
+  jetbrains_plugins: "IDE extension",
   atom_packages: "Package (Atom)", // Atom packages were removed from software inventory. Mapping is maintained for backwards compatibility. (2023-12-04)
   python_packages: "Package (Python)",
   tgz_packages: "Package (tar)",
@@ -229,6 +234,7 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
   pacman_packages: "linux",
   tgz_packages: "linux",
   npm_packages: null,
+  jetbrains_plugins: null,
   atom_packages: null,
   python_packages: null,
   apps: "darwin",
@@ -259,12 +265,30 @@ const BROWSER_TYPE_CONVERSION = {
 
 export type BrowserType = keyof typeof BROWSER_TYPE_CONVERSION;
 
+const JETBRAINS_EXTENSION_FOR_DISPLAY: Record<string, string> = {
+  clion: "CLion",
+  datagrip: "DataGrip",
+  goland: "GoLand",
+  intellij_idea: "IntelliJ IDEA",
+  intellij_idea_community_edition: "IntelliJ IDEA Community Edition",
+  phpstorm: "PhpStorm",
+  pycharm: "PyCharm",
+  pycharm_community_edition: "PyCharm Community Edition",
+  resharper: "ReSharper",
+  rider: "Rider",
+  rubymine: "RubyMine",
+  rust_rov: "RustRover",
+  webstorm: "WebStorm",
+};
+
 export const formatSoftwareType = ({
   source,
   browser,
+  extension_for,
 }: {
   source: SoftwareSource;
   browser?: BrowserType;
+  extension_for?: string;
 }) => {
   let type: string = SOURCE_TYPE_CONVERSION[source] || "Unknown";
   if (browser) {
@@ -272,6 +296,15 @@ export const formatSoftwareType = ({
       BROWSER_TYPE_CONVERSION[browser] || startCase(browser)
     })`;
   }
+
+  // JetBrains plugins: show the IDE they extend
+  if (source === "jetbrains_plugins" && extension_for) {
+    const displayName =
+      JETBRAINS_EXTENSION_FOR_DISPLAY[extension_for] ||
+      startCase(extension_for);
+    return `IDE extension (${displayName})`;
+  }
+
   return type;
 };
 

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -131,6 +131,7 @@ export const SOFTWARE_SOURCE_TO_ICON_MAP = {
   chocolatey_packages: Package,
   pkg_packages: Package,
   vscode_extensions: Extension,
+  jetbrains_plugins: Extension,
 } as const;
 
 /**

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -113,17 +113,13 @@ export const generateSoftwareTableHeaders = ({
       Header: "Type",
       disableSortBy: true,
       accessor: "source",
-      Cell: (cellProps: ITableStringCellProps) => (
-        <TextCell
-          value={cellProps.cell.value}
-          formatter={() =>
-            formatSoftwareType({
-              source: cellProps.cell.value as SoftwareSource,
-              extension_for: cellProps.row.original.extension_for,
-            })
-          }
-        />
-      ),
+      Cell: (cellProps: ITableStringCellProps) => {
+        const value = formatSoftwareType({
+          source: cellProps.cell.value as SoftwareSource,
+          extension_for: cellProps.row.original.extension_for,
+        });
+        return <TextCell value={value} />;
+      },
     },
     {
       Header: (): JSX.Element => {

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -119,6 +119,7 @@ export const generateSoftwareTableHeaders = ({
           formatter={() =>
             formatSoftwareType({
               source: cellProps.cell.value as SoftwareSource,
+              extension_for: cellProps.row.original.extension_for,
             })
           }
         />

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -4277,6 +4277,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				SELECT
 					software_titles.id,
 					software_titles.name,
+					software_titles.browser AS browser,
 					software_titles.source AS source,
 					software_installers.id AS installer_id,
 					software_installers.self_service AS package_self_service,
@@ -4296,6 +4297,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				GROUP BY
 					software_titles.id,
 					software_titles.name,
+					software_titles.browser,
 					software_titles.source,
 					software_installers.id,
 					software_installers.self_service,

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -4313,6 +4313,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				SELECT
 					software_titles.id,
 					software_titles.name,
+					software_titles.browser AS browser,
 					software_titles.source AS source,
 					NULL AS installer_id,
 					NULL AS package_self_service,
@@ -4332,7 +4333,8 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				GROUP BY
 					software_titles.id,
 					software_titles.name,
-					software_titles.source
+					software_titles.source,
+					software_titles.browser
 			`)
 		}
 		stmt = fmt.Sprintf(stmt, replacements...)

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -52,6 +52,8 @@ type Software struct {
 	ExtensionID string `json:"extension_id,omitempty" db:"extension_id"`
 	// Browser is the browser type (from osquery chrome_extensions)
 	Browser string `json:"browser" db:"browser"`
+	// ExtensionFor is the JetBrains product this plugin/extension is for (e.g., "goland", "idea").
+	ExtensionFor string `json:"extension_for,omitempty" db:"extension_for"`
 
 	// Release is the version of the OS this software was released on
 	// (e.g. "30.el7" for a CentOS package).

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -187,6 +187,8 @@ type SoftwareTitle struct {
 	Source string `json:"source" db:"source"`
 	// Browser is the browser type (e.g., "chrome", "firefox", "safari")
 	Browser string `json:"browser,omitempty" db:"browser"`
+	// ExtensionFor is the JetBrains product this plugin/extension is for (e.g., "goland", "idea").
+	ExtensionFor string `json:"extension_for,omitempty"`
 	// HostsCount is the number of hosts that use this software title.
 	HostsCount uint `json:"hosts_count" db:"hosts_count"`
 	// VesionsCount is the number of versions that have the same title.
@@ -229,6 +231,8 @@ type SoftwareTitleListResult struct {
 	Source string `json:"source" db:"source"`
 	// Browser is the browser type (e.g., "chrome", "firefox", "safari")
 	Browser string `json:"browser,omitempty" db:"browser"`
+	// ExtensionFor is the JetBrains product this plugin/extension is for (e.g., "goland", "idea").
+	ExtensionFor string `json:"extension_for,omitempty"`
 	// HostsCount is the number of hosts that use this software title.
 	HostsCount uint `json:"hosts_count" db:"hosts_count"`
 	// VesionsCount is the number of versions that have the same title.

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -514,3 +514,30 @@ type SoftwareCategory struct {
 	ID   uint   `db:"id"`
 	Name string `db:"name"`
 }
+
+const jbPlugins = "jetbrains_plugins"
+
+func moveBrowserToExtFor(source, browser, extFor *string) {
+	if source != nil && *source == jbPlugins {
+		if browser != nil && *browser != "" {
+			*extFor = *browser
+		}
+		*browser = ""
+	}
+}
+
+func NormalizeSoftware(software *Software) {
+	moveBrowserToExtFor(&software.Source, &software.Browser, &software.ExtensionFor)
+}
+
+func NormalizeTitle(t *SoftwareTitle) {
+	moveBrowserToExtFor(&t.Source, &t.Browser, &t.ExtensionFor)
+}
+
+func NormalizeVulnerableSoftware(vs *VulnerableSoftware) {
+	moveBrowserToExtFor(&vs.Source, &vs.Browser, &vs.ExtensionFor)
+}
+
+func NormalizeHostSoftwareWithInstaller(hs *HostSoftwareWithInstaller) {
+	moveBrowserToExtFor(&hs.Source, &hs.Browser, &hs.ExtensionFor)
+}

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -142,6 +142,7 @@ type VulnerableSoftware struct {
 	Version           string  `json:"version" db:"version"`
 	Source            string  `json:"source" db:"source"`
 	Browser           string  `json:"browser" db:"browser"`
+	ExtensionFor      string  `json:"extension_for,omitempty"`
 	GenerateCPE       string  `json:"generated_cpe" db:"generated_cpe"`
 	HostsCount        int     `json:"hosts_count,omitempty" db:"hosts_count"`
 	ResolvedInVersion *string `json:"resolved_in_version" db:"resolved_in_version"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -468,6 +468,7 @@ func SoftwareInstallerPlatformFromExtension(ext string) (string, error) {
 type HostSoftwareWithInstaller struct {
 	ID                uint                            `json:"id" db:"id"`
 	Name              string                          `json:"name" db:"name"`
+	Browser           string                          `json:"browser" db:"browser"`
 	IconUrl           *string                         `json:"icon_url" db:"-"`
 	Source            string                          `json:"source" db:"source"`
 	Status            *SoftwareInstallerStatus        `json:"status" db:"status"`

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -469,6 +469,7 @@ type HostSoftwareWithInstaller struct {
 	ID                uint                            `json:"id" db:"id"`
 	Name              string                          `json:"name" db:"name"`
 	Browser           string                          `json:"browser" db:"browser"`
+	ExtensionFor      string                          `json:"extension_for,omitempty" db:"-"`
 	IconUrl           *string                         `json:"icon_url" db:"-"`
 	Source            string                          `json:"source" db:"source"`
 	Status            *SoftwareInstallerStatus        `json:"status" db:"status"`

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -195,7 +195,6 @@ func TestEnhanceOutputDetails(t *testing.T) {
 	}
 }
 
-
 func TestMoveBrowserToExtFor(t *testing.T) {
 	t.Run("moves when source=jetbrains_plugins and browser non-empty", func(t *testing.T) {
 		src := "jetbrains_plugins"

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2990,11 +2990,8 @@ func (svc *Service) ListHostSoftware(ctx context.Context, hostID uint, opts flee
 		}
 	}
 
-	for i, s := range software {
-		if s.Source == "jetbrains_plugins" {
-			software[i].ExtensionFor = s.Browser
-			software[i].Browser = ""
-		}
+	for _, s := range software {
+		fleet.NormalizeHostSoftwareWithInstaller(s)
 	}
 
 	return software, meta, nil

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2990,6 +2990,13 @@ func (svc *Service) ListHostSoftware(ctx context.Context, hostID uint, opts flee
 		}
 	}
 
+	for i, s := range software {
+		if s.Source == "jetbrains_plugins" {
+			software[i].ExtensionFor = s.Browser
+			software[i].Browser = ""
+		}
+	}
+
 	return software, meta, nil
 }
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1387,6 +1387,9 @@ func preProcessSoftwareResults(
 	fleetdPacmanPackagesExtraQuery := hostDetailQueryPrefix + "software_linux_fleetd_pacman"
 	preProcessSoftwareExtraResults(fleetdPacmanPackagesExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
 
+	jetbrainsPluginsExtraQuery := hostDetailQueryPrefix + "software_jetbrains_plugins"
+	preProcessSoftwareExtraResults(jetbrainsPluginsExtraQuery, host.ID, results, statuses, messages, osquery_utils.DetailQuery{}, logger)
+
 	for name, query := range overrides {
 		fullQueryName := hostDetailQueryPrefix + "software_" + name
 		preProcessSoftwareExtraResults(fullQueryName, host.ID, results, statuses, messages, query, logger)

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -1111,6 +1111,7 @@ func verifyDiscovery(t *testing.T, queries, discovery map[string]string) {
 		hostDetailQueryPrefix + "orbit_info":                              {},
 		hostDetailQueryPrefix + "software_vscode_extensions":              {},
 		hostDetailQueryPrefix + "software_linux_fleetd_pacman":            {},
+		hostDetailQueryPrefix + "software_jetbrains_plugins":              {},
 		hostDetailQueryPrefix + "software_python_packages":                {},
 		hostDetailQueryPrefix + "software_python_packages_with_users_dir": {},
 		hostDetailQueryPrefix + "software_macos_firefox":                  {},

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -343,7 +343,7 @@ func TestGetDetailQueries(t *testing.T) {
 
 	queriesWithUsersAndSoftware := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true}, Integrations{}, nil)
 	qs = baseQueries
-	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_linux_fleetd_pacman",
+	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_jetbrains_plugins", "software_linux_fleetd_pacman",
 		"software_chrome", "software_python_packages", "software_python_packages_with_users_dir", "scheduled_query_stats", "software_macos_firefox", "software_macos_codesign", "software_windows_last_opened_at", "software_deb_last_opened_at", "software_rpm_last_opened_at")
 	require.Len(t, queriesWithUsersAndSoftware, len(qs))
 	sortedKeysCompare(t, queriesWithUsersAndSoftware, qs)

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -199,11 +199,7 @@ func (svc *Service) SoftwareByID(ctx context.Context, id uint, teamID *uint, inc
 		return nil, ctxerr.Wrap(ctx, err, "getting software version by id")
 	}
 
-	// JetBrains plugins
-	if software.Source == "jetbrains_plugins" {
-		software.ExtensionFor = software.Browser
-		software.Browser = ""
-	}
+	fleet.NormalizeSoftware(software)
 
 	return software, nil
 }

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -199,6 +199,12 @@ func (svc *Service) SoftwareByID(ctx context.Context, id uint, teamID *uint, inc
 		return nil, ctxerr.Wrap(ctx, err, "getting software version by id")
 	}
 
+	// JetBrains plugins
+	if software.Source == "jetbrains_plugins" {
+		software.ExtensionFor = software.Browser
+		software.Browser = ""
+	}
+
 	return software, nil
 }
 

--- a/server/service/software_test.go
+++ b/server/service/software_test.go
@@ -201,3 +201,32 @@ func TestServiceSoftwareInventoryAuth(t *testing.T) {
 		})
 	}
 }
+
+func TestSoftwareByIDJetbrainsPlugins(t *testing.T) {
+	ds := new(mock.Store)
+
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	ds.SoftwareByIDFunc = func(ctx context.Context, id uint, teamID *uint, includeCVEScores bool, tmFilter *fleet.TeamFilter) (*fleet.Software, error) {
+		return &fleet.Software{
+			ID:      42,
+			Name:    "Some Plugin",
+			Source:  "jetbrains_plugins",
+			Browser: "goland",
+		}, nil
+	}
+
+	user := &fleet.User{
+		ID:         3,
+		GlobalRole: ptr.String(fleet.RoleObserver),
+	}
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
+
+	software, err := svc.SoftwareByID(ctx, 42, nil, false)
+	require.NoError(t, err)
+	require.Equal(t, uint(42), software.ID)
+	require.Equal(t, "Some Plugin", software.Name)
+	require.Equal(t, "jetbrains_plugins", software.Source)
+	require.Equal(t, "goland", software.ExtensionFor)
+	require.Empty(t, software.Browser)
+}

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -189,11 +189,7 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 		return nil, ctxerr.Wrap(ctx, err, "getting software title by id")
 	}
 
-	// Populate extension_for for jetbrains plugins/extensions
-	if software.Source == "jetbrains_plugins" {
-		software.ExtensionFor = software.Browser
-		software.Browser = ""
-	}
+	fleet.NormalizeTitle(software)
 
 	license, err := svc.License(ctx)
 	if err != nil {

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -107,6 +107,15 @@ func (svc *Service) ListSoftwareTitles(
 		return nil, 0, nil, err
 	}
 
+	// for jetbrains plugins/extensions, we populate the ExtensionFor field
+	// from the Browser field (which holds the JetBrains product name)
+	for i, t := range titles {
+		if t.Source == "jetbrains_plugins" {
+			titles[i].ExtensionFor = t.Browser
+			titles[i].Browser = ""
+		}
+	}
+
 	return titles, count, meta, nil
 }
 
@@ -178,6 +187,12 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 			return nil, fleet.NewPermissionError("Error: You don't have permission to view specified software. It is installed on hosts that belong to team you don't have permissions to view.")
 		}
 		return nil, ctxerr.Wrap(ctx, err, "getting software title by id")
+	}
+
+	// Populate extension_for for jetbrains plugins/extensions
+	if software.Source == "jetbrains_plugins" {
+		software.ExtensionFor = software.Browser
+		software.Browser = ""
 	}
 
 	license, err := svc.License(ctx)

--- a/server/service/vulnerabilities.go
+++ b/server/service/vulnerabilities.go
@@ -230,11 +230,9 @@ func (svc *Service) ListSoftwareByCVE(ctx context.Context, cve string, teamID *u
 	}
 	sw, updatedAt, err := svc.ds.SoftwareByCVE(ctx, cve, teamID)
 
-	for i, s := range sw {
-		if s.Source == "jetbrains_plugins" && s.Browser != "" {
-			sw[i].ExtensionFor = s.Browser
-			sw[i].Browser = ""
-		}
+	for _, s := range sw {
+		fleet.NormalizeVulnerableSoftware(s)
 	}
+
 	return sw, updatedAt, err
 }

--- a/server/service/vulnerabilities.go
+++ b/server/service/vulnerabilities.go
@@ -228,5 +228,13 @@ func (svc *Service) ListSoftwareByCVE(ctx context.Context, cve string, teamID *u
 	if err := svc.authz.Authorize(ctx, &fleet.AuthzSoftwareInventory{TeamID: teamID}, fleet.ActionRead); err != nil {
 		return nil, updatedAt, err
 	}
-	return svc.ds.SoftwareByCVE(ctx, cve, teamID)
+	sw, updatedAt, err := svc.ds.SoftwareByCVE(ctx, cve, teamID)
+
+	for i, s := range sw {
+		if s.Source == "jetbrains_plugins" && s.Browser != "" {
+			sw[i].ExtensionFor = s.Browser
+			sw[i].Browser = ""
+		}
+	}
+	return sw, updatedAt, err
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #22463 

Backend:
- Added a detail query to pull in jetbrains plugins and add the "product_for" attribute to `software.browsers`
  - writing to the existing column to avoid a migration and risk around renaming the column
- When after pulling the attribute from the datastore, it's getting transformed to the new API key `extension_for` if it is a jetbrains plugin.  Figured this pattern will be useful in the near future with upcomin vscode fork support https://github.com/fleetdm/fleet/issues/31397

Frontend:
- add support and translations for the new `extension_for` key (see figma)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [X] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually

