### PR TITLE
Fleet UI: Fix some unreleased bugs for 4.75

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/_styles.scss
+++ b/frontend/components/top_nav/SiteTopNav/_styles.scss
@@ -29,7 +29,7 @@
       display: flex;
       align-items: center;
       gap: $pad-small;
-      color: $core-fleet-white;
+      color: $ui-fleet-black-75;
       font-weight: $regular;
       font-size: $xxx-small;
       cursor: default;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/_styles.scss
@@ -10,7 +10,7 @@
         display: none;
       }
       :hover:not(.component__tooltip-wrapper__tip-text):not(.custom-link--tooltip-link) {
-        background-color: $ui-fleet-black-10;
+        background-color: $ui-off-white;
         .list-item__labels {
           display: none;
         }

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileListItem/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileListItem/_styles.scss
@@ -29,6 +29,7 @@
     &--count {
       align-self: center;
       color: $ui-fleet-black-75;
+      font-size: $x-small; // Remove when global default font is implemented
     }
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/_styles.scss
@@ -20,6 +20,7 @@
     display: flex;
     gap: $pad-xsmall;
     font-size: $xx-small;
+    align-items: center;
   }
 
   &__sha256 {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
@@ -167,7 +167,13 @@ export const generateTableConfig = (
         <GitOpsModeTooltipWrapper
           position="left"
           renderChildren={(disableChildren) => (
-            <div className={disableChildren ? "disabled-by-gitops-mode" : ""}>
+            <div
+              className={
+                disableChildren
+                  ? "disabled-by-gitops-mode abm-actions-wrapper"
+                  : "abm-actions-wrapper"
+              }
+            >
               <ActionsDropdown
                 options={generateActions()}
                 onChange={(value: string) =>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/_styles.scss
@@ -1,34 +1,44 @@
 .apple-business-manager-table {
-
   .data-table-block .data-table {
     td.apple_id__cell {
       max-width: 180px;
     }
 
-    td.macos_team__cell, td.ios_team__cell, td.ipados_team__cell {
+    td.macos_team__cell,
+    td.ios_team__cell,
+    td.ipados_team__cell {
       max-width: 150px;
     }
-  }
 
+    td.actions__cell {
+      .abm-actions-wrapper {
+        display: flex;
+        align-items: center;
+      }
+    }
+  }
 
   // The desired behavior is to hide the header and team cell one by one
   // as the viewport gets smaller. This is achieved by using the max-width
   // media query with the breakpoint values taken from when the table content
   // starts to overflow.
   @media (max-width: $break-lg) {
-    .ipados_team__header, .ipados_team__cell {
+    .ipados_team__header,
+    .ipados_team__cell {
       display: none;
     }
   }
 
   @media (max-width: 1230px) {
-    .ios_team__header, .ios_team__cell {
+    .ios_team__header,
+    .ios_team__cell {
       display: none;
     }
   }
 
   @media (max-width: $break-md) {
-    .macos_team__header, .macos_team__cell {
+    .macos_team__header,
+    .macos_team__cell {
       display: none;
     }
   }

--- a/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSummary/_styles.scss
@@ -16,5 +16,6 @@
 
   .data-set dd {
     overflow: initial;
+    gap: $pad-xsmall; // Future iteration: Consider global gap to for data sets
   }
 }


### PR DESCRIPTION
## Issues
Closes #34062
Closes #33751 
Closes #34057 
Closes #34056 
Closes #34008 

## Description
- Change gitops mode font color miss
- Align actions dropdown vertically centered
- Align installer information vertically centered
- Add gap to operating system icon
- Fix font size for label count
- Fix hover background color of Config profiles

## Some screenshots of fixes

- Gitops mode, tried green first and it was too distracting so I changed it to ui-fleet-black-75
<img width="282" height="138" alt="Screenshot 2025-10-10 at 11 59 15 AM" src="https://github.com/user-attachments/assets/e8514b1a-3f7a-48f5-b7b1-6ce5da102311" />

- center everything on this line
<img width="770" height="334" alt="Screenshot 2025-10-10 at 12 01 21 PM" src="https://github.com/user-attachments/assets/7c2b84b7-f55d-4874-85fb-70ca83659632" />

- 4px spacing
<img width="334" height="250" alt="Screenshot 2025-10-10 at 12 12 59 PM" src="https://github.com/user-attachments/assets/5b283b1e-467e-46e3-ac2d-48c1507448b5" />

