### PR TITLE
Fleet release note template: Supported fleetctl

### DIFF
--- a/docs/Contributing/workflows/releasing-fleet.md
+++ b/docs/Contributing/workflows/releasing-fleet.md
@@ -151,17 +151,18 @@ When the Actions Workflow has been completed, [publish the new version of Fleet]
 
 > Fleet-maintained app updates and vulnerability fixes are applied, whether or not you upgrade.
 
-### Fleet's agent
+### Fleet's agent and fleetctl CLI
 
-The following version of Fleet's agent (`fleetd`) support the latest changes to Fleet:
+The following version of Fleet's agent (fleetd) and fleetctl support the latest changes to Fleet:
 
 <UPDATE VERSIONS AND LINKS BELOW>
 1. [orbit-v1.x.x](https://github.com/fleetdm/fleet/releases/tag/orbit-v1.x.x)
-2. `fleet-desktop-v1.x.x` (included with Orbit)
-3. `osquery-x.x.x`
+2. fleet-desktop-v1.x.x (included with Orbit)
+3. osquery-x.x.x
 4. [fleetd-chrome-v1.x.x](https://github.com/fleetdm/fleet/releases/tag/fleetd-chrome-v1.x.x)
+5. fleetctl vx.x.x
 
-> While newer versions of `fleetd` still function with older versions of the Fleet server (and vice versa), Fleet does not actively test these scenarios and some newer features won't be available.
+> While newer versions of fleetd and fleetctl still function with older versions of the Fleet server (and vice versa), Fleet does not actively test these scenarios and some newer features won't be available.
 
 ### Upgrading
 


### PR DESCRIPTION
- In every Fleet release, remind users that the latest version of fleetctl is the best practice
- Based on feedback from `cisneros`: https://fleetdm.slack.com/archives/C072L58U878/p1761575109554129?thread_ts=1761575081.629709&cid=C072L58U878
- Also remove backticks (`). We don't use those when saying "fleetd" in docs/guides.
