### PR TITLE
update contact url buttons on swift dialog popup for macos mdm migration (#34265)

### DIFF
--- a/frontend/components/forms/validators/valid_url/valid_url.ts
+++ b/frontend/components/forms/validators/valid_url/valid_url.ts
@@ -1,6 +1,6 @@
 // https://github.com/validatorjs/validator.js/blob/master/README.md#validators
 
-import isURL from "validator/lib/isURL";
+import isURL, { IsURLOptions } from "validator/lib/isURL";
 
 interface IValidUrl {
   url: string;
@@ -10,9 +10,18 @@ interface IValidUrl {
 }
 
 export default ({ url, protocols, allowLocalHost = false }: IValidUrl) => {
-  return isURL(url, {
+  const options: Partial<IsURLOptions> = {
     protocols,
     require_protocol: !!protocols?.length,
     require_tld: !allowLocalHost,
-  });
+  };
+
+  // add some additional options specific to file protocol URLs
+  if (protocols?.includes("file")) {
+    options.allow_underscores = true;
+    options.allow_protocol_relative_urls = true;
+    options.require_host = false;
+  }
+
+  return isURL(url, options);
 };


### PR DESCRIPTION
**Related issue:** Fixes #32902

**Cherry Pick PR**

This changes the error message swift dialog popup for macos mdm
migration. it will not correctly show file protocol URLs and makes the
"Contact IT" the primary button action on this popup.
