### PR TITLE
Add CSP to disable Game DVR

### DIFF
--- a/docs/solutions/windows/configuration-profiles/DisableAllowGameDVR.xml
+++ b/docs/solutions/windows/configuration-profiles/DisableAllowGameDVR.xml
@@ -1,6 +1,5 @@
 <Replace>
   <!-- Disable Windows Game Recording and Broadcasting --> 
-  <CmdID>1</CmdID>
   <Item>
     <Meta>
       <Format xmlns="syncml:metinf">int</Format>

--- a/docs/solutions/windows/configuration-profiles/DisableAllowGameDVR.xml
+++ b/docs/solutions/windows/configuration-profiles/DisableAllowGameDVR.xml
@@ -1,0 +1,13 @@
+<Replace>
+  <!-- Disable Windows Game Recording and Broadcasting --> 
+  <CmdID>1</CmdID>
+  <Item>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/ApplicationManagement/AllowGameDVR</LocURI>
+    </Target>
+    <Data>0</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
Verified working with Windows 11 Pro.