### PR TITLE
Removing the software renaming fix introduced in 4.73.3 due to MySQL …

### DIFF
--- a/changes/33612-remove-software-rename-sql
+++ b/changes/33612-remove-software-rename-sql
@@ -1,0 +1,1 @@
+Removing the software renaming fix introduced in 4.73.3 due to MySQL DB performance issues.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -454,9 +454,11 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 				}
 
 				// Update software names for bundle ID matches
-				if err = updateTargetedBundleIDs(ctx, tx, softwareRenames); err != nil {
-					return err
-				}
+				// TEMPORARILY COMMENTED OUT: Performance issue with updateTargetedBundleIDs SQL statement
+				// TODO: Re-enable after gathering more info and optimizing the query
+				// if err = updateTargetedBundleIDs(ctx, tx, softwareRenames); err != nil {
+				// 	return err
+				// }
 			}
 
 			// Use r.Inserted which contains all inserted items (including bundle ID matches)
@@ -482,7 +484,7 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 
 // updateTargetedBundleIDs updates software names when bundle IDs match but names differ.
 // softwareRenames maps software IDs to their new names.
-func updateTargetedBundleIDs(ctx context.Context, tx sqlx.ExtContext, softwareRenames map[uint]string) error {
+func updateTargetedBundleIDs(ctx context.Context, tx sqlx.ExtContext, softwareRenames map[uint]string) error { //nolint:unused
 	if len(softwareRenames) == 0 {
 		return nil
 	}
@@ -707,8 +709,8 @@ func (ds *Datastore) getIncomingSoftwareChecksumsToExistingTitles(
 		)
 		existingChecksums := uniqueTitleStrToChecksums[titleStr]
 		if len(existingChecksums) > 0 {
-			// Log when multiple checksums map to the same title. If we see this regularly, we should fix it.
-			level.Error(ds.logger).Log(
+			// Log when multiple checksums map to the same title.
+			level.Debug(ds.logger).Log(
 				"msg", "multiple checksums mapping to same title",
 				"title_str", titleStr,
 				"new_checksum", checksum,

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -1846,6 +1846,10 @@ func testUpdateHostSoftware(t *testing.T, ds *Datastore) {
 // When software with the same bundle ID but different name is added, the system
 // reuses the existing software entry (matched by bundle ID) and links it to the host
 func testUpdateHostSoftwareSameBundleIDDifferentNames(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "bundle-host", "", "bundlekey", "bundleuuid", time.Now())
 
@@ -1942,6 +1946,10 @@ func testUpdateHostSoftwareSameNameDifferentBundleIDs(t *testing.T, ds *Datastor
 // Test edge case: Multiple software entries with the same bundle ID
 // This validates that bundle ID renaming affects all software with that bundle ID
 func testUpdateHostSoftwareMultipleSameBundleID(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host1 := test.NewHost(t, ds, "multi-bundle-host1", "", "multikey1", "multiuuid1", time.Now())
 	host2 := test.NewHost(t, ds, "multi-bundle-host2", "", "multikey2", "multiuuid2", time.Now())
@@ -9061,6 +9069,10 @@ func testPreInsertSoftwareInventory(t *testing.T, ds *Datastore) {
 // testUpdateHostBundleIDRenameOnlyNoNewSoftware tests if a host reports ONLY renamed software
 // (same bundle ID, different name) with NO new software
 func testUpdateHostBundleIDRenameOnlyNoNewSoftware(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "rename-test-host", "", "renamekey", "renameuuid", time.Now())
 
@@ -9119,6 +9131,10 @@ func testUpdateHostBundleIDRenameOnlyNoNewSoftware(t *testing.T, ds *Datastore) 
 // 2. Existing software with renamed bundle IDs that needs updating
 // This tests that both operations work correctly in the same update.
 func testUpdateHostBundleIDRenameWithNewSoftware(t *testing.T, ds *Datastore) {
+	// TEMPORARILY SKIPPED: updateTargetedBundleIDs is commented out for performance reasons
+	// TODO: Re-enable when updateTargetedBundleIDs is re-enabled
+	t.Skip("Skipping test: updateTargetedBundleIDs is temporarily disabled for performance reasons")
+
 	ctx := t.Context()
 	host := test.NewHost(t, ds, "mixed-test-host", "", "mixedkey", "mixeduuid", time.Now())
 


### PR DESCRIPTION
…DB performance issues. (#33616)

Needs to be cherry picked into 4.73.4 and/or 4.74.0 and 4.75.0

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33612

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
