### PR TITLE
Converted to using the Company Portal FMA

### DIFF
--- a/it-and-security/lib/macos/policies/company-portal-installed.yml
+++ b/it-and-security/lib/macos/policies/company-portal-installed.yml
@@ -1,7 +1,8 @@
 - name: macOS - Company Portal installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.CompanyPortalMac';
   install_software:
-    package_path: ../software/company-portal.yml
+    slug: intune-company-portal/darwin
+#    package_path: ../software/company-portal.yml
   critical: false
   description: This policy triggers automatic install of Company Portal on hosts in the "Conditional access test group" label.
   resolution: Company Portal should be automatically installed. If it is missing, install it from self-service. 

--- a/it-and-security/lib/macos/software/company-portal.yml
+++ b/it-and-security/lib/macos/software/company-portal.yml
@@ -1,1 +1,0 @@
-url: https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_5.2508.0-Upgrade.pkg

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -221,10 +221,6 @@ software:
       self_service: true
       labels_include_any:
         - "Keynote installed"
-    - path: ../lib/macos/software/company-portal.yml # Company Portal for macOS
-      self_service: true
-      labels_include_any:
-        - "Conditional access test group"
     - path: ../lib/macos/software/nudge.yml # Nudge for macOS 
       self_service: false
     - path: ../lib/macos/software/nudge-assets.yml # Nudge assets for macOS
@@ -302,6 +298,10 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+    - slug: intune-company-portal/darwin # Company Portal for macOS
+      self_service: true
+      labels_include_any:
+        - "Conditional access test group"
     - slug: docker/darwin # Docker for macOS (ARM)
       self_service: true
       labels_include_any:


### PR DESCRIPTION
- Removed the company-portal.yml file and updated workstations-canary.yml to reference Company Portal for macOS using an FMA instead of a custom package.