### PR TITLE
GitOps bug: Icon was ignored when using software URL

### DIFF
--- a/changes/33695-gitops-ignores-icon-for-software-when-url-provided
+++ b/changes/33695-gitops-ignores-icon-for-software-when-url-provided
@@ -1,1 +1,0 @@
-* Fixed GitOps bug where icon was ignored when software URL was provided.

--- a/changes/33695-gitops-ignores-icon-for-software-when-url-provided
+++ b/changes/33695-gitops-ignores-icon-for-software-when-url-provided
@@ -1,0 +1,1 @@
+* Fixed GitOps bug where icon was ignored when software URL was provided.


### PR DESCRIPTION
**Related issue:** Resolves #33695

When trying to match package icons, first try to match by hash then by URL.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually