### PR TITLE
Fleet UI unreleased bug: remove buggy hide footer as we should always show the footer help text

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -272,7 +272,6 @@ const SoftwareVulnerabilitiesTable = ({
         pageIndex={currentPage}
         manualSortBy
         pageSize={perPage}
-        hideFooter={perPage >= (data?.count || 0)}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         disableNextPage={!data?.meta.has_next_results}

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -272,7 +272,7 @@ const SoftwareVulnerabilitiesTable = ({
         pageIndex={currentPage}
         manualSortBy
         pageSize={perPage}
-        hideFooter={perPage >= (data?.vulnerabilities?.length || 0)}
+        hideFooter={perPage >= (data?.count || 0)}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         disableNextPage={!data?.meta.has_next_results}


### PR DESCRIPTION

## Issue
Closes #34266 

## Description
- Will need to be cherry picked into RC
- Confirmed this is the only instance of hideFooter that uses server side pagination but mistakenly uses serverside length to decide if pagination should exist BUT should always show the footer because there's help text >.<
- Revisit during dev of #34394

## Screenshot of fix
<img width="848" height="871" alt="Screenshot 2025-10-16 at 4 00 13 PM" src="https://github.com/user-attachments/assets/fff9bcf1-2974-4a29-8b6c-9e9aa17f5f2e" />

## Testing

- [x] QA'd all new/changed functionality manually
