### PR TITLE
fix missing space in tooltip for windows and linux locked tags

### DIFF
--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -47,7 +47,7 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
         <>
           Host is locked. The end user can&apos;t use the host until
           <br />
-          unlocked. To unlock select<b>Actions &gt; Unlock</b>.
+          unlocked. To unlock select <b>Actions &gt; Unlock</b>.
         </>
       );
     },


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

Saw this small missing space when doing the engineering test plan run for lost mode #30889 