### PR TITLE
Cherry-Pick: Allow query editing in GitOps Mode for policies, add ▶ icon to live query "Run" button

### DIFF
--- a/changes/34086-policy-query-editability
+++ b/changes/34086-policy-query-editability
@@ -1,0 +1,1 @@
+* Allowed testing a new or edited policy query via live query while in GitOps Mode.

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -739,7 +739,6 @@ const PolicyForm = ({
             handleSubmit={promptSavePolicy}
             wrapEnabled
             focus={!isEditMode}
-            disabled={gitOpsModeEnabled}
           />
           {renderPlatformCompatibility()}
           {isEditMode && platformSelector.render()}
@@ -819,7 +818,7 @@ const PolicyForm = ({
                 }
                 variant="inverse"
               >
-                Run
+                Run <Icon name="run" />
               </Button>
             </span>
             <ReactTooltip


### PR DESCRIPTION
Merged into `main` in #34838.