### PR TITLE
Update tags on "publish-go-module" workflow

### DIFF
--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - "fleet-v*"
+      - "fleet-*"
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/goreleaser-fleet.yaml
+++ b/.github/workflows/goreleaser-fleet.yaml
@@ -3,7 +3,7 @@ name: goreleaser
 on:
   push:
     tags:
-      - "fleet-*"
+      - "fleet-v*"
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/publish-go-module.yml
+++ b/.github/workflows/publish-go-module.yml
@@ -8,7 +8,7 @@ name: Publish go module
 on:
   push:
     tags:
-      - "v4.*"
+      - "fleet-v*"
 
 defaults:
   run:


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #6994

This updates the publish-go-module.yml to run on `fleet-v*` (e.g. `fleet-v4.76.0`) tags rather than `4.*` tags, which seem to be inconsistently published.