### PR TITLE
Create windows-device-system-bootstartdriver-disabled.xml

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-system-bootstartdriver-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-system-bootstartdriver-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f1d1-56db-7c8c-b912-89b4883b21e4</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/System/BootStartDriverInitialization</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">chr</Format>
+    </Meta>
+    <Data>&lt;disabled/&gt;</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created **Device** profile to disable the setting as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-system#bootstartdriverinitialization)
- Profiles return as **Verified** in FleetUI
- Event Viewer shows no errors
- Registry shows EarlyLaunch entry with expected defaults

<img width="546" height="375" alt="image" src="https://github.com/user-attachments/assets/058d4283-6ea4-4900-abaf-6e9de1f1b1b3" />

<img width="1654" height="1113" alt="image" src="https://github.com/user-attachments/assets/9e5cb2ff-578b-4fe6-9dfb-50d2c6d910ee" />
