### PR TITLE
Wind down UX group

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -180,20 +180,6 @@ Items to cover in the section:
 - Who is involved. This should include who the DRI is.
 - Timeline. When will the working group start? When do we think we'll be done by?
 
-
-### UX group
-
-The goal of the UX group is to catch the Fleet product up with the [latest brand colors/styles](https://github.com/fleetdm/confidential/issues/11765) from the website (fleetdm.com), address [UX debt (spiffier)](https://github.com/fleetdm/confidential/issues/11868), and ship the Fleet product's first [2 graphs](https://github.com/fleetdm/confidential/issues/11864).
-
-This group will kick off on 2025-08-27 and plans to wrap up on 2025-09-29.
-
-| Responsibility                    | Human(s)                  |
-|:----------------------------------|:--------------------------|
-| Product Designer                  | [Mike Thomas](https://www.linkedin.com/in/mike-thomas-52277938) _([@mike-j-thomas](https://github.com/mike-j-thomas))_
-| Product Manager (DRI)             | [Noah Talerman](https://www.linkedin.com/in/noah-talerman/) _([@noahtalerman](https://github.com/noahtalerman))_
-| Quality Assurance                 | [Mike Thomas](https://www.linkedin.com/in/mike-thomas-52277938) _([@mike-j-thomas](https://github.com/mike-j-thomas))_
-| Software Engineer                 | [Luke Heath](https://www.linkedin.com/in/lukeheath/) _([@lukeheath](https://github.com/lukeheath))_
-
 <!--
 Example working group section
 ### Name


### PR DESCRIPTION
- @noahtalerman: The UX working group shipped "purge the purple"! 
  - We didn't get to [the 2 graphs](https://github.com/fleetdm/fleet/issues/33940) but I think that's ok. We can spin up another group for that when the time comes.

After we merge in this PR:
- DONE: @noahtalerman: Archive the Slack channel
- TODO: @noahtalerman + @mike-j-thomas (at next week's `:help-design` sprint kickoff): Run through the [#g-ux design review doc](https://docs.google.com/document/d/1TzLviitXV1QIHIAFpPejQTro5ZThHKEim3yENUfUi1Q/edit?tab=t.0) and ask folks to file feedback as `:help-design` requests
  - For example: https://fleetdm.slack.com/archives/C02A8BRABB5/p1761043962332539
- DONE: @noahtalerman + @mike-j-thomas (at next week's `:help-design` sprint kickoff): Move issues from the #g-ux project onto the :help-design board. Archive the #g-ux board
