### PR TITLE
Update tooltip about setup experience software ordering

### DIFF
--- a/changes/33790-setup-software-install-order
+++ b/changes/33790-setup-software-install-order
@@ -1,0 +1,1 @@
+- Setup experience software now installs in alphanumeric order.

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -110,7 +110,7 @@ const AddInstallSoftware = ({
       <>
         {installSoftwareDuringSetupCount} software item
         {installSoftwareDuringSetupCount > 1 && "s"} will be{" "}
-        <TooltipWrapper tipContent="Software order will vary.">
+        <TooltipWrapper tipContent="Installation order will depend on software name, starting with 0-9 then A-Z.">
           installed during setup.
         </TooltipWrapper>
       </>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33790

# Details

This is just the tooltip update; the code to update the order of software installs is was released as part of #34173 (see https://github.com/fleetdm/fleet/pull/34173/files#diff-c5babdad542a72acf2ec2ecb7cb43967fc53850b6998ac629e253336b87e008b)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

<img width="560" height="321" alt="image" src="https://github.com/user-attachments/assets/1bde02ca-e180-49e1-92a7-e197305dd8ee" />
