### PR TITLE
Set proxy auth token in Android profile reconciler

### DIFF
--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -42,7 +42,10 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting Android client authentication secret for profile reconciler")
 	}
-	client.SetAuthenticationSecret(authSecret)
+	err = client.SetAuthenticationSecret(authSecret)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "setting Android client authentication secret for profile reconciler")
+	}
 
 	reconciler := &profileReconciler{
 		DS:         ds,

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -38,6 +38,12 @@ func ReconcileProfiles(ctx context.Context, ds fleet.Datastore, logger kitlog.Lo
 	}
 
 	client := newAMAPIClient(ctx, logger, licenseKey)
+	authSecret, err := getClientAuthenticationSecret(ctx, ds)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting Android client authentication secret for profile reconciler")
+	}
+	client.SetAuthenticationSecret(authSecret)
+
 	reconciler := &profileReconciler{
 		DS:         ds,
 		Enterprise: enterprise,
@@ -52,6 +58,17 @@ type profileReconciler struct {
 	DS         fleet.Datastore
 	Enterprise *android.Enterprise
 	Client     androidmgmt.Client
+}
+
+func getClientAuthenticationSecret(ctx context.Context, ds fleet.Datastore) (string, error) {
+	assets, err := ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetAndroidFleetServerSecret}, nil)
+	switch {
+	case fleet.IsNotFound(err):
+		return "", nil
+	case err != nil:
+		return "", ctxerr.Wrap(ctx, err, "getting Android authentication secret")
+	}
+	return string(assets[fleet.MDMAssetAndroidFleetServerSecret].Value), nil
 }
 
 func (r *profileReconciler) ReconcileProfiles(ctx context.Context) error {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34261 

Longer term we should rework the calls that create the Android API client to do this but this small fix will suffice for now to unblock QA

No changes file as this is unreleased bugfix into 4.75.0 and changes covered by main story ticket

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results