### PR TITLE
Fix link formatting in fleetd-authentication.md

### DIFF
--- a/articles/fleetd-authentication.md
+++ b/articles/fleetd-authentication.md
@@ -102,7 +102,7 @@ More information can be found on orbit's Github [README](https://github.com/flee
 
 By default, fleetd uses the OS root CA certificate store and also embeds the [Mozilla CA certificate store](https://curl.se/docs/caextract.html).
 Fleetd also supports setting custom root CA certificates that will be used to communicate to Fleet and the TUF server.
-More information can be found on the [Certificates in fleetd]((https://fleetdm.com/guides/certificates-in-fleetd#basic-article) guide.
+More information can be found on the [Certificates in fleetd](https://fleetdm.com/guides/certificates-in-fleetd#basic-article) guide.
 
 ## mTLS
 


### PR DESCRIPTION
Fixed typo in Markdown link for the Certificates in Fleet Guide