### PR TITLE
Add software name cleanup on ingestion for various items where bundle executable isn't well-named

### DIFF
--- a/changes/34159-software-name-cleaup
+++ b/changes/34159-software-name-cleaup
@@ -1,0 +1,1 @@
+* Added several one-off tweaks to software names on macOS apps when vendor-supplied bundle executable names are unclear

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1945,8 +1945,8 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 }
 
 var (
-	dcvVersionFormat      = regexp.MustCompile(`^(\d+\.\d+)\s*\(r(\d+)\)$`)
-	appSoftwareSanitizers = []struct {
+	dcvVersionFormat   = regexp.MustCompile(`^(\d+\.\d+)\s*\(r(\d+)\)$`)
+	basicAppSanitizers = []struct {
 		matchBundleIdentifier string
 		matchName             string
 		mutate                func(*fleet.Software, log.Logger)
@@ -1982,15 +1982,79 @@ var (
 			},
 		},
 		{
-			matchBundleIdentifier: "jp.go.jpki.JPKIUninstall",
-			matchName:             "JPKIUninstall.scpt",
+			matchBundleIdentifier: "com.oracle.OracleDataModeler",
+			matchName:             "datamodeler.sh",
 			mutate: func(s *fleet.Software, logger log.Logger) {
-				s.Name = "JPKIUninstall"
+				s.Name = "OracleDataModeler"
 			},
 		},
-		// TODO TNMS
-		// TODO other items
-		// end of #34159 cleanup
+		{
+			matchBundleIdentifier: "com.easeus.ntfsformacdaemon",
+			matchName:             "euntfsservice",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "EaseUS NTFS Service"
+			},
+		},
+		{
+			matchBundleIdentifier: "com.poly.lens.legacyhost.app",
+			matchName:             "legacyhost",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "Poly Lens Desktop"
+			},
+		},
+		{
+			matchBundleIdentifier: "app.zen-browser.plugincontainer",
+			matchName:             "plugin-container",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "Zen Browser Plugin Container"
+			},
+		},
+		{
+			matchBundleIdentifier: "org.mozilla.plugincontainer",
+			matchName:             "plugin-container",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "Mozilla Plugin Container"
+			},
+		},
+		{
+			matchBundleIdentifier: "com.google.chromeremotedesktop.me2me-host-uninstaller",
+			matchName:             "remoting_host_uninstaller",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "Chrome Remote Desktop Host Uninstaller"
+			},
+		},
+		{
+			matchBundleIdentifier: "runemu",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				if s.BundleIdentifier == "" {
+					s.Name = "Android Emulator"
+				}
+			},
+		},
+		{
+			matchBundleIdentifier: "com.oracle.SQLDeveloper",
+			matchName:             "sqldeveloper.sh/",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "Oracle SQLDeveloper"
+			},
+		},
+		// end of #34159 cleanup in basic matchers
+	}
+	customAppSanitizers = []struct {
+		matches func(*fleet.Software) bool
+		mutate  func(*fleet.Software, log.Logger)
+	}{
+		{
+			matches: func(s *fleet.Software) bool { // #34159
+				return strings.HasPrefix(s.Name, "TNMS ") &&
+					strings.HasPrefix(s.BundleIdentifier, "TNMS_") &&
+					strings.Replace(s.BundleIdentifier, "_", " ", 1) == s.Name
+			},
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "TNMS"
+				s.Version = strings.Replace(s.BundleIdentifier, "TNMS_", "", 1)
+			},
+		},
 	}
 )
 
@@ -2001,10 +2065,21 @@ func MutateSoftwareOnIngestion(s *fleet.Software, logger log.Logger) {
 	// all of our current on-ingest mutations use this table,
 	// so might as well let other stuff go faster and save some redundant checks inside the matchers
 	if s != nil && s.Source == "apps" {
-		for _, sanitizer := range appSoftwareSanitizers {
+		for _, sanitizer := range basicAppSanitizers {
 			if (sanitizer.matchBundleIdentifier != "" || sanitizer.matchName != "") &&
 				(sanitizer.matchBundleIdentifier == "" || sanitizer.matchBundleIdentifier == s.BundleIdentifier) &&
 				(sanitizer.matchName == "" || sanitizer.matchName == s.Name) {
+				defer func() {
+					if r := recover(); r != nil {
+						level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
+					}
+				}()
+				sanitizer.mutate(s, logger)
+				break
+			}
+		}
+		for _, sanitizer := range customAppSanitizers {
+			if sanitizer.matches(s) {
 				defer func() {
 					if r := recover(); r != nil {
 						level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1945,21 +1945,52 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 }
 
 var (
-	dcvVersionFormat   = regexp.MustCompile(`^(\d+\.\d+)\s*\(r(\d+)\)$`)
-	softwareSanitizers = []struct {
-		matches func(*fleet.Software) bool
-		mutate  func(*fleet.Software, log.Logger)
+	dcvVersionFormat      = regexp.MustCompile(`^(\d+\.\d+)\s*\(r(\d+)\)$`)
+	appSoftwareSanitizers = []struct {
+		matchBundleIdentifier string
+		matchName             string
+		mutate                func(*fleet.Software, log.Logger)
 	}{
 		{
-			matches: func(s *fleet.Software) bool {
-				return s.Source == "apps" && s.BundleIdentifier == "com.nicesoftware.dcvviewer"
-			},
+			matchBundleIdentifier: "com.nicesoftware.dcvviewer",
 			mutate: func(s *fleet.Software, logger log.Logger) {
 				if versionMatches := dcvVersionFormat.FindStringSubmatch(s.Version); len(versionMatches) == 3 {
 					s.Version = fmt.Sprintf("%s.%s", versionMatches[1], versionMatches[2])
 				}
 			},
 		},
+		// Bundle executable name cleanup #34159
+		{
+			matchBundleIdentifier: "com.synology.DSAssistant",
+			matchName:             "DSAssistant",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "SynologyAssistant"
+			},
+		},
+		{
+			matchBundleIdentifier: "com.now.gg.BlueStacksMIM",
+			matchName:             "HD-MultiInstanceManager",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "BlueStacksMIM"
+			},
+		},
+		{
+			matchBundleIdentifier: "jp.go.jpki.JPKIUninstall",
+			matchName:             "JPKIUninstall.scpt",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "JPKIUninstall"
+			},
+		},
+		{
+			matchBundleIdentifier: "jp.go.jpki.JPKIUninstall",
+			matchName:             "JPKIUninstall.scpt",
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "JPKIUninstall"
+			},
+		},
+		// TODO TNMS
+		// TODO other items
+		// end of #34159 cleanup
 	}
 )
 
@@ -1967,15 +1998,21 @@ var (
 //
 // Some fields are reported with known incorrect values and we need to fix them before using them.
 func MutateSoftwareOnIngestion(s *fleet.Software, logger log.Logger) {
-	for _, softwareSanitizer := range softwareSanitizers {
-		if softwareSanitizer.matches(s) {
-			defer func() {
-				if r := recover(); r != nil {
-					level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
-				}
-			}()
-			softwareSanitizer.mutate(s, logger)
-			break
+	// all of our current on-ingest mutations use this table,
+	// so might as well let other stuff go faster and save some redundant checks inside the matchers
+	if s != nil && s.Source == "apps" {
+		for _, sanitizer := range appSoftwareSanitizers {
+			if (sanitizer.matchBundleIdentifier != "" || sanitizer.matchName != "") &&
+				(sanitizer.matchBundleIdentifier == "" || sanitizer.matchBundleIdentifier == s.BundleIdentifier) &&
+				(sanitizer.matchName == "" || sanitizer.matchName == s.Name) {
+				defer func() {
+					if r := recover(); r != nil {
+						level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
+					}
+				}()
+				sanitizer.mutate(s, logger)
+				break
+			}
 		}
 	}
 }

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2024,7 +2024,7 @@ var (
 			},
 		},
 		{
-			matchBundleIdentifier: "runemu",
+			matchName: "runemu",
 			mutate: func(s *fleet.Software, logger log.Logger) {
 				if s.BundleIdentifier == "" {
 					s.Name = "Android Emulator"

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -65,6 +65,77 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 	MutateSoftwareOnIngestion(noMatch, log.NewNopLogger())
 	assert.Equal(t, "2024.0 (r8004)", noMatch.Version)
 
+	for expectedName, s := range map[string]*fleet.Software{
+		"SynologyAssistant": {
+			Name:             "DSAssistant",
+			BundleIdentifier: "com.synology.DSAssistant",
+			Source:           "apps",
+		},
+		"BlueStacksMIM": {
+			Name:             "HD-MultiInstanceManager",
+			BundleIdentifier: "com.now.gg.BlueStacksMIM",
+			Source:           "apps",
+		},
+		"JPKIUninstall": {
+			Name:             "JPKIUninstall.scpt",
+			BundleIdentifier: "jp.go.jpki.JPKIUninstall",
+			Source:           "apps",
+		},
+		"OracleDataModeler": {
+			Name:             "datamodeler.sh",
+			BundleIdentifier: "com.oracle.OracleDataModeler",
+			Source:           "apps",
+		},
+		"EaseUS NTFS Service": {
+			Name:             "euntfsservice",
+			BundleIdentifier: "com.easeus.ntfsformacdaemon",
+			Source:           "apps",
+		},
+		"Poly Lens Desktop": {
+			Name:             "legacyhost",
+			BundleIdentifier: "com.poly.lens.legacyhost.app",
+			Source:           "apps",
+		},
+		"Zen Browser Plugin Container": {
+			Name:             "plugin-container",
+			BundleIdentifier: "app.zen-browser.plugincontainer",
+			Source:           "apps",
+		},
+		"Mozilla Plugin Container": {
+			Name:             "plugin-container",
+			BundleIdentifier: "org.mozilla.plugincontainer",
+			Source:           "apps",
+		},
+		"Chrome Remote Desktop Host Uninstaller": {
+			Name:             "remoting_host_uninstaller",
+			BundleIdentifier: "com.google.chromeremotedesktop.me2me-host-uninstaller",
+			Source:           "apps",
+		},
+		"Android Emulator": {
+			Name:             "runemu",
+			BundleIdentifier: "",
+			Source:           "apps",
+		},
+		"Oracle SQLDeveloper": {
+			Name:             "sqldeveloper.sh/",
+			BundleIdentifier: "com.oracle.SQLDeveloper",
+			Source:           "apps",
+		},
+	} {
+		MutateSoftwareOnIngestion(s, log.NewNopLogger())
+		assert.Equal(t, expectedName, s.Name)
+	}
+
+	// Test customAppSanitizers TNMS case
+	tnms := &fleet.Software{
+		Name:             "TNMS 1.2.3",
+		BundleIdentifier: "TNMS_1.2.3",
+		Source:           "apps",
+	}
+	MutateSoftwareOnIngestion(tnms, log.NewNopLogger())
+	assert.Equal(t, "TNMS", tnms.Name)
+	assert.Equal(t, "1.2.3", tnms.Version)
+
 	// TODO #34159
 }
 

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -127,16 +127,14 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 	}
 
 	// Test customAppSanitizers TNMS case
-	tnms := &fleet.Software{
-		Name:             "TNMS 1.2.3",
-		BundleIdentifier: "TNMS_1.2.3",
+	sw := &fleet.Software{
+		Name:             "TNMS 21.10.0.590.1",
+		BundleIdentifier: "TNMS_21.10.0.590.1",
 		Source:           "apps",
 	}
-	MutateSoftwareOnIngestion(tnms, log.NewNopLogger())
-	assert.Equal(t, "TNMS", tnms.Name)
-	assert.Equal(t, "1.2.3", tnms.Version)
-
-	// TODO #34159
+	MutateSoftwareOnIngestion(sw, log.NewNopLogger())
+	assert.Equal(t, "TNMS", sw.Name)
+	assert.Equal(t, "21.10.0.590.1", sw.Version)
 }
 
 func TestDetailQueryNetworkInterfaces(t *testing.T) {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -64,6 +64,8 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 
 	MutateSoftwareOnIngestion(noMatch, log.NewNopLogger())
 	assert.Equal(t, "2024.0 (r8004)", noMatch.Version)
+
+	// TODO #34159
 }
 
 func TestDetailQueryNetworkInterfaces(t *testing.T) {


### PR DESCRIPTION
Fixes #34159. Split from CPE translation fixes so this can be merged into `main` pre-QA.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually