### PR TITLE
Correct capitalization in managed bookmarks

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -514,12 +514,12 @@
                 </dict>
                 <dict>
                     <key>name</key>
-                    <string>🦢 Product design</string>
+                    <string>🦢 Product Design</string>
                     <key>children</key>
                     <array>
                         <dict>
                             <key>name</key>
-                            <string>🦢 Product design (Handbook)</string>
+                            <string>🦢 Product Design (Handbook)</string>
                             <key>url</key>
                             <string>https://fleetdm.com/handbook/product-design</string>
                         </dict>
@@ -563,7 +563,7 @@
                 </dict>
                 <dict>
                     <key>name</key>
-                    <string>🌦️ Customer success</string>
+                    <string>🌦️ Customer Success</string>
                     <key>children</key>
                     <array>
                         <dict>


### PR DESCRIPTION
- @noahtalerman: Proper nouns: https://fleetdm.com/handbook/company/why-this-way#why-does-fleet-use-sentence-case:~:text=if%20a%20word%20would%20normally%20be%20capitalized%20in%20the%20sentence%20(e.g.%2C%20a%20proper%20noun%2C%20an%20acronym%2C%20or%20a%20stylization)%20it%20should%20remain%20capitalized.

<img width="297" height="559" alt="Screenshot 2025-10-16 at 9 35 01 AM" src="https://github.com/user-attachments/assets/e45e230a-87be-4f06-a0b7-1d705ca1ab44" />
