### PR TITLE
Fleet UI: Fix <dl> tag adverse effect, view all host adverse effect

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -282,7 +282,7 @@ $shadow-transition-width: 10px;
         {
           text-align: right;
           max-width: 140px;
-          display: flex;
+          // display: flex causes layout issues on /software/vulnerabilities table
           align-items: center;
         }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/_styles.scss
@@ -1,2 +1,3 @@
 .software-summary-card {
+  @include vertical-card-layout;
 }

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/_styles.scss
@@ -1,7 +1,5 @@
 .software-vuln-summary {
-  display: flex;
-  flex-direction: column;
-  gap: $large;
+  @include vertical-card-layout;
 
   &__header {
     display: flex;
@@ -24,7 +22,7 @@
   }
 
   &__description-list {
-    display: flex;
+    flex-direction: row;
     gap: 24px 40px;
     flex-wrap: wrap;
 

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/_styles.scss
@@ -15,7 +15,6 @@
   h1 {
     font-size: $pad-large;
     font-weight: bold;
-    margin-bottom: $pad-medium;
     display: flex;
     align-items: center;
     gap: $pad-medium;
@@ -23,6 +22,7 @@
 
   &__description-list {
     display: flex;
+    flex-direction: row;
     gap: $pad-xxlarge;
   }
 }


### PR DESCRIPTION
## Issue
Closes #33708 

## Description
- I changed `<dl>` to be `flex-direction: column`, without noticing 2 instances use `flex-direction: row`
- Default is still `flex-direction: column`, updated the two dl instance with `flex-direction: row`
- Cleaned up any padding not matching new patterns within those two parent cards

## Screen recording of 2 sections fixed

https://github.com/user-attachments/assets/0f0ce337-d470-4fbb-b4d9-dd4d148ae7c9


https://github.com/user-attachments/assets/c1284307-6785-43cb-8c49-76725414e9fa



## Testing

- [x] QA'd all new/changed functionality manually
