### PR TITLE
Fleet UI: Host details activity script package uses correct modal

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
@@ -193,7 +193,7 @@ interface ISoftwareInstallDetailsProps {
   contactUrl?: string; // My Device Page only
 }
 
-export const SoftwareInstallDetailsModal = ({
+export const SoftwareScriptDetailsModal = ({
   details: detailsFromProps,
   onCancel,
   hostSoftware,
@@ -341,4 +341,4 @@ export const SoftwareInstallDetailsModal = ({
   );
 };
 
-export default SoftwareInstallDetailsModal;
+export default SoftwareScriptDetailsModal;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -34,6 +34,7 @@ import { IQueryStats } from "interfaces/query_stats";
 import {
   IHostSoftware,
   resolveUninstallStatus,
+  SCRIPT_PACKAGE_SOURCES,
   SoftwareInstallUninstallStatus,
 } from "interfaces/software";
 import { ITeam } from "interfaces/team";
@@ -78,6 +79,7 @@ import {
   SoftwareInstallDetailsModal,
   IPackageInstallDetails,
 } from "components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal";
+import { SoftwareScriptDetailsModal } from "components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal";
 import {
   SoftwareIpaInstallDetailsModal,
   ISoftwareIpaInstallDetails,
@@ -225,6 +227,10 @@ const HostDetailsPage = ({
   const [
     packageInstallDetails,
     setPackageInstallDetails,
+  ] = useState<IPackageInstallDetails | null>(null);
+  const [
+    scriptPackageDetails,
+    setScriptPackageDetails,
   ] = useState<IPackageInstallDetails | null>(null);
   const [
     ipaPackageInstallDetails,
@@ -689,22 +695,33 @@ const HostDetailsPage = ({
           setScriptExecutiontId(details?.script_execution_id || "");
           break;
         case "installed_software":
-          details?.command_uuid
-            ? setIpaPackageInstallDetails({
-                fleetInstallStatus: details?.status as SoftwareInstallUninstallStatus,
-                hostDisplayName:
-                  host?.display_name || details?.host_display_name || "",
-                appName: details?.name || "",
-                commandUuid: details?.command_uuid,
-              })
-            : setPackageInstallDetails({
-                ...details,
-                // FIXME: It seems like the backend is not using the correct display name when it returns
-                // upcoming install activities. As a workaround, we'll prefer the display name from
-                // the host object if it's available.
-                host_display_name:
-                  host?.display_name || details?.host_display_name || "",
-              });
+          if (details?.command_uuid) {
+            setIpaPackageInstallDetails({
+              fleetInstallStatus: details?.status as SoftwareInstallUninstallStatus,
+              hostDisplayName:
+                host?.display_name || details?.host_display_name || "",
+              appName: details?.name || "",
+              commandUuid: details?.command_uuid,
+            });
+          } else if (SCRIPT_PACKAGE_SOURCES.includes(details?.source || "")) {
+            setScriptPackageDetails({
+              ...details,
+              // FIXME: It seems like the backend is not using the correct display name when it returns
+              // upcoming install activities. As a workaround, we'll prefer the display name from
+              // the host object if it's available.
+              host_display_name:
+                host?.display_name || details?.host_display_name || "",
+            });
+          } else {
+            setPackageInstallDetails({
+              ...details,
+              // FIXME: It seems like the backend is not using the correct display name when it returns
+              // upcoming install activities. As a workaround, we'll prefer the display name from
+              // the host object if it's available.
+              host_display_name:
+                host?.display_name || details?.host_display_name || "",
+            });
+          }
           break;
         case "uninstalled_software":
           setPackageUninstallDetails({
@@ -1414,6 +1431,12 @@ const HostDetailsPage = ({
             <SoftwareInstallDetailsModal
               details={packageInstallDetails}
               onCancel={onCancelSoftwareInstallDetailsModal}
+            />
+          )}
+          {scriptPackageDetails && (
+            <SoftwareScriptDetailsModal
+              details={scriptPackageDetails}
+              onCancel={() => setScriptPackageDetails(null)}
             />
           )}
           {ipaPackageInstallDetails && (

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -373,7 +373,7 @@ describe("InstallStatusCell - component", () => {
     });
   });
 
-  it("renders 'Failed run' for a payload-free package that failed to run", async () => {
+  it("renders 'Failed' for a payload-free package that failed to run", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -393,12 +393,10 @@ describe("InstallStatusCell - component", () => {
       />
     );
 
-    expect(
-      screen.getByRole("button", { name: /Failed run/i })
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Failed/i })).toBeInTheDocument();
     expect(screen.getByTestId("error-icon")).toBeInTheDocument();
 
-    await user.hover(screen.getByText(/Failed run/));
+    await user.hover(screen.getByText(/Failed/));
     await waitFor(() => {
       expect(screen.getByText(/The script failed to run/i)).toBeInTheDocument();
     });

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -294,7 +294,7 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
   failed_script: {
     iconName: "error",
-    displayText: "Failed run",
+    displayText: "Failed",
     tooltip: ({ lastInstalledAt, isSelfService }) => (
       <>
         The script failed to run
@@ -501,7 +501,7 @@ const InstallStatusCell = ({
     const displayStatusConfig = [
       {
         condition: true, // Allow click even if no last install to see details modal
-        statuses: ["Failed run", "Run (pending)", "Ran"],
+        statuses: ["Failed", "Run (pending)", "Ran"],
         onClick: onClickScriptStatus,
       },
       {


### PR DESCRIPTION
## Issue
Addresses number 2b, 3, and 4 in #34953

## Description
- The host details page > activity > _script_ package activity was opening the _regular_ package details modal instead of the _script_ package details modal

## Screenshot of fix
Tested with my WindowsVM + ps1 script package

- [x] Correct modal in upcoming activity
<img width="859" height="613" alt="Screenshot 2025-10-31 at 10 04 07 AM" src="https://github.com/user-attachments/assets/b03b8ed2-1ed0-401e-9dc5-6a2ef4667408" />
- [x] Correct modal in activity
<img width="956" height="575" alt="Screenshot 2025-10-31 at 10 11 20 AM" src="https://github.com/user-attachments/assets/f816f807-f0ba-4d18-8b1b-2354b378ff93" />
- [x] Corrected to "Failed" instead of "Failed run"
<img width="1319" height="555" alt="Screenshot 2025-10-31 at 10 48 36 AM" src="https://github.com/user-attachments/assets/5c354186-5386-42e4-99c1-c6614b4c09fa" />


