### PR TITLE
Fleet product: Fix wrong links

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -134,7 +134,7 @@ const AddInstallSoftware = ({
         </p>
         <CustomLink
           newTab
-          url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-assistant`}
+          url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-experience/install-software`}
           text="Learn how"
         />
       </div>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -115,7 +115,7 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
           <CustomLink
             className={`${baseClass}__learn-how-link`}
             newTab
-            url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-assistant`}
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/setup-experience/run-script`}
             text="Learn how"
           />
           {!script ? (

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -979,6 +979,7 @@ module.exports.routes = {
   'GET /learn-more-about/arch-linux-rolling-release': 'https://wiki.archlinux.org/title/Arch_Linux',
   'GET /learn-more-about/google-play-store': 'https://play.google.com/store/apps',
   'GET /learn-more-about/manual-enrollment-profile': '/docs/rest-api/rest-api#get-manual-enrollment-profile',
+  'GET learn-more-about/setup-experience/install-software': '/guides/macos-setup-experience#install-software',
 
   // Sitemap
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -979,8 +979,9 @@ module.exports.routes = {
   'GET /learn-more-about/arch-linux-rolling-release': 'https://wiki.archlinux.org/title/Arch_Linux',
   'GET /learn-more-about/google-play-store': 'https://play.google.com/store/apps',
   'GET /learn-more-about/manual-enrollment-profile': '/docs/rest-api/rest-api#get-manual-enrollment-profile',
-  'GET learn-more-about/setup-experience/install-software': '/guides/macos-setup-experience#install-software',
-
+  'GET /learn-more-about/setup-experience/install-software': '/guides/macos-setup-experience#install-software',
+  'GET /learn-more-about/setup-experience/run-script': '/guides/macos-setup-experience#run-script',
+  
   // Sitemap
   // =============================================================================================================
   // This is for search engines, not humans.  Search engines know to visit fleetdm.com/sitemap.xml to download this

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -981,7 +981,7 @@ module.exports.routes = {
   'GET /learn-more-about/manual-enrollment-profile': '/docs/rest-api/rest-api#get-manual-enrollment-profile',
   'GET /learn-more-about/setup-experience/install-software': '/guides/macos-setup-experience#install-software',
   'GET /learn-more-about/setup-experience/run-script': '/guides/macos-setup-experience#run-script',
- 
+
   // Sitemap
   // =============================================================================================================
   // This is for search engines, not humans.  Search engines know to visit fleetdm.com/sitemap.xml to download this

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -981,7 +981,7 @@ module.exports.routes = {
   'GET /learn-more-about/manual-enrollment-profile': '/docs/rest-api/rest-api#get-manual-enrollment-profile',
   'GET /learn-more-about/setup-experience/install-software': '/guides/macos-setup-experience#install-software',
   'GET /learn-more-about/setup-experience/run-script': '/guides/macos-setup-experience#run-script',
-  
+ 
   // Sitemap
   // =============================================================================================================
   // This is for search engines, not humans.  Search engines know to visit fleetdm.com/sitemap.xml to download this


### PR DESCRIPTION
- @noahtalerman: Redirect goes to this guide: https://github.com/fleetdm/fleet/blob/docs-v4.75.0/articles/macos-setup-experience.md#install-software
  - Guide will point to Windows and Linux setup experience guide when Fleet ships 4.75.
