### PR TITLE
Create windows-device-wirelessdisplay-requirepin.xml

### DIFF
--- a/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
@@ -1,0 +1,13 @@
+<Replace>
+  <CmdID>019a01a3-602f-7c7a-b8b5-0eed67562fbd</CmdID>
+  <Item>
+    <Target>
+      <LocURI>./Device/Vendor/MSFT/Policy/Config/WirelessDisplay/RequirePinForPairing</LocURI>
+    </Target>
+    <Meta>
+      <Format xmlns="syncml:metinf">int</Format>
+    </Meta>
+    <Data>2</Data>
+  </Item>
+</Replace>
+

--- a/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
@@ -9,4 +9,3 @@
     <Data>2</Data>
   </Item>
 </Replace>
-

--- a/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
+++ b/docs/solutions/windows/configuration-profiles/windows-device-wirelessdisplay-requirepin.xml
@@ -1,5 +1,4 @@
 <Replace>
-  <CmdID>019a01a3-602f-7c7a-b8b5-0eed67562fbd</CmdID>
   <Item>
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/WirelessDisplay/RequirePinForPairing</LocURI>


### PR DESCRIPTION
- Uses randomly generated UUID for the CmdID as required by [CmdID Specs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/d7321df8-ecb2-4c81-8a24-54630bc7456f)
- Created **Device** profile to enable the setting as required based on [Microsoft Docs](https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-csp-wirelessdisplay#requirepinforpairing)
- Profiles return as **Verified** in FleetUI
- Event Viewer shows no errors
- Registry confirms PIN requirement

<img width="1468" height="296" alt="image" src="https://github.com/user-attachments/assets/5da9d4d2-a74b-4f0b-a2ec-12008b911766" />
