### PR TITLE
Create windows-device-systemservices-xbox-disabled.xml

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-xbox-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-xbox-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f23e-ca37-7030-90ec-da3c2bda128f</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxAccessoryManagementServiceStartupMode</LocURI>
@@ -11,7 +10,6 @@
   </Item>
 </Replace>
 <Replace>
-  <CmdID>0199f23e-ca37-7135-bdb5-912d6c0aa140</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveAuthManagerServiceStartupMode</LocURI>
@@ -23,7 +21,6 @@
   </Item>
 </Replace>
 <Replace>
-  <CmdID>0199f23e-ca37-79b2-98a0-79be7848c4f4</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveGameSaveServiceStartupMode</LocURI>
@@ -35,7 +32,6 @@
   </Item>
 </Replace>
 <Replace>
-  <CmdID>0199f23e-ca37-7671-bafd-0aba48014837</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveNetworkingServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-xbox-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-xbox-disabled.xml
@@ -1,0 +1,48 @@
+<Replace>
+  <CmdID>0199f23e-ca37-7030-90ec-da3c2bda128f</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxAccessoryManagementServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>
+<Replace>
+  <CmdID>0199f23e-ca37-7135-bdb5-912d6c0aa140</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveAuthManagerServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>
+<Replace>
+  <CmdID>0199f23e-ca37-79b2-98a0-79be7848c4f4</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveGameSaveServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>
+<Replace>
+  <CmdID>0199f23e-ca37-7671-bafd-0aba48014837</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureXboxLiveNetworkingServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created **Device** profile to disable the services as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-systemservices#configurexboxaccessorymanagementservicestartupmode)
- Profiles return as **Verified** in FleetUI
- Event Viewer shows no errors
- Services listed as disabled

<img width="653" height="375" alt="image" src="https://github.com/user-attachments/assets/d059751a-e853-4bd1-ab36-1ee5d5dc9566" />

<img width="1654" height="1113" alt="image" src="https://github.com/user-attachments/assets/a47ec8fd-c889-472f-802c-89787eb42fbe" />
