### PR TITLE
move mdm enrollment activity into the token update and out of authentication

### DIFF
--- a/changes/issue-32009-change-where-mdm_enrollment_activity_happens
+++ b/changes/issue-32009-change-where-mdm_enrollment_activity_happens
@@ -1,0 +1,1 @@
+- change where mdm_enrolled activity is created. It is moved to the Token Update method to ensure the host can recieve additional fleet mdm commands.

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3457,24 +3457,6 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 	// much more difficult to reason about the state of the host. We should try instead
 	// to centralize the flow control in the lifecycle methods.
 	if !scepRenewalInProgress {
-		// Create a new activity for the enrollment, MDM state changes after is reset, fetch the
-		// checkin updatedInfo again
-		updatedInfo, err := svc.ds.GetHostMDMCheckinInfo(r.Context, r.ID)
-		if err != nil {
-			return ctxerr.Wrap(r.Context, err, "getting checkin info in Authenticate message")
-		}
-		mdmEnrolledActivity := &fleet.ActivityTypeMDMEnrolled{
-			HostDisplayName:  updatedInfo.DisplayName,
-			InstalledFromDEP: updatedInfo.DEPAssignedToFleet,
-			MDMPlatform:      fleet.MDMPlatformApple,
-			Platform:         updatedInfo.Platform,
-		}
-		if r.Type == mdm.UserEnrollmentDevice {
-			mdmEnrolledActivity.EnrollmentID = ptr.String(m.EnrollmentID)
-		} else {
-			mdmEnrolledActivity.HostSerial = ptr.String(updatedInfo.HardwareSerial)
-		}
-
 		if svc.keyValueStore != nil {
 			// Set sticky key for MDM enrollments to avoid updating team id on orbit enrollments
 			err = svc.keyValueStore.Set(r.Context, fleet.StickyMDMEnrollmentKeyPrefix+r.ID, "1", fleet.StickyMDMEnrollmentTTL)
@@ -3483,12 +3465,7 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 				level.Error(svc.logger).Log("msg", "failed to set sticky mdm enrollment key", "err", err, "host_uuid", r.ID)
 			}
 		}
-
-		return newActivity(
-			r.Context, nil, mdmEnrolledActivity, svc.ds, svc.logger,
-		)
 	}
-
 	return nil
 }
 
@@ -3528,6 +3505,24 @@ func (svc *MDMAppleCheckinAndCommandService) TokenUpdate(r *mdm.Request, m *mdm.
 			}
 		} else {
 			svc.logger.Log("info", "skipping setup experience enqueueing because DEP migration is in progress", "host_uuid", r.ID)
+		}
+
+		mdmEnrolledActivity := &fleet.ActivityTypeMDMEnrolled{
+			HostDisplayName:  info.DisplayName,
+			InstalledFromDEP: info.DEPAssignedToFleet,
+			MDMPlatform:      fleet.MDMPlatformApple,
+			Platform:         info.Platform,
+		}
+		if r.Type == mdm.UserEnrollmentDevice {
+			mdmEnrolledActivity.EnrollmentID = ptr.String(m.EnrollmentID)
+		} else {
+			mdmEnrolledActivity.HostSerial = ptr.String(info.HardwareSerial)
+		}
+		err = newActivity(
+			r.Context, nil, mdmEnrolledActivity, svc.ds, svc.logger,
+		)
+		if err != nil {
+			return ctxerr.Wrap(r.Context, err, "creating mdm enrolled activity for")
 		}
 	}
 

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1283,7 +1283,6 @@ func TestMDMAuthenticateADE(t *testing.T) {
 	ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{}, nil
 	}
-	
 
 	ds.MDMResetEnrollmentFunc = func(ctx context.Context, hostUUID string, scepRenewalInProgress bool) error {
 		require.Equal(t, uuid, hostUUID)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32009

We have moved the mdm enrollment activity into the token update method instead of the authentcation method. We do this because in token update we are sure that the host can communicate with fleet mdm. This means the mdm_enrolled webhook can now be sent and we will be sure that the server will be able to communicate with the host with additional mdm commands 

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
