### PR TITLE
Avoid creating activities for intermediate installation failures

### DIFF
--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -21411,6 +21411,160 @@ func (s *integrationEnterpriseTestSuite) TestSetupExperienceWindowsWithSoftwareW
 	require.EqualValues(t, "success", orbitRes.Results.Software[1].Status)
 }
 
+// TestSetupExperiencePayloadFreePackageWithRetries tests that when a payload-free package
+// (script package) fails during setup experience with retries enabled, only ONE activity
+// is created for the final failure, not one activity per retry attempt.
+//
+// This test verifies the fix for https://github.com/fleetdm/fleet/issues/34818
+func (s *integrationEnterpriseTestSuite) TestSetupExperiencePayloadFreePackageWithRetries() {
+	t := s.T()
+	ctx := context.Background()
+
+	// Create a team for setup experience
+	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name() + "team1"})
+	require.NoError(t, err)
+
+	// Create temporary script file for testing
+	shContent := "#!/bin/bash\necho 'This will fail'\nexit 1\n"
+	shFile, err := fleet.NewTempFileReader(strings.NewReader(shContent), func() string { return t.TempDir() })
+	require.NoError(t, err)
+	defer shFile.Close()
+
+	// Upload a script package (.sh file) as a software installer
+	payload := &fleet.UploadSoftwareInstallerPayload{
+		Filename:      "test-script.sh",
+		TeamID:        &team.ID,
+		InstallerFile: shFile,
+	}
+	s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+
+	// Get the installer title ID we just created
+	var titleID uint
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &titleID, `SELECT title_id FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, &team.ID, payload.Filename)
+	})
+	require.NotZero(t, titleID)
+
+	// Configure the script package to run as part of the setup experience
+	var swInstallResp putSetupExperienceSoftwareResponse
+	s.DoJSON("PUT", "/api/v1/fleet/setup_experience/software", putSetupExperienceSoftwareRequest{
+		Platform: "linux",
+		TeamID:   team.ID,
+		TitleIDs: []uint{titleID},
+	}, http.StatusOK, &swInstallResp)
+	require.NoError(t, swInstallResp.Err)
+
+	// Create a Linux host for testing
+	name := t.Name() + "-linux"
+	host, err := s.ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now().Add(-time.Minute),
+		OsqueryHostID:   ptr.String(name),
+		NodeKey:         ptr.String(name),
+		UUID:            uuid.New().String(),
+		Hostname:        fmt.Sprintf("%s.local", name),
+		HardwareSerial:  uuid.New().String(),
+		Platform:        "ubuntu",
+		TeamID:          &team.ID,
+	})
+	require.NoError(t, err)
+	orbitKey := setOrbitEnrollment(t, host, s.ds)
+	host.OrbitNodeKey = &orbitKey
+
+	// Manually create a pending software install for setup experience
+	// This simulates what happens when setup experience starts
+	var executionID string
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		execUUID := uuid.New().String()
+		executionID = execUUID
+		_, err := q.ExecContext(ctx, `
+			INSERT INTO host_software_installs (
+				execution_id, host_id, software_installer_id, install_script_exit_code,
+				pre_install_query_output, post_install_script_exit_code, post_install_script_output,
+				user_id, self_service
+			)
+			SELECT ?, ?, id, NULL, '', NULL, '', NULL, 0
+			FROM software_installers
+			WHERE title_id = ? AND global_or_team_id = ?
+		`, execUUID, host.ID, titleID, &team.ID)
+		return err
+	})
+	require.NotEmpty(t, executionID)
+
+	// Count activities before any failures
+	activitiesBefore, _, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	require.NoError(t, err)
+	initialActivityCount := len(activitiesBefore)
+
+	// Simulate retry attempt #1 - FAILS with RetriesRemaining=2
+	s.Do("POST", "/api/fleet/orbit/software_install/result", json.RawMessage(
+		fmt.Sprintf(`{
+			"orbit_node_key": %q,
+			"install_uuid": %q,
+			"install_script_exit_code": 1,
+			"install_script_output": "Attempt 1 failed",
+			"retries_remaining": 2
+		}`, *host.OrbitNodeKey, executionID),
+	), http.StatusNoContent)
+
+	// Verify NO new activity was created for intermediate failure
+	activities1, _, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	require.NoError(t, err)
+	require.Len(t, activities1, initialActivityCount, "Intermediate failure #1 should NOT create an activity")
+
+	// Simulate retry attempt #2 - FAILS with RetriesRemaining=1
+	s.Do("POST", "/api/fleet/orbit/software_install/result", json.RawMessage(
+		fmt.Sprintf(`{
+			"orbit_node_key": %q,
+			"install_uuid": %q,
+			"install_script_exit_code": 1,
+			"install_script_output": "Attempt 2 failed",
+			"retries_remaining": 1
+		}`, *host.OrbitNodeKey, executionID),
+	), http.StatusNoContent)
+
+	// Verify still NO new activity was created
+	activities2, _, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	require.NoError(t, err)
+	require.Len(t, activities2, initialActivityCount, "Intermediate failure #2 should NOT create an activity")
+
+	// Simulate final attempt #3 - FAILS with RetriesRemaining=0 (no more retries)
+	s.Do("POST", "/api/fleet/orbit/software_install/result", json.RawMessage(
+		fmt.Sprintf(`{
+			"orbit_node_key": %q,
+			"install_uuid": %q,
+			"install_script_exit_code": 1,
+			"install_script_output": "Final attempt failed",
+			"retries_remaining": 0
+		}`, *host.OrbitNodeKey, executionID),
+	), http.StatusNoContent)
+
+	// Verify exactly ONE activity was created for the final failure
+	activitiesFinal, _, err := s.ds.ListActivities(ctx, fleet.ListActivitiesOptions{})
+	require.NoError(t, err)
+	require.Len(t, activitiesFinal, initialActivityCount+1, "Final failure should create exactly ONE activity")
+
+	// Find the software installation activity (may not be the first one due to test setup activities)
+	var installActivity *fleet.Activity
+	expectedActivityType := fleet.ActivityTypeInstalledSoftware{}.ActivityName()
+	for i := range activitiesFinal {
+		if activitiesFinal[i].Type == expectedActivityType {
+			installActivity = activitiesFinal[i]
+			break
+		}
+	}
+	require.NotNil(t, installActivity, "Should have found an installed_software activity")
+
+	var activityDetails fleet.ActivityTypeInstalledSoftware
+	require.NoError(t, json.Unmarshal(*installActivity.Details, &activityDetails))
+	require.Equal(t, host.ID, activityDetails.HostID)
+	require.Equal(t, host.DisplayName(), activityDetails.HostDisplayName)
+	require.Equal(t, executionID, activityDetails.InstallUUID)
+	require.Equal(t, "failed_install", activityDetails.Status)
+}
+
 func (s *integrationEnterpriseTestSuite) TestHostDeviceMappingIDP() {
 	t := s.T()
 	ctx := context.Background()

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1381,33 +1381,16 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 	// If this is an intermediate failure that will be retried, handle it specially
 	if result.RetriesRemaining > 0 {
 		// Create a record while keeping the original pending
-		failedExecID, hsi, isNewRecord, err := svc.ds.CreateIntermediateInstallFailureRecord(ctx, result)
+		_, _, _, err := svc.ds.CreateIntermediateInstallFailureRecord(ctx, result)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "save intermediate install failure")
 		}
 
-		// Only create an activity if this is a new record (not a replay of a previous request)
-		if isNewRecord {
-			if err := svc.NewActivity(
-				ctx,
-				nil,
-				fleet.ActivityTypeInstalledSoftware{
-					HostID:              host.ID,
-					HostDisplayName:     host.DisplayName(),
-					SoftwareTitle:       hsi.SoftwareTitle,
-					SoftwarePackage:     hsi.SoftwarePackage,
-					InstallUUID:         failedExecID,
-					Status:              string(result.Status()),
-					Source:              hsi.Source,
-					SelfService:         hsi.SelfService,
-					PolicyID:            nil,
-					PolicyName:          nil,
-					FromSetupExperience: true, // We assume that retries only occur during setup experience
-				},
-			); err != nil {
-				return ctxerr.Wrap(ctx, err, "create activity for intermediate software installation failure")
-			}
-		}
+		// Don't create activities for intermediate failures during setup experience.
+		// Only the final result (RetriesRemaining == 0) should create an activity.
+		// This prevents multiple activity items from appearing when a package fails
+		// during setup experience with retries enabled.
+		// See https://github.com/fleetdm/fleet/issues/34818
 
 		// Don't update setup experience status for intermediate failures
 		return nil


### PR DESCRIPTION
Fixes #34818. Prevents duplicate activity items when software fails during setup experience with retries enabled.

  ## Summary
  When a software package failed during device setup experience, **3 activity items appeared** instead of 1. This happened because activities were created for each retry attempt (attempts 1, 2, and 3) rather than only the final result.

  This affects **all package types** during setup experience (.pkg, .msi, .deb, .sh, .ps1, VPP apps), not just payload-free packages. The bug was discovered during payload-free testing because that feature's test plan explicitly tested failure scenarios.

  This fix ensures:
  - Intermediate failures (RetriesRemaining > 0) do NOT create activities
  - Only final results (RetriesRemaining == 0) create exactly ONE activity
  - Database records for intermediate failures are still created for idempotency
  - Non-setup-experience scenarios remain unaffected

  ## Details
  - Removes activity creation logic from intermediate failure handling in `server/service/orbit.go`
  - Preserves `CreateIntermediateInstallFailureRecord()` call for retry tracking
  - Final results continue through normal path, which correctly determines `FromSetupExperience` flag and creates single activity

  ## Testing
  - [x] Adds integration test `TestSetupExperiencePayloadFreePackageWithRetries`
  - [x] Verifies NO activities for attempts 1-2 (RetriesRemaining = 2, 1)
  - [x] Verifies exactly ONE activity for final attempt (RetriesRemaining = 0)
  - [x] Full test suite passes
