### PR TITLE
Story template: Add "hosted environment" to QA section

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.md
+++ b/.github/ISSUE_TEMPLATE/story.md
@@ -68,6 +68,7 @@ Provide links to any research or helpful resources (ex. Apple documentation). Pu
 
 ### Risk assessment
 
+- Requires testing in a hosted environment: TODO <!-- User story has features that require testing in a hosted environment. Otherwise, remove this item. -->
 - Requires load testing: TODO <!-- User story has performance implications that require load testing. Otherwise, remove this item. -->
 - Risk level: Low / High TODO <!-- Choose one. Consider: Does this change come with performance risks?  Any risk of accidental log spew? Any particular regressions to watch out for?  Any potential compatibility issues, even if it's not technically a breaking change? -->
 - Risk description: TODO <!-- If the risk level is high, explain why. If low, remove. -->


### PR DESCRIPTION
We think this bug slipped through because it's easy to forget testing in a hosted environment: https://github.com/fleetdm/fleet/issues/33917#issuecomment-3382260995
