### PR TITLE
Fleet UI: Change org logo to light background on product and My Device Page

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -137,7 +137,7 @@ const SiteTopNav = ({
 
   const renderNavItem = (navItem: INavItem) => {
     const { name, iconName, withParams } = navItem;
-    const orgLogoURL = config.org_info.org_logo_url;
+    const orgLogoURL = config.org_info.org_logo_url_light_background;
     const active = navItem.location.regex.test(currentPath);
 
     const navItemBaseClass = "site-nav-item";

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -199,6 +199,7 @@ export interface IDeviceUserResponse {
   host: IHostDevice;
   license: ILicense;
   org_logo_url: string;
+  org_logo_url_light_background: string;
   org_contact_url: string;
   disk_encryption_enabled?: boolean;
   platform?: HostPlatform;

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -308,7 +308,7 @@ const DeviceUserPage = ({
   const {
     host,
     license,
-    org_logo_url: orgLogoURL = "",
+    org_logo_url_light_background: orgLogoURL = "",
     org_contact_url: orgContactURL = "",
     global_config: globalConfig = null as IDeviceGlobalConfig | null,
     self_service: hasSelfService = false,

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -21,6 +21,7 @@ export const defaultDeviceHandler = http.get(baseUrl("/device/:token"), () => {
     host: createMockHost(),
     license: createMockLicense(),
     org_logo_url: "",
+    org_logo_url_light_background: "",
     global_config: {
       mdm: { enabled_and_configured: false },
     },
@@ -35,6 +36,7 @@ export const customDeviceHandler = (overrides?: Partial<IDeviceUserResponse>) =>
           host: createMockHost(),
           license: createMockLicense(),
           org_logo_url: "",
+          org_logo_url_light_background: "",
           global_config: {
             mdm: { enabled_and_configured: false },
           },


### PR DESCRIPTION
## Issue
Closes #33603 

## Description
- Now using light background
- Noticed _light_background was missing from FE code for device user page but properly returned from API so had to add it


## Testing

- [x] QA'd all new/changed functionality manually
