### PR TITLE
Fail GitOps run when software package YAML is supplied but fields specific to that file are still specified in the team YAML

### DIFF
--- a/changes/34066-gitops-errors
+++ b/changes/34066-gitops-errors
@@ -1,0 +1,1 @@
+* Added an error message when software is defined in a package YAML file in GitOps but some fields expected in that file were set at the team level. Previously, GitOps would silently ignore the fields set at the team level in this case.


### PR DESCRIPTION
Fixes #34066. Included a changes file because this catches fields other than software icon.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results