### PR TITLE
Update "Setting up your device" page for MacOS Setup Experience

### DIFF
--- a/changes/33173-update-setting-up-your-device
+++ b/changes/33173-update-setting-up-your-device
@@ -1,0 +1,1 @@
+- Updated the "Setting up your device" page to show status of setup script run.

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -286,9 +286,13 @@ func (svc *Service) getHostSetupExperienceStatus(ctx context.Context, host *flee
 	}
 
 	var software []*fleet.SetupExperienceStatusResult
+	var scripts []*fleet.SetupExperienceStatusResult
 	for _, result := range results {
 		if result.IsForSoftware() {
 			software = append(software, result)
+		}
+		if result.IsForScript() {
+			scripts = append(scripts, result)
 		}
 	}
 
@@ -299,5 +303,6 @@ func (svc *Service) getHostSetupExperienceStatus(ctx context.Context, host *flee
 
 	return &fleet.DeviceSetupExperienceStatusPayload{
 		Software: software,
+		Scripts:  scripts,
 	}, nil
 }

--- a/frontend/__mocks__/deviceUserMock.ts
+++ b/frontend/__mocks__/deviceUserMock.ts
@@ -76,7 +76,7 @@ const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupExperienceStatuses
       createMockSetupStepStatus({ name: "Zoom", status: "running" }),
     ],
     scripts: [
-      createMockSetupStepStatus({ name: "test.sh", status: "pending" }),
+      createMockSetupStepStatus({ name: "test.sh", status: "running" }),
     ],
   },
 };

--- a/frontend/__mocks__/deviceUserMock.ts
+++ b/frontend/__mocks__/deviceUserMock.ts
@@ -1,8 +1,9 @@
 import { IDeviceUser } from "interfaces/host";
-import { IDeviceSoftware, ISetupStep } from "interfaces/software";
+import { IDeviceSoftware } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 import {
   IGetDeviceSoftwareResponse,
-  IGetSetupSoftwareStatusesResponse,
+  IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
 import { createMockHostSoftwarePackage } from "./hostMock";
 
@@ -65,7 +66,7 @@ export const createMockSetupSoftwareStatus = (
   return { ...DEFAULT_SETUP_SOFTWARE_STATUS_MOCK, ...overrides };
 };
 
-const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupSoftwareStatusesResponse = {
+const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupExperienceStatusesResponse = {
   setup_experience_results: {
     software: [
       createMockSetupSoftwareStatus({ name: "1Password", status: "pending" }),
@@ -78,8 +79,8 @@ const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupSoftwareStatusesRe
 };
 
 export const createMockSetupSoftwareStatusesResponse = (
-  overrides?: Partial<IGetSetupSoftwareStatusesResponse>
-): IGetSetupSoftwareStatusesResponse => {
+  overrides?: Partial<IGetSetupExperienceStatusesResponse>
+): IGetSetupExperienceStatusesResponse => {
   return {
     ...DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK,
     ...overrides,

--- a/frontend/__mocks__/deviceUserMock.ts
+++ b/frontend/__mocks__/deviceUserMock.ts
@@ -1,5 +1,5 @@
 import { IDeviceUser } from "interfaces/host";
-import { IDeviceSoftware, ISetupSoftwareStatus } from "interfaces/software";
+import { IDeviceSoftware, ISetupStep } from "interfaces/software";
 import {
   IGetDeviceSoftwareResponse,
   IGetSetupSoftwareStatusesResponse,
@@ -53,14 +53,15 @@ export const createMockDeviceSoftwareResponse = (
   };
 };
 
-const DEFAULT_SETUP_SOFTWARE_STATUS_MOCK: ISetupSoftwareStatus = {
+const DEFAULT_SETUP_SOFTWARE_STATUS_MOCK: ISetupStep = {
   name: "Slack",
+  type: "software_install",
   status: "pending",
 };
 
 export const createMockSetupSoftwareStatus = (
-  overrides?: Partial<ISetupSoftwareStatus>
-): ISetupSoftwareStatus => {
+  overrides?: Partial<ISetupStep>
+): ISetupStep => {
   return { ...DEFAULT_SETUP_SOFTWARE_STATUS_MOCK, ...overrides };
 };
 

--- a/frontend/__mocks__/deviceUserMock.ts
+++ b/frontend/__mocks__/deviceUserMock.ts
@@ -75,6 +75,7 @@ const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupExperienceStatuses
       createMockSetupSoftwareStatus({ name: "Slack", status: "success" }),
       createMockSetupSoftwareStatus({ name: "Zoom", status: "running" }),
     ],
+    scripts: [],
   },
 };
 

--- a/frontend/__mocks__/deviceUserMock.ts
+++ b/frontend/__mocks__/deviceUserMock.ts
@@ -54,28 +54,30 @@ export const createMockDeviceSoftwareResponse = (
   };
 };
 
-const DEFAULT_SETUP_SOFTWARE_STATUS_MOCK: ISetupStep = {
+const DEFAULT_SETUP_STEP_STATUS_MOCK: ISetupStep = {
   name: "Slack",
-  type: "software_install",
   status: "pending",
+  type: "",
 };
 
-export const createMockSetupSoftwareStatus = (
+export const createMockSetupStepStatus = (
   overrides?: Partial<ISetupStep>
 ): ISetupStep => {
-  return { ...DEFAULT_SETUP_SOFTWARE_STATUS_MOCK, ...overrides };
+  return { ...DEFAULT_SETUP_STEP_STATUS_MOCK, ...overrides };
 };
 
 const DEFAULT_SETUP_SOFTWARE_STATUSES_RESPONSE_MOCK: IGetSetupExperienceStatusesResponse = {
   setup_experience_results: {
     software: [
-      createMockSetupSoftwareStatus({ name: "1Password", status: "pending" }),
-      createMockSetupSoftwareStatus({ name: "Chrome", status: "failure" }),
-      createMockSetupSoftwareStatus({ name: "Firefox", status: "cancelled" }),
-      createMockSetupSoftwareStatus({ name: "Slack", status: "success" }),
-      createMockSetupSoftwareStatus({ name: "Zoom", status: "running" }),
+      createMockSetupStepStatus({ name: "1Password", status: "pending" }),
+      createMockSetupStepStatus({ name: "Chrome", status: "failure" }),
+      createMockSetupStepStatus({ name: "Firefox", status: "cancelled" }),
+      createMockSetupStepStatus({ name: "Slack", status: "success" }),
+      createMockSetupStepStatus({ name: "Zoom", status: "running" }),
     ],
-    scripts: [],
+    scripts: [
+      createMockSetupStepStatus({ name: "test.sh", status: "pending" }),
+    ],
   },
 };
 

--- a/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/SetupScriptProcessCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/SetupScriptProcessCell.tsx
@@ -1,0 +1,21 @@
+import Graphic from "components/Graphic/Graphic";
+import React from "react";
+
+const baseClass = "setup-script-process-cell";
+
+interface ISetupScriptProcessCell {
+  name: string;
+}
+
+const SetupScriptProcessCell = ({ name }: ISetupScriptProcessCell) => {
+  return (
+    <span className={baseClass}>
+      <Graphic name="file-sh" className={`${baseClass}__icon`} />
+      <div>
+        Run <b>{name || "Unknown script"}</b>
+      </div>
+    </span>
+  );
+};
+
+export default SetupScriptProcessCell;

--- a/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/_styles.scss
@@ -1,0 +1,10 @@
+.setup-script-process-cell {
+  display: flex;
+  align-items: center;
+  gap: $pad-small;
+
+  .graphic {
+      width: $pad-xlarge;
+      scale: 60%;
+  }
+}

--- a/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/index.ts
+++ b/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SetupScriptProcessCell";

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+import { SetupStepStatus } from "interfaces/setup";
+
+import Icon from "components/Icon";
+import { IconNames } from "components/icons";
+import Spinner from "components/Spinner";
+
+const baseClass = "setup-script-status-cell";
+
+interface ISetupScriptStatusCell {
+  status: SetupStepStatus;
+}
+
+const serverToUiStatus = (
+  status: SetupStepStatus
+): { label: string; icon: IconNames | "spinner" } => {
+  switch (status) {
+    case "pending":
+      return { label: "Pending", icon: "pending-outline" };
+    case "running":
+      return { label: "Running", icon: "spinner" };
+    case "success":
+      return { label: "Ran", icon: "success" };
+    case "failure":
+    case "cancelled":
+      return { label: "Failed", icon: "error" };
+    default:
+      return { label: "Pending", icon: "pending-outline" };
+  }
+};
+
+const SetupScriptStatusCell = ({ status }: ISetupScriptStatusCell) => {
+  const { label, icon } = serverToUiStatus(status);
+  return (
+    <div className={baseClass}>
+      {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
+      {label}
+    </div>
+  );
+};
+
+export default SetupScriptStatusCell;

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
@@ -1,0 +1,11 @@
+.setup-script-status-cell {
+  display: flex;
+  align-items: center;
+  gap: $pad-xsmall;
+
+  .loading-spinner {
+    margin: 0;
+    width: $pad-medium;
+    height: $pad-medium;
+  }
+}

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/index.ts
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SetupScriptStatusCell";

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareProcessCell/_styles.scss
@@ -2,4 +2,8 @@
   display: flex;
   align-items: center;
   gap: $pad-small;
+
+  .software-icon__small {
+    width: $pad-xlarge;
+  }
 }

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { SetupStepStatus } from "interfaces/software";
+import { SetupStepStatus } from "interfaces/setup";
 
 import Icon from "components/Icon";
 import { IconNames } from "components/icons";

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { SetupSoftwareStatus } from "interfaces/software";
+import { SetupStepStatus } from "interfaces/software";
 
 import Icon from "components/Icon";
 import { IconNames } from "components/icons";
@@ -9,11 +9,11 @@ import Spinner from "components/Spinner";
 const baseClass = "setup-software-status-cell";
 
 interface ISetupSoftwareStatusCell {
-  status: SetupSoftwareStatus;
+  status: SetupStepStatus;
 }
 
 const serverToUiStatus = (
-  status: SetupSoftwareStatus
+  status: SetupStepStatus
 ): { label: string; icon: IconNames | "spinner" } => {
   switch (status) {
     case "pending":

--- a/frontend/interfaces/setup.ts
+++ b/frontend/interfaces/setup.ts
@@ -15,5 +15,5 @@ export type SetupStepType = typeof SETUP_STEP_TYPES[number];
 export interface ISetupStep {
   name: string | null;
   status: SetupStepStatus;
-  type: SetupStepType;
+  type?: SetupStepType;
 }

--- a/frontend/interfaces/setup.ts
+++ b/frontend/interfaces/setup.ts
@@ -1,0 +1,19 @@
+export const SETUP_STEP_STATUSES = [
+  "pending",
+  "running",
+  "success",
+  "failure",
+  "cancelled", // server should be aggregating cancelled installs with failed, check here just in case
+] as const;
+
+export type SetupStepStatus = typeof SETUP_STEP_STATUSES[number];
+
+export const SETUP_STEP_TYPES = ["software_install", "script_run"];
+
+export type SetupStepType = typeof SETUP_STEP_TYPES[number];
+
+export interface ISetupStep {
+  name: string | null;
+  status: SetupStepStatus;
+  type: SetupStepType;
+}

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -594,23 +594,3 @@ export interface IFleetMaintainedAppDetails {
   software_title_id?: number; // null unless the team already has the software added (as a Fleet-maintained app, App Store (app), or custom package)
   categories: SoftwareCategory[];
 }
-
-export const SETUP_STEP_STATUSES = [
-  "pending",
-  "running",
-  "success",
-  "failure",
-  "cancelled", // server should be aggregating cancelled installs with failed, check here just in case
-] as const;
-
-export type SetupStepStatus = typeof SETUP_STEP_STATUSES[number];
-
-export const SETUP_STEP_TYPES = ["software_install", "script_run"];
-
-export type SetupStepType = typeof SETUP_STEP_TYPES[number];
-
-export interface ISetupStep {
-  name: string | null;
-  status: SetupStepStatus;
-  type: SetupStepType;
-}

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -595,7 +595,7 @@ export interface IFleetMaintainedAppDetails {
   categories: SoftwareCategory[];
 }
 
-export const SETUP_SOFTWARE_STATUSES = [
+export const SETUP_STEP_STATUSES = [
   "pending",
   "running",
   "success",
@@ -603,9 +603,14 @@ export const SETUP_SOFTWARE_STATUSES = [
   "cancelled", // server should be aggregating cancelled installs with failed, check here just in case
 ] as const;
 
-export type SetupSoftwareStatus = typeof SETUP_SOFTWARE_STATUSES[number];
+export type SetupStepStatus = typeof SETUP_STEP_STATUSES[number];
 
-export interface ISetupSoftwareStatus {
+export const SETUP_STEP_TYPES = ["software_install", "script_run"];
+
+export type SetupStepType = typeof SETUP_STEP_TYPES[number];
+
+export interface ISetupStep {
   name: string | null;
-  status: SetupSoftwareStatus;
+  status: SetupStepStatus;
+  type: SetupStepType;
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -138,6 +138,7 @@ describe("Device User Page", () => {
   describe("Setup experience software installation", () => {
     const REGULAR_DUP_MATCHER = /Last fetched/;
     const SETTING_UP_YOUR_DEVICE_MATCHER = /Setting up your device/;
+    const CONFIG_COMPLETE_MATCHER = /Configuration complete/;
 
     const setupTest = async (
       deviceUserResponseOverrides?: Partial<IDeviceUserResponse>,
@@ -218,9 +219,29 @@ describe("Device User Page", () => {
         { query: { setup_only: "1" } }
       );
       await waitFor(() => {
-        expect(
-          screen.getByText(SETTING_UP_YOUR_DEVICE_MATCHER)
-        ).toBeInTheDocument();
+        expect(screen.getByText(CONFIG_COMPLETE_MATCHER)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();
+    });
+    it("checks for setup experience items on Fleet Premium, and renders Setting Up Your Device when all steps are complete if setup_only=1 is in the query", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "linux";
+
+      await setupTest(
+        { host },
+        {
+          setup_experience_results: {
+            software: [
+              { type: "software_installer", name: "step 1", status: "success" },
+            ],
+            scripts: [{ type: "script", name: "step 2", status: "failure" }],
+          },
+        },
+        { query: { setup_only: "1" } }
+      );
+      await waitFor(() => {
+        expect(screen.getByText(CONFIG_COMPLETE_MATCHER)).toBeInTheDocument();
       });
 
       expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -187,6 +187,8 @@ describe("Device User Page", () => {
         expect(
           screen.getByText(SETTING_UP_YOUR_DEVICE_MATCHER)
         ).toBeInTheDocument();
+        expect(screen.getByText(/Installing/)).toBeInTheDocument();
+        expect(screen.getByText(/Running/)).toBeInTheDocument();
       });
 
       expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -194,7 +194,7 @@ describe("Device User Page", () => {
 
       expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();
     });
-    it("checks for setup experience items on Fleet Premium, and renders the normal device user page if there are such steps", async () => {
+    it("checks for setup experience steps on Fleet Premium, and renders the normal device user page if there are such steps", async () => {
       const host = createMockHost() as IHostDevice;
       host.platform = "linux";
 
@@ -209,7 +209,7 @@ describe("Device User Page", () => {
 
       expect(screen.queryByText(SETTING_UP_YOUR_DEVICE_MATCHER)).toBeNull();
     });
-    it("checks for setup experience items on Fleet Premium, and renders Setting Up Your Device even there are no such steps if setup_only=1 is in the query", async () => {
+    it("checks for setup experience steps on Fleet Premium, and renders Setting Up Your Device even if there are no such steps if setup_only=1 is in the query", async () => {
       const host = createMockHost() as IHostDevice;
       host.platform = "linux";
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -195,7 +195,10 @@ describe("Device User Page", () => {
       const host = createMockHost() as IHostDevice;
       host.platform = "linux";
 
-      await setupTest({ host }, { setup_experience_results: {} });
+      await setupTest(
+        { host },
+        { setup_experience_results: { software: [], scripts: [] } }
+      );
 
       await waitFor(() => {
         expect(screen.getByText(REGULAR_DUP_MATCHER)).toBeInTheDocument();
@@ -209,7 +212,7 @@ describe("Device User Page", () => {
 
       await setupTest(
         { host },
-        { setup_experience_results: {} },
+        { setup_experience_results: { software: [], scripts: [] } },
         { query: { setup_only: "1" } }
       );
       await waitFor(() => {

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { screen, waitFor } from "@testing-library/react";
 
 import { IDeviceUserResponse, IHostDevice } from "interfaces/host";
-import createMockHost, { createMockHostEndUser } from "__mocks__/hostMock";
+import createMockHost from "__mocks__/hostMock";
 import mockServer from "test/mock-server";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockLicense from "__mocks__/licenseMock";
@@ -28,6 +28,7 @@ const mockLocation = {
     query: undefined,
     order_key: undefined,
     order_direction: undefined,
+    setup_only: "",
   },
   search: undefined,
 };
@@ -140,7 +141,8 @@ describe("Device User Page", () => {
 
     const setupTest = async (
       deviceUserResponseOverrides?: Partial<IDeviceUserResponse>,
-      setupExperienceOverrides?: Partial<IGetSetupExperienceStatusesResponse>
+      setupExperienceOverrides?: Partial<IGetSetupExperienceStatusesResponse>,
+      mockLocationOverrides = {}
     ) => {
       mockServer.use(customDeviceHandler(deviceUserResponseOverrides));
       mockServer.use(defaultDeviceCertificatesHandler);
@@ -154,11 +156,12 @@ describe("Device User Page", () => {
         <DeviceUserPage
           router={mockRouter}
           params={{ device_auth_token: "testToken" }}
-          location={mockLocation}
+          location={{
+            ...(mockLocation || {}),
+            ...(mockLocationOverrides || {}),
+          }}
         />
       );
-
-      await screen.findByText(/My device/);
 
       return user;
     };
@@ -174,7 +177,7 @@ describe("Device User Page", () => {
       });
     });
 
-    it("checks for setup experience software on Fleet Premium, and renders Setting Up Your Device if there is such software", async () => {
+    it("checks for setup experience steps on Fleet Premium, and renders Setting Up Your Device if there are such steps", async () => {
       const host = createMockHost() as IHostDevice;
       host.platform = "linux";
 
@@ -188,7 +191,7 @@ describe("Device User Page", () => {
 
       expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();
     });
-    it("checks for setup experience software on Fleet Premium, and renders the normal device user page if there is no such software", async () => {
+    it("checks for setup experience items on Fleet Premium, and renders the normal device user page if there are such steps", async () => {
       const host = createMockHost() as IHostDevice;
       host.platform = "linux";
 
@@ -199,6 +202,23 @@ describe("Device User Page", () => {
       });
 
       expect(screen.queryByText(SETTING_UP_YOUR_DEVICE_MATCHER)).toBeNull();
+    });
+    it("checks for setup experience items on Fleet Premium, and renders Setting Up Your Device even there are no such steps if setup_only=1 is in the query", async () => {
+      const host = createMockHost() as IHostDevice;
+      host.platform = "linux";
+
+      await setupTest(
+        { host },
+        { setup_experience_results: {} },
+        { query: { setup_only: "1" } }
+      );
+      await waitFor(() => {
+        expect(
+          screen.getByText(SETTING_UP_YOUR_DEVICE_MATCHER)
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(REGULAR_DUP_MATCHER)).toBeNull();
     });
   });
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tests.tsx
@@ -7,7 +7,7 @@ import mockServer from "test/mock-server";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import createMockLicense from "__mocks__/licenseMock";
 
-import { IGetSetupSoftwareStatusesResponse } from "services/entities/device_user";
+import { IGetSetupExperienceStatusesResponse } from "services/entities/device_user";
 
 import {
   customDeviceHandler,
@@ -140,7 +140,7 @@ describe("Device User Page", () => {
 
     const setupTest = async (
       deviceUserResponseOverrides?: Partial<IDeviceUserResponse>,
-      setupExperienceOverrides?: Partial<IGetSetupSoftwareStatusesResponse>
+      setupExperienceOverrides?: Partial<IGetSetupExperienceStatusesResponse>
     ) => {
       mockServer.use(customDeviceHandler(deviceUserResponseOverrides));
       mockServer.use(defaultDeviceCertificatesHandler);

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -333,25 +333,11 @@ const DeviceUserPage = ({
     data: setupStepStatuses,
     isLoading: isLoadingSetupSteps,
     isError: isErrorSetupSteps,
-  } = useQuery<
-    IGetSetupExperienceStatusesResponse,
-    Error,
-    ISetupStep[] | null | undefined
-  >(
+  } = useQuery<ISetupStep[], Error, ISetupStep[] | null | undefined>(
     ["software-setup-statuses", deviceAuthToken],
     () => deviceUserAPI.getSetupExperienceStatuses({ token: deviceAuthToken }),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      select: (res) => [
-        ...(res.setup_experience_results.software ?? []).map((s) => ({
-          ...s,
-          type: "software",
-        })),
-        ...(res.setup_experience_results.scripts ?? []).map((s) => ({
-          ...s,
-          type: "script",
-        })),
-      ],
       enabled: checkForSetupExperienceSoftware, // this can only become true once the above `dupResponse` is defined by its associated API call response, ensuring this call only fires once the frontend knows if this is a Fleet Premium instance
       refetchInterval: (data) => (hasRemainingSetupSteps(data) ? 5000 : false), // refetch every 5s until finished
       refetchIntervalInBackground: true,

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -10,7 +10,7 @@ import { NotificationContext } from "context/notification";
 import deviceUserAPI, {
   IGetDeviceCertsRequestParams,
   IGetDeviceCertificatesResponse,
-  IGetSetupSoftwareStatusesResponse,
+  IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
 import diskEncryptionAPI from "services/entities/disk_encryption";
 import {
@@ -329,16 +329,16 @@ const DeviceUserPage = ({
   const aboutData = normalizeEmptyValues(pick(host, HOST_ABOUT_DATA));
 
   const {
-    data: softwareSetupStatuses,
-    isLoading: isLoadingSetupSoftware,
-    isError: isErrorSetupSoftware,
+    data: setupStepStatuses,
+    isLoading: isLoadingSetupSteps,
+    isError: isErrorSetupSteps,
   } = useQuery<
-    IGetSetupSoftwareStatusesResponse,
+    IGetSetupExperienceStatusesResponse,
     Error,
-    IGetSetupSoftwareStatusesResponse["setup_experience_results"]["software"]
+    IGetSetupExperienceStatusesResponse["setup_experience_results"]["software"]
   >(
     ["software-setup-statuses", deviceAuthToken],
-    () => deviceUserAPI.getSetupSoftwareStatuses({ token: deviceAuthToken }),
+    () => deviceUserAPI.getSetupExperienceStatuses({ token: deviceAuthToken }),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       select: (res) => res.setup_experience_results.software,
@@ -487,22 +487,21 @@ const DeviceUserPage = ({
       !host ||
       isLoadingHost ||
       isLoadingDeviceCertificates ||
-      isLoadingSetupSoftware
+      isLoadingSetupSteps
     ) {
       return <Spinner />;
     }
-    if (isErrorSetupSoftware) {
+    if (isErrorSetupSteps) {
       return <DataError description="Could not get software setup status." />;
     }
     if (
       checkForSetupExperienceSoftware &&
-      (hasRemainingSetupSteps(softwareSetupStatuses) ||
-        location.query.setup_only)
+      (hasRemainingSetupSteps(setupStepStatuses) || location.query.setup_only)
     ) {
       // at this point, softwareSetupStatuses will be non-empty
       return (
         <SettingUpYourDevice
-          softwareStatuses={softwareSetupStatuses || []}
+          softwareStatuses={setupStepStatuses || []}
           toggleInfoModal={toggleInfoModal}
         />
       );

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -10,7 +10,6 @@ import { NotificationContext } from "context/notification";
 import deviceUserAPI, {
   IGetDeviceCertsRequestParams,
   IGetDeviceCertificatesResponse,
-  IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
 import diskEncryptionAPI from "services/entities/disk_encryption";
 import {

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -2,17 +2,17 @@ import Card from "components/Card";
 import { ISetupStep } from "interfaces/setup";
 import React from "react";
 import InfoButton from "../InfoButton";
-import SetupSoftwareStatusTable from "./SetupStatusTable";
+import SetupStatusTable from "./SetupStatusTable";
 
 const baseClass = "setting-up-your-device";
 
 interface ISettingUpYourDevice {
-  softwareStatuses: ISetupStep[];
+  setupSteps: ISetupStep[];
   toggleInfoModal: () => void;
 }
 
 const SettingUpYourDevice = ({
-  softwareStatuses,
+  setupSteps,
   toggleInfoModal,
 }: ISettingUpYourDevice) => {
   return (
@@ -31,7 +31,7 @@ const SettingUpYourDevice = ({
           Please don&apos;t attempt to restart or shut down the computer unless
           prompted to do so.
         </p>
-        <SetupSoftwareStatusTable statuses={softwareStatuses} />
+        <SetupStatusTable statuses={setupSteps} />
       </Card>
     </div>
   );

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -1,13 +1,13 @@
 import Card from "components/Card";
-import { ISetupSoftwareStatus } from "interfaces/software";
+import { ISetupStep } from "interfaces/software";
 import React from "react";
 import InfoButton from "../InfoButton";
-import SetupSoftwareStatusTable from "./SetupSoftwareStatusTable";
+import SetupSoftwareStatusTable from "./SetupStatusTable";
 
 const baseClass = "setting-up-your-device";
 
 interface ISettingUpYourDevice {
-  softwareStatuses: ISetupSoftwareStatus[];
+  softwareStatuses: ISetupStep[];
   toggleInfoModal: () => void;
 }
 
@@ -17,12 +17,15 @@ const SettingUpYourDevice = ({
 }: ISettingUpYourDevice) => {
   return (
     <div className={`${baseClass} main-content device-user`}>
-      <span className={`${baseClass}__header`}>
+      {/* <span className={`${baseClass}__header`}>
         <h1 className={`${baseClass}__title`}>My device</h1>
         <InfoButton onClick={toggleInfoModal} />
-      </span>
+      </span> */}
       <Card borderRadiusSize="xxlarge" paddingSize="xlarge" includeShadow>
-        <h2>Setting up your device...</h2>
+        <div className={`${baseClass}__header`}>
+          <h2>Setting up your device...</h2>
+          <InfoButton onClick={toggleInfoModal} />
+        </div>
         <p>
           Your computer is currently being configured by your organization.
           Please don&apos;t attempt to restart or shut down the computer unless

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import InfoButton from "../InfoButton";
 import SetupStatusTable from "./SetupStatusTable";
 
+import { hasRemainingSetupSteps } from "../../helpers";
+
 const baseClass = "setting-up-your-device";
 
 interface ISettingUpYourDevice {
@@ -15,22 +17,19 @@ const SettingUpYourDevice = ({
   setupSteps,
   toggleInfoModal,
 }: ISettingUpYourDevice) => {
-  const stepsAllComplete = setupSteps.every(
-    (step) => step.status !== "pending" && step.status !== "running"
-  );
   let title;
   let message;
-  if (stepsAllComplete) {
-    title = "Configuration complete";
-    message =
-      "Your computer has been successfully configured. Setup will continue momentarily.";
-  } else {
+  if (hasRemainingSetupSteps(setupSteps)) {
     title = "Setting up your device...";
     message = `
       Your computer is currently being configured by your organization.
       Please don&apos;t attempt to restart or shut down the computer unless
       prompted to do so.
     `;
+  } else {
+    title = "Configuration complete";
+    message =
+      "Your computer has been successfully configured. Setup will continue momentarily.";
   }
 
   return (

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -15,18 +15,32 @@ const SettingUpYourDevice = ({
   setupSteps,
   toggleInfoModal,
 }: ISettingUpYourDevice) => {
+  const stepsAllComplete = setupSteps.every(
+    (step) => step.status !== "pending" && step.status !== "running"
+  );
+  let title;
+  let message;
+  if (stepsAllComplete) {
+    title = "Configuration complete";
+    message =
+      "Your computer has been successfully configured. Setup will continue momentarily.";
+  } else {
+    title = "Setting up your device...";
+    message = `
+      Your computer is currently being configured by your organization.
+      Please don&apos;t attempt to restart or shut down the computer unless
+      prompted to do so.
+    `;
+  }
+
   return (
     <div className={`${baseClass} main-content device-user`}>
       <Card borderRadiusSize="xxlarge" paddingSize="xlarge">
         <div className={`${baseClass}__header`}>
-          <h2>Setting up your device...</h2>
+          <h2>{title}</h2>
           <InfoButton onClick={toggleInfoModal} />
         </div>
-        <p>
-          Your computer is currently being configured by your organization.
-          Please don&apos;t attempt to restart or shut down the computer unless
-          prompted to do so.
-        </p>
+        <p>{message}</p>
         <SetupStatusTable statuses={setupSteps} />
       </Card>
     </div>

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -1,5 +1,5 @@
 import Card from "components/Card";
-import { ISetupStep } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 import React from "react";
 import InfoButton from "../InfoButton";
 import SetupSoftwareStatusTable from "./SetupStatusTable";

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupSoftwareStatusTable/index.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupSoftwareStatusTable/index.ts
@@ -1,1 +1,0 @@
-export { default } from "./SetupSoftwareStatusTable";

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
@@ -16,6 +16,17 @@ interface ISetupStatusTableProps {
 const SetupStatusTable = ({ statuses }: ISetupStatusTableProps) => {
   const columnConfigs = generateColumnConfigs();
 
+  // Sort the statuses so that scripts are always at the bottom.
+  statuses.sort((a, b) => {
+    if (a.type === b.type) {
+      return 0;
+    }
+    if (a.type === "script") {
+      return 1;
+    }
+    return -1;
+  });
+
   return (
     <div className={baseClass}>
       <TableContainer
@@ -26,6 +37,7 @@ const SetupStatusTable = ({ statuses }: ISetupStatusTableProps) => {
         isAllPagesSelected={false}
         disableTableHeader={false}
         disablePagination
+        manualSortBy
         pageSize={statuses.length}
         emptyComponent={() => (
           // will never be empty

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ISetupStep } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 
 import TableContainer from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTable.tsx
@@ -1,21 +1,19 @@
 import React from "react";
 
-import { ISetupSoftwareStatus } from "interfaces/software";
+import { ISetupStep } from "interfaces/software";
 
 import TableContainer from "components/TableContainer";
 import EmptyTable from "components/EmptyTable";
 
-import generateColumnConfigs from "./SetupSoftwareStatusTableConfig";
+import generateColumnConfigs from "./SetupStatusTableConfig";
 
-const baseClass = "setup-software-status-table";
+const baseClass = "setup-status-table";
 
-interface ISetupSoftwareStatusTableProps {
-  statuses: ISetupSoftwareStatus[];
+interface ISetupStatusTableProps {
+  statuses: ISetupStep[];
 }
 
-const SetupSoftwareStatusTable = ({
-  statuses,
-}: ISetupSoftwareStatusTableProps) => {
+const SetupStatusTable = ({ statuses }: ISetupStatusTableProps) => {
   const columnConfigs = generateColumnConfigs();
 
   return (
@@ -32,8 +30,8 @@ const SetupSoftwareStatusTable = ({
         emptyComponent={() => (
           // will never be empty
           <EmptyTable
-            header="No software to install"
-            info="Software setup status will appear here"
+            header="No setup steps to complete"
+            info="Setup items will appear here"
           />
         )}
       />
@@ -41,4 +39,4 @@ const SetupSoftwareStatusTable = ({
   );
 };
 
-export default SetupSoftwareStatusTable;
+export default SetupStatusTable;

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -2,15 +2,15 @@ import React from "react";
 
 import { CellProps, Column } from "react-table";
 
-import { ISetupSoftwareStatus } from "interfaces/software";
+import { ISetupStep } from "interfaces/software";
 
 import SetupSoftwareProcessCell from "components/TableContainer/DataTable/SetupSoftwareProcessCell";
 import SetupSoftwareStatusCell from "components/TableContainer/DataTable/SetupSoftwareStatusCell";
 
-type ISetupSoftwareStatusTableConfig = Column<ISetupSoftwareStatus>;
-type ITableCellProps = CellProps<ISetupSoftwareStatus>;
+type ISetupStatusTableConfig = Column<ISetupStep>;
+type ITableCellProps = CellProps<ISetupStep>;
 
-const generateColumnConfigs = (): ISetupSoftwareStatusTableConfig[] => [
+const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
   {
     Header: "Process",
     accessor: "name",

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { CellProps, Column } from "react-table";
 
-import { ISetupStep } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 
 import SetupSoftwareProcessCell from "components/TableContainer/DataTable/SetupSoftwareProcessCell";
 import SetupSoftwareStatusCell from "components/TableContainer/DataTable/SetupSoftwareStatusCell";

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -6,6 +6,8 @@ import { ISetupStep } from "interfaces/setup";
 
 import SetupSoftwareProcessCell from "components/TableContainer/DataTable/SetupSoftwareProcessCell";
 import SetupSoftwareStatusCell from "components/TableContainer/DataTable/SetupSoftwareStatusCell";
+import SetupScriptProcessCell from "components/TableContainer/DataTable/SetupScriptProcessCell";
+import SetupScriptStatusCell from "components/TableContainer/DataTable/SetupScriptStatusCell";
 
 type ISetupStatusTableConfig = Column<ISetupStep>;
 type ITableCellProps = CellProps<ISetupStep>;
@@ -16,9 +18,14 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
     accessor: "name",
     disableSortBy: true,
     Cell: (cellProps: ITableCellProps) => {
-      const { name } = cellProps.row.original;
-
-      return <SetupSoftwareProcessCell name={name || "Unknown software"} />;
+      const { name, type } = cellProps.row.original;
+      if (type === "software") {
+        return <SetupSoftwareProcessCell name={name || "Unknown software"} />;
+      }
+      if (type === "script") {
+        return <SetupScriptProcessCell name={name || "Unknown script"} />;
+      }
+      return null;
     },
   },
   {
@@ -26,9 +33,14 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
     accessor: "status",
     disableSortBy: true,
     Cell: (cellProps: ITableCellProps) => {
-      const { status } = cellProps.row.original;
-
-      return <SetupSoftwareStatusCell status={status || "pending"} />;
+      const { status, type } = cellProps.row.original;
+      if (type === "software") {
+        return <SetupSoftwareStatusCell status={status || "pending"} />;
+      }
+      if (type === "script") {
+        return <SetupScriptStatusCell status={status || "pending"} />;
+      }
+      return null;
     },
   },
 ];

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/index.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SetupStatusTable";

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
@@ -22,4 +22,8 @@
   p {
     margin: 0;
   }
+
+  .empty-table__container {
+    max-width: 100%;
+  }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/_styles.scss
@@ -1,7 +1,11 @@
 .setting-up-your-device {
   &__header {
-    display: inline-flex;
+    display: flex;
     justify-content: space-between;
+
+    .info-button {
+      padding-top: 0;
+    }
   }
   &__title {
     font-weight: $bold;

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -1,4 +1,4 @@
-import { ISetupSoftwareStatus } from "interfaces/software";
+import { ISetupStep } from "interfaces/software";
 
 const DEFAULT_ERROR_MESSAGE = "refetch error.";
 
@@ -7,8 +7,8 @@ export const getErrorMessage = (e: unknown, hostName: string) => {
   return `Host "${hostName}" ${DEFAULT_ERROR_MESSAGE}`;
 };
 
-export const getIsSettingUpSoftware = (
-  statuses: ISetupSoftwareStatus[] | null | undefined
+export const hasRemainingSetupSteps = (
+  statuses: ISetupStep[] | null | undefined
 ) => {
   if (!statuses || statuses.length === 0) {
     // not configured or no software selected

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -1,4 +1,4 @@
-import { ISetupStep } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 
 const DEFAULT_ERROR_MESSAGE = "refetch error.";
 

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -176,23 +176,10 @@ export default {
 
   getSetupExperienceStatuses: ({
     token,
-  }: IGetSetupExperienceStatusesParams): Promise<ISetupStep[]> => {
+  }: IGetSetupExperienceStatusesParams): Promise<IGetSetupExperienceStatusesResponse> => {
     const { DEVICE_SETUP_EXPERIENCE_STATUSES } = endpoints;
     const path = DEVICE_SETUP_EXPERIENCE_STATUSES(token);
-    return sendRequest("POST", path).then(
-      (response: IGetSetupExperienceStatusesResponse) => {
-        return [
-          ...(response.setup_experience_results.software ?? []).map((s) => ({
-            ...s,
-            type: "software" as const,
-          })),
-          ...(response.setup_experience_results.scripts ?? []).map((s) => ({
-            ...s,
-            type: "script" as const,
-          })),
-        ];
-      }
-    );
+    return sendRequest("POST", path);
   },
 
   resendProfile: (deviceToken: string, profileUUID: string) => {

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -53,7 +53,7 @@ export interface IGetVppInstallCommandResultsResponse {
   results: IMdmCommandResult[];
 }
 export interface IGetSetupExperienceStatusesResponse {
-  setup_experience_results: { software?: ISetupStep[]; scripts?: ISetupStep[] };
+  setup_experience_results: { software: ISetupStep[]; scripts: ISetupStep[] };
 }
 
 export interface IGetSetupExperienceStatusesParams {
@@ -176,10 +176,23 @@ export default {
 
   getSetupExperienceStatuses: ({
     token,
-  }: IGetSetupExperienceStatusesParams): Promise<IGetSetupExperienceStatusesResponse> => {
+  }: IGetSetupExperienceStatusesParams): Promise<ISetupStep[]> => {
     const { DEVICE_SETUP_EXPERIENCE_STATUSES } = endpoints;
     const path = DEVICE_SETUP_EXPERIENCE_STATUSES(token);
-    return sendRequest("POST", path);
+    return sendRequest("POST", path).then(
+      (response: IGetSetupExperienceStatusesResponse) => {
+        return [
+          ...(response.setup_experience_results.software ?? []).map((s) => ({
+            ...s,
+            type: "software" as const,
+          })),
+          ...(response.setup_experience_results.scripts ?? []).map((s) => ({
+            ...s,
+            type: "script" as const,
+          })),
+        ];
+      }
+    );
   },
 
   resendProfile: (deviceToken: string, profileUUID: string) => {

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -1,6 +1,6 @@
 import { IDeviceUserResponse } from "interfaces/host";
 import { IListOptions } from "interfaces/list_options";
-import { IDeviceSoftware, ISetupSoftwareStatus } from "interfaces/software";
+import { IDeviceSoftware, ISetupStep } from "interfaces/software";
 import { IHostCertificate } from "interfaces/certificates";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
@@ -52,7 +52,7 @@ export interface IGetVppInstallCommandResultsResponse {
   results: IMdmCommandResult[];
 }
 export interface IGetSetupSoftwareStatusesResponse {
-  setup_experience_results: { software?: ISetupSoftwareStatus[] };
+  setup_experience_results: { software?: ISetupStep[] };
 }
 
 export interface IGetSetupSoftwareStatusesParams {

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -1,6 +1,7 @@
 import { IDeviceUserResponse } from "interfaces/host";
 import { IListOptions } from "interfaces/list_options";
-import { IDeviceSoftware, ISetupStep } from "interfaces/software";
+import { IDeviceSoftware } from "interfaces/software";
+import { ISetupStep } from "interfaces/setup";
 import { IHostCertificate } from "interfaces/certificates";
 import sendRequest from "services";
 import endpoints from "utilities/endpoints";
@@ -51,11 +52,11 @@ export interface IGetDeviceCertsRequestParams extends IListOptions {
 export interface IGetVppInstallCommandResultsResponse {
   results: IMdmCommandResult[];
 }
-export interface IGetSetupSoftwareStatusesResponse {
+export interface IGetSetupExperienceStatusesResponse {
   setup_experience_results: { software?: ISetupStep[] };
 }
 
-export interface IGetSetupSoftwareStatusesParams {
+export interface IGetSetupExperienceStatusesParams {
   token: string;
 }
 
@@ -173,11 +174,11 @@ export default {
     return sendRequest("GET", path);
   },
 
-  getSetupSoftwareStatuses: ({
+  getSetupExperienceStatuses: ({
     token,
-  }: IGetSetupSoftwareStatusesParams): Promise<IGetSetupSoftwareStatusesResponse> => {
-    const { DEVICE_SETUP_SOFTWARE_STATUSES } = endpoints;
-    const path = DEVICE_SETUP_SOFTWARE_STATUSES(token);
+  }: IGetSetupExperienceStatusesParams): Promise<IGetSetupExperienceStatusesResponse> => {
+    const { DEVICE_SETUP_EXPERIENCE_STATUSES } = endpoints;
+    const path = DEVICE_SETUP_EXPERIENCE_STATUSES(token);
     return sendRequest("POST", path);
   },
 

--- a/frontend/services/entities/device_user.ts
+++ b/frontend/services/entities/device_user.ts
@@ -53,7 +53,7 @@ export interface IGetVppInstallCommandResultsResponse {
   results: IMdmCommandResult[];
 }
 export interface IGetSetupExperienceStatusesResponse {
-  setup_experience_results: { software?: ISetupStep[] };
+  setup_experience_results: { software?: ISetupStep[]; scripts?: ISetupStep[] };
 }
 
 export interface IGetSetupExperienceStatusesParams {

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -12,7 +12,7 @@ import { baseUrl } from "test/test-utils";
 import { IDeviceUserResponse } from "interfaces/host";
 import {
   IGetDeviceSoftwareResponse,
-  IGetSetupSoftwareStatusesResponse,
+  IGetSetupExperienceStatusesResponse,
 } from "services/entities/device_user";
 import { IGetHostCertificatesResponse } from "services/entities/hosts";
 
@@ -87,7 +87,7 @@ export const defaultDeviceCertificatesHandler = http.get(
 );
 
 export const deviceSetupExperienceHandler = (
-  overrides?: Partial<IGetSetupSoftwareStatusesResponse>
+  overrides?: Partial<IGetSetupExperienceStatusesResponse>
 ) =>
   http.post(baseUrl("/device/:token/setup_experience/status"), () => {
     return HttpResponse.json(

--- a/frontend/test/handlers/device-handler.ts
+++ b/frontend/test/handlers/device-handler.ts
@@ -96,5 +96,5 @@ export const deviceSetupExperienceHandler = (
   });
 
 export const emptySetupExperienceHandler = deviceSetupExperienceHandler({
-  setup_experience_results: { software: [] },
+  setup_experience_results: { software: [], scripts: [] },
 });

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -62,7 +62,7 @@ export default {
   DEVICE_CERTIFICATES: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/certificates`;
   },
-  DEVICE_SETUP_SOFTWARE_STATUSES: (token: string): string => {
+  DEVICE_SETUP_EXPERIENCE_STATUSES: (token: string): string => {
     return `/${API_VERSION}/fleet/device/${token}/setup_experience/status`;
   },
   DEVICE_RESEND_PROFILE: (token: string, profileUUID: string) =>

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -194,6 +194,8 @@ func IsSetupExperienceSupported(hostPlatform string) bool {
 type DeviceSetupExperienceStatusPayload struct {
 	// Software holds the status of the software to install on the device.
 	Software []*SetupExperienceStatusResult `json:"software,omitempty"`
+	// Scripts holds the status of the scripts to run on the device.
+	Scripts []*SetupExperienceStatusResult `json:"scripts,omitempty"`
 }
 
 // HostUUIDForSetupExperience returns the host "UUID" to use during the "Setup experience"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33173

# Details

This PR updates the "Setting up your device" page which appears in Linux and Windows (and as of https://github.com/fleetdm/fleet/issues/30117, MacOS) setup experiences. Front-end updates:

* Lots of renaming of things that were software-specific to now more generically refer to "setup step"
* Removed the "My Device" heading
* Moved the info button inside the table header
* Added status of setup script run to the table
* Updated the empty state to not refer specifically to software
* Added optional `setup_only` query param to the `/device` page which, if set, will always show the "setting up your device" page even if all setup is complete. Normally as soon as setup finishes, the front-end redirects to the regular My Device page. In the case of MacOS setup experience, we don't want this to happen as we expect to either 1) keep the setup experience up indefinitely if we're blocking device setup on software install failure, or 2) close the setup dialog on successful completion. This query param is also handy for testing.
* Added new "Configuration complete" state to be shown when all setup steps are finished (successfully or not). This is only applicable on MacOS, since other platforms will redirect to the My Device page when finished.

This PR also includes one small backend change to the `/device/{token}/setup_experience/status` API endpoint, to have it return a `scripts` array alongside the existing `software` array. This endpoint is not documented publicly.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
Updated existing DeviceUserPage tests that check the SettingUpYourDevice content, and added new tests for the new scripts content and the new query param.

- [X] QA'd all new/changed functionality manually

<img width="1028" height="867" alt="Screenshot 2025-10-02 at 7 20 28 PM" src="https://github.com/user-attachments/assets/7adab2c2-dac1-4463-96fc-13094da2c379" />

(note that as of now we'd only have at most one script, showing multiple here to demonstrate the different states)

<img width="1031" height="524" alt="Screenshot 2025-10-02 at 7 22 01 PM" src="https://github.com/user-attachments/assets/bedaa840-d7ef-4b6f-8daf-6ac3b447594f" />

<img width="1222" height="760" alt="image" src="https://github.com/user-attachments/assets/42cf82d5-53e0-4c4d-b60e-9ac2cc86af68" />


