### PR TITLE
Apply CDATA fix to a couple of problematic CSPs

### DIFF
--- a/docs/solutions/Windows/configuration-profiles/disable remote login - [AllowUsersToConnectRemotely].xml
+++ b/docs/solutions/Windows/configuration-profiles/disable remote login - [AllowUsersToConnectRemotely].xml
@@ -8,7 +8,7 @@
       <LocURI>./Device/Vendor/MSFT/Policy/Config/RemoteDesktopServices/AllowUsersToConnectRemotely</LocURI>
     </Target>
     <Data>
-      <![CDATA[<enabled/><data id="SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services" value="1"/>]]>
+      &lt;enabled/&gt;&lt;data id=&quot;SOFTWARE\Policies\Microsoft\Windows NT\Terminal Services&quot; value=&quot;1&quot;/&gt;
     </Data>
   </Item>
 </Replace>

--- a/docs/solutions/Windows/configuration-profiles/hide account details on sign in - [BlockUserFromShowingAccountDetailsOnSignin].xml
+++ b/docs/solutions/Windows/configuration-profiles/hide account details on sign in - [BlockUserFromShowingAccountDetailsOnSignin].xml
@@ -7,8 +7,6 @@
     <Target>
       <LocURI>./Device/Vendor/MSFT/Policy/Config/ADMX_Logon/BlockUserFromShowingAccountDetailsOnSignin</LocURI>
     </Target>
-    <Data>
-      <![CDATA[<enabled/>]]>
-    </Data>
+    <Data>&lt;enabled/&gt;</Data>
   </Item>
 </Replace>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
Fixes CSPs that were having issues verifying on the call with `customer-rembrandt`. Also removes a CSP that was a duplicate of another - "disable Windows Remote Assistance – [UnsolicitedRemoteAssistance, SolicitedRemoteAssistance].xml" was duplicated by "disable remote assistance - [AllowRemoteAssistance].xml"



