### PR TITLE
Initial proof of concept for macOS streamlined PSSO during enrollment

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1249,6 +1249,9 @@ the way that the Fleet server works.
 					ds,
 					logger,
 				)
+
+				// TODO(pssopoc): determine if we will use a middleware chain here to support a
+				// Fleet-hosted AuthURL flow
 			}
 
 			healthCheckers := make(map[string]health.Checker)

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -999,6 +999,7 @@ type MDMBootstrapPackageStore interface {
 type MDMAppleMachineInfo struct {
 	IMEI                        string `plist:"IMEI,omitempty"`
 	Language                    string `plist:"LANGUAGE,omitempty"`
+	MDMCanRequestPSSOConfig     bool   `plist:"MDM_CAN_REQUEST_PSSO_CONFIG,omitempty"`
 	MDMCanRequestSoftwareUpdate bool   `plist:"MDM_CAN_REQUEST_SOFTWARE_UPDATE"`
 	MEID                        string `plist:"MEID,omitempty"`
 	OSVersion                   string `plist:"OS_VERSION"`
@@ -1025,6 +1026,54 @@ type MDMAppleAccountDrivenUserEnrollDeviceInfo struct {
 	SoftwareUpdateDeviceID   string `plist:"SOFTWARE_UPDATE_DEVICE_ID,omitempty"`
 	SupplementalBuildVersion string `plist:"SUPPLEMENTAL_BUILD_VERSION,omitempty"`
 }
+
+// MDMApplePSSORequiredCode is the [code][1] specified by Apple to indicate that the device
+// needs to configure PSSO before enrollment and setup can proceed.
+//
+// [1]: https://developer.apple.com/documentation/devicemanagement/errorcodeplatformssorequired
+const MDMApplePSSORequiredCode = "com.apple.psso.required"
+
+// MDMApplePSSORequiredDetails is the [details][1] specified by Apple for the
+// required PSSO.
+//
+// [1]: https://developer.apple.com/documentation/devicemanagement/errorcodeplatformssorequired/details-data.dictionary
+type MDMApplePSSORequiredDetails struct {
+	AuthURL    string                      `json:"AuthURL"`
+	Package    MDMApplePSSORequiredPackage `json:"Package"`
+	ProfileURL string                      `json:"ProfileURL"`
+}
+
+// MDMApplePSSORequiredPackage is the [package][1] specified by Apple for the
+// required PSSO.
+//
+// [1]: https://developer.apple.com/documentation/devicemanagement/errorcodeplatformssorequired/details-data.dictionary/package-data.dictionary
+type MDMApplePSSORequiredPackage struct {
+	ManifestURL                    string   `json:"ManifestURL"`
+	PinningCerts                   []string `json:"PinningCerts,omitempty"`
+	PinningRevocationCheckRequired bool     `json:"PinningRevocationCheckRequired,omitempty"`
+}
+
+type MDMApplePSSORequiredConfig struct {
+	AuthURL    string `json:"AuthURL"`
+	Package    string `json:"Package"`
+	ProfileURL string `json:"ProfileURL"`
+}
+
+// MDMApplePSSORequired is the [error response][1] specified by Apple to indicate that the device
+// needs to perform a software update before enrollment and setup can proceed.
+//
+// [1]: https://developer.apple.com/documentation/devicemanagement/errorcodeplatformssorequired
+type MDMApplePSSORequired struct {
+	Code    string                      `json:"code"` // "com.apple.psso.required"
+	Details MDMApplePSSORequiredDetails `json:"details"`
+}
+
+// func NewMDMApplePSSORequired(asset MDMApplePSSORequiredConfig) *MDMApplePSSORequired {
+// 	return &MDMApplePSSORequired{
+// 		Code:    MDMApplePSSORequiredCode,
+// 		Details: MDMApplePSSORequiredDetails{AuthURL: asset.AuthURL, Package: asset.Package, ProfileURL: asset.ProfileURL},
+// 	}
+// }
 
 // MDMAppleSoftwareUpdateRequiredCode is the [code][1] specified by Apple to indicate that the device
 // needs to perform a software update before enrollment and setup can proceed.

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1025,6 +1025,16 @@ type Service interface {
 	// CheckMDMAppleEnrollmentWithMinimumOSVersion checks if the minimum OS version is met for a MDM enrollment
 	CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *MDMAppleMachineInfo) (*MDMAppleSoftwareUpdateRequired, error)
 
+	// CheckMDMAppleEnrollmentWithPSSO checks if the PSSO requirement is met for a MDM enrollment
+	CheckMDMAppleEnrollmentWithPSSO(ctx context.Context, m *MDMAppleMachineInfo) (*MDMApplePSSORequired, error)
+
+	// GetMDMApplePSSOInstaller retrieves the PSSO installer
+	GetMDMApplePSSOInstaller(ctx context.Context, request interface{}) ([]byte, string, error)
+	// GetMDMApplePSSOProfile retrieves the PSSO profile
+	GetMDMApplePSSOProfile(ctx context.Context, request interface{}) (string, error)
+	// GetMDMApplePSSOManifest retrieves the PSSO manifest
+	GetMDMApplePSSOManifest(ctx context.Context, request interface{}) (string, error)
+
 	// GetOTAProfile gets the OTA (over-the-air) profile for a given team based on the enroll secret provided.
 	GetOTAProfile(ctx context.Context, enrollSecret, idpUUID string) ([]byte, error)
 

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -635,6 +635,14 @@ type TriggerLinuxDiskEncryptionEscrowFunc func(ctx context.Context, host *fleet.
 
 type CheckMDMAppleEnrollmentWithMinimumOSVersionFunc func(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error)
 
+type CheckMDMAppleEnrollmentWithPSSOFunc func(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMApplePSSORequired, error)
+
+type GetMDMApplePSSOInstallerFunc func(ctx context.Context, request interface{}) ([]byte, string, error)
+
+type GetMDMApplePSSOProfileFunc func(ctx context.Context, request interface{}) (string, error)
+
+type GetMDMApplePSSOManifestFunc func(ctx context.Context, request interface{}) (string, error)
+
 type GetOTAProfileFunc func(ctx context.Context, enrollSecret string, idpUUID string) ([]byte, error)
 
 type TriggerCronScheduleFunc func(ctx context.Context, name string) error
@@ -1758,6 +1766,18 @@ type Service struct {
 
 	CheckMDMAppleEnrollmentWithMinimumOSVersionFunc        CheckMDMAppleEnrollmentWithMinimumOSVersionFunc
 	CheckMDMAppleEnrollmentWithMinimumOSVersionFuncInvoked bool
+
+	CheckMDMAppleEnrollmentWithPSSOFunc        CheckMDMAppleEnrollmentWithPSSOFunc
+	CheckMDMAppleEnrollmentWithPSSOFuncInvoked bool
+
+	GetMDMApplePSSOInstallerFunc        GetMDMApplePSSOInstallerFunc
+	GetMDMApplePSSOInstallerFuncInvoked bool
+
+	GetMDMApplePSSOProfileFunc        GetMDMApplePSSOProfileFunc
+	GetMDMApplePSSOProfileFuncInvoked bool
+
+	GetMDMApplePSSOManifestFunc        GetMDMApplePSSOManifestFunc
+	GetMDMApplePSSOManifestFuncInvoked bool
 
 	GetOTAProfileFunc        GetOTAProfileFunc
 	GetOTAProfileFuncInvoked bool
@@ -4217,6 +4237,34 @@ func (s *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Contex
 	s.CheckMDMAppleEnrollmentWithMinimumOSVersionFuncInvoked = true
 	s.mu.Unlock()
 	return s.CheckMDMAppleEnrollmentWithMinimumOSVersionFunc(ctx, m)
+}
+
+func (s *Service) CheckMDMAppleEnrollmentWithPSSO(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMApplePSSORequired, error) {
+	s.mu.Lock()
+	s.CheckMDMAppleEnrollmentWithPSSOFuncInvoked = true
+	s.mu.Unlock()
+	return s.CheckMDMAppleEnrollmentWithPSSOFunc(ctx, m)
+}
+
+func (s *Service) GetMDMApplePSSOInstaller(ctx context.Context, request interface{}) ([]byte, string, error) {
+	s.mu.Lock()
+	s.GetMDMApplePSSOInstallerFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMApplePSSOInstallerFunc(ctx, request)
+}
+
+func (s *Service) GetMDMApplePSSOProfile(ctx context.Context, request interface{}) (string, error) {
+	s.mu.Lock()
+	s.GetMDMApplePSSOProfileFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMApplePSSOProfileFunc(ctx, request)
+}
+
+func (s *Service) GetMDMApplePSSOManifest(ctx context.Context, request interface{}) (string, error) {
+	s.mu.Lock()
+	s.GetMDMApplePSSOManifestFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMApplePSSOManifestFunc(ctx, request)
 }
 
 func (s *Service) GetOTAProfile(ctx context.Context, enrollSecret string, idpUUID string) ([]byte, error) {

--- a/server/service/apple_mdm_psso.go
+++ b/server/service/apple_mdm_psso.go
@@ -1,0 +1,304 @@
+package service
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-kit/log/level"
+)
+
+func (svc *Service) CheckMDMAppleEnrollmentWithPSSO(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMApplePSSORequired, error) {
+	// // TODO(pssopoc): confirm how we want to handle authz here
+	// skipauth: The enroll profile endpoint is unauthenticated.
+	svc.authz.SkipAuthorization(ctx)
+
+	if m == nil {
+		// TODO(pssopoc): do we instead want to always fail here if we don't have machine info?
+		level.Debug(svc.logger).Log("msg", "no machine info, skipping psso check")
+		return nil, nil
+	}
+
+	level.Debug(svc.logger).Log("msg", "checking psso", "serial", m.Serial, "current_version", m.OSVersion)
+
+	if !m.MDMCanRequestPSSOConfig {
+		level.Debug(svc.logger).Log("msg", "mdm cannot request psso config, skipping psso check", "serial", m.Serial)
+		return nil, nil
+	}
+
+	appCfg, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "psso: fetching app config")
+	}
+	serverURL := strings.TrimSuffix(appCfg.ServerSettings.ServerURL, "/") // TODO(pssopoc): confirm how this should work with general server url prefix setting and/or custom MDM URL
+
+	return &fleet.MDMApplePSSORequired{
+		Code: fleet.MDMApplePSSORequiredCode,
+		Details: fleet.MDMApplePSSORequiredDetails{
+			AuthURL:    "https://login.microsoft.com/YOUR-TENANT-UUID", // TODO(pssopoc): make configurable and replace with real idp url
+			ProfileURL: serverURL + "/api/latest/fleet/mdm/apple/psso_installer/profile",
+			Package: fleet.MDMApplePSSORequiredPackage{
+				ManifestURL: serverURL + "/api/latest/fleet/mdm/apple/psso_installer/manifest",
+			},
+		},
+	}, nil
+}
+
+type mdmApplePSSOManifestResponse struct {
+	Manifest string `json:"manifest"`
+	Err      error  `json:"error,omitempty"`
+}
+
+func (r mdmApplePSSOManifestResponse) Error() error { return r.Err }
+
+func (r mdmApplePSSOManifestResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(r.Manifest)), 10))
+	w.Header().Set("Content-Type", "application/xml")
+
+	// OK to just log the error here as writing anything on
+	// `http.ResponseWriter` sets the status code to 200 (and it can't be
+	// changed.) Clients should rely on matching content-length with the
+	// header provided.
+	if n, err := w.Write([]byte(r.Manifest)); err != nil {
+		logging.WithExtras(ctx, "err", err, "written", n)
+	}
+}
+
+func mdmApplePSSOManifestEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	m, err := svc.GetMDMApplePSSOManifest(ctx, request) // TODO(pssopoc): replace with real service method, for PoC just call this to enforce the skipauth
+	if err != nil {
+		return mdmApplePSSOManifestResponse{Err: err}, nil
+	}
+
+	return mdmApplePSSOManifestResponse{Manifest: m}, nil
+}
+
+func (svc *Service) GetMDMApplePSSOManifest(ctx context.Context, request interface{}) (string, error) {
+	// // TODO(pssopoc): replace with real service method, for PoC just call this to enforce the skipauth
+	// skipauth: proof of concept endpoint to serve the company portal installer
+	svc.authz.SkipAuthorization(ctx)
+
+	ac, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "fetching app config")
+	}
+	serverURL := strings.TrimSuffix(ac.ServerSettings.ServerURL, "/") // TODO(pssopoc): confirm how this should work with general server url prefix setting and/or custom MDM URL
+
+	level.Debug(svc.logger).Log("msg", "generating psso manifest", "server_url", serverURL)
+
+	return generatePSSOManifest(companyPortalHash, serverURL+"/api/latest/fleet/mdm/apple/psso_installer"), nil
+}
+
+type mdmApplePSSOProfileResponse struct {
+	Profile string `json:"profile"`
+	Err     error  `json:"error,omitempty"`
+}
+
+func (r mdmApplePSSOProfileResponse) Error() error { return r.Err }
+
+func (r mdmApplePSSOProfileResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(r.Profile)), 10))
+	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
+
+	// OK to just log the error here as writing anything on
+	// `http.ResponseWriter` sets the status code to 200 (and it can't be
+	// changed.) Clients should rely on matching content-length with the
+	// header provided.
+	if n, err := w.Write([]byte(r.Profile)); err != nil {
+		logging.WithExtras(ctx, "err", err, "written", n)
+	}
+}
+
+func mdmApplePSSOProfileEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	p, err := svc.GetMDMApplePSSOProfile(ctx, request) // TODO(pssopoc): replace with real service method, for PoC just call this to enforce the skipauth
+	if err != nil {
+		return mdmApplePSSOProfileResponse{Err: err}, nil
+	}
+
+	return mdmApplePSSOProfileResponse{Profile: p}, nil
+}
+
+func (svc *Service) GetMDMApplePSSOProfile(ctx context.Context, request interface{}) (string, error) {
+	// // TODO(pssopoc): replace with real service method, for PoC just call this to enforce the skipauth
+	// skipauth: proof of concept endpoint to serve the company portal installer
+	svc.authz.SkipAuthorization(ctx)
+
+	level.Debug(svc.logger).Log("msg", "serving psso profile")
+
+	// TODO(pssopoc): replace with a method to generate the profile based on admin-configured values
+	return pssoProfile, nil
+}
+
+func mdmApplePSSOInstallerEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	installer, name, err := svc.GetMDMApplePSSOInstaller(ctx, request) // TODO(pssopoc): replace with real service method, for PoC just to call this to enforce the skipauth
+	if err != nil {
+		return mdmAppleGetInstallerResponse{Err: err}, nil
+	}
+
+	return mdmAppleGetInstallerResponse{
+		head:      false,
+		name:      name,
+		size:      int64(len(installer)),
+		installer: installer,
+	}, nil
+}
+
+func (svc *Service) GetMDMApplePSSOInstaller(ctx context.Context, request interface{}) ([]byte, string, error) {
+	// // TODO(pssopoc): replace with real service method, for PoC just call this to enforce the skipauth
+	// skipauth: proof of concept endpoint to serve the company portal installer
+	svc.authz.SkipAuthorization(ctx)
+	return CompanyPortal, "CompanyPortal-Installer.pkg", nil
+}
+
+// // TODO(pssopoc): replace with real service method that allows for uploading the desired PSSO app, for PoC just to call this to enforce the skipauth
+// Embed the company portal app for PoC
+//
+//go:embed testdata/software-installers/CompanyPortal-Installer.pkg
+var CompanyPortal []byte
+
+const companyPortalHash = "2cf89bb6c2af88b0ed44defdcf21a9c023fa6948e4da61e16bec71545a46c329" // TODO(pssopoc): replace with method to obtain hash of the uploaded app
+
+// TODO(pssopoc): replace with a method to retrieve a pre-computed manifest, stored when the
+// installer is uploaded, probably using existing `createManifest` as a starting point
+func generatePSSOManifest(hash string, url string) string {
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>items</key>
+  <array>
+    <dict>
+      <key>assets</key>
+      <array>
+        <dict>
+          <key>kind</key>
+          <string>software-package</string>
+          <key>sha256-size</key>
+          <integer>32</integer>
+          <key>sha256s</key>
+          <array>
+            <string>%s</string>
+          </array>
+          <key>url</key>
+          <string>%s</string>
+        </dict>
+      </array>
+    </dict>
+  </array>
+</dict>
+</plist>`, hash, url)
+}
+
+// TODO(pssopoc): replace this with a method to generate the profile based on admin-configured values
+const pssoProfile = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>ExtensionIdentifier</key>
+			<string>com.microsoft.CompanyPortalMac.ssoextension</string>
+			<key>PayloadDisplayName</key>
+			<string>Extensible Single Sign-On</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.extensiblesso.4D68D4CF-1250-4FF4-AFFB-1176DB539C49</string>
+			<key>PayloadType</key>
+			<string>com.apple.extensiblesso</string>
+			<key>PayloadUUID</key>
+			<string>4D68D4CF-1250-4FF4-AFFB-1176DB539C49</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>PlatformSSO</key>
+			<dict>
+				<key>AuthenticationMethod</key>
+				<string>Password</string>
+				<key>TokenToUserMapping</key>
+				<dict>
+					<key>AccountName</key>
+					<string>preferred_username</string>
+					<key>FullName</key>
+					<string>name</string>
+				</dict>
+				<key>UseSharedDeviceKeys</key>
+				<true/>
+				<key>EnableRegistrationDuringSetup</key>
+				<true/>
+				<key>EnableCreateFirstUserDuringSetup</key>
+				<true/>
+			</dict>
+			<key>RegistrationToken</key>
+			<string>{{DEVICEREGISTRATION}}</string>
+			<key>ScreenLockedBehavior</key>
+			<string>DoNotHandle</string>
+			<key>TeamIdentifier</key>
+			<string>UBF8T346G9</string>
+			<key>Type</key>
+			<string>Redirect</string>
+			<key>URLs</key>
+			<array>
+				<string>https://login.microsoftonline.com</string>
+				<string>https://login.microsoft.com</string>
+				<string>https://sts.windows.net</string>
+				<string>https://login-us.microsoftonline.com</string>
+			</array>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>PlatformSSO</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.platformsso.652B07D0-2E08-45CE-9423-1FCAFFAEC390</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>652B07D0-2E08-45CE-9423-1FCAFFAEC390</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`
+
+// // TODO(pssopoc): PoC currently assumes that the AuthURL is hosted by the IdP rather than Fleet, but
+// // In the Apple docs example, the request is to `Host: idp.example.com`, but the flow is ambiguous.
+// //
+// // They say the device creates an ASWebAuthenticationSession using AuthURL and a callback scheme
+// // that it sets to apple-remotemanagement-user-login (step 10). This starts an authentication flow
+// // with the organization’s identity provider. But then they say the ASWebAuthenticationSession web
+// // flow completes when the device management service returns an HTTP 308 permanent redirect
+// // response to the device.
+// //
+// // This is a very rough sketch of how we might try to implement a Fleet-hosted AuthURL similar to
+// // OTA or account-driven enrollment where Fleet intermediates so that it can populate the
+// // apple-remotemanagement-user-login callback scheme. It would encompass the following steps:
+// // that initiates the following steps:
+// // https://developer.apple.com/documentation/devicemanagement/implementing-platform-sso-during-device-enrollment#Authenticate-the-user
+// // https://developer.apple.com/documentation/devicemanagement/implementing-platform-sso-during-device-enrollment#Process-the-user-authentication-result
+// func ServePSSOAuth(
+// 	svc fleet.Service,
+// 	urlPrefix string,
+// 	ds fleet.Datastore,
+// 	logger log.Logger,
+// ) http.Handler {
+// 	herr := func(w http.ResponseWriter, err string) {
+// 		logger.Log("err", err)
+// 		http.Error(w, err, http.StatusInternalServerError)
+// 	}
+
+// 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// 		endpoint_utils.WriteBrowserSecurityHeaders(w)
+
+// 		// TODO(pssopoc): validate things like required Fleet setup, valid enroll secret, etc
+
+// 		// TODO(pssopoc): initiate IdP auth if needed, for PoC we skip this and assume auth is always successful
+
+// 		// TODO(pssopoc): if we get here, IdP SSO authentication is either not required, or has
+// 		// been successfully completed (e.g., we have received the IdP access token by some means TBD)
+// 		w.Header().Set("Location", "apple-remotemanagement-user-login://authentication-results?access-token=dXNlci1pZGVudGl0eQ")
+// 		w.WriteHeader(http.StatusPermanentRedirect)
+// 	})
+// }


### PR DESCRIPTION
Resolves #33566

### Background

Apple introduced new Platform SSO functions on macOS 26 (Tahoe) to streamline the user authentication
during Setup Assistant.

https://developer.apple.com/documentation/devicemanagement/implementing-platform-sso-during-device-enrollment
https://developer.apple.com/documentation/devicemanagement/errorcodeplatformssorequired
https://developer.apple.com/documentation/devicemanagement/extensiblesinglesignon
https://support.apple.com/guide/deployment/platform-sso-for-macos-dep7bbb05313/web 

Company Portal is the Microsoft application used for PSSO on Apple devices. Microsoft says Company
Portal does not include support for the newly introduced Platform SSO functions on macOS Tahoe 26.
According to Microsoft, these functions will be evaluated and incorporated into future Company
Portal releases as appropriate. No timeline is provided.

https://techcommunity.microsoft.com/blog/microsoft-entra-blog/now-generally-available-platform-sso-for-macos-with-microsoft-entra-id/4437424
https://learn.microsoft.com/en-us/intune/intune-service/configuration/platform-sso-macos
https://learn.microsoft.com/en-us/intune/intune-service/configuration/use-enterprise-sso-plug-in-macos-with-intune

Okta has similarly stated that their Okta Verify app does not currently support the new Platform SSO
functions on macOS 26.

Additionally, Jamf reported the same lack of IdP support in their blog post regarding the new Platform
SSO functions. https://www.jamf.com/blog/macos-26-platform-sso-simplified-setup/ 

### Additional investigation

Despite the IdP vendor's statements about lack of current support, there have been isolated reports
that community members have been able to use new Platform SSO functions on macOS 26; however, the broader
community has not been able to independently confirm those isolated reports. We found no
documentation by vendors or community members that describes a working setup in any detail.

### Proof of concept

Nevertheless, we endeavored to create a proof of concept implementation of the new Platform SSO
functions to see how far we could get. We were able to successfully enroll a macOS 26 device
using the new Platform SSO functions, but we were not able to complete the user authentication
portion of the flow because of the lack of IdP support.

Apple describes the steps for the Platform SSO during enrollment as follows:

1. Post a MACHINEINFO request with a PSSO indicator.
2. Detect PSSO support for the device.
3. Return the required 403 PSSO error response.
4. Fetch the ExtensibleSingleSignOn profile.
5. Return the ExtensibleSingleSignOn profile.
6. Install the ExtensibleSingleSignOn profile.
7. Fetch the package.
8. Return the package.
9. Install the package.
10. Create a web view for AuthURL.
11. Present the sign-in view to the user.
12. Return an HTTP 308 redirect response.
13. Authenticate the user.
14. Post a MACHINEINFO request with the bearer token.
15. Verify the bearer token.
16. Return the enrollment profile.
17. Enroll with the device management service.

We were able to successfully complete steps 1-11, including returning the required 403 PSSO error
with details that allow the device to configure Platform SSO and trigger an initial authentication
with the organization’s identity provider. As expected, the device requested the package manifest,
the package itself (i.e. Microsoft Company Portal app), and the ExtensibleSingleSignOn profile,
which were served by Fleet. The device successfully installed the profile and the package. The
device created a web view for the AuthURL (served by Entra) and presented the sign-in view to the user.

In the web view, we were able to successfully sign with Entra credentials. After completing the web
view sign-in, we were presented with second sign-in form. The second form was a Setup Assistant
dialog with a prompt to sign in to your organization using the Entra username and password.
Attempting to sign in to the second form using the same Entra credentials failed. We believe this is
because Entra does not fully support the `apple-remotemanagement-user-login` callback scheme used by
Platform SSO in the context of device enrollment.

### Follow-up

Monitor IdP vendor announcements and community forums for support of the new Platform SSO functions
on macOS 26. 

Investigate approaches to implement a Fleet-hosted AuthURL to support the
`apple-remotemanagement-user-login` callback scheme (the Apple docs are ambiguous on this part of
the flow). This might be similar to our existing approaches used for OTA enrollment or
account-driven enrollment flows.

Technical design considerations:
- We should take a look at how we handling all the different Apple MDM enrollment flows. We have
  shared endpoints with ad hoc branching logic that is getting quite complex.
- We need to adjust how we are managing DEP profile assignments to accommodate the new PSSO flow.
  - Simplified PSSO during Setup Assistant is incompatible with the `configuration_web_url` approach
    that we currently use for DEP enrollment with end-user auth enabled. For the new features, the
    cloudConfig profile cannot include the `configuration_web_url` key and must instead only use the
    `url` key (i.e. the same key used for DEP enrollment when end-user auth is not enabled).

Design considerations for UX for admins to configure PSSO during Setup Assistant:
- UX for admins upload/designate the required package (e.g. Microsoft Company Portal app)
  - Note that our existing software installer UX may not be the best fit here. The process
    contemplated by Apple seems to be closer to the way we handle InstallEnterpriseApplication
    requests for macOS, where Fleet generates and serves a manifest that in turn points to a
    package hosted by Fleet. We currently use this approach for fleetd base and the bootstrap 
    package, but in earlier iterations (now deprecated) we also used to support it for other
    packages. Potentially the package could be hosted at a location specified by the
    admin; however, in that case, the admin would also need to generate/host the manifest too (or
    Fleet would need to download the package and generate the manifest)
- UX for admins to configure the IdP settings for PSSO in Fleet, including the AuthURL
  provided by the IdP. This will probably not be a 1:1 mapping to the existing IdP settings.
- UX for the PSSO configuration profile. There is a wide range of possible settings and we'll need
  to strike a balance between simplicity and flexibility for power users.