### PR TITLE
Cherry-Pick: Fix icon key name in "View YAML" modal

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -194,7 +194,7 @@ export const createPackageYaml = ({
   }
 
   if (iconUrl) {
-    yaml += `  icon_url:
+    yaml += `  icon:
     path: ./icons/${hyphenatedSWTitle}-icon.png
 `;
   }


### PR DESCRIPTION
Merged into `main` in #34140.