### PR TITLE
Changed the default name of Host Identity CA to 'Fleet Host Identity CA' to avoid conflict with Fleet's Apple MDM CA.

### DIFF
--- a/changes/34217-host-identity-ca
+++ b/changes/34217-host-identity-ca
@@ -1,0 +1,1 @@
+Changed the default name of Host Identity CA to 'Fleet Host Identity CA' to avoid conflict with Fleet's Apple MDM CA.

--- a/ee/server/service/hostidentity/config.go
+++ b/ee/server/service/hostidentity/config.go
@@ -25,7 +25,13 @@ func initAssets(ds fleet.Datastore) error {
 
 	if len(savedAssets) != len(expectedAssets) {
 		// Then we should create them
-		scepCert, scepKey, err := depot.NewSCEPCACertKey()
+		caCert := depot.NewCACert(
+			depot.WithYears(10),
+			depot.WithCommonName("Fleet Host Identity CA"),
+			// Signal that the CA is local to the deployment and not necessarily managed by Fleet or another external vendor
+			depot.WithOrganization("Local Certificate Authority"),
+		)
+		scepCert, scepKey, err := depot.NewCACertKey(caCert)
 		if err != nil {
 			return fmt.Errorf("generating host identity SCEP cert and key: %w", err)
 		}

--- a/server/mdm/scep/depot/fleet.go
+++ b/server/mdm/scep/depot/fleet.go
@@ -6,18 +6,13 @@ import (
 	"crypto/x509"
 )
 
-// NewSCEPCACertKey creates a self-signed CA certificate for use with SCEP and
+// NewCACertKey creates a self-signed CA certificate for use with SCEP and
 // returns the certificate and its private key.
-func NewSCEPCACertKey() (*x509.Certificate, *rsa.PrivateKey, error) {
+func NewCACertKey(caCert *CACert) (*x509.Certificate, *rsa.PrivateKey, error) {
 	key, err := newPrivateKey()
 	if err != nil {
 		return nil, nil, err
 	}
-
-	caCert := NewCACert(
-		WithYears(10),
-		WithCommonName("Fleet"),
-	)
 
 	crtBytes, err := caCert.SelfSign(rand.Reader, key.Public(), key)
 	if err != nil {
@@ -30,6 +25,16 @@ func NewSCEPCACertKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 	}
 
 	return cert, key, nil
+}
+
+// NewSCEPCACertKey creates a self-signed CA certificate for use with SCEP and
+// returns the certificate and its private key.
+func NewSCEPCACertKey() (*x509.Certificate, *rsa.PrivateKey, error) {
+	caCert := NewCACert(
+		WithYears(10),
+		WithCommonName("Fleet"),
+	)
+	return NewCACertKey(caCert)
 }
 
 // Note Apple rejects CSRs if the key size is not 2048.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34217

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
