### PR TITLE
Add .sh packages to Linux setup experience

### DIFF
--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -58,8 +58,8 @@ AND (
 		-- platform is 'linux', so we must check if the installer is compatible with the linux distribution.
 		OR
 		(
-			-- tar.gz can be installed on any Linux distribution
-			si.extension = 'tar.gz'
+			-- tar.gz and sh can be installed on any Linux distribution
+			(si.extension = 'tar.gz' OR si.extension = 'sh')
 			OR
 			(
 				-- deb packages can only be installed on Debian-based hosts.


### PR DESCRIPTION
Fixes #34654.

 ## Summary
  
Fixes payload-free Linux packages (.sh scripts) not installing during setup experience by updating the SQL query to recognize `.sh` as a valid distribution-agnostic installer extension.

## Details

When payload-free packages were added in #31719 (v4.76.0), the SQL query in `EnqueueSetupExperienceItems` wasn't updated to include `.sh` extensions for Linux. This caused two symptoms:

1. Solo `.sh` packages didn't trigger the setup experience browser window
2. `.sh` packages didn't install even when mixed with other package types

The query already recognized `tar.gz` as distribution-agnostic but missed `.sh` scripts, which also work on any Linux distribution (Debian/RHEL).

## Changes

- Updated SQL query in `EnqueueSetupExperienceItems` to include `.sh` alongside `tar.gz` for distribution-agnostic Linux installers
- Added comprehensive test coverage for `.sh` packages in setup experience (4 scenarios: solo/mixed on Debian/RHEL)

## Testing
- [x] Added tests to cover fix
- [x] Confirmed all existing tests pass
