### PR TITLE
Fix non-Linux not displaying all OS version.

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -229,11 +229,7 @@ const SoftwareOSDetailsPage = ({
       maxVulnerabilities === 0
     ) {
       setIsRefetchingVulnerabilities(true);
-      const timer = setTimeout(() => {
-        setMaxVulnerabilities(undefined);
-      }, 5000);
-
-      return () => clearTimeout(timer);
+      setMaxVulnerabilities(undefined);
     }
   }, [osVersionDetails, maxVulnerabilities]);
 

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -173,14 +173,15 @@ const SoftwareOSDetailsPage = ({
   const [maxVulnerabilities, setMaxVulnerabilities] = useState<
     number | undefined
   >(0);
-  const [isRefetchingVulnerabilities, setIsRefetchingVulnerabilities] =
-    useState(false);
+  const [
+    isRefetchingVulnerabilities,
+    setIsRefetchingVulnerabilities,
+  ] = useState(false);
 
   const {
     data: { os_version: osVersionDetails, counts_updated_at } = {},
     isLoading,
     isError: isOsVersionError,
-    isFetching,
   } = useQuery<
     IOSVersionResponse,
     AxiosError,

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -42,6 +42,7 @@ export interface IOSVersionsResponse {
 interface IGetOsVersionOptions {
   os_version_id: number;
   teamId?: number;
+  max_vulnerabilities?: number;
 }
 
 export interface IGetOsVersionQueryKey extends IGetOsVersionOptions {
@@ -94,11 +95,12 @@ export const getOSVersions = ({
 const getOSVersion = ({
   os_version_id,
   teamId,
+  max_vulnerabilities,
 }: IGetOsVersionOptions): Promise<IOSVersionResponse> => {
   const endpoint = endpoints.OS_VERSION(os_version_id);
   const queryString = buildQueryStringFromParams({
     team_id: teamId,
-    max_vulnerabilities: 3, // Limit CVEs to first 3, use vulnerabilities_count for total
+    max_vulnerabilities,
   });
   const path = queryString ? `${endpoint}?${queryString}` : endpoint;
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35166

Fix
- For an OS version, we first fetch the version with max_vulnerabilities=0.
- If the OS version has vulnerabilities and it is non-Linux, then we refetch the OS version without specifying the `max_vulnerabilities` parameter, which fetches all vulnerabilities.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized vulnerability data loading for operating system details with enhanced fetching strategy
  * Improved loading state management for clearer visibility during data retrieval on OS version pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->