### PR TITLE
Fleet UI: Hide version unknown, hide advanced options help text from script packages

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -23,6 +23,7 @@ describe("InstallerDetailsWidget", () => {
     addedTimestamp: "2024-05-06T10:00:00Z",
     versionInfo: <span>v1.2.3</span>,
     isFma: false,
+    isScriptPackage: false,
   };
 
   it("renders the package icon when installerType is 'package'", () => {
@@ -39,6 +40,18 @@ describe("InstallerDetailsWidget", () => {
   it("renders version info and relative time when addedTimestamp is present", () => {
     render(<InstallerDetailsWidget {...defaultProps} />);
     expect(screen.getByText("v1.2.3")).toBeInTheDocument();
+    expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
+  });
+
+  it("does not render version info for a script package", () => {
+    render(
+      <InstallerDetailsWidget
+        {...defaultProps}
+        versionInfo={undefined}
+        isScriptPackage={false}
+      />
+    );
+    expect(screen.queryByText(/version/i)).not.toBeInTheDocument();
     expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import InstallerDetailsWidget from "./InstallerDetailsWidget";

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import InstallerDetailsWidget from "./InstallerDetailsWidget";
@@ -21,7 +21,7 @@ describe("InstallerDetailsWidget", () => {
     softwareName: "Test Software",
     installerType: "package" as const,
     addedTimestamp: "2024-05-06T10:00:00Z",
-    versionInfo: <span>v1.2.3</span>,
+    version: "v1.2.3",
     isFma: false,
     isScriptPackage: false,
   };
@@ -43,15 +43,27 @@ describe("InstallerDetailsWidget", () => {
     expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
   });
 
-  it("does not render version info for a script package", () => {
+  it("does not render Version (unknown) info for a script package", () => {
     render(
       <InstallerDetailsWidget
         {...defaultProps}
-        versionInfo={undefined}
+        version={undefined}
+        isScriptPackage
+      />
+    );
+    expect(screen.queryByText(/Version \(unknown\)/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
+  });
+
+  it("renders Version (unknown) info for a non-script package with no version info", () => {
+    render(
+      <InstallerDetailsWidget
+        {...defaultProps}
+        version={undefined}
         isScriptPackage={false}
       />
     );
-    expect(screen.queryByText(/version/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Version \(unknown\)/i)).toBeInTheDocument();
     expect(screen.getByText(/2 days ago/i)).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -3,10 +3,11 @@
 
 import React, { useState } from "react";
 import classnames from "classnames";
-import { stringToClipboard } from "utilities/copy_text";
 
+import { stringToClipboard } from "utilities/copy_text";
 import { internationalTimeFormat } from "utilities/helpers";
 import { addedFromNow } from "utilities/date_format";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
 
 import Graphic from "components/Graphic";
@@ -14,6 +15,7 @@ import SoftwareIcon from "pages/SoftwarePage/components/icons/SoftwareIcon";
 import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
+import CustomLink from "components/CustomLink";
 
 const baseClass = "installer-details-widget";
 
@@ -52,7 +54,7 @@ interface IInstallerDetailsWidgetProps {
   softwareName: string;
   installerType: "package" | "vpp";
   addedTimestamp?: string;
-  versionInfo?: JSX.Element;
+  version?: string | null;
   sha256?: string | null;
   isFma: boolean;
   isScriptPackage: boolean;
@@ -64,7 +66,7 @@ const InstallerDetailsWidget = ({
   installerType,
   addedTimestamp,
   sha256,
-  versionInfo,
+  version,
   isFma,
   isScriptPackage,
 }: IInstallerDetailsWidgetProps) => {
@@ -95,7 +97,46 @@ const InstallerDetailsWidget = ({
 
   const renderDetails = () => {
     const renderVersionInfo = () => {
-      return isScriptPackage ? "" : <>&bull; {versionInfo}</>;
+      if (isScriptPackage) {
+        return null;
+      }
+
+      let versionInfo = <span>{version}</span>;
+
+      if (installerType === "vpp") {
+        versionInfo = (
+          <TooltipWrapper tipContent={<span>Updated every hour.</span>}>
+            <span>{version}</span>
+          </TooltipWrapper>
+        );
+      }
+
+      if (!version) {
+        versionInfo = (
+          <TooltipWrapper
+            tipContent={
+              <span>
+                Fleet couldn&apos;t read the version from {softwareName}.
+                {installerType === "package" && (
+                  <>
+                    {" "}
+                    <CustomLink
+                      newTab
+                      url={`${LEARN_MORE_ABOUT_BASE_LINK}/read-package-version`}
+                      text="Learn more"
+                      variant="tooltip-link"
+                    />
+                  </>
+                )}
+              </span>
+            }
+          >
+            <span>Version (unknown)</span>
+          </TooltipWrapper>
+        );
+      }
+
+      return <> &bull; {versionInfo}</>;
     };
 
     const renderTimeStamp = () =>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -55,6 +55,7 @@ interface IInstallerDetailsWidgetProps {
   versionInfo?: JSX.Element;
   sha256?: string | null;
   isFma: boolean;
+  isScriptPackage: boolean;
 }
 
 const InstallerDetailsWidget = ({
@@ -65,6 +66,7 @@ const InstallerDetailsWidget = ({
   sha256,
   versionInfo,
   isFma,
+  isScriptPackage,
 }: IInstallerDetailsWidgetProps) => {
   const classNames = classnames(baseClass, className);
 
@@ -92,6 +94,10 @@ const InstallerDetailsWidget = ({
   };
 
   const renderDetails = () => {
+    const renderVersionInfo = () => {
+      return isScriptPackage ? "" : <>&bull; {versionInfo}</>;
+    };
+
     const renderTimeStamp = () =>
       addedTimestamp ? (
         <>
@@ -143,7 +149,8 @@ const InstallerDetailsWidget = ({
 
     return (
       <>
-        {renderInstallerDisplayText(installerType, isFma)} &bull; {versionInfo}
+        {renderInstallerDisplayText(installerType, isFma)}
+        {renderVersionInfo()}
         {renderTimeStamp()}
         {renderSha256()}
       </>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -311,6 +311,7 @@ const SoftwareInstallerCard = ({
               addedTimestamp={addedTimestamp}
               sha256={sha256}
               isFma={isFleetMaintainedApp}
+              isScriptPackage={isScriptPackage}
             />
             <div className={`${baseClass}__tags-wrapper`}>
               {Array.isArray(automaticInstallPolicies) &&
@@ -411,6 +412,7 @@ const SoftwareInstallerCard = ({
           iconUrl={iconUrl}
           softwarePackage={softwareInstaller as ISoftwarePackage}
           onExit={onToggleViewYaml}
+          isScriptPackage={isScriptPackage}
         />
       )}
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -266,36 +266,6 @@ const SoftwareInstallerCard = ({
     }
   }, [renderFlash, softwareId, name, teamId]);
 
-  let versionInfo = <span>{version}</span>;
-
-  if (installerType === "vpp") {
-    versionInfo = (
-      <TooltipWrapper tipContent={<span>Updated every hour.</span>}>
-        <span>{version}</span>
-      </TooltipWrapper>
-    );
-  }
-
-  if (installerType === "package" && !version) {
-    versionInfo = (
-      <TooltipWrapper
-        tipContent={
-          <span>
-            Fleet couldn&apos;t read the version from {name}.{" "}
-            <CustomLink
-              newTab
-              url={`${LEARN_MORE_ABOUT_BASE_LINK}/read-package-version`}
-              text="Learn more"
-              variant="tooltip-link"
-            />
-          </span>
-        }
-      >
-        <span>Version (unknown)</span>
-      </TooltipWrapper>
-    );
-  }
-
   const showActions =
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
 
@@ -307,7 +277,7 @@ const SoftwareInstallerCard = ({
             <InstallerDetailsWidget
               softwareName={softwareInstaller?.name || name}
               installerType={installerType}
-              versionInfo={versionInfo}
+              version={version}
               addedTimestamp={addedTimestamp}
               sha256={sha256}
               isFma={isFleetMaintainedApp}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -6,7 +6,7 @@ import { NotificationContext } from "context/notification";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
 import FileSaver from "file-saver";
-import { ISoftwarePackage } from "interfaces/software";
+import { ISoftwarePackage, SCRIPT_PACKAGE_SOURCES } from "interfaces/software";
 import softwareAPI from "services/entities/software";
 
 import Modal from "components/Modal";
@@ -29,6 +29,7 @@ interface IViewYamlModalProps {
   iconUrl?: string | null;
   softwarePackage: ISoftwarePackage;
   onExit: () => void;
+  isScriptPackage?: boolean;
 }
 
 interface HandleDownloadParams {
@@ -47,6 +48,7 @@ const ViewYamlModal = ({
   iconUrl,
   softwarePackage,
   onExit,
+  isScriptPackage = false,
 }: IViewYamlModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { config } = useContext(AppContext);
@@ -227,6 +229,7 @@ const ViewYamlModal = ({
               ? onDownloadUninstallScript
               : undefined,
             onClickIcon: iconUrl ? onDownloadIcon : undefined,
+            hasAdvancedOptionsAvailable: !isScriptPackage,
           })}
         </p>
         <div className="modal-cta-wrap">

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tests.ts
@@ -285,4 +285,18 @@ describe("renderYamlHelperText", () => {
       )
     ).toBeInTheDocument();
   });
+
+  it("does not render advanced options help text when hasAdvancedOptionsAvailable is false", () => {
+    render(
+      renderDownloadFilesText({
+        installScript: "echo install",
+        onClickInstallScript: noop,
+        hasAdvancedOptionsAvailable: false,
+      })
+    );
+
+    // Should not show the "Advanced options" instructional text
+    expect(screen.queryByText(/If you edited/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Advanced options/i)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/helpers.tsx
@@ -14,6 +14,7 @@ interface RenderYamlHelperText {
   onClickPostInstallScript?: (evt: MouseEvent) => void;
   onClickUninstallScript?: (evt: MouseEvent) => void;
   onClickIcon?: (evt: MouseEvent) => void;
+  hasAdvancedOptionsAvailable?: boolean;
 }
 
 // Helper to join items with commas and Oxford comma before "and"
@@ -48,6 +49,7 @@ export const renderDownloadFilesText = ({
   onClickPostInstallScript,
   onClickUninstallScript,
   onClickIcon,
+  hasAdvancedOptionsAvailable = true,
 }: RenderYamlHelperText): JSX.Element => {
   const items: { key: string; element: JSX.Element }[] = [];
 
@@ -120,10 +122,15 @@ export const renderDownloadFilesText = ({
     <>
       Next, download your {joinWithCommasAnd(items)} and add{" "}
       {items.length === 1 ? "it" : "them"} to your repository using the{" "}
-      {items.length === 1 ? "path" : "paths"} above. If you edited{" "}
-      <b>Advanced options</b>, download and replace the{" "}
-      {items.length === 1 ? "file" : "files"} in your repository with the
-      updated {items.length === 1 ? "one" : "ones"}.
+      {items.length === 1 ? "path" : "paths"} above.
+      {hasAdvancedOptionsAvailable && (
+        <>
+          {" "}
+          If you edited <b>Advanced options</b>, download and replace the{" "}
+          {items.length === 1 ? "file" : "files"} in your repository with the
+          updated {items.length === 1 ? "one" : "ones"}.
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Issue
Closes #34609 
Closes #34637 

## Description
- Hides version unknown from script packages
- Hides advanced options help text from View YAML modal since there's no advanced options for script packages

## Screenshots of fixes

<img width="1227" height="561" alt="Screenshot 2025-10-22 at 2 39 36 PM" src="https://github.com/user-attachments/assets/3b2aa53d-032d-4c23-a818-0de4df672728" />
<img width="1216" height="432" alt="Screenshot 2025-10-22 at 2 39 10 PM" src="https://github.com/user-attachments/assets/014a7106-e816-4d5d-be17-060e32a7b437" />

Thank you @jmwatts  for finding these <3


- [x] QA'd all new/changed functionality manually
