### PR TITLE
Allow host vitals docs edits to be approved by Secuirty & Compliance Tech Lead

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,32 +68,6 @@ go.mod @fleetdm/go
 /docs                                                   @rachaelshaw
 /docs/Configuration                                     @rachaelshaw
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
-
-//  ╔═╗┬ ┬┌┐┌┌─┐┌┬┐  ┌┐ ┬ ┬  ┌─┐┬─┐┌─┐┌┬┐┬ ┬┌─┐┌┬┐  ┌─┐┬─┐┌─┐┬ ┬┌─┐┌─┐
-//  ║ ║││││││├┤  ││  ├┴┐└┬┘  ├─┘├┬┘│ │ │││ ││   │   │ ┬├┬┘│ ││ │├─┘└─┐
-//  ╚═╝└┴┘┘└┘└─┘─┴┘  └─┘ ┴   ┴  ┴└─└─┘─┴┘└─┘└─┘ ┴   └─┘┴└─└─┘└─┘┴  └─┘
------------------------------------------------------------------
-
-# MDM
-/docs/Contributing/architecture/mdm                     @georgekarrv @JordanMontgomery
-/docs/Contributing/product-groups/mdm                   @georgekarrv @JordanMontgomery
-/docs/Contributing/research/mdm                         @georgekarrv @JordanMontgomery
-# Orchestration
-/docs/Contributing/architecture/orchestration           @sharon-fdm @sgress454
-/docs/Contributing/product-groups/orchestration         @sharon-fdm @sgress454
-/docs/Contributing/research/orchestration               @sharon-fdm @sgress454
-# Software
-/docs/Contributing/architecture/software                @georgekarrv @cdcme
-/docs/Contributing/product-groups/software              @georgekarrv @cdcme
-/docs/Contributing/research/software                    @georgekarrv @cdcme
-# Security & Compliance
-/docs/Contributing/architecture/security-compliance     @sharon-fdm @getvictor
-/docs/Contributing/product-groups/security-compliance   @sharon-fdm @getvictor
-/docs/Contributing/research/security-compliance         @sharon-fdm @getvictor
-/docs/Contributing/reference/patterns-backend.md        @fleetdm/go
-
-### End of product group owned docs ###
-
 /docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @sgress454 @getvictor # software ingestion is security & compliance
 /docs/REST\ API/rest-api.md                             @rachaelshaw # « REST API reference documentation
 /docs/Contributing/reference/api-for-contributors.md    @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
@@ -102,6 +76,34 @@ go.mod @fleetdm/go
 /schema                                                 @eashaw # « Data tables (osquery/fleetd schema) documentation
 /render.yaml                                            @edwardsb
 /it-and-security                                        @allenhouchins
+
+################################################################################################
+#  ╔═╗┬ ┬┌┐┌┌─┐┌┬┐  ┌┐ ┬ ┬  ┌─┐┬─┐┌─┐┌┬┐┬ ┬┌─┐┌┬┐  ┌─┐┬─┐┌─┐┬ ┬┌─┐┌─┐
+#  ║ ║││││││├┤  ││  ├┴┐└┬┘  ├─┘├┬┘│ │ │││ ││   │   │ ┬├┬┘│ ││ │├─┘└─┐
+#  ╚═╝└┴┘┘└┘└─┘─┴┘  └─┘ ┴   ┴  ┴└─└─┘─┴┘└─┘└─┘ ┴   └─┘┴└─└─┘└─┘┴  └─┘
+################################################################################################
+
+# MDM
+/docs/Contributing/architecture/mdm                     @georgekarrv @JordanMontgomery
+/docs/Contributing/product-groups/mdm                   @georgekarrv @JordanMontgomery
+/docs/Contributing/research/mdm                         @georgekarrv @JordanMontgomery
+
+# Orchestration
+/docs/Contributing/architecture/orchestration           @sharon-fdm @sgress454
+/docs/Contributing/product-groups/orchestration         @sharon-fdm @sgress454
+/docs/Contributing/research/orchestration               @sharon-fdm @sgress454
+
+# Software
+/docs/Contributing/architecture/software                @georgekarrv @cdcme
+/docs/Contributing/product-groups/software              @georgekarrv @cdcme
+/docs/Contributing/research/software                    @georgekarrv @cdcme
+
+# Security & Compliance
+/docs/Contributing/architecture/security-compliance     @sharon-fdm @getvictor
+/docs/Contributing/product-groups/security-compliance   @sharon-fdm @getvictor
+/docs/Contributing/research/security-compliance         @sharon-fdm @getvictor
+/docs/Contributing/reference/patterns-backend.md        @fleetdm/go
+
 ##############################################################################################
 # 🌐 Repo automation and change control settings
 ##############################################################################################

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,7 +69,10 @@ go.mod @fleetdm/go
 /docs/Configuration                                     @rachaelshaw
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
 
-### Owned by product groups ###
+//  ╔═╗┬ ┬┌┐┌┌─┐┌┬┐  ┌┐ ┬ ┬  ┌─┐┬─┐┌─┐┌┬┐┬ ┬┌─┐┌┬┐  ┌─┐┬─┐┌─┐┬ ┬┌─┐┌─┐
+//  ║ ║││││││├┤  ││  ├┴┐└┬┘  ├─┘├┬┘│ │ │││ ││   │   │ ┬├┬┘│ ││ │├─┘└─┐
+//  ╚═╝└┴┘┘└┘└─┘─┴┘  └─┘ ┴   ┴  ┴└─└─┘─┴┘└─┘└─┘ ┴   └─┘┴└─└─┘└─┘┴  └─┘
+-----------------------------------------------------------------
 
 # MDM
 /docs/Contributing/architecture/mdm                     @georgekarrv @JordanMontgomery

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,6 +68,9 @@ go.mod @fleetdm/go
 /docs                                                   @rachaelshaw
 /docs/Configuration                                     @rachaelshaw
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
+
+### Owned by product groups ###
+
 # MDM
 /docs/Contributing/architecture/mdm                     @georgekarrv @JordanMontgomery
 /docs/Contributing/product-groups/mdm                   @georgekarrv @JordanMontgomery
@@ -85,6 +88,10 @@ go.mod @fleetdm/go
 /docs/Contributing/product-groups/security-compliance   @sharon-fdm @getvictor
 /docs/Contributing/research/security-compliance         @sharon-fdm @getvictor
 /docs/Contributing/reference/patterns-backend.md        @fleetdm/go
+
+### End of product group owned docs ###
+
+/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @sgress454 @getvictor # software ingestion is security & compliance
 /docs/REST\ API/rest-api.md                             @rachaelshaw # « REST API reference documentation
 /docs/Contributing/reference/api-for-contributors.md    @rachaelshaw @lukeheath # « Advanced / contributors-only API reference documentation
 /docs/Contributing/reference/audit-logs.md              @rachaelshaw @lukeheath # « Advanced / contributors-only audit log documentation
@@ -110,7 +117,7 @@ go.mod @fleetdm/go
 /handbook/company/open-positions.yml                            @sampfluger88
 #/handbook/company/product-groups.md                            Covered in custom.js
 /handbook/company/go-to-market-groups.md                        @sampfluger88
-/handbook/finance/security.md                   			    @allenhouchins         
+/handbook/finance/security.md                   			    @allenhouchins
 /handbook/finance/README.md                                     @sampfluger88
 /handbook/finance/finance.rituals.yml                           @sampfluger88
 /handbook/people                    			        	    @sampfluger88


### PR DESCRIPTION
Software ingestion via osquery is owned by S&C, and e.g. adding sources to software ingestion requires revisions to detail queries. So, given that tech leads can approve these changes, might as well not bottleneck on the orchestration tech lead for this, and the added reviewer gives a little bit more of a heads-up when orchestration makes tweaks to detail queries for non-ingestion reasons (or when assisting with ingestion-related work like we've been doing this sprint).