### PR TITLE
Cherry-Pick: Update copy to indicate that iOS/iPadOS work with vitals labels

### DIFF
--- a/changes/32072-ios-idp-labels
+++ b/changes/32072-ios-idp-labels
@@ -1,0 +1,1 @@
+* Added support for assigning host labels based on idP attributes for iOS and iPadOS hosts

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -455,8 +455,8 @@ const NewLabelPage = ({
               />
             </span>
             <span className="form-field__help-text">
-              Currently, label criteria can be IdP group or department on macOS
-              and Android hosts.
+              Currently, label criteria can be IdP group or department on macOS,
+              iOS, iPadOS, and Android hosts.
             </span>
           </div>
         );


### PR DESCRIPTION
Merged into `main` in #33919.