### PR TITLE
Bugfix for 4.76.0: make software title status counts consistent with reported host status

### DIFF
--- a/changes/31083-fix-inconsistent-software-title-status-counts
+++ b/changes/31083-fix-inconsistent-software-title-status-counts
@@ -1,0 +1,1 @@
+* Fixed the software title counts by status to be consistent with the status reported in the host's software list and filter by status.

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -182,12 +182,15 @@ upcoming AS (
 ),
 
 -- select most recent past activities for each host
+-- NOTE if you change this logic make sure to change vppAppHostStatusNamedQuery accordingly
 past AS (
 	SELECT
 		hvsi.host_id,
 		CASE
-			WHEN ncr.status = :mdm_status_acknowledged THEN
+			WHEN hvsi.verification_at IS NOT NULL THEN
 				:software_status_installed
+			WHEN hvsi.verification_failed_at IS NOT NULL THEN
+				:software_status_failed
 			WHEN ncr.status = :mdm_status_error OR ncr.status = :mdm_status_format_error THEN
 				:software_status_failed
 			ELSE
@@ -277,6 +280,8 @@ func vppAppHostStatusNamedQuery(hvsiAlias, ncrAlias, colAlias string) string {
 		colAlias = " AS " + colAlias
 	}
 
+	// NOTE: if you change this logic, make sure to also change
+	// GetSummaryHostVPPAppInstalls accordingly.
 	return fmt.Sprintf(`
 	CASE
 		WHEN %sverification_at IS NOT NULL THEN

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -193,6 +193,8 @@ past AS (
 				:software_status_failed
 			WHEN ncr.status = :mdm_status_error OR ncr.status = :mdm_status_format_error THEN
 				:software_status_failed
+			WHEN ncr.status = :mdm_status_acknowledged THEN
+				:software_status_pending
 			ELSE
 				NULL -- either pending or not installed via VPP App
 		END AS status


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For the bug found while trying to repro https://github.com/fleetdm/fleet/issues/31083#issuecomment-3461597355 (see the last comment before the list of recordings)

See bug in https://drive.google.com/file/d/1fL9L4VxS8QKjFBhr9pKEfBWZPxpbMkOw/view?usp=drive_link (starting at 3:25), and the bug fix:

<img width="1646" height="800" alt="image" src="https://github.com/user-attachments/assets/ed82024b-ebe4-4d9c-9877-ff20bc43f131" />

Clicking on "failed" correctly shows the matching host in the filtered list.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

