### PR TITLE
Cancel setup experience if software fails: updates from QA

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -260,6 +260,11 @@ const DeviceUserPage = ({
       refetchOnWindowFocus: false,
       retry: false,
       onSuccess: ({ host: responseHost }) => {
+        // If we're just showing the setup screen,
+        // we don't need to refetch or alert on offline hosts.
+        if (location.query.setup_only) {
+          return;
+        }
         // Handle spinner and timer for refetch
         if (isRefetching(responseHost)) {
           setShowRefetchSpinner(true);
@@ -545,6 +550,7 @@ const DeviceUserPage = ({
             false
           }
           toggleInfoModal={toggleInfoModal}
+          platform={host.platform}
         />
       );
     }

--- a/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/SettingUpYourDevice/SettingUpYourDevice.tsx
@@ -19,12 +19,14 @@ interface ISettingUpYourDevice {
   setupSteps: ISetupStep[];
   toggleInfoModal: () => void;
   requireAllSoftware: boolean;
+  platform: string;
 }
 
 const SettingUpYourDevice = ({
   setupSteps,
   toggleInfoModal,
   requireAllSoftware,
+  platform,
 }: ISettingUpYourDevice) => {
   const [showError, setShowError] = useState(false);
   let title;
@@ -43,7 +45,7 @@ const SettingUpYourDevice = ({
         <p>
           <Icon name="error-outline" color="status-error" size="small" />{" "}
           <TooltipWrapper
-            tipContent={<>CONTROL (⌃) + Command (⌘) + ⏻ or Touch ID</>}
+            tipContent={<>Hold down power button/Touch ID for 5 seconds</>}
           >
             Restart your device
           </TooltipWrapper>{" "}
@@ -75,7 +77,9 @@ const SettingUpYourDevice = ({
       <Card borderRadiusSize="xxlarge" paddingSize="xlarge">
         <div className={`${baseClass}__header`}>
           <h2>{title}</h2>
-          {!failedSoftware && <InfoButton onClick={toggleInfoModal} />}
+          {!failedSoftware && platform !== "darwin" && (
+            <InfoButton onClick={toggleInfoModal} />
+          )}
         </div>
         {message}
         {!failedSoftware && <SetupStatusTable statuses={setupSteps} />}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** 
Resolves #35219
Resolves #35232 
Resolves #35228 

* https://github.com/fleetdm/fleet/issues/35219 (Transparency link is not clickable in Info modal for new setup experience): we just dropped the link entirely on the setup page for macOS:

<img width="843" height="468" alt="image" src="https://github.com/user-attachments/assets/b68ce846-ca0c-4fec-9269-fa53c0f4317d" />

(still there on Linux and Windows):

<img width="898" height="456" alt="image" src="https://github.com/user-attachments/assets/ca14d91f-fa91-47eb-b506-d645c8666961" />

* https://github.com/fleetdm/fleet/issues/35232 (Key combination in tooltip for macOS setup experience failed software install doesn't work on modern macs): we updated the tooltip to explain how to turn off the computer instead:

<img width="361" height="103" alt="image" src="https://github.com/user-attachments/assets/d96ff9eb-c983-4b00-a8f5-31c1d42e412f" />

 * https://github.com/fleetdm/fleet/issues/35228 (New setup experience for macOS always shows "This host if offline. Please try refetching host vitals later." error pop up): this check is no longer made when viewing the "setting up your computer" page.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

