### PR TITLE
Website: update emailAddress input validation

### DIFF
--- a/website/api/controllers/create-vanta-authorization-request.js
+++ b/website/api/controllers/create-vanta-authorization-request.js
@@ -11,6 +11,7 @@ module.exports = {
     emailAddress: {
       type: 'string',
       required: true,
+      isEmail: true,
     },
     fleetInstanceUrl: {
       type: 'string',

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -11,6 +11,7 @@ module.exports = {
 
     emailAddress: {
       required: true,
+      isEmail: true,
       type: 'string',
       description: 'A return email address where we can respond.',
       example: 'hermione@hogwarts.edu'

--- a/website/api/controllers/deliver-deal-registration-submission.js
+++ b/website/api/controllers/deliver-deal-registration-submission.js
@@ -10,11 +10,11 @@ module.exports = {
   inputs: {
     submittersFirstName: {type: 'string'},
     submittersLastName: {type: 'string'},
-    submittersEmailAddress: {type: 'string'},
+    submittersEmailAddress: {type: 'string', isEmail: true,},
     submittersOrganization: {type: 'string'},
     customersFirstName: {type: 'string'},
     customersLastName: {type: 'string'},
-    customersEmailAddress: {type: 'string'},
+    customersEmailAddress: {type: 'string', isEmail: true,},
     linkedinUrl: {type: 'string', defaultsTo: 'N/A'},
     customersOrganization: {type: 'string'},
     customersCurrentMdm: {type: 'string', defaultsTo: 'N/A'},

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -10,6 +10,7 @@ module.exports = {
   inputs: {
     emailAddress: {
       required: true,
+      isEmail: true,
       type: 'string',
       description: 'A return email address where we can respond.',
       example: 'hermione@hogwarts.edu'

--- a/website/api/controllers/entrance/login.js
+++ b/website/api/controllers/entrance/login.js
@@ -19,6 +19,7 @@ password attempt.`,
     emailAddress: {
       description: 'The email to try in this attempt, e.g. "irl@example.com".',
       type: 'string',
+      isEmail: true,
       required: true
     },
 


### PR DESCRIPTION
Closes: #33548

Changes:
- Added `isEmail` validation to emailAddress inputs. The updated endpoints will now return 400 responses if a user bypasses the frontend validation.