### PR TITLE
Fleet UI: Show run/running for setup experience software scripts

### DIFF
--- a/frontend/interfaces/setup.ts
+++ b/frontend/interfaces/setup.ts
@@ -1,3 +1,5 @@
+import { SoftwareSource } from "./software";
+
 export const SETUP_STEP_STATUSES = [
   "pending",
   "running",
@@ -22,5 +24,5 @@ export interface ISetupStep {
   status: SetupStepStatus;
   type: SetupStepType;
   error?: string | null;
-  source?: string; // Software source (e.g., "sh_packages", "ps1_packages", "apps")
+  source?: SoftwareSource; // Software source (e.g., "sh_packages", "ps1_packages", "apps")
 }

--- a/frontend/interfaces/setup.ts
+++ b/frontend/interfaces/setup.ts
@@ -11,7 +11,7 @@ export type SetupStepStatus = typeof SETUP_STEP_STATUSES[number];
 /** These type extends onto API returned software steps */
 export const SETUP_STEP_TYPES = [
   "software_install", // API key: software
-  "software_script_run", // API key: software, key: name ending in .sh or .ps1 for now
+  "software_script_run", // API key: software, detected via source === "sh_packages" || "ps1_packages"
   "script_run", // API key: scripts
 ];
 
@@ -22,4 +22,5 @@ export interface ISetupStep {
   status: SetupStepStatus;
   type: SetupStepType;
   error?: string | null;
+  source?: string; // Software source (e.g., "sh_packages", "ps1_packages", "apps")
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SetupStatusTable/SetupStatusTableConfig.tsx
@@ -19,10 +19,10 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
     disableSortBy: true,
     Cell: (cellProps: ITableCellProps) => {
       const { name, type } = cellProps.row.original;
-      if (type === "software_install" || type === "software_script_run") {
+      if (type === "software_install") {
         return <SetupSoftwareProcessCell name={name || "Unknown software"} />;
       }
-      if (type === "script_run") {
+      if (type === "script_run" || type === "software_script_run") {
         return <SetupScriptProcessCell name={name || "Unknown script"} />;
       }
       return null;
@@ -34,10 +34,10 @@ const generateColumnConfigs = (): ISetupStatusTableConfig[] => [
     disableSortBy: true,
     Cell: (cellProps: ITableCellProps) => {
       const { status, type } = cellProps.row.original;
-      if (type === "software_install" || type === "software_script_run") {
+      if (type === "software_install") {
         return <SetupSoftwareStatusCell status={status || "pending"} />;
       }
-      if (type === "script_run") {
+      if (type === "script_run" || type === "software_script_run") {
         return <SetupScriptStatusCell status={status || "pending"} />;
       }
       return null;

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -39,11 +39,10 @@ export const getFailedSoftwareInstall = (
   return firstWithError ?? failedSoftware[0];
 };
 
-/** Checks if name value ends with .sh or .ps1 as
- * there's no other key to identify payload-free software
- * Update if/when API adds better identifier */
+/** Checks if the software is a payload-free script package (sh or ps1)
+ * by examining the source field from the API */
 export const isSoftwareScriptSetup = (s: ISetupStep) => {
-  if (!s.name) return false;
+  if (!s.source) return false;
 
-  return s.name.endsWith(".sh") || s.name.endsWith(".ps1");
+  return s.source === "sh_packages" || s.source === "ps1_packages";
 };

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -453,6 +453,10 @@ SELECT
 	NULLIF(va.platform, '') AS vpp_app_platform,
 	ses.script_content_id,
 	COALESCE(si.title_id, COALESCE(va.title_id, NULL)) AS software_title_id,
+	COALESCE(
+		(SELECT source FROM software_titles WHERE id = si.title_id),
+		(SELECT source FROM software_titles WHERE id = va.title_id)
+	) AS source,
     CASE
         WHEN hsi.execution_status = 'failed_install' THEN
             CASE

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -942,7 +942,16 @@ func testSetupExperienceStatusResults(t *testing.T, ds *Datastore) {
 	// We need a new user first
 	user, err := ds.NewUser(ctx, &fleet.User{Name: "Foo", Email: "foo@example.com", GlobalRole: ptr.String("admin"), Password: []byte("12characterslong!")})
 	require.NoError(t, err)
-	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{Filename: "test.app", Version: "1.0.0", UserID: user.ID, ValidatedLabels: &fleet.LabelIdentsWithScope{}})
+	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Filename:        "test.pkg",
+		Title:           "Test Software",
+		Version:         "1.0.0",
+		Source:          "apps",
+		Platform:        "darwin",
+		Extension:       "pkg",
+		UserID:          user.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
 	require.NoError(t, err)
 	installer, err := ds.GetSoftwareInstallerMetadataByID(ctx, installerID)
 	require.NoError(t, err)
@@ -991,10 +1000,11 @@ func testSetupExperienceStatusResults(t *testing.T, ds *Datastore) {
 	expRes := []*fleet.SetupExperienceStatusResult{
 		{
 			HostUUID:            hostUUID,
-			Name:                "software",
+			Name:                "Test Software",
 			Status:              fleet.SetupExperienceStatusPending,
 			SoftwareInstallerID: ptr.Uint(installerID),
 			SoftwareTitleID:     installer.TitleID,
+			Source:              ptr.String("apps"),
 		},
 		{
 			HostUUID:        hostUUID,
@@ -1002,12 +1012,14 @@ func testSetupExperienceStatusResults(t *testing.T, ds *Datastore) {
 			Status:          fleet.SetupExperienceStatusPending,
 			VPPAppTeamID:    ptr.Uint(vppAppsTeamsID),
 			SoftwareTitleID: ptr.Uint(vppApp.TitleID),
+			Source:          ptr.String("apps"),
 		},
 		{
 			HostUUID:                hostUUID,
 			Name:                    "script",
 			Status:                  fleet.SetupExperienceStatusPending,
 			SetupExperienceScriptID: ptr.Uint(scriptID),
+			Source:                  nil, // Scripts don't have a source (no software title)
 		},
 	}
 

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -53,6 +53,10 @@ type SetupExperienceStatusResult struct {
 	Error                           *string                           `db:"error" json:"error" `
 	// SoftwareTitleID must be filled through a JOIN
 	SoftwareTitleID *uint `json:"software_title_id,omitempty" db:"software_title_id"`
+	// Source must be filled through a JOIN. It indicates the source of the software
+	// (e.g., "sh_packages", "ps1_packages", "apps", etc.) and is used by the frontend
+	// to determine appropriate UI display (e.g., "Run" vs "Install" verbs).
+	Source *string `json:"source,omitempty" db:"source"`
 }
 
 func (s *SetupExperienceStatusResult) IsValid() error {


### PR DESCRIPTION
## Issue
Closes #34934

## Description
- Show run/running instead for software install scripts (.sh and .ps1) 

- [ ] Confirm API that this code relies on