### PR TITLE
Website: update /try redirects

### DIFF
--- a/website/api/controllers/view-fleet-premium-trial-or-redirect.js
+++ b/website/api/controllers/view-fleet-premium-trial-or-redirect.js
@@ -16,12 +16,22 @@ module.exports = {
     redirectToLiveFleetInstance: {
       description: 'The user was redirected to their Fleet Premium trial instance.',
       responseType: 'redirect',
+    },
+    redirectToCustomerDashboard: {
+      description: 'This user was redirected to their customer dashboard',
+      responseType: 'redirect'
     }
 
   },
 
 
   fn: async function () {
+
+    // If the user has a license key, we'll redirect them to the customer dashboard.
+    let userHasExistingSubscription = await Subscription.findOne({user: this.req.me.id});
+    if (userHasExistingSubscription) {
+      throw {redirectToCustomerDashboard: '/customers/dashboard'};
+    }
 
     let trialIsExpired = false;
     let trialLicenseKey;


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/35222

Changes:
- Updated the `view-fleet-premium-trial-or-redirect` action to redirect users who have purchased a self-service Fleet Premium license to their customer dashboard.