### PR TITLE
Add CVE exclusion for Dota when we don't report the version number correctly

### DIFF
--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -197,6 +197,21 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.TargetSW == "visual_studio_code"
 			},
 		},
+		// When we're inventorying the Steam launcher for Dota, version recorded is 1.0,
+		// which shows a bunch of false positive CVEs. See #34323.
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2020-7949": {},
+				"CVE-2020-7950": {},
+				"CVE-2020-7951": {},
+				"CVE-2020-7952": {},
+				"CVE-2020-9005": {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.Vendor == "valvesoftware" && cpeMeta.Product == "dota_2" &&
+					cpeMeta.TargetSW == "macos" && cpeMeta.Version == "1\\.0"
+			},
+		},
 		// Issue #18733 incorrect CPEs that should be matching
 		// visual studio code extensions
 		CPEMatchingRule{

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -209,7 +209,7 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 			},
 			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
 				return cpeMeta.Vendor == "valvesoftware" && cpeMeta.Product == "dota_2" &&
-					cpeMeta.TargetSW == "macos" && cpeMeta.Version == "1\\.0"
+					cpeMeta.TargetSW == "macos" && (cpeMeta.Version == "1\\.0" || cpeMeta.Version == "1\\.0\\.0")
 			},
 		},
 		// Issue #18733 incorrect CPEs that should be matching

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -522,6 +522,16 @@ func TestCPEFromSoftwareIntegration(t *testing.T) {
 				BundleIdentifier: "com.apple.finder",
 			}, cpe: "cpe:2.3:a:apple:finder:12.5:*:*:*:*:macos:*:*",
 		},
+		{ // Make sure we generate the expected CPE so we can match it downstream and drop the false negative vulns
+			software: fleet.Software{
+				Name:             "Dota 2",
+				Source:           "apps",
+				Version:          "1.0", // default version; on ingestion it's actually blank
+				Vendor:           "",
+				BundleIdentifier: "",
+			},
+			cpe: "cpe:2.3:a:valvesoftware:dota_2:1.0:*:*:*:*:macos:*:*",
+		},
 		{
 			software: fleet.Software{
 				Name:             "Firefox.app",

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -327,6 +327,15 @@ func TestTranslateCPEToCVE(t *testing.T) {
 				"CVE-2020-9005",
 			},
 		},
+		"cpe:2.3:a:valvesoftware:dota_2:1.0.0:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2020-7949",
+				"CVE-2020-7950",
+				"CVE-2020-7951",
+				"CVE-2020-7952",
+				"CVE-2020-9005",
+			},
+		},
 		"cpe:2.3:a:valvesoftware:dota_2:1.337:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{
 				{ID: "CVE-2020-9005" /*resolvedInVersion: "2020-02-17"*/}, // we don't do non-semver resolved-in

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -317,6 +317,24 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: false,
 		},*/
+		// #34323
+		"cpe:2.3:a:valvesoftware:dota_2:1.0:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2020-7949",
+				"CVE-2020-7950",
+				"CVE-2020-7951",
+				"CVE-2020-7952",
+				"CVE-2020-9005",
+			},
+		},
+		"cpe:2.3:a:valvesoftware:dota_2:1.337:*:*:*:*:macos:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2020-9005" /*resolvedInVersion: "2020-02-17"*/}, // we don't do non-semver resolved-in
+				{ID: "CVE-2020-7950", resolvedInVersion: "7.23f"},
+			},
+			continuesToUpdate: true,
+		},
+		// end of #34323
 		"cpe:2.3:a:adobe:animate:*:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{
 				{ID: "CVE-2023-44325"},


### PR DESCRIPTION
Resolves #34323. Bit heavy-handed but our osquery ingestion doesn't pick up the version number right now so this is as good as we can do, and if we _do_ start picking up the version number this fix is surgical enough that it won't create a false negative.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests