### PR TITLE
Make sure find (no duplicates) keeps sorted order -> 4.76

### DIFF
--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -240,7 +240,7 @@ func validateDigicertCACN(cn string, errPrefix string) error {
 		return fleet.NewInvalidArgumentError("certificate_common_name", fmt.Sprintf("%sCA Common Name (CN) cannot be empty", errPrefix))
 	}
 	fleetVars := variables.Find(cn)
-	for fleetVar := range fleetVars {
+	for _, fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):
 			// ok
@@ -262,7 +262,7 @@ func validateDigicertSeatID(seatID string, errPrefix string) error {
 		return fleet.NewInvalidArgumentError("certificate_seat_id", fmt.Sprintf("%sCA Seat ID cannot be empty", errPrefix))
 	}
 	fleetVars := variables.Find(seatID)
-	for fleetVar := range fleetVars {
+	for _, fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):
 			// ok
@@ -286,7 +286,7 @@ func validateDigicertUserPrincipalNames(userPrincipalNames []string, errPrefix s
 			fmt.Sprintf("%sDigiCert certificate_user_principal_name cannot be empty if specified", errPrefix))
 	}
 	fleetVars := variables.Find(userPrincipalNames[0])
-	for fleetVar := range fleetVars {
+	for _, fleetVar := range fleetVars {
 		switch fleetVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP), string(fleet.FleetVarHostHardwareSerial):
 			// ok

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -306,7 +306,7 @@ func PreprocessWindowsProfileContents(hostUUID string, profileContents string) s
 
 	// Process each Fleet variable
 	result := profileContents
-	for fleetVar := range fleetVars {
+	for _, fleetVar := range fleetVars {
 		if fleetVar == string(fleet.FleetVarHostUUID) {
 			// Replace HOST_UUID with the actual host UUID
 			// Use XML escaping for the replacement value to be safe and prevent XML injection

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -456,7 +456,7 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 
 	// Convert profile variable names to FleetVarName type
 	varNames := make([]fleet.FleetVarName, 0, len(profileVars))
-	for varName := range profileVars {
+	for _, varName := range profileVars {
 		varNames = append(varNames, fleet.FleetVarName(varName))
 	}
 	newCP, err := svc.ds.NewMDMAppleConfigProfile(ctx, *cp, varNames)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -512,7 +512,7 @@ func CheckProfileIsNotSigned(data []byte) error {
 	return nil
 }
 
-func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo, groupedCAs *fleet.GroupedCertificateAuthorities) (map[string]struct{}, error) {
+func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo, groupedCAs *fleet.GroupedCertificateAuthorities) ([]string, error) {
 	fleetVars := variables.FindKeepDuplicates(contents)
 	if len(fleetVars) == 0 {
 		return nil, nil
@@ -673,12 +673,8 @@ func validateConfigProfileFleetVariables(contents string, lic *fleet.LicenseInfo
 			return nil, err
 		}
 	}
-	// Convert slice to map for deduplication
-	result := make(map[string]struct{}, len(fleetVars))
-	for _, v := range fleetVars {
-		result[v] = struct{}{}
-	}
-	return result, nil
+
+	return variables.Dedupe(fleetVars), nil
 }
 
 // additionalDigiCertValidation checks that Password/ContentType fields match DigiCert Fleet variables exactly,
@@ -5097,7 +5093,7 @@ func preprocessProfileContents(
 		// validation works as expected
 		// In the future we should expand variablesUpdatedAt logic to include non-CA variables as
 		// well
-		for fleetVar := range fleetVars {
+		for _, fleetVar := range fleetVars {
 			if fleetVar == string(fleet.FleetVarSCEPRenewalID) ||
 				fleetVar == string(fleet.FleetVarNDESSCEPChallenge) || fleetVar == string(fleet.FleetVarNDESSCEPProxyURL) ||
 				strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPChallengePrefix)) || strings.HasPrefix(fleetVar, string(fleet.FleetVarSmallstepSCEPProxyURLPrefix)) ||
@@ -5110,7 +5106,7 @@ func preprocessProfileContents(
 		}
 
 	initialFleetVarLoop:
-		for fleetVar := range fleetVars {
+		for _, fleetVar := range fleetVars {
 			switch {
 			case fleetVar == string(fleet.FleetVarNDESSCEPChallenge) || fleetVar == string(fleet.FleetVarNDESSCEPProxyURL):
 				configured, err := isNDESSCEPConfigured(ctx, groupedCAs, ds, hostProfilesToInstallMap, userEnrollmentsToHostUUIDsMap, profUUID, target)
@@ -5231,7 +5227,7 @@ func preprocessProfileContents(
 			hostContents := contentsStr
 			failed := false
 		fleetVarLoop:
-			for fleetVar := range fleetVars {
+			for _, fleetVar := range fleetVars {
 				var err error
 				switch {
 				case fleetVar == string(fleet.FleetVarNDESSCEPChallenge):
@@ -5563,7 +5559,7 @@ func preprocessProfileContents(
 func replaceFleetVarInItem(ctx context.Context, ds fleet.Datastore, target *cmdTarget, hostUUID string, caVarsCache map[string]string, item *string,
 ) (bool, error) {
 	caFleetVars := variables.Find(*item)
-	for caVar := range caFleetVars {
+	for _, caVar := range caFleetVars {
 		switch caVar {
 		case string(fleet.FleetVarHostEndUserEmailIDP):
 			email, ok := caVarsCache[string(fleet.FleetVarHostEndUserEmailIDP)]

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -5848,10 +5848,7 @@ func TestValidateConfigProfileFleetVariables(t *testing.T) {
 				assert.Empty(t, vars)
 			} else {
 				assert.NoError(t, err)
-				gotVars := make([]string, 0, len(vars))
-				for v := range vars {
-					gotVars = append(gotVars, v)
-				}
+				gotVars := vars
 				assert.ElementsMatch(t, tc.vars, gotVars)
 			}
 		})

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1812,7 +1812,7 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 	}
 
 	// Check if all found variables are supported
-	for varName := range foundVars {
+	for _, varName := range foundVars {
 		if !slices.Contains(fleetVarsSupportedInWindowsProfiles, fleet.FleetVarName(varName)) {
 			return nil, fleet.NewInvalidArgumentError("profile", fmt.Sprintf("Fleet variable $FLEET_VAR_%s is not supported in Windows profiles.", varName))
 		}
@@ -2081,7 +2081,7 @@ func (svc *Service) BatchSetMDMProfiles(
 	profilesVariablesByIdentifier := make([]fleet.MDMProfileIdentifierFleetVariables, 0, len(profilesVariablesByIdentifierMap))
 	for identifier, variables := range profilesVariablesByIdentifierMap {
 		varNames := make([]fleet.FleetVarName, 0, len(variables))
-		for varName := range variables {
+		for _, varName := range variables {
 			varNames = append(varNames, fleet.FleetVarName(varName))
 		}
 		profilesVariablesByIdentifier = append(profilesVariablesByIdentifier, fleet.MDMProfileIdentifierFleetVariables{

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1756,7 +1756,7 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 
 	// Collect Fleet variables used in the profile
 	var usesFleetVars []fleet.FleetVarName
-	for varName := range foundVars {
+	for _, varName := range foundVars {
 		usesFleetVars = append(usesFleetVars, fleet.FleetVarName(varName))
 	}
 
@@ -1800,7 +1800,7 @@ var fleetVarsSupportedInWindowsProfiles = []fleet.FleetVarName{
 	fleet.FleetVarHostUUID,
 }
 
-func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInfo) (map[string]struct{}, error) {
+func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInfo) ([]string, error) {
 	foundVars := variables.Find(contents)
 	if len(foundVars) == 0 {
 		return nil, nil
@@ -2207,7 +2207,7 @@ func (svc *Service) BatchSetMDMProfiles(
 
 func validateFleetVariables(ctx context.Context, ds fleet.Datastore, appConfig *fleet.AppConfig, lic *fleet.LicenseInfo, appleProfiles map[int]*fleet.MDMAppleConfigProfile,
 	windowsProfiles map[int]*fleet.MDMWindowsConfigProfile, appleDecls map[int]*fleet.MDMAppleDeclaration,
-) (map[string]map[string]struct{}, error) {
+) (map[string][]string, error) {
 	var err error
 
 	groupedCAs, err := ds.GetGroupedCertificateAuthorities(ctx, true)
@@ -2215,7 +2215,7 @@ func validateFleetVariables(ctx context.Context, ds fleet.Datastore, appConfig *
 		return nil, ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
-	profileVarsByProfIdentifier := make(map[string]map[string]struct{})
+	profileVarsByProfIdentifier := make(map[string][]string)
 	for _, p := range appleProfiles {
 		profileVars, err := validateConfigProfileFleetVariables(string(p.Mobileconfig), lic, groupedCAs)
 		if err != nil {

--- a/server/variables/variables_test.go
+++ b/server/variables/variables_test.go
@@ -10,7 +10,7 @@ func TestFind(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
-		expected map[string]struct{}
+		expected []string
 	}{
 		{
 			name:     "no variables",
@@ -20,45 +20,45 @@ func TestFind(t *testing.T) {
 		{
 			name:    "single variable without braces",
 			content: "Device ID: $FLEET_VAR_HOST_UUID",
-			expected: map[string]struct{}{
-				"HOST_UUID": {},
+			expected: []string{
+				"HOST_UUID",
 			},
 		},
 		{
 			name:    "single variable with braces",
 			content: "Device ID: ${FLEET_VAR_HOST_UUID}",
-			expected: map[string]struct{}{
-				"HOST_UUID": {},
+			expected: []string{
+				"HOST_UUID",
 			},
 		},
 		{
 			name:    "multiple different variables",
 			content: "Host: $FLEET_VAR_HOST_UUID, Email: ${FLEET_VAR_HOST_EMAIL}, Serial: $FLEET_VAR_HOST_SERIAL",
-			expected: map[string]struct{}{
-				"HOST_UUID":   {},
-				"HOST_EMAIL":  {},
-				"HOST_SERIAL": {},
+			expected: []string{
+				"HOST_SERIAL",
+				"HOST_EMAIL",
+				"HOST_UUID",
 			},
 		},
 		{
 			name:    "duplicate variables",
 			content: "ID1: $FLEET_VAR_HOST_UUID, ID2: ${FLEET_VAR_HOST_UUID}, ID3: $FLEET_VAR_HOST_UUID",
-			expected: map[string]struct{}{
-				"HOST_UUID": {},
+			expected: []string{
+				"HOST_UUID",
 			},
 		},
 		{
 			name:    "variables in XML content",
 			content: `<Replace><Data>Device: $FLEET_VAR_HOST_UUID</Data></Replace>`,
-			expected: map[string]struct{}{
-				"HOST_UUID": {},
+			expected: []string{
+				"HOST_UUID",
 			},
 		},
 		{
 			name:    "mixed case sensitivity",
 			content: "Valid: $FLEET_VAR_HOST_UUID, Invalid: $fleet_var_host_uuid",
-			expected: map[string]struct{}{
-				"HOST_UUID": {},
+			expected: []string{
+				"HOST_UUID",
 			},
 		},
 	}


### PR DESCRIPTION
This PR _cherry picks_ (by recreating **some** of the work) done in #34707, where I caught variables not ordered correctly after first fix attempt.

This PR brings that change into 4.76