### PR TITLE
Revert "Cherry-pick: Handle multiple software entries with the same bundle ID during renames (#33993)

### DIFF
--- a/changes/33468-multiple-versions-bundle-ID
+++ b/changes/33468-multiple-versions-bundle-ID
@@ -1,1 +1,0 @@
-* Fixed edge case when renaming macOS software mapped to multiple checksums.


### PR DESCRIPTION
This reverts commit a39e3fa0a496fe5fbd24e94c4cbe305e309d639d.