### PR TITLE
Fleet UI: Fix link, info banner spacing, certificates modal padding

### DIFF
--- a/frontend/components/DataSet/_styles.scss
+++ b/frontend/components/DataSet/_styles.scss
@@ -4,11 +4,6 @@
   font-size: $x-small;
   gap: $pad-xsmall;
 
-  &__horizontal {
-    display: flex;
-    gap: $pad-small;
-  }
-
   dt {
     font-weight: $bold;
     display: flex;

--- a/frontend/components/InfoBanner/InfoBanner.stories.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.stories.tsx
@@ -1,30 +1,69 @@
 import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import CustomLink from "components/CustomLink";
-
 import InfoBanner from ".";
-
 import "../../index.scss";
 
 const meta: Meta<typeof InfoBanner> = {
   component: InfoBanner,
   title: "Components/InfoBanner",
+  argTypes: {
+    color: {
+      control: { type: "select" },
+      options: ["purple", "yellow", "grey"],
+    },
+    borderRadius: {
+      control: { type: "select" },
+      options: ["medium", "xlarge"],
+    },
+    pageLevel: { control: "boolean" },
+    closable: { control: "boolean" },
+    icon: {
+      control: { type: "select" },
+      options: [undefined, "info", "warning", "error", "success"],
+    },
+    cta: { table: { disable: true } }, // Kept as is for JSX
+    children: { table: { disable: true }, description: "React.ReactNode" },
+    className: { control: "text" },
+  },
+  parameters: { controls: { expanded: true } },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof InfoBanner>;
 
-export const Default: Story = {
+const defaultChildren = (
+  <>
+    <b>Fleet</b> is unable to run a live query. Refresh the page or log in
+    again. If this keeps happening please{" "}
+    <CustomLink
+      url="https://github.com/fleetdm/fleet/issues/new/choose"
+      text="file an issue"
+      newTab
+      variant="banner-link"
+    />
+  </>
+);
+
+const sampleCta = (
+  <CustomLink
+    url="http://localhost:6006/"
+    text="Reopen Storybook"
+    newTab
+    variant="banner-link"
+  />
+);
+
+export const Playground: Story = {
   args: {
-    children: <div>This is an Info Banner.</div>,
-    cta: (
-      <CustomLink
-        url="http://localhost:6006/"
-        text="Reopen Storybook"
-        newTab
-        // TODO: variant="info-banner" after merge
-      />
-    ),
+    children: defaultChildren,
+    cta: sampleCta,
+    color: "purple",
+    borderRadius: "medium",
+    pageLevel: false,
+    closable: true,
+    icon: "info",
   },
+  render: (args) => <InfoBanner {...args} />,
 };

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -20,7 +20,7 @@ export interface IInfoBannerProps {
   cta?: JSX.Element;
   /** closable and link are mutually exclusive */
   closable?: boolean;
-  icon?: IconNames;
+  icon?: IconNames; // TODO: This is unused but several banners have icons within children that can be refactored to use this for consistent styling
 }
 
 const InfoBanner = ({

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -15,6 +15,8 @@
   }
 
   &__info {
+    // Do not use display flex as it will have adverse effects on spacing around tags
+    align-content: center;
     p {
       margin: $pad-small 0 0 0; // TOFIX: this causes weird top margin noticed in #28110
     }

--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -6,6 +6,7 @@
   font-size: $x-small;
   font-weight: $regular;
   color: $core-fleet-black;
+  line-height: $line-height;
 
   &__page-banner {
     padding: $pad-large $pad-xlarge;
@@ -14,9 +15,6 @@
   }
 
   &__info {
-    display: flex;
-    align-items: center;
-
     p {
       margin: $pad-small 0 0 0; // TOFIX: this causes weird top margin noticed in #28110
     }

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -50,9 +50,10 @@ const ViewAllHostsButton = ({
   const onClick = (e: MouseEvent): void => {
     if (!noLink) {
       e.stopPropagation(); // Allows for button to have different onClick behavior than the row's onClick behavior
-    }
-    if (path) {
-      browserHistory.push(path);
+
+      if (path) {
+        browserHistory.push(path);
+      }
     }
   };
 

--- a/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/CertificateDetailsModal/_styles.scss
@@ -1,9 +1,6 @@
 .certificate-details-modal {
-
   &__content {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-xlarge;
+    @include vertical-card-layout;
   }
 
   h3 {
@@ -15,18 +12,12 @@
     display: flex;
     gap: $pad-small;
     flex-direction: column;
-    padding-top: $pad-xlarge;
+    padding-top: $gap-modal-component;
     border-top: 1px solid $ui-fleet-black-10;
 
     &:first-child {
       padding-top: 0;
       border-top: none;
-    }
-
-    dl {
-      display: flex;
-      flex-direction: column;
-      gap: $pad-xsmall;
     }
   }
 }

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -233,6 +233,7 @@ hr {
 }
 
 dl {
+  @include vertical-data-set-layout;
   margin: 0;
   padding: 0;
 }

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -252,6 +252,12 @@ $max-width: 2560px;
   gap: $gap-page-component;
 }
 
+@mixin flex-column-16px-gap {
+  display: flex;
+  flex-direction: column;
+  gap: $gap-data-sets;
+}
+
 @mixin vertical-form-layout {
   @include flex-column-24px-gap;
 }
@@ -268,6 +274,10 @@ $max-width: 2560px;
 // Separate in case there's any tab level styling we need
 @mixin vertical-page-tab-panel-layout {
   @include flex-column-24px-gap;
+}
+
+@mixin vertical-data-set-layout {
+  @include flex-column-16px-gap;
 }
 
 @mixin button-dropdown {

--- a/frontend/styles/var/padding.scss
+++ b/frontend/styles/var/padding.scss
@@ -20,3 +20,4 @@ $gap-form: $pad-large;
 $gap-form-component: $pad-small;
 $gap-data-sets: $pad-medium;
 $gap-table-elements: $pad-medium;
+$gap-modal-component: $pad-large;


### PR DESCRIPTION
## Issues
Closes #33582 
Closes #33618 

## Description
- Revert `<InfoBanner/>` display: flex which caused the bug 
- Spruce up storybook's infobanner so it's actually usable
- Fix `ViewAllHostLink` prop `noLink` to not click out to default view all host page
- Within Certifcates modal, update padding to match main UI

## Screen recording reviewing fixes
https://fleetdm.zoom.us/clips/share/APLzh0t5Q4WWgts1Gb811A

# Checklist for submitter

- [x] QA'd all new/changed functionality manually
