### PR TITLE
Removing the software renaming fix introduced in 4.73.3 due to MySQL DB performance issues.

### DIFF
--- a/changes/33612-remove-software-rename-sql
+++ b/changes/33612-remove-software-rename-sql
@@ -1,0 +1,1 @@
+Removing the software renaming fix introduced in 4.73.3 due to MySQL DB performance issues.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -484,7 +484,7 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 
 // updateTargetedBundleIDs updates software names when bundle IDs match but names differ.
 // softwareRenames maps software IDs to their new names.
-func updateTargetedBundleIDs(ctx context.Context, tx sqlx.ExtContext, softwareRenames map[uint]string) error {
+func updateTargetedBundleIDs(ctx context.Context, tx sqlx.ExtContext, softwareRenames map[uint]string) error { //nolint:unused
 	if len(softwareRenames) == 0 {
 		return nil
 	}

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -454,9 +454,11 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 				}
 
 				// Update software names for bundle ID matches
-				if err = updateTargetedBundleIDs(ctx, tx, softwareRenames); err != nil {
-					return err
-				}
+				// TEMPORARILY COMMENTED OUT: Performance issue with updateTargetedBundleIDs SQL statement
+				// TODO: Re-enable after gathering more info and optimizing the query
+				// if err = updateTargetedBundleIDs(ctx, tx, softwareRenames); err != nil {
+				// 	return err
+				// }
 			}
 
 			// Use r.Inserted which contains all inserted items (including bundle ID matches)

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -709,8 +709,8 @@ func (ds *Datastore) getIncomingSoftwareChecksumsToExistingTitles(
 		)
 		existingChecksums := uniqueTitleStrToChecksums[titleStr]
 		if len(existingChecksums) > 0 {
-			// Log when multiple checksums map to the same title. If we see this regularly, we should fix it.
-			level.Error(ds.logger).Log(
+			// Log when multiple checksums map to the same title.
+			level.Debug(ds.logger).Log(
 				"msg", "multiple checksums mapping to same title",
 				"title_str", titleStr,
 				"new_checksum", checksum,

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1846,6 +1846,10 @@ func testUpdateHostSoftware(t *testing.T, ds *Datastore) {
 // When software with the same bundle ID but different name is added, the system
 // reuses the existing software entry (matched by bundle ID) and links it to the host
 func testUpdateHostSoftwareSameBundleIDDifferentNames(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "bundle-host", "", "bundlekey", "bundleuuid", time.Now())
 
@@ -1942,6 +1946,10 @@ func testUpdateHostSoftwareSameNameDifferentBundleIDs(t *testing.T, ds *Datastor
 // Test edge case: Multiple software entries with the same bundle ID
 // This validates that bundle ID renaming affects all software with that bundle ID
 func testUpdateHostSoftwareMultipleSameBundleID(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host1 := test.NewHost(t, ds, "multi-bundle-host1", "", "multikey1", "multiuuid1", time.Now())
 	host2 := test.NewHost(t, ds, "multi-bundle-host2", "", "multikey2", "multiuuid2", time.Now())
@@ -9061,6 +9069,10 @@ func testPreInsertSoftwareInventory(t *testing.T, ds *Datastore) {
 // testUpdateHostBundleIDRenameOnlyNoNewSoftware tests if a host reports ONLY renamed software
 // (same bundle ID, different name) with NO new software
 func testUpdateHostBundleIDRenameOnlyNoNewSoftware(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "rename-test-host", "", "renamekey", "renameuuid", time.Now())
 
@@ -9119,6 +9131,10 @@ func testUpdateHostBundleIDRenameOnlyNoNewSoftware(t *testing.T, ds *Datastore) 
 // 2. Existing software with renamed bundle IDs that needs updating
 // This tests that both operations work correctly in the same update.
 func testUpdateHostBundleIDRenameWithNewSoftware(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "mixed-test-host", "", "mixedkey", "mixeduuid", time.Now())
 


### PR DESCRIPTION
Needs to be cherry picked into 4.73.4 and/or 4.74.0 and 4.75.0

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33612

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

