### PR TITLE
Update `macOS - Enrollment profile up to date` policy

### DIFF
--- a/it-and-security/lib/macos/policies/enrollment-profile-up-to-date.yml
+++ b/it-and-security/lib/macos/policies/enrollment-profile-up-to-date.yml
@@ -1,5 +1,9 @@
 - name: macOS - Enrollment profile up to date
-  query: SELECT 1 FROM mdm where topic = "com.apple.mgmt.External.8a3367bf-49d7-4dc3-ae41-c9de95f7b424";
+  query: |
+    SELECT 1 FROM mdm 
+    WHERE topic = "com.apple.mgmt.External.8a3367bf-49d7-4dc3-ae41-c9de95f7b424"
+       OR topic IS NULL 
+       OR topic = '';
   critical: true
   description: Recently we had to update files used for managing Apple devices. This policy checks to see if you have the most recent enrollment profile installed. Not having this profile means this device is no longer communicating with Fleet via MDM.
   resolution: |-


### PR DESCRIPTION
- Logic now makes sure devices non MDM-enrolled aren't receiving a policy failure