### PR TITLE
Rename "Single sign-on options" settings page to "Single sign-on (SSO)"

### DIFF
--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -79,8 +79,8 @@ Create a new SAML app in Microsoft Entra Admin Center:
  ![The new SAML app's details page in Enta Admin Center](https://raw.githubusercontent.com/fleetdm/fleet/main/docs/images/entra-sso-configuration-step-6.png)
 
 On your Fleet server: 
-1. Navigate to **Settings > Organization settings > Single sign-on options**.
-2. On the **Single sign-on options** page:
+1. Navigate to **Settings > Organization settings > Single sign-on (SSO)**.
+2. On the **Single sign-on (SSO)** page:
    - Check the box to **Enable single sign-on**.
    - For **Identity provider name**, enter `Entra`.
    - For **Entity ID**, enter `fleet`.

--- a/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationNavItems.tsx
@@ -40,7 +40,7 @@ const getIntegrationSettingsNavItems = (
       Card: ChangeManagement,
     },
     {
-      title: "Single sign-on options",
+      title: "Single sign-on (SSO)",
       urlSection: "sso",
       path: PATHS.ADMIN_INTEGRATIONS_SSO,
       Card: Sso,

--- a/frontend/pages/admin/IntegrationsPage/IntegrationPage.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationPage.tests.tsx
@@ -90,7 +90,7 @@ describe("Integrations Page", () => {
         />
       );
 
-      expect(await screen.findAllByText("Single sign-on options")).toHaveLength(
+      expect(await screen.findAllByText("Single sign-on (SSO)")).toHaveLength(
         3
       );
     });

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -161,7 +161,7 @@ const Sso = ({
   };
 
   return (
-    <SettingsSection title="Single sign-on options">
+    <SettingsSection title="Single sign-on (SSO)">
       <form onSubmit={onFormSubmit} autoComplete="off">
         {/* "form" class applies global form styling to fields for free */}
         <div


### PR DESCRIPTION
As part of https://github.com/fleetdm/fleet/issues/25798, we planned to rename "Single sign-on options" to "Single sign-on (SSO)". However, we missed adding a check for the copy change in the test plan, so we didn't catch that the change didn't make it in.

The documentation/guide changes referencing the new page name were already merged as part of 4.71.