### PR TITLE
Part of #30890: Support all iOS/iPadOS enrollment methods

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
@@ -36,17 +36,13 @@ const PREVIEW_DISPLAY_OPTIONS: Record<
   },
   ios: {
     description: (
-      <p>
-        When an iOS host enrolls, the selected software is installed.
-      </p>
+      <p>When an iOS host enrolls, the selected software is installed.</p>
     ),
     videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available
   },
   ipados: {
     description: (
-      <p>
-        When an iPadOS host enrolls, the selected software is installed.
-      </p>
+      <p>When an iPadOS host enrolls, the selected software is installed.</p>
     ),
     videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available
   },

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwarePreview/InstallSoftwarePreview.tsx
@@ -37,8 +37,7 @@ const PREVIEW_DISPLAY_OPTIONS: Record<
   ios: {
     description: (
       <p>
-        When an iOS host in Apple Business Manager (ABM) enrolls, the selected
-        software is installed.
+        When an iOS host enrolls, the selected software is installed.
       </p>
     ),
     videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available
@@ -46,8 +45,7 @@ const PREVIEW_DISPLAY_OPTIONS: Record<
   ipados: {
     description: (
       <p>
-        When an iPadOS host in Apple Business Manager (ABM) enrolls, the
-        selected software is installed.
+        When an iPadOS host enrolls, the selected software is installed.
       </p>
     ),
     videoSrc: MacInstallSoftwareEndUserPreview, // TODO: update with new video when it's available


### PR DESCRIPTION
UPDATE: @noahtalerman: Closed this PR because I misunderstood. In 4.76.0, Fleet will only support hosts that automatically enroll via ABM: https://github.com/fleetdm/fleet/issues/30890#issuecomment-3410862180

---

- Part of the following user story: https://github.com/fleetdm/fleet/issues/30890
- Context: https://github.com/fleetdm/fleet/issues/30890#issuecomment-3408445511
- Still TODO: Update the tab logic. We want the "iOS" and "iPadOS" tabs to be available if MDM is turned on but ABM isn't.

