### PR TITLE
Add disable-toast-notifications-from-lock.xml

### DIFF
--- a/it-and-security/lib/windows/configuration-profiles/disable-toast-notifications-from-lock.xml
+++ b/it-and-security/lib/windows/configuration-profiles/disable-toast-notifications-from-lock.xml
@@ -1,0 +1,13 @@
+ <Replace>
+  <CmdID>1</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/AboveLock/AllowToasts</LocURI>
+    </Target>
+    <Meta>
+      <Format>int</Format>
+      <Type>text/plain</Type>
+    </Meta>
+    <Data>0</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
This Windows configuration profile disables notifications on the lock screen.

## Testing

- [x] QA'd all new/changed functionality manually

