### PR TITLE
[Fleet server configuration] Clarify that only one can be set

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -744,6 +744,8 @@ AWS region to use for Identity and Access Management (IAM) authentication. This 
 
 Optionally, when using Identity and Access Management (IAM) authentication, this is the Amazon Resource Name (ARN) of the server private key.
 
+Only one of `server_private_key_arn` or `server_private_key` can be set.
+
 If set, Fleet reads the private key from AWS Secrets Manager instead of directly from `server_private_key`.
 
 - Default value: `""`


### PR DESCRIPTION
- Clarified that only one of `server_private_key_arn` or `server_private_key` can be set.

Context: https://github.com/fleetdm/fleet/issues/31321#issuecomment-3412996433
