### PR TITLE
Fix issues with OTEL SigNoz deployments for loadtests

### DIFF
--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -5,7 +5,7 @@ locals {
   # Tracing configuration - either OTEL or Elastic APM
   otel_environment_variables = var.enable_otel ? {
     OTEL_SERVICE_NAME               = terraform.workspace
-    OTEL_EXPORTER_OTLP_ENDPOINT     = "http://${module.signoz[0].otel_collector_endpoint}"
+    OTEL_EXPORTER_OTLP_ENDPOINT     = "http://${data.terraform_remote_state.signoz[0].outputs.otel_collector_endpoint}"
     FLEET_LOGGING_TRACING_ENABLED   = "true"
     FLEET_LOGGING_TRACING_TYPE      = "opentelemetry"
   } : {}

--- a/infrastructure/loadtesting/terraform/infra/providers.tf
+++ b/infrastructure/loadtesting/terraform/infra/providers.tf
@@ -12,14 +12,6 @@ terraform {
       source  = "paultyng/git"
       version = "~> 0.1.0"
     }
-    helm = {
-      source  = "hashicorp/helm"
-      version = "~> 2.11"
-    }
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = "~> 2.23"
-    }
   }
   backend "s3" {
     bucket               = "fleet-terraform-state20220408141538466600000002"
@@ -63,22 +55,6 @@ data "terraform_remote_state" "shared" {
   }
 }
 
-data "terraform_remote_state" "eks_vpc" {
-  count   = var.enable_otel ? 1 : 0
-  backend = "s3"
-  config = {
-    bucket         = "fleet-terraform-state20220408141538466600000002"
-    key            = "loadtesting/shared/eks-vpc/terraform.tfstate"
-    region         = "us-east-2"
-    encrypt        = true
-    kms_key_id     = "9f98a443-ffd7-4dbe-a9c3-37df89b2e42a"
-    dynamodb_table = "tf-remote-state-lock"
-    assume_role = {
-      role_arn = "arn:aws:iam::353365949058:role/terraform-loadtesting"
-    }
-  }
-}
-
 provider "docker" {
   # Configuration options
   registry_auth {
@@ -89,34 +65,3 @@ provider "docker" {
 }
 
 provider "git" {}
-
-# Data sources for SigNoz EKS cluster authentication
-data "aws_eks_cluster" "signoz" {
-  count = var.enable_otel ? 1 : 0
-  name  = module.signoz[0].cluster_name
-}
-
-data "aws_eks_cluster_auth" "signoz" {
-  count = var.enable_otel ? 1 : 0
-  name  = module.signoz[0].cluster_name
-}
-
-# Helm provider for SigNoz EKS cluster
-provider "helm" {
-  alias = "signoz"
-
-  kubernetes {
-    host                   = var.enable_otel ? data.aws_eks_cluster.signoz[0].endpoint : ""
-    cluster_ca_certificate = var.enable_otel ? base64decode(data.aws_eks_cluster.signoz[0].certificate_authority[0].data) : ""
-    token                  = var.enable_otel ? data.aws_eks_cluster_auth.signoz[0].token : ""
-  }
-}
-
-# Kubernetes provider for SigNoz EKS cluster
-provider "kubernetes" {
-  alias = "signoz"
-
-  host                   = var.enable_otel ? data.aws_eks_cluster.signoz[0].endpoint : ""
-  cluster_ca_certificate = var.enable_otel ? base64decode(data.aws_eks_cluster.signoz[0].certificate_authority[0].data) : ""
-  token                  = var.enable_otel ? data.aws_eks_cluster_auth.signoz[0].token : ""
-}

--- a/infrastructure/loadtesting/terraform/infra/signoz.tf
+++ b/infrastructure/loadtesting/terraform/infra/signoz.tf
@@ -1,36 +1,38 @@
 # SigNoz deployment for OpenTelemetry tracing
-# Conditionally deployed when var.enable_otel = true
+# SigNoz is deployed as a separate Terraform root module
+# This reads its outputs via remote state
 
-module "signoz" {
-  count  = var.enable_otel ? 1 : 0
-  source = "../signoz"
-
-  aws_region   = data.aws_region.current.region
-  cluster_name = "signoz-${terraform.workspace}"
-
-  # Use dedicated EKS VPC with proper Kubernetes tags
-  vpc_id     = data.terraform_remote_state.eks_vpc[0].outputs.vpc.vpc_id
-  subnet_ids = data.terraform_remote_state.eks_vpc[0].outputs.vpc.private_subnets
-
-  providers = {
-    aws        = aws
-    helm       = helm.signoz
-    kubernetes = kubernetes.signoz
+# Read SigNoz deployment from remote state
+data "terraform_remote_state" "signoz" {
+  count   = var.enable_otel ? 1 : 0
+  backend = "s3"
+  config = {
+    bucket               = "fleet-terraform-state20220408141538466600000002"
+    key                  = "loadtesting/loadtesting/signoz/terraform.tfstate"
+    workspace_key_prefix = "loadtesting"
+    region               = "us-east-2"
+    encrypt              = true
+    kms_key_id           = "9f98a443-ffd7-4dbe-a9c3-37df89b2e42a"
+    dynamodb_table       = "tf-remote-state-lock"
+    assume_role = {
+      role_arn = "arn:aws:iam::353365949058:role/terraform-loadtesting"
+    }
   }
+  workspace = terraform.workspace
 }
 
-# Outputs from SigNoz module
+# Outputs from SigNoz remote state
 output "signoz_cluster_name" {
   description = "SigNoz EKS cluster name"
-  value       = var.enable_otel ? module.signoz[0].cluster_name : null
+  value       = var.enable_otel ? try(data.terraform_remote_state.signoz[0].outputs.cluster_name, "SigNoz not deployed yet") : null
 }
 
 output "signoz_otel_collector_endpoint" {
   description = "Internal OTLP collector endpoint for Fleet"
-  value       = var.enable_otel ? module.signoz[0].otel_collector_endpoint : null
+  value       = var.enable_otel ? try(data.terraform_remote_state.signoz[0].outputs.otel_collector_endpoint, "SigNoz not deployed yet") : null
 }
 
 output "signoz_configure_kubectl" {
   description = "Command to configure kubectl for SigNoz"
-  value       = var.enable_otel ? module.signoz[0].configure_kubectl : null
+  value       = var.enable_otel ? try(data.terraform_remote_state.signoz[0].outputs.configure_kubectl, "SigNoz not deployed yet") : null
 }

--- a/infrastructure/loadtesting/terraform/signoz/README.md
+++ b/infrastructure/loadtesting/terraform/signoz/README.md
@@ -1,24 +1,88 @@
-# SigNoz module for Fleet loadtest OTEL tracing
+# SigNoz for Fleet Loadtesting
 
-OpenTelemetry observability backend module, deployed conditionally from the Fleet loadtest infrastructure.
-
-## Usage
-
-This module is deployed automatically when `enable_otel=true` is set in the parent loadtest infrastructure:
-
-```bash
-cd infrastructure/loadtesting/terraform/infra
-terraform workspace new <workspace_name>
-terraform apply -var=enable_otel=true
-```
-
-## What gets deployed
-
-- **EKS cluster** for SigNoz in shared eks-vpc (K8s 1.31, 2x t3.large nodes)
-- **OTLP endpoint**: Internal LoadBalancer (not publicly accessible)
-- **SigNoz UI**: Public LoadBalancer on port 8080
-- **Storage**: EBS CSI driver with gp2 default storage class
+SigNoz provides OpenTelemetry tracing for Fleet loadtest environments. It's deployed as a standalone Terraform root module to ensure it's available before Fleet starts up.
 
 ## Architecture
 
-SigNoz uses the shared `eks-vpc` (not fleet-vpc) which has proper Kubernetes subnet tags. The eks-vpc is shared across all workspaces (like fleet-vpc), but each workspace deploys its own SigNoz EKS cluster within it.
+- **EKS Cluster**: Per-workspace (e.g., `signoz-victor-baseline`)
+- **Kubernetes**: v1.31
+- **Node group**: 2x t3.xlarge nodes
+- **Components**:
+  - SigNoz UI (public LoadBalancer on port 8080)
+  - OTLP Collector (internal LoadBalancer on port 4317)
+  - ClickHouse (200Gi storage)
+
+## Deployment order
+
+**IMPORTANT**: SigNoz must be deployed BEFORE the main Fleet infrastructure to capture telemetry from Fleet's initial bootup.
+
+1. Deploy shared EKS VPC (one time, shared across workspaces, should already be deployed)
+2. Deploy SigNoz (this directory)
+3. Deploy Fleet infrastructure (../infra)
+
+## Usage
+
+```bash
+# 1. Initialize and select workspace
+cd infrastructure/loadtesting/terraform/signoz
+terraform init
+terraform workspace new <workspace_name>  # Match your infra workspace
+
+# 2. Deploy SigNoz
+terraform apply
+
+# 3. Wait for deployment to complete (~10-15 minutes)
+# The OTLP collector endpoint will be shown in outputs
+
+# 4. Now deploy Fleet infrastructure
+cd ../infra
+terraform apply
+```
+
+## Accessing SigNoz UI
+
+```bash
+# Get the SigNoz UI URL
+terraform output -raw get_signoz_ui_url | bash
+
+# Or configure kubectl and access directly
+$(terraform output -raw configure_kubectl)
+kubectl get svc -n signoz signoz -o jsonpath='http://{.status.loadBalancer.ingress[0].hostname}:8080'
+```
+
+## Managing storage and retention
+
+**IMPORTANT**: ClickHouse has limited storage. To prevent running out of space:
+
+1. **Reduce trace retention period** in the SigNoz UI:
+    - Navigate to Settings → Retention Period
+    - Lower the retention period for traces (default may be too long for loadtesting)
+    - Consider 1-3 days for active loadtest environments
+
+2. **Monitor ClickHouse storage**:
+   ```bash
+   # Check ClickHouse pod storage usage
+   kubectl exec -n signoz chi-signoz-clickhouse-cluster-0-0-0 -- df -h /var/lib/clickhouse
+
+   # Check database sizes
+   kubectl exec -n signoz chi-signoz-clickhouse-cluster-0-0-0 -- clickhouse-client --query "SELECT database, formatReadableSize(sum(bytes_on_disk)) AS size FROM system.parts WHERE active GROUP BY database ORDER BY sum(bytes_on_disk) DESC"
+   ```
+
+3. **What happens when storage is full**:
+    - ClickHouse will reject new writes
+    - **New traces will NOT be captured**
+    - OTEL collector will log errors about failed writes
+    - Fleet will continue running but traces will be lost
+
+## Outputs
+
+The main Fleet infrastructure reads these outputs via remote state:
+- `cluster_name`: EKS cluster name
+- `otel_collector_endpoint`: Internal OTLP endpoint for Fleet to send traces
+- `configure_kubectl`: Command to configure kubectl access
+
+## Destroying
+
+```bash
+terraform destroy
+```

--- a/infrastructure/loadtesting/terraform/signoz/main.tf
+++ b/infrastructure/loadtesting/terraform/signoz/main.tf
@@ -9,18 +9,93 @@ terraform {
     helm = {
       source  = "hashicorp/helm"
       version = "~> 2.11"
-      configuration_aliases = [helm]
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.23"
-      configuration_aliases = [kubernetes]
+    }
+  }
+
+  backend "s3" {
+    bucket               = "fleet-terraform-state20220408141538466600000002"
+    key                  = "loadtesting/loadtesting/signoz/terraform.tfstate"
+    workspace_key_prefix = "loadtesting"
+    region               = "us-east-2"
+    encrypt              = true
+    kms_key_id           = "9f98a443-ffd7-4dbe-a9c3-37df89b2e42a"
+    dynamodb_table       = "tf-remote-state-lock"
+    assume_role = {
+      role_arn = "arn:aws:iam::353365949058:role/terraform-loadtesting"
     }
   }
 }
 
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      environment = "loadtest-signoz"
+      terraform   = "https://github.com/fleetdm/fleet/tree/main/infrastructure/loadtesting/terraform/signoz"
+      workspace   = terraform.workspace
+    }
+  }
+}
+
+# Read EKS VPC from remote state
+data "terraform_remote_state" "eks_vpc" {
+  backend = "s3"
+  config = {
+    bucket         = "fleet-terraform-state20220408141538466600000002"
+    key            = "loadtesting/shared/eks-vpc/terraform.tfstate"
+    region         = "us-east-2"
+    encrypt        = true
+    kms_key_id     = "9f98a443-ffd7-4dbe-a9c3-37df89b2e42a"
+    dynamodb_table = "tf-remote-state-lock"
+    assume_role = {
+      role_arn = "arn:aws:iam::353365949058:role/terraform-loadtesting"
+    }
+  }
+}
+
+# Providers for Helm/Kubernetes after cluster is created
+provider "helm" {
+  kubernetes {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    exec {
+      api_version = "client.authentication.k8s.io/v1beta1"
+      command     = "aws"
+      args = [
+        "eks",
+        "get-token",
+        "--cluster-name",
+        module.eks.cluster_name,
+        "--region",
+        var.aws_region
+      ]
+    }
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "aws"
+    args = [
+      "eks",
+      "get-token",
+      "--cluster-name",
+      module.eks.cluster_name,
+      "--region",
+      var.aws_region
+    ]
+  }
+}
+
 locals {
-  cluster_name = var.cluster_name
+  cluster_name = "signoz-${terraform.workspace}"
 }
 
 # Use shared fleet VPC
@@ -33,8 +108,8 @@ module "eks" {
 
   endpoint_public_access = true
 
-  vpc_id     = var.vpc_id
-  subnet_ids = var.subnet_ids
+  vpc_id     = data.terraform_remote_state.eks_vpc.outputs.vpc.vpc_id
+  subnet_ids = data.terraform_remote_state.eks_vpc.outputs.vpc.private_subnets
 
   # IMPORTANT: Install critical addons BEFORE node group to avoid circular dependency
   # Nodes need VPC CNI to become Ready, but terraform waits for nodes to be Ready
@@ -61,7 +136,7 @@ module "eks" {
       min_size       = 2
       max_size       = 2
       desired_size   = 2
-      instance_types = ["t3.large"]
+      instance_types = ["t3.xlarge"]
     }
   }
 
@@ -108,15 +183,47 @@ data "aws_eks_addon_version" "ebs_csi" {
   most_recent        = true
 }
 
+# Wait for EBS CSI driver to be active
+resource "time_sleep" "wait_for_ebs_csi" {
+  depends_on = [aws_eks_addon.ebs_csi]
+
+  create_duration = "60s"
+}
+
+# Create gp3 storage class using EBS CSI driver
+resource "kubernetes_storage_class_v1" "gp3" {
+  metadata {
+    name = "gp3"
+    annotations = {
+      "storageclass.kubernetes.io/is-default-class" = "true"
+    }
+  }
+
+  storage_provisioner    = "ebs.csi.aws.com"
+  reclaim_policy         = "Delete"
+  allow_volume_expansion = true
+  volume_binding_mode    = "WaitForFirstConsumer"
+
+  parameters = {
+    type      = "gp3"
+    encrypted = "true"
+    fsType    = "ext4"
+  }
+
+  depends_on = [time_sleep.wait_for_ebs_csi]
+}
+
 # SigNoz via Helm
 resource "helm_release" "signoz" {
   name       = "signoz"
   repository = "https://charts.signoz.io"
   chart      = "signoz"
   namespace  = "signoz"
-  timeout    = 900
+  timeout    = 1200 # 20 minutes for initial deployment
 
   create_namespace = true
+  wait             = true
+  wait_for_jobs    = false
 
   set {
     name  = "cloud"
@@ -139,17 +246,81 @@ resource "helm_release" "signoz" {
     value = "internal"
   }
 
+  # Clickhouse storage configuration
   set {
     name  = "clickhouse.persistence.size"
-    value = "20Gi"
+    value = "200Gi"
   }
 
   set {
-    name  = "clickhouse.persistence.storageClassName"
+    name  = "clickhouse.persistence.storageClass"
     value = "gp3"
   }
 
+  # Zookeeper storage configuration
+  set {
+    name  = "zookeeper.persistence.storageClass"
+    value = "gp3"
+  }
+
+  # SigNoz (alertmanager) storage configuration
+  set {
+    name  = "alertmanager.persistence.storageClass"
+    value = "gp3"
+  }
+
+  # ClickHouse resource configuration for loadtest
+  # Default 100m CPU and 200Mi memory are way too low for high-volume telemetry
+  set {
+    name  = "clickhouse.resources.requests.cpu"
+    value = "2000m"
+  }
+
+  set {
+    name  = "clickhouse.resources.requests.memory"
+    value = "4Gi"
+  }
+
+  set {
+    name  = "clickhouse.resources.limits.cpu"
+    value = "4000m"
+  }
+
+  set {
+    name  = "clickhouse.resources.limits.memory"
+    value = "8Gi"
+  }
+
+  # OTEL Collector resource configuration for loadtest
+  # Default 200Mi is way too low and causes OOMKills
+  set {
+    name  = "otelCollector.resources.requests.memory"
+    value = "2Gi"
+  }
+
+  set {
+    name  = "otelCollector.resources.limits.memory"
+    value = "4Gi"
+  }
+
+  set {
+    name  = "otelCollector.resources.requests.cpu"
+    value = "500m"
+  }
+
+  set {
+    name  = "otelCollector.resources.limits.cpu"
+    value = "2000m"
+  }
+
+  # Only need 1 replica since we have 1 LoadBalancer endpoint
+  set {
+    name  = "otelCollector.replicaCount"
+    value = "1"
+  }
+
   depends_on = [
-    module.eks
+    module.eks,
+    kubernetes_storage_class_v1.gp3
   ]
 }

--- a/infrastructure/loadtesting/terraform/signoz/variables.tf
+++ b/infrastructure/loadtesting/terraform/signoz/variables.tf
@@ -3,18 +3,3 @@ variable "aws_region" {
   type        = string
   default     = "us-east-2"
 }
-
-variable "cluster_name" {
-  description = "Name of the EKS cluster for SigNoz"
-  type        = string
-}
-
-variable "vpc_id" {
-  description = "VPC ID for SigNoz EKS cluster (shared fleet VPC)"
-  type        = string
-}
-
-variable "subnet_ids" {
-  description = "Subnet IDs for SigNoz EKS cluster (private subnets from fleet VPC)"
-  type        = list(string)
-}


### PR DESCRIPTION
  SigNoz converted from child module to standalone root module with independent state.

  **Critical Impact**

  Deployment order is now required:
  1. Deploy infrastructure/loadtesting/terraform/signoz/ FIRST
  2. Then deploy infrastructure/loadtesting/terraform/infra/

  Communication between modules via Terraform remote state.

  **Key Configuration Changes**

  - SigNoz creates its own EKS cluster: signoz-${workspace}
  - Instance type: t3.xlarge (upgraded from t3.large for resource headroom)
  - ClickHouse disk: 200Gi (was 20Gi) with 2-day retention
  - Resource limits configured to prevent OOMKills during loadtest
  - wait_for_jobs = false to avoid Helm deployment deadlock


<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32331


