### PR TITLE
Loadtesting - osquery_perf docker image build fixes

### DIFF
--- a/infrastructure/loadtesting/terraform/infra/variables.tf
+++ b/infrastructure/loadtesting/terraform/infra/variables.tf
@@ -1,6 +1,6 @@
 variable "tag" {
   description = "The tag to deploy. This would be the same as the branch name"
-  default     = "v4.72.0"
+  default     = "v4.75.1"
 }
 
 variable "fleet_task_count" {

--- a/infrastructure/loadtesting/terraform/osquery_perf/README.md
+++ b/infrastructure/loadtesting/terraform/osquery_perf/README.md
@@ -107,16 +107,16 @@ terraform workspace delete <workspace_name>
 | Name | Version |
 |------|---------|
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.68.0 |
-| <a name="requirement_docker"></a> [docker](#requirement\_docker) | ~> 2.16.0 |
-| <a name="requirement_git"></a> [git](#requirement\_git) | ~> 0.1.0 |
+| <a name="requirement_docker"></a> [docker](#requirement\_docker) | ~> 3.6.0 |
+| <a name="requirement_git"></a> [git](#requirement\_git) | 2025.10.10 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.13.0 |
-| <a name="provider_docker"></a> [docker](#provider\_docker) | 2.16.0 |
-| <a name="provider_git"></a> [git](#provider\_git) | 0.1.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.18.0 |
+| <a name="provider_docker"></a> [docker](#provider\_docker) | 3.6.2 |
+| <a name="provider_git"></a> [git](#provider\_git) | 2025.10.10 |
 | <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
 
 ## Modules
@@ -129,13 +129,14 @@ terraform workspace delete <workspace_name>
 
 | Name | Type |
 |------|------|
+| [docker_image.loadtest](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/image) | resource |
 | [docker_registry_image.loadtest](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/resources/registry_image) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_ecr_authorization_token.token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_authorization_token) | data source |
 | [aws_ecr_repository.fleet](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ecr_repository) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [docker_registry_image.dockerhub](https://registry.terraform.io/providers/kreuzwerker/docker/latest/docs/data-sources/registry_image) | data source |
-| [git_repository.tf](https://registry.terraform.io/providers/metio/git/latest/docs/data-sources/repository) | data source |
+| [git_repository.tf](https://registry.terraform.io/providers/metio/git/2025.10.10/docs/data-sources/repository) | data source |
 | [terraform_remote_state.infra](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 | [terraform_remote_state.shared](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -146,7 +147,7 @@ terraform workspace delete <workspace_name>
 | <a name="input_extra_flags"></a> [extra\_flags](#input\_extra\_flags) | Comma delimited list (string) for passing extra flags to osquery-perf containers | `list(string)` | <pre>[<br/>  "--orbit_prob",<br/>  "0.0"<br/>]</pre> | no |
 | <a name="input_git_branch"></a> [git\_branch](#input\_git\_branch) | The git branch to use to build loadtest containers.  Only needed if docker tag doesn't match the git branch | `string` | `null` | no |
 | <a name="input_loadtest_containers"></a> [loadtest\_containers](#input\_loadtest\_containers) | Number of loadtest containers to deploy | `number` | `1` | no |
-| <a name="input_tag"></a> [tag](#input\_tag) | The tag to deploy. This would be the same as the branch name | `string` | `""` | no |
+| <a name="input_tag"></a> [tag](#input\_tag) | The docker image tag to deploy. The image must exist in fleetdm/fleet docker repository | `any` | n/a | yes |
 
 ## Outputs
 

--- a/infrastructure/loadtesting/terraform/osquery_perf/docker.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/docker.tf
@@ -14,8 +14,8 @@ resource "docker_registry_image" "loadtest" {
 }
 
 resource "docker_image" "loadtest" {
-  name          = "${data.aws_ecr_repository.fleet.repository_url}:loadtest-${local.loadtest_tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
-  keep_locally  = true
+  name         = "${data.aws_ecr_repository.fleet.repository_url}:loadtest-${local.loadtest_tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
+  keep_locally = true
   build {
     context    = "../docker/"
     dockerfile = "loadtest.Dockerfile"

--- a/infrastructure/loadtesting/terraform/osquery_perf/docker.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/docker.tf
@@ -9,9 +9,13 @@ data "aws_ecr_repository" "fleet" {
 }
 
 resource "docker_registry_image" "loadtest" {
-  name          = "${data.aws_ecr_repository.fleet.repository_url}:loadtest-${local.loadtest_tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
+  name          = docker_image.loadtest.name
   keep_remotely = true
+}
 
+resource "docker_image" "loadtest" {
+  name          = "${data.aws_ecr_repository.fleet.repository_url}:loadtest-${local.loadtest_tag}-${split(":", data.docker_registry_image.dockerhub.sha256_digest)[1]}"
+  keep_locally  = true
   build {
     context    = "../docker/"
     dockerfile = "loadtest.Dockerfile"

--- a/infrastructure/loadtesting/terraform/osquery_perf/providers.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/providers.tf
@@ -6,7 +6,7 @@ terraform {
     }
     docker = {
       source  = "kreuzwerker/docker"
-      version = "~> 2.16.0"
+      version = "~> 3.6.0"
     }
     git = {
       source  = "metio/git"

--- a/infrastructure/loadtesting/terraform/osquery_perf/variables.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/variables.tf
@@ -1,7 +1,5 @@
 variable "tag" {
-  description = "The tag to deploy. This would be the same as the branch name"
-  type        = string
-  default     = ""
+  description = "The docker image tag to deploy. The image must exist in fleetdm/fleet docker repository"
 }
 
 variable "git_branch" {


### PR DESCRIPTION
- Bumps docker provider from 2.16.0 to 3.6.x
- Moves builds from `docker_registry_image` to new `docker_image` resource