### PR TITLE
Clarify SCEP challenge string limitations on Windows

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -517,6 +517,7 @@ Custom SCEP proxy:
 
 * NDES SCEP proxy is currently supported for macOS devices via Apple config profiles. Support for DDM (Declarative Device Management) is coming soon, as is support for iOS, iPadOS, Windows, and Linux.
 * Fleet server assumes a one-time challenge password expiration time of 60 minutes.
+* On Windows, special characters in SCEP challenge strings such as `! @ # $ % ^ & * _ ()` should not be used. 
 
 ## How to deploy certificates to a user's login keychain
 


### PR DESCRIPTION
Added note about special characters in SCEP challenge strings for Windows.