### PR TITLE
Fleet UI: Update labels page styling

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -181,7 +181,6 @@ const ActionsDropdown = ({
     }
   };
 
-  console.log("variant", variant);
   const customStyles: StylesConfig<IDropdownOption, false> = {
     control: (provided, state) => ({
       ...provided,
@@ -191,7 +190,7 @@ const ActionsDropdown = ({
       // Need minHeight to override default
       minHeight: variant === "small-button" ? "20px" : "32px", // Match button height
       padding: variant === "small-button" ? "2px 4px" : "8px", // Match button padding
-      backgroundColor: "initial",
+      backgroundColor: state.isFocused ? COLORS["ui-fleet-black-5"] : "initial",
       border: 0,
       boxShadow: "none",
       cursor: "pointer",
@@ -205,8 +204,11 @@ const ActionsDropdown = ({
           stroke: COLORS["ui-fleet-black-75-over"],
         },
       },
-      "&:active .actions-dropdown-select__indicator path": {
-        stroke: COLORS["ui-fleet-black-75-down"],
+      "&:active": {
+        background: COLORS["ui-fleet-black-5"], // Match button hover
+        ".actions-dropdown-select__indicator path": {
+          stroke: COLORS["ui-fleet-black-75-down"],
+        },
       },
       // TODO: Figure out a way to apply separate &:focus-visible styling
       // Currently only relying on &:focus styling for tabbing through app

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -3,7 +3,10 @@ import PATHS from "router/paths";
 import { browserHistory } from "react-router";
 import classnames from "classnames";
 
+import { IDropdownOption } from "interfaces/dropdownOption";
+
 import Button from "components/buttons/Button";
+import ActionsDropdown from "components/ActionsDropdown";
 import Icon from "components/Icon";
 import { getPathWithQueryParams, QueryParams } from "utilities/url";
 
@@ -16,11 +19,13 @@ interface IHostLinkProps {
   condensed?: boolean;
   excludeChevron?: boolean;
   responsive?: boolean;
-  customContent?: React.ReactNode;
+  /** Custom text replaces "View all hosts" in button or "Actions" in dropdown */
+  customText?: string;
   /** Table links shows on row hover and tab focus only */
   rowHover?: boolean;
   /** Don't actually create a button, useful when click is handled by an ancestor */
   noLink?: boolean;
+  dropdown?: { options: IDropdownOption[]; onChange: (value: string) => void };
 }
 
 const baseClass = "view-all-hosts-button";
@@ -32,10 +37,12 @@ const ViewAllHostsButton = ({
   condensed = false,
   excludeChevron = false,
   responsive = false,
-  customContent,
+  customText,
   rowHover = false,
   noLink = false,
+  dropdown,
 }: IHostLinkProps): JSX.Element => {
+  console.log("rowHover", rowHover);
   const viewAllHostsButtonClass = classnames(baseClass, className, {
     [`${baseClass}__condensed`]: condensed,
     "row-hover-button": rowHover,
@@ -56,6 +63,19 @@ const ViewAllHostsButton = ({
     }
   };
 
+  if (dropdown) {
+    return (
+      <ActionsDropdown
+        className={viewAllHostsButtonClass}
+        options={dropdown.options}
+        onChange={dropdown.onChange}
+        placeholder={customText || "Actions"}
+        variant="small-button"
+        menuAlign="right"
+      />
+    );
+  }
+
   return (
     <Button
       className={viewAllHostsButtonClass}
@@ -67,7 +87,7 @@ const ViewAllHostsButton = ({
         <span
           className={`${baseClass}__text${responsive ? "--responsive" : ""}`}
         >
-          {customContent ?? "View all hosts"}
+          {customText ?? "View all hosts"}
         </span>
       )}
       {!excludeChevron && (

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -25,6 +25,7 @@ interface IHostLinkProps {
   rowHover?: boolean;
   /** Don't actually create a button, useful when click is handled by an ancestor */
   noLink?: boolean;
+  /** When provided, replaces View all hosts button with ActionDropdown */
   dropdown?: { options: IDropdownOption[]; onChange: (value: string) => void };
 }
 

--- a/frontend/components/ViewAllHostsLink/_styles.scss
+++ b/frontend/components/ViewAllHostsLink/_styles.scss
@@ -1,4 +1,7 @@
 .view-all-hosts-button {
+  display: flex;
+  align-items: center;
+
   &__text {
     &--responsive {
       @media (max-width: $break-md) {
@@ -14,5 +17,20 @@
   // For tabbing through the app
   &:focus-visible.row-hover-button {
     opacity: 1;
+  }
+
+  // React-select's dropdown opacity must be controlled at input level for keyboard nav
+  &.row-hover-button.actions-dropdown {
+    opacity: 1;
+
+    // Control opacity of dropdown
+    .actions-dropdown-select__control {
+      opacity: 0;
+
+      &:hover,
+      &--is-focused {
+        opacity: 1;
+      }
+    }
   }
 }

--- a/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/components/ScriptBatchHostsTable/ScriptBatchHostsTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/components/ScriptBatchHostsTable/ScriptBatchHostsTableConfig.tsx
@@ -31,7 +31,7 @@ const ScriptOutputCell = (cellProps: CellProps<IScriptBatchHostResult>) => {
         value={cellProps.row.original.script_output_preview}
       />
       <ViewAllHostsLink
-        customContent="View script details"
+        customText="View script details"
         rowHover
         noLink
         responsive
@@ -63,7 +63,7 @@ const generateColumnConfigs = (
           />
           {SCRIPT_BATCH_HOST_NOT_EXECUTED_STATUSES.includes(hostStatus) && (
             <ViewAllHostsLink
-              customContent="View host details"
+              customText="View host details"
               rowHover
               noLink
               responsive

--- a/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Certificates/CertificatesTable/CertificatesTableConfig.tsx
@@ -105,7 +105,7 @@ const generateTableConfig = (): IHostCertificatesTableConfig[] => {
             noLink
             rowHover
             excludeChevron
-            customContent="View details"
+            customText="View details"
           />
         );
       },

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -149,13 +149,10 @@ const generateTableHeaders = (
             rowHover
             noLink
             excludeChevron
-            customContent={
-              <ActionsDropdown
-                options={dropdownOptions}
-                onChange={(value: string) => onClickAction(value, label)}
-                placeholder="Actions"
-              />
-            }
+            dropdown={{
+              options: dropdownOptions,
+              onChange: (value: string) => onClickAction(value, label),
+            }}
           />
         );
       },

--- a/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
@@ -113,19 +113,19 @@ const ManageLabelsPage = ({ router }: IManageLabelsPageProps): JSX.Element => {
               <h1>Labels</h1>
             </div>
           </div>
+          {canAddLabel && (
+            <div className={`${baseClass}__action-button-container`}>
+              <Button
+                className={`${baseClass}__create-button`}
+                onClick={onCreateLabelClick}
+              >
+                Add label
+              </Button>
+            </div>
+          )}
         </div>
-        {canAddLabel && (
-          <div className={`${baseClass}__action-button-container`}>
-            <Button
-              className={`${baseClass}__create-button`}
-              onClick={onCreateLabelClick}
-            >
-              Add label
-            </Button>
-          </div>
-        )}
+        <PageDescription content="Group hosts for targeting and filtering." />
       </div>
-      <PageDescription content="Group hosts for targeting and filtering" />
       {renderTable()}
       {labelToDelete && (
         <DeleteLabelModal

--- a/frontend/pages/labels/ManageLabelsPage/_styles.scss
+++ b/frontend/pages/labels/ManageLabelsPage/_styles.scss
@@ -1,15 +1,18 @@
 .manage-labels-page {
+  @include vertical-page-layout;
+
   &__header-wrap {
-    @include normalize-team-header;
+    display: flex;
+    flex-direction: column;
+    gap: $pad-xsmall;
   }
 
   &__header {
-    display: flex;
-    align-items: center;
+    @include normalize-team-header;
   }
 
   &__text {
-    margin-right: 16px;
+    margin-right: $pad-large;
   }
 
   &__title {


### PR DESCRIPTION
## Issue
Closes #33629
Parent stories: Conf 11765 + #33079

## Description
- Update padding to be consistent with other main pages
- Add period to match Figma and other pages
  - <img width="257" height="227" alt="Screenshot 2025-09-30 at 9 56 11 AM" src="https://github.com/user-attachments/assets/44dba6fb-6ac8-47bc-b803-53cd271227b7" />
- Align menu on right to match Figma and some of the other pages
  - <img width="293" height="183" alt="Screenshot 2025-09-30 at 9 56 15 AM" src="https://github.com/user-attachments/assets/f3627934-9d0e-476a-945b-ed6350fbb9c5" />
- Update ViewAllHostButton to work with Actions dropdown
  - Ensure dropdown is keyboard accessible

## Screenrecording of fix
https://fleetdm.zoom.us/clips/share/NmePAsFMRQmIXTsxgi4EoQ

## Testing

- [x] QA'd all new/changed functionality manually
