### PR TITLE
Cherry-Pick 4.76: Don't try to pull config profiles when MDM isn't enabled for any platform when generating GitOps YAML

### DIFF
--- a/changes/33677-generate-gitops-fix
+++ b/changes/33677-generate-gitops-fix
@@ -1,0 +1,1 @@
+* Fixed `fleetctl generate-gitops` when MDM is not turned on

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1021,30 +1021,35 @@ func (cmd *GenerateGitopsCommand) generateControls(teamId *uint, teamName string
 		result[jsonFieldName(t, "Scripts")] = scripts
 	}
 
-	profiles, err := cmd.generateProfiles(teamId, teamName)
-	if err != nil {
-		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
-		return nil, err
-	}
+	if cmd.AppConfig.MDM.EnabledAndConfigured ||
+		cmd.AppConfig.MDM.WindowsEnabledAndConfigured ||
+		cmd.AppConfig.MDM.AndroidEnabledAndConfigured {
 
-	if cmd.AppConfig.MDM.EnabledAndConfigured && profiles != nil {
-		if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
-				"custom_settings": profiles["apple_profiles"],
+		profiles, err := cmd.generateProfiles(teamId, teamName)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating profiles: %s\n", err)
+			return nil, err
+		}
+
+		if cmd.AppConfig.MDM.EnabledAndConfigured && profiles != nil {
+			if len(profiles["apple_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "MacOSSettings")] = map[string]interface{}{
+					"custom_settings": profiles["apple_profiles"],
+				}
 			}
 		}
-	}
-	if cmd.AppConfig.MDM.WindowsEnabledAndConfigured && profiles != nil {
-		if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
-				"custom_settings": profiles["windows_profiles"],
+		if cmd.AppConfig.MDM.WindowsEnabledAndConfigured && profiles != nil {
+			if len(profiles["windows_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "WindowsSettings")] = map[string]interface{}{
+					"custom_settings": profiles["windows_profiles"],
+				}
 			}
 		}
-	}
-	if cmd.AppConfig.MDM.AndroidEnabledAndConfigured && profiles != nil {
-		if len(profiles["android_profiles"].([]map[string]interface{})) > 0 {
-			result[jsonFieldName(t, "AndroidSettings")] = map[string]interface{}{
-				"custom_settings": profiles["android_profiles"],
+		if cmd.AppConfig.MDM.AndroidEnabledAndConfigured && profiles != nil {
+			if len(profiles["android_profiles"].([]map[string]interface{})) > 0 {
+				result[jsonFieldName(t, "AndroidSettings")] = map[string]interface{}{
+					"custom_settings": profiles["android_profiles"],
+				}
 			}
 		}
 	}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -24,6 +24,7 @@ import (
 type MockClient struct {
 	IsFree           bool
 	TeamNameOverride string
+	WithoutMDM       bool
 }
 
 func (c *MockClient) GetAppConfig() (*fleet.EnrichedAppConfig, error) {
@@ -38,6 +39,13 @@ func (c *MockClient) GetAppConfig() (*fleet.EnrichedAppConfig, error) {
 	if c.IsFree == true {
 		appConfig.License.Tier = fleet.TierFree
 	}
+
+	if c.WithoutMDM {
+		appConfig.MDM.EnabledAndConfigured = false
+		appConfig.MDM.AndroidEnabledAndConfigured = false
+		appConfig.MDM.WindowsEnabledAndConfigured = false
+	}
+
 	return &appConfig, nil
 }
 
@@ -107,7 +115,11 @@ func (MockClient) ListScripts(query string) ([]*fleet.Script, error) {
 	}
 }
 
-func (MockClient) ListConfigurationProfiles(teamID *uint) ([]*fleet.MDMConfigProfilePayload, error) {
+func (c MockClient) ListConfigurationProfiles(teamID *uint) ([]*fleet.MDMConfigProfilePayload, error) {
+	if c.WithoutMDM {
+		return nil, errors.New("should not have pulled configuration profiles endpoint")
+	}
+
 	if teamID == nil {
 		return []*fleet.MDMConfigProfilePayload{
 			{
@@ -618,6 +630,30 @@ func TestGenerateGitops(t *testing.T) {
 	require.NoError(t, err, buf.String())
 
 	compareDirs(t, "./testdata/generateGitops/test_dir_premium", tempDir)
+
+	t.Cleanup(func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			t.Fatalf("failed to remove temp dir: %v", err)
+		}
+	})
+}
+
+func TestGenerateGitopsWithoutMDM(t *testing.T) {
+	fleetClient := &MockClient{WithoutMDM: true}
+	action := createGenerateGitopsAction(fleetClient)
+	buf := new(bytes.Buffer)
+	tempDir := os.TempDir() + "/" + uuid.New().String()
+	flagSet := flag.NewFlagSet("test", flag.ContinueOnError)
+	flagSet.String("dir", tempDir, "")
+
+	cliContext := cli.NewContext(&cli.App{
+		Name:      "test",
+		Usage:     "test",
+		Writer:    buf,
+		ErrWriter: buf,
+	}, flagSet, nil)
+	err := action(cliContext)
+	require.NoError(t, err, buf.String()) // just checking for success to verify #33667
 
 	t.Cleanup(func() {
 		if err := os.RemoveAll(tempDir); err != nil {


### PR DESCRIPTION
Merged into `main` in #34549.