### PR TITLE
Add sticky MDM enrollment Redis key

### DIFF
--- a/changes/26879-add-sticky-enrollment-redis-key
+++ b/changes/26879-add-sticky-enrollment-redis-key
@@ -1,0 +1,1 @@
+* Fixed an issue where a host transfer on `mdm_enrolled` activity would be reversed by orbit enroll

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -774,6 +774,7 @@ the way that the Fleet server works.
 				scepConfigMgr,
 				digiCertService,
 				conditionalAccessMicrosoftProxy,
+				redis_key_value.New(redisPool),
 			)
 			if err != nil {
 				initFatal(err, "initializing service")
@@ -1278,7 +1279,7 @@ the way that the Fleet server works.
 			if len(config.Server.PrivateKey) > 0 {
 				commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
 				ddmService := service.NewMDMAppleDDMService(ds, logger)
-				mdmCheckinAndCommandService := service.NewMDMAppleCheckinAndCommandService(ds, commander, logger)
+				mdmCheckinAndCommandService := service.NewMDMAppleCheckinAndCommandService(ds, commander, logger, redis_key_value.New(redisPool))
 
 				mdmCheckinAndCommandService.RegisterResultsHandler("InstalledApplicationList", service.NewInstalledApplicationListResultsHandler(ds, commander, logger, config.Server.VPPVerifyTimeout, config.Server.VPPVerifyRequestDelay))
 

--- a/ee/server/integrationtest/hostidentity/suite.go
+++ b/ee/server/integrationtest/hostidentity/suite.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest"
@@ -48,6 +49,7 @@ func SetUpSuiteWithConfig(t *testing.T, uniqueTestName string, requireSignature 
 	}
 	ds, fleetCfg, fleetSvc, ctx := integrationtest.SetUpMySQLAndService(t, uniqueTestName, &service.TestServerOpts{
 		License: license,
+		Pool:    redistest.SetupRedis(t, t.Name(), false, false, false),
 	})
 
 	// Apply config modifications

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -98,6 +98,7 @@ func setupMockDatastorePremiumService(t testing.TB) (*mock.Store, *eeservice.Ser
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -25,6 +25,9 @@ const (
 	// RefetchCriticalQueriesUntil field when migrating a device from a
 	// third-party MDM solution to Fleet.
 	RefetchMDMUnenrollCriticalQueryDuration = 3 * time.Minute
+
+	StickyMDMEnrollmentKeyPrefix = "sticky_mdm_enrollment_" // + host UUID
+	StickyMDMEnrollmentTTL       = 30 * time.Minute
 )
 
 // FleetVarName represents the name of a Fleet variable (without the FLEET_VAR_ prefix).

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -162,6 +162,8 @@ func WithEnrollOrbitIdentityCert(identityCert *types.HostIdentityCertificate) Da
 	}
 }
 
+// WithEnrollOrbitIgnoreTeamUpdate sets whether to ignore team updates for datastore Orbit enrollment
+// it only acts on existing hosts (i.e. it won't ignore the team id on new hosts)
 func WithEnrollOrbitIgnoreTeamUpdate(ignore bool) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.IgnoreTeamUpdate = ignore

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -117,11 +117,12 @@ type OrbitHostInfo struct {
 
 // DatastoreEnrollOrbitConfig holds the configuration for datastore Orbit enrollment
 type DatastoreEnrollOrbitConfig struct {
-	IsMDMEnabled bool
-	HostInfo     OrbitHostInfo
-	OrbitNodeKey string
-	TeamID       *uint
-	IdentityCert *types.HostIdentityCertificate
+	IsMDMEnabled     bool
+	HostInfo         OrbitHostInfo
+	OrbitNodeKey     string
+	TeamID           *uint
+	IdentityCert     *types.HostIdentityCertificate
+	IgnoreTeamUpdate bool // when true the host's team won't be updated on enrollment where an entry already exists.
 }
 
 // DatastoreEnrollOrbitOption is a functional option for configuring datastore Orbit enrollment
@@ -158,6 +159,12 @@ func WithEnrollOrbitTeamID(teamID *uint) DatastoreEnrollOrbitOption {
 func WithEnrollOrbitIdentityCert(identityCert *types.HostIdentityCertificate) DatastoreEnrollOrbitOption {
 	return func(c *DatastoreEnrollOrbitConfig) {
 		c.IdentityCert = identityCert
+	}
+}
+
+func WithEnrollOrbitIgnoreTeamUpdate(ignore bool) DatastoreEnrollOrbitOption {
+	return func(c *DatastoreEnrollOrbitConfig) {
+		c.IgnoreTeamUpdate = ignore
 	}
 }
 

--- a/server/fleet/osquery.go
+++ b/server/fleet/osquery.go
@@ -77,14 +77,15 @@ type PermissivePacks map[string]PermissivePackContent
 
 // DatastoreEnrollOsqueryConfig holds the configuration for datastore Host enrollment
 type DatastoreEnrollOsqueryConfig struct {
-	IsMDMEnabled   bool
-	OsqueryHostID  string
-	HardwareUUID   string
-	HardwareSerial string
-	NodeKey        string
-	TeamID         *uint
-	Cooldown       time.Duration
-	IdentityCert   *types.HostIdentityCertificate
+	IsMDMEnabled     bool
+	OsqueryHostID    string
+	HardwareUUID     string
+	HardwareSerial   string
+	NodeKey          string
+	TeamID           *uint
+	Cooldown         time.Duration
+	IdentityCert     *types.HostIdentityCertificate
+	IgnoreTeamUpdate bool // when true the host's team won't be updated on enrollment where an entry already exists.
 }
 
 // DatastoreEnrollOsqueryOption is a functional option for configuring datastore Host enrollment
@@ -142,5 +143,13 @@ func WithEnrollOsqueryCooldown(cooldown time.Duration) DatastoreEnrollOsqueryOpt
 func WithEnrollOsqueryIdentityCert(identityCert *types.HostIdentityCertificate) DatastoreEnrollOsqueryOption {
 	return func(c *DatastoreEnrollOsqueryConfig) {
 		c.IdentityCert = identityCert
+	}
+}
+
+// WithEnrollOsqueryIgnoreTeamUpdate sets whether to ignore team updates for datastore Host enrollment
+// it only acts on existing hosts (i.e. it won't ignore the team id on new hosts)
+func WithEnrollOsqueryIgnoreTeamUpdate(ignore bool) DatastoreEnrollOsqueryOption {
+	return func(c *DatastoreEnrollOsqueryConfig) {
+		c.IgnoreTeamUpdate = ignore
 	}
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3575,11 +3575,13 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 			mdmEnrolledActivity.HostSerial = ptr.String(updatedInfo.HardwareSerial)
 		}
 
-		// Set sticky key for MDM enrollments to avoid updating team id on orbit enrollments
-		err = svc.keyValueStore.Set(r.Context, fleet.StickyMDMEnrollmentKeyPrefix+r.ID, "1", fleet.StickyMDMEnrollmentTTL)
-		if err != nil {
-			// We do not want to fail here, just log the error to notify
-			level.Error(svc.logger).Log("msg", "failed to set sticky mdm enrollment key", "err", err, "host_uuid", r.ID)
+		if svc.keyValueStore != nil {
+			// Set sticky key for MDM enrollments to avoid updating team id on orbit enrollments
+			err = svc.keyValueStore.Set(r.Context, fleet.StickyMDMEnrollmentKeyPrefix+r.ID, "1", fleet.StickyMDMEnrollmentTTL)
+			if err != nil {
+				// We do not want to fail here, just log the error to notify
+				level.Error(svc.logger).Log("msg", "failed to set sticky mdm enrollment key", "err", err, "host_uuid", r.ID)
+			}
 		}
 
 		return newActivity(

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	fleetmdm "github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
@@ -48,6 +49,7 @@ import (
 	nanodep_mock "github.com/fleetdm/fleet/v4/server/mock/nanodep"
 	scep_mock "github.com/fleetdm/fleet/v4/server/mock/scep"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/test"
 	kitlog "github.com/go-kit/log"
 	"github.com/google/uuid"
@@ -1175,8 +1177,10 @@ func TestMDMAuthenticateManualEnrollment(t *testing.T) {
 	ds := new(mock.Store)
 	mdmLifecycle := mdmlifecycle.New(ds, kitlog.NewNopLogger(), newActivity)
 	svc := MDMAppleCheckinAndCommandService{
-		ds:           ds,
-		mdmLifecycle: mdmLifecycle,
+		ds:            ds,
+		mdmLifecycle:  mdmLifecycle,
+		keyValueStore: redis_key_value.New(redistest.NopRedis()),
+		logger:        kitlog.NewNopLogger(),
 	}
 	ctx := context.Background()
 	uuid, serial, model := "ABC-DEF-GHI", "XYZABC", "MacBookPro 16,1"
@@ -1243,8 +1247,10 @@ func TestMDMAuthenticateADE(t *testing.T) {
 	ds := new(mock.Store)
 	mdmLifecycle := mdmlifecycle.New(ds, kitlog.NewNopLogger(), newActivity)
 	svc := MDMAppleCheckinAndCommandService{
-		ds:           ds,
-		mdmLifecycle: mdmLifecycle,
+		ds:            ds,
+		mdmLifecycle:  mdmLifecycle,
+		keyValueStore: redis_key_value.New(redistest.NopRedis()),
+		logger:        kitlog.NewNopLogger(),
 	}
 	ctx := context.Background()
 	uuid, serial, model := "ABC-DEF-GHI", "XYZABC", "MacBookPro 16,1"

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -18327,7 +18327,7 @@ func (s *integrationMDMTestSuite) TestStickyMDMTeamEnrollment() {
 	// RE-enroll orbit and see team transfer
 	s.DoJSON("POST", "/api/fleet/orbit/enroll", request, http.StatusOK, &response)
 
-	// Check that the host is still in no-team
+	// Check that the host is now in the team
 	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
 	require.NoError(t, err)
 	require.NotNil(t, hostLite)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/bindata"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/datastore/s3"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -68,10 +69,12 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest/scep_server"
 	"github.com/fleetdm/fleet/v4/server/service/mock"
 	"github.com/fleetdm/fleet/v4/server/service/osquery_utils"
+	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/service/schedule"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/fleetdm/fleet/v4/server/worker"
 	kitlog "github.com/go-kit/log"
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	micromdm "github.com/micromdm/micromdm/mdm/mdm"
@@ -184,7 +187,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 		NewNanoMDMLogger(pushLog),
 	)
 	mdmCommander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
-	redisPool := redistest.SetupRedis(s.T(), "zz", false, false, false)
+	s.redisPool = redistest.SetupRedis(s.T(), "zz", false, false, false)
 	s.withServer.lq = live_query_mock.New(s.T())
 
 	wlog := kitlog.NewJSONLogger(os.Stdout)
@@ -253,7 +256,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 		DEPStorage:            depStorage,
 		SCEPStorage:           scepStorage,
 		MDMPusher:             mdmPushService,
-		Pool:                  redisPool,
+		Pool:                  s.redisPool,
 		Lq:                    s.lq,
 		SoftwareInstallStore:  softwareInstallerStore,
 		BootstrapPackageStore: bootstrapPackageStore,
@@ -18262,4 +18265,72 @@ func (s *integrationMDMTestSuite) TestWipeWindowsReenrollAsNewHost() {
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", newHost.ID), nil, http.StatusOK, &wipeResp)
 	require.Equal(t, fleet.PendingActionWipe, wipeResp.PendingAction)
 	require.Equal(t, fleet.DeviceStatusUnlocked, wipeResp.DeviceStatus)
+}
+
+// This test case covers the bug https://github.com/fleetdm/fleet/issues/26879
+func (s *integrationMDMTestSuite) TestStickyMDMTeamEnrollment() {
+	t := s.T()
+	ctx := t.Context()
+
+	teamEnrollSecret := "sticky-mdm-team-enroll-secret" //nolint:gosec // G101: false positive, test value only
+	// Create a single team with MDM enabled
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "mdm team", Secrets: []*fleet.EnrollSecret{{Secret: teamEnrollSecret}}})
+	require.NoError(t, err)
+
+	// Enable MDM for appconfig
+	appConfig, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	appConfig.MDM.EnabledAndConfigured = true
+	err = s.ds.SaveAppConfig(ctx, appConfig)
+	require.NoError(t, err)
+
+	// Create a MDM apple device
+	host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
+
+	// Check that redis key was set
+	keyValueStore := redis_key_value.New(s.redisPool)
+	val, err := keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, val)
+
+	// Get the team to check that it enrolled into no-team
+	hostLite, err := s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite)
+	require.Nil(t, hostLite.TeamID)
+
+	request := contract.EnrollOrbitRequest{
+		EnrollSecret:   teamEnrollSecret,
+		HardwareUUID:   host.UUID,
+		HardwareSerial: mdmDevice.SerialNumber,
+		Hostname:       host.Hostname,
+		Platform:       host.Platform,
+		PlatformLike:   host.PlatformLike,
+		HardwareModel:  host.HardwareModel,
+	}
+	response := EnrollOrbitResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/enroll", request, http.StatusOK, &response)
+
+	// Check that the host is still in no-team
+	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite)
+	require.Nil(t, hostLite.TeamID)
+
+	// Delete the key to re-enroll
+	conn := redis.ConfigureDoer(s.redisPool, s.redisPool.Get())
+	defer conn.Close()
+
+	_, err = redigo.Int64(conn.Do("DEL", "key_value_"+fleet.StickyMDMEnrollmentKeyPrefix+host.UUID))
+	require.NoError(t, err)
+
+	// RE-enroll orbit and see team transfer
+	s.DoJSON("POST", "/api/fleet/orbit/enroll", request, http.StatusOK, &response)
+
+	// Check that the host is still in no-team
+	hostLite, err = s.ds.HostLiteByIdentifier(ctx, host.UUID)
+	require.NoError(t, err)
+	require.NotNil(t, hostLite)
+	require.NotNil(t, hostLite.TeamID)
+	require.Equal(t, team.ID, *hostLite.TeamID)
 }

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -178,9 +178,13 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		return "", fleet.OrbitError{Message: "app config load failed: " + err.Error()}
 	}
 
+	// Check for sticky MDM enrollment flag. When set (e.g., after a host transfer),
+	// this prevents enrollment-based team changes for a time window to avoid race conditions
+	// with MDM profile delivery.
 	stickyEnrollment, err := svc.keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+hostInfo.HardwareUUID)
 	if err != nil {
-		// We do not want to fail here, just log the error to notify
+		// Log error but continue enrollment (fail-open approach). If Redis is unavailable,
+		// enrollment proceeds without sticky behavior rather than blocking.
 		level.Error(svc.logger).Log("msg", "failed to get sticky enrollment", "err", err, "host_uuid", hostInfo.HardwareUUID)
 	}
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -156,6 +156,19 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 		return "", newOsqueryErrorWithInvalidNode("app config load failed: " + err.Error())
 	}
 
+	var stickyEnrollment *string
+	if svc.keyValueStore != nil {
+		// Check for sticky MDM enrollment flag. When set (e.g., after a host transfer),
+		// this prevents enrollment-based team changes for a time window to avoid race conditions
+		// with MDM profile delivery.
+		stickyEnrollment, err = svc.keyValueStore.Get(ctx, fleet.StickyMDMEnrollmentKeyPrefix+hardwareUUID)
+		if err != nil {
+			// Log error but continue enrollment (fail-open approach). If Redis is unavailable,
+			// enrollment proceeds without sticky behavior rather than blocking.
+			level.Error(svc.logger).Log("msg", "failed to get sticky enrollment", "err", err, "host_uuid", hardwareUUID)
+		}
+	}
+
 	host, err := svc.ds.EnrollOsquery(ctx,
 		fleet.WithEnrollOsqueryMDMEnabled(appConfig.MDM.EnabledAndConfigured),
 		fleet.WithEnrollOsqueryHostID(hostIdentifier),
@@ -165,6 +178,7 @@ func (svc *Service) EnrollOsquery(ctx context.Context, enrollSecret, hostIdentif
 		fleet.WithEnrollOsqueryTeamID(secret.TeamID),
 		fleet.WithEnrollOsqueryCooldown(svc.config.Osquery.EnrollCooldown),
 		fleet.WithEnrollOsqueryIdentityCert(identityCert),
+		fleet.WithEnrollOsqueryIgnoreTeamUpdate(stickyEnrollment != nil),
 	)
 	if err != nil {
 		return "", newOsqueryErrorWithInvalidNode("save enroll failed: " + err.Error())

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -66,6 +66,8 @@ type Service struct {
 	digiCertService   fleet.DigiCertService
 
 	conditionalAccessMicrosoftProxy ConditionalAccessMicrosoftProxy
+
+	keyValueStore fleet.KeyValueStore
 }
 
 // ConditionalAccessMicrosoftProxy is the interface of the Microsoft compliance proxy.
@@ -138,6 +140,7 @@ func NewService(
 	scepConfigService fleet.SCEPConfigService,
 	digiCertService fleet.DigiCertService,
 	conditionalAccessProxy ConditionalAccessMicrosoftProxy,
+	keyValueStore fleet.KeyValueStore,
 ) (fleet.Service, error) {
 	authorizer, err := authz.NewAuthorizer()
 	if err != nil {
@@ -175,6 +178,7 @@ func NewService(
 		digiCertService:      digiCertService,
 
 		conditionalAccessMicrosoftProxy: conditionalAccessProxy,
+		keyValueStore:                   keyValueStore,
 	}
 	return validationMiddleware{svc, ds, sso}, nil
 }

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -425,13 +425,15 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 
 	memLimitStore, _ := memstore.New(0)
 	var limitStore throttled.GCRAStore = memLimitStore
-	redisPool := redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
+	var redisPool fleet.RedisPool
 	if len(opts) > 0 && opts[0].Pool != nil {
 		redisPool = opts[0].Pool
 		limitStore = &redis.ThrottledStore{
 			Pool:      opts[0].Pool,
 			KeyPrefix: "ratelimit::",
 		}
+	} else {
+		redisPool = redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
 	}
 
 	if len(opts) > 0 {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #26879 

We decided to opt for a sticky enrollment approach, and I opted for using redis, so this PR also adds a redis key value store to the free service to use.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents Orbit enrollment from undoing team transfers triggered during MDM enrollment, preserving the correct team assignment on re-enrollment.
  - Introduces a temporary “sticky” enrollment period (~30 minutes) during Apple MDM check-in and Orbit enrollment to reduce unintended team changes.
  - Improves reliability of team-scoped enroll secrets and host transfers in short re-enrollment windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->