### PR TITLE
Adding DataGrip as FMA

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/datagrip.json
+++ b/ee/maintained-apps/inputs/homebrew/datagrip.json
@@ -1,0 +1,8 @@
+{
+  "name": "DataGrip",
+  "slug": "datagrip/darwin",
+  "unique_identifier": "com.jetbrains.datagrip",
+  "token": "datagrip",
+  "installer_format": "dmg",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -86,6 +86,13 @@
       "description": "Cursor AI boosts your coding productivity by giving smart, context-aware code suggestions, quick explanations, and easy refactors — all inside your editor."
     },
     {
+      "name": "DataGrip",
+      "slug": "datagrip/darwin",
+      "platform": "darwin",
+      "unique_identifier": "com.jetbrains.datagrip",
+      "description": "DataGrip by JetBrains is an IDE for databases. It is designed to work with databases installed locally, on a server, or in the cloud."
+    },
+    {
       "name": "Amazon DCV",
       "slug": "dcv-viewer/darwin",
       "platform": "darwin",
@@ -258,7 +265,7 @@
       "slug": "yubico-yubikey-manager/darwin",
       "platform": "darwin",
       "unique_identifier": "com.yubico.ykman",
-      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: <a target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\">https://www.yubico.com/support/download/yubikey-manager</a>"
+      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: \u003ca target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\"\u003ehttps://www.yubico.com/support/download/yubikey-manager\u003c/a\u003e"
     },
     {
       "name": "Zoom",

--- a/ee/maintained-apps/outputs/datagrip/darwin.json
+++ b/ee/maintained-apps/outputs/datagrip/darwin.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "2025.2.4",
+      "queries": {
+        "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.datagrip';"
+      },
+      "installer_url": "https://download.jetbrains.com/datagrip/datagrip-2025.2.4-aarch64.dmg",
+      "install_script_ref": "77aafb38",
+      "uninstall_script_ref": "bdf3b6cd",
+      "sha256": "13d41b91c0194078afed78974f5023a793822c46609e6273dfacd831bebecc83",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "77aafb38": "#!/bin/sh\n\n# variables\nAPPDIR=\"/Applications/\"\nTMPDIR=$(dirname \"$(realpath $INSTALLER_PATH)\")\n# functions\n\nquit_application() {\n  local bundle_id=\"$1\"\n  local timeout_duration=10\n\n  # check if the application is running\n  if ! osascript -e \"application id \\\"$bundle_id\\\" is running\" 2\u003e/dev/null; then\n    return\n  fi\n\n  local console_user\n  console_user=$(stat -f \"%Su\" /dev/console)\n  if [[ $EUID -eq 0 \u0026\u0026 \"$console_user\" == \"root\" ]]; then\n    echo \"Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'.\"\n    return\n  fi\n\n  echo \"Quitting application '$bundle_id'...\"\n\n  # try to quit the application within the timeout period\n  local quit_success=false\n  SECONDS=0\n  while (( SECONDS \u003c timeout_duration )); do\n    if osascript -e \"tell application id \\\"$bundle_id\\\" to quit\" \u003e/dev/null 2\u003e\u00261; then\n      if ! pgrep -f \"$bundle_id\" \u003e/dev/null 2\u003e\u00261; then\n        echo \"Application '$bundle_id' quit successfully.\"\n        quit_success=true\n        break\n      fi\n    fi\n    sleep 1\n  done\n\n  if [[ \"$quit_success\" = false ]]; then\n    echo \"Application '$bundle_id' did not quit.\"\n  fi\n}\n\n\n# extract contents\nMOUNT_POINT=$(mktemp -d /tmp/dmg_mount_XXXXXX)\nhdiutil attach -plist -nobrowse -readonly -mountpoint \"$MOUNT_POINT\" \"$INSTALLER_PATH\"\nsudo cp -R \"$MOUNT_POINT\"/* \"$TMPDIR\"\nhdiutil detach \"$MOUNT_POINT\"\n# copy to the applications folder\nquit_application 'com.jetbrains.datagrip'\nif [ -d \"$APPDIR/DataGrip.app\" ]; then\n\tsudo mv \"$APPDIR/DataGrip.app\" \"$TMPDIR/DataGrip.app.bkp\"\nfi\nsudo cp -R \"$TMPDIR/DataGrip.app\" \"$APPDIR\"\n",
+    "bdf3b6cd": "#!/bin/sh\n\n# variables\nAPPDIR=\"/Applications/\"\nLOGGED_IN_USER=$(scutil \u003c\u003c\u003c \"show State:/Users/ConsoleUser\" | awk '/Name :/ { print $3 }')\n# functions\n\ntrash() {\n  local logged_in_user=\"$1\"\n  local target_file=\"$2\"\n  local timestamp=\"$(date +%Y-%m-%d-%s)\"\n  local rand=\"$(jot -r 1 0 99999)\"\n\n  # replace ~ with /Users/$logged_in_user\n  if [[ \"$target_file\" == ~* ]]; then\n    target_file=\"/Users/$logged_in_user${target_file:1}\"\n  fi\n\n  local trash=\"/Users/$logged_in_user/.Trash\"\n  local file_name=\"$(basename \"${target_file}\")\"\n\n  if [[ -e \"$target_file\" ]]; then\n    echo \"removing $target_file.\"\n    mv -f \"$target_file\" \"$trash/${file_name}_${timestamp}_${rand}\"\n  else\n    echo \"$target_file doesn't exist.\"\n  fi\n}\n\nsudo rm -rf \"$APPDIR/DataGrip.app\"\nsudo rm -rf 'datagrip'\ntrash $LOGGED_IN_USER '~/Library/Application Support/JetBrains/DataGrip*'\ntrash $LOGGED_IN_USER '~/Library/Caches/JetBrains/DataGrip*'\ntrash $LOGGED_IN_USER '~/Library/Logs/JetBrains/DataGrip*'\ntrash $LOGGED_IN_USER '~/Library/Saved Application State/com.jetbrains.datagrip.savedState'\n"
+  }
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35002 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
