### PR TITLE
Fix alignment on "This feature is included in Fleet Premium" message

### DIFF
--- a/frontend/components/PremiumFeatureMessage/_styles.scss
+++ b/frontend/components/PremiumFeatureMessage/_styles.scss
@@ -12,6 +12,7 @@
   .premium-feature-message {
     display: flex;
     gap: 4px;
+    align-items: center;
 
     p {
       // need to set line-height to normal for the icons and text to be aligned


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34133 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually

Before:
<img width="420" height="46" alt="image" src="https://github.com/user-attachments/assets/e6117197-c966-42be-8fb6-e3a6e18e203e" />

After:
<img width="420" height="50" alt="image" src="https://github.com/user-attachments/assets/880a6c0b-932b-4bf8-8ff8-33f1d1b0c8f7" />
