### PR TITLE
Update cis-policy-queries.yml

### DIFF
--- a/ee/cis/kubernetes_1.33/cis-policy-queries.yml
+++ b/ee/cis/kubernetes_1.33/cis-policy-queries.yml
@@ -72,6 +72,27 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
+  name: CIS - Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)
+  platform: linux
+  description: |
+    Configure TLS encryption for the etcd service.
+  resolution: |
+    Remediation:
+    By default, RKE2 generates cert and key files for etcd. These are located in /var/lib/rancher/rke2/server/tls/etcd/.
+     If this check fails, ensure that the configuration file /var/lib/rancher/rke2/server/db/etcd/config has not been modified to use custom cert and key files.
+  query: |
+    SELECT 1 AS success
+    FROM 
+        processes
+    WHERE 
+        name = 'etcd' AND cmdline LIKE '%--cert-file%' AND cmdline LIKE '%--key-file%';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+  contributors: mccormickjw
+---
+apiVersion: v1
+kind: policy
+spec:
   name: CIS - Ensure that the scheduler.conf file ownership is set to root:root
   platform: linux
   description: CIS K8s benchamrk 1.1.16 -> Ensure that the scheduler.conf file ownership is set to root:root.

--- a/ee/cis/kubernetes_1.33/cis-policy-queries.yml
+++ b/ee/cis/kubernetes_1.33/cis-policy-queries.yml
@@ -89,7 +89,11 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: mccormickjw
-  name: CIS - 1.2.9 - v1.12 - Ensure that the admission control plugin EventRateLimit is set (Manual)
+---
+apiVersion: v1
+kind: policy
+spec:
+ name: CIS - 1.2.9 - v1.12 - Ensure that the admission control plugin EventRateLimit is set (Manual)
   platforms: linux
   platform: linux
   description: |


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
