### PR TITLE
Fleet UI: Undo filter same row as header name

### DIFF
--- a/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/DefaultColumnFilter/_styles.scss
@@ -1,5 +1,5 @@
 .filter-cell {
-  max-width: 70px;
+  max-width: 100%;
 
   input {
     height: 36px;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -133,10 +133,9 @@ $shadow-transition-width: 10px;
         }
 
         .column-header {
-          // Filters next to header name
           display: flex;
+          flex-direction: column; // Filters under header name
           min-width: max-content;
-          gap: $pad-small;
 
           span {
             display: flex;
@@ -151,7 +150,13 @@ $shadow-transition-width: 10px;
 
         // Sort arrows change color on hover
         .sortable-header {
-          height: 36px;
+          padding: $pad-xsmall 0;
+
+          .column-header {
+            .header-cell {
+              min-height: 36px;
+            }
+          }
 
           &:hover {
             .header-cell:not(.ascending) {

--- a/frontend/pages/queries/details/components/QueryReport/_styles.scss
+++ b/frontend/pages/queries/details/components/QueryReport/_styles.scss
@@ -4,6 +4,12 @@
       width: 95px; // Min width for 6 digits host IDs
     }
 
+    .last_fetched__header {
+      .column-header {
+        margin-bottom: 36px; // Fills space where filter is removed
+      }
+    }
+
     .data-table__wrapper {
       overflow-x: scroll;
     }


### PR DESCRIPTION
## Issue
Closes #34039 

## Description
Undo putting filter next to header name as it's not good UX to have a small search box

## Screen recording of fix

https://github.com/user-attachments/assets/6d90677b-da2c-413d-a77e-06d63d009a76



- [x] QA'd all new/changed functionality manually
  - Clicked around the app to spot check if this impacted anything else