### PR TITLE
Add GitOps and generate-gitops smoke tests to release QA

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-qa.md
+++ b/.github/ISSUE_TEMPLATE/release-qa.md
@@ -70,6 +70,13 @@ Smoke tests are limited to core functionality and serve as a pre-release final r
  
 </td><td>pass/fail</td></tr>
 
+<tr><td>GitOps and generate-gitops</td><td>
+
+1. `fleetctl generate-gitops` from a version-matched fleetctl successfully outputs YAML from a brand new Fleet server (net of auto-populated teams etc.).
+2. Running GitOps succeeds on the files created in the previous step, either using the `gitops.sh` script directly (from the `fleet-gitops` repo) or by using the GitOps GitHub or GitLab workflow (attempting via one of these three is sufficient).
+ 
+</td><td>pass/fail</td></tr>
+
 </table>
 
 ### MDM


### PR DESCRIPTION
Action item from the #33677 / #34527 postmortem.