### PR TITLE
Update copy to indicate that iOS/iPadOS work with vitals labels

### DIFF
--- a/changes/32072-ios-idp-labels
+++ b/changes/32072-ios-idp-labels
@@ -1,0 +1,1 @@
+* Added support for assigning host labels based on idP attributes for iOS and iPadOS hosts

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -455,8 +455,8 @@ const NewLabelPage = ({
               />
             </span>
             <span className="form-field__help-text">
-              Currently, label criteria can be IdP group or department on macOS
-              and Android hosts.
+              Currently, label criteria can be IdP group or department on macOS,
+              iOS, iPadOS, and Android hosts.
             </span>
           </div>
         );


### PR DESCRIPTION
For #32072. Should be cherry-picked to 4.75 since that's where the support was added.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results