### PR TITLE
Fix for 4.73.2 misnumbered migrations

### DIFF
--- a/changes/33562-4.73.2-migration-fix
+++ b/changes/33562-4.73.2-migration-fix
@@ -1,0 +1,1 @@
+* Added logic to detect and fix migration issues caused by improperly published Fleet v4.73.2 Linux binary

--- a/cmd/fleet/prepare.go
+++ b/cmd/fleet/prepare.go
@@ -143,7 +143,7 @@ func printFleetv4732UnknownStateMessage(statusCode fleet.MigrationStatusCode) {
 	if statusCode == fleet.NeedsFleetv4732Fix {
 		extra = "the automatic fix did not result in the expected state."
 	}
-	fmt.Printf("################################################################################\n" +
+	fmt.Print("################################################################################\n" +
 		"# WARNING:\n" +
 		"#   Your Fleet database has misnumbered migrations introduced in some released\n" +
 		"#   v4.73.2 artifacts. Fleet attempts to fix this problem automatically, however\n" +

--- a/cmd/fleet/prepare.go
+++ b/cmd/fleet/prepare.go
@@ -55,6 +55,8 @@ To setup Fleet infrastructure, use one of the available commands.
 				if !noPrompt {
 					printFleetv4732FixMessage()
 					bufio.NewScanner(os.Stdin).Scan()
+				} else {
+					fmt.Println("Applying automatic fix for mis-numbered v4.73.2 migrations")
 				}
 				if err := ds.FixFleetv4732Migrations(cmd.Context()); err != nil {
 					initFatal(err, "fixing v4.73.2 migrations")

--- a/cmd/fleet/prepare.go
+++ b/cmd/fleet/prepare.go
@@ -51,6 +51,20 @@ To setup Fleet infrastructure, use one of the available commands.
 			if err != nil {
 				initFatal(err, "retrieving migration status")
 			}
+			if status.StatusCode == fleet.NeedsFleetv4732Fix {
+				if !noPrompt {
+					printFleetv4732FixMessage()
+					bufio.NewScanner(os.Stdin).Scan()
+				}
+				if err := ds.FixFleetv4732Migrations(cmd.Context()); err != nil {
+					initFatal(err, "fixing v4.73.2 migrations")
+				}
+				// re-check status after fix
+				status, err = ds.MigrationStatus(cmd.Context())
+				if err != nil {
+					initFatal(err, "retrieving migration status")
+				}
+			}
 
 			switch status.StatusCode {
 			case fleet.NoMigrationsCompleted:
@@ -63,6 +77,8 @@ To setup Fleet infrastructure, use one of the available commands.
 					printMissingMigrationsPrompt(status.MissingTable, status.MissingData)
 					bufio.NewScanner(os.Stdin).Scan()
 				}
+			case fleet.NeedsFleetv4732Fix, fleet.UnknownFleetv4732State:
+				printFleetv4732UnknownStateMessage(status.StatusCode)
 			case fleet.UnknownMigrations:
 				printUnknownMigrationsMessage(status.UnknownTable, status.UnknownData)
 				if dev {
@@ -111,6 +127,29 @@ func printMissingMigrationsPrompt(tables []int64, data []int64) {
 		"#   Press Enter to continue, or Control-c to exit.\n"+
 		"################################################################################\n",
 		tablesAndDataToString(tables, data))
+}
+
+func printFleetv4732FixMessage() {
+	fmt.Printf("################################################################################\n" +
+		"# WARNING:\n" +
+		"#   Your Fleet database has misnumbered migrations introduced in some released\n" +
+		"#   v4.73.2 artifacts. Fleet will automatically perform this fix prior to database\n" +
+		"#   migrations. Please back up your data before continuing.\n" +
+		"################################################################################\n")
+}
+
+func printFleetv4732UnknownStateMessage(statusCode fleet.MigrationStatusCode) {
+	extra := "your Fleet database is in an unknown state."
+	if statusCode == fleet.NeedsFleetv4732Fix {
+		extra = "the automatic fix did not result in the expected state."
+	}
+	fmt.Printf("################################################################################\n" +
+		"# WARNING:\n" +
+		"#   Your Fleet database has misnumbered migrations introduced in some released\n" +
+		"#   v4.73.2 artifacts. Fleet attempts to fix this problem automatically, however\n" +
+		"#  " + extra + "\n" +
+		"#   Please contact Fleet support for assistance in resolving this.\n" +
+		"################################################################################\n")
 }
 
 func tablesAndDataToString(tables, data []int64) string {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -269,6 +269,10 @@ the way that the Fleet server works.
 				if dev {
 					os.Exit(1)
 				}
+			case fleet.NeedsFleetv4732Fix:
+				printFleetv4732FixNeededMessage()
+			case fleet.UnknownFleetv4732State:
+				printFleetv4732UnknownStateMessage(migrationStatus.StatusCode)
 			case fleet.SomeMigrationsCompleted:
 				tables, data := migrationStatus.MissingTable, migrationStatus.MissingData
 				printMissingMigrationsWarning(tables, data)
@@ -1590,6 +1594,22 @@ func printMissingMigrationsWarning(tables []int64, data []int64) {
 		"#     - Use command line argument --upgrades_allow_missing_migrations=true\n"+
 		"################################################################################\n",
 		tablesAndDataToString(tables, data), os.Args[0])
+}
+
+func printFleetv4732FixNeededMessage() {
+	fmt.Printf("################################################################################\n"+
+		"# WARNING:\n"+
+		"#   Your Fleet database has misnumbered migrations introduced in some released\n"+
+		"#   v4.73.2 artifacts. Fleet will automatically perform this fix prior to database\n"+
+		"#   migrations. Please back up your data before continuing.\n"+
+		"#\n"+
+		"#   Run `%s prepare db` to perform migrations.\n"+
+		"#\n"+
+		"#   To run the server without performing migrations:\n"+
+		"#     - Set environment variable FLEET_UPGRADES_ALLOW_MISSING_MIGRATIONS=1, or,\n"+
+		"#     - Set config updates.allow_missing_migrations to true, or,\n"+
+		"#     - Use command line argument --upgrades_allow_missing_migrations=true\n"+
+		"################################################################################\n", os.Args[0])
 }
 
 func initLicense(config configpkg.FleetConfig, devLicense, devExpiredLicense bool) (*fleet.LicenseInfo, error) {

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -271,8 +271,14 @@ the way that the Fleet server works.
 				}
 			case fleet.NeedsFleetv4732Fix:
 				printFleetv4732FixNeededMessage()
+				if !config.Upgrades.AllowMissingMigrations {
+					os.Exit(1)
+				}
 			case fleet.UnknownFleetv4732State:
 				printFleetv4732UnknownStateMessage(migrationStatus.StatusCode)
+				if !config.Upgrades.AllowMissingMigrations {
+					os.Exit(1)
+				}
 			case fleet.SomeMigrationsCompleted:
 				tables, data := migrationStatus.MissingTable, migrationStatus.MissingData
 				printMissingMigrationsWarning(tables, data)

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -67,6 +67,8 @@ by an exit code of zero.`,
 			switch status.StatusCode {
 			case fleet.AllMigrationsCompleted:
 				// only continue if db is considered up-to-date
+			case fleet.NeedsFleetv4732Fix, fleet.UnknownFleetv4732State:
+				migrationError = errors.New("database has misnumbered migrations from v4.73.2")
 			case fleet.NoMigrationsCompleted:
 				migrationError = errors.New("no migrations completed")
 			case fleet.SomeMigrationsCompleted:

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -86,6 +86,7 @@ func TestV4732MigrationFix(t *testing.T) {
 	assert.EqualValues(t, fleet.AllMigrationsCompleted, status.StatusCode)
 
 	_, err = ds.writer(context.Background()).Exec(`INSERT INTO `+tables.MigrationClient.TableName+` (version_id, is_applied) VALUES (?, 1)`, fleet4732BadMigrationID1)
+	require.NoError(t, err)
 	status, err = ds.MigrationStatus(context.Background())
 	require.NoError(t, err)
 	require.NotNil(t, status)

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -85,6 +85,7 @@ func TestV4732MigrationFix(t *testing.T) {
 	require.NotNil(t, status)
 	assert.EqualValues(t, fleet.AllMigrationsCompleted, status.StatusCode)
 
+	// Insert a bad migration again which should trigger the unknown state
 	_, err = ds.writer(context.Background()).Exec(`INSERT INTO `+tables.MigrationClient.TableName+` (version_id, is_applied) VALUES (?, 1)`, fleet4732BadMigrationID1)
 	require.NoError(t, err)
 	status, err = ds.MigrationStatus(context.Background())

--- a/server/datastore/mysql/migrations_test.go
+++ b/server/datastore/mysql/migrations_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql/testing_utils"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/data"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/tables"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/stretchr/testify/assert"
@@ -54,6 +55,93 @@ func TestMigrationStatus(t *testing.T) {
 	assert.EqualValues(t, fleet.AllMigrationsCompleted, status.StatusCode)
 	assert.Empty(t, status.MissingTable)
 	assert.Empty(t, status.MissingData)
+}
+
+func TestV4732MigrationFix(t *testing.T) {
+	ds := createMySQLDSForMigrationTests(t, t.Name())
+	t.Cleanup(func() {
+		ds.Close()
+	})
+	status, err := ds.MigrationStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.EqualValues(t, fleet.NoMigrationsCompleted, status.StatusCode)
+
+	recreate4732BadState(t, ds)
+
+	status, err = ds.MigrationStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.EqualValues(t, fleet.NeedsFleetv4732Fix, status.StatusCode)
+
+	err = ds.FixFleetv4732Migrations(context.Background())
+	require.NoError(t, err)
+
+	err = ds.MigrateTables(context.Background())
+	require.NoError(t, err)
+
+	status, err = ds.MigrationStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.EqualValues(t, fleet.AllMigrationsCompleted, status.StatusCode)
+
+	_, err = ds.writer(context.Background()).Exec(`INSERT INTO `+tables.MigrationClient.TableName+` (version_id, is_applied) VALUES (?, 1)`, fleet4732BadMigrationID1)
+	status, err = ds.MigrationStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	assert.EqualValues(t, fleet.UnknownFleetv4732State, status.StatusCode)
+}
+
+// Apply the proper 4.73.2 migrations
+func recreate4732GoodState(t *testing.T, ds *Datastore) {
+	var version int64
+	var err error
+
+	const maxDataMigration = 20230525175650
+
+	// Migrate up to 4.73.1
+	for version < fleet4731GoodMigrationID {
+		err = tables.MigrationClient.UpByOne(ds.writer(context.Background()).DB, "")
+		require.NoError(t, err)
+		version, err = tables.MigrationClient.GetDBVersion(ds.writer(context.Background()).DB)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(fleet4731GoodMigrationID), version)
+
+	// Apply data migrations which were deprecated before 4.73.2 and should never change so no need for
+	// upbyone, etc. but we'll verify below that we're at expected version
+	err = data.MigrationClient.Up(ds.writer(context.Background()).DB, "")
+	require.NoError(t, err)
+	version, err = data.MigrationClient.GetDBVersion(ds.writer(context.Background()).DB)
+	require.NoError(t, err)
+	require.EqualValues(t, int64(maxDataMigration), version)
+
+	// Apply the migrations from fleet v4.73.2
+	err = tables.MigrationClient.UpByOne(ds.writer(context.Background()).DB, "")
+	require.NoError(t, err)
+	version, err = tables.MigrationClient.GetDBVersion(ds.writer(context.Background()).DB)
+	require.NoError(t, err)
+	require.EqualValues(t, fleet4732GoodMigrationID2, version)
+
+	err = tables.MigrationClient.UpByOne(ds.writer(context.Background()).DB, "")
+	require.NoError(t, err)
+	version, err = tables.MigrationClient.GetDBVersion(ds.writer(context.Background()).DB)
+	require.NoError(t, err)
+	require.EqualValues(t, fleet4732GoodMigrationID1, version)
+}
+
+// Recreate the bad state that some customers ended up with after running fleet v4.73.2 migrations
+func recreate4732BadState(t *testing.T, ds *Datastore) {
+	recreate4732GoodState(t, ds)
+
+	_, err := ds.writer(context.Background()).Exec(`UPDATE `+tables.MigrationClient.TableName+` SET version_id = ? WHERE version_id = ?`, fleet4732BadMigrationID1, fleet4732GoodMigrationID1)
+	require.NoError(t, err)
+	_, err = ds.writer(context.Background()).Exec(`UPDATE `+tables.MigrationClient.TableName+` SET version_id = ? WHERE version_id = ?`, fleet4732BadMigrationID2, fleet4732GoodMigrationID2)
+	require.NoError(t, err)
+
+	version, err := tables.MigrationClient.GetDBVersion(ds.writer(context.Background()).DB)
+	require.NoError(t, err)
+	require.EqualValues(t, fleet4732BadMigrationID1, version)
 }
 
 func TestMigrations(t *testing.T) {

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -445,7 +445,7 @@ func (ds *Datastore) CheckFleetv4732BadMigrations(appliedTable []int64) *fleet.M
 	if len(appliedTable) > 2 &&
 		appliedTable[len(appliedTable)-1] == fleet4732BadMigrationID1 &&
 		appliedTable[len(appliedTable)-2] == fleet4732BadMigrationID2 &&
-		appliedTable[len(appliedTable)-3] != fleet4731GoodMigrationID {
+		appliedTable[len(appliedTable)-3] == fleet4731GoodMigrationID {
 		return &fleet.MigrationStatus{
 			StatusCode: fleet.NeedsFleetv4732Fix,
 		}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2554,6 +2554,11 @@ const (
 	AllMigrationsCompleted
 	// UnknownMigrations means some unidentified migrations were detected on the database.
 	UnknownMigrations
+	// NeedsFleetv4732Fix means the database needs the special fix migration for fleet v4.73.2
+	NeedsFleetv4732Fix
+	// UnknownFleetv4732State means the database has the broken migrations from fleet v4.73.2 however
+	// it is not in the expected state and needs manual intervention.
+	UnknownFleetv4732State
 )
 
 // TODO: we have a similar but different interface in the service package,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33562 

Detects and if possible fixes migrations which were misnumbered in the released 4.73.2 Linux binary(it was based on the commit before the renumbering commit was added). This does not affect the released 4.73.2 docker images and this code does nothing on these since the migrations will not be detected

We specifically look for the 3 most recent migrations being the mis-numbered 4.73.2 and 4.73.1 migrations in the expected order. If neither of the mis-numbered migrations are found, nothing is done. Likewise if the order is not right or the order is not exactly right(e.g. if intervening migrations, for instance from 4.74.0 have been applied) we do not apply the fix. Finally, the fix is only ever applied in the existing migration path and fleet will never try to apply the fleet automatically by just running the fleet server(though it will detect the condition and complain)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed

## Database migrations

- [x] Checked table schema to confirm autoupdate
- [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [x] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [x] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

