### PR TITLE
Update product design rituals

### DIFF
--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -59,7 +59,7 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
 4. If the story requires API or YAML file changes, open a pull request (PR) to the reference docs with the proposed design. Pay attention to existing conventions (URL structure, parameter names, response format) and aim to be consistent. Your PR should follow these guidelines:
    - Make a PR against the docs release branch for the version you expect this feature to be in. Docs release branches are named using the format `docs-vX.X.X`, so if you're designing for Fleet 4.61.0, you would make a PR to `docs-v4.61.0`.
    - Add a link to the issue in the PR description.
-   - Attach the `~api-or-yaml-design` label and add a milestone. (This helps us spot unmerged PRs.)
+   - Attach the `~api-or-yaml-design` label. (This helps the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris) prioritize API/YAML PR review.)
    - Mark the PR ready for review. (Draft PRs do not auto-request reviews.)
    - After your changes are approved by the API design DRI, they will merge your changes into the docs release branch.
 

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -105,4 +105,25 @@
   frequency: "Triweekly" 
   description: "Retro: What went well? What could go better? What to remember for next time?" 
   moreInfoUrl:  
-  dri: "noahtalerman" 
+  dri: "noahtalerman"
+-
+  task: "Review reference docs for upcoming release"
+  startedOn: "2025-10-20"
+  frequency: "Triweekly"
+  description: "After sprint kickoff, check for unmerged API design PRs on the release docs branch (filter: is:pr is:open base:docs-vX.X.X). For stories that made it into the sprint, merge the PR. For stories that did not make it in, close the PR and @-mention the author."
+  moreInfoUrl: ""
+  dri: "rachaelshaw"
+-
+  task: "Create release documentation PR"
+  startedOn: "2025-10-31"
+  frequency: "Triweekly"
+  description: "1. Close any draft PRs (to auto-generated docs) for released features. 2. Prepare documentation PR to `main`. 3. @-mention release DRI"
+  moreInfoUrl: ""
+  dri: "rachaelshaw"
+-
+  task: "Update release documentation branches"
+  startedOn: "2025-10-31"
+  frequency: "Triweekly"
+  description: "After a release documentation PR is merged to `main`, merge the latest from `main` into each upcoming release docs branch."
+  moreInfoUrl: ""
+  dri: "rachaelshaw"

--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -77,12 +77,6 @@
   description: "Review user stories in the 'In review' column on the drafting board with each product group's Product Designer, Engineering Mananger, and Quality Assurance Engineer."
   dri: "noahtalerman"
 - 
-  task: "🦢🚀🤝 Product Design + Frontend Engineering"
-  startedOn: "2025-04-23"
-  frequency: "Triweekly"
-  description: "Product Designers and Frontend Engineers meet to discuss proposed changes to design conventions, UI components, and potential overlap/collisions between in progress wireframes."
-  dri: "rachaelshaw"
-- 
   task: "Revise quarterly roadmap blog post"
   startedOn: "2025-07-18"
   frequency: "Triweekly"


### PR DESCRIPTION
+ Remove "🦢🚀🤝 Product Design + Frontend Engineering" ritual
+ Formalize the rituals for release docs: add post-sprint-kickoff, pre-release, and post-release documentation tasks