### PR TITLE
Website: Update pricing.ejs - Change button text

### DIFF
--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -71,7 +71,7 @@
                 </div>
               </div>
               <div>
-                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact">Get a demo</a>
+                <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/contact">Talk to sales</a>
               </div>
             </div>
           </div>


### PR DESCRIPTION
On the pricing page (https://fleetdm.com/pricing) there are currently two buttons that say Get a demo — one in the header and one on the pricing table. Could we explore changing the button in the table to say Talk to sales,Get a quote, or something similar and change the backend routing to go directly to a sales queue to pick up? The thinking: if a buyer is already going to that page, they likely want to talk to sales to get a quote. They also have an opportunity to still book a demo on that page in the header.

Closes https://github.com/fleetdm/confidential/issues/12102
