### PR TITLE
33494 optimize os versions response

### DIFF
--- a/changes/33494-os-version-response-time
+++ b/changes/33494-os-version-response-time
@@ -1,0 +1,1 @@
+- optimized os_versions API response time

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2131,7 +2131,15 @@ func osVersionsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 	}, nil
 }
 
-func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *string, name *string, version *string, opts fleet.ListOptions, includeCVSS bool) (*fleet.OSVersions, int, *fleet.PaginationMetadata, error) {
+func (svc *Service) OSVersions(
+	ctx context.Context,
+	teamID *uint,
+	platform *string,
+	name *string,
+	version *string,
+	opts fleet.ListOptions,
+	includeCVSS bool,
+) (*fleet.OSVersions, int, *fleet.PaginationMetadata, error) {
 	var count int
 	if err := svc.authz.Authorize(ctx, &fleet.Host{TeamID: teamID}, fleet.ActionList); err != nil {
 		return nil, count, nil, err
@@ -2154,7 +2162,6 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 		if err := svc.authz.Authorize(ctx, &fleet.AuthzSoftwareInventory{TeamID: teamID}, fleet.ActionRead); err != nil {
 			return nil, count, nil, err
 		}
-
 		if *teamID != 0 {
 			exists, err := svc.ds.TeamExists(ctx, *teamID)
 			if err != nil {
@@ -2170,6 +2177,8 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 	if !ok {
 		return nil, count, nil, fleet.ErrNoContext
 	}
+
+	// Load all OS versions (unpaged)
 	osVersions, err := svc.ds.OSVersions(
 		ctx, &fleet.TeamFilter{
 			User:            vc.User,
@@ -2178,47 +2187,12 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 		}, platform, name, version,
 	)
 	if err != nil && fleet.IsNotFound(err) {
-		// It is possible that os exists, but aggregation job has not run yet.
 		osVersions = &fleet.OSVersions{}
 	} else if err != nil {
 		return nil, count, nil, err
 	}
 
-	// Use batch query for better performance.
-	// Note: The OSVersions API endpoint does not include kernels (ds.ListKernelsByOS).
-	if len(osVersions.OSVersions) > 0 {
-		vulnsMap, err := svc.ds.ListVulnsByMultipleOSVersions(ctx, osVersions.OSVersions, includeCVSS, teamID)
-		if err != nil {
-			return nil, count, nil, ctxerr.Wrap(ctx, err, "list vulns by multiple os versions")
-		}
-
-		// Populate each OS version with its vulnerabilities
-		for i := range osVersions.OSVersions {
-			osV := &osVersions.OSVersions[i]
-			key := fmt.Sprintf("%s-%s", osV.NameOnly, osV.Version)
-
-			// Populate GeneratedCPEs for Darwin
-			if osV.Platform == "darwin" {
-				osV.GeneratedCPEs = []string{
-					fmt.Sprintf("cpe:2.3:o:apple:macos:%s:*:*:*:*:*:*:*", osV.Version),
-					fmt.Sprintf("cpe:2.3:o:apple:mac_os_x:%s:*:*:*:*:*:*:*", osV.Version),
-				}
-			}
-
-			// Populate Vulnerabilities from batch result
-			osV.Vulnerabilities = make(fleet.Vulnerabilities, 0) // avoid null in JSON
-			if vulns, ok := vulnsMap[key]; ok {
-				for _, vuln := range vulns {
-					vuln.DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", vuln.CVE)
-					osV.Vulnerabilities = append(osV.Vulnerabilities, vuln)
-				}
-			}
-
-			// Initialize Kernels array to avoid null in JSON
-			osV.Kernels = make([]*fleet.Kernel, 0)
-		}
-	}
-
+	// Sort by hosts_count (default: desc to match previous behavior)
 	if opts.OrderKey == "hosts_count" && opts.OrderDirection == fleet.OrderAscending {
 		sort.Slice(osVersions.OSVersions, func(i, j int) bool {
 			return osVersions.OSVersions[i].HostsCount < osVersions.OSVersions[j].HostsCount
@@ -2229,12 +2203,47 @@ func (svc *Service) OSVersions(ctx context.Context, teamID *uint, platform *stri
 		})
 	}
 
+	// Total count BEFORE pagination
 	count = len(osVersions.OSVersions)
 
-	var metaData *fleet.PaginationMetadata
-	osVersions.OSVersions, metaData = paginateOSVersions(osVersions.OSVersions, opts)
+	// Paginate first
+	var meta *fleet.PaginationMetadata
+	paged, meta := paginateOSVersions(osVersions.OSVersions, opts)
 
-	return osVersions, count, metaData, nil
+	// Pull vulnerabilities ONLY for the paginated slice, as the full list slows
+	// response times down significantly with many CVEs.
+	if len(paged) > 0 {
+		vulnsMap, err := svc.ds.ListVulnsByMultipleOSVersions(ctx, paged, includeCVSS, teamID)
+		if err != nil {
+			return nil, count, nil, ctxerr.Wrap(ctx, err, "list vulns by multiple os versions (paged)")
+		}
+
+		// Populate only the paginated entries
+		for i := range paged {
+			osV := &paged[i]
+
+			if osV.Platform == "darwin" {
+				osV.GeneratedCPEs = []string{
+					fmt.Sprintf("cpe:2.3:o:apple:macos:%s:*:*:*:*:*:*:*", osV.Version),
+					fmt.Sprintf("cpe:2.3:o:apple:mac_os_x:%s:*:*:*:*:*:*:*", osV.Version),
+				}
+			}
+
+			osV.Vulnerabilities = make(fleet.Vulnerabilities, 0) // avoid null
+			key := fmt.Sprintf("%s-%s", osV.NameOnly, osV.Version)
+			if vulns, ok := vulnsMap[key]; ok {
+				for _, v := range vulns {
+					v.DetailsLink = fmt.Sprintf("https://nvd.nist.gov/vuln/detail/%s", v.CVE)
+					osV.Vulnerabilities = append(osV.Vulnerabilities, v)
+				}
+			}
+
+			osV.Kernels = make([]*fleet.Kernel, 0) // avoid null
+		}
+	}
+
+	// Return only the page, but with total count
+	return &fleet.OSVersions{OSVersions: paged}, count, meta, nil
 }
 
 func paginateOSVersions(slice []fleet.OSVersion, opts fleet.ListOptions) ([]fleet.OSVersion, *fleet.PaginationMetadata) {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1299,7 +1299,8 @@ func TestEmptyTeamOSVersions(t *testing.T) {
 	}
 
 	ds.ListVulnsByMultipleOSVersionsFunc = func(ctx context.Context, osVersions []fleet.OSVersion, includeCVSS bool,
-		teamID *uint) (map[string]fleet.Vulnerabilities, error) {
+		teamID *uint,
+	) (map[string]fleet.Vulnerabilities, error) {
 		return nil, nil
 	}
 
@@ -1337,14 +1338,17 @@ func TestOSVersionsListOptions(t *testing.T) {
 		{HostsCount: 6, NameOnly: "Ubuntu 21.04", Platform: "ubuntu"},
 	}
 
+	now := time.Now()
+
 	ds.OSVersionsFunc = func(
 		ctx context.Context, teamFilter *fleet.TeamFilter, platform *string, name *string, version *string,
 	) (*fleet.OSVersions, error) {
-		return &fleet.OSVersions{CountsUpdatedAt: time.Now(), OSVersions: testVersions}, nil
+		return &fleet.OSVersions{CountsUpdatedAt: now, OSVersions: testVersions}, nil
 	}
 
 	ds.ListVulnsByMultipleOSVersionsFunc = func(ctx context.Context, osVersions []fleet.OSVersion, includeCVSS bool,
-		teamID *uint) (map[string]fleet.Vulnerabilities, error) {
+		teamID *uint,
+	) (map[string]fleet.Vulnerabilities, error) {
 		return nil, nil
 	}
 
@@ -1359,6 +1363,7 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Equal(t, "Windows 11 Pro 21H2", vers.OSVersions[3].NameOnly)
 	assert.Equal(t, "macOS 12.2", vers.OSVersions[4].NameOnly)
 	assert.Equal(t, "macOS 12.1", vers.OSVersions[5].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	// test ascending count sort
 	opts = fleet.ListOptions{OrderKey: "hosts_count", OrderDirection: fleet.OrderAscending}
@@ -1371,6 +1376,7 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Equal(t, "Windows 11 Pro 22H2", vers.OSVersions[3].NameOnly)
 	assert.Equal(t, "Ubuntu 20.04", vers.OSVersions[4].NameOnly)
 	assert.Equal(t, "Ubuntu 21.04", vers.OSVersions[5].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	// pagination
 	opts = fleet.ListOptions{Page: 0, PerPage: 2}
@@ -1379,6 +1385,7 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Len(t, vers.OSVersions, 2)
 	assert.Equal(t, "Ubuntu 21.04", vers.OSVersions[0].NameOnly)
 	assert.Equal(t, "Ubuntu 20.04", vers.OSVersions[1].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	opts = fleet.ListOptions{Page: 1, PerPage: 2}
 	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, nil, nil, nil, opts, false)
@@ -1386,6 +1393,7 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Len(t, vers.OSVersions, 2)
 	assert.Equal(t, "Windows 11 Pro 22H2", vers.OSVersions[0].NameOnly)
 	assert.Equal(t, "Windows 11 Pro 21H2", vers.OSVersions[1].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	// pagination + ascending hosts_count sort
 	opts = fleet.ListOptions{Page: 0, PerPage: 2, OrderKey: "hosts_count", OrderDirection: fleet.OrderAscending}
@@ -1394,18 +1402,21 @@ func TestOSVersionsListOptions(t *testing.T) {
 	assert.Len(t, vers.OSVersions, 2)
 	assert.Equal(t, "macOS 12.1", vers.OSVersions[0].NameOnly)
 	assert.Equal(t, "macOS 12.2", vers.OSVersions[1].NameOnly)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	// per page too high
 	opts = fleet.ListOptions{Page: 0, PerPage: 1000}
 	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, nil, nil, nil, opts, false)
 	require.NoError(t, err)
 	assert.Len(t, vers.OSVersions, 6)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 
 	// Page number too high
 	opts = fleet.ListOptions{Page: 1000, PerPage: 2}
 	vers, _, _, err = svc.OSVersions(test.UserContext(ctx, test.UserAdmin), nil, nil, nil, nil, opts, false)
 	require.NoError(t, err)
 	assert.Len(t, vers.OSVersions, 0)
+	assert.Equal(t, now, vers.CountsUpdatedAt)
 }
 
 func TestHostEncryptionKey(t *testing.T) {

--- a/tools/software/vulnerabilities/README.md
+++ b/tools/software/vulnerabilities/README.md
@@ -5,7 +5,7 @@ into your local development Fleet server without needing a real host or osquery-
 
 ## Usage
 
-1. Ensure your local development enviornment is running using `docker-compose up` and `fleet serve`
+1. Ensure your local development environment is running using `docker-compose up` and `fleet serve`
 
 2. Optional: Review and modify the software titles in the following files in this folder:
 
@@ -18,7 +18,7 @@ into your local development Fleet server without needing a real host or osquery-
 3. Run the data seeder
 
 ```bash
-go run ./tools/seed_data/seed_vuln_data.go --ubuntu 1 --macos 1 --windows 1 --linux-kernels 1
+go run ./tools/software/vulnerabilities/seed_data/seed_vuln_data.go --ubuntu 1 --macos 1 --windows 1 --linux-kernels 1
 ```
 
 You should now see new hosts with the configured software attached in the UI and database.  This

--- a/tools/software/vulnerabilities/README.md
+++ b/tools/software/vulnerabilities/README.md
@@ -1,13 +1,13 @@
 # Vulnerability Data Seeder
 
-The purpose of `seed_vuln_data.go` is to provide developers an easy way to insert software titles
-into your local development Fleet server in order to troubleshoot false positive|negative vulnerabilities.
+The purpose of `seed_vuln_data.go` is to provide developers an easy way to insert hosts and software
+into your local development Fleet server without needing a real host or osquery-perf
 
 ## Usage
 
 1. Ensure your local development enviornment is running using `docker-compose up` and `fleet serve`
 
-2. Review and modify the software titles in the following files in this folder:
+2. Optional: Review and modify the software titles in the following files in this folder:
 
     - software_macos.csv
     - software_ubuntu.csv
@@ -18,7 +18,7 @@ into your local development Fleet server in order to troubleshoot false positive
 3. Run the data seeder
 
 ```bash
-go run ./tools/seed_data/seed_vuln_data.go
+go run ./tools/seed_data/seed_vuln_data.go --ubuntu 1 --macos 1 --windows 1 --linux-kernels 1
 ```
 
 You should now see new hosts with the configured software attached in the UI and database.  This

--- a/tools/software/vulnerabilities/seed_vuln_data.go
+++ b/tools/software/vulnerabilities/seed_vuln_data.go
@@ -26,8 +26,9 @@ var (
 	mysqlDB   = "fleet"
 
 	// CSV paths
-	macCSVPath = "./tools/software/vulnerabilities/software-macos.csv"
-	winCSVPath = "./tools/software/vulnerabilities/software-win.csv"
+	macCSVPath    = "./tools/software/vulnerabilities/software-macos.csv"
+	winCSVPath    = "./tools/software/vulnerabilities/software-win.csv"
+	ubuntuCSVPath = "./tools/software/vulnerabilities/software-ubuntu.csv"
 )
 
 func readCSVFile(filePath string) ([]fleet.Software, error) {
@@ -209,6 +210,20 @@ func main() {
 			for _, h := range winHosts {
 				if _, err := ds.UpdateHostSoftware(ctx, h.ID, winSoftware); err != nil {
 					fmt.Printf("update Windows host software failed (%s): %v\n", h.Hostname, err)
+				}
+			}
+		}
+	}
+
+	// Ubuntu software
+	if len(ubuntuIDs) > 0 {
+		ubuntuSoftware, err := readCSVFile(ubuntuCSVPath)
+		if err != nil {
+			fmt.Printf("read Ubuntu software csv failed: %v\n", err)
+		} else {
+			for _, ubuntuID := range ubuntuIDs {
+				if _, err := ds.UpdateHostSoftware(ctx, ubuntuID, ubuntuSoftware); err != nil {
+					fmt.Printf("update Ubuntu host software failed (%d): %v\n", ubuntuID, err)
 				}
 			}
 		}

--- a/tools/software/vulnerabilities/seed_vuln_data.go
+++ b/tools/software/vulnerabilities/seed_vuln_data.go
@@ -1,76 +1,25 @@
 package main
 
 import (
-	"database/sql"
+	"context"
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
+	"github.com/WatchBeam/clock"
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/jmoiron/sqlx"
+
+	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
-type Host struct {
-	ID               int        `db:"id"`
-	OsqueryHostID    string     `db:"osquery_host_id"`
-	CreatedAt        time.Time  `db:"created_at"`
-	UpdatedAt        *time.Time `db:"updated_at"`
-	DetailUpdatedAt  time.Time  `db:"detail_updated_at"`
-	NodeKey          string     `db:"node_key"`
-	Hostname         string     `db:"hostname"`
-	Uuid             string     `db:"uuid"`
-	Platform         string     `db:"platform"`
-	OsqueryVersion   string     `db:"osquery_version"`
-	OsVersion        string     `db:"os_version"`
-	Build            string     `db:"build"`
-	PlatformLike     string     `db:"platform_like"`
-	CodeName         string     `db:"code_name"`
-	Uptime           int64      `db:"uptime"`
-	Memory           int64      `db:"memory"`
-	CpuType          string     `db:"cpu_type"`
-	CpuSubtype       string     `db:"cpu_subtype"`
-	CpuBrand         string     `db:"cpu_brand"`
-	CpuPhysicalCores int        `db:"cpu_physical_cores"`
-	CpuLogicalCores  int        `db:"cpu_logical_cores"`
-	HardwareVendor   string     `db:"hardware_vendor"`
-	HardwareModel    string     `db:"hardware_model"`
-	HardwareVersion  string     `db:"hardware_version"`
-	HardwareSerial   string     `db:"hardware_serial"`
-	ComputerName     string     `db:"computer_name"`
-	PrimaryIP        string     `db:"primary_ip"`
-	PrimaryMac       string     `db:"primary_mac"`
-	LabelUpdatedAt   time.Time  `db:"label_updated_at"`
-	LastEnrolledAt   time.Time  `db:"last_enrolled_at"`
-	RefetchRequested int        `db:"refetch_requested"`
-	PublicIP         string     `db:"public_ip"`
-}
+const linuxHosts = 800
 
-type HostDisplayName struct {
-	HostID int64  `db:"host_id"`
-	Name   string `db:"display_name"`
-}
-
-type Software struct {
-	ID               int64  `db:"id"`
-	Name             string `db:"name"`
-	Version          string `db:"version"`
-	Source           string `db:"source"`
-	BundleIdentifier string `db:"bundle_identifier"`
-	Release          string `db:"release"`
-	VendorOld        string `db:"vendor_old"`
-	Arch             string `db:"arch"`
-	Vendor           string `db:"vendor"`
-}
-
-type HostSoftware struct {
-	HostID     int64 `db:"host_id"`
-	SoftwareID int64 `db:"software_id"`
-}
-
-func readCSVFile(filePath string) ([]Software, error) {
+func readCSVFile(filePath string) ([]fleet.Software, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
 		return nil, err
@@ -83,9 +32,9 @@ func readCSVFile(filePath string) ([]Software, error) {
 		return nil, err
 	}
 
-	var software []Software
+	var software []fleet.Software
 	for _, line := range lines[1:] { // Skip header line
-		software = append(software, Software{
+		software = append(software, fleet.Software{
 			Name:             line[0],
 			Version:          line[1],
 			Source:           line[2],
@@ -99,253 +48,151 @@ func readCSVFile(filePath string) ([]Software, error) {
 	return software, nil
 }
 
-func insertOrUpdateSoftware(db *sqlx.DB, hostID int, software Software) error {
-	// Check if the software already exists
-	var existingID int64
-	query := `SELECT id FROM software WHERE name = ? AND version = ? AND source = ?`
-	err := db.Get(&existingID, query, software.Name, software.Version, software.Source)
-	if err != nil && errors.Is(err, sql.ErrNoRows) {
-		return fmt.Errorf("select software: %w", err)
-	}
-	software.ID = existingID
-
-	if existingID > 0 {
-		// Update existing record, set ID for the update
-		software.ID = existingID
-		updateQuery := `UPDATE software SET bundle_identifier = :bundle_identifier, ` + "`release` = :release, vendor_old = :vendor_old, arch = :arch, vendor = :vendor WHERE id = :id"
-		_, err := db.NamedExec(updateQuery, software)
-		if err != nil {
-			return fmt.Errorf("update software: %w", err)
-		}
-	} else {
-		// Insert new record
-		insertQuery := `INSERT INTO software (name, version, source, bundle_identifier, ` + "`release`," + ` vendor_old, arch, vendor) VALUES (:name, :version, :source, :bundle_identifier, :release, :vendor_old, :arch, :vendor)`
-		res, err := db.NamedExec(insertQuery, software)
-		if err != nil {
-			return fmt.Errorf("insert software: %w", err)
-		}
-		software.ID, err = res.LastInsertId()
-		if err != nil {
-			return fmt.Errorf("get last insert id: %w", err)
-		}
-	}
-
-	err = insertOrUpdateHostSoftware(db, HostSoftware{
-		HostID:     int64(hostID),
-		SoftwareID: software.ID,
-	})
-	if err != nil {
-		return fmt.Errorf("insert host software: %w", err)
-	}
-
-	return nil
-}
-
-func insertOrUpdateHost(db *sqlx.DB, host Host) (int, error) {
-	// Check if the host already exists
-	var existingID int
-	query := `SELECT id FROM hosts WHERE osquery_host_id = ?`
-	err := db.Get(&existingID, query, host.OsqueryHostID)
-	if err != nil && err != sql.ErrNoRows {
-		return existingID, fmt.Errorf("select host: %w", err)
-	}
-
-	if existingID > 0 {
-		// Update existing record
-		updateQuery := `UPDATE hosts SET updated_at = :updated_at, detail_updated_at = :detail_updated_at, node_key = :node_key, hostname = :hostname, uuid = :uuid, platform = :platform, osquery_version = :osquery_version, os_version = :os_version, build = :build, platform_like = :platform_like, code_name = :code_name, uptime = :uptime, memory = :memory, cpu_type = :cpu_type, cpu_subtype = :cpu_subtype, cpu_brand = :cpu_brand, cpu_physical_cores = :cpu_physical_cores, cpu_logical_cores = :cpu_logical_cores, hardware_vendor = :hardware_vendor, hardware_model = :hardware_model, hardware_version = :hardware_version, hardware_serial = :hardware_serial, computer_name = :computer_name, primary_ip = :primary_ip, primary_mac = :primary_mac, label_updated_at = :label_updated_at, last_enrolled_at = :last_enrolled_at, refetch_requested = :refetch_requested, public_ip = :public_ip WHERE id = :id`
-		_, err := db.NamedExec(updateQuery, host)
-		if err != nil {
-			return 0, fmt.Errorf("update host: %w", err)
-		}
-		err = insertOrUpdateHostDisplayName(db, HostDisplayName{
-			HostID: int64(existingID),
-			Name:   host.Hostname,
-		})
-		if err != nil {
-			return 0, fmt.Errorf("insert host display name: %w", err)
-		}
-		return existingID, nil
-
-	}
-
-	// Insert new record
-	insertQuery := `INSERT INTO hosts (osquery_host_id, created_at, detail_updated_at, node_key, hostname, uuid, platform, osquery_version, os_version, build, platform_like, code_name, uptime, memory, cpu_type, cpu_subtype, cpu_brand, cpu_physical_cores, cpu_logical_cores, hardware_vendor, hardware_model, hardware_version, hardware_serial, computer_name, primary_ip, primary_mac, label_updated_at, last_enrolled_at, refetch_requested, public_ip) VALUES (:osquery_host_id, :created_at, :detail_updated_at, :node_key, :hostname, :uuid, :platform, :osquery_version, :os_version, :build, :platform_like, :code_name, :uptime, :memory, :cpu_type, :cpu_subtype, :cpu_brand, :cpu_physical_cores, :cpu_logical_cores, :hardware_vendor, :hardware_model, :hardware_version, :hardware_serial, :computer_name, :primary_ip, :primary_mac, :label_updated_at, :last_enrolled_at, :refetch_requested, :public_ip)`
-	res, err := db.NamedExec(insertQuery, host)
-	if err != nil {
-		return 0, fmt.Errorf("insert host: %w", err)
-	}
-	id, err := res.LastInsertId()
-	if err != nil {
-		return 0, fmt.Errorf("get last insert id: %w", err)
-	}
-
-	err = insertOrUpdateHostDisplayName(db, HostDisplayName{
-		HostID: id,
-		Name:   host.Hostname,
-	})
-	if err != nil {
-		return 0, fmt.Errorf("insert host display name: %w", err)
-	}
-
-	return int(id), nil
-}
-
-func insertOrUpdateHostDisplayName(db *sqlx.DB, hdn HostDisplayName) error {
-	// Check if the host already exists
-	var foundDN HostDisplayName
-	query := `SELECT host_id, display_name FROM host_display_names WHERE host_id = ?`
-	err := db.Get(&foundDN, query, hdn.HostID)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("select host display name: %w", err)
-	}
-
-	if err == sql.ErrNoRows {
-		// Insert new record
-		insertQuery := `INSERT INTO host_display_names (host_id, display_name) VALUES (:host_id, :display_name)`
-		_, err := db.NamedExec(insertQuery, hdn)
-		if err != nil {
-			return fmt.Errorf("insert host display name: %w", err)
-		}
-	}
-
-	return nil
-}
-
-func insertOrUpdateHostSoftware(db *sqlx.DB, hs HostSoftware) error {
-	// Check if the host already exists
-	var foundhs HostSoftware
-	query := `SELECT host_id, software_id FROM host_software WHERE host_id = ? AND software_id = ?`
-	err := db.Get(&foundhs, query, hs.HostID, hs.SoftwareID)
-	if err != nil && err != sql.ErrNoRows {
-		return fmt.Errorf("select host software: %w", err)
-	}
-
-	if err == sql.ErrNoRows {
-		// Insert new record
-		insertQuery := `INSERT INTO host_software (host_id, software_id) VALUES (:host_id, :software_id)`
-		_, err := db.NamedExec(insertQuery, hs)
-		if err != nil {
-			return fmt.Errorf("insert host software: %w", err)
-		}
-	}
-
-	return nil
-}
-
 func main() {
-	// Database connection string
-	dsn := "fleet:insecure@tcp(localhost:3306)/fleet"
-
-	// Connect to database
-	db, err := sqlx.Connect("mysql", dsn)
+	ds, err := mysql.New(config.MysqlConfig{
+		Protocol: "tcp",
+		Address:  "localhost:3306",
+		Username: "fleet",
+		Password: "insecure",
+		Database: "fleet",
+	}, clock.C)
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer db.Close()
-
-	// Host data to insert
-	host := Host{
-		OsqueryHostID:    "sample_host_id",
-		CreatedAt:        time.Now(),
-		DetailUpdatedAt:  time.Now(),
-		NodeKey:          "sample_node_key",
-		Hostname:         "sample_hostname",
-		Uuid:             "sample_uuid",
-		Platform:         "sample_platform",
-		OsqueryVersion:   "sample_version",
-		OsVersion:        "sample_os_version",
-		Build:            "sample_build",
-		PlatformLike:     "sample_platform_like",
-		CodeName:         "sample_code_name",
-		Uptime:           1000,
-		Memory:           8000,
-		CpuType:          "sample_cpu_type",
-		CpuSubtype:       "sample_cpu_subtype",
-		CpuBrand:         "sample_cpu_brand",
-		CpuPhysicalCores: 4,
-		CpuLogicalCores:  8,
-		HardwareVendor:   "sample_vendor",
-		HardwareModel:    "sample_model",
-		HardwareVersion:  "sample_hardware_version",
-		HardwareSerial:   "sample_serial",
-		ComputerName:     "sample_computer_name",
-		PrimaryIP:        "192.168.1.1",
-		PrimaryMac:       "00:11:22:33:44:55",
-		LabelUpdatedAt:   time.Now(),
-		LastEnrolledAt:   time.Now(),
-		RefetchRequested: 0,
-		PublicIP:         "203.0.113.1",
-	}
+	defer ds.Close()
 
 	// macos Host
-	host.Platform = "darwin"
-	host.OsVersion = "Mac OS X 10.14.6"
-	host.Hostname = "macos-seed-host"
-	host.ComputerName = "macos-seed-host"
-	host.OsqueryHostID = "macos-seed-host"
-	host.NodeKey = "macos-seed-host"
-	macosID, err := insertOrUpdateHost(db, host)
+	fmt.Print("Creating macOS host...\n")
+	var macosHost *fleet.Host
+	// get host if it already exists
+	macosHost, err = ds.HostByIdentifier(context.Background(), "macos-seed-host")
 	if err != nil {
-		log.Fatal(err) //nolint:gocritic // ignore exitAfterDefer
+		fmt.Printf("get macos host failed: %v\n", err)
+
+		macosHost, err = ds.NewHost(context.Background(), &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         ptr.String("macos-seed-host"),
+			UUID:            "macos-seed-host",
+			Hostname:        "macos-seed-host",
+			PrimaryIP:       "192.168.1.100",
+			PrimaryMac:      "00:11:22:33:44:55",
+			Platform:        "darwin",
+			OSVersion:       "Mac OS X 10.14.6",
+		})
+		if err != nil {
+			fmt.Printf("create macos host failed: %v\n", err)
+		}
 	}
 
 	// windows Host
-	host.Platform = "windows"
-	host.OsVersion = "Windows 11 Enterprise"
-	host.ComputerName = "windows-seed-host"
-	host.Hostname = "windows-seed-host"
-	host.OsqueryHostID = "windows-seed-host"
-	host.NodeKey = "windows-seed-host"
-	winID, err := insertOrUpdateHost(db, host)
+	fmt.Print("Creating Windows host...\n")
+
+	// get host if it already exists
+	var winHost *fleet.Host
+	winHost, err = ds.HostByIdentifier(context.Background(), "windows-seed-host")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Printf("get windows host failed: %v\n", err)
+
+		winHost, err = ds.NewHost(context.Background(), &fleet.Host{
+			DetailUpdatedAt: time.Now(),
+			LabelUpdatedAt:  time.Now(),
+			PolicyUpdatedAt: time.Now(),
+			SeenTime:        time.Now(),
+			NodeKey:         ptr.String("windows-seed-host"),
+			UUID:            "windows-seed-host",
+			Hostname:        "windows-seed-host",
+			PrimaryIP:       "192.168.1.101",
+			PrimaryMac:      "00:11:22:33:44:56",
+			Platform:        "windows",
+			OSVersion:       "Windows 11 Enterprise",
+		})
+		if err != nil {
+			fmt.Printf("create windows host failed: %v\n", err)
+		}
 	}
 
-	// ubuntu Host
-	host.Platform = "debian"
-	host.OsVersion = "Ubuntu 22.04.1 LTS"
-	host.Hostname = "ubuntu-seed-host"
-	host.ComputerName = "ubuntu-seed-host"
-	host.OsqueryHostID = "ubuntu-seed-host"
-	host.NodeKey = "ubuntu-seed-host"
-	ubuntuID, err := insertOrUpdateHost(db, host)
-	if err != nil {
-		log.Fatal(err)
+	fmt.Print("Creating Ubuntu hosts...\n")
+	var ubuntuIDs []uint
+	// ubuntu Hosts
+	for i := 0; i < linuxHosts; i++ {
+		var host *fleet.Host
+		host, err = ds.HostByIdentifier(context.Background(), fmt.Sprintf("ubuntu-seed-host-%d", len(ubuntuIDs)+1))
+		if err != nil {
+			host, err = ds.NewHost(context.Background(), &fleet.Host{
+				DetailUpdatedAt: time.Now(),
+				LabelUpdatedAt:  time.Now(),
+				PolicyUpdatedAt: time.Now(),
+				SeenTime:        time.Now(),
+				NodeKey:         ptr.String(fmt.Sprintf("ubuntu-seed-host-%d", len(ubuntuIDs)+1)),
+				UUID:            fmt.Sprintf("ubuntu-seed-host-%d", len(ubuntuIDs)+1),
+				Hostname:        fmt.Sprintf("ubuntu-seed-host-%d", len(ubuntuIDs)+1),
+				PrimaryIP:       fmt.Sprintf("192.168.1.%d", len(ubuntuIDs)+2),
+				PrimaryMac:      fmt.Sprintf("00:11:22:33:44:%02d", len(ubuntuIDs)+2),
+				Platform:        "ubuntu",
+				OSVersion:       "Ubuntu 20.04.6 LTS",
+			})
+			if err != nil {
+				fmt.Printf("create ubuntu host failed: %v\n", err)
+				continue
+			}
+		}
+
+		err = ds.UpdateHostOperatingSystem(context.Background(), host.ID, fleet.OperatingSystem{
+			Name:           "Ubuntu",
+			Version:        fmt.Sprintf("20.04.%d", i),
+			Platform:       "ubuntu",
+			Arch:           "x86_64",
+			KernelVersion:  "5.4.0-148-generic",
+			DisplayVersion: "20.04",
+		})
+		if err != nil {
+			fmt.Printf("update ubuntu host OS failed: %v\n", err)
+			continue
+		}
+
+		ubuntuIDs = append(ubuntuIDs, host.ID)
 	}
 
 	// Insert macOS software
-	macSoftware, err := readCSVFile("./tools/seed_data/software-macos.csv")
+	macSoftware, err := readCSVFile("./tools/software/vulnerabilities/software-macos.csv")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Printf("read macos software csv file failed: %v\n", err)
+		return
 	}
-	for _, s := range macSoftware {
-		err := insertOrUpdateSoftware(db, macosID, s)
-		if err != nil {
-			log.Fatal(err)
-		}
+
+	fmt.Printf("%v\n", macSoftware)
+	_, err = ds.UpdateHostSoftware(context.Background(), macosHost.ID, macSoftware)
+	if err != nil {
+		fmt.Printf("update macos host software failed: %v\n", err)
+		return
 	}
 
 	// Insert win software
-	winSoftware, err := readCSVFile("./tools/seed_data/software-win.csv")
+	winSoftware, err := readCSVFile("./tools/software/vulnerabilities/software-win.csv")
 	if err != nil {
-		log.Fatal(err)
+		fmt.Printf("read windows software csv file failed: %v\n", err)
+		return
 	}
-	for _, s := range winSoftware {
-		err := insertOrUpdateSoftware(db, winID, s)
-		if err != nil {
-			log.Fatal(err)
-		}
+	_, err = ds.UpdateHostSoftware(context.Background(), winHost.ID, winSoftware)
+	if err != nil {
+		fmt.Printf("update windows host software failed: %v\n", err)
+		return
 	}
 
-	// Insert ubuntu software
-	ubuntuSoftware, err := readCSVFile("./tools/seed_data/software-ubuntu.csv")
-	if err != nil {
-		log.Fatal(err)
-	}
-	for _, s := range ubuntuSoftware {
-		err := insertOrUpdateSoftware(db, ubuntuID, s)
+	for i, ubuntuID := range ubuntuIDs {
+		_, err := ds.UpdateHostSoftware(context.Background(), ubuntuID, []fleet.Software{
+			{
+				Name:     fmt.Sprintf("linux-image-6.8.0-%d-generic", i+1),
+				Version:  fmt.Sprintf("6.8.0-%d", i+1),
+				Source:   "Package (deb)",
+				IsKernel: true,
+			},
+		})
 		if err != nil {
-			log.Fatal(err)
+			fmt.Printf("insert software for Ubuntu host failed: %v\n", err)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33494

- Pulling in vulnerability data for only the paginated os versions returned.  Tested with 800 linux Operating systems (1 kernel each).  Response time in localdev went from 52s -> 3s.
- Updated seed tool to help with this

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [ ] Added/updated automated tests (note: skipped benchmark testing here, no functional changes)


- [X] QA'd all new/changed functionality manually




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - OS versions view now supports pagination, returns total count/metadata, and lets you sort by host count.

- Performance
  - Faster OS versions API responses by limiting processing to the current page.

- Documentation
  - Updated vulnerability seeding guide: clearer steps, optional title review, platform-specific CSVs, added idempotency note.

- Tools
  - Revamped vulnerability seeder: datastore-driven host/software creation, supports macOS, Windows, Ubuntu cohorts, and optional Linux kernel packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->