### PR TITLE
Cherry-Pick: Fail GitOps run when software package YAML is supplied but fields specific to that file are still specified in the team YAML

### DIFF
--- a/changes/34066-gitops-errors
+++ b/changes/34066-gitops-errors
@@ -1,0 +1,1 @@
+* Added an error message when software is defined in a package YAML file in GitOps but some fields expected in that file were set at the team level. Previously, GitOps would silently ignore the fields set at the team level in this case.


### PR DESCRIPTION
Merged into `main` in #34142.