### PR TITLE
`hash_sha256` is the `cdhash_sha256`

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4289,7 +4289,7 @@ On macOS hosts, `last_opened_at` is supported for software from the `apps` sourc
 
 On Windows hosts, `last_opened_at` is supported for software from the `programs` source. On Linux hosts, `last_opened_at` is supported for software from the `deb_packages` and `rpm_packages` sources. On Windows and Linux hosts, it represents the last open time of any version.
 
-Currently, `hash_sha256` is only supported for macOS software from the `apps` source.
+Currently, `hash_sha256` is only supported for macOS software from the `apps` source. `hash_sha256` is the [`cdhash_sha256`](https://fleetdm.com/tables/codesign).
 
 #### Example
 


### PR DESCRIPTION
The `hash_sha256` from the [`/hosts/:id/software` Fleet API](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-software) is an attribute that Santa can use to block applications: https://northpole.dev/features/binary-authorization/#cdhash

https://fleetdm.com/tables/codesign:

<img width="894" height="449" alt="Screenshot 2025-10-27 at 1 49 29 PM" src="https://github.com/user-attachments/assets/287750b5-ef38-4eba-aa8c-085520150be0" />
