### PR TITLE
Osquery perf split common software between hosts

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -2878,14 +2878,14 @@ func main() {
 	}
 
 	var (
-		serverURL        = flag.String("server_url", "https://localhost:8080", "URL (with protocol and port of osquery server)")
-		enrollSecret     = flag.String("enroll_secret", "", "Enroll secret to authenticate enrollment")
-		hostCount        = flag.Int("host_count", 10, "Number of hosts to start (default 10)")
-		totalHostCount   = flag.Int("total_host_count", 0, "Total number of hosts across all containers (if 0, uses host_count)")
-		hostIndexOffset  = flag.Int("host_index_offset", 0, "Starting index offset for this container's hosts (default 0)")
-		randSeed         = flag.Int64("seed", time.Now().UnixNano(), "Seed for random generator (default current time)")
-		startPeriod    = flag.Duration("start_period", 10*time.Second, "Duration to spread start of hosts over")
-		configInterval = flag.Duration("config_interval", 1*time.Minute, "Interval for config requests")
+		serverURL       = flag.String("server_url", "https://localhost:8080", "URL (with protocol and port of osquery server)")
+		enrollSecret    = flag.String("enroll_secret", "", "Enroll secret to authenticate enrollment")
+		hostCount       = flag.Int("host_count", 10, "Number of hosts to start (default 10)")
+		totalHostCount  = flag.Int("total_host_count", 0, "Total number of hosts across all containers (if 0, uses host_count)")
+		hostIndexOffset = flag.Int("host_index_offset", 0, "Starting index offset for this container's hosts (default 0)")
+		randSeed        = flag.Int64("seed", time.Now().UnixNano(), "Seed for random generator (default current time)")
+		startPeriod     = flag.Duration("start_period", 10*time.Second, "Duration to spread start of hosts over")
+		configInterval  = flag.Duration("config_interval", 1*time.Minute, "Interval for config requests")
 		// Flag logger_tls_period defines how often to check for sending scheduled query results.
 		// osquery-perf will send log requests with results only if there are scheduled queries configured AND it's their time to run.
 		logInterval         = flag.Duration("logger_tls_period", 10*time.Second, "Interval for scheduled queries log requests")

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1705,7 +1705,7 @@ func (a *agent) softwareMacOS() []map[string]string {
 
 			duplicateBundleSoftware = append(duplicateBundleSoftware, map[string]string{
 				"name":              name,
-				"version":           "0.0.1",
+				"version":           fmt.Sprintf("0.0.1%d", duplicateIdx),
 				"bundle_identifier": bundleID,
 				"source":            "apps",
 				"installed_path":    fmt.Sprintf("/some/path/DuplicateBundle_%d.app", duplicateIdx),


### PR DESCRIPTION
If the total requested common software is 10,000 and there are 200 hosts. Instead of all hosts having 10,000 pieces of software, each host will have a 50 software slice of the 10,000 total requested. This is controlled by `common_software_count`. If you wish to have each host have a certain amount of software, use the `unique_software_count`

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33668