### PR TITLE
Fleet product: Change label from 'Manage users' to 'Users'

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tests.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tests.tsx
@@ -49,7 +49,7 @@ describe("SiteTopNav - component", () => {
     ).toBeInTheDocument();
 
     expect(
-      screen.getByRole("menuitem", { name: /manage users/i })
+      screen.getByRole("menuitem", { name: /users/i })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("menuitem", { name: /my account/i })
@@ -102,7 +102,7 @@ describe("SiteTopNav - component", () => {
     ).toBeInTheDocument();
 
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for free global observer", async () => {
     const render = createCustomRenderer({
@@ -144,7 +144,7 @@ describe("SiteTopNav - component", () => {
 
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for premium global admin", async () => {
     const render = createCustomRenderer({
@@ -177,7 +177,7 @@ describe("SiteTopNav - component", () => {
       screen.getByRole("menuitem", { name: /settings/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("menuitem", { name: /manage users/i })
+      screen.getByRole("menuitem", { name: /users/i })
     ).toBeInTheDocument();
     expect(
       screen.getByRole("menuitem", { name: /my account/i })
@@ -230,7 +230,7 @@ describe("SiteTopNav - component", () => {
     ).toBeInTheDocument();
 
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for premium global observer", async () => {
     const render = createCustomRenderer({
@@ -272,7 +272,7 @@ describe("SiteTopNav - component", () => {
 
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for premium team admin", async () => {
     const render = createCustomRenderer({
@@ -317,7 +317,7 @@ describe("SiteTopNav - component", () => {
       screen.getByRole("menuitem", { name: /sign out/i })
     ).toBeInTheDocument();
 
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for premium team maintainer", async () => {
     const render = createCustomRenderer({
@@ -360,7 +360,7 @@ describe("SiteTopNav - component", () => {
     ).toBeInTheDocument();
 
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
   it("renders correct navigation for premium team observer", async () => {
     const render = createCustomRenderer({
@@ -403,6 +403,6 @@ describe("SiteTopNav - component", () => {
 
     expect(screen.queryByText(/controls/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/settings/i)).not.toBeInTheDocument();
-    expect(screen.queryByText(/manage users/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/users/i)).not.toBeInTheDocument();
   });
 });

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -135,7 +135,7 @@ const UserMenu = ({
 
   if (isGlobalAdmin) {
     const manageUserNavItem = {
-      label: "Manage users",
+      label: "Users",
       value: "manage-users",
       onClick: () => onUserMenuItemClick(PATHS.ADMIN_USERS),
     };


### PR DESCRIPTION
- @noahtalerman: Noun is used for all other items except "Sign out":

<img width="252" height="362" alt="Image" src="https://github.com/user-attachments/assets/34280bf0-5e74-46ed-b425-49faecbca18f" />