### PR TITLE
Correct tables used for lookup in cert-based auth

### DIFF
--- a/server/datastore/mysql/host_identity_scep.go
+++ b/server/datastore/mysql/host_identity_scep.go
@@ -2,7 +2,11 @@ package mysql
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
 	"database/sql"
+	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"fmt"
 
@@ -59,4 +63,55 @@ func (ds *Datastore) GetHostIdentityCertByName(ctx context.Context, name string)
 		return nil, err
 	}
 	return &hostIdentityCert, nil
+}
+
+// GetMDMSCEPCertBySerial looks up an MDM SCEP certificate by serial number
+// and returns the device UUID it's associated with. This is used for iOS/iPadOS
+// certificate-based authentication on the My Device page.
+//
+// This query uses the nano_cert_auth_associations table which maps device IDs to
+// certificate hashes. The serial number lookup in scep_certificates provides
+// the raw certificate data, but we need the nanomdm association to get the device UUID.
+func (ds *Datastore) GetMDMSCEPCertBySerial(ctx context.Context, serialNumber uint64) (deviceUUID string, err error) {
+	// First get the certificate by serial
+	var certPEM string
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &certPEM, `
+		SELECT certificate_pem
+		FROM scep_certificates
+		WHERE serial = ?
+			AND not_valid_after > NOW()
+			AND revoked = 0`, serialNumber)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", notFound("MDM SCEP certificate")
+	case err != nil:
+		return "", err
+	}
+
+	// Calculate the SHA256 hash of the certificate the same way nanomdm does
+	// (see server/mdm/nanomdm/service/certauth/certauth.go HashCert function)
+	// The hash is calculated from cert.Raw (DER-encoded bytes), not the PEM string
+	block, _ := pem.Decode([]byte(certPEM))
+	if block == nil {
+		return "", fmt.Errorf("failed to decode PEM certificate")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse certificate: %w", err)
+	}
+	hashed := sha256.Sum256(cert.Raw)
+	hash := hex.EncodeToString(hashed[:])
+
+	// Look up the device UUID by certificate hash
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &deviceUUID, `
+		SELECT id
+		FROM nano_cert_auth_associations
+		WHERE sha256 = ?`, hash)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return "", notFound("MDM certificate association")
+	case err != nil:
+		return "", err
+	}
+	return deviceUUID, nil
 }

--- a/server/datastore/mysql/host_identity_scep.go
+++ b/server/datastore/mysql/host_identity_scep.go
@@ -93,7 +93,7 @@ func (ds *Datastore) GetMDMSCEPCertBySerial(ctx context.Context, serialNumber ui
 	// The hash is calculated from cert.Raw (DER-encoded bytes), not the PEM string
 	block, _ := pem.Decode([]byte(certPEM))
 	if block == nil {
-		return "", fmt.Errorf("failed to decode PEM certificate")
+		return "", errors.New("failed to decode PEM certificate")
 	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2429,6 +2429,9 @@ type Datastore interface {
 	GetHostIdentityCertByName(ctx context.Context, name string) (*types.HostIdentityCertificate, error)
 	// UpdateHostIdentityCertHostIDBySerial updates the host ID associated with a certificate using its serial number.
 	UpdateHostIdentityCertHostIDBySerial(ctx context.Context, serialNumber uint64, hostID uint) error
+	// GetMDMSCEPCertBySerial looks up an MDM SCEP certificate by serial number and returns the device UUID.
+	// This is used for iOS/iPadOS certificate-based authentication.
+	GetMDMSCEPCertBySerial(ctx context.Context, serialNumber uint64) (deviceUUID string, err error)
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Certificate Authorities

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1569,6 +1569,8 @@ type GetHostIdentityCertByNameFunc func(ctx context.Context, name string) (*type
 
 type UpdateHostIdentityCertHostIDBySerialFunc func(ctx context.Context, serialNumber uint64, hostID uint) error
 
+type GetMDMSCEPCertBySerialFunc func(ctx context.Context, serialNumber uint64) (string, error)
+
 type NewCertificateAuthorityFunc func(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error)
 
 type GetCertificateAuthorityByIDFunc func(ctx context.Context, id uint, includeSecrets bool) (*fleet.CertificateAuthority, error)
@@ -3908,6 +3910,9 @@ type DataStore struct {
 
 	UpdateHostIdentityCertHostIDBySerialFunc        UpdateHostIdentityCertHostIDBySerialFunc
 	UpdateHostIdentityCertHostIDBySerialFuncInvoked bool
+
+	GetMDMSCEPCertBySerialFunc        GetMDMSCEPCertBySerialFunc
+	GetMDMSCEPCertBySerialFuncInvoked bool
 
 	NewCertificateAuthorityFunc        NewCertificateAuthorityFunc
 	NewCertificateAuthorityFuncInvoked bool
@@ -9351,6 +9356,13 @@ func (s *DataStore) UpdateHostIdentityCertHostIDBySerial(ctx context.Context, se
 	s.UpdateHostIdentityCertHostIDBySerialFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostIdentityCertHostIDBySerialFunc(ctx, serialNumber, hostID)
+}
+
+func (s *DataStore) GetMDMSCEPCertBySerial(ctx context.Context, serialNumber uint64) (string, error) {
+	s.mu.Lock()
+	s.GetMDMSCEPCertBySerialFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetMDMSCEPCertBySerialFunc(ctx, serialNumber)
 }
 
 func (s *DataStore) NewCertificateAuthority(ctx context.Context, ca *fleet.CertificateAuthority) (*fleet.CertificateAuthority, error) {

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -273,8 +273,8 @@ func (svc *Service) AuthenticateDeviceByCertificate(ctx context.Context, certSer
 		return nil, false, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("authentication error: missing host UUID"))
 	}
 
-	// Look up the certificate by serial number
-	cert, err := svc.ds.GetHostIdentityCertBySerialNumber(ctx, certSerial)
+	// Look up the MDM SCEP certificate by serial number to get the device UUID
+	certDeviceUUID, err := svc.ds.GetMDMSCEPCertBySerial(ctx, certSerial)
 	switch {
 	case err == nil:
 		// OK
@@ -284,8 +284,8 @@ func (svc *Service) AuthenticateDeviceByCertificate(ctx context.Context, certSer
 		return nil, false, ctxerr.Wrap(ctx, err, "lookup certificate by serial")
 	}
 
-	// Verify certificate matches the host UUID (CN should match UUID)
-	if cert.CommonName != hostUUID {
+	// Verify certificate's device UUID matches the requested host UUID
+	if certDeviceUUID != hostUUID {
 		return nil, false, ctxerr.Wrap(ctx, fleet.NewAuthRequiredError("authentication error: certificate does not match host"))
 	}
 


### PR DESCRIPTION
Fixes cert-based auth to do device lookup using the correct tables