### PR TITLE
Update WhatsApp block rule in Santa profile

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-rules.mobileconfig
@@ -37,11 +37,11 @@
 									<dict>
 										<!-- Block WhatsApp.app -->
 										<key>identifier</key>
-										<string>14d13064f890af298973a17e30a5c921aacd7c7b0915e7e593b9e6dcd4ffe31a</string>
+										<string>54a8ec11bcea48a276b1fdce556a29108ba77de4</string>
 										<key>policy</key>
 										<string>BLOCKLIST</string>
 										<key>rule_type</key>
-										<string>BINARY</string>
+										<string>CDHASH</string>
 									</dict>									
 								</array>
 							</dict>


### PR DESCRIPTION
Changed the identifier and rule_type for WhatsApp.app in the Santa configuration profile from BINARY to CDHASH, updating the hash value accordingly.