### PR TITLE
Fleet UI: Do not call delete for icon that doesn't exist

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -573,19 +573,23 @@ const EditIconModal = ({
       // Process icon change
       try {
         if (!iconState.formData?.icon) {
-          await softwareAPI.deleteSoftwareIcon(softwareId, teamIdForApi);
-          notifications.push({
-            id: "icon-removed",
-            alertType: "success",
-            isVisible: true,
-            message: (
-              <>
-                Successfully removed icon from <b>{software?.name}</b>.
-              </>
-            ),
-            persistOnPageChange: false,
-          });
+          // No new upload, so either removing existing custom icon or no change
+          if (originalIsApiCustom) {
+            await softwareAPI.deleteSoftwareIcon(softwareId, teamIdForApi);
+            notifications.push({
+              id: "icon-removed",
+              alertType: "success",
+              isVisible: true,
+              message: (
+                <>
+                  Successfully removed icon from <b>{software?.name}</b>.
+                </>
+              ),
+              persistOnPageChange: false,
+            });
+          }
         } else {
+          // New custom icon upload
           await softwareAPI.editSoftwareIcon(
             softwareId,
             teamIdForApi,


### PR DESCRIPTION
## Issue
Followup for #33779

## Description
- When editing the software name, the UI was calling the delete icon API for an empty icon even though it was empty to begin with
- Fix is only to call the delete icon API if it is an empty icon but there was a custom icon to begin with

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

## Testing

- [x] QA'd all new/changed functionality manually
