### PR TITLE
Update engagement events in receive-from-clay.js

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -35,7 +35,6 @@ module.exports = {
         'Website - Newsletter',
         'Event - Sales-led event',
         'Event - Marketing-led event',
-        'Event - Engaged with Fleetie at event',
         'GitHub - Stared fleetdm/fleet',
         'GitHub - Forked fleetdm/fleet',
         'GitHub - Contributed to fleetdm/fleet',
@@ -63,6 +62,8 @@ module.exports = {
         'Implemented a trial key',
         'Signed up for Sales-led event',
         'Signed up for Marketing-led event',
+        'Engaged with Fleetie at Sales-led event'
+        'Engaged with Fleetie at Marketing-led event'
         'Attended a Fleet happy hour',
         'Stared the fleetdm/fleet repo on GitHub',
         'Forked the fleetdm/fleet repo on GitHub',

--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -62,8 +62,8 @@ module.exports = {
         'Implemented a trial key',
         'Signed up for Sales-led event',
         'Signed up for Marketing-led event',
-        'Engaged with Fleetie at Sales-led event'
-        'Engaged with Fleetie at Marketing-led event'
+        'Engaged with Fleetie at Sales-led event',
+        'Engaged with Fleetie at Marketing-led event',
         'Attended a Fleet happy hour',
         'Stared the fleetdm/fleet repo on GitHub',
         'Forked the fleetdm/fleet repo on GitHub',


### PR DESCRIPTION
Removed an engagement event and added two new engagement events for Sales-led and Marketing-led.
