### PR TITLE
Website: create historical events for "Send a message" submissions

### DIFF
--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -109,16 +109,25 @@ Fleet Premium subscription details:
       },
     });
 
-
-    sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
-      emailAddress: emailAddress,
-      firstName: firstName,
-      lastName: lastName,
-      contactSource: 'Website - Contact forms',
-      description: `Sent a contact form message: ${message}`,
+    sails.helpers.flow.build(async ()=>{
+      let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+        emailAddress: emailAddress,
+        firstName: firstName,
+        lastName: lastName,
+        contactSource: 'Website - Contact forms',
+        description: `Sent a contact form message: ${message}`,
+      });
+      // Create the new Fleet website page view record.
+      await sails.helpers.salesforce.createHistoricalEvent.with({
+        salesforceAccountId: recordIds.salesforceAccountId,
+        salesforceContactId: recordIds.salesforceContactId,
+        eventType: 'Intent signal',
+        intentSignal: 'Submitted the "Send a message" form',
+        eventContent: message,
+      });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {
-        sails.log.warn(`Background task failed: When a user submitted a contact form message, a lead/contact could not be updated in the CRM for this email address: ${emailAddress}.`, err);
+        sails.log.warn(`Background task failed: When a user submitted a contact form message, a contact/account/historical event could not be created/updated in the CRM for this email address: ${emailAddress}.`, err);
       }
       return;
     });


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/32358

Changes:
- Updated the `deliver-contact-form-message` action to create a historical event in our CRM when users submit the "Send a message" form.