### PR TITLE
Fleet UI: Animate arrows for host actions dd and reveal buttons

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -145,34 +145,29 @@ const ActionsDropdown = ({
     };
   }, [menuIsOpen]);
 
-  // Shows a brand "Action" button instead
-  const ButtonControl = (
-    props: DropdownIndicatorProps<IDropdownOption, false>
-  ) => {
-    const { selectProps } = props;
-    const handleButtonClick = () => {
-      if (selectProps.menuIsOpen) {
-        setMenuIsOpen(false);
-        if (selectProps.onMenuClose) selectProps.onMenuClose();
-      } else {
-        setMenuIsOpen(true);
-        if (selectProps.onMenuOpen) selectProps.onMenuOpen();
-      }
-    };
+  const isBrandButton = variant === "brand-button";
 
-    return (
-      <Button
-        type="button"
-        onClick={handleButtonClick}
-        className={`${baseClass}__button`}
-        disabled={selectProps.isDisabled}
-        aria-haspopup="listbox"
-        aria-expanded={selectProps.menuIsOpen}
-      >
-        Actions
-      </Button>
-    );
-  };
+  // CustomControl rerenders on state change, preventing arrow animation
+  // Render brand button outside of CustomControl instead
+  const renderBrandButton = () => (
+    <Button
+      type="button"
+      onClick={() => setMenuIsOpen((v) => !v)}
+      className={`${baseClass}__button`}
+      disabled={disabled}
+      aria-haspopup="listbox"
+      aria-expanded={menuIsOpen}
+    >
+      <span>Actions</span>
+      <Icon
+        name="chevron-down"
+        color="core-fleet-white"
+        className={`actions-dropdown__icon${
+          menuIsOpen ? " actions-dropdown__icon--open" : ""
+        }`}
+      />
+    </Button>
+  );
 
   const handleChange = (newValue: IDropdownOption | null) => {
     if (newValue) {
@@ -257,7 +252,7 @@ const ActionsDropdown = ({
       borderRadius: "4px",
       zIndex: 6,
       border: 0,
-      margin: 0,
+      marginTop: isBrandButton ? "20px" : "0",
       width: "auto",
       minWidth: "100%",
       position: "absolute",
@@ -300,10 +295,11 @@ const ActionsDropdown = ({
 
   return (
     <div className={`${baseClass}__wrapper`} ref={wrapperRef}>
+      {isBrandButton && renderBrandButton()}
       <Select<IDropdownOption, false>
         ref={selectRef}
         options={options}
-        placeholder={variant === "brand-button" ? "" : placeholder}
+        placeholder={isBrandButton ? "" : placeholder}
         onChange={handleChange}
         isDisabled={disabled}
         isSearchable={isSearchable}
@@ -317,7 +313,7 @@ const ActionsDropdown = ({
           Option: CustomOption,
           SingleValue: () => null, // Doesn't replace placeholder text with selected text
           // Note: react-select doesn't support skipping disabled options when keyboarding through
-          ...(variant === "brand-button" && { Control: ButtonControl }), // Needed for brand-action button
+          ...(isBrandButton && { Control: () => null }), // Remove Control entirely and renderBrandButton instead
         }}
         controlShouldRenderValue={false} // Doesn't change placeholder text to selected text
         isOptionSelected={() => false} // Hides any styling on selected option

--- a/frontend/components/ActionsDropdown/_styles.scss
+++ b/frontend/components/ActionsDropdown/_styles.scss
@@ -8,4 +8,25 @@
 .actions-dropdown__wrapper {
   display: flex;
   align-items: center;
+
+  button .children-wrapper {
+    gap: $pad-xsmall;
+
+    .actions-dropdown__icon svg {
+      transition: transform 0.25s ease;
+      transform: rotate(0deg);
+    }
+
+    .actions-dropdown__icon--open svg {
+      transform: rotate(180deg);
+    }
+  }
+}
+
+//  react-select does not actually move the browser’s focus
+// (which governs :focus-visible) between each option
+// Remove blue default outline that only attaches to first option
+// and rely on grey :focus for keyboard accessibility
+.actions-dropdown__option:focus-visible {
+  outline: none;
 }

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -54,7 +54,7 @@ $base-class: "button";
         width: 100%;
         height: 100%;
         position: absolute;
-        border: 1px solid $core-fleet-black;
+        border: 1px solid $core-focused-outline;
         border-radius: 6px;
       }
     }

--- a/frontend/components/buttons/RevealButton/RevealButton.tsx
+++ b/frontend/components/buttons/RevealButton/RevealButton.tsx
@@ -56,8 +56,11 @@ const RevealButton = ({
         {buttonText}
         {caretPosition === "after" && (
           <Icon
-            name={isShowing ? "chevron-up" : "chevron-down"}
+            name="chevron-down"
             color="ui-fleet-black-75"
+            className={`reveal-button__caret ${
+              isShowing ? "reveal-button__caret--open" : ""
+            }`}
           />
         )}
       </>

--- a/frontend/components/buttons/RevealButton/_styles.scss
+++ b/frontend/components/buttons/RevealButton/_styles.scss
@@ -4,6 +4,14 @@
   padding: $pad-small $pad-xxsmall; // larger clickable area
   min-width: max-content;
 
+  .reveal-button__caret svg {
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transform: rotate(0deg);
+  }
+  .reveal-button__caret--open svg {
+    transform: rotate(180deg);
+  }
+
   svg {
     path {
       fill: none; // Chevron icon uses stroke color


### PR DESCRIPTION
## Issue
Closes #33329 

## Description
- Add arrow to host actions dropdown including an animation
- Add animation to reveal buttons right-side arrow to match rest of UI arrow animations

## Screen recordings of fixes

Action dropdown on host page shown on Chrome, Safari, FF

https://github.com/user-attachments/assets/27507c1e-47c9-4448-a864-9a187b3f0bd6

Example of reveal button animation added

https://github.com/user-attachments/assets/338d7d6d-3263-482e-9e2e-e91bb9e89e4d


## Testing

- [x] QA'd all new/changed functionality manually
 