### PR TITLE
Fix script package unsupported fields in GitOps

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1432,46 +1432,59 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 		if softwareTitle.SoftwarePackage != nil {
 			filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
-			if softwareTitle.SoftwarePackage.InstallScript != "" {
-				script := softwareTitle.SoftwarePackage.InstallScript
-				fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["install_script"] = map[string]interface{}{
-					"path": path,
-				}
-				cmd.FilesToWrite[fileName] = script
-			}
 
-			if softwareTitle.SoftwarePackage.PostInstallScript != "" {
-				script := softwareTitle.SoftwarePackage.PostInstallScript
-				fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["post_install_script"] = map[string]interface{}{
-					"path": path,
-				}
-				cmd.FilesToWrite[fileName] = script
-			}
+			// Detect if this is a script package (.sh or .ps1 file)
+			// Script packages have the file contents as the install script internally,
+			// but these fields should NOT be exposed in GitOps YAML as they are not
+			// user-configurable for script packages.
+			isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
+				(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
+					strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
 
-			if softwareTitle.SoftwarePackage.UninstallScript != "" {
-				script := softwareTitle.SoftwarePackage.UninstallScript
-				fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["uninstall_script"] = map[string]interface{}{
-					"path": path,
+			// Only output install_script, post_install_script, uninstall_script, and
+			// pre_install_query for non-script packages
+			if !isScriptPackage {
+				if softwareTitle.SoftwarePackage.InstallScript != "" {
+					script := softwareTitle.SoftwarePackage.InstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["install_script"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = script
 				}
-				cmd.FilesToWrite[fileName] = script
-			}
 
-			if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
-				query := softwareTitle.SoftwarePackage.PreInstallQuery
-				fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["pre_install_query"] = map[string]interface{}{
-					"path": path,
+				if softwareTitle.SoftwarePackage.PostInstallScript != "" {
+					script := softwareTitle.SoftwarePackage.PostInstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["post_install_script"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = script
 				}
-				cmd.FilesToWrite[fileName] = []map[string]interface{}{{
-					"query": query,
-				}}
+
+				if softwareTitle.SoftwarePackage.UninstallScript != "" {
+					script := softwareTitle.SoftwarePackage.UninstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["uninstall_script"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = script
+				}
+
+				if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
+					query := softwareTitle.SoftwarePackage.PreInstallQuery
+					fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["pre_install_query"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = []map[string]interface{}{{
+						"query": query,
+					}}
+				}
 			}
 
 			if softwareTitle.SoftwarePackage.SelfService {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1138,14 +1138,17 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 	var shScriptPkg, ps1ScriptPkg, regularPkg map[string]interface{}
 	for _, pkg := range packages {
 		p := pkg.(map[string]interface{})
-		if url, ok := p["url"].(string); ok {
-			if url == "https://example.com/download/my-script.sh" {
-				shScriptPkg = p
-			} else if url == "https://example.com/download/setup.ps1" {
-				ps1ScriptPkg = p
-			} else if url == "https://example.com/download/regular-package.deb" {
-				regularPkg = p
-			}
+		url, ok := p["url"].(string)
+		if !ok {
+			continue
+		}
+		switch url {
+		case "https://example.com/download/my-script.sh":
+			shScriptPkg = p
+		case "https://example.com/download/setup.ps1":
+			ps1ScriptPkg = p
+		case "https://example.com/download/regular-package.deb":
+			regularPkg = p
 		}
 	}
 
@@ -1244,11 +1247,11 @@ func (c *MockClientWithScriptPackage) ListSoftwareTitles(query string) ([]fleet.
 	}
 }
 
-func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTitle, error) {
-	switch ID {
+func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(id uint, teamID *uint) (*fleet.SoftwareTitle, error) {
+	switch id {
 	case 3:
 		if *teamID != 2 {
-			return nil, fmt.Errorf("team ID mismatch")
+			return nil, errors.New("team ID mismatch")
 		}
 		// InstallScript is populated internally from file contents, but these fields
 		// should NOT be output in GitOps YAML
@@ -1267,7 +1270,7 @@ func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(ID uint, teamID *uint
 		}, nil
 	case 4:
 		if *teamID != 2 {
-			return nil, fmt.Errorf("team ID mismatch")
+			return nil, errors.New("team ID mismatch")
 		}
 		return &fleet.SoftwareTitle{
 			ID: 4,
@@ -1284,7 +1287,7 @@ func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(ID uint, teamID *uint
 		}, nil
 	case 5:
 		if *teamID != 2 {
-			return nil, fmt.Errorf("team ID mismatch")
+			return nil, errors.New("team ID mismatch")
 		}
 		// InstallScript is populated internally from file contents, but these fields
 		// should NOT be output in GitOps YAML
@@ -1302,7 +1305,7 @@ func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(ID uint, teamID *uint
 			},
 		}, nil
 	default:
-		return c.MockClient.GetSoftwareTitleByID(ID, teamID)
+		return c.MockClient.GetSoftwareTitleByID(id, teamID)
 	}
 }
 

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1100,6 +1100,219 @@ func TestGenerateSoftware(t *testing.T) {
 	}
 }
 
+// TestGenerateSoftwareScriptPackages tests that script packages (.sh and .ps1)
+// do not output install_script, post_install_script, uninstall_script, or
+// pre_install_query fields in GitOps YAML, even though these fields may be
+// populated internally (the file contents become the install script).
+func TestGenerateSoftwareScriptPackages(t *testing.T) {
+	fleetClient := &MockClientWithScriptPackage{}
+	appConfig, err := fleetClient.GetAppConfig()
+	require.NoError(t, err)
+
+	cmd := &GenerateGitopsCommand{
+		Client:       fleetClient,
+		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
+		Messages:     Messages{},
+		FilesToWrite: make(map[string]interface{}),
+		AppConfig:    appConfig,
+		SoftwareList: make(map[uint]Software),
+	}
+
+	softwareRaw, err := cmd.generateSoftware("team.yml", 2, "script-team", false)
+	require.NoError(t, err)
+	require.NotNil(t, softwareRaw)
+
+	var software map[string]interface{}
+	b, err := yaml.Marshal(softwareRaw)
+	require.NoError(t, err)
+	fmt.Println("software with script packages:\n", string(b))
+
+	err = yaml.Unmarshal(b, &software)
+	require.NoError(t, err)
+
+	packages, ok := software["packages"].([]interface{})
+	require.True(t, ok, "packages should be an array")
+	require.Len(t, packages, 3, "should have 3 packages: 1 regular + 2 scripts (.sh and .ps1)")
+
+	// Identify by URL since hash_sha256 includes comment tokens
+	var shScriptPkg, ps1ScriptPkg, regularPkg map[string]interface{}
+	for _, pkg := range packages {
+		p := pkg.(map[string]interface{})
+		if url, ok := p["url"].(string); ok {
+			if url == "https://example.com/download/my-script.sh" {
+				shScriptPkg = p
+			} else if url == "https://example.com/download/setup.ps1" {
+				ps1ScriptPkg = p
+			} else if url == "https://example.com/download/regular-package.deb" {
+				regularPkg = p
+			}
+		}
+	}
+
+	require.NotNil(t, shScriptPkg, ".sh script package should exist")
+	require.NotNil(t, ps1ScriptPkg, ".ps1 script package should exist")
+	require.NotNil(t, regularPkg, "regular package should exist")
+
+	_, hasInstallScript := shScriptPkg["install_script"]
+	require.False(t, hasInstallScript, ".sh script package should NOT have install_script in YAML output")
+
+	_, hasPostInstallScript := shScriptPkg["post_install_script"]
+	require.False(t, hasPostInstallScript, ".sh script package should NOT have post_install_script in YAML output")
+
+	_, hasUninstallScript := shScriptPkg["uninstall_script"]
+	require.False(t, hasUninstallScript, ".sh script package should NOT have uninstall_script in YAML output")
+
+	_, hasPreInstallQuery := shScriptPkg["pre_install_query"]
+	require.False(t, hasPreInstallQuery, ".sh script package should NOT have pre_install_query in YAML output")
+
+	_, hasInstallScript = ps1ScriptPkg["install_script"]
+	require.False(t, hasInstallScript, ".ps1 script package should NOT have install_script in YAML output")
+
+	_, hasPostInstallScript = ps1ScriptPkg["post_install_script"]
+	require.False(t, hasPostInstallScript, ".ps1 script package should NOT have post_install_script in YAML output")
+
+	_, hasUninstallScript = ps1ScriptPkg["uninstall_script"]
+	require.False(t, hasUninstallScript, ".ps1 script package should NOT have uninstall_script in YAML output")
+
+	_, hasPreInstallQuery = ps1ScriptPkg["pre_install_query"]
+	require.False(t, hasPreInstallQuery, ".ps1 script package should NOT have pre_install_query in YAML output")
+
+	require.Contains(t, shScriptPkg, "url", ".sh script package should have url")
+	require.Contains(t, shScriptPkg, "hash_sha256", ".sh script package should have hash_sha256")
+	require.Contains(t, ps1ScriptPkg, "url", ".ps1 script package should have url")
+	require.Contains(t, ps1ScriptPkg, "hash_sha256", ".ps1 script package should have hash_sha256")
+
+	require.Contains(t, regularPkg, "install_script", "regular package should have install_script")
+	require.Contains(t, regularPkg, "post_install_script", "regular package should have post_install_script")
+	require.Contains(t, regularPkg, "uninstall_script", "regular package should have uninstall_script")
+	require.Contains(t, regularPkg, "pre_install_query", "regular package should have pre_install_query")
+
+	for filename := range cmd.FilesToWrite {
+		require.NotContains(t, filename, "my-script-linux-install", "should not write install script file for .sh script package")
+		require.NotContains(t, filename, "my-script-linux-postinstall", "should not write post-install script file for .sh script package")
+		require.NotContains(t, filename, "my-script-linux-uninstall", "should not write uninstall script file for .sh script package")
+		require.NotContains(t, filename, "my-script-linux-preinstallquery", "should not write pre-install query file for .sh script package")
+
+		require.NotContains(t, filename, "powershell-script-windows-install", "should not write install script file for .ps1 script package")
+		require.NotContains(t, filename, "powershell-script-windows-postinstall", "should not write post-install script file for .ps1 script package")
+		require.NotContains(t, filename, "powershell-script-windows-uninstall", "should not write uninstall script file for .ps1 script package")
+		require.NotContains(t, filename, "powershell-script-windows-preinstallquery", "should not write pre-install query file for .ps1 script package")
+	}
+}
+
+type MockClientWithScriptPackage struct {
+	MockClient
+}
+
+func (c *MockClientWithScriptPackage) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListResult, error) {
+	switch query {
+	case "available_for_install=1&team_id=2":
+		return []fleet.SoftwareTitleListResult{
+			{
+				ID:         3,
+				Name:       "My Script",
+				HashSHA256: ptr.String("script-package-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:     "my-script.sh",
+					Platform: "linux",
+					Version:  "1.0",
+				},
+			},
+			{
+				ID:         4,
+				Name:       "Regular Package",
+				HashSHA256: ptr.String("regular-package-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:     "regular-package.deb",
+					Platform: "linux",
+					Version:  "2.0",
+				},
+			},
+			{
+				ID:         5,
+				Name:       "PowerShell Script",
+				HashSHA256: ptr.String("ps1-script-hash"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:     "setup.ps1",
+					Platform: "windows",
+					Version:  "1.5",
+				},
+			},
+		}, nil
+	default:
+		return c.MockClient.ListSoftwareTitles(query)
+	}
+}
+
+func (c *MockClientWithScriptPackage) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTitle, error) {
+	switch ID {
+	case 3:
+		if *teamID != 2 {
+			return nil, fmt.Errorf("team ID mismatch")
+		}
+		// InstallScript is populated internally from file contents, but these fields
+		// should NOT be output in GitOps YAML
+		return &fleet.SoftwareTitle{
+			ID: 3,
+			SoftwarePackage: &fleet.SoftwareInstaller{
+				InstallScript:     "#!/bin/bash\necho 'This is the script content'",
+				PostInstallScript: "",
+				UninstallScript:   "",
+				PreInstallQuery:   "",
+				SelfService:       true,
+				Platform:          "linux",
+				URL:               "https://example.com/download/my-script.sh",
+				Name:              "my-script.sh",
+			},
+		}, nil
+	case 4:
+		if *teamID != 2 {
+			return nil, fmt.Errorf("team ID mismatch")
+		}
+		return &fleet.SoftwareTitle{
+			ID: 4,
+			SoftwarePackage: &fleet.SoftwareInstaller{
+				InstallScript:     "install script content",
+				PostInstallScript: "post-install script content",
+				UninstallScript:   "uninstall script content",
+				PreInstallQuery:   "SELECT 1",
+				SelfService:       false,
+				Platform:          "linux",
+				URL:               "https://example.com/download/regular-package.deb",
+				Name:              "regular-package.deb",
+			},
+		}, nil
+	case 5:
+		if *teamID != 2 {
+			return nil, fmt.Errorf("team ID mismatch")
+		}
+		// InstallScript is populated internally from file contents, but these fields
+		// should NOT be output in GitOps YAML
+		return &fleet.SoftwareTitle{
+			ID: 5,
+			SoftwarePackage: &fleet.SoftwareInstaller{
+				InstallScript:     "Write-Host 'This is the PowerShell script content'",
+				PostInstallScript: "",
+				UninstallScript:   "",
+				PreInstallQuery:   "",
+				SelfService:       true,
+				Platform:          "windows",
+				URL:               "https://example.com/download/setup.ps1",
+				Name:              "setup.ps1",
+			},
+		}, nil
+	default:
+		return c.MockClient.GetSoftwareTitleByID(ID, teamID)
+	}
+}
+
+func (c *MockClientWithScriptPackage) GetSetupExperienceSoftware(platform string, teamID uint) ([]fleet.SoftwareTitleListResult, error) {
+	if teamID == 2 {
+		return []fleet.SoftwareTitleListResult{}, nil
+	}
+	return c.MockClient.GetSetupExperienceSoftware(platform, teamID)
+}
+
 func TestGeneratePolicies(t *testing.T) {
 	// Get the test app config.
 	fleetClient := &MockClient{}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2111,6 +2111,16 @@ func (svc *Service) softwareBatchUpload(
 				installer.InstallerFile = tfr
 				filename = maintained_apps.FilenameFromResponse(resp)
 				installer.Filename = filename
+
+				// For script packages (.sh and .ps1), clear unsupported fields early.
+				// Determine extension from filename to validate before metadata extraction.
+				ext := strings.ToLower(filepath.Ext(filename))
+				ext = strings.TrimPrefix(ext, ".")
+				if fleet.IsScriptPackage(ext) {
+					installer.PostInstallScript = ""
+					installer.UninstallScript = ""
+					installer.PreInstallQuery = ""
+				}
 			}
 
 			if p.Slug != nil && *p.Slug != "" {
@@ -2183,8 +2193,15 @@ func (svc *Service) softwareBatchUpload(
 				}
 			}
 
-			// custom scripts only for exe installers
-			if installer.Extension != "exe" {
+			// For script packages (.sh and .ps1), clear unsupported fields
+			// The file contents become the install script, so post_install_script,
+			// uninstall_script, and pre_install_query are not supported.
+			if fleet.IsScriptPackage(installer.Extension) {
+				installer.PostInstallScript = ""
+				installer.UninstallScript = ""
+				installer.PreInstallQuery = ""
+			} else if installer.Extension != "exe" {
+				// custom scripts only for exe installers and non-script packages
 				if installer.InstallScript == "" {
 					installer.InstallScript = file.GetInstallScript(installer.Extension)
 				}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -18582,7 +18582,8 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
 		installer := titleResp.SoftwareTitle.SoftwarePackage
 
-		require.Empty(t, installer.InstallScript, ".sh script package should not have install_script")
+		require.Equal(t, string(shScriptContent), installer.InstallScript, ".sh script package should have install_script from file contents")
+		require.NotEqual(t, "echo 'This should be ignored'", installer.InstallScript, "user-provided install_script should be overwritten")
 		require.Empty(t, installer.PostInstallScript, ".sh script package should not have post_install_script")
 		require.Empty(t, installer.UninstallScript, ".sh script package should not have uninstall_script")
 		require.Empty(t, installer.PreInstallQuery, ".sh script package should not have pre_install_query")
@@ -18628,7 +18629,8 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
 		installer := titleResp.SoftwareTitle.SoftwarePackage
 
-		require.Empty(t, installer.InstallScript, ".ps1 script package should not have install_script")
+		require.Equal(t, string(ps1ScriptContent), installer.InstallScript, ".ps1 script package should have install_script from file contents")
+		require.NotEqual(t, "Write-Host 'This should be ignored'", installer.InstallScript, "user-provided install_script should be overwritten")
 		require.Empty(t, installer.PostInstallScript, ".ps1 script package should not have post_install_script")
 		require.Empty(t, installer.UninstallScript, ".ps1 script package should not have uninstall_script")
 		require.Empty(t, installer.PreInstallQuery, ".ps1 script package should not have pre_install_query")

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -18525,6 +18525,118 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerOrbitDownloadFailu
 	s.lastActivityMatches(wantAct.ActivityName(), string(jsonMustMarshal(t, wantAct)), 0)
 }
 
+// TestScriptPackageUploadValidation tests that script packages (.sh and .ps1)
+// properly ignore unsupported fields (install_script, post_install_script,
+// uninstall_script, pre_install_query) when uploaded via the API. These fields
+// are not supported because the file contents themselves become the install script.
+func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
+	t := s.T()
+
+	tmpDir := t.TempDir()
+
+	shScriptPath := filepath.Join(tmpDir, "test-script.sh")
+	shScriptContent := []byte("#!/bin/bash\necho 'Installing...'\n")
+	err := os.WriteFile(shScriptPath, shScriptContent, 0644)
+	require.NoError(t, err)
+
+	ps1ScriptPath := filepath.Join(tmpDir, "test-script.ps1")
+	ps1ScriptContent := []byte("Write-Host 'Installing...'\n")
+	err = os.WriteFile(ps1ScriptPath, ps1ScriptContent, 0644)
+	require.NoError(t, err)
+
+	t.Run("sh script package ignores unsupported fields", func(t *testing.T) {
+		installerFile, err := fleet.NewKeepFileReader(shScriptPath)
+		require.NoError(t, err)
+		defer installerFile.Close()
+
+		// Upload with unsupported fields populated
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:     "echo 'This should be ignored'",
+			PostInstallScript: "echo 'Post-install should be ignored'",
+			UninstallScript:   "echo 'Uninstall should be ignored'",
+			PreInstallQuery:   "SELECT 1",
+			Filename:          "test-script.sh",
+			InstallerFile:     installerFile,
+		}
+
+		s.uploadSoftwareInstaller(t, payload, 200, "")
+
+		// Verify fields were cleared
+		var listResp listSoftwareTitlesResponse
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, 200, &listResp, "team_id", "0", "available_for_install", "true")
+
+		var found bool
+		var titleID uint
+		for _, sw := range listResp.SoftwareTitles {
+			if sw.SoftwarePackage != nil && sw.SoftwarePackage.Name == "test-script.sh" {
+				found = true
+				titleID = sw.ID
+				break
+			}
+		}
+		require.True(t, found, "Script package should be created")
+
+		var titleResp getSoftwareTitleResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, 200, &titleResp, "team_id", "0")
+
+		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
+		installer := titleResp.SoftwareTitle.SoftwarePackage
+
+		require.Empty(t, installer.InstallScript, ".sh script package should not have install_script")
+		require.Empty(t, installer.PostInstallScript, ".sh script package should not have post_install_script")
+		require.Empty(t, installer.UninstallScript, ".sh script package should not have uninstall_script")
+		require.Empty(t, installer.PreInstallQuery, ".sh script package should not have pre_install_query")
+
+		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, 204, "team_id", "0")
+	})
+
+	t.Run("ps1 script package ignores unsupported fields", func(t *testing.T) {
+		installerFile, err := fleet.NewKeepFileReader(ps1ScriptPath)
+		require.NoError(t, err)
+		defer installerFile.Close()
+
+		// Upload with unsupported fields populated
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallScript:     "Write-Host 'This should be ignored'",
+			PostInstallScript: "Write-Host 'Post-install should be ignored'",
+			UninstallScript:   "Write-Host 'Uninstall should be ignored'",
+			PreInstallQuery:   "SELECT 1",
+			Filename:          "test-script.ps1",
+			InstallerFile:     installerFile,
+		}
+
+		s.uploadSoftwareInstaller(t, payload, 200, "")
+
+		// Verify fields were cleared
+		var listResp listSoftwareTitlesResponse
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, 200, &listResp, "team_id", "0", "available_for_install", "true")
+
+		var found bool
+		var titleID uint
+		for _, sw := range listResp.SoftwareTitles {
+			if sw.SoftwarePackage != nil && sw.SoftwarePackage.Name == "test-script.ps1" {
+				found = true
+				titleID = sw.ID
+				break
+			}
+		}
+		require.True(t, found, "Script package should be created")
+
+		var titleResp getSoftwareTitleResponse
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, 200, &titleResp, "team_id", "0")
+
+		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
+		installer := titleResp.SoftwareTitle.SoftwarePackage
+
+		require.Empty(t, installer.InstallScript, ".ps1 script package should not have install_script")
+		require.Empty(t, installer.PostInstallScript, ".ps1 script package should not have post_install_script")
+		require.Empty(t, installer.UninstallScript, ".ps1 script package should not have uninstall_script")
+		require.Empty(t, installer.PreInstallQuery, ".ps1 script package should not have pre_install_query")
+
+		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, 204, "team_id", "0")
+	})
+}
+
 func (s *integrationEnterpriseTestSuite) TestBatchSoftwareUploadWithSHAs() {
 	t := s.T()
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -18559,11 +18559,11 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 			InstallerFile:     installerFile,
 		}
 
-		s.uploadSoftwareInstaller(t, payload, 200, "")
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
 
 		// Verify fields were cleared
 		var listResp listSoftwareTitlesResponse
-		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, 200, &listResp, "team_id", "0", "available_for_install", "true")
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, http.StatusOK, &listResp, "team_id", "0", "available_for_install", "true")
 
 		var found bool
 		var titleID uint
@@ -18577,7 +18577,7 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 		require.True(t, found, "Script package should be created")
 
 		var titleResp getSoftwareTitleResponse
-		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, 200, &titleResp, "team_id", "0")
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, http.StatusOK, &titleResp, "team_id", "0")
 
 		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
 		installer := titleResp.SoftwareTitle.SoftwarePackage
@@ -18606,11 +18606,11 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 			InstallerFile:     installerFile,
 		}
 
-		s.uploadSoftwareInstaller(t, payload, 200, "")
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
 
 		// Verify fields were cleared
 		var listResp listSoftwareTitlesResponse
-		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, 200, &listResp, "team_id", "0", "available_for_install", "true")
+		s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, http.StatusOK, &listResp, "team_id", "0", "available_for_install", "true")
 
 		var found bool
 		var titleID uint
@@ -18624,7 +18624,7 @@ func (s *integrationEnterpriseTestSuite) TestScriptPackageUploadValidation() {
 		require.True(t, found, "Script package should be created")
 
 		var titleResp getSoftwareTitleResponse
-		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, 200, &titleResp, "team_id", "0")
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), nil, http.StatusOK, &titleResp, "team_id", "0")
 
 		require.NotNil(t, titleResp.SoftwareTitle.SoftwarePackage)
 		installer := titleResp.SoftwareTitle.SoftwarePackage


### PR DESCRIPTION
Fixes #34643.

## Summary

Fixes script packages (`.sh` and `.ps1`) incorrectly outputting unsupported fields in GitOps YAML and accepting invalid configuration during upload.

## Details
Script packages (`.sh` and `.ps1`) are payload-free packages where the file contents become the install script. Unlike regular packages, they don't support `install_script`, `post_install_script`, `uninstall_script`, or `pre_install_query` fields because these would conflict with the package's behavior.

However, Fleet was:

1. Outputting unsupported fields when generating GitOps YAML via `fleetctl generate gitops`, causing confusion about which fields are valid, and
2. Accepting and storing unsupported fields when applying GitOps YAML or uploading via API, leading to inconsistent state

## Changes

  - Adds script package detection in GitOps generation using filename extension (.sh or .ps1)
  - Script packages now only output: `url`, `hash_sha256`, `self_service`, `categories`, `labels`
  - Regular packages continue to output all script fields normally
  - Adds server-side validation to clear unsupported fields:
    - for script packages in upload path
    - in GitOps batch download path
    - after metadata extraction
  - Adds test coverage in:
    - `generate_gitops_test.go` for output filtering
    - `integration_enterprise_test.go` for API upload validation

  ## Testing
  - [x] Added tests for output filtering bug (1 above)
  - [x] Added tests for input validation bug (2 above)
  - [x] Verified new and existing tests pass
  - [x] Verified YAML output: script packages only show basic fields, regular packages show all fields
