### PR TITLE
Website: Add deny list of email domains for contact form messages.

### DIFF
--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -44,13 +44,21 @@ module.exports = {
 
     success: {
       description: 'The message was sent successfully.'
-    }
+    },
+    invalidEmailDomain: {
+      description: 'This email address is on a denylist of domains and was not delivered.',
+      responseType: 'badRequest'
+    },
 
   },
 
 
   fn: async function({emailAddress, firstName, lastName, message}) {
 
+    let emailDomain = emailAddress.split('@')[1];
+    if(_.includes(sails.config.custom.bannedEmailDomainsForContactFormSubmissions, emailDomain.toLowerCase())){
+      throw 'invalidEmailDomain';
+    }
 
     let userHasPremiumSubscription = false;
     let thisSubscription;

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -383,7 +383,7 @@ module.exports.custom = {
     'yandex.ru',       'ymail.com',    'zoho.com',         'zonnet.nl'
   ],
 
-  // For website signups & contact form submissions:
+  // For website signups & "Talk to us" form submissions:
   bannedEmailDomainsForWebsiteSubmissions: [
     'gmail.com',
     'yahoo.com',
@@ -398,6 +398,13 @@ module.exports.custom = {
     'yandex.ru',
     'ymail.com',
     'qq.com',
+    'example.com',
+  ],
+
+  // For contact form submissions.
+  // Note: We're using a separate list for the contact form because we previously allowed signups/license dispenser purchases with a personal email address.
+  bannedEmailDomainsForContactFormSubmissions: [
+    'example.com'
   ],
 
   /***************************************************************************

--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -36,7 +36,7 @@
             <input class="form-control" id="contact-email-address" name="email-address" type="email" :class="[formErrors.emailAddress ? 'is-invalid' : cloudError && cloudError === 'invalidEmailDomain' ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" autocomplete="email" focus-first>
             <div class="invalid-feedback" v-if="formErrors.emailAddress">Please enter a valid work email address</div>
             <cloud-error class="p-0 mt-1 mb-0 bg-transparent invalid-feedback" v-if="cloudError && cloudError === 'invalidEmailDomain'">
-              <p>Please enter a valid work email address</p>
+              <p>Please enter a valid email address</p>
             </cloud-error>
 
           </div>


### PR DESCRIPTION
Closes: #33548

Changes:
- Added a new configuration variable `sails.config.custom.bannedEmailDomainsForContactFormSubmissions` that contains a list of domains (currently a single domain) that cannot be used to submit the contact form
- Updated the `bannedEmailDomainsForWebsiteSubmissions` list to include `example.com`
- Updated the deliver-contact-form-message action to return an `invalidEmailDomain` exit if the contact form is submitted with an email domain in the `bannedEmailDomainsForContactFormSubmissions` list