### PR TITLE
Fleet UI: Resurface post-install script output

### DIFF
--- a/changes/32948-post-install-output
+++ b/changes/32948-post-install-output
@@ -1,0 +1,1 @@
+- Fleet UI bug fix: Surface post install script output in Software Install Details modal

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -1,163 +1,299 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import { renderWithSetup } from "test/test-utils";
+import { renderWithSetup, createCustomRenderer } from "test/test-utils";
+import { createMockHostSoftware } from "__mocks__/hostMock";
 import { createMockSoftwareInstallResult } from "__mocks__/softwareMock";
-import { StatusMessage, ModalButtons } from "./SoftwareInstallDetailsModal";
+import {
+  getDefaultSoftwareInstallHandler,
+  softwareInstallHandlerNoOutputs,
+  softwareInstallHandlerOnlyInstallOutput,
+} from "test/handlers/software-handlers";
+import mockServer from "test/mock-server";
+import { noop } from "lodash";
 
-describe("SoftwareInstallDetailsModal - StatusMessage component", () => {
-  it("renders basic 'is installed' message when not installed by fleet (no installResult provided)", () => {
-    render(<StatusMessage softwareName="CoolApp" isDUP={false} />);
-    expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
-    expect(screen.getByText(/is installed/)).toBeInTheDocument();
+import SoftwareInstallDetailsModal, {
+  StatusMessage,
+  ModalButtons,
+} from "./SoftwareInstallDetailsModal";
+
+describe("SoftwareInstallDetailsModal", () => {
+  describe("StatusMessage component", () => {
+    it("renders basic 'is installed' message when not installed by fleet (no installResult provided)", () => {
+      render(<StatusMessage softwareName="CoolApp" isDUP={false} />);
+      expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
+      expect(screen.getByText(/is installed/)).toBeInTheDocument();
+    });
+
+    it("on software library page/pending activity, renders pending install message with host and package name", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "pending_install",
+          })}
+          isDUP={false}
+        />
+      );
+
+      expect(screen.queryByTestId("pending-outline-icon")).toBeInTheDocument();
+      expect(
+        screen.getByText(/is installing or will install/)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/\(com\.cool\.app\)/)).toBeInTheDocument();
+      expect(screen.getByText(/Test Host/)).toBeInTheDocument();
+      expect(screen.getByText(/when it comes online/)).toBeInTheDocument();
+    });
+
+    it("on device user page, renders failed install with retry option with contact link", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+          })}
+          isDUP
+          contactUrl="http://support"
+        />
+      );
+
+      expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
+      expect(screen.getByText(/failed to install/)).toBeInTheDocument();
+      expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
+      // Host name should not be rendered for device user page
+      expect(screen.queryByText(/Test Host/)).not.toBeInTheDocument();
+      expect(screen.getByText(/You can retry/)).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /contact your IT admin/ })
+      ).toHaveAttribute("href", "http://support");
+    });
+
+    it("on device user page, renders failed install with retry option without contact link", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+          })}
+          isDUP
+        />
+      );
+
+      expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
+      expect(screen.getByText(/failed to install/)).toBeInTheDocument();
+      expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
+      // Host name should not be rendered for device user page
+      expect(screen.queryByText(/Test Host/)).not.toBeInTheDocument();
+      expect(screen.getByText(/You can retry/)).toBeInTheDocument();
+      // Don't show link of not provided
+      expect(
+        screen.queryByRole("link", { name: /contact your IT admin/ })
+      ).not.toBeInTheDocument();
+    });
+
+    it("on host details page, renders failed install without retry", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+          })}
+          isDUP={false}
+          contactUrl="http://support"
+        />
+      );
+
+      expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
+      expect(screen.getByText(/failed to install/)).toBeInTheDocument();
+      expect(screen.getByText(/Test Host/)).toBeInTheDocument();
+      expect(screen.queryByText(/You can retry/)).not.toBeInTheDocument();
+    });
+
+    it("on host details page/install activity, renders installed message with timestamp", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "installed",
+          })}
+          isDUP={false}
+        />
+      );
+
+      expect(screen.queryByTestId("success-icon")).toBeInTheDocument();
+      expect(screen.getByText(/Fleet installed/)).toBeInTheDocument();
+      expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
+      expect(screen.getByText(/Test Host/)).toBeInTheDocument();
+      expect(screen.getByText(/\(com\.cool\.app\)/)).toBeInTheDocument();
+      expect(screen.getByText(/\d+.*ago/)).toBeInTheDocument();
+    });
   });
 
-  it("on software library page/pending activity, renders pending install message with host and package name", () => {
-    render(
-      <StatusMessage
-        softwareName="CoolApp"
-        installResult={createMockSoftwareInstallResult({
-          status: "pending_install",
-        })}
-        isDUP={false}
-      />
-    );
+  describe("ModalButtons component", () => {
+    it("on device user page, shows Retry/Cancel for failed install and triggers handlers", async () => {
+      const onCancel = jest.fn();
+      const onRetry = jest.fn();
 
-    expect(screen.queryByTestId("pending-outline-icon")).toBeInTheDocument();
-    expect(
-      screen.getByText(/is installing or will install/)
-    ).toBeInTheDocument();
-    expect(screen.getByText(/\(com\.cool\.app\)/)).toBeInTheDocument();
-    expect(screen.getByText(/Test Host/)).toBeInTheDocument();
-    expect(screen.getByText(/when it comes online/)).toBeInTheDocument();
+      const { user } = renderWithSetup(
+        <ModalButtons
+          deviceAuthToken="token123"
+          status="failed_install"
+          hostSoftwareId={99}
+          onCancel={onCancel}
+          onRetry={onRetry}
+        />
+      );
+      expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Cancel" })
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: "Retry" }));
+      expect(onRetry).toHaveBeenCalledWith(99);
+      expect(onCancel).toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: "Cancel" }));
+      expect(onCancel).toHaveBeenCalledTimes(2);
+    });
+
+    it("shows Done button for pending install", () => {
+      const onCancel = jest.fn();
+      render(<ModalButtons status="pending_install" onCancel={onCancel} />);
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Retry" })
+      ).not.toBeInTheDocument();
+    });
+
+    it("on device user page, shows Done button for installed software", () => {
+      const onCancel = jest.fn();
+      render(
+        <ModalButtons
+          deviceAuthToken="token123"
+          status="installed"
+          onCancel={onCancel}
+        />
+      );
+      expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    });
   });
 
-  it("on device user page, renders failed install with retry option with contact link", () => {
-    render(
-      <StatusMessage
-        softwareName="CoolApp"
-        installResult={createMockSoftwareInstallResult({
-          status: "failed_install",
-        })}
-        isDUP
-        contactUrl="http://support"
-      />
-    );
+  const baseDetails = {
+    install_uuid: "uuid-123",
+    host_display_name: "Test Host",
+  };
 
-    expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
-    expect(screen.getByText(/failed to install/)).toBeInTheDocument();
-    expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
-    // Host name should not be rendered for device user page
-    expect(screen.queryByText(/Test Host/)).not.toBeInTheDocument();
-    expect(screen.getByText(/You can retry/)).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: /contact your IT admin/ })
-    ).toHaveAttribute("href", "http://support");
+  const baseHostSoftware = createMockHostSoftware({
+    id: 99,
+    name: "CoolApp",
+    installed_versions: [],
   });
 
-  it("on device user page, renders failed install with retry option without contact link", () => {
-    render(
-      <StatusMessage
-        softwareName="CoolApp"
-        installResult={createMockSoftwareInstallResult({
-          status: "failed_install",
-        })}
-        isDUP
-      />
-    );
+  describe("Install Details Section", () => {
+    afterEach(() => {
+      mockServer.resetHandlers();
+    });
 
-    expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
-    expect(screen.getByText(/failed to install/)).toBeInTheDocument();
-    expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
-    // Host name should not be rendered for device user page
-    expect(screen.queryByText(/Test Host/)).not.toBeInTheDocument();
-    expect(screen.getByText(/You can retry/)).toBeInTheDocument();
-    // Don't show link of not provided
-    expect(
-      screen.queryByRole("link", { name: /contact your IT admin/ })
-    ).not.toBeInTheDocument();
-  });
+    it("does not show install details outputs until Details is clicked", async () => {
+      mockServer.use(
+        getDefaultSoftwareInstallHandler({ install_uuid: "uuid-123" })
+      );
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
 
-  it("on host details page, renders failed install without retry", () => {
-    render(
-      <StatusMessage
-        softwareName="CoolApp"
-        installResult={createMockSoftwareInstallResult({
-          status: "failed_install",
-        })}
-        isDUP={false}
-        contactUrl="http://support"
-      />
-    );
+      renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={baseHostSoftware}
+          onCancel={noop}
+        />
+      );
 
-    expect(screen.queryByTestId("error-icon")).toBeInTheDocument();
-    expect(screen.getByText(/failed to install/)).toBeInTheDocument();
-    expect(screen.getByText(/Test Host/)).toBeInTheDocument();
-    expect(screen.queryByText(/You can retry/)).not.toBeInTheDocument();
-  });
+      // waiting for the button to render
+      const detailsButton = await screen.findByRole("button", {
+        name: /Details/i,
+      });
 
-  it("on host details page/install activity, renders installed message with timestamp", () => {
-    render(
-      <StatusMessage
-        softwareName="CoolApp"
-        installResult={createMockSoftwareInstallResult({
-          status: "installed",
-        })}
-        isDUP={false}
-      />
-    );
+      expect(detailsButton).toBeInTheDocument();
+      expect(
+        screen.queryByLabelText("Install script output:")
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByLabelText(/Post-install script output:/i)
+      ).not.toBeInTheDocument();
+    });
 
-    expect(screen.queryByTestId("success-icon")).toBeInTheDocument();
-    expect(screen.getByText(/Fleet installed/)).toBeInTheDocument();
-    expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
-    expect(screen.getByText(/Test Host/)).toBeInTheDocument();
-    expect(screen.getByText(/\(com\.cool\.app\)/)).toBeInTheDocument();
-    expect(screen.getByText(/\d+.*ago/)).toBeInTheDocument();
-  });
-});
+    it("shows install and post-install outputs after clicking Details", async () => {
+      mockServer.use(
+        getDefaultSoftwareInstallHandler({
+          install_uuid: baseDetails.install_uuid,
+        })
+      );
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+      const { user } = renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={baseHostSoftware}
+          onCancel={noop}
+        />
+      );
 
-describe("SoftwareInstallDetailsModal - ModalButtons component", () => {
-  it("on device user page, shows Retry/Cancel for failed install and triggers handlers", async () => {
-    const onCancel = jest.fn();
-    const onRetry = jest.fn();
+      const detailsBtn = await screen.findByRole("button", {
+        name: /Details/i,
+      });
+      await user.click(detailsBtn);
 
-    const { user } = renderWithSetup(
-      <ModalButtons
-        deviceAuthToken="token123"
-        status="failed_install"
-        hostSoftwareId={99}
-        onCancel={onCancel}
-        onRetry={onRetry}
-      />
-    );
-    expect(screen.getByRole("button", { name: "Retry" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+      await screen.findByText("Install script output:");
+      expect(screen.getByText("Install script ran")).toBeInTheDocument();
+      expect(
+        screen.getByText(/Post-install script output:/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText("Post-install success")).toBeInTheDocument();
+    });
 
-    await user.click(screen.getByRole("button", { name: "Retry" }));
-    expect(onRetry).toHaveBeenCalledWith(99);
-    expect(onCancel).toHaveBeenCalled();
+    it("does not render output textareas if script outputs are empty", async () => {
+      mockServer.use(softwareInstallHandlerNoOutputs);
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+      const { user } = renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={baseHostSoftware}
+          onCancel={noop}
+        />
+      );
 
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-    expect(onCancel).toHaveBeenCalledTimes(2);
-  });
+      const detailsBtn = await screen.findByRole("button", {
+        name: /Details/i,
+      });
+      await user.click(detailsBtn);
 
-  it("shows Done button for pending install", () => {
-    const onCancel = jest.fn();
-    render(<ModalButtons status="pending_install" onCancel={onCancel} />);
-    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
-    expect(
-      screen.queryByRole("button", { name: "Retry" })
-    ).not.toBeInTheDocument();
-  });
+      expect(
+        screen.queryByText(/Install script output:/i)
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/Post-install script output:/i)
+      ).not.toBeInTheDocument();
+    });
 
-  it("on device user page, shows Done button for installed software", () => {
-    const onCancel = jest.fn();
-    render(
-      <ModalButtons
-        deviceAuthToken="token123"
-        status="installed"
-        onCancel={onCancel}
-      />
-    );
-    expect(screen.getByRole("button", { name: "Done" })).toBeInTheDocument();
+    it("shows only the install output if post-install output is empty", async () => {
+      mockServer.use(softwareInstallHandlerOnlyInstallOutput);
+      const renderWithServer = createCustomRenderer({ withBackendMock: true });
+      const { user } = renderWithServer(
+        <SoftwareInstallDetailsModal
+          details={baseDetails}
+          hostSoftware={baseHostSoftware}
+          onCancel={noop}
+        />
+      );
+
+      const detailsBtn = await screen.findByRole("button", {
+        name: /Details/i,
+      });
+      await user.click(detailsBtn);
+
+      await screen.findByText("Install script output:");
+      expect(screen.getByText(/install only/i)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/Post-install script output:/i)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -5,8 +5,8 @@ import { createMockHostSoftware } from "__mocks__/hostMock";
 import { createMockSoftwareInstallResult } from "__mocks__/softwareMock";
 import {
   getDefaultSoftwareInstallHandler,
-  softwareInstallHandlerNoOutputs,
-  softwareInstallHandlerOnlyInstallOutput,
+  getSoftwareInstallHandlerNoOutputs,
+  getSoftwareInstallHandlerOnlyInstallOutput,
 } from "test/handlers/software-handlers";
 import mockServer from "test/mock-server";
 import { noop } from "lodash";
@@ -194,9 +194,7 @@ describe("SoftwareInstallDetailsModal", () => {
     });
 
     it("does not show install details outputs until Details is clicked", async () => {
-      mockServer.use(
-        getDefaultSoftwareInstallHandler({ install_uuid: "uuid-123" })
-      );
+      mockServer.use(getDefaultSoftwareInstallHandler);
       const renderWithServer = createCustomRenderer({ withBackendMock: true });
 
       renderWithServer(
@@ -222,11 +220,7 @@ describe("SoftwareInstallDetailsModal", () => {
     });
 
     it("shows install and post-install outputs after clicking Details", async () => {
-      mockServer.use(
-        getDefaultSoftwareInstallHandler({
-          install_uuid: baseDetails.install_uuid,
-        })
-      );
+      mockServer.use(getDefaultSoftwareInstallHandler);
       const renderWithServer = createCustomRenderer({ withBackendMock: true });
       const { user } = renderWithServer(
         <SoftwareInstallDetailsModal
@@ -250,7 +244,7 @@ describe("SoftwareInstallDetailsModal", () => {
     });
 
     it("does not render output textareas if script outputs are empty", async () => {
-      mockServer.use(softwareInstallHandlerNoOutputs);
+      mockServer.use(getSoftwareInstallHandlerNoOutputs);
       const renderWithServer = createCustomRenderer({ withBackendMock: true });
       const { user } = renderWithServer(
         <SoftwareInstallDetailsModal
@@ -274,7 +268,7 @@ describe("SoftwareInstallDetailsModal", () => {
     });
 
     it("shows only the install output if post-install output is empty", async () => {
-      mockServer.use(softwareInstallHandlerOnlyInstallOutput);
+      mockServer.use(getSoftwareInstallHandlerOnlyInstallOutput);
       const renderWithServer = createCustomRenderer({ withBackendMock: true });
       const { user } = renderWithServer(
         <SoftwareInstallDetailsModal

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -248,22 +248,40 @@ export const SoftwareInstallDetailsModal = ({
     return "If you uninstalled it outside of Fleet it will still show as installed.";
   };
 
-  const renderInstallDetailsSection = () => (
-    <>
-      <RevealButton
-        isShowing={showInstallDetails}
-        showText="Details"
-        hideText="Details"
-        caretPosition="after"
-        onClick={toggleInstallDetails}
-      />
-      {showInstallDetails && swInstallResult?.output && (
-        <Textarea label="Install script output:" variant="code">
-          {swInstallResult.output}
-        </Textarea>
-      )}
-    </>
-  );
+  const renderInstallDetailsSection = () => {
+    const outputs = [
+      {
+        label: "Install script output:",
+        value: swInstallResult?.output,
+      },
+      {
+        label: "Post-install script output:",
+        value: swInstallResult?.post_install_script_output,
+      },
+    ];
+
+    return (
+      <>
+        <RevealButton
+          isShowing={showInstallDetails}
+          showText="Details"
+          hideText="Details"
+          caretPosition="after"
+          onClick={toggleInstallDetails}
+        />
+        {showInstallDetails &&
+          outputs.map(
+            ({ label, value }) =>
+              value && (
+                <Textarea key={label} label={label} variant="code">
+                  {value}
+                </Textarea>
+              )
+          )}
+      </>
+    );
+  };
+
   const excludeVersions = ["pending_install", "failed_install"].includes(
     swInstallResult?.status || ""
   );

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -1,0 +1,49 @@
+import { http, HttpResponse } from "msw";
+import { baseUrl } from "test/test-utils";
+import { ISoftwareInstallResult } from "interfaces/software";
+import { createMockSoftwareInstallResult } from "__mocks__/softwareMock";
+
+// Installed with outputs
+export const getDefaultSoftwareInstallHandler = (
+  overrides: Partial<ISoftwareInstallResult>
+) =>
+  http.get(baseUrl("/software/install/:install_uuid/results"), ({ params }) => {
+    return HttpResponse.json({
+      results: createMockSoftwareInstallResult({
+        install_uuid: overrides.install_uuid ?? "abc-123",
+        status: "installed",
+        output: "Install script ran",
+        post_install_script_output: "Post-install success",
+      }),
+    });
+  });
+
+// Installed, no outputs
+export const softwareInstallHandlerNoOutputs = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: createMockSoftwareInstallResult({
+        install_uuid: params.install_uuid as string,
+        status: "installed",
+        output: "",
+        post_install_script_output: "",
+      }),
+    });
+  }
+);
+
+// Installed, only install output
+export const softwareInstallHandlerOnlyInstallOutput = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: createMockSoftwareInstallResult({
+        install_uuid: params.install_uuid as string,
+        status: "installed",
+        output: "Install only",
+        post_install_script_output: "",
+      }),
+    });
+  }
+);

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -1,25 +1,24 @@
 import { http, HttpResponse } from "msw";
 import { baseUrl } from "test/test-utils";
-import { ISoftwareInstallResult } from "interfaces/software";
 import { createMockSoftwareInstallResult } from "__mocks__/softwareMock";
 
 // Installed with outputs
-export const getDefaultSoftwareInstallHandler = (
-  overrides: Partial<ISoftwareInstallResult>
-) =>
-  http.get(baseUrl("/software/install/:install_uuid/results"), ({ params }) => {
+export const getDefaultSoftwareInstallHandler = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
     return HttpResponse.json({
       results: createMockSoftwareInstallResult({
-        install_uuid: overrides.install_uuid ?? "abc-123",
+        install_uuid: params.install_uuid as string,
         status: "installed",
         output: "Install script ran",
         post_install_script_output: "Post-install success",
       }),
     });
-  });
+  }
+);
 
 // Installed, no outputs
-export const softwareInstallHandlerNoOutputs = http.get(
+export const getSoftwareInstallHandlerNoOutputs = http.get(
   baseUrl("/software/install/:install_uuid/results"),
   ({ params }) => {
     return HttpResponse.json({
@@ -34,7 +33,7 @@ export const softwareInstallHandlerNoOutputs = http.get(
 );
 
 // Installed, only install output
-export const softwareInstallHandlerOnlyInstallOutput = http.get(
+export const getSoftwareInstallHandlerOnlyInstallOutput = http.get(
   baseUrl("/software/install/:install_uuid/results"),
   ({ params }) => {
     return HttpResponse.json({


### PR DESCRIPTION
## Issue
Closes #32948

## Description 
- Add post-install script output section back in

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
