### PR TITLE
YAML reference: Only one package, App Store app, or Fleet-maintained app per software

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -450,7 +450,7 @@ The `software` section allows you to configure packages, Apple App Store apps, a
 
 Currently, you can specify `install_software` in the [`policies` YAML](#policies) to automatically install a custom package or App Store app when a host fails a policy. [Automatic install support for Fleet-maintained apps](https://github.com/fleetdm/fleet/issues/29584) is coming soon.
 
-Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS in `packages` and `fleet_maintained_apps`, only one of them will be added to Fleet.
+Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS twice in `packages` or once in `packages` and once in `fleet_maintained_apps`, only one of them will be added to Fleet.
 
 #### Example
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -450,6 +450,8 @@ The `software` section allows you to configure packages, Apple App Store apps, a
 
 Currently, you can specify `install_software` in the [`policies` YAML](#policies) to automatically install a custom package or App Store app when a host fails a policy. [Automatic install support for Fleet-maintained apps](https://github.com/fleetdm/fleet/issues/29584) is coming soon.
 
+Currently, Fleet only allows one package, Apple App Store app, or Fleet-maintained app for a specific software. This means, if you specify a Google Chrome for macOS in `packages` and `fleet_maintained_apps`, only one of them will be added to Fleet.
+
 #### Example
 
 `teams/team-name.yml`, or `teams/no-team.yml`


### PR DESCRIPTION
Docs to address the following bug:
- #32607
