### PR TITLE
[Guide updates] Setup experience: Install software when employee-owned iOS/iPadOS hosts enroll

### DIFF
--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -161,14 +161,33 @@ To replace the Fleet logo with your organization's logo:
 
 ### Install software
 
-To configure software to be installed during setup experience:
+You can install software during first time macOS, iOS, iPadOS and [Windows and Linux setup](https://fleetdm.com/guides/windows-linux-setup-experience). Android support is coming soon.
+
+For macOS, Windows, and Linux hosts, software installs are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. When Fleet retries, IT admins can see error messages for all attempts in the **Host details > Activity** card. The end user only sees an error message if the third, and final, attempt fails.
+
+Retries only happen for custom packages and Fleet-maintained apps. For App Store (VPP) apps, the MDM command to install the app is sent once and either succeeds or fails. If it fails, the app won’t install no matter how many times Fleet resends the command.
+
+Currently, for macOS hosts, software is only installed on hosts that automatically enroll to Fleet via Apple Business Manager (ABM). For iOS and iPadOS hosts, software is only installed on hosts that enroll via ABM and hosts that manually enroll via the `/enroll` link (profile-based device enrollment).
+
+Add setup experience software:
 
 1. Click on the **Controls** tab in the main navigation bar,  then **Setup experience** > **4. Install software**.
 
 2. Click **Add software**, then select or search for the software you want installed during the setup experience.
 3. Press **Save** to save your selection.
 
-> Software installations during setup experience are automatically attempted up to 3 times (1 initial attempt + 2 retries) to handle intermittent network issues or temporary failures. This ensures a more reliable setup process for end users. 
+To see the end user experience on iOS/iPadOS, check out the [iOS video](https://www.youtube.com/shorts/_XXNGrQPqys) and [iPadOS video](https://www.youtube.com/shorts/IIzo4NyUolM).
+#### Blocking setup on failed software installs
+
+You may additionally configure the setup experience to halt immediately if any software item fails to install. To enable this feature:
+
+1. Click **Show advanced options** on the Install Software screen.
+2. Check the "Cancel setup if software install fails" checkbox.
+3. Press **Save**. 
+
+When this feature is enabled, any failed software will immediately end the setup experience and display a screen similar to this one, allowing the user to view details of the failure for troubleshooting purposes:
+
+![screen shot of Fleet setup experience failed view](../website/assets/images/articles/setup-experience-failed-470x245@2x.png)
 
 ### Run script
 

--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -177,13 +177,14 @@ Add setup experience software:
 3. Press **Save** to save your selection.
 
 To see the end user experience on iOS/iPadOS, check out the [iOS video](https://www.youtube.com/shorts/_XXNGrQPqys) and [iPadOS video](https://www.youtube.com/shorts/IIzo4NyUolM).
-#### Blocking setup on failed software installs
 
-You may additionally configure the setup experience to halt immediately if any software item fails to install. To enable this feature:
+#### Stop setup on failed software installs
 
-1. Click **Show advanced options** on the Install Software screen.
-2. Check the "Cancel setup if software install fails" checkbox.
-3. Press **Save**. 
+For macOS hosts, you can configure the setup experience to stop if any software item fails to install:
+
+1. In **Controls > Setup experience > Install software > macOS**, select **Show advanced options**.
+2. Check the **Cancel setup if software install fails** checkbox.
+3. Select **Save**. 
 
 When this feature is enabled, any failed software will immediately end the setup experience and display a screen similar to this one, allowing the user to view details of the failure for troubleshooting purposes:
 


### PR DESCRIPTION
Guide updates for the following user story: 
- https://github.com/fleetdm/fleet/issues/34042

@noahtalerman: This PR includes changes from `v4.76.0-docs` branch. Yet to be pulled into `docs-v4.78.0`
