### PR TITLE
Don't show edit option for host vitals labels, error if landing on edit UI for a host vitals label

### DIFF
--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -51,7 +51,11 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       onSuccess: (data) => {
         // can't edit host_vitals labels yet
         if (data.label_membership_type === "host_vitals") {
-          router.replace(PATHS.MANAGE_HOSTS_LABEL(data.id));
+          renderFlash(
+            "error",
+            "Host vitals labels are not editable. Delete the label and re-add it to make changes."
+          );
+          router.replace(PATHS.MANAGE_LABELS);
         }
       },
     }

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -71,18 +71,19 @@ const generateActionDropdownOptions = (
     label.author_id === currentUser.id;
 
   if (hasGlobalWritePermission || hasLabelAuthorWritePermission) {
-    options.push(
-      {
+    if (label.label_membership_type !== "host_vitals") {
+      options.push({
         label: "Edit",
         disabled: false,
         value: "edit",
-      },
-      {
-        label: "Delete",
-        disabled: false,
-        value: "delete",
-      }
-    );
+      });
+    }
+
+    options.push({
+      label: "Delete",
+      disabled: false,
+      value: "delete",
+    });
   }
 
   return options;


### PR DESCRIPTION
Fixes #34010. Also switches the landing page on edit error to the labels list from hosts filtered by the label, since the next step is likely "delete the label and add it back."

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results