### PR TITLE
Windows Configuration Profiles - Disabling System Services

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ftpsvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ftpsvc-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7d7c-b6ca-597d08a1839d</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureMicrosoftFTPServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ftpsvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ftpsvc-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7d7c-b6ca-597d08a1839d</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureMicrosoftFTPServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssharedaccess-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssharedaccess-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-76d9-99cb-d122e5b6e6f1</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureInternetConnectionSharingServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssharedaccess-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssharedaccess-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-76d9-99cb-d122e5b6e6f1</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureInternetConnectionSharingServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssvc-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7dee-92cc-0a69d91d6c8a</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWindowsMobileHotspotServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-icssvc-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7dee-92cc-0a69d91d6c8a</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWindowsMobileHotspotServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-routingremoteaccess-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-routingremoteaccess-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7699-8735-e316ffc0564e</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureRoutingAndRemoteAccessServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-routingremoteaccess-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-routingremoteaccess-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7699-8735-e316ffc0564e</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureRoutingAndRemoteAccessServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-rpclocator-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-rpclocator-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7882-9309-44b8f0633b01</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureRemoteProcedureCallLocatorServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-rpclocator-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-rpclocator-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7882-9309-44b8f0633b01</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureRemoteProcedureCallLocatorServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ssdpsrv-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ssdpsrv-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-703f-99a1-abecba6b71f8</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureSSDPDiscoveryServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ssdpsrv-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-ssdpsrv-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-703f-99a1-abecba6b71f8</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureSSDPDiscoveryServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-upnphost-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-upnphost-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7802-9b16-efae4418f444</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureUPnPDeviceHostServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-upnphost-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-upnphost-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7802-9b16-efae4418f444</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureUPnPDeviceHostServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-w3svc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-w3svc-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7966-a812-4b1d5c5c54cb</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWorldWideWebPublishingServiceStartupMode</LocURI>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-w3svc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-w3svc-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7966-a812-4b1d5c5c54cb</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWorldWideWebPublishingServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-wpmnetworksvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-wpmnetworksvc-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-7af7-99ba-2f418f05e77b</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWindowsMediaPlayerNetworkSharingServiceStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>

--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-wpmnetworksvc-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-wpmnetworksvc-disabled.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>0199f25b-795f-7af7-99ba-2f418f05e77b</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureWindowsMediaPlayerNetworkSharingServiceStartupMode</LocURI>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created **Device** profile to disable the services as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-systemservices)
- Profiles return as **Verified** in FleetUI
- Event Viewer shows no errors
- Services listed as disabled

Adds configuration profiles for disabling the following services on startup

Windows Mobile Hotspot Service (icssvc) - 0199f25b-795f-7dee-92cc-0a69d91d6c8a 
Internet Connection Sharing (ICS) (SharedAccess) - 0199f25b-795f-76d9-99cb-d122e5b6e6f1
Routing and Remote Access (RemoteAccess) - 0199f25b-795f-7699-8735-e316ffc0564e
Remote Procedure Call (RPC) Locator (RpcLocator) - 0199f25b-795f-7882-9309-44b8f0633b01
SSDP Discovery (SSDPSRV) - 0199f25b-795f-703f-99a1-abecba6b71f8
UPnP Device Host (upnphost) - 0199f25b-795f-7802-9b16-efae4418f444
Windows Media Player Network Sharing Service (WMPNetworkSvc) - 0199f25b-795f-7af7-99ba-2f418f05e77b
World Wide Web Publishing Service (W3SVC) - 0199f25b-795f-7966-a812-4b1d5c5c54cb (Non-standard Service)
Microsoft FTP Service (FTPSVC) - 0199f25b-795f-7d7c-b6ca-597d08a1839d (Non-standard Service)