### PR TITLE
Fixed UI bug with org logo on My Device page

### DIFF
--- a/changes/33136-custom-organization-logo-bug
+++ b/changes/33136-custom-organization-logo-bug
@@ -1,0 +1,1 @@
+* Changed display logic for the organization logo component on the My Device page to prevent flickering.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -56,7 +56,6 @@ import PoliciesCard from "../cards/Policies";
 import InfoModal from "./InfoModal";
 import { getErrorMessage, hasRemainingSetupSteps } from "./helpers";
 
-import FleetIcon from "../../../../../assets/images/fleet-avatar-24x24@2x.png";
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
 import AutoEnrollMdmModal from "./AutoEnrollMdmModal";
 import ManualEnrollMdmModal from "./ManualEnrollMdmModal";

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -749,7 +749,11 @@ const DeviceUserPage = ({
             <li className="site-nav-item dup-org-logo" key="dup-org-logo">
               <div className="site-nav-item__logo-wrapper">
                 <div className="site-nav-item__logo">
-                  <OrgLogoIcon className="logo" src={orgLogoURL || FleetIcon} />
+                  {isLoadingHost ? (
+                    <Spinner />
+                  ) : (
+                    <OrgLogoIcon className="logo" src={orgLogoURL} />
+                  )}
                 </div>
               </div>
             </li>


### PR DESCRIPTION
Changed display logic for the organization logo component on the 'My Device' page to prevent flickering.

**Related issue:** Resolves #33136 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually