### PR TITLE
add defender smartscreen windows CSP policies

### DIFF
--- a/docs/solutions/windows/configuration-profiles/automatic-data-collection-in-defender smartscreen-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/automatic-data-collection-in-defender smartscreen-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+    <!-- Disables automatic data collection for defender smartscreen -->
+    <Item>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/Policy/Config/WebThreatDefense/AutomaticDataCollection</LocURI>
+        </Target>
+        <Data>0</Data>
+    </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify malicious-enabled.xml
+++ b/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify malicious-enabled.xml
@@ -1,0 +1,13 @@
+<Replace>
+    <!-- Enable Defender SmartScreen to warn users if they type their work or school
+    password into a malicious scenario -->
+    <Item>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/Policy/Config/WebThreatDefense/NotifyMalicious</LocURI>
+        </Target>
+        <Data>1</Data>
+    </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify-password reuse-enabled.xml
+++ b/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify-password reuse-enabled.xml
@@ -1,0 +1,13 @@
+<Replace>
+    <!-- Enable Defender SmartScreen to warn users if reusing their work or school
+    password -->
+    <Item>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/Policy/Config/WebThreatDefense/NotifyPasswordReuse</LocURI>
+        </Target>
+        <Data>1</Data>
+    </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify-unsafe app-enabled.xml
+++ b/docs/solutions/windows/configuration-profiles/defender-smartscreen-notify-unsafe app-enabled.xml
@@ -1,0 +1,13 @@
+<Replace>
+    <!-- Enable Defender SmartScreen to warn users if they type their work or school password into
+    text editor apps -->
+    <Item>
+        <Meta>
+            <Format xmlns="syncml:metinf">int</Format>
+        </Meta>
+        <Target>
+            <LocURI>./Device/Vendor/MSFT/Policy/Config/WebThreatDefense/NotifyUnsafeApp</LocURI>
+        </Target>
+        <Data>1</Data>
+    </Item>
+</Replace>


### PR DESCRIPTION
Adds 4 defender smartscreen policies, to enable notifying and one for disabling automatic data collection.