### PR TITLE
Website: Add Docsearch public key to Website's custom configuration.

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -421,6 +421,9 @@ module.exports.custom = {
     excludeWeekends: true
   },
 
+  // Docsearch search-only public key.
+  algoliaPublicKey: 'f3c02b646222734376a5e94408d6fead',// [?]: https://docsearch.algolia.com/docs/legacy/faq/#can-i-share-the-apikey-in-my-repo
+
   // Zapier:
   // zapierWebhookSecret: '…',
 


### PR DESCRIPTION
Changes: 
- Added the Algolia Docsearch public search-only API key to the website's custom configuration.

Note: https://docsearch.algolia.com/docs/legacy/faq/#can-i-share-the-apikey-in-my-repo