### PR TITLE
Create windows-device-systemservices-simptcp-disabled.xml

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-systemservices-simptcp-disabled.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-systemservices-simptcp-disabled.xml
@@ -1,0 +1,12 @@
+<Replace>
+  <CmdID>0199f25b-795f-772e-9037-dd02873185e7</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/SystemServices/ConfigureSimpleTCPIPServicesStartupMode</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>4</Data>
+  </Item>
+</Replace>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created **Device** profile to disable the setting as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-system#bootstartdriverinitialization)
- Profiles return as **Verified** in FleetUI (Requires device restart)
- Event Viewer shows no errors
- Service shows as disabled