### PR TITLE
DRAFT: Windows Custom SCEP PoC

### DIFF
--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -61,6 +61,7 @@ const (
 	FleetVarCustomSCEPProxyURLPrefix     FleetVarName = "CUSTOM_SCEP_PROXY_URL_"
 	FleetVarSmallstepSCEPChallengePrefix FleetVarName = "SMALLSTEP_SCEP_CHALLENGE_"
 	FleetVarSmallstepSCEPProxyURLPrefix  FleetVarName = "SMALLSTEP_SCEP_PROXY_URL_"
+	FleetVarSCEPWindowsCertificateID     FleetVarName = "SCEP_WINDOWS_CERTIFICATE_ID"
 
 	// OneTimeChallengeTTL is the time to live for one-time challenges.
 	OneTimeChallengeTTL = 1 * time.Hour

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1012,6 +1012,10 @@ type SyncMLCmd struct {
 	// AddCommands is a catch-all for any nested <Add> commands,
 	// which can be found under <Atomic> elements.
 	AddCommands []SyncMLCmd `xml:"Add,omitempty"`
+
+	// ExecCommands is a catch-all for any nested <Exec> commands,
+	// which can be found under <Atomic> elements.
+	ExecCommands []SyncMLCmd `xml:"Exec,omitempty"`
 }
 
 // ParseWindowsMDMCommand parses the raw XML as a single Windows MDM command.

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -105,25 +105,25 @@ func (m *MDMWindowsConfigProfile) ValidateUserProvided() error {
 		case xml.StartElement:
 			// Top-level comments should be followed by <Replace> or <Add> elements
 			if inComment {
-				if !inValidNode && t.Name.Local != "Replace" && t.Name.Local != "Add" {
-					return errors.New("Windows configuration profiles can only have <Replace> or <Add> top level elements after comments")
+				if !inValidNode && t.Name.Local != "Replace" && t.Name.Local != "Add" && t.Name.Local != "Exec" {
+					return errors.New("Windows configuration profiles can only have <Replace> or <Add> or <Exec> top level elements after comments")
 				}
 				inValidNode = true
 				inComment = false
 			}
 
 			switch t.Name.Local {
-			case "Replace", "Add":
+			case "Replace", "Add", "Exec":
 				inValidNode = true
 			case "LocURI":
 				if !inValidNode {
-					return errors.New("Windows configuration profiles can only have <Replace> or <Add> top level elements.")
+					return errors.New("Windows configuration profiles can only have <Replace> or <Add> or <Exec> top level elements.")
 				}
 				inLocURI = true
 
 			default:
 				if !inValidNode {
-					return errors.New("Windows configuration profiles can only have <Replace> or <Add> top level elements.")
+					return errors.New("Windows configuration profiles can only have <Replace> or <Add> or <Exec> top level elements.")
 				}
 			}
 

--- a/server/mdm/scep/server/transport.go
+++ b/server/mdm/scep/server/transport.go
@@ -59,6 +59,19 @@ func MakeHTTPHandlerWithIdentifier(e *Endpoints, rootPath string, logger kitlog.
 		encodeSCEPResponse,
 		opts...,
 	))
+	// To emulate MS-NDES
+	r.Path(rootPath + "{identifier}/pkiclient.exe").Methods("GET").Handler(kithttp.NewServer(
+		e.GetEndpoint,
+		decodeSCEPRequestWithIdentifier,
+		encodeSCEPResponse,
+		opts...,
+	))
+	r.Path(rootPath + "{identifier}/pkiclient.exe").Methods("POST").Handler(kithttp.NewServer(
+		e.PostEndpoint,
+		decodeSCEPRequestWithIdentifier,
+		encodeSCEPResponse,
+		opts...,
+	))
 
 	return r
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1798,6 +1798,9 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 // supported in Windows configuration profiles.
 var fleetVarsSupportedInWindowsProfiles = []fleet.FleetVarName{
 	fleet.FleetVarHostUUID,
+	fleet.FleetVarSCEPWindowsCertificateID,
+	fleet.FleetVarCustomSCEPChallengePrefix,
+	fleet.FleetVarCustomSCEPProxyURLPrefix,
 }
 
 func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInfo) (map[string]struct{}, error) {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1816,7 +1816,7 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 
 	// Check if all found variables are supported
 	for varName := range foundVars {
-		if !slices.Contains(fleetVarsSupportedInWindowsProfiles, fleet.FleetVarName(varName)) {
+		if !slices.Contains(fleetVarsSupportedInWindowsProfiles, fleet.FleetVarName(varName)) && !strings.HasPrefix(varName, "CUSTOM_SCEP_") {
 			return nil, fleet.NewInvalidArgumentError("profile", fmt.Sprintf("Fleet variable $FLEET_VAR_%s is not supported in Windows profiles.", varName))
 		}
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked table schema to confirm autoupdate
- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
