### PR TITLE
Show warning when viewing settings without auth

### DIFF
--- a/changes/32229-show-flash-warning-unauth-settings-access
+++ b/changes/32229-show-flash-warning-unauth-settings-access
@@ -1,0 +1,1 @@
+* Added flash warning when an un-authorized user tries to access teams settings.

--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -248,6 +248,7 @@ const SiteTopNav = ({
             onLogout={onLogoutUser}
             onUserMenuItemClick={onUserMenuItemClick}
             currentUser={currentUser}
+            currentTeam={currentTeam}
             isAnyTeamAdmin={isAnyTeamAdmin}
             isGlobalAdmin={isGlobalAdmin}
           />


### PR DESCRIPTION
**Related issue:** Resolves #32229

Show flash warning when viewing settings from a team where auth is not granted.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually