### PR TITLE
Fleet UI: Fix wobble links in truncated text cell links

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -330,8 +330,8 @@ $shadow-transition-width: 10px;
 
           &:hover {
             .data-table__tooltip-truncated-text-container {
-              // @include link;
               @include animated-bottom-border;
+              margin-bottom: 0; // Undo margin-bottom of animated bottom border
 
               &:hover {
                 margin-bottom: 0; // Undo margin-bottom of animated bottom border


### PR DESCRIPTION
## Issue
Closes #33338
Parent Conf 11765

## Description
- Text links "wobble" on hover 1px for links within tooltip truncated text container

## Screenrecording of no wobble Chrome, FF, Safari
https://fleetdm.zoom.us/clips/share/I8atIXdmQJyznJukUY0jhA

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:
