### PR TITLE
Fleet UI: Fix "existing software" error message and make other add sw error messages consistent

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStoreVpp/helpers.tsx
@@ -1,6 +1,13 @@
-import React, { ReactElement } from "react";
+import { ReactElement } from "react";
 import { getErrorReason } from "interfaces/errors";
 import { IMdmVppToken } from "interfaces/mdm";
+
+import {
+  ADD_SOFTWARE_ERROR_PREFIX,
+  DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE,
+  ensurePeriod,
+  formatAlreadyAvailableInstallMessage,
+} from "../helpers";
 
 /**
  * Checks if the given team has an available VPP token (either a token
@@ -26,47 +33,27 @@ export const teamHasVPPToken = (
   });
 };
 
-const ADD_SOFTWARE_ERROR_PREFIX = "Couldn't add software.";
-const DEFAULT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Please try again.`;
-
-const generateAlreadyAvailableMessage = (
-  msg: string
-): string | ReactElement => {
-  // This regex matches the API message where the title already has a software package (non-VPP) available for install.
-  const regex = new RegExp(
-    `${ADD_SOFTWARE_ERROR_PREFIX} (.+) already.+on the (.+) team.`
-  );
-
-  const match = msg.match(regex);
-
-  if (match) {
-    return (
-      <>
-        {ADD_SOFTWARE_ERROR_PREFIX} <b>{match[1]}</b> already has a package or
-        app available for install on the <b>{match[2]}</b> team.{" "}
-      </>
-    );
-  }
-
-  if (msg.includes("VPPApp")) {
-    return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install on this team.`;
-  }
-
-  return DEFAULT_ERROR_MESSAGE;
-};
-
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (e: unknown): string | ReactElement => {
-  let reason = getErrorReason(e);
+  const reason = getErrorReason(e);
 
   // software is already available for install
   if (reason.toLowerCase().includes("already")) {
-    return generateAlreadyAvailableMessage(reason);
+    const alreadyAvailableMessage = formatAlreadyAvailableInstallMessage(
+      reason
+    );
+    if (alreadyAvailableMessage) {
+      return alreadyAvailableMessage;
+    }
+
+    if (reason.includes("VPPApp")) {
+      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install on this team.`;
+    }
   }
 
-  if (reason && !reason.endsWith(".")) {
-    reason += ".";
+  if (reason) {
+    return `${ADD_SOFTWARE_ERROR_PREFIX} ${ensurePeriod(reason)}`;
   }
 
-  return reason || DEFAULT_ERROR_MESSAGE;
+  return DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE;
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/helpers.tsx
@@ -8,7 +8,13 @@ import CustomLink from "components/CustomLink";
 
 import { generateSecretErrMsg } from "pages/SoftwarePage/helpers";
 
-const DEFAULT_ERROR_MESSAGE = "Couldn't add. Please try again.";
+import {
+  ADD_SOFTWARE_ERROR_PREFIX,
+  DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE,
+  REQUEST_TIMEOUT_ERROR_MESSAGE,
+  ensurePeriod,
+  formatAlreadyAvailableInstallMessage,
+} from "../helpers";
 
 // eslint-disable-next-line import/prefer-default-export
 export const getErrorMessage = (err: unknown) => {
@@ -18,13 +24,27 @@ export const getErrorMessage = (err: unknown) => {
   const reason = getErrorReason(err);
 
   if (isTimeout) {
-    return "Couldn't add. Request timeout. Please make sure your server and load balancer timeout is long enough.";
-  } else if (reason.includes("Secret variable")) {
+    return REQUEST_TIMEOUT_ERROR_MESSAGE;
+  }
+
+  // software is already available for install
+  if (reason.toLowerCase().includes("already")) {
+    const alreadyAvailableMessage = formatAlreadyAvailableInstallMessage(
+      reason
+    );
+    if (alreadyAvailableMessage) {
+      return alreadyAvailableMessage;
+    }
+  }
+
+  if (reason.includes("Secret variable")) {
     return generateSecretErrMsg(err);
-  } else if (reason.includes("Unable to extract necessary metadata")) {
+  }
+
+  if (reason.includes("Unable to extract necessary metadata")) {
     return (
       <>
-        Couldn&apos;t add. Unable to extract necessary metadata.{" "}
+        {ADD_SOFTWARE_ERROR_PREFIX} Unable to extract necessary metadata.{" "}
         <CustomLink
           url={`${LEARN_MORE_ABOUT_BASE_LINK}/package-metadata-extraction`}
           text="Learn more"
@@ -33,7 +53,8 @@ export const getErrorMessage = (err: unknown) => {
         />
       </>
     );
-  } else if (reason.includes("not a valid .tar.gz archive")) {
+  }
+  if (reason.includes("not a valid .tar.gz archive")) {
     return (
       <>
         This is not a valid .tar.gz archive.{" "}
@@ -47,5 +68,9 @@ export const getErrorMessage = (err: unknown) => {
     );
   }
 
-  return reason || DEFAULT_ERROR_MESSAGE;
+  if (reason) {
+    return `${ADD_SOFTWARE_ERROR_PREFIX} ${ensurePeriod(reason)}`;
+  }
+
+  return DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE;
 };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -40,10 +40,6 @@ import FleetAppDetailsModal from "./FleetAppDetailsModal";
 import { getErrorMessage } from "./helpers";
 import TooltipWrapper from "../../../../../components/TooltipWrapper";
 
-const DEFAULT_ERROR_MESSAGE = "Couldn't add. Please try again.";
-const REQUEST_TIMEOUT_ERROR_MESSAGE =
-  "Couldn't add. Request timeout. Please make sure your server and load balancer timeout is long enough.";
-
 const baseClass = "fleet-maintained-app-details-page";
 
 interface IFleetAppSummaryProps {
@@ -244,18 +240,7 @@ const FleetMaintainedAppDetailsPage = ({
     } catch (error) {
       const ae = (typeof error === "object" ? error : {}) as AxiosResponse;
 
-      const errorMessage = getErrorMessage(ae);
-
-      if (
-        ae.status === 408 ||
-        errorMessage.includes("json decoder error") // 400 bad request when really slow
-      ) {
-        renderFlash("error", REQUEST_TIMEOUT_ERROR_MESSAGE);
-      } else if (errorMessage) {
-        renderFlash("error", errorMessage);
-      } else {
-        renderFlash("error", DEFAULT_ERROR_MESSAGE);
-      }
+      renderFlash("error", getErrorMessage(ae));
     }
 
     setShowAddFleetAppSoftwareModal(false);

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tests.tsx
@@ -1,0 +1,64 @@
+import React from "react";
+import { render } from "@testing-library/react";
+
+import {
+  ensurePeriod,
+  formatAlreadyAvailableInstallMessage,
+  ADD_SOFTWARE_ERROR_PREFIX,
+} from "./helpers"; // Adjust path as needed
+
+// --- ensurePeriod tests ---
+
+describe("ensurePeriod", () => {
+  it("adds a period to a string that doesn't end with a period", () => {
+    expect(ensurePeriod("Test string")).toBe("Test string.");
+  });
+
+  it("returns the original string if it already ends with a period", () => {
+    expect(ensurePeriod("Test string.")).toBe("Test string.");
+  });
+
+  it("returns an empty string unchanged", () => {
+    expect(ensurePeriod("")).toBe("");
+  });
+
+  it("returns the original string if the string is only a period", () => {
+    expect(ensurePeriod(".")).toBe(".");
+  });
+});
+
+// --- formatAlreadyAvailableInstallMessage tests ---
+
+describe("formatAlreadyAvailableInstallMessage", () => {
+  it("returns a React fragment with the correct text and team when the string matches the regex", () => {
+    // Example input: "Couldn't add. MyApp already has a package or app available for install on the Marketing team."
+    const msg = `${ADD_SOFTWARE_ERROR_PREFIX} MyApp already has a package or app available for install on the Marketing team.`;
+    const result = formatAlreadyAvailableInstallMessage(msg);
+
+    // Render for querying text
+    const { container } = render(<>{result}</>);
+
+    expect(container.textContent).toContain("Couldn't add.");
+    expect(container.textContent).toContain("MyApp");
+    expect(container.textContent).toContain("Marketing team");
+  });
+
+  it("returns null if the string does not match the expected pattern", () => {
+    const msg = "Random error message not matching pattern";
+    const result = formatAlreadyAvailableInstallMessage(msg);
+    expect(result).toBeNull();
+  });
+
+  it("works for different app names and team names", () => {
+    const msg = `${ADD_SOFTWARE_ERROR_PREFIX} Zoom already has a package or app available for install on the Engineering team.`;
+    const result = formatAlreadyAvailableInstallMessage(msg);
+
+    const { container } = render(<>{result}</>);
+    expect(container.textContent).toContain("Zoom");
+    expect(container.textContent).toContain("Engineering team");
+  });
+
+  it("returns null if the input is empty", () => {
+    expect(formatAlreadyAvailableInstallMessage("")).toBeNull();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
@@ -1,0 +1,43 @@
+import React from "react";
+
+export const ADD_SOFTWARE_ERROR_PREFIX = "Couldn't add.";
+export const DEFAULT_ADD_SOFTWARE_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Please try again.`;
+export const REQUEST_TIMEOUT_ERROR_MESSAGE = `${ADD_SOFTWARE_ERROR_PREFIX} Request timeout. Please make sure your server and load balancer timeout is long enough.`;
+
+/**
+ * Ensures that a string ends with a period.
+ * If the string is empty or already ends with a period, it is returned unchanged.
+ */
+export const ensurePeriod = (str: string) => {
+  if (str && !str.endsWith(".")) {
+    return `${str}.`;
+  }
+  return str;
+};
+
+/**
+ * Matches API messages indicating that a software package or VPP is already available
+ * for install on a team.
+ *
+ * Example matches:
+ * - When adding a VPP and the team already has a software package
+ * - When adding a software package and the team already has a VPP
+ *
+ * Returns a formatted React element if matched; otherwise, returns null.
+ */
+export const formatAlreadyAvailableInstallMessage = (msg: string) => {
+  const regex = new RegExp(
+    `${ADD_SOFTWARE_ERROR_PREFIX} (.+) already.+on the (.+) team.`
+  );
+  const match = msg.match(regex);
+
+  if (match) {
+    return (
+      <>
+        {ADD_SOFTWARE_ERROR_PREFIX} <b>{match[1]}</b> already has a package or
+        app available for install on the <b>{match[2]}</b> team.{" "}
+      </>
+    );
+  }
+  return null;
+};

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/helpers.tsx
@@ -16,20 +16,15 @@ export const ensurePeriod = (str: string) => {
 };
 
 /**
- * Matches API messages indicating that a software package or VPP is already available
- * for install on a team.
- *
- * Example matches:
- * - When adding a VPP and the team already has a software package
- * - When adding a software package and the team already has a VPP
- *
- * Returns a formatted React element if matched; otherwise, returns null.
- */
+ *  Matches API messages after the fixed Couldn't add software. prefix,
+ * and renders just the part about what is available for install.
+ * Returns a formatted React element if matched; otherwise, returns null. */
 export const formatAlreadyAvailableInstallMessage = (msg: string) => {
-  const regex = new RegExp(
-    `${ADD_SOFTWARE_ERROR_PREFIX} (.+) already.+on the (.+) team.`
-  );
-  const match = msg.match(regex);
+  // Remove prefix (with or without trailing space)
+  const cleaned = msg.replace(/^Couldn't add software\.?\s*/, "");
+  // New regex for "<package> already has a package or app available for install on the <team> team."
+  const regex = /^(.+?) already.+on the (.+?) team\./;
+  const match = cleaned.match(regex);
 
   if (match) {
     return (


### PR DESCRIPTION
## Issue
For #32082 

## Description
- When adding VPP/package, show same error message if app already exists
- Normalize add software error messages as much as possible

## Screenrecording

https://fleetdm.zoom.us/clips/share/6wnaf8YPTwG8c0AJJnZtow

# Checklist for submitter


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
