### PR TITLE
One license warning per gitops run

### DIFF
--- a/changes/33054-gitops-license-warning
+++ b/changes/33054-gitops-license-warning
@@ -1,0 +1,1 @@
+* Show only one license warning during gitops runs

--- a/changes/33054-gitops-license-warning
+++ b/changes/33054-gitops-license-warning
@@ -1,1 +1,1 @@
-* Show only one license warning during gitops runs
+* Changed license warning to only show one time during gitops runs

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -40,8 +40,9 @@ type Client struct {
 	token         string
 	customHeaders map[string]string
 
-	outputWriter io.Writer
-	errWriter    io.Writer
+	outputWriter       io.Writer
+	errWriter          io.Writer
+	seenLicenseExpired bool
 }
 
 type ClientOption func(*Client) error
@@ -138,8 +139,9 @@ func (c *Client) doContextWithBodyAndHeaders(ctx context.Context, verb, path, ra
 		return nil, ctxerr.Wrap(ctx, err, "do request")
 	}
 
-	if resp.Header.Get(fleet.HeaderLicenseKey) == fleet.HeaderLicenseValueExpired {
+	if !c.seenLicenseExpired && resp.Header.Get(fleet.HeaderLicenseKey) == fleet.HeaderLicenseValueExpired {
 		fleet.WriteExpiredLicenseBanner(c.errWriter)
+		c.seenLicenseExpired = true
 	}
 
 	return resp, nil


### PR DESCRIPTION

**Related issue:** Resolves #33054

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
