### PR TITLE
fix unlock action and refresh host state for ios/ipad

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -229,7 +229,7 @@ const canUnlock = ({
     isMacMdmEnabledAndConfigured &&
     isEnrolledInMdm;
 
-  // "unlocking" for a macos devices host means that somebody saw the unlock pin, but
+  // "unlocking" for a macos devices host means that somebody saw the unlock pin, but we
   // shouldn't prevent users from trying to see the pin again so we still want to show
   // the unlock option when macos hosts are unlocking. This is not the same for
   // ios/ipad devices.

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -5,6 +5,7 @@ import { IDropdownOption } from "interfaces/dropdownOption";
 import {
   isLinuxLike,
   isAppleDevice,
+  isMacOS,
   isMobilePlatform,
   isAndroid,
   isIPadOrIPhone,
@@ -228,12 +229,12 @@ const canUnlock = ({
     isMacMdmEnabledAndConfigured &&
     isEnrolledInMdm;
 
-  // TODO: check if this is still the behaviour for apple hosts
-  // "unlocking" for a apple devices host means that somebody saw the unlock pin, but
-  // shouldn't prevent users from trying to see the pin again, which is
-  // considered an "unlock"
+  // "unlocking" for a macos devices host means that somebody saw the unlock pin, but
+  // shouldn't prevent users from trying to see the pin again so we still want to show
+  // the unlock option when macos hosts are unlocking. This is not the same for
+  // ios/ipad devices.
   const isValidState =
-    (hostMdmDeviceStatus === "unlocking" && isAppleDevice(hostPlatform)) ||
+    (hostMdmDeviceStatus === "unlocking" && isMacOS(hostPlatform)) ||
     hostMdmDeviceStatus === "locked";
 
   return (

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -2,7 +2,7 @@ import React, { useRef } from "react";
 import ReactTooltip from "react-tooltip";
 import classnames from "classnames";
 
-import { isAndroid } from "interfaces/platform";
+import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
 
 import Button from "components/buttons/Button";
 import Icon from "components/Icon/Icon";
@@ -102,13 +102,11 @@ const HostHeader = ({
 }: IHostSummaryProps): JSX.Element => {
   const { platform } = summaryData;
 
-  const isAndroidHost = isAndroid(platform);
-  const isIosOrIpadosHost = platform === "ios" || platform === "ipados";
   const hostDisplayName = useRef<HTMLHeadingElement>(null);
   const isTruncated = useCheckTruncatedElement(hostDisplayName);
 
   const renderRefetch = () => {
-    if (isAndroidHost) {
+    if (isAndroid(platform)) {
       return null;
     }
 
@@ -116,8 +114,8 @@ const HostHeader = ({
     let isDisabled = false;
     let tooltip;
 
-    // we don't have a concept of "online" for iPads and iPhones, so always enable refetch
-    if (!isIosOrIpadosHost) {
+    // we don't have a concept of "online" for iPads and iPhones
+    if (!isIPadOrIPhone(platform)) {
       // deviceStatus can be `undefined` in the case of the MyDevice Page not sending
       // this prop. When this is the case or when it is `unlocked`, we only take
       // into account the host being online or offline for correctly render the
@@ -134,6 +132,20 @@ const HostHeader = ({
         tooltip = !isOnline
           ? REFETCH_TOOLTIP_MESSAGES.offline
           : REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
+      }
+    } else {
+      // ios and ipad devices refresh buttons disable state is determined only by the
+      // host mdm device status.
+      // eslint-disable-next-line
+      if (
+        hostMdmDeviceStatus === undefined ||
+        hostMdmDeviceStatus === "unlocked"
+      ) {
+        isDisabled = false;
+        tooltip = null;
+      } else {
+        isDisabled = true;
+        tooltip = REFETCH_TOOLTIP_MESSAGES[hostMdmDeviceStatus];
       }
     }
 


### PR DESCRIPTION
**Related issue:** Resolves #34206

this fixes two issues with ios/ipad hosts and lock/unlock functionality.

1. this disables the unlock host action when the ios or ipad host is unlocking
2. this disables the ios or ipad hosts refresh button if the host is not unlocked
 
