### PR TITLE
Fix path for Controls top nav link

### DIFF
--- a/changes/33222-fix-controls-top-nav
+++ b/changes/33222-fix-controls-top-nav
@@ -1,0 +1,1 @@
+- Fixed issue where "Controls" link in the top nav didn't always go to the default controls page.

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -67,6 +67,7 @@ export default (
         pathname: PATHS.CONTROLS,
       },
       exclude: !isMaintainerOrAdmin,
+      alwaysToPathname: true,
       withParams: { type: "query", names: ["team_id"] },
     },
     {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33222

# Details

This PR fixes an issue where clicking "Controls" in the top nav doesn't go to the expected page when the current page is a Controls tab like "Scripts". The expected page is the default "Controls" page, i.e. the first tab (currently the  "OS Settings" tab).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
I made a pass at this but it requires either the router or mocking the `<Link>/<ContextLink>` components which seems like overkill for this.

- [X] QA'd all new/changed functionality manually
![33222](https://github.com/user-attachments/assets/e3af7a65-f216-45ee-b75c-40b090608942)

