### PR TITLE
Fleet UI: Fix CSS on edit icon modal

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -467,7 +467,9 @@ const EditIconModal = ({
               uploadedAt={iconUploadedAt}
             />
           )}
-          <TooltipTruncatedText value={previewInfo.name} />
+          <div className={`${baseClass}__self-service-preview-name`}>
+            <TooltipTruncatedText value={previewInfo.name} />
+          </div>
         </div>
       </Card>
       <div

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
@@ -3,6 +3,10 @@
     font-size: $medium;
   }
 
+  .modal__content {
+    @include vertical-modal-layout;
+  }
+
   &__preview-card {
     max-height: 203px;
     overflow: hidden;
@@ -66,6 +70,14 @@
     .software-icon__xsmall {
       border-radius: $border-radius-small;
     }
+  }
+
+  // Required for tooltip truncating long software names
+  &__self-service-preview-name {
+    max-width: 180px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   &__mask-overlay {

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -271,6 +271,11 @@ $max-width: 2560px;
   @include flex-column-24px-gap;
 }
 
+// Separate in case there's any modal level styling we need
+@mixin vertical-modal-layout {
+  @include flex-column-24px-gap;
+}
+
 // Separate in case there's any tab level styling we need
 @mixin vertical-page-tab-panel-layout {
   @include flex-column-24px-gap;


### PR DESCRIPTION
## Issue
Closes #34524 

## Description 
- Add vertical padding
- Tooltip truncate software name (weird because I'm pretty sure it was working before)

## Screenshot of fixes

<img width="855" height="697" alt="Screenshot 2025-10-20 at 12 48 07 PM" src="https://github.com/user-attachments/assets/bcdc9287-6dd9-4e07-920e-671409507c70" />



## Testing

- [x] QA'd all new/changed functionality manually


Should merge this into 4.76
