### PR TITLE
Better api error for EUA manual macOS profile download

### DIFF
--- a/changes/33447-better-api-error-for-eua-manual-macos-profile
+++ b/changes/33447-better-api-error-for-eua-manual-macos-profile
@@ -1,0 +1,1 @@
+* Fails with a descriptive error on the manual MacOS profile download

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -39,7 +39,6 @@ const ManualEnrollMdmModal = ({
       if (e && typeof e === "object" && "data" in e) {
         const axiosResponse = e as AxiosResponse;
         if (axiosResponse.data) {
-          console.log(axiosResponse);
           const dataBlob = axiosResponse.data as Blob;
           const blobText = await dataBlob.text();
           console.log("blob text", blobText);

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -41,7 +41,6 @@ const ManualEnrollMdmModal = ({
         if (axiosResponse.data) {
           const dataBlob = axiosResponse.data as Blob;
           const blobText = await dataBlob.text();
-          console.log("blob text", blobText);
           if (
             blobText.includes(
               "The team associated with the enroll_secret has end user authentication enabled so the OTA profile won't work."

--- a/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/ManualEnrollMdmModal/ManualEnrollMdmModal.tsx
@@ -29,7 +29,6 @@ const ManualEnrollMdmModal = ({
       const profileContent = await mdmAPI.downloadManualEnrollmentProfile(
         token
       );
-      console.log(profileContent);
       const file = new File(
         [profileContent],
         "fleet-mdm-enrollment-profile.mobileconfig"

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -271,6 +271,13 @@ func TestAppleMDMAuthorization(t *testing.T) {
 		}, nil
 	}
 
+	ds.VerifyEnrollSecretFunc = func(ctx context.Context, enrollSecret string) (*fleet.EnrollSecret, error) {
+		return &fleet.EnrollSecret{
+			Secret: "abcd",
+			TeamID: nil,
+		}, nil
+	}
+
 	checkAuthErr := func(t *testing.T, err error, shouldFailWithAuth bool) {
 		t.Helper()
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -10321,6 +10321,14 @@ func (s *integrationMDMTestSuite) TestDontIgnoreAnyProfileErrors() {
 	t := s.T()
 	ctx := context.Background()
 
+	appConfig, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	appConfig.MDM.MacOSSetup = fleet.MacOSSetup{
+		EnableEndUserAuthentication: false,
+	}
+	err = s.ds.SaveAppConfig(ctx, appConfig)
+	require.NoError(t, err)
+
 	// Create a host and a couple of profiles
 	host, mdmDevice := createHostThenEnrollMDM(s.ds, s.server.URL, t)
 
@@ -15122,6 +15130,14 @@ func (s *integrationMDMTestSuite) TestDigiCertIntegration() {
 	ctx := context.Background()
 	s.setSkipWorkerJobs(t)
 	digiCertServer := createMockDigiCertServer(t)
+
+	appConfig, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	appConfig.MDM.MacOSSetup = fleet.MacOSSetup{
+		EnableEndUserAuthentication: false,
+	}
+	err = s.ds.SaveAppConfig(ctx, appConfig)
+	require.NoError(t, err)
 
 	// Add DigiCert config
 	ca := newMockDigicertCA(digiCertServer.server.URL, "my_CA")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33447 

User error:
<img width="1020" height="213" alt="image" src="https://github.com/user-attachments/assets/daa90fa3-aa43-4734-9f29-4744ca6fb3e2" />

As far as I could tell it was not possible to customize the error message shown when installing the failing profile.
We have some code that mentions iOS/iPadOS and after replicating, it seems it does not work the same for macOS.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

