### PR TITLE
Fleet UI: Fix conditions to ensure script modal doesn't open for nonscript installs

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -134,6 +134,7 @@ describe("InstallStatusCell - component", () => {
             software_package: createMockHostSoftwarePackage({
               name: "mock software.sh",
             }),
+            source: "sh_packages",
           }),
           ui_status: "ran_script",
         }}

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -9,6 +9,7 @@ import {
   IVPPHostSoftware,
   SoftwareUninstallStatus,
   IAppLastInstall,
+  SCRIPT_PACKAGE_SOURCES,
 } from "interfaces/software";
 import { Colors } from "styles/var/colors";
 
@@ -497,15 +498,17 @@ const InstallStatusCell = ({
         (software.status === "failed_install" || isInstalledInFleetAndUI)) ||
       recentlyTakenAction;
 
+    const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(software.source);
+
     // Status groups and their click handlers
     const displayStatusConfig = [
       {
-        condition: true, // Allow click even if no last install to see details modal
+        condition: isScriptPackage, // Still allows click even if no last install to see details modal
         statuses: ["Failed", "Run (pending)", "Ran"],
         onClick: onClickScriptStatus,
       },
       {
-        condition: true, // Allow click even if no last install to see details modal
+        condition: !isScriptPackage, // Still allows click even if no last install to see details modal
         statuses: ["Failed", "Install (pending)", "Installed"],
         onClick: onClickInstallStatus,
       },
@@ -522,6 +525,7 @@ const InstallStatusCell = ({
     ];
 
     // Find a matching config for the current display text
+    // Given the condition is met and the display text is in the statuses array
     const match = displayStatusConfig.find(
       ({ condition, statuses }) =>
         condition && statuses.includes(resolvedDisplayText as string)


### PR DESCRIPTION
## Issue
Fixes unreleased bug introduced when fixing #34953 

## Description
- Fixes unreleased bug flagged by @jmwatts 

> Hmm... something isn't right now... When I click on a failed VPP install I get this modal

- Whack a mole line that was pushed that caused this bug https://github.com/fleetdm/fleet/pull/35050/files#r2482642559

## Testing

- [x] QA'd all new/changed functionality manually
