### PR TITLE
Cherry-Pick: Don't show edit option for host vitals labels, error if landing on edit UI for a host vitals label

### DIFF
--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -51,7 +51,11 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       onSuccess: (data) => {
         // can't edit host_vitals labels yet
         if (data.label_membership_type === "host_vitals") {
-          router.replace(PATHS.MANAGE_HOSTS_LABEL(data.id));
+          renderFlash(
+            "error",
+            "Host vitals labels are not editable. Delete the label and re-add it to make changes."
+          );
+          router.replace(PATHS.MANAGE_LABELS);
         }
       },
     }

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -71,18 +71,19 @@ const generateActionDropdownOptions = (
     label.author_id === currentUser.id;
 
   if (hasGlobalWritePermission || hasLabelAuthorWritePermission) {
-    options.push(
-      {
+    if (label.label_membership_type !== "host_vitals") {
+      options.push({
         label: "Edit",
         disabled: false,
         value: "edit",
-      },
-      {
-        label: "Delete",
-        disabled: false,
-        value: "delete",
-      }
-    );
+      });
+    }
+
+    options.push({
+      label: "Delete",
+      disabled: false,
+      value: "delete",
+    });
   }
 
   return options;


### PR DESCRIPTION
Merged into `main` in #34139.