### PR TITLE
Android Proxy: debug token scopes for android enterprise creation

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enterprise.js
+++ b/website/api/controllers/android-proxy/create-android-enterprise.js
@@ -91,6 +91,15 @@ module.exports = {
         }
       });
 
+      // Debugging case: Log the actual token scopes in use.
+      const accessTokenObj = await authClient.getAccessToken();
+      const rawToken = accessTokenObj.token || accessTokenObj; // depending on version
+      // eslint-disable-next-line no-undef
+      const tokenInfoRes = await fetch(`https://oauth2.googleapis.com/tokeninfo?access_token=${rawToken}`);
+      const tokenInfo = await tokenInfoRes.json();
+      sails.log.debug('Token scopes actually in use:', tokenInfo.scope);
+
+
       // [?]: https://cloud.google.com/pubsub/docs/reference/rest/v1/projects.topics/getIamPolicy
       // Retrieve the IAM policy for the created pubsub topic.
       // !IMPORTANT: This should not be wrapped in a sails.helpers.flow.build, as we've seen issues with it not working properly.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Attempt at debugging #34776 

Another attempt to further debug this issue. This attempt tries to verify that the scopes for the token is correct, and is not overriden by another call to the scopes.

The reason is that the `www-authenticate` response header is saying `error="insufficient_scope"`