### PR TITLE
Fix intune company portal checksum

### DIFF
--- a/ee/maintained-apps/outputs/intune-company-portal/darwin.json
+++ b/ee/maintained-apps/outputs/intune-company-portal/darwin.json
@@ -8,7 +8,7 @@
       "installer_url": "https://officecdn.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/CompanyPortal_5.2508.1-Upgrade.pkg",
       "install_script_ref": "a407504a",
       "uninstall_script_ref": "773a6033",
-      "sha256": "f02c69315e47b99c20b77d72f1a994dc7cd004f7cadc5e06abda1ff0bd47a5cc",
+      "sha256": "ac165e3a3c364b9def29c07a7719ac0c4fd541309dbdb1e3a57485bedb8f526d",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Resolves: #34640
One time fix using the hash computed from the file downloaded from the URL.
No ingestion change since we don't want this to happen again, and there is a now a validation check for the checksum hash that will prevent this situation.

## Testing

- [x] QA'd all new/changed functionality manually 
- [x] App adds successfully to team
- [x] App installs on host
- [x] App opens on host
- [x] App uninstalls on host
