### PR TITLE
Use more flexible pattern match instead of fake timers

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
@@ -78,7 +78,7 @@ describe("ScriptListItem", () => {
       />
     );
 
-    fireEvent.click(screen.getByText("over 4 years ago"));
+    fireEvent.click(screen.getByText(/years ago/));
     expect(onClickScript).toHaveBeenCalledWith(MAC_SCRIPT);
     expect(onEdit).not.toHaveBeenCalled();
     expect(onDelete).not.toHaveBeenCalled();

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListItem/ScriptListItem.tests.tsx
@@ -19,14 +19,6 @@ const WINDOWS_SCRIPT: IScript = {
   updated_at: "2021-01-01",
 };
 
-beforeAll(() => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date("2025-05-02T00:00:00Z")); // "over 4 years ago" after created_at
-});
-afterAll(() => {
-  jest.useRealTimers();
-});
-
 describe("ScriptListItem", () => {
   const onDelete = jest.fn();
   const onClickScript = jest.fn();


### PR DESCRIPTION
- Revert commit 85032e8aa0ae3b690777809e7d04f6471d29951e, which caused the test to hang indefinitely
- Use more flexible matcher