### PR TITLE
Fix docker publish failures

### DIFF
--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -16,8 +16,6 @@ on:
       - "website/**"
       - "mdm-profiles/**"
   workflow_dispatch: # Manual
-  schedule:
-    - cron: '0 4 * * *' # Every day at 4 AM
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
@@ -94,8 +92,8 @@ jobs:
 
       # We use the trivy command and not the github action because it doesn't support loading VEX files yet.
       - name: Check high/critical vulnerabilities before publishing (trivy)
-        # Only run this on the schedule run or when tagging RCs.
-        if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-') || github.event.schedule == '0 4 * * *'
+        # Only run this when tagging RCs.
+        if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-')
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
@@ -116,8 +114,8 @@ jobs:
             fleetdm/fleet:${{ steps.generate_tag.outputs.FLEET_IMAGE_TAG }}
 
       - name: Check high/critical vulnerabilities before publishing (docker scout)
-        # Only run this on the schedule run or when tagging RCs.
-        if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-') || github.event.schedule == '0 4 * * *'
+        # Only run this when tagging RCs.
+        if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-')
         uses: docker/scout-action@381b657c498a4d287752e7f2cfb2b41823f566d9 # v1.17.1
         with:
           command: cves
@@ -157,7 +155,7 @@ jobs:
           done
 
       - name: Slack notification
-        if: github.event.schedule == '0 4 * * *' && failure()
+        if: startsWith(github.ref, 'rc-minor-') || startsWith(github.ref, 'rc-patch-') && failure()
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         with:
           payload: |

--- a/security/status.md
+++ b/security/status.md
@@ -5,6 +5,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleet` docker image
 
+### [CVE-2025-9230](https://nvd.nist.gov/vuln/detail/CVE-2025-9230)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet uses Go cryptography packages.
+- **Products:**: `fleet`,`pkg:apk/alpine/openssl@3.3.3-r0?os_name=alpine&os_version=3.21`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2025-10-01 10:09:03
+
 ### [CVE-2025-46569](https://nvd.nist.gov/vuln/detail/CVE-2025-46569)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/fleet/CVE-2025-9230.vex.json
+++ b/security/vex/fleet/CVE-2025-9230.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-ed1618ee6fbec1892fa1a2e20fa5284dfb9cb90a6cb70b918938d20b6202a91f",
+  "author": "@lucasmrod",
+  "timestamp": "2025-10-01T10:09:03.862167-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2025-9230"
+      },
+      "timestamp": "2025-10-01T10:09:03.862168-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/openssl@3.3.3-r0?os_name=alpine&os_version=3.21"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet uses Go cryptography packages.",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixing https://github.com/fleetdm/fleet/actions/runs/18150944735.

- It seems that when not using the RC versions it cannot determine the version of the github.com/fleetdm/fleet/v4 package , so it assumes it's using `v4.0.0` thus causing alerts around our recent SAML vulnerability (already fixed). So I'm changing it to only run on RC cuts, not every day.
- Also adding a skip rule for a new CVE that we are not affected by.
