### PR TITLE
For R.C. - Fleet UI: Fix conditions to ensure script modal doesn't open for nonscript installs (#35078)

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -131,6 +131,7 @@ describe("InstallStatusCell - component", () => {
             software_package: createMockHostSoftwarePackage({
               name: "mock software.sh",
             }),
+            source: "sh_packages",
           }),
           ui_status: "ran_script",
         }}

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -9,6 +9,7 @@ import {
   IVPPHostSoftware,
   SoftwareUninstallStatus,
   IAppLastInstall,
+  SCRIPT_PACKAGE_SOURCES,
 } from "interfaces/software";
 import { Colors } from "styles/var/colors";
 
@@ -491,15 +492,17 @@ const InstallStatusCell = ({
         (software.status === "failed_install" || isInstalledInFleetAndUI)) ||
       recentlyTakenAction;
 
+    const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(software.source);
+
     // Status groups and their click handlers
     const displayStatusConfig = [
       {
-        condition: true, // Allow click even if no last install to see details modal
+        condition: isScriptPackage, // Still allows click even if no last install to see details modal
         statuses: ["Failed", "Run (pending)", "Ran"],
         onClick: onClickScriptStatus,
       },
       {
-        condition: true, // Allow click even if no last install to see details modal
+        condition: !isScriptPackage, // Still allows click even if no last install to see details modal
         statuses: ["Failed", "Install (pending)", "Installed"],
         onClick: onClickInstallStatus,
       },
@@ -516,6 +519,7 @@ const InstallStatusCell = ({
     ];
 
     // Find a matching config for the current display text
+    // Given the condition is met and the display text is in the statuses array
     const match = displayStatusConfig.find(
       ({ condition, statuses }) =>
         condition && statuses.includes(resolvedDisplayText as string)


### PR DESCRIPTION
## Issue
Closes #31083

Fixes unreleased bug introduced when fixing #34953

## Description
- Merged into `main` with #35078
- This is for the 4.76 RC