### PR TITLE
Windows Var Replacement: use updated profile contents instead of incoming

### DIFF
--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -353,7 +353,7 @@ func preprocessWindowsProfileContents(ctx context.Context, logger kitlog.Logger,
 		if fleetVar == string(fleet.FleetVarHostUUID) {
 			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostUUIDRegexp, result, hostUUID)
 		} else if fleetVar == string(fleet.FleetVarHostEndUserEmailIDP) {
-			replacedContents, replacedVariable, err := profiles.ReplaceHostEndUserEmailIDPVariable(ctx, ds, profileContents, hostUUID)
+			replacedContents, replacedVariable, err := profiles.ReplaceHostEndUserEmailIDPVariable(ctx, ds, result, hostUUID)
 			if err != nil {
 				return profileContents, ctxerr.Wrap(ctx, err, "replacing host end user email IDP variable")
 			}


### PR DESCRIPTION
This fixes a bug, but also fixes the flaky test runs seen in [Slack](https://fleetdm.slack.com/archives/C019WG4GH0A/p1761192670589249).