### PR TITLE
Melpike design challenge

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -438,6 +438,21 @@ The `macos_migration` section lets you control the [end user migration workflow]
 
 Can only be configured for all teams (`default.yml`).
 
+## vulnerabilities
+
+```yaml
+vulnerabilities:
+  dismissed:
+    - cve: CVE-2025-23432
+      reason: dkdkda
+      notes:
+      owner:
+    - cve: CVE-2025-23432
+      reason: dkdkda
+      notes:
+      owner:
+```
+
 ## software
 
 > **Experimental feature**. This feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -933,6 +933,7 @@ org_settings:
 - `enable_vulnerabilities_webhook` (default: `false`)
 - `destination_url` is the URL to `POST` to when the condition for the webhook triggers (default: `""`).
 - `host_batch_size` is the maximum number of host identifiers to send in one webhook request. A value of `0` means all host identifiers with a detected vulnerability will be sent in a single request.
+- `include_status_details` designates whether or not to include the new field of status-details object.
 
 #### Example
 
@@ -943,6 +944,7 @@ org_settings:
       enable_vulnerabilities_webhook: true
       destination_url: https://example.org/webhook_handler
       host_batch_size: 0
+      include_status_details: true
 ```
 
 Can only be configured for all teams (`org_settings`).

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -10974,16 +10974,17 @@ Update vulnerability status details when changes are made to status, notes, and/
 | cve     | string  | path  | The cve to get information about (format must be CVE-YYYY-<4 or more digits>, case-insensitive).                             |
 | team_id | integer | query | _Available in Fleet Premium_. Filters response data to the specified team. Use `0` to filter by hosts assigned to "No team". |
 
-`POST /api/v1/fleet/vulnerabilities/:cve`
+`POST /api/v1/fleet/vulnerabilities`
 
 #### Example
 
-`POST /api/v1/fleet/vulnerabilities/cve-2022-30190`
+`POST /api/v1/fleet/vulnerabilities`
 
 ##### Request body
 
 ```json
 {
+  "cves": ["CVE-2025-1000"],
   "status_details": {
 	"status": "Dismissed",
 	"reason": "Deferred",

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9883,6 +9883,10 @@ Returns information about the specified software. By default, `versions` are sor
     "app_store_app": null,
     "counts_updated_at": "2024-11-03T22:39:36Z",
     "source": "apps",
+	"vulnerability_counts": {
+	  "vulnerable_count": 2,
+	  "dismissed_count": 0,
+	},
     "hosts_count": 48,
     "versions": [
       {
@@ -10829,6 +10833,7 @@ Deletes software that's available for install. This won't uninstall the software
 
 - [List vulnerabilities](#list-vulnerabilities)
 - [Get vulnerability](#get-vulnerability)
+- [Update vulnerability](#update-vulnerability)
 
 ### List vulnerabilities
 
@@ -10860,6 +10865,13 @@ Retrieves a list of all CVEs affecting software and/or OS versions.
       "cve": "CVE-2022-30190",
       "created_at": "2022-06-01T00:15:00Z",
       "hosts_count": 1234,
+	  "status_details": {
+	    "status": "Dismissed",
+		"reason": "Deferred",
+		"notes": "",
+	    "last_updated": "2025-09-30T13:45:00Z",
+	    "owner": "UserId123",
+	  },
       "hosts_count_updated_at": "2023-12-20T15:23:57Z",
       "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2022-30190",
       "cvss_score": 7.8,// Available in Fleet Premium
@@ -10908,6 +10920,97 @@ If no vulnerable OS versions or software were found, but Fleet is aware of the v
   "created_at": "2022-06-01T00:15:00Z",
   "hosts_count": 1234,
   "hosts_count_updated_at": "2023-12-20T15:23:57Z",
+  "status_details": {
+	"status": "Dismissed",
+	"reason": "Deferred",
+	"notes": "",
+	"last_updated": "2025-09-30T13:45:00Z",
+	"owner": "UserId123",
+  },
+  "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2022-30190",
+  "cvss_score": 7.8,// Available in Fleet Premium
+  "epss_probability": 0.9729,// Available in Fleet Premium
+  "cisa_known_exploit": false,// Available in Fleet Premium
+  "cve_published": "2022-06-01T00:15:00Z",// Available in Fleet Premium
+  "cve_description": "Microsoft Windows Support Diagnostic Tool (MSDT) Remote Code Execution Vulnerability.",// Available in Fleet Premium
+  "os_versions" : [
+    {
+      "os_version_id": 6,
+      "hosts_count": 200,
+      "name": "macOS 14.1.2",
+      "name_only": "macOS",
+      "version": "14.1.2",
+
+      "resolved_in_version": "14.2",
+      "generated_cpes": [
+        "cpe:2.3:o:apple:macos:*:*:*:*:*:14.2:*:*",
+        "cpe:2.3:o:apple:mac_os_x:*:*:*:*:*:14.2:*:*"
+      ]
+    }
+  ],
+  "software": [
+    {
+      "id": 2363,
+      "software_title_id": 124,
+      "name": "Docker Desktop",
+      "version": "4.9.1",
+      "source": "programs",
+      "generated_cpe": "cpe:2.3:a:docker:docker_desktop:4.9.1:*:*:*:*:windows:*:*",
+      "hosts_count": 50,
+      "resolved_in_version": "5.0.0"
+    }
+  ]
+}
+```
+
+### Update vulnerability
+
+Update vulnerability status details when changes are made to status, notes, and/or reason.
+
+#### Parameters
+
+| Name    | Type    | In    | Description                                                                                                                  |
+|---------|---------|-------|------------------------------------------------------------------------------------------------------------------------------|
+| cve     | string  | path  | The cve to get information about (format must be CVE-YYYY-<4 or more digits>, case-insensitive).                             |
+| team_id | integer | query | _Available in Fleet Premium_. Filters response data to the specified team. Use `0` to filter by hosts assigned to "No team". |
+
+`POST /api/v1/fleet/vulnerabilities/:cve`
+
+#### Example
+
+`POST /api/v1/fleet/vulnerabilities/cve-2022-30190`
+
+##### Request body
+
+```json
+{
+  "status_details": {
+	"status": "Dismissed",
+	"reason": "Deferred",
+	"notes": "",
+	"last_updated": "2025-09-30T13:45:00Z",
+	"owner": "UserId123",
+  }
+}
+```
+
+##### Default response
+
+`Status: 200`
+
+```json
+"vulnerability": {
+  "cve": "CVE-2022-30190",
+  "created_at": "2022-06-01T00:15:00Z",
+  "hosts_count": 1234,
+  "hosts_count_updated_at": "2023-12-20T15:23:57Z",
+  "status_details": {
+	"status": "Dismissed",
+	"reason": "Deferred",
+	"notes": "",
+	"last_updated": "2025-09-30T13:45:00Z",
+	"owner": "UserId123",
+  },
   "details_link": "https://nvd.nist.gov/vuln/detail/CVE-2022-30190",
   "cvss_score": 7.8,// Available in Fleet Premium
   "epss_probability": 0.9729,// Available in Fleet Premium


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
