### PR TITLE
3 Unreleased bug fixes

### DIFF
--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -563,6 +563,11 @@ const DataTable = ({
     </thead>
   );
 
+  const shouldShowFooter =
+    !hideFooter &&
+    ((isClientSidePagination && (canNextPage || canPreviousPage)) ||
+      renderPagination);
+
   return (
     <div className={baseClass}>
       {isLoading && (
@@ -671,7 +676,7 @@ const DataTable = ({
           </tbody>
         </table>
       </div>
-      {!hideFooter && (
+      {shouldShowFooter && (
         <div className={`${baseClass}__footer`}>
           {renderTableHelpText && !!rows?.length && (
             <div className={`${baseClass}__table-help-text`}>

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -564,9 +564,16 @@ const DataTable = ({
   );
 
   const shouldShowFooter =
+    // footer is not explicitly hidden
     !hideFooter &&
+    // and any of:
+
+    // table is client-side paginated with more than 1 page of rows
     ((isClientSidePagination && (canNextPage || canPreviousPage)) ||
-      renderPagination);
+      // table's pagination is externally controlled
+      renderPagination ||
+      // there is help text and at least 1 row of data
+      (renderTableHelpText && !!rows?.length));
 
   return (
     <div className={baseClass}>

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTable.tests.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTable.tests.tsx
@@ -73,11 +73,11 @@ describe("LabelsTable", () => {
       />
     );
 
-    // Custom labels should be visible
-    expect(screen.getByText("Custom label 1")).toBeInTheDocument();
-    expect(screen.getByText("Custom label 2")).toBeInTheDocument();
-    expect(screen.getByText("First custom label")).toBeInTheDocument();
-    expect(screen.getByText("Second custom label")).toBeInTheDocument();
+    // Custom labels should be visible, each with the regular copy and the full name in a tooltip
+    expect(screen.queryAllByText("Custom label 1")).toHaveLength(2);
+    expect(screen.queryAllByText("Custom label 2")).toHaveLength(2);
+    expect(screen.queryAllByText("First custom label")).toHaveLength(2);
+    expect(screen.queryAllByText("Second custom label")).toHaveLength(2);
 
     // Builtin labels should not be visible
     expect(screen.queryByText("All hosts")).not.toBeInTheDocument();

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTable.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTable.tsx
@@ -1,5 +1,6 @@
+import React, { memo } from "react";
+
 import { ILabel } from "interfaces/label";
-import React from "react";
 
 import { IUser } from "interfaces/user";
 
@@ -49,4 +50,4 @@ const LabelsTable = ({ labels, onClickAction, currentUser }: ILabelsTable) => {
   );
 };
 
-export default LabelsTable;
+export default memo(LabelsTable);

--- a/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/LabelsTable/LabelsTableConfig.tsx
@@ -13,6 +13,7 @@ import { IUser } from "interfaces/user";
 import { capitalize } from "lodash";
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ViewAllHostsLink from "components/ViewAllHostsLink";
+import TooltipTruncatedTextCell from "components/TableContainer/DataTable/TooltipTruncatedTextCell";
 
 interface IHeaderProps {
   column: {
@@ -105,7 +106,7 @@ const generateTableHeaders = (
       accessor: "name",
       disableSortBy: false,
       Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value} />
+        <TooltipTruncatedTextCell value={cellProps.cell.value} />
       ),
     },
     {
@@ -118,7 +119,7 @@ const generateTableHeaders = (
       ),
       accessor: "description",
       Cell: (cellProps: ICellProps) => (
-        <TextCell value={cellProps.cell.value || ""} />
+        <TooltipTruncatedTextCell value={cellProps.cell.value || ""} />
       ),
     },
     {

--- a/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
@@ -70,25 +70,28 @@ const ManageLabelsPage = ({ router }: IManageLabelsPageProps): JSX.Element => {
     }
   }, [labelToDelete, refetch, renderFlash]);
 
-  const onClickAction = (action: string, label: ILabel): void => {
-    switch (action) {
-      case "view_hosts":
-        router.push(PATHS.MANAGE_HOSTS_LABEL(label.id));
-        break;
-      case "edit":
-        router.push(PATHS.EDIT_LABEL(label.id));
-        break;
-      case "delete":
-        setLabelToDelete(label);
-        break;
-      default:
-    }
-  };
+  const onClickAction = useCallback(
+    (action: string, label: ILabel): void => {
+      switch (action) {
+        case "view_hosts":
+          router.push(PATHS.MANAGE_HOSTS_LABEL(label.id));
+          break;
+        case "edit":
+          router.push(PATHS.EDIT_LABEL(label.id));
+          break;
+        case "delete":
+          setLabelToDelete(label);
+          break;
+        default:
+      }
+    },
+    [router]
+  );
 
   const canAddLabel =
     isGlobalAdmin || isGlobalMaintainer || isAnyTeamMaintainerOrTeamAdmin;
 
-  const renderTable = () => {
+  const renderTable = useCallback(() => {
     if (isLoading || !currentUser || !labels) {
       return <Spinner />;
     }
@@ -102,7 +105,7 @@ const ManageLabelsPage = ({ router }: IManageLabelsPageProps): JSX.Element => {
         onClickAction={onClickAction}
       />
     );
-  };
+  }, [currentUser, error, isLoading, labels, onClickAction]);
 
   return (
     <MainContent className={baseClass}>


### PR DESCRIPTION
# 3 unreleased bug fixes:

## Resolves #34123 
Footer when paginated:
<img width="1519" height="1123" alt="Screenshot 2025-10-14 at 1 23 00 PM" src="https://github.com/user-attachments/assets/d69d27b4-44e4-4458-92be-e0dfaeab527f" />

No footer when only one page:
<img width="1523" height="1007" alt="Screenshot 2025-10-14 at 1 20 45 PM" src="https://github.com/user-attachments/assets/2d8266bb-c872-4888-98b1-3af7147fd27f" />


## Resolves #34169 
Name + description are now truncated:
<img width="1732" height="710" alt="Screenshot 2025-10-14 at 11 11 32 AM" src="https://github.com/user-attachments/assets/02a60892-e678-413e-a7d4-5c6d39980cd2" />


## Resolves #34170 
Labels page no longer re-renders unnecessarily

- [x] QA'd all new/changed functionality manually
- [x] Confirmed that the fix is not expected to adversely impact load test results
