### PR TITLE
Update Microsoft Edge install script

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/microsoft-edge.json
+++ b/ee/maintained-apps/inputs/homebrew/microsoft-edge.json
@@ -4,6 +4,8 @@
   "unique_identifier": "com.microsoft.edgemac",
   "token": "microsoft-edge",
   "installer_format": "dmg",
-  "default_categories": ["Browsers"],
-  "install_script_path": "scripts/microsoft-edge-install.sh"
+  "default_categories": [
+    "Browsers"
+  ],
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/microsoft-edge-install.sh"
 }

--- a/ee/maintained-apps/inputs/homebrew/microsoft-edge.json
+++ b/ee/maintained-apps/inputs/homebrew/microsoft-edge.json
@@ -4,5 +4,6 @@
   "unique_identifier": "com.microsoft.edgemac",
   "token": "microsoft-edge",
   "installer_format": "dmg",
-  "default_categories": ["Browsers"]
+  "default_categories": ["Browsers"],
+  "install_script_path": "scripts/microsoft-edge-install.sh"
 }

--- a/ee/maintained-apps/inputs/homebrew/scripts/microsoft-edge-install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/microsoft-edge-install.sh
@@ -62,3 +62,4 @@ if [ -d "$APPDIR/Microsoft Edge.app" ] && [ -d "$TMPDIR/Microsoft Edge.app.bkp" 
 	echo "Installation verified, backup file removed"
 fi
 
+

--- a/ee/maintained-apps/inputs/homebrew/scripts/microsoft-edge-install.sh
+++ b/ee/maintained-apps/inputs/homebrew/scripts/microsoft-edge-install.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# variables
+APPDIR="/Applications/"
+TMPDIR=$(dirname "$(realpath $INSTALLER_PATH)")
+
+# functions
+
+quit_application() {
+  local bundle_id="$1"
+  local timeout_duration=10
+
+  # check if the application is running
+  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+    return
+  fi
+
+  local console_user
+  console_user=$(stat -f "%Su" /dev/console)
+  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+    echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
+    return
+  fi
+
+  echo "Quitting application '$bundle_id'..."
+
+  # try to quit the application within the timeout period
+  local quit_success=false
+  SECONDS=0
+  while (( SECONDS < timeout_duration )); do
+    if osascript -e "tell application id \"$bundle_id\" to quit" >/dev/null 2>&1; then
+      if ! pgrep -f "$bundle_id" >/dev/null 2>&1; then
+        echo "Application '$bundle_id' quit successfully."
+        quit_success=true
+        break
+      fi
+    fi
+    sleep 1
+  done
+
+  if [[ "$quit_success" = false ]]; then
+    echo "Application '$bundle_id' did not quit."
+  fi
+}
+
+# extract contents
+MOUNT_POINT=$(mktemp -d /tmp/dmg_mount_XXXXXX)
+hdiutil attach -plist -nobrowse -readonly -mountpoint "$MOUNT_POINT" "$INSTALLER_PATH"
+sudo cp -R "$MOUNT_POINT"/* "$TMPDIR"
+hdiutil detach "$MOUNT_POINT"
+
+# copy to the applications folder
+quit_application 'com.microsoft.edgemac'
+if [ -d "$APPDIR/Microsoft Edge.app" ]; then
+	sudo mv "$APPDIR/Microsoft Edge.app" "$TMPDIR/Microsoft Edge.app.bkp"
+fi
+sudo cp -R "$TMPDIR/Microsoft Edge.app" "$APPDIR"
+
+# Clean up backup file if installation was successful
+if [ -d "$APPDIR/Microsoft Edge.app" ] && [ -d "$TMPDIR/Microsoft Edge.app.bkp" ]; then
+	sudo rm -rf "$TMPDIR/Microsoft Edge.app.bkp"
+	echo "Installation verified, backup file removed"
+fi
+


### PR DESCRIPTION
Added logic to the install script to clean up its bkp (backup file) after successfully installing the app.  

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
