### PR TITLE
API reference: OTA profiles don't work if end user auth is enabled

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -5916,7 +5916,9 @@ Deletes the custom MDM setup enrollment profile assigned to a team or no team.
 
 The returned value is a signed `.mobileconfig` OTA enrollment profile (see [Apple enrollment profile docs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/OTASecurity/OTASecurity.html)). Install this profile on macOS, iOS, or iPadOS hosts to enroll them to a specific team in Fleet and turn on MDM features.
 
-To enroll macOS hosts, turn on MDM features, and add [human-device mapping](#get-human-device-mapping), install the [manual enrollment profile](#get-manual-enrollment-profile) instead.
+If the team in Fleet has [end user authentication](https://fleetdm.com/guides/macos-setup-experience#end-user-authentication) enabled, the OTA enrollment profile won't work. Use the [manual enrollment profile](#get-manual-enrollment-profile) instead.
+
+To enroll macOS hosts, turn on MDM features, and add [human-device mapping](#get-human-device-mapping), use the [manual enrollment profile](#get-manual-enrollment-profile) instead.
 
 #### Parameters
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -978,6 +978,7 @@ module.exports.routes = {
   'GET /learn-more-about/install-google-play-apps': 'https://github.com/fleetdm/fleet/issues/25595',
   'GET /learn-more-about/arch-linux-rolling-release': 'https://wiki.archlinux.org/title/Arch_Linux',
   'GET /learn-more-about/google-play-store': 'https://play.google.com/store/apps',
+  'GET /learn-more-about/manual-enrollment-profile': '/docs/rest-api/rest-api#get-manual-enrollment-profile',
 
   // Sitemap
   // =============================================================================================================


### PR DESCRIPTION
- @noahtalerman: We shipped a breaking change in Fleet 4.73 that resulted in this bug: https://github.com/fleetdm/fleet/issues/33447
 - To fix this bug we decided to...
   - Accept this breaking change, document it (this PR), and add an improved error message. See [bug](https://github.com/fleetdm/fleet/issues/33447).
   - Improve the manual enrollment flow for macOS hosts. User story is [here](https://github.com/fleetdm/fleet/issues/33640).
   - Both changes are targeted for 4.77
