### PR TITLE
Allow specifying setup experience apps for iOS/iPadOS

### DIFF
--- a/changes/30890-added-install-software-ios-ipados
+++ b/changes/30890-added-install-software-ios-ipados
@@ -1,0 +1,1 @@
+* Added the ability to specify VPP apps for automatic installation during ADE iOS and iPadOS host enrollment

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -849,7 +849,7 @@ func (ds *Datastore) cancelHostUpcomingActivity(ctx context.Context, tx sqlx.Ext
 		return nil, ctxerr.Wrap(ctx, err, "load host UUID fields")
 	}
 	hostUUID := host.UUID
-	if host.Platform == "darwin" || fleet.IsLinux(host.Platform) || host.Platform == "windows" {
+	if host.Platform == "darwin" || host.Platform == "ios" || host.Platform == "ipados" || fleet.IsLinux(host.Platform) || host.Platform == "windows" {
 		hostUUID, err = fleet.HostUUIDForSetupExperience(&host)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "failed to get host's UUID for the setup experience")

--- a/server/datastore/mysql/activities.go
+++ b/server/datastore/mysql/activities.go
@@ -849,7 +849,7 @@ func (ds *Datastore) cancelHostUpcomingActivity(ctx context.Context, tx sqlx.Ext
 		return nil, ctxerr.Wrap(ctx, err, "load host UUID fields")
 	}
 	hostUUID := host.UUID
-	if host.Platform == "darwin" || host.Platform == "ios" || host.Platform == "ipados" || fleet.IsLinux(host.Platform) || host.Platform == "windows" {
+	if fleet.IsSetupExperienceSupported(host.Platform) {
 		hostUUID, err = fleet.HostUUIDForSetupExperience(&host)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "failed to get host's UUID for the setup experience")

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -157,7 +157,7 @@ WHERE global_or_team_id = ?`
 
 func (ds *Datastore) SetSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, titleIDs []uint) error {
 	if platform != string(fleet.MacOSPlatform) && platform != "windows" && platform != "linux" && platform != string(fleet.IOSPlatform) && platform != string(fleet.IPadOSPlatform) {
-		return ctxerr.Errorf(ctx, "platform %q is not supported, only %q, \"windows\", or \"linux\" platforms are supported", platform, fleet.MacOSPlatform)
+		return ctxerr.Errorf(ctx, "platform %q is not supported, only %q, %q, %q, \"windows\", or \"linux\" platforms are supported", platform, fleet.MacOSPlatform, fleet.IOSPlatform, fleet.IPadOSPlatform)
 	}
 
 	titleIDQuestionMarks := strings.Join(slices.Repeat([]string{"?"}, len(titleIDs)), ",")
@@ -362,7 +362,7 @@ func (ds *Datastore) GetSetupExperienceCount(ctx context.Context, platform strin
 
 func (ds *Datastore) ListSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, opts fleet.ListOptions) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {
 	if platform != string(fleet.MacOSPlatform) && platform != "windows" && platform != "linux" && platform != string(fleet.IOSPlatform) && platform != string(fleet.IPadOSPlatform) {
-		return nil, 0, nil, ctxerr.Errorf(ctx, "platform %q is not supported, only %q, \"windows\", or \"linux\" platforms are supported", platform, fleet.MacOSPlatform)
+		return nil, 0, nil, ctxerr.Errorf(ctx, "platform %q is not supported, only %q, %q, %q, \"windows\", or \"linux\" platforms are supported", platform, fleet.MacOSPlatform, fleet.IOSPlatform, fleet.IPadOSPlatform)
 	}
 
 	opts.IncludeMetadata = true

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -249,7 +249,9 @@ WHERE id IN (%s)`
 			for _, tuple := range softwareIDPlatforms {
 				delete(missingTitleIDs, tuple.TitleID)
 				if tuple.Platform != platform {
-					return ctxerr.Errorf(ctx, "invalid platform for requested software installer: %d (%s, %s), vs. expected %s", tuple.ID, tuple.Name, tuple.Platform, platform)
+					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+						Message: fmt.Sprintf("invalid platform for requested software installer: %d (%s, %s), vs. expected %s", tuple.ID, tuple.Name, tuple.Platform, platform),
+					})
 				}
 				softwareIDs = append(softwareIDs, tuple.ID)
 			}
@@ -267,7 +269,9 @@ WHERE id IN (%s)`
 			for _, tuple := range vppIDPlatforms {
 				delete(missingTitleIDs, tuple.TitleID)
 				if tuple.Platform != platform {
-					return ctxerr.Errorf(ctx, "invalid platform for requested AppStoreApp title: %d (%s, %s), vs. expected %s", tuple.ID, tuple.Name, tuple.Platform, platform)
+					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+						Message: fmt.Sprintf("invalid platform for requested AppStoreApp title: %d (%s, %s), vs. expected %s", tuple.ID, tuple.Name, tuple.Platform, platform),
+					})
 				}
 				vppAppTeamIDs = append(vppAppTeamIDs, tuple.ID)
 			}
@@ -288,7 +292,7 @@ WHERE id IN (%s)`
 		}
 
 		// Unset all vpp apps
-		if platform == string(fleet.MacOSPlatform) {
+		if platform == string(fleet.MacOSPlatform) || platform == string(fleet.IOSPlatform) || platform == string(fleet.IPadOSPlatform) {
 			if _, err := tx.ExecContext(ctx, stmtUnsetVPPAppsTeams, platform, teamID); err != nil {
 				return ctxerr.Wrap(ctx, err, "unsetting vpp app teams")
 			}

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -156,7 +156,6 @@ WHERE global_or_team_id = ?`
 }
 
 func (ds *Datastore) SetSetupExperienceSoftwareTitles(ctx context.Context, platform string, teamID uint, titleIDs []uint) error {
-	// TODO EJM clean up
 	if platform != string(fleet.MacOSPlatform) && platform != "windows" && platform != "linux" && platform != string(fleet.IOSPlatform) && platform != string(fleet.IPadOSPlatform) {
 		return ctxerr.Errorf(ctx, "platform %q is not supported, only %q, \"windows\", or \"linux\" platforms are supported", platform, fleet.MacOSPlatform)
 	}

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -682,13 +682,14 @@ func testSetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 	assert.False(t, *titles[0].SoftwarePackage.InstallDuringSetup)
 	assert.False(t, *titles[1].AppStoreApp.InstallDuringSetup)
 
-	// iOS software
+	// iOS software. iOS only supports VPP apps so should not check installers
+	// even if one somehow exists
 	err = ds.SetSetupExperienceSoftwareTitles(ctx, "ios", team2.ID, []uint{titleSoftware["file4"]})
-	require.ErrorContains(t, err, "is not supported")
+	require.ErrorContains(t, err, "not available")
 
 	// ios vpp app
 	err = ds.SetSetupExperienceSoftwareTitles(ctx, "darwin", team1.ID, []uint{titleVPP["2:ios"]})
-	require.ErrorContains(t, err, "not available")
+	require.ErrorContains(t, err, "invalid platform for requested AppStoreApp")
 
 	// wrong team
 	err = ds.SetSetupExperienceSoftwareTitles(ctx, "darwin", team1.ID, []uint{titleVPP["3"]})

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -186,8 +186,10 @@ type SetupExperienceStatusPayload struct {
 }
 
 // IsSetupExperienceSupported returns whether "Setup experience" is supported for the host's platform.
+// TODO: Setup Experience supports a wide range of platforms now but has a feature matrix where not all
+// platforms support all features. May be worth refactoring to check for supported features instead
 func IsSetupExperienceSupported(hostPlatform string) bool {
-	return hostPlatform == "darwin" || hostPlatform == "windows" || IsLinux(hostPlatform)
+	return hostPlatform == "darwin" || hostPlatform == "ios" || hostPlatform == "ipados" || hostPlatform == "windows" || IsLinux(hostPlatform)
 }
 
 // DeviceSetupExperienceStatusPayload holds the status of the "Setup experience" for a device.
@@ -197,7 +199,7 @@ type DeviceSetupExperienceStatusPayload struct {
 }
 
 // HostUUIDForSetupExperience returns the host "UUID" to use during the "Setup experience"
-// for a non-darwin host.
+// for a non-Apple host.
 //
 // The setup_experience_status_results uses the host's "UUID" as the host identifier because the table
 // was created to implement "Setup experience" for macOS devices.
@@ -206,7 +208,7 @@ type DeviceSetupExperienceStatusPayload struct {
 // use the host.OsqueryHostID as UUID. For Windows/Linux devices, the "Setup experience" will be triggered after orbit
 // and osquery enrollment, thus host.OsqueryHostID will always be set and unique.
 func HostUUIDForSetupExperience(host *Host) (string, error) {
-	if host.Platform == string(MacOSPlatform) {
+	if host.Platform == string(MacOSPlatform) || host.Platform == string(IOSPlatform) || host.Platform == string(IPadOSPlatform) {
 		return host.UUID, nil
 	}
 	// Currently it seems this field is always set when orbit or osquery enroll,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3864,7 +3864,6 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 			cmdResult.Status == fleet.MDMAppleStatusCommandFormatError {
 
 			// this might be a setup experience VPP install, so we'll try to update setup experience status
-			// TODO: consider limiting this to only macOS hosts
 			var fromSetupExperience bool
 			if updated, err := maybeUpdateSetupExperienceStatus(r.Context, svc.ds, fleet.SetupExperienceVPPInstallResult{
 				HostUUID:      cmdResult.Identifier(),

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -1753,8 +1753,7 @@ func (s *integrationMDMTestSuite) TestSetupExperienceVPPCRUD() {
 	expectedApps := []*fleet.VPPApp{macOSApp1, macOSApp2, iOSApp2, iPadOSApp2, iPadOSApp3}
 
 	var addAppResp addAppStoreAppResponse
-	// Add apps as non-self-service
-	var titleIDs []uint
+	// Add apps
 	getSoftwareTitleIDFromApp := func(app *fleet.VPPApp) uint {
 		var titleID uint
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -1773,7 +1772,6 @@ func (s *integrationMDMTestSuite) TestSetupExperienceVPPCRUD() {
 			&addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: app.AdamID, Platform: app.Platform},
 			http.StatusOK, &addAppResp)
 		titleIDsByApp[app] = getSoftwareTitleIDFromApp(app)
-		titleIDs = append(titleIDs, titleIDsByApp[app])
 
 		// Add apps to the other team as well so that they are available but should not show up in setup experience
 		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/mdm/mdmtest"
@@ -23,6 +24,7 @@ import (
 	"github.com/jmoiron/sqlx"
 	micromdm "github.com/micromdm/micromdm/mdm/mdm"
 	"github.com/micromdm/plist"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1645,11 +1647,232 @@ func (s *integrationMDMTestSuite) TestSetupExperienceEndpointsWithPlatform() {
 	res := s.DoRawWithHeaders("PUT", "/api/v1/fleet/setup_experience/software", []byte(`{"platform": "foobar", "team_id": 0}`), http.StatusBadRequest, nil)
 	errMsg := extractServerErrorText(res.Body)
 	require.NoError(t, res.Body.Close())
-	require.Contains(t, errMsg, "platform \"foobar\" unsupported, platform must be \"macos\", \"windows\", or \"linux\"")
+	require.Contains(t, errMsg, "platform \"foobar\" unsupported, platform must be \"macos\", \"ios\", \"ipados\", \"windows\", or \"linux\"")
 	res = s.DoRawWithHeaders("GET", "/api/v1/fleet/setup_experience/software?platform=foobar&team_id=0", nil, http.StatusBadRequest, nil)
 	errMsg = extractServerErrorText(res.Body)
 	require.NoError(t, res.Body.Close())
-	require.Contains(t, errMsg, "platform \"foobar\" unsupported, platform must be \"macos\", \"windows\", or \"linux\"")
+	require.Contains(t, errMsg, "platform \"foobar\" unsupported, platform must be \"macos\", \"ios\", \"ipados\", \"windows\", or \"linux\"")
+}
+
+func (s *integrationMDMTestSuite) TestSetupExperienceVPPCRUD() {
+	t := s.T()
+	ctx := context.Background()
+
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "team 1"})
+	require.NoError(t, err)
+
+	// Just for testing isolation
+	otherTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "team 2"})
+	require.NoError(t, err)
+
+	orgName := "Fleet Device Management Inc."
+	token := "mycooltoken"
+	expTime := time.Now().Add(200 * time.Hour).UTC().Round(time.Second)
+	expDate := expTime.Format(fleet.VPPTimeFormat)
+	tokenJSON := fmt.Sprintf(`{"expDate":"%s","token":"%s","orgName":"%s"}`, expDate, token, orgName)
+	t.Setenv("FLEET_DEV_VPP_URL", s.appleVPPConfigSrv.URL)
+	var validToken uploadVPPTokenResponse
+	s.uploadDataViaForm("/api/latest/fleet/vpp_tokens", "token", "token.vpptoken", []byte(base64.StdEncoding.EncodeToString([]byte(tokenJSON))), http.StatusAccepted, "", &validToken)
+
+	var getVPPTokenResp getVPPTokensResponse
+	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &getVPPTokenResp)
+
+	t.Cleanup(func() {
+		s.appleVPPConfigSrvConfig.Assets = defaultVPPAssetList
+	})
+
+	// Associate team to the VPP token.
+	var resPatchVPP patchVPPTokensTeamsResponse
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", getVPPTokenResp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID, otherTeam.ID}}, http.StatusOK, &resPatchVPP)
+
+	// app 1 macOS only
+	macOSApp1 := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{
+			VPPAppID: fleet.VPPAppID{
+				AdamID:   "1",
+				Platform: fleet.MacOSPlatform,
+			},
+		},
+		Name:             "App 1",
+		BundleIdentifier: "a-1",
+		IconURL:          "https://example.com/images/1",
+		LatestVersion:    "1.0.0",
+	}
+	// App 2 supports macOS, iOS, iPadOS
+	macOSApp2 := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{
+			VPPAppID: fleet.VPPAppID{
+				AdamID:   "2",
+				Platform: fleet.MacOSPlatform,
+			},
+		},
+		Name:             "App 2",
+		BundleIdentifier: "b-2",
+		IconURL:          "https://example.com/images/2",
+		LatestVersion:    "2.0.0",
+	}
+	iOSApp2 := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{
+			VPPAppID: fleet.VPPAppID{
+				AdamID:   "2",
+				Platform: fleet.IOSPlatform,
+			},
+		},
+		Name:             "App 2",
+		BundleIdentifier: "b-2",
+		IconURL:          "https://example.com/images/2",
+		LatestVersion:    "2.0.0",
+	}
+	iPadOSApp2 := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{
+			VPPAppID: fleet.VPPAppID{
+				AdamID:   "2",
+				Platform: fleet.IPadOSPlatform,
+			},
+		},
+		Name:             "App 2",
+		BundleIdentifier: "b-2",
+		IconURL:          "https://example.com/images/2",
+		LatestVersion:    "2.0.0",
+	}
+
+	// App 3 is iPadOS only
+	iPadOSApp3 := &fleet.VPPApp{
+		VPPAppTeam: fleet.VPPAppTeam{
+			VPPAppID: fleet.VPPAppID{
+				AdamID:   "3",
+				Platform: fleet.IPadOSPlatform,
+			},
+		},
+		Name:             "App 3",
+		BundleIdentifier: "c-3",
+		IconURL:          "https://example.com/images/3",
+		LatestVersion:    "3.0.0",
+	}
+
+	expectedApps := []*fleet.VPPApp{macOSApp1, macOSApp2, iOSApp2, iPadOSApp2, iPadOSApp3}
+
+	var addAppResp addAppStoreAppResponse
+	// Add apps as non-self-service
+	var titleIDs []uint
+	getSoftwareTitleIDFromApp := func(app *fleet.VPPApp) uint {
+		var titleID uint
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			ctx := context.Background()
+			return sqlx.GetContext(ctx, q, &titleID, `SELECT title_id FROM vpp_apps WHERE adam_id = ? AND platform = ?`, app.AdamID, app.Platform)
+		})
+		require.NoError(t, err)
+
+		return titleID
+	}
+
+	titleIDsByApp := make(map[*fleet.VPPApp]uint)
+	for _, app := range expectedApps {
+		addAppResp = addAppStoreAppResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",
+			&addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: app.AdamID, Platform: app.Platform},
+			http.StatusOK, &addAppResp)
+		titleIDsByApp[app] = getSoftwareTitleIDFromApp(app)
+		titleIDs = append(titleIDs, titleIDsByApp[app])
+
+		// Add apps to the other team as well so that they are available but should not show up in setup experience
+		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",
+			&addAppStoreAppRequest{TeamID: &otherTeam.ID, AppStoreID: app.AdamID, Platform: app.Platform},
+			http.StatusOK, &addAppResp)
+	}
+
+	// Helper function for inspecting returned list of software marked for setup experience
+	getReturnedSetupExperienceTitleIDs := func(titles []fleet.SoftwareTitleListResult) []uint {
+		var titleIDs []uint
+		for _, title := range titles {
+			if (title.AppStoreApp != nil && title.AppStoreApp.InstallDuringSetup != nil && *title.AppStoreApp.InstallDuringSetup == true) ||
+				(title.SoftwarePackage != nil && title.SoftwarePackage.InstallDuringSetup != nil && *title.SoftwarePackage.InstallDuringSetup == true) {
+				titleIDs = append(titleIDs, title.ID)
+			}
+		}
+		return titleIDs
+	}
+
+	checkSetupExperienceSoftware := func(t *testing.T, platform string, teamID uint, expectedTitleIDs []uint) {
+		var respGetSetupExperience getSetupExperienceSoftwareResponse
+		s.DoJSON("GET", "/api/latest/fleet/setup_experience/software", getSetupExperienceSoftwareRequest{},
+			http.StatusOK,
+			&respGetSetupExperience,
+			"platform", platform,
+			"team_id", fmt.Sprint(teamID),
+		)
+		assert.ElementsMatch(t, getReturnedSetupExperienceTitleIDs(respGetSetupExperience.SoftwareTitles), expectedTitleIDs)
+	}
+
+	putSetupExperienceSoftwareForPlatform := func(t *testing.T, platform string, teamID uint, titleIDs []uint) {
+		var swInstallResp putSetupExperienceSoftwareResponse
+		s.DoJSON("PUT", "/api/v1/fleet/setup_experience/software", putSetupExperienceSoftwareRequest{
+			Platform: platform,
+			TeamID:   teamID,
+			TitleIDs: titleIDs,
+		}, http.StatusOK, &swInstallResp)
+	}
+
+	// Set the 2 apps for macOS
+	putSetupExperienceSoftwareForPlatform(t, "macos", team.ID, []uint{titleIDsByApp[macOSApp1], titleIDsByApp[macOSApp2]})
+
+	// Should return both of the items we set for macOS
+	checkSetupExperienceSoftware(t, "macos", team.ID, []uint{titleIDsByApp[macOSApp1], titleIDsByApp[macOSApp2]})
+
+	// Should return nothing for iOS/iPadOS
+	checkSetupExperienceSoftware(t, "ios", team.ID, []uint{})
+	checkSetupExperienceSoftware(t, "ipados", team.ID, []uint{})
+
+	// Should return nothing for macOS on other team
+	checkSetupExperienceSoftware(t, "macos", otherTeam.ID, []uint{})
+
+	// Add an app for iOS
+	putSetupExperienceSoftwareForPlatform(t, "ios", team.ID, []uint{titleIDsByApp[iOSApp2]})
+
+	// Fetch iOS apps for the team and now it should be listed
+	checkSetupExperienceSoftware(t, "ios", team.ID, []uint{titleIDsByApp[iOSApp2]})
+
+	// Should still return nothing for iPadOS
+	checkSetupExperienceSoftware(t, "ipados", team.ID, []uint{})
+
+	// Should still return both of the items we set for macOS
+	checkSetupExperienceSoftware(t, "macos", team.ID, []uint{titleIDsByApp[macOSApp1], titleIDsByApp[macOSApp2]})
+
+	// Add apps for iPadOS
+	putSetupExperienceSoftwareForPlatform(t, "ipados", team.ID, []uint{titleIDsByApp[iPadOSApp2], titleIDsByApp[iPadOSApp3]})
+
+	// Fetch iPadOS apps for the team and now they should be listed
+	checkSetupExperienceSoftware(t, "ipados", team.ID, []uint{titleIDsByApp[iPadOSApp2], titleIDsByApp[iPadOSApp3]})
+
+	// Should return nothing for iOS/iPadOS/macOS on the other team
+	checkSetupExperienceSoftware(t, "ios", otherTeam.ID, []uint{})
+	checkSetupExperienceSoftware(t, "ipados", otherTeam.ID, []uint{})
+	checkSetupExperienceSoftware(t, "macos", otherTeam.ID, []uint{})
+
+	// try to add an ipadOS app to macOS and iOS, both should fail
+	res := s.DoRaw("PUT", "/api/v1/fleet/setup_experience/software", []byte(fmt.Sprintf(`{"platform": "macos", "team_id": %d, "software_title_ids": [%d]}`, team.ID, titleIDsByApp[iPadOSApp2])), http.StatusBadRequest)
+	errMsg := extractServerErrorText(res.Body)
+	require.NoError(t, res.Body.Close())
+	assert.Contains(t, errMsg, "invalid platform for requested AppStoreApp")
+
+	res = s.DoRaw("PUT", "/api/v1/fleet/setup_experience/software", []byte(fmt.Sprintf(`{"platform": "ios", "team_id": %d, "software_title_ids": [%d]}`, team.ID, titleIDsByApp[iPadOSApp2])), http.StatusBadRequest)
+	errMsg = extractServerErrorText(res.Body)
+	require.NoError(t, res.Body.Close())
+	assert.Contains(t, errMsg, "invalid platform for requested AppStoreApp")
+
+	// Lists should be unchanged after the failed attempts
+	checkSetupExperienceSoftware(t, "macos", team.ID, []uint{titleIDsByApp[macOSApp1], titleIDsByApp[macOSApp2]})
+	checkSetupExperienceSoftware(t, "ios", team.ID, []uint{titleIDsByApp[iOSApp2]})
+
+	// Clear iPadOS and verify macOS and iPadOS are unaffected
+	putSetupExperienceSoftwareForPlatform(t, "ipados", team.ID, []uint{})
+
+	// iPadOS should be empty now
+	checkSetupExperienceSoftware(t, "ipados", team.ID, []uint{})
+
+	// macOS/iPadOS lists should be unchanged
+	checkSetupExperienceSoftware(t, "macos", team.ID, []uint{titleIDsByApp[macOSApp1], titleIDsByApp[macOSApp2]})
+	checkSetupExperienceSoftware(t, "ios", team.ID, []uint{titleIDsByApp[iOSApp2]})
 }
 
 // TestSetupExperienceEndpointsPlatformIsolation tests that setting the setup experience software items

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -1677,10 +1677,6 @@ func (s *integrationMDMTestSuite) TestSetupExperienceVPPCRUD() {
 	var getVPPTokenResp getVPPTokensResponse
 	s.DoJSON("GET", "/api/latest/fleet/vpp_tokens", &getVPPTokensRequest{}, http.StatusOK, &getVPPTokenResp)
 
-	t.Cleanup(func() {
-		s.appleVPPConfigSrvConfig.Assets = defaultVPPAssetList
-	})
-
 	// Associate team to the VPP token.
 	var resPatchVPP patchVPPTokensTeamsResponse
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/vpp_tokens/%d/teams", getVPPTokenResp.Tokens[0].ID), patchVPPTokensTeamsRequest{TeamIDs: []uint{team.ID, otherTeam.ID}}, http.StatusOK, &resPatchVPP)

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -273,8 +273,8 @@ func maybeUpdateSetupExperienceStatus(ctx context.Context, ds fleet.Datastore, r
 }
 
 func validateSetupExperiencePlatform(platform string) error {
-	if platform != "" && platform != "macos" && platform != "windows" && platform != "linux" {
-		return badRequestf("platform %q unsupported, platform must be \"macos\", \"windows\", or \"linux\"", platform)
+	if platform != "" && platform != "macos" && platform != "ios" && platform != "ipados" && platform != "windows" && platform != "linux" {
+		return badRequestf("platform %q unsupported, platform must be \"macos\", \"ios\", \"ipados\", \"windows\", or \"linux\"", platform)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33698 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
