### PR TITLE
Fleet UI: Fix preview icon from changing

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -500,7 +500,7 @@ const EditIconModal = ({
             // Known limitation: we cannot see VPP app icons as the fallback when a custom icon
             // is set as VPP icon is not returned by the API if a custom icon is returned
             <SoftwareIcon
-              name={displayName || previewInfo.name}
+              name={previewInfo.name}
               source={previewInfo.source}
               url={isSoftwarePackage ? undefined : software.icon_url} // fallback PNG icons only exist for VPP apps
               uploadedAt={iconUploadedAt}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
@@ -59,10 +59,10 @@
 
   &__self-service-preview {
     position: relative;
-    top: -76px;
+    top: -79px;
     left: 188px;
     display: flex;
-    gap: $pad-small;
+    gap: $pad-xsmall;
     font-size: 12px;
     align-items: center;
     max-width: 210px;


### PR DESCRIPTION
## Issue
Closes #35356

## Description
- Bug solution: Don't use display name for default icon indexing, only given name
- Other: Fix alignment in the self-service preview to be more aligned with other software icon/name in preview

## Screenrecording of fix

https://github.com/user-attachments/assets/785aa842-80e2-4e7d-9549-b53bd9e45150


# Checklist for submitter


- [x] QA'd all new/changed functionality manually
