### PR TITLE
Unenroll Android BYOD hosts

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1057,6 +1057,19 @@ the way that the Fleet server works.
 				initFatal(err, "failed to register mdm_android_profile_manager schedule")
 			}
 
+			// Register Android MDM Device Reconciler schedule (same interval as Android profile manager)
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return newAndroidMDMDeviceReconcilerSchedule(
+					ctx,
+					instanceID,
+					ds,
+					logger,
+					config.License.Key,
+				)
+			}); err != nil {
+				initFatal(err, "failed to register mdm_android_device_reconciler schedule")
+			}
+
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 				return newMDMAPNsPusher(
 					ctx,

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -367,8 +367,22 @@ const modifyOptions = (
   };
 
   let optionsToDisable: IDropdownOption[] = [];
+  // When the host is offline, always disable Query, but allow Unenroll for iOS/iPadOS and Android.
+  if (!isHostOnline) {
+    optionsToDisable = optionsToDisable.concat(
+      options.filter((option) => option.value === "query")
+    );
+
+    // Disable "Turn off MDM" (Unenroll) when offline for all platforms except iOS/iPadOS and Android
+    if (!isIPadOrIPhone(hostPlatform) && !isAndroid(hostPlatform)) {
+      optionsToDisable = optionsToDisable.concat(
+        options.filter((option) => option.value === "mdmOff")
+      );
+    }
+  }
+
+  // While device status is updating, or device is locked/wiped, disable Query and Turn off MDM
   if (
-    (!isIPadOrIPhone(hostPlatform) && !isHostOnline) ||
     isDeviceStatusUpdating(hostMdmDeviceStatus) ||
     hostMdmDeviceStatus === "locked" ||
     hostMdmDeviceStatus === "wiped"

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -34,11 +34,15 @@ const UnenrollMdmModal = ({
   const submitUnenrollMdm = async () => {
     setRequestState("unenrolling");
     try {
-      await mdmAPI.unenrollHostFromMdm(hostId, 5000);
+      if (isAndroid(hostPlatform)) {
+        await mdmAPI.unenrollAndroidHostFromMdm(hostId, 5000);
+      } else {
+        await mdmAPI.unenrollHostFromMdm(hostId, 5000);
+      }
       const successMessage =
         isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform) ? (
           <>
-            <b>{hostName}</b> will unenrolled next time this host checks in.
+            <b>{hostName}</b> will be unenrolled next time this host checks in.
           </>
         ) : (
           <>

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -119,6 +119,11 @@ const mdmService = {
       timeout
     );
   },
+  // Android-specific: admin-initiated unenroll uses POST /api/_version_/fleet/hosts/{id}/mdm/unenroll
+  unenrollAndroidHostFromMdm: (hostId: number, timeout?: number) => {
+    const path = `${endpoints.HOST_MDM(hostId)}/unenroll`;
+    return sendRequest("POST", path, undefined, undefined, timeout);
+  },
   requestCSR: () => {
     const { MDM_REQUEST_CSR } = endpoints;
 

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -373,6 +373,15 @@ UPDATE host_mdm
 	return ctxerr.Wrap(ctx, err, "set host_mdm to unenrolled for android")
 }
 
+// SetAndroidHostUnenrolled sets a single android host to unenrolled in host_mdm.
+func (ds *Datastore) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error {
+	_, err := ds.writer(ctx).ExecContext(ctx, `
+UPDATE host_mdm
+	SET server_url = '', mdm_id = NULL, enrolled = 0
+	WHERE host_id = ?`, hostID)
+	return ctxerr.Wrap(ctx, err, "set host_mdm to unenrolled for android host")
+}
+
 func upsertAndroidHostMDMInfoDB(ctx context.Context, tx sqlx.ExtContext, serverURL string, fromDEP, enrolled bool, hostIDs ...uint) error {
 	if len(hostIDs) == 0 {
 		return nil

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -900,6 +900,8 @@ const hostMDMSelect = `,
 				ELSE CAST(FALSE AS JSON)
 				END
 			)
+			WHEN h.platform = 'android' THEN
+				CASE WHEN hmdm.enrolled = 1 THEN CAST(TRUE AS JSON) ELSE CAST(FALSE AS JSON) END
 			WHEN h.platform IN ('ios', 'ipados', 'darwin') THEN (` +
 	// NOTE: if you change any of the conditions in this
 	// query, please update the AreHostsConnectedToFleetMDM

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -24,6 +24,7 @@ const (
 	CronMDMAppleProfileManager       CronScheduleName = "mdm_apple_profile_manager"
 	CronMDMWindowsProfileManager     CronScheduleName = "mdm_windows_profile_manager"
 	CronMDMAndroidProfileManager     CronScheduleName = "mdm_android_profile_manager"
+	CronMDMAndroidDeviceReconciler   CronScheduleName = "mdm_android_device_reconciler"
 	CronAppleMDMIPhoneIPadRefetcher  CronScheduleName = "apple_mdm_iphone_ipad_refetcher"
 	CronAppleMDMAPNsPusher           CronScheduleName = "apple_mdm_apns_pusher"
 	CronCalendar                     CronScheduleName = "calendar"

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2286,6 +2286,11 @@ type Datastore interface {
 	// profiles with the specified UUIDs.
 	GetMDMAndroidProfilesContents(ctx context.Context, uuids []string) (map[string]json.RawMessage, error)
 
+	// ListAndroidEnrolledDevicesForReconcile returns the list of Android devices
+	// that are currently marked as enrolled in Fleet (host_mdm.enrolled=1).
+	// It returns a minimal device struct with host and device identifiers.
+	ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// SCIM
 

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2409,6 +2409,7 @@ type AndroidDatastore interface {
 	AndroidHostLiteByHostUUID(ctx context.Context, hostUUID string) (*AndroidHost, error)
 	AppConfig(ctx context.Context) (*AppConfig, error)
 	BulkSetAndroidHostsUnenrolled(ctx context.Context) error
+	SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error
 	DeleteMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName) error
 	GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []MDMAssetName,
 		queryerContext sqlx.QueryerContext) (map[MDMAssetName]MDMConfigAsset, error)

--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -21,6 +21,8 @@ type EnterprisesPoliciesPatchFunc func(ctx context.Context, policyName string, p
 
 type EnterprisesDevicesPatchFunc func(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
 
+type EnterprisesDevicesDeleteFunc func(ctx context.Context, deviceName string) error
+
 type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
 
 type EnterpriseDeleteFunc func(ctx context.Context, enterpriseName string) error
@@ -41,6 +43,9 @@ type Client struct {
 
 	EnterprisesDevicesPatchFunc        EnterprisesDevicesPatchFunc
 	EnterprisesDevicesPatchFuncInvoked bool
+
+	EnterprisesDevicesDeleteFunc        EnterprisesDevicesDeleteFunc
+	EnterprisesDevicesDeleteFuncInvoked bool
 
 	EnterprisesEnrollmentTokensCreateFunc        EnterprisesEnrollmentTokensCreateFunc
 	EnterprisesEnrollmentTokensCreateFuncInvoked bool
@@ -83,6 +88,13 @@ func (p *Client) EnterprisesDevicesPatch(ctx context.Context, deviceName string,
 	p.EnterprisesDevicesPatchFuncInvoked = true
 	p.mu.Unlock()
 	return p.EnterprisesDevicesPatchFunc(ctx, deviceName, device)
+}
+
+func (p *Client) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {
+	p.mu.Lock()
+	p.EnterprisesDevicesDeleteFuncInvoked = true
+	p.mu.Unlock()
+	return p.EnterprisesDevicesDeleteFunc(ctx, deviceName)
 }
 
 func (p *Client) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {

--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -21,6 +21,8 @@ type EnterprisesPoliciesPatchFunc func(ctx context.Context, policyName string, p
 
 type EnterprisesDevicesPatchFunc func(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
 
+type EnterprisesDevicesGetFunc func(ctx context.Context, deviceName string) (*androidmanagement.Device, error)
+
 type EnterprisesDevicesDeleteFunc func(ctx context.Context, deviceName string) error
 
 type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
@@ -43,6 +45,9 @@ type Client struct {
 
 	EnterprisesDevicesPatchFunc        EnterprisesDevicesPatchFunc
 	EnterprisesDevicesPatchFuncInvoked bool
+
+	EnterprisesDevicesGetFunc        EnterprisesDevicesGetFunc
+	EnterprisesDevicesGetFuncInvoked bool
 
 	EnterprisesDevicesDeleteFunc        EnterprisesDevicesDeleteFunc
 	EnterprisesDevicesDeleteFuncInvoked bool
@@ -88,6 +93,13 @@ func (p *Client) EnterprisesDevicesPatch(ctx context.Context, deviceName string,
 	p.EnterprisesDevicesPatchFuncInvoked = true
 	p.mu.Unlock()
 	return p.EnterprisesDevicesPatchFunc(ctx, deviceName, device)
+}
+
+func (p *Client) EnterprisesDevicesGet(ctx context.Context, deviceName string) (*androidmanagement.Device, error) {
+	p.mu.Lock()
+	p.EnterprisesDevicesGetFuncInvoked = true
+	p.mu.Unlock()
+	return p.EnterprisesDevicesGetFunc(ctx, deviceName)
 }
 
 func (p *Client) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -15,6 +15,9 @@ type Service interface {
 	// CreateEnrollmentToken creates an enrollment token for a new Android device.
 	CreateEnrollmentToken(ctx context.Context, enrollSecret, idpUUID string) (*EnrollmentToken, error)
 	ProcessPubSubPush(ctx context.Context, token string, message *PubSubMessage) error
+
+	// UnenrollAndroidHost triggers unenrollment (work profile removal) for the given Android host ID.
+	UnenrollAndroidHost(ctx context.Context, hostID uint) error
 }
 
 // /////////////////////////////////////////////

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -30,6 +30,10 @@ type Client interface {
 	// On success it returns the updated device with latest applied policy information.
 	EnterprisesDevicesPatch(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
 
+	// EnterprisesDevicesGet retrieves a device by resource name.
+	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/get
+	EnterprisesDevicesGet(ctx context.Context, deviceName string) (*androidmanagement.Device, error)
+
 	// EnterprisesDevicesDelete deletes an enrolled device (work profile) in the enterprise.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/delete
 	EnterprisesDevicesDelete(ctx context.Context, deviceName string) error

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -30,6 +30,10 @@ type Client interface {
 	// On success it returns the updated device with latest applied policy information.
 	EnterprisesDevicesPatch(ctx context.Context, deviceName string, device *androidmanagement.Device) (*androidmanagement.Device, error)
 
+	// EnterprisesDevicesDelete deletes an enrolled device (work profile) in the enterprise.
+	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/delete
+	EnterprisesDevicesDelete(ctx context.Context, deviceName string) error
+
 	// EnterprisesEnrollmentTokensCreate creates an enrollment token for a given enterprise. It is used to enroll an Android device.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens/create
 	EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -186,6 +186,17 @@ func (g *GoogleClient) EnterprisesDevicesPatch(ctx context.Context, deviceName s
 	return ret, nil
 }
 
+func (g *GoogleClient) EnterprisesDevicesGet(ctx context.Context, deviceName string) (*androidmanagement.Device, error) {
+	if g == nil || g.mgmt == nil {
+		return nil, errors.New("android management service not initialized")
+	}
+	ret, err := g.mgmt.Enterprises.Devices.Get(deviceName).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("getting device %s: %w", deviceName, err)
+	}
+	return ret, nil
+}
+
 func (g *GoogleClient) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {
 	if g == nil || g.mgmt == nil {
 		return errors.New("android management service not initialized")

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -186,6 +186,21 @@ func (g *GoogleClient) EnterprisesDevicesPatch(ctx context.Context, deviceName s
 	return ret, nil
 }
 
+func (g *GoogleClient) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {
+	if g == nil || g.mgmt == nil {
+		return errors.New("android management service not initialized")
+	}
+	_, err := g.mgmt.Enterprises.Devices.Delete(deviceName).Context(ctx).Do()
+	switch {
+	case googleapi.IsNotModified(err):
+		g.logger.Log("msg", "Android device already deleted", "device_name", deviceName)
+		return nil
+	case err != nil:
+		return fmt.Errorf("deleting device %s: %w", deviceName, err)
+	}
+	return nil
+}
+
 func (g *GoogleClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken,
 ) (*androidmanagement.EnrollmentToken, error) {
 	if g == nil || g.mgmt == nil {

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -182,6 +182,23 @@ func (p *ProxyClient) EnterprisesDevicesPatch(ctx context.Context, deviceName st
 	return ret, nil
 }
 
+func (p *ProxyClient) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {
+	if p == nil || p.mgmt == nil {
+		return errors.New("android management service not initialized")
+	}
+	call := p.mgmt.Enterprises.Devices.Delete(deviceName).Context(ctx)
+	call.Header().Set("Authorization", "Bearer "+p.fleetServerSecret)
+	_, err := call.Do()
+	switch {
+	case googleapi.IsNotModified(err) || isErrorCode(err, http.StatusNotFound):
+		p.logger.Log("msg", "Android device already deleted", "device_name", deviceName)
+		return nil
+	case err != nil:
+		return fmt.Errorf("deleting device %s: %w", deviceName, err)
+	}
+	return nil
+}
+
 func (p *ProxyClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,
 	token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {
 	if p == nil || p.mgmt == nil {

--- a/server/mdm/android/service/androidmgmt/proxy_client.go
+++ b/server/mdm/android/service/androidmgmt/proxy_client.go
@@ -182,6 +182,19 @@ func (p *ProxyClient) EnterprisesDevicesPatch(ctx context.Context, deviceName st
 	return ret, nil
 }
 
+func (p *ProxyClient) EnterprisesDevicesGet(ctx context.Context, deviceName string) (*androidmanagement.Device, error) {
+	if p == nil || p.mgmt == nil {
+		return nil, errors.New("android management service not initialized")
+	}
+	call := p.mgmt.Enterprises.Devices.Get(deviceName).Context(ctx)
+	call.Header().Set("Authorization", "Bearer "+p.fleetServerSecret)
+	ret, err := call.Do()
+	if err != nil {
+		return nil, fmt.Errorf("getting device %s: %w", deviceName, err)
+	}
+	return ret, nil
+}
+
 func (p *ProxyClient) EnterprisesDevicesDelete(ctx context.Context, deviceName string) error {
 	if p == nil || p.mgmt == nil {
 		return errors.New("android management service not initialized")

--- a/server/mdm/android/service/handler.go
+++ b/server/mdm/android/service/handler.go
@@ -25,6 +25,7 @@ func attachFleetAPIRoutes(r *mux.Router, fleetSvc fleet.Service, svc android.Ser
 	ue.GET("/api/_version_/fleet/android_enterprise", getEnterpriseEndpoint, nil)
 	ue.DELETE("/api/_version_/fleet/android_enterprise", deleteEnterpriseEndpoint, nil)
 	ue.GET("/api/_version_/fleet/android_enterprise/signup_sse", enterpriseSSE, nil)
+	ue.POST("/api/_version_/fleet/hosts/{id}/mdm/unenroll", unenrollAndroidHostEndpoint, androidHostUnenrollRequest{})
 
 	// //////////////////////////////////////////
 	// Unauthenticated endpoints

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -31,8 +31,13 @@ func pubSubPushEndpoint(ctx context.Context, request interface{}, svc android.Se
 
 func (svc *Service) ProcessPubSubPush(ctx context.Context, token string, message *android.PubSubMessage) error {
 	notificationType, ok := message.Attributes["notificationType"]
+	if !ok || len(notificationType) == 0 {
+		// Nothing to process
+		svc.authz.SkipAuthorization(ctx)
+		return nil
+	}
 	level.Debug(svc.logger).Log("msg", "Received PubSub message", "notification", notificationType)
-	if !ok || len(notificationType) == 0 || android.NotificationType(notificationType) == android.PubSubTest {
+	if android.NotificationType(notificationType) == android.PubSubTest {
 		// Nothing to process
 		svc.authz.SkipAuthorization(ctx)
 		return nil
@@ -111,7 +116,21 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 		return ctxerr.Wrap(ctx, err, "unmarshal Android status report message")
 	}
 
-	if device.AppliedState == string(android.DeviceStateDeleted) {
+	// Consider both appliedState and state fields for deletion, to handle variations in payloads.
+	isDeleted := strings.ToUpper(device.AppliedState) == string(android.DeviceStateDeleted)
+	if !isDeleted {
+		var alt struct {
+			AppliedState string `json:"appliedState"`
+			State        string `json:"state"`
+		}
+		// Best-effort parse; ignore error if shape doesn't match.
+		_ = json.Unmarshal(rawData, &alt)
+		if strings.ToUpper(alt.AppliedState) == string(android.DeviceStateDeleted) || strings.ToUpper(alt.State) == string(android.DeviceStateDeleted) {
+			isDeleted = true
+		}
+	}
+
+	if isDeleted {
 		level.Debug(svc.logger).Log("msg", "Android device deleted from MDM", "device.name", device.Name,
 			"device.enterpriseSpecificId", device.HardwareInfo.EnterpriseSpecificId)
 
@@ -175,6 +194,40 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshal Android enrollment message")
 	}
+
+	// Some deployments may report work profile removal under ENROLLMENT notifications.
+	// Detect DELETED here too and treat as unenrollment confirmation.
+	isDeleted := strings.ToUpper(device.AppliedState) == string(android.DeviceStateDeleted)
+	if !isDeleted {
+		var alt struct {
+			AppliedState string `json:"appliedState"`
+			State        string `json:"state"`
+		}
+		_ = json.Unmarshal(rawData, &alt)
+		if strings.ToUpper(alt.AppliedState) == string(android.DeviceStateDeleted) || strings.ToUpper(alt.State) == string(android.DeviceStateDeleted) {
+			isDeleted = true
+		}
+	}
+	if isDeleted {
+		// Bypass re-enrollment and flip host to unenrolled.
+		host, herr := svc.getExistingHost(ctx, &device)
+		if herr != nil {
+			return ctxerr.Wrap(ctx, herr, "get host for deleted android device (ENROLLMENT)")
+		}
+		if host != nil {
+			if err := svc.ds.SetAndroidHostUnenrolled(ctx, host.Host.ID); err != nil {
+				return ctxerr.Wrap(ctx, err, "set android host unenrolled on DELETED state (ENROLLMENT)")
+			}
+			displayName := svc.getComputerName(&device)
+			_ = svc.fleetSvc.NewActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+				HostSerial:       "",
+				HostDisplayName:  displayName,
+				InstalledFromDEP: false,
+			})
+		}
+		return nil
+	}
+
 	err = svc.enrollHost(ctx, &device)
 	if err != nil {
 		level.Debug(svc.logger).Log("msg", "Error enrolling Android host", "data", rawData)
@@ -302,6 +355,7 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enrolling Android host")
 	}
+	// Enrollment activities are intentionally not emitted for Android at this time.
 	return nil
 }
 
@@ -311,20 +365,20 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshilling enrollment token data")
 	}
-
+	
 	enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, enrollmentTokenRequest.EnrollSecret)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
-
+	
 	deviceID, err := svc.getDeviceID(ctx, device)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting device ID")
 	}
-
+	
 	gigsTotalDiskSpace, gigsDiskSpaceAvailable, percentDiskSpaceAvailable :=
 		svc.calculateAndroidStorageMetrics(ctx, device, false)
-
+	
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			TeamID:                    enrollSecret.GetTeamID(),
@@ -369,7 +423,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enrolling Android host")
 	}
-
+	
 	if enrollmentTokenRequest.IdpUUID != "" {
 		level.Info(svc.logger).Log("msg", "associating android host with idp account", "host_uuid", host.UUID, "idp_uuid", enrollmentTokenRequest.IdpUUID)
 		err := svc.ds.AssociateHostMDMIdPAccount(ctx, host.UUID, enrollmentTokenRequest.IdpUUID)
@@ -377,7 +431,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 			return ctxerr.Wrap(ctx, err, "associating host with idp account")
 		}
 	}
-
+	
 	return nil
 }
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -365,20 +365,20 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "unmarshilling enrollment token data")
 	}
-	
+
 	enrollSecret, err := svc.ds.VerifyEnrollSecret(ctx, enrollmentTokenRequest.EnrollSecret)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "verifying enroll secret")
 	}
-	
+
 	deviceID, err := svc.getDeviceID(ctx, device)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting device ID")
 	}
-	
+
 	gigsTotalDiskSpace, gigsDiskSpaceAvailable, percentDiskSpaceAvailable :=
 		svc.calculateAndroidStorageMetrics(ctx, device, false)
-	
+
 	host := &fleet.AndroidHost{
 		Host: &fleet.Host{
 			TeamID:                    enrollSecret.GetTeamID(),
@@ -423,7 +423,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enrolling Android host")
 	}
-	
+
 	if enrollmentTokenRequest.IdpUUID != "" {
 		level.Info(svc.logger).Log("msg", "associating android host with idp account", "host_uuid", host.UUID, "idp_uuid", enrollmentTokenRequest.IdpUUID)
 		err := svc.ds.AssociateHostMDMIdPAccount(ctx, host.UUID, enrollmentTokenRequest.IdpUUID)
@@ -431,7 +431,7 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 			return ctxerr.Wrap(ctx, err, "associating host with idp account")
 		}
 	}
-	
+
 	return nil
 }
 

--- a/server/mdm/android/service/reconcile_devices.go
+++ b/server/mdm/android/service/reconcile_devices.go
@@ -1,0 +1,100 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	kitlog "github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"google.golang.org/api/googleapi"
+)
+
+// ReconcileAndroidDevices polls AMAPI for devices that Fleet still considers enrolled
+// and flips them to unenrolled if Google reports them missing (404).
+// This complements (does not replace) Pub/Sub DELETED handling.
+func ReconcileAndroidDevices(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger, licenseKey string) error {
+	appConfig, err := ds.AppConfig(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get app config")
+	}
+	if !appConfig.MDM.AndroidEnabledAndConfigured {
+		return nil
+	}
+
+	// Ensure an enterprise exists, otherwise nothing to do, and keep its ID to build device resource names.
+	enterprise, err := ds.GetEnterprise(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get android enterprise")
+	}
+
+	client := newAMAPIClient(ctx, logger, licenseKey)
+
+	// Best-effort set authentication secret for proxy client usage (no-op for Google client).
+	if assets, err := ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidFleetServerSecret}, nil); err == nil {
+		if asset, ok := assets[fleet.MDMAssetAndroidFleetServerSecret]; ok && len(asset.Value) > 0 {
+			_ = client.SetAuthenticationSecret(string(asset.Value))
+		}
+	}
+
+	devices, err := ds.ListAndroidEnrolledDevicesForReconcile(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "list enrolled android devices for reconcile")
+	}
+	if len(devices) == 0 {
+		return nil
+	}
+
+	checked := 0
+	unenrolled := 0
+	for _, dev := range devices {
+		if dev == nil || dev.DeviceID == "" {
+			continue
+		}
+		checked++
+		deviceName := fmt.Sprintf("%s/devices/%s", enterprise.Name(), dev.DeviceID)
+		_, err := client.EnterprisesDevicesGet(ctx, deviceName)
+		switch {
+		case err == nil:
+			// Device exists, no-op.
+			continue
+		case isNotFound(err):
+			if derr := ds.SetAndroidHostUnenrolled(ctx, dev.HostID); derr != nil {
+				level.Error(logger).Log("msg", "failed to mark android host unenrolled during reconcile", "host_id", dev.HostID, "err", derr)
+				continue
+			}
+			// Emit system activity to mirror Pub/Sub DELETED handling.
+			var displayName, serial string
+			if hosts, herr := ds.ListHostsLiteByIDs(ctx, []uint{dev.HostID}); herr == nil && len(hosts) == 1 && hosts[0] != nil {
+				displayName = hosts[0].DisplayName()
+				serial = hosts[0].HardwareSerial
+			}
+			if aerr := ds.NewActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
+				HostSerial:       serial,
+				HostDisplayName:  displayName,
+				InstalledFromDEP: false,
+			}, nil, time.Now()); aerr != nil {
+				level.Debug(logger).Log("msg", "failed to create mdm_unenrolled activity during android reconcile", "host_id", dev.HostID, "err", aerr)
+			}
+			unenrolled++
+			level.Debug(logger).Log("msg", "android device missing in Google; marked unenrolled", "host_id", dev.HostID, "device", deviceName)
+		default:
+			level.Debug(logger).Log("msg", "error reconciling android device", "device", deviceName, "err", err)
+		}
+	}
+
+	level.Debug(logger).Log("msg", "android reconcile complete", "checked", checked, "unenrolled", unenrolled)
+	return nil
+}
+
+func isNotFound(err error) bool {
+	var ge *googleapi.Error
+	if errors.As(err, &ge) {
+		return ge.Code == http.StatusNotFound
+	}
+	return false
+}

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -787,3 +787,66 @@ func (svc *Service) cleanupDeletedEnterprise(ctx context.Context, enterprise *an
 		level.Error(svc.logger).Log("msg", "failed to unenroll Android hosts after enterprise deletion", "err", unenrollErr)
 	}
 }
+
+// Admin-initiated Android unenroll
+// Request decoder for POST /api/_version_/fleet/hosts/{id}/mdm/unenroll
+type androidHostUnenrollRequest struct {
+	HostID uint `url:"id"`
+}
+
+func unenrollAndroidHostEndpoint(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer {
+	req := request.(*androidHostUnenrollRequest)
+	err := svc.UnenrollAndroidHost(ctx, req.HostID)
+	return android.DefaultResponse{Err: err}
+}
+
+// UnenrollAndroidHost calls AMAPI to delete the device (work profile) and emits an activity.
+// The actual MDM status flip to Off is performed when Pub/Sub sends DELETED for the device.
+func (svc *Service) UnenrollAndroidHost(ctx context.Context, hostID uint) error {
+	// Load host and authorize based on team
+	h, err := svc.fleetSvc.GetHostLite(ctx, hostID)
+	if err != nil {
+		return err
+	}
+	if err := svc.authz.Authorize(ctx, h, fleet.ActionWrite); err != nil {
+		return err
+	}
+	if strings.ToLower(h.Platform) != "android" {
+		return &fleet.BadRequestError{Message: "host is not an android device"}
+	}
+
+	// Resolve Android device and enterprise
+	ah, err := svc.ds.AndroidHostLiteByHostUUID(ctx, h.UUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting android host by uuid")
+	}
+	enterprise, err := svc.ds.GetEnterprise(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting android enterprise")
+	}
+	if ah.Device == nil || ah.Device.DeviceID == "" || enterprise.EnterpriseID == "" {
+		return &fleet.BadRequestError{Message: "missing android device or enterprise id"}
+	}
+
+	// Authenticate client and call AMAPI delete
+	secret, err := svc.getClientAuthenticationSecret(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting Android authentication secret")
+	}
+	_ = svc.androidAPIClient.SetAuthenticationSecret(secret)
+	deviceName := fmt.Sprintf("enterprises/%s/devices/%s", enterprise.EnterpriseID, ah.Device.DeviceID)
+	if err := svc.androidAPIClient.EnterprisesDevicesDelete(ctx, deviceName); err != nil {
+		return ctxerr.Wrap(ctx, err, "amapi delete device")
+	}
+
+	// Emit activity: admin told Fleet to unenroll
+	displayName := fleet.HostDisplayName(h.ComputerName, h.Hostname, h.HardwareModel, h.HardwareSerial)
+	if err := svc.fleetSvc.NewActivity(ctx, authz.UserFromContext(ctx), fleet.ActivityTypeMDMUnenrolled{
+		HostSerial:       h.HardwareSerial,
+		HostDisplayName:  displayName,
+		InstalledFromDEP: false,
+	}); err != nil {
+		return ctxerr.Wrap(ctx, err, "create android unenroll activity")
+	}
+	return nil
+}

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -81,6 +81,11 @@ func (ds *AndroidDSWithMock) DeleteOtherEnterprises(ctx context.Context, id uint
 	return ds.Datastore.DeleteOtherEnterprises(ctx, id)
 }
 
+// Disambiguate method promoted from both mysql.Datastore and mock.Store
+func (ds *AndroidDSWithMock) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error {
+	return ds.Datastore.SetAndroidHostUnenrolled(ctx, hostID)
+}
+
 type WithServer struct {
 	suite.Suite
 	Svc      android.Service

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
 )
 
 //go:generate go run ./mockimpl/impl.go -o datastore_mock.go "s *DataStore" "fleet.Datastore"
@@ -45,3 +46,6 @@ func (m *Store) Name() string { return "mock" }
 
 // Added to satisfy fleet.Datastore interface after Android unenroll additions.
 func (m *Store) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }
+
+// Added to satisfy fleet.Datastore interface after Android reconcile additions.
+func (m *Store) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) { return nil, nil }

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -42,3 +42,6 @@ func (m *Store) MigrationStatus(ctx context.Context) (*fleet.MigrationStatus, er
 	return &fleet.MigrationStatus{}, nil
 }
 func (m *Store) Name() string { return "mock" }
+
+// Added to satisfy fleet.Datastore interface after Android unenroll additions.
+func (m *Store) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }

--- a/server/mock/datastore.go
+++ b/server/mock/datastore.go
@@ -48,4 +48,6 @@ func (m *Store) Name() string { return "mock" }
 func (m *Store) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }
 
 // Added to satisfy fleet.Datastore interface after Android reconcile additions.
-func (m *Store) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) { return nil, nil }
+func (m *Store) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) {
+	return nil, nil
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -27,7 +27,9 @@ var _ fleet.Datastore = (*DataStore)(nil)
 func (s *DataStore) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }
 
 // Added to satisfy fleet.Datastore interface after Android reconcile additions.
-func (s *DataStore) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) { return nil, nil }
+func (s *DataStore) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) {
+	return nil, nil
+}
 
 type HealthCheckFunc func() error
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -26,6 +26,9 @@ var _ fleet.Datastore = (*DataStore)(nil)
 // Added to satisfy fleet.Datastore interface after Android unenroll additions.
 func (s *DataStore) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }
 
+// Added to satisfy fleet.Datastore interface after Android reconcile additions.
+func (s *DataStore) ListAndroidEnrolledDevicesForReconcile(ctx context.Context) ([]*android.Device, error) { return nil, nil }
+
 type HealthCheckFunc func() error
 
 type NewCarveFunc func(ctx context.Context, metadata *fleet.CarveMetadata) (*fleet.CarveMetadata, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -23,6 +23,9 @@ import (
 
 var _ fleet.Datastore = (*DataStore)(nil)
 
+// Added to satisfy fleet.Datastore interface after Android unenroll additions.
+func (s *DataStore) SetAndroidHostUnenrolled(ctx context.Context, hostID uint) error { return nil }
+
 type HealthCheckFunc func() error
 
 type NewCarveFunc func(ctx context.Context, metadata *fleet.CarveMetadata) (*fleet.CarveMetadata, error)


### PR DESCRIPTION
Implements #31822. Admins can now unenroll Android hosts, and when a user deletes their work profile from an Android device, that host is automagically unenrolled from Fleet.

## Summary
There are three ways an Android host might be unenrolled from Fleet: 

1. From within the Fleet UI
2. From Google Cloud Console/Workspaces or API call, or
3. By end user action

This PR aims to address all three:

  - Admin-initiated unenrollment: an admin can unenroll a host from (1) the UI or (2) via API or Console; Fleet calls AMAPI `enterprises.devices.delete`. MDM stays On until Google confirms, at which point the host flips to MDM Off and an activity is recorded.

  - User-initiated unenrollment (3): because Google may not emit a final status report for user-initiated removals, Fleet now runs a periodic reconciler (cron) that polls AMAPI to verify device existence and flips the host to unenrolled if it’s gone. We still handle the fast-path when Google does send a `DELETED` status via Pub/Sub.

## Details
  
### Admin-initiated unenrollment

Admins can unenroll Android devices via Fleet or via API call/Console action. Fleet needs to handle both scenarios.
  
#### Via Fleet UI

When an admin unenrolls an Android host via Fleet, here's what happens:
  
  - The UI exposes an Unenroll action for Android hosts when Android MDM is enabled and the host is enrolled. For Android, Unenroll is allowed even if the host is offline.
  - The UI calls `POST /api/_version_/fleet/hosts/{id}/mdm/unenroll`.
  - The Android service resolves the Android device resource name and calls AMAPI `Enterprises.Devices.Delete` to schedule work profile removal.
  - On success, Fleet immediately emits an activity indicating the admin told Fleet to unenroll the device (copy handled in frontend based on actor presence). Host MDM remains On until Google confirms removal.
  - When Google later confirms the deletion (either via Pub/Sub or via reconcile polling), Fleet flips host_mdm.enrolled to Off and emits the system activity “is unenrolled from Fleet.”
  
#### Via API call/Console action

When an admin unenrolls an Android host via API call, here's what happens:

- Call: `POST /api/latest/fleet/hosts/{HOST_ID}/mdm/unenroll`.
- Fleet calls AMAPI `enterprises.devices.delete` for `enterprises/{enterpriseId}/devices/{deviceId}`.
- On success, Fleet emits the “told Fleet to unenroll …” activity and waits for confirmation before flipping MDM Off.
- Confirmation path:
  - Fast path: Pub/Sub `STATUS_REPORT` (or `ENROLLMENT`) includes `appliedState`/`state = DELETED`. Fleet marks host unenrolled and emits the system `mdm_unenrolled` activity.
  - Backstop: the reconcile cron detects the device has been removed (AMAPI `GET` returns 404) and performs the same flip + activity.
  
### User-initiated unenrollment

Users can unenroll their devices by removing their work profile, directly or by any action that would remove it, like factory resetting their device. When this happens, no event is emitted to Google:

> DELETED: The device was deleted. This state is never returned by an API call, but is used in the final status report when the device acknowledges the deletion. If the device is deleted via the API call, this state is published to Pub/Sub. If the user deletes the work profile or resets the device, **the device state will remain unknown to the server**. [Source](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices#devicestate) (emphasis mine)

_Note: This was verified by monitoring Pub/Sub._

So, we check periodically that Android devices still exist. If we find one that doesn't, we unenroll it as described above.

- Pub/Sub fast path:
  - `ProcessPubSubPush` handles `notificationType = "ENROLLMENT"` and `"STATUS_REPORT"`.
  - `handlePubSubStatusReport`/`handlePubSubEnrollment` detect `DELETED` in either `appliedState` or `state`. If detected, Fleet calls `SetAndroidHostUnenrolled(hostID)` and emits the system `mdm_unenrolled` activity using the device’s display name. We only look at `notificationType` (as emitted by Google).
- Reconciler (new cron, same cadence as other Android ticks):
  - Schedule name: `mdm_android_device_reconciler` (runs ~every 30 seconds, like `mdm_android_profile_manager`).
  - It lists all Android devices Fleet still considers enrolled (`host_mdm.enrolled=1`) via `ListAndroidEnrolledDevicesForReconcile`.
  - For each device, it builds `deviceName = enterprises/{enterpriseId}/devices/{deviceId}` and calls AMAPI `Enterprises.Devices.Get`.
  - If AMAPI returns `404`, Fleet flips the host to unenrolled via `SetAndroidHostUnenrolled(ctx, hostID)` and emits the same system `mdm_unenrolled` activity as the Pub/Sub path. Other errors are logged and skipped; 200 is a no-op.
  
### Supporting changes

- Datastore:
  - `SetAndroidHostUnenrolled(ctx, hostID)` updates `host_mdm` for a single Android host: clears `server_url`, `mdm_id`, and sets `enrolled = 0`.
  - `ListAndroidEnrolledDevicesForReconcile(ctx)` returns enrolled Android device records (host ID, device ID, enterprise-specific ID) for the reconciler.
- Android service endpoint for admin unenroll was wired at `POST /api/_version_/fleet/hosts/{id}/mdm/unenroll`.
- Frontend wiring:
  - Unenroll action shows for enrolled Android hosts (fixes state so Android sets `connected_to_fleet = true` when enrolled).
  - Unenroll remains enabled for Android even when offline, and the request path uses the correct POST endpoint.

## Testing

  - [x] Android Pub/Sub enrollment/status report tests continue to passing
  - [x] Datastore tests for Android methods passing
  - [x] Service authorization and enterprise lifecycle tests passing
  
### Manual QA
  
#### Admin-initiated
  1) Enroll an Android device (BYOD). Confirm Host Details shows `MDM: On` and the Actions dropdown includes Unenroll.
  2) Click Unenroll in UI, or use API or Google Console.
  3) Observe the immediate activity “<Actor> told Fleet to unenroll …”. MDM remains On.
  4) When the device processes deletion and Google posts confirmation (or when the reconciler runs and sees 404), Fleet flips to `MDM: Off` and emits the system “<Device> is unenrolled from Fleet.”

#### User-initiated
  1) Remove the work profile on the device.
  2) If Google posts a final `DELETED` status report, Fleet should flip immediately. Otherwise, wait for the reconciler (defaults to ~30s cadence) to detect the missing device and flip MDM Off, emitting the system activity.