### PR TITLE
Avoid overriding local state with server state on ChangeManagement component

### DIFF
--- a/changes/28713-gitops-checkbox-status-does-not-stay
+++ b/changes/28713-gitops-checkbox-status-does-not-stay
@@ -1,3 +1,2 @@
-* Fixed bug with the ChangeManagement component where server state was overriding local UI state.
 * Fixed bug with the ChangeManagement component where the GitOps checkbox local UI state was being reset due to GET request after PATCH request.
 * Refactored PATH fleet/config end-point to use the primary DB node for both persisting changes and fetching modified App Config.

--- a/changes/28713-gitops-checkbox-status-does-not-stay
+++ b/changes/28713-gitops-checkbox-status-does-not-stay
@@ -1,1 +1,2 @@
-* Fixed bug with the ChangeManagement component were server state was overriding local UI state.
+* Fixed bug with the ChangeManagement component where server state was overriding local UI state.
+* Fixed bug with the ChangeManagement component where the GitOps checkbox local UI state was being reset due to GET request after PATCH request.

--- a/changes/28713-gitops-checkbox-status-does-not-stay
+++ b/changes/28713-gitops-checkbox-status-does-not-stay
@@ -1,0 +1,1 @@
+* Fixed bug with the ChangeManagement component were server state was overriding local UI state.

--- a/changes/28713-gitops-checkbox-status-does-not-stay
+++ b/changes/28713-gitops-checkbox-status-does-not-stay
@@ -1,2 +1,3 @@
 * Fixed bug with the ChangeManagement component where server state was overriding local UI state.
 * Fixed bug with the ChangeManagement component where the GitOps checkbox local UI state was being reset due to GET request after PATCH request.
+* Refactored PATH fleet/config end-point to use the primary DB node for both persisting changes and fetching modified App Config.

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState, useEffect, useRef } from "react";
 
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
@@ -53,6 +53,7 @@ const validate = (formData: IChangeManagementFormData) => {
 };
 
 const ChangeManagement = () => {
+  const queryClient = useQueryClient();
   const { setConfig } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -117,18 +118,22 @@ const ChangeManagement = () => {
     }
     setIsUpdating(true);
     try {
-      await configAPI.update({
+      const updatedConfig = await configAPI.update({
         gitops: {
           gitops_mode_enabled: formData.gitOpsModeEnabled,
           repository_url: formData.repoURL,
         },
       });
+
+      queryClient.setQueryData(["integrations"], updatedConfig);
+      setConfig(updatedConfig);
+
       renderFlash("success", "Successfully updated settings");
-      setIsUpdating(false);
-      refetchConfig();
     } catch (e) {
       const message = getErrorReason(e);
       renderFlash("error", message || "Failed to update settings");
+      setIsUpdating(false);
+    } finally {
       setIsUpdating(false);
     }
   };

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -132,7 +132,6 @@ const ChangeManagement = () => {
     } catch (e) {
       const message = getErrorReason(e);
       renderFlash("error", message || "Failed to update settings");
-      setIsUpdating(false);
     } finally {
       setIsUpdating(false);
     }

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useState, useEffect, useRef } from "react";
 
 import { useQuery } from "react-query";
 
@@ -64,7 +64,10 @@ const ChangeManagement = () => {
   const [formErrors, setFormErrors] = useState<IChangeManagementFormErrors>({});
   const [isUpdating, setIsUpdating] = useState(false);
 
+  const formInitialized = useRef(false);
+
   const {
+    data: config,
     isLoading: isLoadingConfig,
     error: isLoadingConfigError,
     refetch: refetchConfig,
@@ -73,17 +76,23 @@ const ChangeManagement = () => {
     () => configAPI.loadAll(),
     {
       onSuccess: (data) => {
-        const {
-          gitops: {
-            gitops_mode_enabled: gitOpsModeEnabled,
-            repository_url: repoURL,
-          },
-        } = data;
-        setFormData({ gitOpsModeEnabled, repoURL });
         setConfig(data);
       },
     }
   );
+
+  useEffect(() => {
+    if (config && !formInitialized.current) {
+      const {
+        gitops: {
+          gitops_mode_enabled: gitOpsModeEnabled,
+          repository_url: repoURL,
+        },
+      } = config;
+      setFormData({ gitOpsModeEnabled, repoURL });
+      formInitialized.current = true;
+    }
+  }, [config]);
 
   const { isPremiumTier } = useContext(AppContext);
 

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -751,7 +751,7 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 	}
 
 	// retrieve new app config with obfuscated secrets
-	obfuscatedAppConfig, err := svc.ds.AppConfig(ctx)
+	obfuscatedAppConfig, err := svc.ds.AppConfig(ctxdb.RequirePrimary(ctx, true))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION

**Related issue:** Resolves #28713 

Fixed bug with the ChangeManagement component were server state was overriding local UI state.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually