### PR TITLE
[Guide updates] Setup experience: Install software when company-owned iOS/iPadOS hosts enroll

### DIFF
--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -163,7 +163,7 @@ To replace the Fleet logo with your organization's logo:
 
 You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience).
 
-For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet reties, IT admins can error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
 
 Currently, for macOS, iOS, and iPadOS hosts, software is only installed on hosts that automatically enroll to Fleet via Apple Business Manager (ABM).
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -163,7 +163,7 @@ To replace the Fleet logo with your organization's logo:
 
 You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience).
 
-For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails. Currently, retries only happen for custom packages and Fleet-maintained apps. App Store (VPP) apps are coming soon.
 
 Currently, for macOS, iOS, and iPadOS hosts, software is only installed on hosts that automatically enroll to Fleet via Apple Business Manager (ABM).
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -174,7 +174,7 @@ Add setup experience software:
 2. Click **Add software**, then select or search for the software you want installed during the setup experience.
 3. Press **Save** to save your selection.
 
-To see the end user experience on iOS/iPadOS, check out the [iOS video](TODO) and [iPadOS video](TODO).
+To see the end user experience on iOS/iPadOS, check out the [iOS video](https://www.youtube.com/shorts/_XXNGrQPqys) and [iPadOS video](https://www.youtube.com/shorts/IIzo4NyUolM).
 
 ### Run script
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -161,9 +161,11 @@ To replace the Fleet logo with your organization's logo:
 
 ### Install software
 
-You can install software during first time macOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience#basic-article).
+You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience).
 
-Software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet reties, IT admins can error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet reties, IT admins can error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+
+Currently, for macOS, iOS, and iPadOS hosts, software is only installed on hosts that automatically enroll to Fleet via Apple Business Manager (ABM).
 
 Add setup experience software:
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -163,7 +163,9 @@ To replace the Fleet logo with your organization's logo:
 
 You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience).
 
-For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails. Currently, retries only happen for custom packages and Fleet-maintained apps. App Store (VPP) apps are coming soon.
+For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+
+Retries only happen for custom packages and Fleet-maintained apps. For App Store (VPP) apps, the MDM command to install the app is sent once and either succeeds or fails. If it fails, the app won’t install no matter how many times Fleet resends the command.
 
 Currently, for macOS, iOS, and iPadOS hosts, software is only installed on hosts that automatically enroll to Fleet via Apple Business Manager (ABM).
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -161,7 +161,7 @@ To replace the Fleet logo with your organization's logo:
 
 ### Install software
 
-You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience).
+You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience). Android support is coming soon.
 
 For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -174,6 +174,8 @@ Add setup experience software:
 2. Click **Add software**, then select or search for the software you want installed during the setup experience.
 3. Press **Save** to save your selection.
 
+To see the end user experience on iOS/iPadOS, check out the [iOS video](TODO) and [iPadOS video](TODO).
+
 ### Run script
 
 To configure a script to run during setup experience:


### PR DESCRIPTION
Guide updates for the following user story:
- #30890