### PR TITLE
Update cis-policy-queries.yml

### DIFF
--- a/ee/cis/kubernetes_1.33/cis-policy-queries.yml
+++ b/ee/cis/kubernetes_1.33/cis-policy-queries.yml
@@ -30,33 +30,36 @@ spec:
 ---
 3
 ---
-4
----
-5
----
+#4
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS 2.2 - Ensure that the --client-cert-auth argument is set to true
+  name: CIS - Ensure that the scheduler.conf file ownership is set to root:root
   platform: linux
-  description: |
-    Enable client authencation on etcd service.
-  resolution: |
-    Edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml on the master node and set the parameter --client-cert-auth="true"
+  description: CIS K8s benchamrk 1.1.16 -> Ensure that the scheduler.conf file ownership is set to root:root.
+  resolution: The scheduler.conf file is the kubeconfig file for the Scheduler. You should set its file ownership to maintain the integrity of the file. The file should be owned by root:root.
   query: |
     SELECT 1 WHERE
-        EXISTS (
-            SELECT 1
-            FROM processes
-            WHERE name = 'etcd'
-            AND cmdline LIKE '%--client-cert-auth=true%'
-        )
+      EXISTS(
+        SELECT 
+          1 as pass 
+        FROM 
+          file 
+        WHERE 
+          path = '/var/lib/rancher/rke2/server/cred/scheduler.kubeconfig' 
+          AND uid = 0 
+          AND gid = 0;
+          )
         OR NOT EXISTS (
-            SELECT 1 FROM processes WHERE name = 'etcd'
-        );
+          SELECT 1 FROM file WHERE path = '/var/lib/rancher/rke2/server/cred/scheduler.kubeconfig'
+          );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
-  contributors: kc9wwh
+  contributors: rsjaklic20
+---
+5
+---
+6
 ---
 7
 ---


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
