### PR TITLE
Cherry-pick: Fleet UI: Update osquery version options

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -86,6 +86,7 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.20.0 +", value: "5.20.0" },
   { label: "5.19.0 +", value: "5.19.0" },
   { label: "5.18.1 +", value: "5.18.1" },
   { label: "5.18.0 +", value: "5.18.0" },


### PR DESCRIPTION
Merged into `main` in #34723.