### PR TITLE
Wire up docs for crowdstrike_falcon table

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -79,6 +79,7 @@ export const MACADMINS_EXTENSION_TABLES: Record<string, QueryablePlatform[]> = {
   mdm: ["darwin"],
   munki_info: ["darwin"],
   munki_install: ["darwin"],
+  crowdstrike_falcon: ["darwin", "linux"],
   // network_quality: ["darwin"], // TODO: add this table if/when it is incorporated into orbit
   puppet_info: ["darwin", "linux", "windows"],
   puppet_logs: ["darwin", "linux", "windows"],

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -5529,6 +5529,51 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/crontab.yml"
   },
   {
+    "name": "crowdstrike_falcon",
+    "notes": "This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).",
+    "description": "Information about Crowdstrike Falcon, collected via the falconctl utility.",
+    "platforms": [
+      "darwin",
+      "linux"
+    ],
+    "evented": false,
+    "examples": "Output most table information, swapping customer ID for its length to avoid leaking sensitive information.\n\n```\nSELECT agent_id, LENGTH(cid), falcon_version, reduced_functionality_mode, sensor_loaded FROM crowdstrike_falcon;\n```",
+    "columns": [
+      {
+        "name": "agent_id",
+        "description": "The agent ID for the current install of Falcon",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "cid",
+        "description": "The CrowdStrike customer ID",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "falcon_version",
+        "description": "The version of Falcon Sensor installed",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "reduced_functionality_mode",
+        "description": "Whether Falcon Sensor is in reduced functionality mode (true/false)",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "sensor_loaded",
+        "description": "Whether Falcon Sensor is loaded (true/false)",
+        "required": false,
+        "type": "text"
+      }
+    ],
+    "url": "https://fleetdm.com/tables/crowdstrike_falcon",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/crowdstrike_falcon.yml"
+  },
+  {
     "name": "cryptoinfo",
     "description": "Get info about a certificate on the host.",
     "evented": false,

--- a/schema/tables/crowdstrike_falcon.yml
+++ b/schema/tables/crowdstrike_falcon.yml
@@ -1,0 +1,34 @@
+name: crowdstrike_falcon
+notes: This table is from the [Mac Admins osquery extension](https://github.com/macadmins/osquery-extension).
+description: Information about Crowdstrike Falcon, collected via the falconctl utility.
+platforms:
+  - darwin
+  - linux
+evented: false
+examples: |-
+  Output most table information, swapping customer ID for its length to avoid leaking sensitive information.
+
+  ```
+  SELECT agent_id, LENGTH(cid), falcon_version, reduced_functionality_mode, sensor_loaded FROM crowdstrike_falcon;
+  ```
+columns:
+  - name: agent_id
+    description: The agent ID for the current install of Falcon
+    required: false
+    type: text
+  - name: cid
+    description: The CrowdStrike customer ID
+    required: false
+    type: text
+  - name: falcon_version
+    description: The version of Falcon Sensor installed
+    required: false
+    type: text
+  - name: reduced_functionality_mode
+    description: Whether Falcon Sensor is in reduced functionality mode (true/false)
+    required: false
+    type: text
+  - name: sensor_loaded
+    description: Whether Falcon Sensor is loaded (true/false)
+    required: false
+    type: text


### PR DESCRIPTION
For #33193. No changes file as this is just documentation for the table shipping in fleetd 1.50, which has a changes file of its own.

## Testing

- [x] QA'd all new/changed functionality manually