### PR TITLE
Website: (Microsoft proxy) Add partner ID to requests to Microsoft API in update-one-devices-compliance-status

### DIFF
--- a/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
+++ b/website/api/controllers/microsoft-proxy/update-one-devices-compliance-status.js
@@ -101,6 +101,7 @@ module.exports = {
         DeviceId: deviceId,
         DeviceName: deviceName,
         UserId: informationAboutThisUser.id,
+        PartnerId: sails.config.custom.compliancePartnerClientId,
         // LastCheckInTime is a global timestamp indicating the time of device sync with partner service.
         LastCheckInTime: new Date(lastCheckInTime * 1000).toISOString(),
         // LastUpdateTime is a global timestamp indicating the order of messages.


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/34306

Changes:
- Updated the request to the Microsoft API in the update-one-devices-compliance-status action to include Fleet's partner ID.