### PR TITLE
Add tooltip+truncation to Hosts table `hostname` column

### DIFF
--- a/changes/32155-hosts-table-truncation
+++ b/changes/32155-hosts-table-truncation
@@ -1,0 +1,2 @@
+* Update Hosts table > hostname column to truncate overflowing hostnames
+ and place the full name in a tooltip on hover.

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -177,7 +177,7 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
     accessor: "hostname",
     id: "hostname",
     Cell: (cellProps: IHostTableStringCellProps) => (
-      <TextCell value={cellProps.cell.value} />
+      <TooltipTruncatedTextCell value={cellProps.cell.value} />
     ),
   },
   {


### PR DESCRIPTION
## #32155 

`hostname` and `UUID` columns truncate appropriately:
![ezgif-5eb0ee8702a8ec](https://github.com/user-attachments/assets/4e9762e6-0ef4-4c60-8221-e2006a604133)


- [x] Changes file added for user-visible changes in `changes/`
- [x] QA'd all new/changed functionality manually