### PR TITLE
Website: Update created account record type

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -265,6 +265,7 @@ module.exports = {
             // eslint-disable-next-line camelcase
             Current_Assignment_Reason__c: 'Inbound Lead',// TODO verify that this matters. if not, do not set it.
             Prospect_Status__c: 'Assigned',// eslint-disable-line camelcase
+            Type: 'Prospect',
 
             Name: enrichmentData.employer.organization,// IFWMIH: We know organization exists
             Website: enrichmentData.employer.emailDomain,


### PR DESCRIPTION
Changes:
- Updated the `update-or-create-contact-and-account` helper to set a `Type` on new account records created.