### PR TITLE
Fleet API: Surface org_logo_url_light_background to my device page

### DIFF
--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -203,12 +203,13 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	}
 
 	return getDeviceHostResponse{
-		Host:          resp,
-		OrgLogoURL:    ac.OrgInfo.OrgLogoURL,
-		OrgContactURL: ac.OrgInfo.ContactURL,
-		License:       *license,
-		GlobalConfig:  deviceGlobalConfig,
-		SelfService:   hasSelfService,
+		Host:                      resp,
+		OrgLogoURL:                ac.OrgInfo.OrgLogoURL,
+		OrgLogoURLLightBackground: ac.OrgInfo.OrgLogoURLLightBackground,
+		OrgContactURL:             ac.OrgInfo.ContactURL,
+		License:                   *license,
+		GlobalConfig:              deviceGlobalConfig,
+		SelfService:               hasSelfService,
 	}, nil
 }
 


### PR DESCRIPTION
## Issue
Closes #33603

## Description
Missing passing `_light_background` org logo to my device page which is needed for the new light UX

## Screenshot of E2E working
<img width="1239" height="201" alt="Screenshot 2025-09-30 at 2 15 16 PM" src="https://github.com/user-attachments/assets/b2845dae-8d6c-474f-ad36-3d602f947234" />



## Testing

- [x] QA'd all new/changed functionality manually
