### PR TITLE
Revert edit icon alignment (#35304)

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -86,13 +86,6 @@
     }
   }
 
-  &__policy-description-wrapper,
-  &__policy-resolution-wrapper {
-    .icon {
-      align-self: flex-start;
-    }
-  }
-
   &__policy-name-wrapper {
     .no-value {
       min-width: 112px;


### PR DESCRIPTION
**Related issue:** Resolves #34999 

Reverts edit icon alignment introduced [here](https://github.com/fleetdm/fleet/pull/35247)