### PR TITLE
Cherry pick: Add macos web setup experience capability check

### DIFF
--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1195,6 +1195,8 @@ func main() {
 				UpdateRunner: updateRunner, RootDir: c.String("root-dir"), Interval: nudgeLaunchInterval,
 			}))
 			setupExperiencer := setupexperience.NewSetupExperiencer(orbitClient, deviceClient, c.String("root-dir"), trw)
+			// Use the legacy UI if the server indicates so via capabilities.
+			setupExperiencer.UseLegacyUI = !orbitClient.GetServerCapabilities().Has(fleet.CapabilityMacOSWebSetupExperience)
 			orbitClient.RegisterConfigReceiver(setupExperiencer)
 			orbitClient.RegisterConfigReceiver(update.ApplySwiftDialogDownloaderMiddleware(updateRunner))
 

--- a/orbit/pkg/setup_experience/setup_experience.go
+++ b/orbit/pkg/setup_experience/setup_experience.go
@@ -46,6 +46,8 @@ type SetupExperiencer struct {
 	started           bool
 	trw               *token.ReadWriter
 	stopTokenRotation func()
+	uiSteps           map[string]swiftdialog.ListItem // For legacy swiftDialog UI to track current steps
+	UseLegacyUI       bool
 }
 
 func NewSetupExperiencer(orbitClient OrbitClient, deviceClient DeviceClient, rootDirPath string, trw *token.ReadWriter) *SetupExperiencer {
@@ -55,6 +57,7 @@ func NewSetupExperiencer(orbitClient OrbitClient, deviceClient DeviceClient, roo
 		closeChan:    make(chan struct{}),
 		rootDirPath:  rootDirPath,
 		trw:          trw,
+		uiSteps:      make(map[string]swiftdialog.ListItem),
 	}
 }
 
@@ -62,6 +65,11 @@ func (s *SetupExperiencer) Run(oc *fleet.OrbitConfig) error {
 	if !oc.Notifications.RunSetupExperience {
 		log.Debug().Msg("skipping setup experience: notification flag is not set")
 		return nil
+	}
+
+	// If using the legacy UI, then call that method.
+	if s.UseLegacyUI {
+		return s.RunLegacy(oc)
 	}
 
 	// Ensure that the token rotation checker is started, so that we have a valid token
@@ -391,4 +399,291 @@ func WriteSetupExperienceStatusFile(rootDir string, exp *SetupExperienceInfo) er
 		return fmt.Errorf("write setup experience completed file: %w", err)
 	}
 	return nil
+}
+
+func (s *SetupExperiencer) RunLegacy(oc *fleet.OrbitConfig) error {
+	const doneMessage = `### Setup is complete\n\nPlease contact your IT Administrator if there were any errors.`
+
+	if !oc.Notifications.RunSetupExperience {
+		log.Debug().Msg("skipping setup experience: notification flag is not set")
+		return nil
+	}
+
+	_, binaryPath, _ := update.LocalTargetPaths(
+		s.rootDirPath,
+		"swiftDialog",
+		update.SwiftDialogMacOSTarget,
+	)
+
+	if _, err := os.Stat(binaryPath); err != nil {
+		log.Info().Msg("skipping setup experience: swiftDialog is not installed")
+		return nil
+	}
+
+	log.Info().Msg("checking setup experience status")
+
+	// Poll the status endpoint. This also releases the device if we're done.
+	payload, err := s.OrbitClient.GetSetupExperienceStatus(false)
+	if err != nil {
+		return err
+	}
+
+	// If swiftDialog isn't up yet, then launch it
+	orgLogo := payload.OrgLogoURL
+	if orgLogo == "" {
+		orgLogo = "https://fleetdm.com/images/permanent/fleet-mark-color-40x40@4x.png"
+	}
+
+	if err := s.startSwiftDialogLegacy(binaryPath, orgLogo); err != nil {
+		return err
+	}
+
+	// Defer this so that s.started is only false the first time this function runs.
+	defer func() { s.started = true }()
+
+	select {
+	case <-s.closeChan:
+		log.Info().Str("receiver", "setup_experiencer").Msg("swiftDialog closed")
+		return nil
+	default:
+		// ok
+	}
+
+	// We're rendering the initial loading UI (shown while there are still profiles, bootstrap package,
+	// and account configuration to verify) right off the bat, so we can just no-op if any of those
+	// are not terminal
+
+	log.Info().Msg("setup experience: checking for pending statuses")
+
+	if payload.BootstrapPackage != nil {
+		if payload.BootstrapPackage.Status != fleet.MDMBootstrapPackageFailed && payload.BootstrapPackage.Status != fleet.MDMBootstrapPackageInstalled {
+			log.Info().Msg("setup experience: bootstrap package pending")
+			return nil
+		}
+	}
+
+	if isPending, name := anyProfilePending(payload.ConfigurationProfiles); isPending {
+		log.Info().Msg(fmt.Sprintf("setup experience: profile pending: %s", name))
+		return nil
+	}
+
+	if payload.AccountConfiguration != nil {
+		if payload.AccountConfiguration.Status != fleet.MDMAppleStatusAcknowledged &&
+			payload.AccountConfiguration.Status != fleet.MDMAppleStatusError &&
+			payload.AccountConfiguration.Status != fleet.MDMAppleStatusCommandFormatError {
+
+			log.Info().Msg("setup experience: account config pending")
+			return nil
+		}
+	}
+
+	// Note that we are setting this based on the current payload only just in case something
+	// was removed from the payload that was there earlier(e.g. a deleted software title).
+	allStepsDone := true
+
+	// Log the payload JSON
+	log.Debug().Msgf("setup experience: payload: %+v", payload)
+
+	// Now render the UI for the software and script.
+	if len(payload.Software) > 0 || payload.Script != nil {
+		log.Info().Msg("setup experience: rendering software and script UI")
+
+		var stepsDone int
+		var prog uint
+		var steps []*fleet.SetupExperienceStatusResult
+		if len(payload.Software) > 0 {
+			steps = payload.Software
+		}
+
+		if payload.Script != nil {
+			steps = append(steps, payload.Script)
+		}
+
+		// Check for any items that were in the payload that are no longer there. This can happen
+		// if a software title was deleted, for instance
+		for uiStepName, uiStep := range s.uiSteps {
+			uiStepExistsInPayload := false
+			for _, step := range steps {
+				if uiStep.Title == step.Name {
+					uiStepExistsInPayload = true
+					break
+				}
+			}
+			if !uiStepExistsInPayload {
+				log.Info().Msgf("Setup Experience: list item %s removed from payload", uiStep.Title)
+				err = s.sd.DeleteListItemByTitle(uiStep.Title)
+				if err != nil {
+					log.Info().Err(err).Msg("deleting list item removed from payload from setup experience UI")
+				}
+				delete(s.uiSteps, uiStepName)
+			}
+		}
+
+		for _, step := range steps {
+			currentStepState := resultToListItem(step)
+			if priorStepState, ok := s.uiSteps[step.Name]; ok {
+				if currentStepState != priorStepState {
+					// We only want to resend on change so we're not unnecessarily scrolling the UI
+					err = s.sd.UpdateListItemByTitle(currentStepState.Title, currentStepState.StatusText, currentStepState.Status)
+					if err != nil {
+						log.Info().Err(err).Msg("updating list item in setup experience UI")
+					}
+				} else {
+					log.Info().Msgf("setup experience: no change in status for %s", step.Name)
+				}
+			} else {
+				err = s.sd.AddListItem(currentStepState)
+				if err != nil {
+					log.Info().Err(err).Msg("adding list item in setup experience UI")
+				}
+				s.uiSteps[step.Name] = currentStepState
+			}
+
+			if step.Status == fleet.SetupExperienceStatusFailure || step.Status == fleet.SetupExperienceStatusSuccess {
+				stepsDone++
+				// The swiftDialog progress bar is out of 100
+				for range int(float32(1) / float32(len(steps)) * 100) {
+					prog++
+				}
+			} else {
+				allStepsDone = false
+			}
+		}
+
+		if err = s.sd.UpdateProgress(prog); err != nil {
+			log.Info().Err(err).Msg("updating progress bar in setup experience UI")
+		}
+
+		if err := s.sd.ShowList(); err != nil {
+			log.Info().Err(err).Msg("showing progress bar in setup experience UI")
+		}
+
+		if err := s.sd.UpdateProgressText(fmt.Sprintf("%.0f%%", float32(stepsDone)/float32(len(steps))*100)); err != nil {
+			log.Info().Err(err).Msg("updating progress text in setup experience UI")
+		}
+
+	}
+
+	// If we get here, we can render the "done" UI.
+
+	if allStepsDone {
+		if err := s.sd.SetMessage(doneMessage); err != nil {
+			log.Info().Err(err).Msg("setting message in setup experience UI")
+		}
+
+		if err := s.sd.CompleteProgress(); err != nil {
+			log.Info().Err(err).Msg("completing progress bar in setup experience UI")
+		}
+
+		if len(payload.Software) > 0 || payload.Script != nil {
+			// need to call this because SetMessage removes the list from the view for some reason :(
+			if err := s.sd.ShowList(); err != nil {
+				log.Info().Err(err).Msg("showing list in setup experience UI")
+			}
+		}
+
+		if err := s.sd.UpdateProgressText("100%"); err != nil {
+			log.Info().Err(err).Msg("updating progress text in setup experience UI")
+		}
+
+		if err := s.sd.EnableButton1(true); err != nil {
+			log.Info().Err(err).Msg("enabling close button in setup experience UI")
+		}
+
+		// Sleep for a few seconds to let the user see the done message before closing
+		// the UI
+		time.Sleep(3 * time.Second)
+
+		if err := s.sd.Quit(); err != nil {
+			log.Info().Err(err).Msg("quitting setup experience UI on completion")
+		}
+	}
+
+	return nil
+}
+
+func (s *SetupExperiencer) startSwiftDialogLegacy(binaryPath, orgLogo string) error {
+	if s.started {
+		log.Info().Msg("swiftDialog started")
+		return nil
+	}
+
+	log.Info().Msg("creating swiftDialog instance")
+
+	created := make(chan struct{})
+	swiftDialog, err := swiftdialog.Create(context.Background(), binaryPath)
+	if err != nil {
+		return errors.New("creating swiftDialog instance: %w")
+	}
+	s.sd = swiftDialog
+
+	iconSize, err := swiftdialog.GetIconSize(orgLogo)
+	if err != nil {
+		log.Error().Err(err).Msg("setup experience: getting icon size")
+		iconSize = swiftdialog.DefaultIconSize
+	}
+
+	go func() {
+		initOpts := &swiftdialog.SwiftDialogOptions{
+			Title:            "none",
+			Message:          "### Setting up your Mac...\n\nYour Mac is being configured by your organization using Fleet. This process may take some time to complete. Please don't attempt to restart or shut down the computer unless prompted to do so.",
+			Icon:             orgLogo,
+			MessageAlignment: swiftdialog.AlignmentCenter,
+			CentreIcon:       true,
+			Height:           "625",
+			Big:              true,
+			ProgressText:     "Configuring your device...",
+			Button1Text:      "Close",
+			Button1Disabled:  true,
+			BlurScreen:       true,
+			OnTop:            true,
+			QuitKey:          "X", // Capital X to require command+shift+x
+		}
+
+		if err := s.sd.Start(context.Background(), initOpts, true); err != nil {
+			log.Error().Err(err).Msg("starting swiftDialog instance")
+		}
+
+		if err = s.sd.ShowProgress(); err != nil {
+			log.Error().Err(err).Msg("setting initial setup experience progress")
+		}
+
+		if err := s.sd.SetIconSize(iconSize); err != nil {
+			log.Error().Err(err).Msg("setting initial setup experience icon size")
+		}
+
+		log.Debug().Msg("swiftDialog process started")
+		created <- struct{}{}
+
+		if _, err = s.sd.Wait(); err != nil {
+			log.Error().Err(err).Msg("swiftdialog.Wait failed")
+		}
+
+		s.closeChan <- struct{}{}
+	}()
+	<-created
+	return nil
+}
+
+func resultToListItem(result *fleet.SetupExperienceStatusResult) swiftdialog.ListItem {
+	statusText := "Pending"
+	status := swiftdialog.StatusWait
+
+	switch result.Status {
+	case fleet.SetupExperienceStatusFailure:
+		status = swiftdialog.StatusFail
+		statusText = "Failed"
+	case fleet.SetupExperienceStatusSuccess:
+		status = swiftdialog.StatusSuccess
+		statusText = "Installed"
+		if result.IsForScript() {
+			statusText = "Ran"
+		}
+	}
+
+	return swiftdialog.ListItem{
+		Title:      result.Name,
+		Status:     status,
+		StatusText: statusText,
+	}
 }

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -91,6 +91,9 @@ const (
 	// CapabilityWebSetupExperience denotes the ability of the server to support installing software
 	// as part of a non-blocking setup experience for Linux and Windows
 	CapabilityWebSetupExperience Capability = "web_setup_experience"
+	// CapabilityMacOSWebSetupExperience denotes the ability of the server to support
+	// a web-based setup experience UI for macOS devices
+	CapabilityMacOSWebSetupExperience Capability = "macos_web_setup_experience"
 )
 
 func GetServerOrbitCapabilities() CapabilityMap {
@@ -102,6 +105,7 @@ func GetServerOrbitCapabilities() CapabilityMap {
 		CapabilityLinuxDiskEncryptionEscrow: {},
 		CapabilitySetupExperience:           {},
 		CapabilityWebSetupExperience:        {},
+		CapabilityMacOSWebSetupExperience:   {},
 	}
 }
 


### PR DESCRIPTION
Cherry pick of [7fa8793](https://github.com/fleetdm/fleet/commit/7fa8793b1ee3015e74a93d7940e41142f03c5976) (#34582) to 4.76.0 so that it reports the new `CapabilityMacOSWebSetupExperience` capability and triggers the new web-based setup experience for macOS.