### PR TITLE
Bring back SSO routes in a way that doesn't break other integration sub-routes, always show EUA SSO settings

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -33,7 +33,11 @@ const IntegrationsPage = ({
   const { renderFlash } = useContext(NotificationContext);
   const { isPremiumTier } = useContext(AppContext);
 
-  const { section, subsection } = params;
+  let { section } = params;
+  const { subsection } = params;
+  if (!section && !!subsection) {
+    section = "sso";
+  }
   const [isUpdatingSettings, setIsUpdatingSettings] = useState(false);
 
   // // // settings that live under the integrations page

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -202,10 +202,6 @@ const EndUserAuthSection = ({
     );
   };
 
-  if (!config?.mdm.apple_bm_enabled_and_configured) {
-    return null;
-  }
-
   return <div className={baseClass}>{renderContent()}</div>;
 };
 

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -202,6 +202,10 @@ const routes = (
                   path="integrations/:section"
                   component={AdminIntegrationsPage}
                 />
+                <Route
+                  path="integrations/sso/:subsection"
+                  component={AdminIntegrationsPage}
+                />
                 <Route component={ExcludeInSandboxRoutes}>
                   <Route path="users" component={AdminUserManagementPage} />
                 </Route>


### PR DESCRIPTION
More fixes for #34525. Found another bug while clicking around, which I'll file as an unreleased.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually