### PR TITLE
Update script and profile uploaders

### DIFF
--- a/frontend/components/FileUploader/index.ts
+++ b/frontend/components/FileUploader/index.ts
@@ -1,1 +1,1 @@
-export { default } from "./FileUploader";
+export { default, ISupportedGraphicNames } from "./FileUploader";

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileCard/AddProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileCard/AddProfileCard.tsx
@@ -16,7 +16,7 @@ const AddProfileCard = ({ setShowModal }: IAddProfileCardProps) => (
     <div className={`${baseClass}__card--content-wrap`}>
       <ProfileGraphic
         baseClass={baseClass}
-        title="Update configuration profile"
+        title="Upload configuration profile"
         message={
           <>
             .mobileconfig and .json for macOS, iOS, and iPadOS.

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ProfileUploader/components/AddProfileModal/AddProfileModal.tsx
@@ -43,7 +43,7 @@ const FileChooser = ({ isLoading, onFileOpen }: IFileChooserProps) => (
   <div className={`${baseClass}__file-chooser`}>
     <ProfileGraphic
       baseClass={baseClass}
-      title="Update configuration profile"
+      title="Upload configuration profile"
       message={
         <>
           .mobileconfig and .json for macOS, iOS, and iPadOS.

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptUploader/ScriptUploader.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptUploader/ScriptUploader.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 
-import FileUploader from "components/FileUploader";
+import FileUploader, { ISupportedGraphicNames } from "components/FileUploader";
 import { getFileDetails } from "utilities/file/fileUtils";
 
 const baseClass = "script-uploader";
@@ -27,12 +27,22 @@ const ScriptPackageUploader = ({
   const buttonType = forModal ? "brand-inverse-icon" : undefined;
   const buttonMessage = forModal ? "Choose file" : "Add script";
   const extension = selectedFile?.name.match(/(sh|ps1)$/i)?.[1];
-  const graphicName = extension === "ps1" ? "file-ps1" : "file-sh";
+  let graphicName: ISupportedGraphicNames[];
+  switch (extension) {
+    case "ps1":
+      graphicName = ["file-ps1"];
+      break;
+    case "sh":
+      graphicName = ["file-sh"];
+      break;
+    default:
+      graphicName = ["file-sh", "file-ps1"];
+  }
 
   return (
     <FileUploader
       className={baseClass}
-      graphicName={[graphicName]}
+      graphicName={graphicName}
       message="Shell (.sh) for macOS and Linux or PowerShell (.ps1) for Windows"
       title="Upload script"
       accept=".sh,.ps1"

--- a/frontend/pages/ManageControlsPage/Scripts/components/ScriptUploader/ScriptUploader.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/ScriptUploader/ScriptUploader.tsx
@@ -26,11 +26,13 @@ const ScriptPackageUploader = ({
 
   const buttonType = forModal ? "brand-inverse-icon" : undefined;
   const buttonMessage = forModal ? "Choose file" : "Add script";
+  const extension = selectedFile?.name.match(/(sh|ps1)$/i)?.[1];
+  const graphicName = extension === "ps1" ? "file-ps1" : "file-sh";
 
   return (
     <FileUploader
       className={baseClass}
-      graphicName={["file-sh", "file-ps1"]}
+      graphicName={[graphicName]}
       message="Shell (.sh) for macOS and Linux or PowerShell (.ps1) for Windows"
       title="Upload script"
       accept=".sh,.ps1"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32632 

# Details

Resolves a couple of issues caught in QA:

1. Script uploader now shows correct icon in empty state, *nix shell script uploaded and Powershell script uploaded:
<img width="640" alt="image" src="https://github.com/user-attachments/assets/7467d596-f3f9-43a3-9bfc-bb08d56e2c2b" />
<img width="640" height="360" alt="image" src="https://github.com/user-attachments/assets/6d148672-38a5-49d1-b0ca-cb9e5d992b81" />
<img width="640" height="314" alt="image" src="https://github.com/user-attachments/assets/b4dc3069-f54d-40d1-b7ef-3d1afc1a2e21" />

2. Updated title text for profile upload from "Update configuration profile" to "Upload configuration profile"
<img width="640" height="275" alt="image" src="https://github.com/user-attachments/assets/3daead86-3b40-415a-8472-6895402840bd" />
<img width="640" height="579" alt="image" src="https://github.com/user-attachments/assets/40583c0f-83a6-4800-be21-f9e6fd5304d3" />




# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
