### PR TITLE
Fix capitalization in workflow name

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -1,4 +1,4 @@
-name: 'Apply latest configuration to dogfood with gitops'
+name: 'Apply latest configuration to dogfood with GitOps'
 
 on:
   push:


### PR DESCRIPTION
We use "GitOps" as a proper noun: https://fleetdm.com/docs/configuration/yaml-files
