### PR TITLE
Cherry-pick Fleet Helm v6.7.0 into update-changelog-prepare-4.76.0

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.6.21
+version: v6.7.0
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -102,6 +102,8 @@ spec:
             value: "{{ .Values.fleet.carving.s3.endpointURL }}"
           - name: FLEET_S3_FORCE_S3_PATH_STYLE
             value: "{{ .Values.fleet.carving.s3.forceS3PathStyle }}"
+          - name: FLEET_S3_CARVES_REGION
+            value: "{{ .Values.fleet.carving.s3.region }}"
           {{- if ne .Values.fleet.carving.s3.accessKeyID "" }}
           - name: FLEET_S3_ACCESS_KEY_ID
             value: "{{ .Values.fleet.carving.s3.accessKeyID }}"
@@ -125,6 +127,8 @@ spec:
             value: "{{ .Values.fleet.softwareInstallers.s3.endpointURL }}"
           - name: FLEET_S3_SOFTWARE_INSTALLERS_FORCE_S3_PATH_STYLE
             value: "{{ .Values.fleet.softwareInstallers.s3.forceS3PathStyle }}"
+          - name: FLEET_S3_SOFTWARE_INSTALLERS_REGION
+            value: "{{ .Values.fleet.softwareInstallers.s3.region }}"
           {{- if ne .Values.fleet.softwareInstallers.s3.accessKeyID "" }}
           - name: FLEET_S3_SOFTWARE_INSTALLERS_ACCESS_KEY_ID
             value: "{{ .Values.fleet.softwareInstallers.s3.accessKeyID }}"

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -105,6 +105,7 @@ fleet:
       prefix: ""
       accessKeyID: ""
       secretKey: s3-bucket
+      region: ""
       endpointURL: ""
       forceS3PathStyle: false
       stsAssumeRoleARN: ""
@@ -114,6 +115,7 @@ fleet:
       prefix: ""
       accessKeyID: ""
       secretKey: software-installers
+      region: ""
       endpointURL: ""
       forceS3PathStyle: false
       stsAssumeRoleARN: ""


### PR DESCRIPTION
- Bumps helm chart to `v6.7.0`
- Adds support for `softwareinstallers` bucket `region`
- Adds support for `carving` bucket `region`