### PR TITLE
FE: Buggy test fix

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
@@ -19,6 +19,14 @@ const WINDOWS_SCRIPT: IScript = {
   updated_at: "2021-01-01",
 };
 
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2025-05-02T00:00:00Z")); // "over 4 years ago" after created_at
+});
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 describe("ScriptListItem", () => {
   const onDelete = jest.fn();
   const onClickScript = jest.fn();


### PR DESCRIPTION
## Description
- Time ago hardcoded as over 4 years ago, now rendering as almost 5 years ago
- https://github.com/fleetdm/fleet/pull/25995/files#r2394654399
<img width="709" height="389" alt="Screenshot 2025-10-01 at 9 34 59 AM" src="https://github.com/user-attachments/assets/ed01dbbf-1ab4-44ce-aabf-8dfb7d88ffec" />

Fixed to always render "over 4 years ago" after created_at date


## Testing

- [x] Added/updated automated tests