### PR TITLE
Adds msialwaysinstall profiles

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-applicationmanagement-msialwaysinstall-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-applicationmanagement-msialwaysinstall-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f196-3441-7177-b056-bcaf2aa2f063</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/ApplicationManagement/MSIAlwaysInstallWithElevatedPrivileges</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>0</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-user-applicationmanagement-msialwaysinstall-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-user-applicationmanagement-msialwaysinstall-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f197-5907-7164-af5e-706787d9f942</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./User/Vendor/MSFT/Policy/Config/ApplicationManagement/MSIAlwaysInstallWithElevatedPrivileges</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>0</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created both **User** and **Device** profiles as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-applicationmanagement#msialwaysinstallwithelevatedprivileges)
- Profiles return as **Verified** in FleetUI
- Event Viewer shows no errors
- Registry shows provider set for both **Device** and **User** scopes

<img width="1009" height="464" alt="image" src="https://github.com/user-attachments/assets/90df1b0c-651f-4bfb-bf19-ceb30e34be8e" />

<img width="1654" height="1113" alt="image" src="https://github.com/user-attachments/assets/ed325e97-6d3a-4c53-b700-75f38490cc6d" />

