### PR TITLE
Use App Store Connect API for notarization

### DIFF
--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -63,9 +63,13 @@ jobs:
 
       - name: Install rcodesign
         run: |
-          # Install rcodesign via cargo (Rust package manager)
-          brew install rust
-          cargo install apple-codesign
+          # Download pre-built rcodesign binary for faster installation
+          RCODESIGN_VERSION="0.27.0"
+          curl -L "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign%2F${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-aarch64-apple-darwin.tar.gz" -o rcodesign.tar.gz
+          tar xzf rcodesign.tar.gz
+          sudo mv apple-codesign-${RCODESIGN_VERSION}-aarch64-apple-darwin/rcodesign /usr/local/bin/
+          chmod +x /usr/local/bin/rcodesign
+          rcodesign --version
 
       - name: Build, codesign and notarize orbit
         run: go run ./orbit/tools/build/build.go

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -5,12 +5,12 @@ on:
   push:
     paths:
       # The workflow can be triggered by modifying ORBIT_VERSION env.
-      - '.github/workflows/build-orbit.yaml'
+      - ".github/workflows/build-orbit.yaml"
   pull_request:
     paths:
-      - 'orbit/**.go'
+      - "orbit/**.go"
       # The workflow can be triggered by modifying ORBIT_VERSION env.
-      - '.github/workflows/build-orbit.yaml'
+      - ".github/workflows/build-orbit.yaml"
 
 env:
   ORBIT_VERSION: 1.20.0
@@ -59,15 +59,22 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          go-version-file: "go.mod"
+
+      - name: Install rcodesign
+        run: |
+          brew install rcodesign
 
       - name: Build, codesign and notarize orbit
-        run: go run ./orbit/tools/build/build.go 
+        run: go run ./orbit/tools/build/build.go
         env:
           GITHUB_TOKEN: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          AC_API_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY_ID }}
+          AC_API_KEY_ISSUER: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
+          AC_API_KEY_CONTENT: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY }}
           CODESIGN_IDENTITY: 51049B247B25B3119FAE7E9C0CC4375A43E47237
           ORBIT_VERSION: ${{ env.ORBIT_VERSION }}
           ORBIT_COMMIT: ${{ github.sha }}

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -63,7 +63,9 @@ jobs:
 
       - name: Install rcodesign
         run: |
-          brew install rcodesign
+          # Install rcodesign via cargo (Rust package manager)
+          brew install rust
+          cargo install apple-codesign
 
       - name: Build, codesign and notarize orbit
         run: go run ./orbit/tools/build/build.go

--- a/.github/workflows/build-orbit.yaml
+++ b/.github/workflows/build-orbit.yaml
@@ -71,9 +71,6 @@ jobs:
         run: go run ./orbit/tools/build/build.go
         env:
           GITHUB_TOKEN: ${{ secrets.FLEET_RELEASE_GITHUB_PAT }}
-          AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
-          AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           AC_API_KEY_ID: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY_ID }}
           AC_API_KEY_ISSUER: ${{ secrets.APPLE_APP_STORE_CONNECT_ISSUER_ID }}
           AC_API_KEY_CONTENT: ${{ secrets.APPLE_APP_STORE_CONNECT_KEY }}

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -204,12 +204,22 @@ The `fleetctl package` command supports signing and notarizing macOS fleetd via 
 Check out the example below:
 
 ```sh
-  AC_USERNAME=appleid@example.com AC_PASSWORD=app-specific-password fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLL SECRET]
+  AC_API_KEY_ID=ABC123DEFG AC_API_KEY_ISSUER=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee AC_API_KEY_CONTENT="$(cat ~/AuthKey_ABC123DEFG.p8)" fleetctl package --type pkg --sign-identity=[PATH TO SIGN IDENTITY] --notarize --fleet-url=[YOUR FLEET URL] --enroll-secret=[YOUR ENROLL SECRET]
 ```
 
 The above command must be run on a macOS device, as the notarizing and signing of macOS fleetd can only be done on macOS devices.
 
-Also, remember to replace both `AC_USERNAME` and `AC_PASSWORD` environment variables with your Apple ID and a valid [app-specific](https://support.apple.com/en-ca/HT204397) password, respectively. Some organizations (notably those with Apple Enterprise Developer Accounts) may also need to specify `AC_TEAM_ID`. This value can be found on the [Apple Developer "Membership" page](https://developer.apple.com/account/#!/membership) under "Team ID."
+Remember to replace the environment variables with your App Store Connect API credentials:
+- `AC_API_KEY_ID`: Your App Store Connect API Key ID
+- `AC_API_KEY_ISSUER`: Your App Store Connect API Key Issuer ID
+- `AC_API_KEY_CONTENT`: The full content of your `.p8` API key file
+
+To obtain these credentials:
+1. Go to [App Store Connect](https://appstoreconnect.apple.com/access/api)
+2. Click "Keys" under "Team Keys"
+3. Generate a new key with "Developer" access
+4. Download the `.p8` file (you can only download it once!)
+5. Note the Key ID and Issuer ID displayed on the page
 
 ### Grant full disk access to osquery on macOS
 

--- a/orbit/pkg/packaging/macos.go
+++ b/orbit/pkg/packaging/macos.go
@@ -180,8 +180,18 @@ func BuildPkg(opt Options) (string, error) {
 	if opt.Notarize {
 		switch {
 		case isDarwin:
-			if err := NotarizeStaple(generatedPath, "com.fleetdm.orbit"); err != nil {
-				return "", err
+			// Check if we have App Store Connect API keys (new method)
+			if len(opt.AppStoreConnectAPIKeyID) > 0 && len(opt.AppStoreConnectAPIKeyIssuer) > 0 {
+				// Use rcodesign with App Store Connect API (new method, required as of October 2024)
+				if err := rNotarizeStaple(generatedPath, opt.AppStoreConnectAPIKeyID, opt.AppStoreConnectAPIKeyIssuer, opt.AppStoreConnectAPIKeyContent); err != nil {
+					return "", err
+				}
+			} else {
+				// Fall back to legacy method (deprecated by Apple as of October 17, 2024)
+				log.Warn().Msg("Using legacy notarization method. This is deprecated and will stop working. Please use App Store Connect API keys instead.")
+				if err := NotarizeStaple(generatedPath, "com.fleetdm.orbit"); err != nil {
+					return "", err
+				}
 			}
 		case isLinuxNative:
 			if len(opt.AppStoreConnectAPIKeyID) == 0 || len(opt.AppStoreConnectAPIKeyIssuer) == 0 {

--- a/orbit/pkg/packaging/macos_notarize.go
+++ b/orbit/pkg/packaging/macos_notarize.go
@@ -1,22 +1,16 @@
 package packaging
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
-	"sync"
 
-	"github.com/fatih/color"
-	"github.com/mitchellh/gon/notarize"
-	"github.com/mitchellh/gon/staple"
 	"github.com/rs/zerolog/log"
 )
 
-// RNotarize will notarize using rcodesign with App Store Connect API keys.
+// Notarize will notarize using rcodesign with App Store Connect API keys.
 // Note that the provided path must be a .zip, .dmg or .pkg.
-func RNotarize(path, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
+func Notarize(path, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
 	keyPath, err := writeAPIKeys(apiKeyIssuer, apiKeyID, apiKeyContent)
 	if err != nil {
 		return fmt.Errorf("write API keys: %w", err)
@@ -46,115 +40,4 @@ func RNotarize(path, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
 
 	log.Info().Str("output", string(out)).Msg("notarization completed with App Store Connect API")
 	return nil
-}
-
-// Notarize will do the Notarization step. Note that the provided path must be a .zip, .dmg or .pkg.
-func Notarize(path, bundleIdentifier string) error {
-	username, ok := os.LookupEnv("AC_USERNAME")
-	if !ok {
-		return errors.New("AC_USERNAME must be set in environment")
-	}
-
-	password, ok := os.LookupEnv("AC_PASSWORD")
-	if !ok {
-		return errors.New("AC_PASSWORD must be set in environment")
-	}
-
-	// This is typically optional, though seems to be required if the organization has an Apple
-	// Enterprise Dev account.
-	teamID, _ := os.LookupEnv("AC_TEAM_ID")
-
-	// FIXME Ignoring new log output for now.
-	_, notary_log, err := notarize.Notarize(
-		context.Background(),
-		&notarize.Options{
-			File:        path,
-			DeveloperId: username,
-			Password:    password,
-			Provider:    teamID,
-			Status: &statusHuman{
-				Lock: &sync.Mutex{},
-			},
-		},
-	)
-	if err != nil {
-		return fmt.Errorf("notarize: %w", err)
-	}
-
-	log.Info().Str("logs", notary_log.JobId).Msg("notarization completed")
-
-	return nil
-}
-
-// Staple will do the "stapling" step of Notarization. Note that this only works on .app, .pkg and .dmg
-// (not .zip or plain binaries).
-func Staple(path string) error {
-	if err := staple.Staple(context.Background(), &staple.Options{File: path}); err != nil {
-		return fmt.Errorf("staple notarization: %w", err)
-	}
-
-	return nil
-}
-
-// NotarizeStaple will notarize and staple a macOS artifact.
-func NotarizeStaple(path, bundleIdentifier string) error {
-	if err := Notarize(path, bundleIdentifier); err != nil {
-		return err
-	}
-
-	if err := Staple(path); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// This status plugin copied from
-// https://github.com/mitchellh/gon/blob/v0.2.3/cmd/gon/status_human.go since it
-// is not exposed from the gon library.
-
-// statusHuman implements notarize.Status and outputs information to
-// the CLI for human consumption.
-type statusHuman struct {
-	Prefix string
-	Lock   *sync.Mutex
-
-	lastInfoStatus string
-	lastLogStatus  string
-}
-
-func (s *statusHuman) Submitting() {
-	s.Lock.Lock()
-	defer s.Lock.Unlock()
-
-	color.New().Fprintf(os.Stdout, "    %sSubmitting file for notarization...\n", s.Prefix)
-}
-
-func (s *statusHuman) Submitted(uuid string) {
-	s.Lock.Lock()
-	defer s.Lock.Unlock()
-
-	color.New().Fprintf(os.Stdout, "    %sSubmitted. Request UUID: %s\n", s.Prefix, uuid)
-	color.New().Fprintf(
-		os.Stdout, "    %sWaiting for results from Apple. This can take minutes to hours.\n", s.Prefix)
-}
-
-func (s *statusHuman) InfoStatus(info notarize.Info) {
-	s.Lock.Lock()
-	defer s.Lock.Unlock()
-
-	if info.Status != s.lastInfoStatus {
-		s.lastInfoStatus = info.Status
-		color.New().Fprintf(os.Stdout, "    %sInfoStatus: %s\n", s.Prefix, info.Status)
-	}
-}
-
-func (s *statusHuman) LogStatus(log notarize.Log) {
-	s.Lock.Lock()
-	defer s.Lock.Unlock()
-
-	if log.Status != s.lastLogStatus {
-		s.lastLogStatus = log.Status
-		color.New().Fprintf(os.Stdout, "    %sLogStatus: %s\n", s.Prefix, log.Status)
-	}
 }

--- a/orbit/pkg/packaging/macos_notarize.go
+++ b/orbit/pkg/packaging/macos_notarize.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"sync"
 
 	"github.com/fatih/color"
@@ -12,6 +13,40 @@ import (
 	"github.com/mitchellh/gon/staple"
 	"github.com/rs/zerolog/log"
 )
+
+// RNotarize will notarize using rcodesign with App Store Connect API keys.
+// Note that the provided path must be a .zip, .dmg or .pkg.
+func RNotarize(path, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
+	keyPath, err := writeAPIKeys(apiKeyIssuer, apiKeyID, apiKeyContent)
+	if err != nil {
+		return fmt.Errorf("write API keys: %w", err)
+	}
+	defer os.Remove(keyPath)
+
+	// Create a temporary directory for rcodesign output
+	tmpDir, err := os.MkdirTemp("", "rcodesign-")
+	if err != nil {
+		return fmt.Errorf("create temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	log.Info().Str("path", path).Msg("submitting file for notarization with App Store Connect API")
+
+	// Use rcodesign to notarize (without stapling since we can't staple a zip)
+	out, err := exec.Command("rcodesign",
+		"notarize",
+		path,
+		"--api-issuer", apiKeyIssuer,
+		"--api-key", apiKeyID,
+	).CombinedOutput()
+	if err != nil {
+		log.Error().Str("output", string(out)).Msg("rcodesign notarize failed")
+		return fmt.Errorf("rcodesign notarize: %w", err)
+	}
+
+	log.Info().Str("output", string(out)).Msg("notarization completed with App Store Connect API")
+	return nil
+}
 
 // Notarize will do the Notarization step. Note that the provided path must be a .zip, .dmg or .pkg.
 func Notarize(path, bundleIdentifier string) error {

--- a/orbit/pkg/packaging/macos_rcodesign.go
+++ b/orbit/pkg/packaging/macos_rcodesign.go
@@ -37,7 +37,7 @@ func rSign(pkgPath, cert string) error {
 	}, retry.WithMaxAttempts(3))
 }
 
-func rNotarizeStaple(pkg, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
+func notarizeStaple(pkg, apiKeyID, apiKeyIssuer, apiKeyContent string) error {
 	path, err := writeAPIKeys(apiKeyIssuer, apiKeyID, apiKeyContent)
 	defer os.Remove(path)
 	if err != nil {

--- a/orbit/pkg/packaging/macos_rcodesign.go
+++ b/orbit/pkg/packaging/macos_rcodesign.go
@@ -69,11 +69,11 @@ func writeAPIKeys(issuer, id, content string) (string, error) {
 		return "", fmt.Errorf("finding home dir: %s", err)
 	}
 
-	// The underliying tools (rcodesign and Transporter) expect to find a
+	// The underlying tools (rcodesign and Transporter) expect to find a
 	// certificate key in this path.
 	path := filepath.Join(homedir, ".appstoreconnect", "private_keys")
-	if err = secure.MkdirAll(path, 0o600); err != nil {
-		return "", fmt.Errorf("finding home dir: %s", err)
+	if err = secure.MkdirAll(path, 0o700); err != nil {
+		return "", fmt.Errorf("creating api key directory: %s", err)
 	}
 
 	keyPath := filepath.Join(path, fmt.Sprintf("AuthKey_%s.p8", id))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added App Store Connect API key-based macOS notarization and stapling using external tooling.
* **Chores**
  * Build workflow updated to install rcodesign and pass API key credentials for notarization.
  * Notarization now requires API key credentials when enabled; legacy platform-specific flows removed.
* **Documentation**
  * Updated docs and examples to show App Store Connect API key configuration and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->