### PR TITLE
allow file protocol in org contact url in UI

### DIFF
--- a/changes/issue-32902-allow-file-contact-url
+++ b/changes/issue-32902-allow-file-contact-url
@@ -1,0 +1,1 @@
+- allow setting a org support url to use the "file" protocol in the url

--- a/frontend/components/forms/validators/valid_url/valid_url.ts
+++ b/frontend/components/forms/validators/valid_url/valid_url.ts
@@ -5,7 +5,7 @@ import isURL from "validator/lib/isURL";
 interface IValidUrl {
   url: string;
   /**  Validate protocols specified */
-  protocols?: ("http" | "https")[];
+  protocols?: ("http" | "https" | "file")[];
   allowLocalHost?: boolean;
 }
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -132,8 +132,9 @@ const Info = ({
       <form onSubmit={onFormSubmit} autoComplete="off">
         {/* "form" class applies global form styling to fields for free */}
         <div
-          className={`form ${gitOpsModeEnabled ? "disabled-by-gitops-mode" : ""
-            }`}
+          className={`form ${
+            gitOpsModeEnabled ? "disabled-by-gitops-mode" : ""
+          }`}
         >
           <div className={`${cardClass}__logo-field-set`}>
             <InputField

--- a/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Info/Info.tsx
@@ -90,7 +90,7 @@ const Info = ({
     if (!orgSupportURL) {
       errors.org_support_url = `Organization support URL must be present`;
     } else if (
-      !validUrl({ url: orgSupportURL, protocols: ["http", "https"] })
+      !validUrl({ url: orgSupportURL, protocols: ["http", "https", "file"] })
     ) {
       errors.org_support_url = `${orgSupportURL} is not a valid URL`;
     }
@@ -132,9 +132,8 @@ const Info = ({
       <form onSubmit={onFormSubmit} autoComplete="off">
         {/* "form" class applies global form styling to fields for free */}
         <div
-          className={`form ${
-            gitOpsModeEnabled ? "disabled-by-gitops-mode" : ""
-          }`}
+          className={`form ${gitOpsModeEnabled ? "disabled-by-gitops-mode" : ""
+            }`}
         >
           <div className={`${cardClass}__logo-field-set`}>
             <InputField


### PR DESCRIPTION
**Related issue:** Fixes #32902

This allows file protocol urls when setting a support URL via the UI.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
