### PR TITLE
send back correct platform in mdm unenroll activity when unenrolling android (#34242)

### DIFF
--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -151,7 +151,7 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 				HostSerial:       "",
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
-				Platform:         host.Platform,
+				Platform:         "android",
 			})
 		}
 		return nil
@@ -224,7 +224,7 @@ func (svc *Service) handlePubSubEnrollment(ctx context.Context, token string, ra
 				HostSerial:       "",
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
-				Platform:         host.Platform,
+				Platform:         "android",
 			})
 		}
 		return nil

--- a/server/mdm/android/service/reconcile_devices.go
+++ b/server/mdm/android/service/reconcile_devices.go
@@ -68,17 +68,16 @@ func ReconcileAndroidDevices(ctx context.Context, ds fleet.Datastore, logger kit
 				continue
 			}
 			// Emit system activity to mirror Pub/Sub DELETED handling.
-			var displayName, serial, platform string
+			var displayName, serial string
 			if hosts, herr := ds.ListHostsLiteByIDs(ctx, []uint{dev.HostID}); herr == nil && len(hosts) == 1 && hosts[0] != nil {
 				displayName = hosts[0].DisplayName()
 				serial = hosts[0].HardwareSerial
-				platform = hosts[0].Platform
 			}
 			if aerr := ds.NewActivity(ctx, nil, fleet.ActivityTypeMDMUnenrolled{
 				HostSerial:       serial,
 				HostDisplayName:  displayName,
 				InstalledFromDEP: false,
-				Platform:         platform,
+				Platform:         "android",
 			}, nil, time.Now()); aerr != nil {
 				level.Debug(logger).Log("msg", "failed to create mdm_unenrolled activity during android reconcile", "host_id", dev.HostID, "err", aerr)
 			}

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -845,7 +845,7 @@ func (svc *Service) UnenrollAndroidHost(ctx context.Context, hostID uint) error 
 		HostSerial:       h.HardwareSerial,
 		HostDisplayName:  displayName,
 		InstalledFromDEP: false,
-		Platform:         h.Platform,
+		Platform:         "android",
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "create android unenroll activity")
 	}


### PR DESCRIPTION
**Related issue:** Resolves #33807

Cherry pick PR

sends back the correct platform on the activity details for the mdm unenroll activitiy for android

