### PR TITLE
[DO NOT MERGE] Don't make extra queries for unused data when grabbing team config for conditional access, 4.75.1 edition

### DIFF
--- a/changes/35333-less-heavy-team-get-on-conditional-access
+++ b/changes/35333-less-heavy-team-get-on-conditional-access
@@ -1,0 +1,1 @@
+* Use a lighter-weight query for checking if a team is enabled for conditional access.

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2422,7 +2422,7 @@ func (svc *Service) conditionalAccessConfiguredAndEnabledForTeam(ctx context.Con
 	}
 
 	// Host belongs to a team, thus we load the team configuration.
-	team, err := svc.ds.Team(ctx, *hostTeamID)
+	team, err := svc.ds.TeamWithoutExtras(ctx, *hostTeamID)
 	if err != nil {
 		return false, false, ctxerr.Wrap(ctx, err, "failed to load team config")
 	}


### PR DESCRIPTION
#35337, but make it on top of 4.75.1 instead of `main`.