### PR TITLE
Fleet UI: Fix header unstyled button

### DIFF
--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -151,6 +151,8 @@ $shadow-transition-width: 10px;
 
         // Sort arrows change color on hover
         .sortable-header {
+          height: 36px;
+
           &:hover {
             .header-cell:not(.ascending) {
               .ascending-arrow {

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
@@ -5,6 +5,7 @@ import { CellProps, Column } from "react-table";
 import { IVulnerabilityOSVersion } from "interfaces/operating_system";
 
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 
 import PATHS from "router/paths";
 import OSIcon from "pages/SoftwarePage/components/icons/OSIcon";
@@ -61,9 +62,14 @@ const generateColumnConfigs = (
     },
     {
       Header: () => (
-        <>
-          Resolved in <div className="resolved-suffix">version</div>
-        </>
+        <HeaderCell
+          value={
+            <>
+              Resolved in <div className="resolved-suffix">version</div>
+            </>
+          }
+          disableSortBy
+        />
       ),
       disableSortBy: true,
       accessor: "resolved_in_version",

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -8,6 +8,7 @@ import PATHS from "router/paths";
 
 import LinkCell from "components/TableContainer/DataTable/LinkCell";
 import TextCell from "components/TableContainer/DataTable/TextCell";
+import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
 import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import { InjectedRouter } from "react-router";
@@ -62,9 +63,14 @@ const generateColumnConfigs = (
     },
     {
       Header: () => (
-        <>
-          Resolved in <div className="resolved-suffix">version</div>
-        </>
+        <HeaderCell
+          value={
+            <>
+              Resolved in <div className="resolved-suffix">version</div>
+            </>
+          }
+          disableSortBy
+        />
       ),
       disableSortBy: true,
       accessor: "resolved_in_version",


### PR DESCRIPTION
## Issue
Closes #33610 

## Description
- Issue with header buttons unstyled
  - Made click size to be 36px height to match other header buttons
  - Wrestled with trying to center but didn't want to put display: flex and adversely break something else
- Using display flex 8px between filters and header caused this "Resolved in version" responsiveness to have an 8px gap
  - Fixed by wrapping in HeaderCell

## Screenshots
<img width="363" height="215" alt="Screenshot 2025-10-01 at 3 54 13 PM" src="https://github.com/user-attachments/assets/ed395c8d-1db9-4cb9-80ed-bbe088b0bdf2" />
<img width="432" height="181" alt="Screenshot 2025-10-01 at 3 54 22 PM" src="https://github.com/user-attachments/assets/10504041-3d07-4bf2-8b48-0a81dddfec51" />


<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter


- [x] QA'd all new/changed functionality manually
