### PR TITLE
Copy change: Add a step to the BitLocker PIN modal

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -37,7 +37,7 @@ const BitLockerPinModal = ({
               <li>
                 <p>
                   Click <b>Change how the drive is unlocked at startup</b>. If 
-                  this option doesn&apos;t show up, wait a minute and relaunch{" "}
+                  this option doesn&apos;t show up, wait a minute and relaunch{" "}
                   <b>Manage BitLocker</b>.
                 </p>
               </li>

--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -36,6 +36,13 @@ const BitLockerPinModal = ({
               </li>
               <li>
                 <p>
+                  Click <b>Change how the drive is unlocked at startup</b>. If 
+                  this option doesn&apos;t show up, wait a minute and relaunch 
+                  <b>Manage BitLocker</b>.
+                </p>
+              </li>
+              <li>
+                <p>
                   Choose <b>Enter a PIN (recommended)</b> and follow the prompts
                   to create a PIN. If you don&apos;t see this option, wait 1
                   minute and refresh the <b>BitLocker Drive Encryption</b>{" "}

--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -36,7 +36,7 @@ const BitLockerPinModal = ({
               </li>
               <li>
                 <p>
-                  Click <b>Change how the drive is unlocked at startup</b>. If 
+                  Click <b>Change how the drive is unlocked at startup</b>. If
                   this option doesn&apos;t show up, wait a minute and relaunch{" "}
                   <b>Manage BitLocker</b>.
                 </p>

--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -37,8 +37,8 @@ const BitLockerPinModal = ({
               <li>
                 <p>
                   Click <b>Change how the drive is unlocked at startup</b>. If 
-                  this option doesn&apos;t show up, wait a minute and
-                  relaunch <b>Manage BitLocker</b>.
+                  this option doesn&apos;t show up, wait a minute and relaunch{" "}
+                  <b>Manage BitLocker</b>.
                 </p>
               </li>
               <li>

--- a/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/BitLockerPinModal/BitLockerPinModal.tsx
@@ -37,16 +37,14 @@ const BitLockerPinModal = ({
               <li>
                 <p>
                   Click <b>Change how the drive is unlocked at startup</b>. If 
-                  this option doesn&apos;t show up, wait a minute and relaunch 
-                  <b>Manage BitLocker</b>.
+                  this option doesn&apos;t show up, wait a minute and
+                  relaunch <b>Manage BitLocker</b>.
                 </p>
               </li>
               <li>
                 <p>
                   Choose <b>Enter a PIN (recommended)</b> and follow the prompts
-                  to create a PIN. If you don&apos;t see this option, wait 1
-                  minute and refresh the <b>BitLocker Drive Encryption</b>{" "}
-                  window.
+                  to create a PIN.
                 </p>
               </li>
               <li>


### PR DESCRIPTION
Follow-up copy change for BitLocker PIN modal on "My device" page, based on [dogfooding feedback](https://github.com/fleetdm/fleet/issues/32898#issuecomment-3308662704).

For user story:

+ #33726 