### PR TITLE
Update google-chrome-managed-bookmarks.mobileconfig

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -357,7 +357,7 @@
                             <key>name</key>
                             <string>Issue: 🦟Bug report</string>
                             <key>url</key>
-                            <string>https://github.com/fleetdm/fleet/issues/new?assignees=&amp;labels=bug%2C%3Areproduce&amp;projects=&amp;template=bug-report.md&amp;title=</string>
+                            <string>https://github.com/fleetdm/fleet/issues/new?template=bug-report.md</string>
                         </dict>
                         <dict>
                             <key>name</key>


### PR DESCRIPTION
- Use the template URL instead so that any default label changes are always reflected.
