### PR TITLE
Cherry-Pick: Add missing reference to Android hosts on label criteria

### DIFF
--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -456,7 +456,7 @@ const NewLabelPage = ({
             </span>
             <span className="form-field__help-text">
               Currently, label criteria can be IdP group or department on macOS
-              hosts.
+              and Android hosts.
             </span>
           </div>
         );


### PR DESCRIPTION
Merged into `main` in #33755.