### PR TITLE
Make styling more consistent in edit policies view for Firefox.

### DIFF
--- a/changes/34999-text-cut-off-in-policies-view
+++ b/changes/34999-text-cut-off-in-policies-view
@@ -1,1 +1,1 @@
-* Make styling more consistent in policies view for FireFox.
+* Make styling more consistent in edit policies view for FireFox.

--- a/changes/34999-text-cut-off-in-policies-view
+++ b/changes/34999-text-cut-off-in-policies-view
@@ -1,0 +1,1 @@
+* Make styling more consistent in policies view for FireFox.

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -86,6 +86,13 @@
     }
   }
 
+  &__policy-description-wrapper,
+  &__policy-resolution-wrapper {
+    .icon {
+      align-self: flex-start;
+    }
+  }
+
   &__policy-name-wrapper {
     .no-value {
       min-width: 112px;
@@ -127,9 +134,12 @@
     white-space: normal;
     background-color: transparent;
     overflow: hidden;
+    font-size: $x-small;
   }
 
   &__policy-name {
+   font-size:$large;
+
     &.input-field--error {
       border: 1px solid $core-vibrant-red;
     }


### PR DESCRIPTION
**Related issue:** Resolves [#34999](https://github.com/fleetdm/fleet/issues/34999)

- Align edit icon to start of line.
- Fix font size for policy name and contents elements.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually