### PR TITLE
add UI to support install software for ios and ipad on setup experience

### DIFF
--- a/changes/issue-33701-ui-install-software-ios-ipad
+++ b/changes/issue-33701-ui-install-software-ios-ipad
@@ -1,0 +1,1 @@
+- add UI for installing software for ios and ipad during the setup experience

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -213,6 +213,8 @@ export const SETUP_EXPERIENCE_PLATFORMS = [
   "macos",
   "windows",
   "linux",
+  "ios",
+  "ipados",
 ] as const;
 
 export type SetupExperiencePlatform = typeof SETUP_EXPERIENCE_PLATFORMS[number];

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -43,6 +43,8 @@ export const PLATFORM_BY_INDEX: SetupExperiencePlatform[] = [
   "macos",
   "windows",
   "linux",
+  "ios",
+  "ipados",
 ];
 export interface InstallSoftwareLocation {
   search: string;
@@ -152,7 +154,9 @@ const InstallSoftware = ({
       const appleMdmAndAbmEnabled =
         globalConfig?.mdm.enabled_and_configured &&
         globalConfig?.mdm.apple_bm_enabled_and_configured;
-      const turnOnAppleMdm = platform === "macos" && !appleMdmAndAbmEnabled;
+      const turnOnAppleMdm =
+        (platform === "macos" || platform === "ios" || platform === "ipados") &&
+        !appleMdmAndAbmEnabled;
 
       const turnOnWindowsMdm =
         platform === "windows" &&
@@ -205,10 +209,18 @@ const InstallSoftware = ({
             <Tab>
               <TabText>Linux</TabText>
             </Tab>
+            <Tab>
+              <TabText>iOS</TabText>
+            </Tab>
+            <Tab>
+              <TabText>iPadOS</TabText>
+            </Tab>
           </TabList>
-          <TabPanel>{renderTabContent(PLATFORM_BY_INDEX[0])}</TabPanel>
-          <TabPanel>{renderTabContent(PLATFORM_BY_INDEX[1])}</TabPanel>
-          <TabPanel>{renderTabContent(PLATFORM_BY_INDEX[2])}</TabPanel>
+          {PLATFORM_BY_INDEX.map((platform) => {
+            return (
+              <TabPanel key={platform}>{renderTabContent(platform)}</TabPanel>
+            );
+          })}
         </Tabs>
       </TabNav>
       {showSelectSoftwareModal && softwareTitles && (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -42,11 +42,26 @@ const AddInstallSoftware = ({
   );
 
   const getAddedText = () => {
+    let platformText = "";
+
+    switch (platform) {
+      case "macos":
+        platformText = "macOS";
+        break;
+      case "ios":
+        platformText = "iOS";
+        break;
+      case "ipados":
+        platformText = "iPadOS";
+        break;
+      default:
+        platformText = capitalize(platform);
+    }
+
     if (noSoftwareUploaded) {
       return (
         <>
-          No {platform === "macos" ? "macOS" : capitalize(platform)} software
-          available. You can add software on the{" "}
+          No {platformText} software available. You can add software on the{" "}
           <LinkWithContext
             to={PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}
             currentQueryParams={{ team_id: currentTeamId }}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
@@ -9,41 +9,85 @@ import MacInstallSoftwareEndUserPreview from "../../../../../../../../assets/vid
 
 const baseClass = "install-software-preview";
 
+interface IPreviewDisplayConfig {
+  description: React.ReactNode;
+  videoSrc: string;
+}
+
+const PREVIEW_DISPLAY_OPTIONS: Record<
+  SetupExperiencePlatform,
+  IPreviewDisplayConfig
+> = {
+  macos: {
+    description: (
+      <>
+        <p>
+          During the <b>Remote Management</b> screen, the end user will see
+          selected software being installed. They won&apos;t be able to continue
+          until software is installed.
+        </p>
+        <p>
+          If there are any errors, they will be able to continue and will be
+          instructed to contact their IT admin.
+        </p>
+      </>
+    ),
+    videoSrc: MacInstallSoftwareEndUserPreview,
+  },
+  ios: {
+    description: (
+      <p>
+        When an iOS host in Apple Business Manager (ABM) enrolls, the selected
+        software is installed.
+      </p>
+    ),
+    videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available
+  },
+  ipados: {
+    description: (
+      <p>
+        When an iPadOS host in Apple Business Manager (ABM) enrolls, the
+        selected software is installed.
+      </p>
+    ),
+    videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available
+  },
+  linux: {
+    description: (
+      <>
+        <p>
+          When Fleet&apos;s agent (fleetd) is installed, fleetd will open the{" "}
+          <b>Fleet Desktop &gt; My device</b> page in the default browser.
+        </p>
+        <p>The end use will see selected software being installed.</p>
+      </>
+    ),
+    videoSrc: LinuxAndWindowsInstallSoftwareEndUserPreview,
+  },
+  windows: {
+    description: (
+      <>
+        <p>
+          When Fleet&apos;s agent (fleetd) is installed, fleetd will open the{" "}
+          <b>Fleet Desktop &gt; My device</b> page in the default browser.
+        </p>
+        <p>The end use will see selected software being installed.</p>
+      </>
+    ),
+    videoSrc: LinuxAndWindowsInstallSoftwareEndUserPreview,
+  },
+};
+
 interface InstallSoftwarePreviewProps {
   platform: SetupExperiencePlatform;
 }
+
 const InstallSoftwarePreview = ({ platform }: InstallSoftwarePreviewProps) => {
-  const [copy, videoSrc] =
-    platform === "macos"
-      ? [
-          <>
-            <p>
-              During the <b>Remote Management</b> screen, the end user will see
-              selected software being installed. They won&apos;t be able to
-              continue until software is installed.
-            </p>
-            <p>
-              If there are any errors, they will be able to continue and will be
-              instructed to contact their IT admin.
-            </p>
-          </>,
-          MacInstallSoftwareEndUserPreview,
-        ]
-      : [
-          <>
-            <p>
-              When Fleet&apos;s agent (fleetd) is installed, fleetd will open
-              the <b>Fleet Desktop &gt; My device</b> page in the default
-              browser.
-            </p>
-            <p>The end user will see selected software being installed.</p>
-          </>,
-          LinuxAndWindowsInstallSoftwareEndUserPreview,
-        ];
+  const { description, videoSrc } = PREVIEW_DISPLAY_OPTIONS[platform];
   return (
     <Card color="grey" paddingSize="xxlarge" className={baseClass}>
       <h3>End user experience</h3>
-      {copy}
+      {description}
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <video
         className={`${baseClass}__preview-video`}


### PR DESCRIPTION
**Related issue:** Resolves #33701

Adds the UI needed to install software for ios and ipad during the setup experience.

> NOTE: the video still needs to be recorded and placed in the code for ios and ipad

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
