### PR TITLE
Add missing reference to Android hosts on label criteria

### DIFF
--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -456,7 +456,7 @@ const NewLabelPage = ({
             </span>
             <span className="form-field__help-text">
               Currently, label criteria can be IdP group or department on macOS
-              hosts.
+              and Android hosts.
             </span>
           </div>
         );


### PR DESCRIPTION
Fixes a miss in #31464.

## Testing

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results