### PR TITLE
Do not return MDM=off android hosts from reconciler (#34304)->4.75.0

### DIFF
--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -20,7 +20,7 @@ module.exports = {
 
 
   exits: {
-    success: { description: 'The device of an Android enterprise was successfully updated.' }
+    success: { description: 'The device of an Android enterprise was successfully updated.' },
     deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
   },
 

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -21,6 +21,7 @@ module.exports = {
 
   exits: {
     success: { description: 'The device of an Android enterprise was successfully updated.' }
+    deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
   },
 
 
@@ -79,6 +80,10 @@ module.exports = {
       });
       return patchDeviceResponse.data;
     }).intercept((err) => {
+      let errorString = err.toString();
+      if (errorString.includes('Device is no longer being managed')) {
+        return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};
+      }
       return new Error(`When attempting to update a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     });
 


### PR DESCRIPTION
Cherry-pick of #34304

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34299

Unreleased bug in Android Config profiles 4.75.0 feature. No changes file as such. I'm not entirely sure how to cause this as I was unable to repro it locally, there may be a timing issue or something, so I haven't fully QA'd manually. QA was limited to verifying basic reconciler functionality

Also updated Website endpoint to not throw a 5XX since we expect this to occasionally happen

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
