### PR TITLE
Return a 404 for device not found instead of 5XX

### DIFF
--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -23,7 +23,8 @@ module.exports = {
     success: { description: 'The device of an Android enterprise was successfully retrieved.' },
     missingAuthHeader: { description: 'This request was missing an authorization header.', responseType: 'unauthorized'},
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
-    notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound'},
+    notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
+    deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
   },
 
 
@@ -81,6 +82,10 @@ module.exports = {
       });
       return getDeviceResult.data;
     }).intercept((err) => {
+      let errorString = err.toString();
+      if (errorString.includes('Device is no longer being managed')) {
+        return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};
+      }
       return new Error(`When attempting to get a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     });
 


### PR DESCRIPTION
Haven't fully QA'd as I am not sure how to repro locally(when I test the pubsub arrives before we ever run the reconciler) however this should cause 4xx to be returned from the website instead of 5xx for android unenrolled. We use the exact same code on a different endpoint

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34988 partially. This just helps reduce alerts to help-p1 and implements the interface that the server is expecting
