### PR TITLE
Fix failing migration by conditionally deleting old constraint

### DIFF
--- a/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
+++ b/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
@@ -137,7 +137,11 @@ ALTER TABLE mdm_configuration_profile_labels
 
 	// our mysql version at the time this constraint was added did not support CHECK constraints so this may or may not exist for us
 	// to delete, so we create the new wider constraint above then, optionally, delete the older narrow one
-	checkIfOldConstraintExists := `SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS WHERE CONSTRAINT_TYPE = 'CHECK' AND TABLE_NAME = 'mdm_configuration_profile_labels' AND CONSTRAINT_NAME = 'ck_mdm_configuration_profile_labels_apple_or_windows'`
+	checkIfOldConstraintExists := `
+	SELECT COUNT(*)
+	FROM INFORMATION_SCHEMA.TABLE_CONSTRAINTS
+	WHERE CONSTRAINT_SCHEMA = DATABASE() AND CONSTRAINT_TYPE = 'CHECK' AND TABLE_NAME = 'mdm_configuration_profile_labels'
+	AND CONSTRAINT_NAME = 'ck_mdm_configuration_profile_labels_apple_or_windows'`
 	var constraintCount int
 	if err := tx.QueryRow(checkIfOldConstraintExists).Scan(&constraintCount); err != nil {
 		return fmt.Errorf("check for old CHECK constraint on mdm_configuration_profile_labels: %w", err)

--- a/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
+++ b/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
@@ -143,6 +143,7 @@ ALTER TABLE mdm_configuration_profile_labels
 		return fmt.Errorf("check for old CHECK constraint on mdm_configuration_profile_labels: %w", err)
 	}
 	if constraintCount > 0 {
+		fmt.Printf("Constraint count: %d\n", constraintCount)
 		dropOldConstraint := `
 			ALTER TABLE mdm_configuration_profile_labels
 			DROP CONSTRAINT ck_mdm_configuration_profile_labels_apple_or_windows

--- a/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
+++ b/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles.go
@@ -147,7 +147,6 @@ ALTER TABLE mdm_configuration_profile_labels
 		return fmt.Errorf("check for old CHECK constraint on mdm_configuration_profile_labels: %w", err)
 	}
 	if constraintCount > 0 {
-		fmt.Printf("Constraint count: %d\n", constraintCount)
 		dropOldConstraint := `
 			ALTER TABLE mdm_configuration_profile_labels
 			DROP CONSTRAINT ck_mdm_configuration_profile_labels_apple_or_windows

--- a/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles_test.go
@@ -103,10 +103,12 @@ func TestUp_20250922083056(t *testing.T) {
 	require.NoError(t, err)
 	// empty android host got updated, non-empty stayed the same, mac host not updated
 	require.Equal(t, []string{"from-enterprise", "got-one", ""}, got)
+}
 
-	// Add a final test where we create a DB without the old apple-or-windows constraint and verify the migration does not error
-	db = applyUpToPrev(t)
-	_, err = db.Exec(`ALTER TABLE mdm_configuration_profile_labels DROP CONSTRAINT ck_mdm_configuration_profile_labels_apple_or_windows`)
+func TestUp_20250922083056_checkconstraint_missing(t *testing.T) {
+	// Create a DB without the old apple-or-windows constraint and verify the migration does not error
+	db := applyUpToPrev(t)
+	_, err := db.Exec(`ALTER TABLE mdm_configuration_profile_labels DROP CONSTRAINT ck_mdm_configuration_profile_labels_apple_or_windows`)
 	require.NoError(t, err)
 	applyNext(t, db)
 }

--- a/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles_test.go
+++ b/server/datastore/mysql/migrations/tables/20250922083056_AddTableMDMAndroidProfiles_test.go
@@ -103,4 +103,10 @@ func TestUp_20250922083056(t *testing.T) {
 	require.NoError(t, err)
 	// empty android host got updated, non-empty stayed the same, mac host not updated
 	require.Equal(t, []string{"from-enterprise", "got-one", ""}, got)
+
+	// Add a final test where we create a DB without the old apple-or-windows constraint and verify the migration does not error
+	db = applyUpToPrev(t)
+	_, err = db.Exec(`ALTER TABLE mdm_configuration_profile_labels DROP CONSTRAINT ck_mdm_configuration_profile_labels_apple_or_windows`)
+	require.NoError(t, err)
+	applyNext(t, db)
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33876 

Modifies the migration to check for the old constraint before deleting it in case it was created on mysql 5.7

No changes file since this is an unreleased bug

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

## Database migrations

- [x] Checked table schema to confirm autoupdate
- [x] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [x] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [x] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).
