### PR TITLE
Add OIN instructions to SSO configuration documentation

### DIFF
--- a/articles/foreign-vitals-map-idp-users-to-hosts.md
+++ b/articles/foreign-vitals-map-idp-users-to-hosts.md
@@ -16,15 +16,29 @@ Learn how to enforce authentication in the [setup experience guide](https://flee
 
 ## Okta
 
+Fleet's Okta integration supports the following SCIM features:
+
+**Provisioning to Fleet (Push):**
+- Push New Users - Create new users in Fleet from Okta
+- Push Profile Updates - Update existing user attributes in Fleet when changed in Okta
+- Push Groups - Provision Okta groups to Fleet and maintain group memberships
+- Deactivate Users - Remove user access when deactivated in Okta
+
+**Provisioning from Fleet (Import):**
+- Import New Users - Not supported (Fleet does not create users in Okta)
+- Import Profile Updates - Not supported (Fleet does not modify Okta user profiles)
+
 To map users from Okta to hosts in Fleet, we'll do the following steps:
 
 1. [Create application in Okta](#step-1-create-application-in-okta)
 2. [Connect Okta to Fleet](#step-2-connect-okta-to-fleet)
-3. [Map users and groups to hosts in Fleet](#step-3-map-users-and-groups-to-hosts-in-fleet)
+3. [Enable provisioning to Fleet](#step-3-enable-provisioning-to-fleet)
+4. [Assign users to the application](#step-4-assign-users-to-the-application)
+5. [Configure push groups](#step-5-configure-push-groups)
 
-#### Step 1: Create application in Okta
+#### Step 1: Create an application in Okta
 
-1. Head to Okta admin dashboard.
+1. Head to the Okta admin dashboard.
 2. In the main menu, select **Applications > Applications**, then select **Create App Integration**.
 3. Select **SAML 2.0** option and select **Next**.
 4. On the **General Settings** page, add a friendly **App name** (e.g Fleet SCIM), and select **Next**.
@@ -45,20 +59,50 @@ To map users from Okta to hosts in Fleet, we'll do the following steps:
 7. Select the **Test Connector Configuration** button. You should see success message in Okta.
 8. In Fleet, head to **Settings > Integrations > Identity provider (IdP)** and verify that Fleet successfully received the request from IdP.
 9. Back in Okta, select **Save**.
-10. Under the **Provisioning** tab, select **To App** and then select **Edit** in the **Provisioning to App** section. Enable **Create Users**, **Update User Attributes**, **Deactivate Users**, and then select **Save**.
-11. On the same page, make sure that `givenName` and `familyName` have Okta values assigned to it. Currently, Fleet requires the `userName`, `givenName`, and `familyName` SCIM attributes. Fleet also supports the `department` attribute (optional). Delete the rest of the attributes.
+
+#### Step 3: Enable provisioning to Fleet
+
+1. Under the **Provisioning** tab, select **To App** and then select **Edit** in the **Provisioning to App** section.
+2. Enable **Create Users**, **Update User Attributes**, and **Deactivate Users**, then select **Save**.
+3. On the same page, verify that `givenName` and `familyName` have Okta values assigned to them. Currently, Fleet requires the `userName`, `givenName`, and `familyName` SCIM attributes. Fleet also supports the `department` attribute (optional). Delete the rest of the attributes.
 ![Okta SCIM attributes mapping](../website/assets/images/articles/okta-scim-attributes-mapping-402x181@2x.png)
 
-#### Step 3: Map users and groups to hosts in Fleet
+#### Step 4: Assign users to the application
 
-To send users and groups information to Fleet, you have to assign them to your new SCIM app.
+To send user information to Fleet, assign users to your SCIM app. You can assign users individually or by group.
 
-1. In Okta's main menu **Directory > Groups** and then select **Add group**. Name it "Fleet human-device mapping".
-2. On the same page, select the **Rules** tab. Create a rule that will assign users to your  "Fleet human-device mapping" group.
+**Option A: Assign by group (recommended)**
+1. In Okta's main menu, select **Directory > Groups** and then select **Add group**. Name it "Fleet human-device mapping".
+2. On the same page, select the **Rules** tab. Create a rule that will assign users to your "Fleet human-device mapping" group.
 ![Okta group rule](../website/assets/images/articles/okta-scim-group-rules-1000x522@2x.png)
-3. In the main menu, select **Applications > Applications**  and select your new SCIM app. Then, select the **Assignments** tab.
-4. Select **Assign > Assign to Groups** and then select **Assign** next to the "Fleet human-device mapping" group. Then, select **Done**. Now all users that you assigned to the  "Fleet human-device mapping" group will be provisioned to Fleet.
-5. On the same page, select **Push Groups** tab. Then, select **Push Groups > Find groups by name** and add all groups that you assigned to "Fleet human-device mapping" group previously (make sure that **Push group memberships immediately** is selected). All groups will be provisioned in Fleet, and Fleet will map those groups to users.
+3. In the main menu, select **Applications > Applications** and select your SCIM app. Then, select the **Assignments** tab.
+4. Select **Assign > Assign to Groups** and then select **Assign** next to the "Fleet human-device mapping" group. Select **Done**.
+
+**Option B: Assign individual users**
+1. In the main menu, select **Applications > Applications** and select your SCIM app.
+2. Select the **Assignments** tab, then **Assign > Assign to People**.
+3. Select **Assign** next to each user you want to provision to Fleet, then select **Done**.
+
+#### Step 5: Configure push groups
+
+Group Push provisions Okta groups to Fleet and maintains group memberships. For a user's group memberships to appear in Fleet:
+- The user must be assigned to the Fleet SCIM application (see Step 4)
+- The user must be a member of the group in Okta
+- The group must be configured for Push in the application
+
+To enable Group Push:
+
+1. In your Fleet SCIM app, select the **Push Groups** tab.
+2. Select **Push Groups > Find groups by name**.
+3. Search for and add the groups you want to provision to Fleet (e.g., "Fleet human-device mapping" and any other groups assigned to the app).
+4. Ensure **Push group memberships immediately** is selected for each group.
+5. Select **Save**.
+
+**Important notes about Group Push:**
+- Only users who are both assigned to the app AND members of pushed groups will have group data in Fleet
+- If you remove a user from a pushed group in Okta, the group membership will be removed from Fleet
+- If you unassign a user from the app, all their group memberships will be removed from Fleet
+- Group push happens immediately, but can take a few minutes to reflect in Fleet
 
 ## Microsoft Entra ID
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -6,8 +6,207 @@ To configure SSO, follow steps for your IdP and then complete [Fleet configurati
 
 > JIT? SAML implementation supports just-in-time (JIT) user provisioning, as well as both IdP-initiated login and service-initiated (SP) login.
 
+**Using Fleet MDM?** If you're using automatic enrollment (ADE/DEP), you'll need two separate SSO apps in your IdP - one for your admin console and one for end user authentication during device setup. See [End user authentication for MDM](#end-user-authentication-for-mdm) after you've configured your IdP.
+
 
 ## Okta
+
+Fleet offers two ways to set up Okta:
+
+1. **[Okta Integration Network (OIN)](#okta-integration-network-oin)** - Use the pre-configured Fleet app from Okta's catalog (recommended for most users)
+2. **[Custom SAML app](#okta-custom-saml-app)** - Manually create a SAML app in Okta (for testing or advanced configurations)
+
+### Okta Integration Network (OIN)
+
+The Fleet app is available in the Okta Integration Network catalog. This is the fastest way to set up SAML SSO and SCIM provisioning for your Fleet admin console.
+
+**Note:** The OIN app is for Fleet admin/user access only. If you're using MDM with automatic enrollment, you'll need a separate custom SAML app for end user authentication. See [End user authentication for MDM](#end-user-authentication-for-mdm) below.
+
+**What you'll need:**
+- Fleet Premium license (required for both SAML SSO and SCIM provisioning)
+- Fleet admin access
+- Okta admin access
+
+#### Supported features
+
+**SAML 2.0 Single Sign-On:**
+- SP-initiated SSO
+- IdP-initiated SSO
+- Just-In-Time (JiT) provisioning
+
+**SCIM 2.0 Provisioning:**
+- Create users
+- Update user attributes
+- Deactivate users
+- Reactivate users
+- Push groups
+
+#### Add Fleet from the OIN catalog
+
+1. Sign in to your Okta Admin Console as an administrator
+2. Go to **Applications** > **Applications**
+3. Click **Browse App Catalog**
+4. Search for "Fleet" and select the Fleet application
+5. Click **Add Integration**
+6. On the General Settings page, configure the application label (optional) and click **Done**
+
+#### Configure SAML settings
+
+1. In the Fleet application, go to the **General** tab
+2. Click **Edit** in the App Settings section
+3. Configure:
+   - **Application label**: Fleet (or whatever you want users to see)
+   - **Entity ID**: Choose any unique identifier (e.g., `fleet` or `fleet.example.com`) - you'll use this same value in Fleet later
+   - **Fleet Instance Base URL**: Your Fleet server domain without https:// (e.g., `acmeco.cloud.fleetdm.com`)
+4. Click **Save**
+
+#### Assign users to Fleet
+
+1. Go to the **Assignments** tab
+2. Click **Assign** and choose:
+   - **Assign to People**: For individual users
+   - **Assign to Groups**: For groups of users
+3. Click **Assign** next to the users or groups you want
+4. Click **Done**
+
+#### Complete SAML configuration in Fleet
+
+After configuring SAML in Okta, finish the setup in Fleet:
+
+1. In the Fleet application in Okta, go to the **Sign On** tab
+2. Under **SAML 2.0** > **Metadata details**, copy the Metadata URL
+3. In Fleet, go to **Settings** > **Integrations** > **Single sign-on (SSO)**
+4. Configure:
+   - Check **Enable single sign-on**
+   - **Identity provider name**: Okta (or whatever you want to call it)
+   - **Entity ID**: Use the **exact same value** you entered in Okta (e.g., `fleet`)
+   - **Metadata URL**: Paste the URL from step 2
+5. Click **Save**
+
+**Important:** The Entity ID must match exactly between Okta and Fleet or SSO won't work.
+
+Once SAML is set up, users can sign into Fleet directly from Fleet's login page:
+
+1. Go to your Fleet instance login page
+2. Click the **Login with Okta** button below the email/password fields
+3. Enter your Okta credentials
+4. You'll be redirected back to Fleet and signed in
+
+This means users can bookmark your Fleet instance and always start there, rather than going through the Okta dashboard.
+
+#### Configure SCIM provisioning
+
+SCIM automates user and group management between Okta and Fleet.
+
+##### Create Fleet API token
+
+First, create an API token in Fleet:
+
+1. Install fleetctl (Fleet's command-line tool)
+2. Run this command to create an API-only user with maintainer permissions:
+   ```
+   fleetctl user create --name 'API User' --email 'api@example.com' --password 'temp@pass123' --api-only --global-role 'maintainer'
+   ```
+3. Copy the API token from the output
+
+For detailed instructions, see [Create API-only user](https://fleetdm.com/guides/fleetctl#create-api-only-user).
+
+##### Enable provisioning in Okta
+
+1. In the Fleet application, go to the **Provisioning** tab
+2. Click **Configure API Integration**
+3. Check **Enable API integration**
+4. Enter:
+   - **Base URL**: `https://your-fleet-instance.com/api/v1/fleet/scim`
+   - **API Token**: Paste your Fleet API token
+5. Click **Test API Credentials** to verify the connection
+6. If successful, click **Save**
+
+##### Configure provisioning settings
+
+1. Under the **Provisioning** tab, click **To App** in the left sidebar
+2. Click **Edit** in the Provisioning to App section
+3. Enable:
+   - **Create Users**: Automatically create users in Fleet when assigned in Okta
+   - **Update User Attributes**: Update user info when changed in Okta
+   - **Deactivate Users**: Deactivate users in Fleet when unassigned or deactivated in Okta
+4. Click **Save**
+
+##### Configure attribute mappings
+
+1. On the **Provisioning** tab, click **To App**
+2. Scroll to the attribute mappings section
+3. Make sure these required attributes are mapped:
+   - **userName** → Okta username
+   - **givenName** → First name
+   - **familyName** → Last name
+4. Optional attributes:
+   - **department** → Department
+   - **FLEET_JIT_USER_ROLE_GLOBAL** → User's Fleet role (see below)
+5. Remove any other unmapped attributes that Fleet doesn't support
+6. Click **Save**
+
+**Setting up FLEET_JIT_USER_ROLE_GLOBAL:**
+
+This attribute automatically assigns Fleet permissions when users are provisioned. It's especially useful with Just-In-Time (JiT) provisioning.
+
+Supported values:
+- `admin` - Full administrative access to Fleet
+- `maintainer` - Can manage hosts, queries, policies, and software
+- `observer_plus` - Read-only access plus ability to run queries
+- `observer` - Read-only access to Fleet
+
+How to configure:
+1. In the attribute mappings, find **FLEET_JIT_USER_ROLE_GLOBAL**
+2. Map it to an Okta user attribute with the desired Fleet role
+3. Common setups:
+   - Static value: Set to `"observer"` (with quotes) for all users
+   - Group-based: Use an expression like `String.contains(user.groups, "Fleet Admins") ? "admin" : "observer"`
+
+If you don't configure this, provisioned users default to observer role.
+
+##### Push groups (optional)
+
+To sync Okta groups with Fleet:
+
+1. Go to the **Push Groups** tab
+2. Click **Push Groups** > **Find groups by name**
+3. Search for and select the groups you want to push
+4. Make sure **Push group memberships immediately** is selected
+5. Click **Save**
+
+#### Verify everything works
+
+1. Sign in to Fleet as an admin
+2. Go to **Settings** > **Integrations** > **Identity provider (IdP)**
+3. Check that Fleet's receiving requests from Okta
+4. Verify users and groups are showing up correctly
+
+#### Troubleshooting
+
+**Users not provisioning:**
+- Check that your SCIM API token is valid and has maintainer permissions
+- Look for error messages in the **Provisioning** tab in Okta
+- Verify all required attributes (userName, givenName, familyName) are mapped
+- Double-check your Base URL: `https://your-fleet-instance.com/api/v1/fleet/scim`
+
+**SAML authentication issues:**
+- Make sure your Fleet Server URL doesn't have a trailing slash
+- Confirm users are assigned to the Fleet app in Okta
+- If you're not using SCIM, check that Just-In-Time provisioning is enabled
+- Verify the SAML metadata is configured in Fleet
+
+**Group membership not syncing:**
+- Confirm groups are pushed in the **Push Groups** tab
+- Check that **Push group memberships immediately** is enabled
+- Verify users are actually members of the pushed groups in Okta
+
+**Need help?**
+- Work with your Fleet customer success manager
+- Email Fleet support: support@fleetdm.com
+- Check Fleet docs: https://fleetdm.com/docs
+
+### Okta custom SAML app
 
 Create a new SAML app in Okta:
 
@@ -22,8 +221,6 @@ Once configured, you will need to retrieve the issuer URI from **View Setup Inst
 > The Provider Sign-on URL within **View Setup Instructions** has a similar format as the Provider SAML Metadata URL, but this link provides a redirect to _sign into_ the application, not the metadata necessary for dynamic configuration.
 
 ## Google Workspace
-
-If you're configuring [end user authentication](https://fleetdm.com/guides/macos-setup-experience#end-user-authentication-and-end-user-license-agreement-eula), use `https://<your_fleet_url>/api/v1/fleet/mdm/sso/callback` for the **Single sign on URL** instead.
 
 Create a new SAML app in Google Workspace:
 
@@ -65,7 +262,6 @@ Create a new SAML app in Google Workspace:
 8. Enable SSO for a test user and try logging in. Note that Google sometimes takes a long time to propagate the SSO configuration, and it can help to try logging in to Fleet with an Incognito/Private window in the browser.
 
 ## Entra
-
 Create a new SAML app in Microsoft Entra Admin Center:
 1. From the left sidebar, navigate to **Applications > Enterprise Applications**.
 2. At the top of the page, click **+ New Application**.
@@ -102,7 +298,7 @@ Fleet can be configured to use authentik as an identity provider. To continue, y
 
 1. Log in to authentik and click **Admin interface**.
 
-2. Navigate to **Applications -> Applications** and click **Create with Provider** to create an application and provider pair.
+2. Navigate to **Applications -> Applications** and click **Create with Provider** to create an application and provider pair.
 
 3. Enter "Fleet" for the **App name** and click **Next**.
 
@@ -139,6 +335,31 @@ IdPs generally requires the following information:
 - Subject Type - `email`.
 
 After supplying the above information, your IdP will generate an issuer URI and metadata that will be used to configure Fleet as a service provider.
+
+## End user authentication for MDM
+
+If you're using Fleet MDM with automatic enrollment (ADE/DEP), you need **two separate SSO apps** in your IdP - one for the Fleet admin console and one for end user authentication during device setup.
+
+**Why two apps?**
+
+Having separate apps gives you flexibility with security:
+- **Admin console app**: Fleet admins and users sign into Fleet's web UI (`/api/v1/fleet/sso/callback`)
+- **End user auth app**: Employees authenticate during out-of-box macOS setup (`/api/v1/fleet/mdm/sso/callback`)
+
+With two apps, you can apply different conditional access policies or security controls. Maybe you want MFA required for admins but not during device setup. Or stricter device compliance checks for the admin portal. Separate apps let you tailor security to each use case.
+
+**Setting up the end user authentication app:**
+
+You'll need to create a custom SAML app for end user authentication. The OIN app doesn't support the MDM callback URL yet.
+
+1. Create a new custom SAML app in your IdP (follow the [Okta custom SAML app](#okta-custom-saml-app) instructions if using Okta)
+2. Use `https://<your_fleet_url>/api/v1/fleet/mdm/sso/callback` for the SSO callback URL
+3. Set **Name ID** to email (required) - Fleet uses this to populate the macOS account name
+4. Assign users who'll be setting up new Macs
+5. In Fleet, go to **Settings** > **Integrations** > **Mobile device management (MDM)** > **End user authentication** and configure the connection
+6. Enable it at **Controls** > **Setup experience** > **End user authentication**
+
+For complete setup instructions, see the [macOS setup experience guide](https://fleetdm.com/guides/macos-setup-experience#end-user-authentication-and-end-user-license-agreement-eula).
 
 ## Fleet configuration
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -48,17 +48,13 @@ The Fleet app is available in the Okta Integration Network catalog. This is the 
 3. Click **Browse App Catalog**
 4. Search for "Fleet" and select the Fleet application
 5. Click **Add Integration**
-6. On the General Settings page, configure the application label (optional) and click **Done**
+6. Put in an appropriate name for your Fleet instance as the **Application Label** (e.g., `Fleet Production`)
+7. For **Entity ID**, use the **exact same value** you entered in Fleet under **Settings > Integrations > Single-sign on (SSO)** (e.g., `fleet`).
+<img width="1196" height="994" alt="A screenshot of the SSO settings screen in Fleet" src="https://github.com/user-attachments/assets/faace0e0-210f-494a-8cec-bed9769b6417" />
 
-#### Configure SAML settings
+8. For **Fleet instance base URL**, put in the URL of your Fleet instance as listed under **Settings > Organization settings > Fleet web address** (e.g., `https://fleetprod.cloud.fleetdm.com`).
+<img width="1124" height="479" alt="A screenshot of the Fleet web address settings screen in Fleet" src="https://github.com/user-attachments/assets/ce45244d-6627-4a19-949a-f7723b21e739" />
 
-1. In the Fleet application, go to the **General** tab
-2. Click **Edit** in the App Settings section
-3. Configure:
-   - **Application label**: Fleet (or whatever you want users to see)
-   - **Entity ID**: Choose any unique identifier (e.g., `fleet` or `fleet.example.com`) - you'll use this same value in Fleet later
-   - **Fleet Instance Base URL**: Your Fleet server domain without https:// (e.g., `acmeco.cloud.fleetdm.com`)
-4. Click **Save**
 
 #### Assign users to Fleet
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -201,11 +201,6 @@ To sync Okta groups with Fleet:
 - Check that **Push group memberships immediately** is enabled
 - Verify users are actually members of the pushed groups in Okta
 
-**Need help?**
-- Work with your Fleet customer success manager
-- Email Fleet support: support@fleetdm.com
-- Check Fleet docs: https://fleetdm.com/docs
-
 ### Okta custom SAML app
 
 Create a new SAML app in Okta:

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -69,7 +69,7 @@ The Fleet app is available in Okta's catalog. This is the fastest way to set up 
    - **Metadata URL**: Paste the URL from Okta
    - Click **Save**
 
-Fleet's SAML implementation requires the following attributes:
+Fleet's SAML implementation requires the following attributes to be populated in Okta:
 - `username`
 - `displayName`
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -52,7 +52,7 @@ The Fleet app is available in Okta's catalog. This is the fastest way to set up 
    - **Application Label**: Name for your Fleet instance (e.g., "Fleet Production")
    - **Entity ID**: Must match exactly what you set in Fleet under **Settings > Integrations > Single sign-on (SSO)** (e.g., `fleet`)
    - **Fleet instance base URL**: Your Fleet URL from **Settings > Organization settings > Fleet web address** (e.g., `fleetprod.cloud.fleetdm.com`)
-   > Note: Be sure to omit `https://` as it will be added automatically when the app is created in Okta.
+   > Note: Be sure to omit `https://` as it will be added automatically when the app is created in Okta. 
 
 6. Assign users:
    - Go to the **Assignments** tab
@@ -68,6 +68,12 @@ The Fleet app is available in Okta's catalog. This is the fastest way to set up 
    - **Entity ID**: Must match Okta exactly (e.g., `fleet`)
    - **Metadata URL**: Paste the URL from Okta
    - Click **Save**
+
+Fleet's SAML implementation requires the following attributes:
+- `username`
+- `displayName`
+
+Fleet also has [optional](#customization-of-user-roles) attributes that can be used for Just-In-Time (JIT) provisioning to assign administrative roles to Fleet globally or to a specific team.
 
 **Important:** The Entity ID must match exactly between Okta and Fleet or SSO won't work.
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -94,17 +94,12 @@ SCIM lets you automatically provision users and groups from Okta to Fleet. This 
 1. In your Fleet Okta app, go to the **Provisioning** tab
 2. Click **Configure API Integration**
 3. Check **Enable API integration**
-4. Configure the connection:
-   - **SCIM connector base URL**: `https://<your_fleet_server_url>/api/v1/fleet/scim`
-   - **Unique identifier field for users**: `userName`
-   - **Supported provisioning actions**: Select **Push New Users**, **Push Profile Updates**, and **Push Groups**
-   - **Authentication Mode**: `HTTP Header`
-5. Generate your Fleet API token:
+4. Generate your Fleet API token:
    - [Create a Fleet API-only user](https://fleetdm.com/guides/fleetctl#create-api-only-user) with maintainer permissions
    - Copy the API token and paste it in Okta's **Authorization** field
-6. Click **Test API Credentials** - you should see a success message
-7. In Fleet, go to **Settings > Integrations > Identity provider (IdP)** and verify Fleet received the test request
-8. Back in Okta, click **Save**
+5. Click **Test API Credentials** - you should see a success message
+6. In Fleet, go to **Settings > Integrations > Identity provider (IdP)** and verify Fleet received the test request
+7. Back in Okta, click **Save**
 
 **Step 2: Enable provisioning**
 

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -51,7 +51,8 @@ The Fleet app is available in Okta's catalog. This is the fastest way to set up 
 5. Configure the basics:
    - **Application Label**: Name for your Fleet instance (e.g., "Fleet Production")
    - **Entity ID**: Must match exactly what you set in Fleet under **Settings > Integrations > Single sign-on (SSO)** (e.g., `fleet`)
-   - **Fleet instance base URL**: Your Fleet URL from **Settings > Organization settings > Fleet web address** (e.g., `https://fleetprod.cloud.fleetdm.com`)
+   - **Fleet instance base URL**: Your Fleet URL from **Settings > Organization settings > Fleet web address** (e.g., `fleetprod.cloud.fleetdm.com`)
+   > Note: Be sure to omit `https://` as it will be added automatically when the app is created in Okta.
 
 6. Assign users:
    - Go to the **Assignments** tab

--- a/docs/Deploy/single-sign-on-sso.md
+++ b/docs/Deploy/single-sign-on-sso.md
@@ -62,7 +62,7 @@ The Fleet app is available in Okta's catalog. This is the fastest way to set up 
 7. Complete the Fleet side:
    - In Okta, go to your Fleet app's **Sign On** tab
    - Under **SAML 2.0** > **Metadata details**, copy the **Metadata URL**
-   - In Fleet, go to **Settings** > **Integrations** > **Single sign-on (SSO)**
+   - In Fleet, go to **Settings** > **Integrations** > **Single sign-on (SSO)** > **End users**
    - Check **Enable single sign-on**
    - **Identity provider name**: `Okta` (or whatever you want)
    - **Entity ID**: Must match Okta exactly (e.g., `fleet`)


### PR DESCRIPTION
Expanded documentation on configuring SSO with Okta, Google Workspace, and Entra, including detailed steps for both admin and end-user authentication setups. Added troubleshooting tips and clarified the need for separate SSO apps for MDM.