### PR TITLE
fix copy for company owned unenrollment modal

### DIFF
--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -297,14 +297,22 @@ export const isBYODManualEnrollment = (
   return enrollmentStatus === "On (manual)";
 };
 
-export const isBYODAccountDrivenEnrollment = (
+/** This checks if the device is enrolled via an Apple ID user enrollment.
+ * We refer to that as "account driven user enrollment" */
+export const isBYODAccountDrivenUserEnrollment = (
   enrollmentStatus: MdmEnrollmentStatus | null
 ) => {
   return enrollmentStatus === "On (personal)";
 };
 
-export const isCompanyOwnedEnrollment = (
+/** This check is the device is enrolled via Automated Device Enrollment (ADE, also known as DEP)
+ * This was previously known as automatic enrollment but was updatd to company owned. Here we check
+ * for both to current and legacy enrollment status */
+export const isAutomaticDeviceEnrollment = (
   enrollmentStatus: MdmEnrollmentStatus | null
 ) => {
-  return enrollmentStatus === "On (company-owned)";
+  return (
+    enrollmentStatus === "On (company-owned)" ||
+    enrollmentStatus === "On (automatic)"
+  );
 };

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -66,13 +66,14 @@ const condenseDeviceUsers = (users: IDeviceUser[]): string[] => {
   const condensed =
     users.length === 4
       ? users
-        .slice(-4)
-        .map((u) => u.email)
-        .reverse()
+          .slice(-4)
+
+          .map((u) => u.email)
+          .reverse()
       : users
-        .slice(-3)
-        .map((u) => u.email)
-        .reverse() || [];
+          .slice(-3)
+          .map((u) => u.email)
+          .reverse() || [];
   return users.length > 4
     ? condensed.concat(`+${users.length - 3} more`) // TODO: confirm limit
     : condensed;

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -11,7 +11,7 @@ import {
   isAppleDevice,
   isMobilePlatform,
 } from "interfaces/platform";
-import { isBYODAccountDrivenEnrollment } from "interfaces/mdm";
+import { isBYODAccountDrivenUserEnrollment } from "interfaces/mdm";
 
 import TooltipWrapperArchLinuxRolling from "components/TooltipWrapperArchLinuxRolling";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -66,13 +66,13 @@ const condenseDeviceUsers = (users: IDeviceUser[]): string[] => {
   const condensed =
     users.length === 4
       ? users
-          .slice(-4)
-          .map((u) => u.email)
-          .reverse()
+        .slice(-4)
+        .map((u) => u.email)
+        .reverse()
       : users
-          .slice(-3)
-          .map((u) => u.email)
-          .reverse() || [];
+        .slice(-3)
+        .map((u) => u.email)
+        .reverse() || [];
   return users.length > 4
     ? condensed.concat(`+${users.length - 3} more`) // TODO: confirm limit
     : condensed;
@@ -644,7 +644,7 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
       // TODO(android): is iOS/iPadOS supported?
       if (
         isAndroid(cellProps.row.original.platform) ||
-        isBYODAccountDrivenEnrollment(
+        isBYODAccountDrivenUserEnrollment(
           cellProps.row.original.mdm.enrollment_status
         )
       ) {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -11,7 +11,7 @@ import {
 } from "interfaces/platform";
 import { isScriptSupportedPlatform } from "interfaces/script";
 import {
-  isBYODAccountDrivenEnrollment,
+  isBYODAccountDrivenUserEnrollment,
   MdmEnrollmentStatus,
 } from "interfaces/mdm";
 
@@ -184,7 +184,7 @@ const canWipeHost = ({
   // in MDM. These hosts cannot be wiped.
   const isAccountDrivenEnrolledIosOrIpadosDevice =
     isIPadOrIPhone(hostPlatform) &&
-    isBYODAccountDrivenEnrollment(hostMdmEnrollmentStatus);
+    isBYODAccountDrivenUserEnrollment(hostMdmEnrollmentStatus);
 
   return (
     isPremiumTier &&

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1027,7 +1027,8 @@ const HostDetailsPage = ({
               {/* There is a special case for BYOD account driven enrolled mdm hosts where we are not
                currently supporting software installs. This check should be removed
                when we add that feature. */}
-              {isBYODAccountDrivenUserEnrollment(host.mdm.enrollment_status) ? (
+              {isBYODAccountDrivenUserEnrollment(host.mdm.enrollment_status) ||
+              isAndroidHost ? (
                 <EmptyTable
                   header="Software library is currently not supported on this host."
                   info={

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -42,7 +42,7 @@ import {
   IHostCertificate,
   CERTIFICATES_DEFAULT_SORT,
 } from "interfaces/certificates";
-import { isBYODAccountDrivenEnrollment } from "interfaces/mdm";
+import { isBYODAccountDrivenUserEnrollment } from "interfaces/mdm";
 
 import { normalizeEmptyValues, wrapFleetHelper } from "utilities/helpers";
 import permissions from "utilities/permissions";
@@ -66,7 +66,6 @@ import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import MainContent, { IMainContentConfig } from "components/MainContent";
 import BackButton from "components/BackButton";
-import Card from "components/Card";
 import CustomLink from "components/CustomLink/CustomLink";
 import EmptyTable from "components/EmptyTable";
 
@@ -1027,10 +1026,8 @@ const HostDetailsPage = ({
             <TabPanel>
               {/* There is a special case for BYOD account driven enrolled mdm hosts where we are not
                currently supporting software installs. This check should be removed
-               when we add that feature.
-               We also are not currently supporting Android software installs */}
-              {isBYODAccountDrivenEnrollment(host.mdm.enrollment_status) ||
-              isAndroidHost ? (
+               when we add that feature. */}
+              {isBYODAccountDrivenUserEnrollment(host.mdm.enrollment_status) ? (
                 <EmptyTable
                   header="Software library is currently not supported on this host."
                   info={

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1037,7 +1037,7 @@ const HostDetailsPage = ({
                         newTab
                         text="Learn more"
                         url={
-                          isBYODAccountDrivenEnrollment(
+                          isBYODAccountDrivenUserEnrollment(
                             host.mdm.enrollment_status
                           )
                             ? BYOD_SW_INSTALL_LEARN_MORE_LINK

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -4,14 +4,13 @@ import DataError from "components/DataError";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { NotificationContext } from "context/notification";
-import CustomLink from "components/CustomLink";
 
 import mdmAPI from "services/entities/mdm";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
-  isBYODAccountDrivenEnrollment,
+  isAutomaticDeviceEnrollment,
+  isBYODAccountDrivenUserEnrollment,
   isBYODManualEnrollment,
-  isCompanyOwnedEnrollment,
   MdmEnrollmentStatus,
 } from "interfaces/mdm";
 
@@ -81,7 +80,7 @@ const UnenrollMdmModal = ({
           share the link with end user.
         </p>
       );
-    } else if (isBYODAccountDrivenEnrollment(enrollmentStatus)) {
+    } else if (isBYODAccountDrivenUserEnrollment(enrollmentStatus)) {
       return (
         <p>
           To re-enroll, ask your end user to navigate to{" "}
@@ -92,7 +91,7 @@ const UnenrollMdmModal = ({
           on their host and to log in with their work email.
         </p>
       );
-    } else if (isCompanyOwnedEnrollment(enrollmentStatus)) {
+    } else if (isAutomaticDeviceEnrollment(enrollmentStatus)) {
       return (
         <p>
           To re-enroll, make sure that the host is still in Apple Business

--- a/frontend/pages/hosts/details/cards/About/About.tsx
+++ b/frontend/pages/hosts/details/cards/About/About.tsx
@@ -4,7 +4,7 @@ import classnames from "classnames";
 import { IHostMdmData, IMunkiData } from "interfaces/host";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 import {
-  isBYODAccountDrivenEnrollment,
+  isBYODAccountDrivenUserEnrollment,
   MDM_ENROLLMENT_STATUS_UI_MAP,
 } from "interfaces/mdm";
 import {
@@ -55,7 +55,7 @@ const About = ({ aboutData, munki, mdm, className }: IAboutProps) => {
     // for all host types, we show the Enrollment ID dataset if the host
     // is enrolled in MDM personally. Personal (BYOD) devices do not report
     // their serial numbers, so we show the Enrollment ID instead.
-    if (mdm && isBYODAccountDrivenEnrollment(mdm.enrollment_status)) {
+    if (mdm && isBYODAccountDrivenUserEnrollment(mdm.enrollment_status)) {
       deviceIdDataSet = (
         <DataSet
           title={


### PR DESCRIPTION
**Related issue:** Resolves #33807

This is a quick fix to show the copy correctly for company enrolled unenrollment modal.

We also improve the naming of the enrollment status checks
