### PR TITLE
For R.C. - Fleet UI unreleased bug: remove buggy hide footer as we should always…

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -272,7 +272,6 @@ const SoftwareVulnerabilitiesTable = ({
         pageIndex={currentPage}
         manualSortBy
         pageSize={perPage}
-        hideFooter={perPage >= (data?.vulnerabilities?.length || 0)}
         showMarkAllPages={false}
         isAllPagesSelected={false}
         disableNextPage={!data?.meta.has_next_results}


### PR DESCRIPTION
… show the footer help text (#34405)

This was merged into main with #34405 this is for the 4.75 RC

```
 2055  git checkout fleetdm/rc-minor-fleet-v4.75.0
 2056  git checkout -b 34266-pagination-bug-rc
 2057  git log main
 2058  git cherry-pick fccc30be12c16124a7a3d1164389c38f819a8328
 2059  git push -u fleetdm 34266-pagination-bug-rc
```