### PR TITLE
Website: Update Android Proxy endpoints to return 404 responses if an Android Enterprise are not managed by Fleet

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -46,6 +46,13 @@ module.exports = {
       return this.res.unauthorized();
     }
 
+    // Check the list of Android Enterprises managed by Fleet to see if this Android Enterprise is still managed.
+    let isEnterpriseManagedByFleet = await sails.helpers.androidProxy.getIsEnterpriseManagedByFleet(androidEnterpriseId);
+    // Return a 404 response if this Android enterprise is no longer managed by Fleet.
+    if(!isEnterpriseManagedByFleet) {
+      return this.res.notFound();
+    }
+
     let newEnrollmentToken = await sails.helpers.flow.build(async ()=>{
       let { google } = require('googleapis');
       let androidmanagement = google.androidmanagement('v1');

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -49,6 +49,14 @@ module.exports = {
     if (thisAndroidEnterprise.fleetServerSecret !== fleetServerSecret) {
       return this.res.unauthorized();
     }
+
+    // Check the list of Android Enterprises managed by Fleet to see if this Android Enterprise is still managed.
+    let isEnterpriseManagedByFleet = await sails.helpers.androidProxy.getIsEnterpriseManagedByFleet(androidEnterpriseId);
+    // Return a 404 response if this Android enterprise is no longer managed by Fleet.
+    if(!isEnterpriseManagedByFleet) {
+      return this.res.notFound();
+    }
+
     // Update the policy for this Android enterprise.
     // Note: We're using sails.helpers.flow.build here to handle any errors that occurr using google's node library.
     let modifyPoliciesResponse = await sails.helpers.flow.build(async () => {

--- a/website/api/helpers/android-proxy/get-is-enterprise-managed-by-fleet.js
+++ b/website/api/helpers/android-proxy/get-is-enterprise-managed-by-fleet.js
@@ -1,0 +1,81 @@
+module.exports = {
+
+
+  friendlyName: 'Get is enterprise managed by fleet',
+
+
+  description: 'Checks the list of Android Enterprises managed by Fleet\'s Enterprise Management Google project and returns true if the provided enterprise ID is present.',
+
+
+  inputs: {
+    androidEnterpriseId: {
+      type: 'string',
+      required: true,
+      description: 'The enterprise ID of the Android Enterprise '
+    }
+  },
+
+
+  exits: {
+
+    success: {
+      outputFriendlyName: 'Is enterprise managed by fleet',
+      outputType: 'boolean',
+    },
+  },
+
+
+  fn: async function ({androidEnterpriseId}) {
+
+    require('assert')(sails.config.custom.androidEnterpriseServiceAccountEmailAddress);
+    require('assert')(sails.config.custom.androidEnterpriseServiceAccountPrivateKey);
+    require('assert')(sails.config.custom.androidEnterpriseProjectId);
+
+    let isEnterpriseManagedByFleet = false;
+
+    // Log into google.
+    let { google } = require('googleapis');
+    let androidmanagement = google.androidmanagement('v1');
+    let googleAuth = new google.auth.GoogleAuth({
+      scopes: ['https://www.googleapis.com/auth/androidmanagement'],
+      credentials: {
+        client_email: sails.config.custom.androidEnterpriseServiceAccountEmailAddress,// eslint-disable-line camelcase
+        private_key: sails.config.custom.androidEnterpriseServiceAccountPrivateKey,// eslint-disable-line camelcase
+      },
+    });
+    let authClient = await googleAuth.getClient();
+    google.options({auth: authClient});
+
+    // Use Google's LIST call to check if enterprise exists.
+    let enterprises = [];
+    let tokenForNextPageOfEnterprises;
+    await sails.helpers.flow.until(async ()=>{
+      let listEnterprisesResponse = await androidmanagement.enterprises.list({
+        projectId: sails.config.custom.androidEnterpriseProjectId,
+        pageSize: 100,
+        pageToken: tokenForNextPageOfEnterprises,
+      });
+      tokenForNextPageOfEnterprises = listEnterprisesResponse.data.nextPageToken;
+      enterprises = enterprises.concat(listEnterprisesResponse.data.enterprises);
+
+      if(!listEnterprisesResponse.data.nextPageToken){
+        return true;
+      }
+    });
+
+    // Check the list of enterprises
+    let enterpriseExistsInTheListOfEnterprises = _.find(enterprises, (enterprise)=>{
+      return enterprise.name === `enterprises/${androidEnterpriseId}` || enterprise.name === androidEnterpriseId;
+    });
+
+    if(enterpriseExistsInTheListOfEnterprises){
+      isEnterpriseManagedByFleet = true;
+    }
+
+    // Send back the result through the success exit.
+    return isEnterpriseManagedByFleet;
+  }
+
+
+};
+


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/33266

Changes:
- Added a new helper `sails.helpers.androidProxy.getIsEnterpriseManagedByFleet`. This helper returns `true` if a provided Android Enterprise ID is present in the list of all Android Enterprises managed by Fleet, or `false` if it is not in the list.
- Updated `create-android-enrollment-token`, `create-android-signup-url`, and `modify-android-policies` to return a 404 response to the requesting Fleet instance if their Android Enterprise is not managed by Fleet.