### PR TITLE
Match Fleet-maintained app update PR assignees to current software team members

### DIFF
--- a/.github/workflows/ingest-maintained-apps.yml
+++ b/.github/workflows/ingest-maintained-apps.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           # DEVS=$(awk '/### Software group/{flag=1; next} /#/{flag=0} flag' ./fleet/handbook/company/product-groups.md | awk '/\| Developer[ ]*\|/ {sub(/\| Developer[ ]*\|/, ""); print}' | grep -o '@[^]]*' | tr -d '@' | tr '\n' ',' | sed 's/,$//')
           # :-(
-          DEVS="iansltx,jahzielv,ksykulev,jkatz01"
+          DEVS="jahzielv,jkatz01,mna,cdcme"
           echo "github_ids=$DEVS" >> ${GITHUB_OUTPUT}
 
       - name: Log Info


### PR DESCRIPTION
May need to check codeowners on GitHub YAML files in general. Not sure whether tech leads should be on that list?