### PR TITLE
Website: Update enrichment helper queries when organization is provided.

### DIFF
--- a/website/api/helpers/iq/get-enriched.js
+++ b/website/api/helpers/iq/get-enriched.js
@@ -208,7 +208,6 @@ module.exports = {
           dis_max: {// eslint-disable-line camelcase
             queries: [
               { match_phrase: { name: { query: organization } } },// eslint-disable-line camelcase
-              { match: { name: { query: organization, operator: 'and', fuzziness: 'AUTO' } } }
             ]
           }
         });


### PR DESCRIPTION
Changes:
- Updated the get-enriched helper to only send a single query for organization name (if `organization` is provided).