### PR TITLE
Website: (Configuration builder) Add windows settings

### DIFF
--- a/website/assets/js/pages/configuration-builder.page.js
+++ b/website/assets/js/pages/configuration-builder.page.js
@@ -1745,7 +1745,7 @@ parasails.registerPage('configuration-builder', {
         subcategorySlug: 'windows-date-and-time',
         subcategoryName: 'Date & time',
         description: 'Settings related to screen lock and passwords.',
-        learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-devicelock',
+        learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider',
         payloads: [
           {
             name: 'Allow users to change date and time settings',
@@ -2234,7 +2234,7 @@ parasails.registerPage('configuration-builder', {
             subcategoryName: 'Personalization',
             subcategorySlug: 'windows-personalization',
             description: 'Settings for personalizing a Windows devices.',// TODO: improve/rewrite.
-            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-smartscreen',
+            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider',
             payloads: [
               {
                 name: 'Allow personalization policies on non-EDU versions of Windows',
@@ -2312,7 +2312,7 @@ parasails.registerPage('configuration-builder', {
             subcategoryName: 'Functionality',
             subcategorySlug: 'windows-functionality',
             description: 'Settings that restrict specific windows features',// TODO: improve/rewrite.
-            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-smartscreen',
+            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider',
             payloads: [
               // { TODO: research this.
               //   name: 'Enable advanced powershell logging',

--- a/website/assets/js/pages/configuration-builder.page.js
+++ b/website/assets/js/pages/configuration-builder.page.js
@@ -1740,6 +1740,32 @@ parasails.registerPage('configuration-builder', {
     // windows payloads
     windowsCategoriesAndPayloads: [
       {
+        categoryName: 'Date & time',
+        categorySlug: 'windows-date-and-time',
+        subcategorySlug: 'windows-date-and-time',
+        subcategoryName: 'Date & time',
+        description: 'Settings related to screen lock and passwords.',
+        learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-devicelock',
+        payloads: [
+          {
+            name: 'Allow users to change date and time settings',
+            uniqueSlug: 'windows-device-lock-enable-device-lock',
+            tooltip: 'Allows the user to change date and time settings.',
+            category: 'Date & time',
+            supportedAccessTypes: ['add', 'replace'],
+            formInput: {
+              type: 'boolean',
+            },
+            formOutput: {
+              settingFormat: 'int',
+              settingTarget: './Device/Vendor/MSFT/Policy/Config/Settings/AllowDateTime',
+              trueValue: 1,
+              falseValue: 0,
+            },
+          },
+        ],
+      },
+      {
         categoryName: 'Privacy & security',
         categorySlug: 'windows-privacy-and-security',
         subcategories: [
@@ -2200,6 +2226,220 @@ parasails.registerPage('configuration-builder', {
                 formOutput: {
                   settingFormat: 'int',
                   settingTarget: './Device/Vendor/MSFT/Policy/Config/SmartScreen/EnableAppInstallControl',
+                },
+              },
+            ],
+          },
+          {
+            subcategoryName: 'Personalization',
+            subcategorySlug: 'windows-personalization',
+            description: 'Settings for personalizing a Windows devices.',// TODO: improve/rewrite.
+            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-smartscreen',
+            payloads: [
+              {
+                name: 'Allow personalization policies on non-EDU versions of Windows',
+                tooltip: `Allows Personalization CSPs to be deployed on non-Enterprise versions of Windows. Setting this value to true triggers the action to configure a device as education environment. Thorough testing is crucial to ensure it does not disrupt workflows or create compatibility issues.`,
+                uniqueSlug: 'windows-allow-personalization-policies',
+                category: 'Personalization',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'bool',
+                  settingTarget: './Vendor/MSFT/SharedPC/SetEduPolicies',
+                  trueValue: true,
+                  falseValue: false,
+                },
+              },
+              {
+                name: 'Set wallpaper from a URL',
+                tooltip: `Sets a device's wallpaper from a URL.`,
+                uniqueSlug: 'windows-set-wallpaper-url',
+                category: 'Personalization',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'text',
+                },
+                alsoAutoSetWhenSelected: [
+                  {
+                    dependingOnSettingSlug: 'windows-allow-personalization-policies',
+                    dependingOnSettingValue: true,
+                  }
+                ],
+                formOutput: {
+                  settingFormat: 'chr',
+                  settingTarget: './Vendor/MSFT/Personalization/DesktopImageUrl',
+                },
+              },
+              {
+                name: 'Set lockscreen image from a URL',
+                tooltip: `Sets a device's lockscreen image from a URL.`,
+                uniqueSlug: 'windows-set-lockscreen-url',
+                category: 'Personalization',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'text',
+                },
+                alsoAutoSetWhenSelected: [
+                  {
+                    dependingOnSettingSlug: 'windows-allow-personalization-policies',
+                    dependingOnSettingValue: true,
+                  }
+                ],
+                formOutput: {
+                  settingFormat: 'chr',
+                  settingTarget: './Vendor/MSFT/Personalization/LockScreenImageUrl',
+                },
+              },
+              {
+                name: 'Set device name',
+                tooltip: `This policy setting lets you configure whether to turn on Windows Defender SmartScreen in Microsoft Edge.`,
+                uniqueSlug: 'windows-set-device-name',
+                category: 'Personalization',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'text',
+                },
+                formOutput: {
+                  settingFormat: 'chr',
+                  settingTarget: './Device/Vendor/MSFT/DeviceName',
+                },
+              },
+            ],
+          },
+          {
+            subcategoryName: 'Functionality',
+            subcategorySlug: 'windows-functionality',
+            description: 'Settings that restrict specific windows features',// TODO: improve/rewrite.
+            learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-smartscreen',
+            payloads: [
+              // { TODO: research this.
+              //   name: 'Enable advanced powershell logging',
+              //   tooltip: `Allows Personalization CSPs to be deployed on non-Enterprise versions of Windows. Setting this value to true triggers the action to configure a device as education environment. Thorough testing is crucial to ensure it does not disrupt workflows or create compatibility issues.`,
+              //   uniqueSlug: 'windows-allow-personalization-policies',
+              //   category: 'Personalization',
+              //   supportedAccessTypes: ['add', 'replace'],
+              //   formInput: {
+              //     type: 'boolean',
+              //   },
+              //   formOutput: {
+              //     settingFormat: 'int',
+              //     settingTarget: './Vendor/MSFT/SharedPC/SetEduPolicies',
+              //     trueValue: ``,
+              //     falseValue: false,
+              //   },
+              // },
+              {
+                name: 'Disable AI data analysis',
+                tooltip: `Whether snapshots of the screen can be saved for use with Recall. By default, snapshots for Recall aren't enabled. IT administrators can't, on their own, enable saving snapshots on behalf of their users. If you set this policy to disabled, end users will have a choice to save snapshots of their screen and use Recall to find things they've seen on their device.`,
+                uniqueSlug: 'windows-disable-ai-analysis',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './Device/Vendor/MSFT/Policy/Config/WindowsAI/DisableAIDataAnalysis',
+                  trueValue: 1,
+                  falseValue: 0,
+                },
+              },
+              {
+                name: 'Disable clipboard history',
+                tooltip: `Whether the history of clipboard contents can be stored in memory.`,
+                uniqueSlug: 'windows-disable-clipboard-history',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './Device/Vendor/MSFT/Policy/Config/Experience/AllowClipboardHistory',
+                  trueValue: 0,
+                  falseValue: 1,
+                },
+              },
+              // {
+              //   name: 'Disable Cortana',
+              //   tooltip: `Whether Cortana is allowed on the device`,
+              //   uniqueSlug: 'windows-disable-cortana',
+              //   category: 'Functionality',
+              //   supportedAccessTypes: ['add', 'replace'],
+              //   formInput: {
+              //     type: 'boolean',
+              //   },
+              //   formOutput: {
+              //     settingFormat: 'int',
+              //     settingTarget: './Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana',
+              //     trueValue: 0,
+              //     falseValue: 1,
+              //   },
+              // },
+              {
+                name: 'Disable screen capture',
+                tooltip: `Whether screen capture is disabled on the device.`,
+                uniqueSlug: 'windows-disable-screen-capture',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './Device/Vendor/MSFT/Policy/Config/Experience/AllowScreenCapture',
+                  trueValue: 0,
+                  falseValue: 1,
+                },
+              },
+              {
+                name: 'Disable Windows spotlight',
+                tooltip: `Whether to turn off all Windows spotlight features.`,
+                uniqueSlug: 'windows-disable-windows-spotlight',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './User/Vendor/MSFT/Policy/Config/Experience/AllowWindowsSpotlight',
+                  trueValue: 0,
+                  falseValue: 1,
+                },
+              },
+              {
+                name: 'Disable OneDrive',
+                tooltip: `Prevent apps and features from working with files on OneDrive`,
+                uniqueSlug: 'windows-disable-onedrive',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './Device/Vendor/MSFT/Policy/Config/System/DisableOneDriveFileSync',
+                  trueValue: 1,
+                  falseValue: 0,
+                },
+              },
+              {
+                name: 'Disable quick setting panel',
+                tooltip: `Remove the quick settings from the bottom right area on the taskbar.`,
+                uniqueSlug: 'windows-disable-quick-settings',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'chr',
+                  settingTarget: './User/Vendor/MSFT/Policy/Config/Start/DisableControlCenter',
+                  trueValue: 1,
+                  falseValue: 0,
                 },
               },
             ],

--- a/website/assets/js/pages/configuration-builder.page.js
+++ b/website/assets/js/pages/configuration-builder.page.js
@@ -2314,22 +2314,6 @@ parasails.registerPage('configuration-builder', {
             description: 'Settings that restrict specific windows features',// TODO: improve/rewrite.
             learnMoreLinkUrl: 'https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider',
             payloads: [
-              // { TODO: research this.
-              //   name: 'Enable advanced powershell logging',
-              //   tooltip: `Allows Personalization CSPs to be deployed on non-Enterprise versions of Windows. Setting this value to true triggers the action to configure a device as education environment. Thorough testing is crucial to ensure it does not disrupt workflows or create compatibility issues.`,
-              //   uniqueSlug: 'windows-allow-personalization-policies',
-              //   category: 'Personalization',
-              //   supportedAccessTypes: ['add', 'replace'],
-              //   formInput: {
-              //     type: 'boolean',
-              //   },
-              //   formOutput: {
-              //     settingFormat: 'int',
-              //     settingTarget: './Vendor/MSFT/SharedPC/SetEduPolicies',
-              //     trueValue: ``,
-              //     falseValue: false,
-              //   },
-              // },
               {
                 name: 'Disable AI data analysis',
                 tooltip: `Whether snapshots of the screen can be saved for use with Recall. By default, snapshots for Recall aren't enabled. IT administrators can't, on their own, enable saving snapshots on behalf of their users. If you set this policy to disabled, end users will have a choice to save snapshots of their screen and use Recall to find things they've seen on their device.`,
@@ -2362,22 +2346,22 @@ parasails.registerPage('configuration-builder', {
                   falseValue: 1,
                 },
               },
-              // {
-              //   name: 'Disable Cortana',
-              //   tooltip: `Whether Cortana is allowed on the device`,
-              //   uniqueSlug: 'windows-disable-cortana',
-              //   category: 'Functionality',
-              //   supportedAccessTypes: ['add', 'replace'],
-              //   formInput: {
-              //     type: 'boolean',
-              //   },
-              //   formOutput: {
-              //     settingFormat: 'int',
-              //     settingTarget: './Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana',
-              //     trueValue: 0,
-              //     falseValue: 1,
-              //   },
-              // },
+              {
+                name: 'Disable Cortana',
+                tooltip: `Whether Cortana is allowed on the device`,
+                uniqueSlug: 'windows-disable-cortana',
+                category: 'Functionality',
+                supportedAccessTypes: ['add', 'replace'],
+                formInput: {
+                  type: 'boolean',
+                },
+                formOutput: {
+                  settingFormat: 'int',
+                  settingTarget: './Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana',
+                  trueValue: 0,
+                  falseValue: 1,
+                },
+              },
               {
                 name: 'Disable screen capture',
                 tooltip: `Whether screen capture is disabled on the device.`,

--- a/website/views/pages/configuration-builder.ejs
+++ b/website/views/pages/configuration-builder.ejs
@@ -81,9 +81,10 @@
       <div purpose="category-selector" >
         <div purpose="category-options" v-if="selectedPlatform === 'windows'">
           <div v-for="category in windowsCategoriesAndPayloads">
-            <a @click="clickExpandCategory(category.categorySlug)" :class="[expandedCategory === category.categorySlug ? 'selected' : '' ]" >{{category.categoryName}}</a>
+            <a @click="clickExpandCategory(category.categorySlug)" :class="[expandedCategory === category.categorySlug ? 'selected' : '' ]"  v-if="category.subcategories">{{category.categoryName}}</a>
+            <a @click="clickSelectPayloadCategory(category)" :class="[expandedCategory === category.categorySlug ? 'selected' : '' ]"  v-else>{{category.categoryName}}</a>
 
-            <div purpose="subcategories" v-if="expandedCategory === category.categorySlug">
+            <div purpose="subcategories" v-if="expandedCategory === category.categorySlug && category.subcategories">
               <a @click="clickSelectPayloadCategory(subcategory)" v-for="subcategory in category.subcategories">{{subcategory.subcategoryName}}</a>
             </div>
           </div>
@@ -185,11 +186,13 @@
                     <p class="mb-0"><strong>{{option.name}}</strong></p>
                     <div class="d-flex flex-row align-items-center" v-if="selectedPlatform === 'windows'">
                       <a href="https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider" target="_blank" no-icon><img style="margin-right: 6px; height: 14px" class="d-inline" purpose="tooltip-icon" src="/images/icon-more-info-14x14@2x.png" alt="More info" data-html="true"  data-toggle="tooltip" tabindex="0" data-placement="top" title="<%= '<p class="text-white">A Windows CSP profile may require the ADD action to work on initial delivery. To modify a previously delivered setting, the REPLACE action may be needed.</p> <p class="d-flex flex-row align-items-center mb-0">Click <img src="/images/icon-more-info-25-14x14@2x.png" class="mx-1" style="height: 12px; display: inline;" alt="more info"> to learn more</p>'%>"></a>
-                      <select :class="[formErrors[option.uniqueSlug+'-access-type'] ? 'is-invalid' : '']" purpose="access-type-select" v-model.trim="configurationBuilderFormData[option.uniqueSlug+'-access-type']" class="form-control" style="width: 120px">
-                        <option selected value="undefined" >Access type</option>
-                        <option :value="accessType" style="text-transform: uppercase;" v-for="accessType in option.supportedAccessTypes">{{accessType}}</option>
-                      </select>
-                      <div class="invalid-feedback" v-if="formErrors[option.uniqueSlug+'-access-type']">Please select an<br> access type</div>
+                      <div class="d-flex flex-column">
+                        <select :class="[formErrors[option.uniqueSlug+'-access-type'] ? 'is-invalid' : '']" purpose="access-type-select" v-model.trim="configurationBuilderFormData[option.uniqueSlug+'-access-type']" class="form-control" style="width: 120px">
+                          <option selected value="undefined" >Access type</option>
+                          <option :value="accessType" style="text-transform: uppercase;" v-for="accessType in option.supportedAccessTypes">{{accessType}}</option>
+                        </select>
+                        <div class="invalid-feedback" v-if="formErrors[option.uniqueSlug+'-access-type']">Please select an<br> access type</div>
+                      </div>
                     </div>
                   </div>
                   <% // Number input %>


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/33293

Changes:
- Added three categories of Windows settings to the configuration builder: "Date & time", "Personalization", and "Functionality"
- Updated the configuration builder to support categories with no subcategories