### PR TITLE
Add CVE scanning for fleetdm/wix and split out workflows

### DIFF
--- a/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
+  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
@@ -1,4 +1,4 @@
-name: Build fleetctl docker dependencies and check vulnerabilities
+name: Build fleetdm/bomutils and check vulnerabilities
 
 on:
   workflow_dispatch:
@@ -38,22 +38,16 @@ jobs:
         with:
           go-version-file: "go.mod"
 
-      - name: Build fleetdm/wix
-        run: make wix-docker
-
       - name: Build fleetdm/bomutils
         run: make bomutils-docker
-
-      - name: Build fleetdm/fleetctl
-        run: make fleetctl-docker
 
       - name: List VEX files
         id: generate_vex_files
         run: |
-          echo "VEX_FILES=$(ls -1 ./security/vex/fleetctl/ | while IFS= read -r line; do echo "./security/vex/fleetctl/$line"; done | tr '\n' ',' | sed 's/.$//')" >> $GITHUB_OUTPUT
+          echo "VEX_FILES=$(ls -1 ./security/vex/bomutils/ | while IFS= read -r line; do echo "./security/vex/bomutils/$line"; done | tr '\n' ',' | sed 's/.$//')" >> $GITHUB_OUTPUT
 
       # We use the trivy command and not the github action because it doesn't support loading VEX files yet.
-      - name: Run Trivy vulnerability scanner on fleetdm/fleetctl
+      - name: Run Trivy vulnerability scanner on fleetdm/bomutils
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
@@ -71,35 +65,9 @@ jobs:
             --pkg-types=os,library \
             --severity=HIGH,CRITICAL \
             --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
-            fleetdm/fleetctl
+            fleetdm/bomutils
 
-      - name: Run Trivy vulnerability scanner on fleetdm/wix
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-        with:
-          image-ref: "fleetdm/wix"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL"
-
-      - name: Run Trivy vulnerability scanner on fleetdm/bomutils
-        uses: aquasecurity/trivy-action@6c175e9c4083a92bbca2f9724c8a5e33bc2d97a5 # 0.30.0
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
-        with:
-          image-ref: "fleetdm/bomutils"
-          format: "table"
-          exit-code: "1"
-          ignore-unfixed: true
-          vuln-type: "os,library"
-          severity: "CRITICAL"
-
-      - name: Slack root notification
+      - name: Slack notification
         if: github.event.schedule == '0 6 * * *' && failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
@@ -111,7 +79,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "⚠️ Build fleetctl docker dependencies and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                    "text": "⚠️ Build fleetdm/bomutils and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
                   }
                 }
               ]

--- a/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
-  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
+  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -1,0 +1,89 @@
+name: Build fleetdm/fleetctl and check vulnerabilities
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-22.04
+    environment: Docker Hub
+    permissions:
+      id-token: write # for aws-actions/configure-aws-credentials
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build fleetdm/fleetctl
+        run: make fleetctl-docker
+
+      - name: List VEX files
+        id: generate_vex_files
+        run: |
+          echo "VEX_FILES=$(ls -1 ./security/vex/fleetctl/ | while IFS= read -r line; do echo "./security/vex/fleetctl/$line"; done | tr '\n' ',' | sed 's/.$//')" >> $GITHUB_OUTPUT
+
+      # We use the trivy command and not the github action because it doesn't support loading VEX files yet.
+      - name: Run Trivy vulnerability scanner on fleetdm/fleetctl
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+        run: |
+          mkdir trivy-download
+          cd trivy-download
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
+          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          mv trivy ..
+          cd ..
+          chmod +x ./trivy
+          ./trivy image \
+            --exit-code=1 \
+            --ignore-unfixed \
+            --pkg-types=os,library \
+            --severity=HIGH,CRITICAL \
+            --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
+            fleetdm/fleetctl
+
+      - name: Slack notification
+        if: github.event.schedule == '0 6 * * *' && failure()
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ Build fleetdm/fleetctl and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
-  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
@@ -4,6 +4,7 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
+  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
@@ -1,0 +1,89 @@
+name: Build fleetdm/wix and check vulnerabilities
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+# This allows a subsequently queued workflow run to interrupt previous runs
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id}}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    # fail-fast using bash -eo pipefail. See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-check:
+    runs-on: ubuntu-22.04
+    environment: Docker Hub
+    permissions:
+      id-token: write # for aws-actions/configure-aws-credentials
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Set up Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: "go.mod"
+
+      - name: Build fleetdm/wix
+        run: make wix-docker
+
+      - name: List VEX files
+        id: generate_vex_files
+        run: |
+          echo "VEX_FILES=$(ls -1 ./security/vex/wix/ | while IFS= read -r line; do echo "./security/vex/wix/$line"; done | tr '\n' ',' | sed 's/.$//')" >> $GITHUB_OUTPUT
+
+      # We use the trivy command and not the github action because it doesn't support loading VEX files yet.
+      - name: Run Trivy vulnerability scanner on fleetdm/wix
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
+        run: |
+          mkdir trivy-download
+          cd trivy-download
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
+          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          mv trivy ..
+          cd ..
+          chmod +x ./trivy
+          ./trivy image \
+            --exit-code=1 \
+            --ignore-unfixed \
+            --pkg-types=os,library \
+            --severity=HIGH,CRITICAL \
+            --vex="${{ steps.generate_vex_files.outputs.VEX_FILES }}" \
+            fleetdm/wix
+
+      - name: Slack notification
+        if: github.event.schedule == '0 6 * * *' && failure()
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
+        with:
+          payload: |
+            {
+              "text": "${{ job.status }}\n${{ github.event.pull_request.html_url || github.event.head.html_url }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "⚠️ Build fleetdm/wix and check vulnerabilities failed.\nhttps://github.com/fleetdm/fleet/actions/runs/${{  github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_G_HELP_ENGINEERING_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
@@ -4,7 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 6 * * *"
-  pull_request: # TODO(lucas): Remove before merge
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -838,6 +838,10 @@ vex-report:
 	sh -c 'go run ./tools/vex-parser ./security/vex/fleet >> security/status.md'
 	sh -c 'echo "## \`fleetdm/fleetctl\` docker image\n" >> security/status.md'
 	sh -c 'go run ./tools/vex-parser ./security/vex/fleetctl >> security/status.md'
+	sh -c 'echo "## \`fleetdm/wix\` docker image\n" >> security/status.md'
+	sh -c 'go run ./tools/vex-parser ./security/vex/wix >> security/status.md'
+	sh -c 'echo "## \`fleetdm/bomutils\` docker image\n" >> security/status.md'
+	sh -c 'go run ./tools/vex-parser ./security/vex/bomutils >> security/status.md'
 
 # make update-go version=1.24.4
 UPDATE_GO_DOCKERFILES := ./Dockerfile-desktop-linux ./infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile ./tools/mdm/migration/mdmproxy/Dockerfile

--- a/security/status.md
+++ b/security/status.md
@@ -213,3 +213,17 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2025-04-10 14:46:52
 
+## `fleetdm/wix` docker image
+
+### [CVE-2023-31484](https://nvd.nist.gov/vuln/detail/CVE-2023-31484)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The WiX toolset is unaffected by the perl vulnerability.
+- **Products:**: `wix`,`pkg:deb/debian/perl-base`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-10-01 08:36:42
+
+## `fleetdm/bomutils` docker image
+
+No vulnerabilities tracked at the moment.
+

--- a/security/vex/wix/CVE-2023-31484.vex.json
+++ b/security/vex/wix/CVE-2023-31484.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-dd2fd838ffd7cbb9c6a05ac58f6b060bdc817e27e26001811b8d8b2d7b82e565",
+  "author": "@lucasmrod",
+  "timestamp": "2025-10-01T08:36:42.291252065-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2023-31484"
+      },
+      "timestamp": "2025-10-01T08:36:42.291255121-03:00",
+      "products": [
+        {
+          "@id": "wix"
+        },
+        {
+          "@id": "pkg:deb/debian/perl-base"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The WiX toolset is unaffected by the perl vulnerability.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Attempting to fix https://github.com/fleetdm/fleet/actions/runs/18120473187/job/51564073671#step:11:38

Changes:
- The docker images are too big so they started to cause issues in Github runners. Thus I'm splitting the one workflow into three separate workflows, one for each image.
- While we are at it: start tracking vulnerabilities in fleetdm/wix and fleetdm/bomutils.

New runs:
- https://github.com/fleetdm/fleet/actions/runs/18161326970/job/51692559418
- https://github.com/fleetdm/fleet/actions/runs/18161326953/job/51692559257
- https://github.com/fleetdm/fleet/actions/runs/18161326952/job/51692559172