### PR TITLE
Reconcile SCIM users cron

### DIFF
--- a/changes/34607-reconcile-scim
+++ b/changes/34607-reconcile-scim
@@ -1,0 +1,1 @@
+- reconciles scim user to hosts when IDP mappings are created before the scim user exists

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1084,6 +1084,12 @@ func newFrequentCleanupsSchedule(
 			err = lq.CleanupInactiveQueries(ctx, completed)
 			return err
 		}),
+		schedule.WithJob("reconcile_host_scim_user_mappings", func(ctx context.Context) error {
+			// Reconcile hosts with mdm_idp_accounts emails but no SCIM user mapping
+			// This helps fill gaps when SCIM users are provisioned after MDM enrollment
+			// or when automatic matching during SCIM user creation fails
+			return ds.ReconcileHostSCIMUserMappings(ctx)
+		}),
 	)
 
 	return s, nil

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4335,7 +4335,7 @@ func (ds *Datastore) associateHostWithScimUser(ctx context.Context, hostID uint,
 func associateHostWithScimUser(ctx context.Context, tx sqlx.ExtContext, hostID uint, scimUserID uint) error {
 	_, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?, ?)`,
+		`INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE scim_user_id = scim_user_id, created_at = created_at`,
 		hostID, scimUserID,
 	)
 	if err != nil {

--- a/server/datastore/mysql/scim_test.go
+++ b/server/datastore/mysql/scim_test.go
@@ -2497,18 +2497,9 @@ func testReconcileHostSCIMUserMappings(t *testing.T, ds *Datastore) {
 	// Create a test host
 	host := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
 
-	// Create an MDM IdP account and add it to mdm_idp_accounts table
-	idpAccount := &fleet.MDMIdPAccount{
-		UUID:     "test-idp-uuid",
-		Username: "testuser",
-		Email:    "testuser@example.com",
-	}
-	err := ds.InsertMDMIdPAccount(ctx, idpAccount)
-	require.NoError(t, err)
-
 	// Manually insert a host_email with mdm_idp_accounts source
 	// (normally this would be done by the reconciliation process in mdm.go)
-	_, err = ds.writer(ctx).ExecContext(ctx,
+	_, err := ds.writer(ctx).ExecContext(ctx,
 		"INSERT INTO host_emails (host_id, email, source) VALUES (?, ?, ?)",
 		host.ID, "testuser@example.com", fleet.DeviceMappingMDMIdpAccounts)
 	require.NoError(t, err)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2327,6 +2327,9 @@ type Datastore interface {
 	// ScimUsersExist checks if all the provided SCIM user IDs exist in the datastore
 	// If the slice is empty, it returns true
 	ScimUsersExist(ctx context.Context, ids []uint) (bool, error)
+	// ReconcileHostSCIMUserMappings finds hosts with mdm_idp_accounts emails but no SCIM user mapping
+	// and attempts to create the mapping based on email/username matching
+	ReconcileHostSCIMUserMappings(ctx context.Context) error
 	// ReplaceScimUser replaces an existing SCIM user in the database
 	ReplaceScimUser(ctx context.Context, user *ScimUser) error
 	// DeleteScimUser deletes a SCIM user from the database

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1497,6 +1497,8 @@ type ScimUserByHostIDFunc func(ctx context.Context, hostID uint) (*fleet.ScimUse
 
 type ScimUsersExistFunc func(ctx context.Context, ids []uint) (bool, error)
 
+type ReconcileHostSCIMUserMappingsFunc func(ctx context.Context) error
+
 type ReplaceScimUserFunc func(ctx context.Context, user *fleet.ScimUser) error
 
 type DeleteScimUserFunc func(ctx context.Context, id uint) error
@@ -3776,6 +3778,9 @@ type DataStore struct {
 
 	ScimUsersExistFunc        ScimUsersExistFunc
 	ScimUsersExistFuncInvoked bool
+
+	ReconcileHostSCIMUserMappingsFunc        ReconcileHostSCIMUserMappingsFunc
+	ReconcileHostSCIMUserMappingsFuncInvoked bool
 
 	ReplaceScimUserFunc        ReplaceScimUserFunc
 	ReplaceScimUserFuncInvoked bool
@@ -9039,6 +9044,13 @@ func (s *DataStore) ScimUsersExist(ctx context.Context, ids []uint) (bool, error
 	s.ScimUsersExistFuncInvoked = true
 	s.mu.Unlock()
 	return s.ScimUsersExistFunc(ctx, ids)
+}
+
+func (s *DataStore) ReconcileHostSCIMUserMappings(ctx context.Context) error {
+	s.mu.Lock()
+	s.ReconcileHostSCIMUserMappingsFuncInvoked = true
+	s.mu.Unlock()
+	return s.ReconcileHostSCIMUserMappingsFunc(ctx)
 }
 
 func (s *DataStore) ReplaceScimUser(ctx context.Context, user *fleet.ScimUser) error {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34607 Resolves #34667

Found cases where there is a missing row in the `host_scim_users` join table after hosts ran through ADE (#34607).  The missing row is also expected when a SCIM user is created/activated after a manual IDP user device mapping (#34667).  This PR adds a new cron activity to reconcile IDP users by creating missing rows when a valid SCIM user is found. 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests

- [X] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatic reconciliation links devices to SCIM users using IdP emails during frequent maintenance, ensuring hosts are associated even if user records are created later.

- Bug Fixes
  - Resolves missing or delayed device-to-user associations that could occur when IdP mappings were created before corresponding SCIM users, improving onboarding consistency and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->