### PR TITLE
Add Cloud Computing Policy to the Handbook

### DIFF
--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -897,6 +897,7 @@ Effective security is a team effort. This involves the participation and support
 
 All Fleet employees and long-term collaborators are expected to read and electronically sign the *acceptable use of end-user computing* policy. They should also be aware of the others and consult them as needed. This is to make sure systems built and used are done in a compliant manner.
 
+
 ### Acceptable use of Cloud Computing
 
 | Policy owner   | Effective date |

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -905,7 +905,7 @@ All Fleet employees and long-term collaborators are expected to read and electro
 | @lukeheath       | 2025-10-01   |
 
 
-This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services
+This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services.
 
 - All cloud environments owned and operated by the company including Infrastructure-as-a-Service (IaaS), Platform-as-a-Service (PaaS), and Software-as-a-Service (SaaS) deployed or managed by the Company are governed by this policy.
 - Company's cloud resources must only be used for legitimate business purposes approved by the Company.

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -1,4 +1,4 @@
-/# Security
+# Security
 
 
 ## Fleet security

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -906,7 +906,7 @@ All Fleet employees and long-term collaborators are expected to read and electro
 
 
 This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services.
-- All cloud environments owned and operated by the company including Infrastructure-as-a-Service (IaaS), Platform-as-a-Service (PaaS), and Software-as-a-Service (SaaS) deployed or managed by the Company are governed by this policy.
+- All cloud environments owned and operated by the company, including "Infrastructure-as-a-Service" (IaaS), "Platform-as-a-Service" (PaaS), and "Software-as-a-Service" (SaaS) deployed or managed by the company are governed by this policy.
 - Company's cloud resources must only be used for legitimate business purposes approved by the Company.
 - Users must access company-owned cloud systems only with company-managed accounts and approved identity methods.
 - Company data must only be stored in the company’s  cloud environments that have been security-reviewed and approved by the Information Security team.

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -913,6 +913,7 @@ This policy applies to all users of the company's cloud computing resources, inc
 - Personal use of company-provisioned cloud services is prohibited.
 - Unauthorized sharing, downloading, or uploading of the company intellectual property to non-company cloud accounts is strictly forbidden.
 
+
 #### Prohibited Activities
 
 Users must not use the company's cloud resources to:

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -1,4 +1,4 @@
-# Security
+/# Security
 
 
 ## Fleet security
@@ -897,6 +897,31 @@ Effective security is a team effort. This involves the participation and support
 
 All Fleet employees and long-term collaborators are expected to read and electronically sign the *acceptable use of end-user computing* policy. They should also be aware of the others and consult them as needed. This is to make sure systems built and used are done in a compliant manner.
 
+### Acceptable use of Cloud Computing
+
+| Policy owner   | Effective date |
+| -------------- | -------------- |
+| @lheath       | 2025-10-01   |
+
+
+This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services
+
+- All cloud environments owned and operated by the company including Infrastructure-as-a-Service (IaaS), Platform-as-a-Service (PaaS), and Software-as-a-Service (SaaS) deployed or managed by the Company are governed by this policy.
+- Company's cloud resources must only be used for legitimate business purposes approved by the Company.
+- Users must access company-owned cloud systems only with company-managed accounts and approved identity methods.
+- Company data must only be stored in the company’s  cloud environments that have been security-reviewed and approved by the Information Security team.
+- Personal use of company-provisioned cloud services is prohibited.
+- Unauthorized sharing, downloading, or uploading of the company intellectual property to non-company cloud accounts is strictly forbidden.
+
+#### Prohibited Activities
+
+Users must not use the company's cloud resources to:
+
+- Attempt to disable, bypass, or interfere with cloud security controls.
+- Deploy workloads that violatethe company policies or applicable laws (e.g., cryptocurrency mining, illegal content).
+- Conduct personal business, personal profit activities, or malicious activity.
+- Introduce unapproved third-party integrations, extensions, or APIs.
+- Store, process, or transmit unencrypted PII, PHI, PCI, or sensitive company data outside approved company cloud environments.
 
 ### Acceptable use of end-user computing
 

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -906,7 +906,6 @@ All Fleet employees and long-term collaborators are expected to read and electro
 
 
 This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services.
-
 - All cloud environments owned and operated by the company including Infrastructure-as-a-Service (IaaS), Platform-as-a-Service (PaaS), and Software-as-a-Service (SaaS) deployed or managed by the Company are governed by this policy.
 - Company's cloud resources must only be used for legitimate business purposes approved by the Company.
 - Users must access company-owned cloud systems only with company-managed accounts and approved identity methods.

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -898,7 +898,7 @@ Effective security is a team effort. This involves the participation and support
 All Fleet employees and long-term collaborators are expected to read and electronically sign the *acceptable use of end-user computing* policy. They should also be aware of the others and consult them as needed. This is to make sure systems built and used are done in a compliant manner.
 
 
-### Acceptable use of Cloud Computing
+### Acceptable use of cloud computing policy
 
 | Policy owner   | Effective date |
 | -------------- | -------------- |

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -909,7 +909,7 @@ This policy applies to all users of the company's cloud computing resources, inc
 - All cloud environments owned and operated by the company, including "Infrastructure-as-a-Service" (IaaS), "Platform-as-a-Service" (PaaS), and "Software-as-a-Service" (SaaS) deployed or managed by the company are governed by this policy.
 - Fleet's cloud resources must only be used for legitimate business purposes approved by the company.
 - Users must access company-owned cloud systems only with company-managed accounts and approved identity methods.
-- Company data must only be stored in the company’s  cloud environments that have been security-reviewed and approved by the Information Security team.
+- Company data must only be stored in the company’s cloud environments that have been security-reviewed and approved by the Information Security team.
 - Personal use of company-provisioned cloud services is prohibited.
 - Unauthorized sharing, downloading, or uploading of the company intellectual property to non-company cloud accounts is strictly forbidden.
 

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -923,6 +923,7 @@ Users must not use the company's cloud resources to:
 - Introduce unapproved third-party integrations, extensions, or APIs.
 - Store, process, or transmit unencrypted PII, PHI, PCI, or sensitive company data outside approved company cloud environments.
 
+
 ### Acceptable use of end-user computing
 
 > _Created from [JupiterOne/security-policy-templates](https://github.com/JupiterOne/security-policy-templates). [CC BY-SA 4 license](https://creativecommons.org/licenses/by-sa/4.0/)_

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -902,7 +902,7 @@ All Fleet employees and long-term collaborators are expected to read and electro
 
 | Policy owner   | Effective date |
 | -------------- | -------------- |
-| @lheath       | 2025-10-01   |
+| @lukeheath       | 2025-10-01   |
 
 
 This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -917,7 +917,6 @@ This policy applies to all users of the company's cloud computing resources, inc
 #### Prohibited Activities
 
 Users must not use the company's cloud resources to:
-
 - Attempt to disable, bypass, or interfere with cloud security controls.
 - Deploy workloads that violatethe company policies or applicable laws (e.g., cryptocurrency mining, illegal content).
 - Conduct personal business, personal profit activities, or malicious activity.

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -918,7 +918,7 @@ This policy applies to all users of the company's cloud computing resources, inc
 
 Users must not use the company's cloud resources to:
 - Attempt to disable, bypass, or interfere with cloud security controls.
-- Deploy workloads that violatethe company policies or applicable laws (e.g., cryptocurrency mining, illegal content).
+- Deploy workloads that violate the company policies or applicable laws (e.g., cryptocurrency mining, illegal content).
 - Conduct personal business, personal profit activities, or malicious activity.
 - Introduce unapproved third-party integrations, extensions, or APIs.
 - Store, process, or transmit unencrypted PII, PHI, PCI, or sensitive company data outside approved company cloud environments.

--- a/handbook/finance/security.md
+++ b/handbook/finance/security.md
@@ -907,7 +907,7 @@ All Fleet employees and long-term collaborators are expected to read and electro
 
 This policy applies to all users of the company's cloud computing resources, including employees, contractors, vendors, and partners with access to the cloud services.
 - All cloud environments owned and operated by the company, including "Infrastructure-as-a-Service" (IaaS), "Platform-as-a-Service" (PaaS), and "Software-as-a-Service" (SaaS) deployed or managed by the company are governed by this policy.
-- Company's cloud resources must only be used for legitimate business purposes approved by the Company.
+- Fleet's cloud resources must only be used for legitimate business purposes approved by the company.
 - Users must access company-owned cloud systems only with company-managed accounts and approved identity methods.
 - Company data must only be stored in the company’s  cloud environments that have been security-reviewed and approved by the Information Security team.
 - Personal use of company-provisioned cloud services is prohibited.


### PR DESCRIPTION

Add Cloud Computing Policy to the Handbook. Customers have required this to be in our Policy.  
Verified that the policy is rendered correctly and consistent with the style in the handbook.
No Issue creates as this is just a documentation change to the policy.
