### PR TITLE
Fleet UI: Followup row hover unreleased fix, comment cleans

### DIFF
--- a/frontend/components/InfoBanner/_styles.scss
+++ b/frontend/components/InfoBanner/_styles.scss
@@ -15,7 +15,7 @@
   }
 
   &__info {
-    // Do not use display flex as it will have adverse effects on spacing around tags
+    // Do not use display flex as it will have adverse effects on spacing around HTML tags
     align-content: center;
     p {
       margin: $pad-small 0 0 0; // TOFIX: this causes weird top margin noticed in #28110

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -241,11 +241,30 @@
       opacity: 0;
       transition: 250ms;
       text-overflow: none;
+
+      // React-select's dropdown opacity must be controlled at input level for keyboard nav
+      // So must be controlled at input level here as well
+      &.actions-dropdown {
+        opacity: 1;
+        .actions-dropdown-select__control {
+          opacity: 0;
+
+          &:hover,
+          &--is-focused {
+            opacity: 1;
+          }
+        }
+      }
     }
     &:hover,
     &:focus-visible {
       .row-hover-button {
         opacity: 1;
+      }
+      .row-hover-button.actions-dropdown {
+        .actions-dropdown-select__control {
+          opacity: 1;
+        }
       }
     }
   }

--- a/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
+++ b/frontend/components/ViewAllHostsLink/ViewAllHostsButton.tsx
@@ -43,7 +43,6 @@ const ViewAllHostsButton = ({
   noLink = false,
   dropdown,
 }: IHostLinkProps): JSX.Element => {
-  console.log("rowHover", rowHover);
   const viewAllHostsButtonClass = classnames(baseClass, className, {
     [`${baseClass}__condensed`]: condensed,
     "row-hover-button": rowHover,

--- a/frontend/components/ViewAllHostsLink/_styles.scss
+++ b/frontend/components/ViewAllHostsLink/_styles.scss
@@ -18,19 +18,4 @@
   &:focus-visible.row-hover-button {
     opacity: 1;
   }
-
-  // React-select's dropdown opacity must be controlled at input level for keyboard nav
-  &.row-hover-button.actions-dropdown {
-    opacity: 1;
-
-    // Control opacity of dropdown
-    .actions-dropdown-select__control {
-      opacity: 0;
-
-      &:hover,
-      &--is-focused {
-        opacity: 1;
-      }
-    }
-  }
 }

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -255,7 +255,7 @@ $max-width: 2560px;
 @mixin flex-column-16px-gap {
   display: flex;
   flex-direction: column;
-  gap: $gap-data-sets;
+  gap: $pad-medium;
 }
 
 @mixin vertical-form-layout {


### PR DESCRIPTION
## Issue
Closes #33629 

## Description
- Whoops, in fixing the keyboard accessibility for the dropdown, I accidentally removed row-hover to show the dropdown
- Both now fixed
- Also, updated a few nits that Jacob caught

## Screen recording

https://github.com/user-attachments/assets/bff06599-2289-42a0-be83-676c38485998


<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

- [x] QA'd all new/changed functionality manually
