### PR TITLE
Hide software host count, versions table when no hosts have the software installed

### DIFF
--- a/changes/32635-hide-count-and-versions-when-no-hosts-installed
+++ b/changes/32635-hide-count-and-versions-when-no-hosts-installed
@@ -1,0 +1,1 @@
+- Hide software host count and version table when no hosts have the software installed.

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -56,7 +56,7 @@ export const SummaryCard = ({
   <Card borderRadiusSize="xxlarge" className={`${baseClass}__summary-section`}>
     <SoftwareDetailsSummary
       title={osVersion.name}
-      hosts={osVersion.hosts_count}
+      hostCount={osVersion.hosts_count}
       countsUpdatedAt={countsUpdatedAt}
       queryParams={{
         os_name: osVersion.name_only,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -367,7 +367,6 @@ const EditIconModal = ({
               !currentIconUrl && software.icon_url ? software.icon_url : null
             }
             versions={versions}
-            hosts={0} // required field but not shown in isPreview
             iconPreviewUrl={iconState.previewUrl}
             iconUploadedAt={iconUploadedAt}
           />

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -53,10 +53,10 @@ const SoftwareSummaryCard = ({
 
   const [iconUploadedAt, setIconUploadedAt] = useState("");
 
-  // Hide versions table for tgz_packages, sh_packages, & ps1_packages only
+  // Hide versions table for tgz_packages, sh_packages, & ps1_packages and when no hosts have the
+  // software installed
   const showVersionsTable =
-    !!title.versions?.length &&
-    !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source);
+    !!title.hosts_count && !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source);
 
   const hasEditPermissions =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -54,7 +54,9 @@ const SoftwareSummaryCard = ({
   const [iconUploadedAt, setIconUploadedAt] = useState("");
 
   // Hide versions table for tgz_packages, sh_packages, & ps1_packages only
-  const showVersionsTable = !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source);
+  const showVersionsTable =
+    !!title.versions?.length &&
+    !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source);
 
   const hasEditPermissions =
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -79,7 +79,7 @@ const SoftwareSummaryCard = ({
           title={title.name}
           type={formatSoftwareType(title)}
           versions={title.versions?.length ?? 0}
-          hosts={title.hosts_count}
+          hostCount={title.hosts_count}
           countsUpdatedAt={title.counts_updated_at}
           queryParams={{
             software_title_id: softwareId,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
@@ -39,6 +39,8 @@ export const TitleVersionsLastUpdatedInfo = (lastUpdatedAt: string) => {
   );
 };
 
+// This empty state is no longer ever used since this table is hidden when there is no software.
+// Keeping here for convenience in case that decision is ever changed.
 const NoVersionsDetected = (isAvailableForInstall = false): JSX.Element => {
   return (
     <Card borderRadiusSize="medium">

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -181,7 +181,7 @@ const SoftwareVersionDetailsPage = ({
               <SoftwareDetailsSummary
                 title={`${softwareVersion.name}, ${softwareVersion.version}`}
                 type={formatSoftwareType(softwareVersion)}
-                hosts={hostsCount ?? 0}
+                hostCount={hostsCount}
                 queryParams={{
                   software_version_id: softwareVersion.id,
                   team_id: teamIdForApi,

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -30,7 +30,7 @@ const baseClass = "software-details-summary";
 interface ISoftwareDetailsSummaryProps {
   title: string;
   type?: string;
-  hosts: number;
+  hostCount?: number;
   countsUpdatedAt?: string;
   /** The query param that will be added when user clicks on the host count
    * Optional as isPreview mode doesn't have host count/link
@@ -54,7 +54,7 @@ interface ISoftwareDetailsSummaryProps {
 const SoftwareDetailsSummary = ({
   title,
   type,
-  hosts,
+  hostCount,
   countsUpdatedAt,
   queryParams,
   name,
@@ -71,8 +71,7 @@ const SoftwareDetailsSummary = ({
   // Remove host count for tgz_packages, sh_packages, and ps1_packages only
   // or if viewing details summary from edit icon preview modal
   const showHostCount =
-    !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source || "") &&
-    iconPreviewUrl === undefined;
+    !!hostCount && !NO_VERSION_OR_HOST_DATA_SOURCES.includes(source || "");
 
   const renderSoftwareIcon = () => {
     if (
@@ -143,7 +142,7 @@ const SoftwareDetailsSummary = ({
                       <TooltipWrapper tipContent="View all hosts">
                         <CustomLink
                           url={hostCountPath}
-                          text={hosts.toString()}
+                          text={hostCount.toString()}
                         />
                       </TooltipWrapper>
                     }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32635
Hide host count and version table when no hosts have the software installed

<img width="1518" height="568" alt="Screenshot 2025-10-17 at 4 36 13 PM" src="https://github.com/user-attachments/assets/4f77d039-d9d0-427e-a3f4-a8774a3f6ff7" />



- [x] Changes file added for user-visible changes in `changes/`
- [x] QA'd all new/changed functionality manually

