### PR TITLE
Fleet UI: Update generateResultCountText to handle "certificates"

### DIFF
--- a/frontend/components/TableContainer/utilities/TableContainerUtils.tests.tsx
+++ b/frontend/components/TableContainer/utilities/TableContainerUtils.tests.tsx
@@ -1,0 +1,45 @@
+import { generateResultsCountText } from "./TableContainerUtils";
+
+describe("generateResultsCountText", () => {
+  it("handles 'teams', 'items' 'results' 'users' 'hosts' 'labels' correctly", () => {
+    expect(generateResultsCountText("teams", 0)).toBe("0 teams");
+    expect(generateResultsCountText("teams", 1)).toBe("1 team");
+    expect(generateResultsCountText("teams", 2)).toBe("2 teams");
+
+    expect(generateResultsCountText("items", 1)).toBe("1 item");
+    expect(generateResultsCountText("items", 5)).toBe("5 items");
+
+    expect(generateResultsCountText("results", 1)).toBe("1 result");
+    expect(generateResultsCountText("results", 10)).toBe("10 results");
+
+    expect(generateResultsCountText("users", 1)).toBe("1 user");
+    expect(generateResultsCountText("users", 3)).toBe("3 users");
+
+    expect(generateResultsCountText("hosts", 1)).toBe("1 host");
+    expect(generateResultsCountText("hosts", 9)).toBe("9 hosts");
+
+    expect(generateResultsCountText("labels", 1)).toBe("1 label");
+    expect(generateResultsCountText("labels", 4)).toBe("4 labels");
+
+    expect(generateResultsCountText("versions", 1)).toBe("1 version");
+    expect(generateResultsCountText("versions", 7)).toBe("7 versions");
+  });
+
+  it("handles 'policies' and 'queries' correctly", () => {
+    expect(generateResultsCountText("policies", 1)).toBe("1 policy");
+    expect(generateResultsCountText("policies", 6)).toBe("6 policies");
+
+    expect(generateResultsCountText("queries", 1)).toBe("1 query");
+    expect(generateResultsCountText("queries", 2)).toBe("2 queries");
+  });
+
+  it("handles 'certificates' correctly", () => {
+    expect(generateResultsCountText("certificates", 1)).toBe("1 certificate");
+    expect(generateResultsCountText("certificates", 2)).toBe("2 certificates");
+  });
+
+  it("handles 'classes' correctly with singular form 'class' provided", () => {
+    expect(generateResultsCountText("classes", 1, "class")).toBe("1 class");
+    expect(generateResultsCountText("classes", 2, "class")).toBe("2 classes");
+  });
+});

--- a/frontend/components/TableContainer/utilities/TableContainerUtils.ts
+++ b/frontend/components/TableContainer/utilities/TableContainerUtils.ts
@@ -1,27 +1,28 @@
 const DEFAULT_RESULTS_NAME = "results";
 
+/**
+ * Returns a proper results count text — singular or plural as needed.
+ * For regular cases, computes singular by removing "ies" or "s".
+ * For irregular cases, pass singularName.
+ */
 export const generateResultsCountText = (
   name: string = DEFAULT_RESULTS_NAME,
-  resultsCount?: number
+  resultsCount?: number,
+  singularName?: string
 ): string => {
   if (!resultsCount || resultsCount === 0) return `0 ${name}`;
-  // If there is 1 result and the last 3 letters in the result
-  // name are "ies," we remove the "ies" and add "y"
-  // to make the name singular
-  if (resultsCount === 1 && name.slice(-3) === "ies") {
-    return `${resultsCount} ${name.slice(0, -3)}y`;
-  }
 
-  // If there is 1 result and the last 2 letters in the result
-  // name are "es," we remove the "es" to make the name singular
-  if (resultsCount === 1 && name.slice(-2) === "es") {
-    return `${resultsCount} ${name.slice(0, -2)}y`;
-  }
-
-  // If there is 1 result and the last letter in the result
-  // name is "s," we remove the "s" to make the name singular
-  if (resultsCount === 1 && name[name.length - 1] === "s") {
-    return `${resultsCount} ${name.slice(0, -1)}`;
+  // If exactly 1 result, return singular form.
+  if (resultsCount === 1) {
+    if (singularName) {
+      return `1 ${singularName}`;
+    }
+    if (name.endsWith("ies")) {
+      return `1 ${name.slice(0, -3)}y`;
+    }
+    if (name.endsWith("s")) {
+      return `1 ${name.slice(0, -1)}`;
+    }
   }
 
   return `${resultsCount.toLocaleString()} ${name}`;


### PR DESCRIPTION
## Issue
Closes bug


## Description
- Certificates was rendering as "certificaty"
- Sleeper bug popped up when we added certificates table into UI

## Screenshot of bug (Before)
<img width="302" height="221" alt="Screenshot 2025-10-07 at 4 21 00 PM" src="https://github.com/user-attachments/assets/c58139a4-e439-49d0-8c70-2d6ecd67788b" />



## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
