### PR TITLE
update copy, add one-time cron to update default policy

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1084,6 +1084,12 @@ the way that the Fleet server works.
 			}
 
 			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
+				return cronEnableAndroidAppReportsOnDefaultPolicy(ctx, instanceID, ds, logger, androidSvc)
+			}); err != nil {
+				initFatal(err, "failed to register enable_android_app_reports_on_default_policy cron")
+			}
+
+			if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 				return newMDMAPNsPusher(
 					ctx,
 					instanceID,

--- a/frontend/pages/SoftwarePage/components/tables/EmptySoftwareTable/EmptySoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/EmptySoftwareTable/EmptySoftwareTable.tsx
@@ -7,6 +7,7 @@ import {
   ISoftwareDropdownFilterVal,
   ISoftwareVulnFiltersParams,
 } from "pages/SoftwarePage/SoftwareTitles/SoftwareTable/helpers";
+import { HostPlatform, isAndroid } from "interfaces/platform";
 
 export interface IEmptySoftwareTableProps {
   softwareFilter?: ISoftwareDropdownFilterVal;
@@ -15,6 +16,7 @@ export interface IEmptySoftwareTableProps {
   isSoftwareDisabled?: boolean;
   noSearchQuery?: boolean;
   installableSoftwareExists?: boolean;
+  platform?: HostPlatform;
 }
 
 const generateTypeText = (
@@ -38,6 +40,7 @@ const EmptySoftwareTable = ({
   isSoftwareDisabled,
   noSearchQuery,
   installableSoftwareExists,
+  platform,
 }: IEmptySoftwareTableProps): JSX.Element => {
   const softwareTypeText = generateTypeText(
     tableName,
@@ -70,6 +73,11 @@ const EmptySoftwareTable = ({
       };
     }
 
+    let info = `Expecting to see ${softwareTypeText}? Check back later.`;
+    if (isAndroid(platform || "")) {
+      info = `${info} It may take up to 24 hours for Android to report the software.`;
+    }
+
     if (!isFiltered) {
       if (softwareFilter === "allSoftware") {
         if (installableSoftwareExists) {
@@ -80,14 +88,14 @@ const EmptySoftwareTable = ({
         }
         return {
           header: `No ${tableName} detected`,
-          info: `Expecting to see ${softwareTypeText}? Check back later.`,
+          info,
         };
       }
     }
 
     return {
       header: "No items match the current search criteria",
-      info: `Expecting to see ${softwareTypeText}? Check back later.`,
+      info,
     };
   };
 

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTable/HostSoftwareTable.tsx
@@ -55,7 +55,10 @@ const EmptyComponent = React.memo(
     return vulnFilterAndNotSupported ? (
       <VulnsNotSupported platformText={PLATFORM_DISPLAY_NAMES[platform]} />
     ) : (
-      <EmptySoftwareTable noSearchQuery={searchQuery === ""} />
+      <EmptySoftwareTable
+        noSearchQuery={searchQuery === ""}
+        platform={platform}
+      />
     );
   }
 );

--- a/server/fleet/cron_schedules.go
+++ b/server/fleet/cron_schedules.go
@@ -39,6 +39,9 @@ const (
 	CronHostVitalsLabelMembership      CronScheduleName = "host_vitals_label_membership"
 	CronBatchActivityCompletionChecker CronScheduleName = "batch_activity_completion_checker"
 	CronScheduledBatchActivities       CronScheduleName = "scheduled_batch_activities"
+	// CronEnableAndroidAppReportsOnDefaultPolicy enables applications reports on the default Android MDM policy (profile).
+	// This job only runs once after upgrading to v4.76.0.
+	CronEnableAndroidAppReportsOnDefaultPolicy CronScheduleName = "enable_android_app_reports_on_default_policy"
 )
 
 type CronSchedulesService interface {

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -18,6 +18,7 @@ type Service interface {
 
 	// UnenrollAndroidHost triggers unenrollment (work profile removal) for the given Android host ID.
 	UnenrollAndroidHost(ctx context.Context, hostID uint) error
+	EnableAppReportsOnDefaultPolicy(ctx context.Context) error
 }
 
 // /////////////////////////////////////////////

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -877,7 +877,7 @@ func (svc *Service) EnableAppReportsOnDefaultPolicy(ctx context.Context) error {
 	}
 	_ = svc.androidAPIClient.SetAuthenticationSecret(secret)
 
-	policyName := fmt.Sprintf("%s/policies/%s", enterprise.Name(), fmt.Sprintf("%d", defaultAndroidPolicyID))
+	policyName := fmt.Sprintf("%s/policies/%d", enterprise.Name(), defaultAndroidPolicyID)
 	_, err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{
 		StatusReportingSettings: &androidmanagement.StatusReportingSettings{
 			DeviceSettingsEnabled:        true,

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -319,7 +319,7 @@ func (svc *Service) EnterpriseSignupCallback(ctx context.Context, signupToken st
 		return ctxerr.Wrap(ctx, err, "updating enterprise")
 	}
 
-	appReportsEnabled := false //license.IsPremium(ctx)
+	appReportsEnabled := license.IsPremium(ctx)
 
 	policyName := fmt.Sprintf("%s/policies/%s", enterprise.Name(), fmt.Sprintf("%d", defaultAndroidPolicyID))
 	_, err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -319,7 +319,7 @@ func (svc *Service) EnterpriseSignupCallback(ctx context.Context, signupToken st
 		return ctxerr.Wrap(ctx, err, "updating enterprise")
 	}
 
-	appReportsEnabled := license.IsPremium(ctx)
+	appReportsEnabled := false //license.IsPremium(ctx)
 
 	policyName := fmt.Sprintf("%s/policies/%s", enterprise.Name(), fmt.Sprintf("%d", defaultAndroidPolicyID))
 	_, err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{
@@ -855,6 +855,46 @@ func (svc *Service) UnenrollAndroidHost(ctx context.Context, hostID uint) error 
 		Platform:         "android",
 	}); err != nil {
 		return ctxerr.Wrap(ctx, err, "create android unenroll activity")
+	}
+	return nil
+}
+
+func (svc *Service) EnableAppReportsOnDefaultPolicy(ctx context.Context) error {
+	enterprise, err := svc.ds.GetEnterprise(ctx)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			// Then Android MDM isn't setup yet, so no-op
+			level.Info(svc.logger).Log("msg", "skipping android default policy migration, Android MDM is not turned on")
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "getting android enterprise")
+	}
+	appReportsEnabled := license.IsPremium(ctx)
+
+	secret, err := svc.getClientAuthenticationSecret(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "getting client authentication secret")
+	}
+	_ = svc.androidAPIClient.SetAuthenticationSecret(secret)
+
+	policyName := fmt.Sprintf("%s/policies/%s", enterprise.Name(), fmt.Sprintf("%d", defaultAndroidPolicyID))
+	_, err = svc.androidAPIClient.EnterprisesPoliciesPatch(ctx, policyName, &androidmanagement.Policy{
+		StatusReportingSettings: &androidmanagement.StatusReportingSettings{
+			DeviceSettingsEnabled:        true,
+			MemoryInfoEnabled:            true,
+			NetworkInfoEnabled:           true,
+			DisplayInfoEnabled:           true,
+			PowerManagementEventsEnabled: true,
+			HardwareStatusEnabled:        true,
+			SystemPropertiesEnabled:      true,
+			SoftwareInfoEnabled:          true, // Android OS version, etc.
+			CommonCriteriaModeEnabled:    true,
+			ApplicationReportsEnabled:    appReportsEnabled,
+			ApplicationReportingSettings: nil,
+		},
+	})
+	if err != nil && !androidmgmt.IsNotModifiedError(err) {
+		return ctxerr.Wrapf(ctx, err, "enabling app reports on %d default policy", defaultAndroidPolicyID)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34899 

# Changes summary
- Added a one-time scheduled job that will run a 45 seconds after server startup
  - This job updates the default Android MDM policy to enable application reports, so that devices that were enrolled before 4.76.0 will start reporting software inventory
- Updates the Fleet admin UI to call out that Android software inventory may take up to 24 hours to populate.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
