### PR TITLE
Website: Update name of value returned by Microsoft proxy endpoint (`result.details` » `result.detail`)

### DIFF
--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -24,6 +24,7 @@ module.exports = {
 
 
   exits: {
+    success: { description: 'A compliance status result was returned to the Fleet instance.', outputType: {} },
     tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'}
   },
 
@@ -69,7 +70,7 @@ module.exports = {
     };
     // If the status is "Failed", attach the error details to the response body.
     if(parsedComplianceUpdateResponse.Status === 'Failed') {
-      result.details = parsedComplianceUpdateResponse.ErrorDetail;
+      result.detail = parsedComplianceUpdateResponse.ErrorDetail;
     }
     // All done.
     return result;

--- a/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
+++ b/website/api/controllers/microsoft-proxy/get-one-compliance-status-result.js
@@ -24,7 +24,7 @@ module.exports = {
 
 
   exits: {
-    success: { description: 'A compliance status result was returned to the Fleet instance.', outputType: {} },
+    success: { description: 'A compliance status update result was returned to the Fleet instance.', outputType: {} },
     tenantNotFound: {description: 'No existing Microsoft compliance tenant was found for the Fleet instance that sent the request.', responseType: 'unauthorized'}
   },
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/34306

Changes:
- Updated the `microsoft-proxy/get-one-compliance-status-result` endpoint to send error details from failed compliance status updates as `result.detail`.

Context:
Fleet instances expect this endpoint to return a value named `detail` https://github.com/fleetdm/fleet/blob/94d801f9e1425e4c77334c87b2bc31f2697c5a0d/server/service/conditional_access_microsoft_proxy/conditional_access_microsoft_proxy.go#L171-L172