### PR TITLE
Update script upload UI: updates from QA

### DIFF
--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListHeading/ScriptListHeading.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListHeading/ScriptListHeading.tsx
@@ -1,3 +1,4 @@
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import React from "react";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
@@ -11,20 +12,26 @@ interface IScriptListHeading {
 const ScriptListHeading = ({ onClickAddScript }: IScriptListHeading) => {
   return (
     <div className={baseClass}>
-      <div className={`${baseClass}__heading-group`}>
-        <span>Script</span>
-        <span className={`${baseClass}__button-container`}>
-          <Button
-            variant="brand-inverse-icon"
-            onClick={() => {
-              return onClickAddScript();
-            }}
-          >
-            <Icon name="plus" color="core-fleet-green" />
-            <span>Add script</span>
-          </Button>
-        </span>
-      </div>
+      <span className={`${baseClass}__heading-title`}>Scripts</span>
+      <span className={`${baseClass}__heading-actions`}>
+        <GitOpsModeTooltipWrapper
+          position="left"
+          renderChildren={(disableChildren) => (
+            <Button
+              disabled={disableChildren}
+              variant="brand-inverse-icon"
+              className={`${baseClass}__add-button`}
+              onClick={onClickAddScript}
+              iconStroke
+            >
+              <>
+                <Icon name="plus" color="core-fleet-green" />
+                Add script
+              </>
+            </Button>
+          )}
+        />
+      </span>
     </div>
   );
 };

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptListHeading/_styles.scss
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptListHeading/_styles.scss
@@ -1,47 +1,19 @@
 .script-list-heading {
-  font-weight: $bold;
   display: flex;
+  align-items: center;
   justify-content: space-between;
+  font-size: $x-small;
+  font-weight: $bold;
 
-  &__heading-group {
-    flex: 1;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-
-    .button--brand-inverse-icon {
-      height: 16px;
-      padding: 0px;
-    }
+  &__heading-title {
+    align-content: center;
   }
 
-  &__button-container {
-    height: 16px;
+  &__heading-actions {
+    margin: -$pad-medium 0; // Remove vertical padding of button increasing container height
   }
 
-  &__script-statuses {
-    display: flex;
-    justify-content: center;
-  }
-
-  &__status > div {
-    display: flex;
-    align-items: center;
-    width: 100px;
-    justify-content: center;
-
-    span {
-      margin-left: 12px;
-    }
-  }
-
-  &__tooltip-text {
-    font-weight: normal;
-  }
-
-  @media (max-width: $break-md) {
-    &__script-statuses {
-      justify-content: flex-end;
-    }
+  &__add-button {
+    vertical-align: middle;
   }
 }

--- a/frontend/utilities/file/fileUtils.ts
+++ b/frontend/utilities/file/fileUtils.ts
@@ -1,6 +1,6 @@
 import { PackageType } from "interfaces/package_type";
 
-type IPlatformDisplayName = "macOS" | "Windows" | "Linux";
+type IPlatformDisplayName = "macOS" | "Windows" | "Linux" | "macOS & Linux";
 
 export const FILE_EXTENSIONS_TO_PLATFORM_DISPLAY_NAME: Record<
   string,
@@ -15,7 +15,7 @@ export const FILE_EXTENSIONS_TO_PLATFORM_DISPLAY_NAME: Record<
   deb: "Linux",
   rpm: "Linux",
   "tar.gz": "Linux",
-  sh: "Linux",
+  sh: "macOS & Linux",
   ps1: "Windows",
 };
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32632
**Related issue:** Resolves #34454 

# Details

Addresses the following QA-reported issues with #32632:

* Adding a .sh script file does not show it is valid for macOS
<img width="617" height="183" alt="image" src="https://github.com/user-attachments/assets/39dcf884-ffbc-43b3-a06b-ad88520d6a16" />

* With Gitops mode enabled the 'add scripts' button is still clickable
<img width="693" height="151" alt="image" src="https://github.com/user-attachments/assets/84c6e77d-ed1c-4e8a-8ebd-099d9da5405a" />

* Controls > Scripts: "Add script" is missing padding (#34454)
<img width="173" height="79" alt="image" src="https://github.com/user-attachments/assets/d89cb728-f4ba-427b-868f-f072196777ae" />

# Checklist for submitter

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


