### PR TITLE
Docs: Add messaging about 🪲 #35309

### DIFF
--- a/articles/macos-setup-experience.md
+++ b/articles/macos-setup-experience.md
@@ -141,6 +141,8 @@ To sign the package we need a valid Developer ID Installer certificate:
 
 ## Software and script
 
+> As of Fleet 4.59.0, there is a known bug in which, if [GitOps](https://fleetdm.com/docs/configuration/yaml-files) runs while a new Mac is going through Setup Assistant, the script will not run. Follow the [GitHub issue](https://github.com/fleetdm/fleet/issues/35309) to learn more.
+
 You can configure software installations and a script to be executed during Setup Assistant. This capability allows you to configure your end users' machines during the unboxing experience, speeding up their onboarding and reducing setup time.
 
 If you configure software and/or a script for setup experience, users will see a window like this pop open after their device enrolls in MDM via ADE:

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -438,6 +438,8 @@ If certificate authority (CA) variables (ex. `$FLEET_VAR_DIGICERT_DATA_<CA_NAME>
 
 ### macos_setup
 
+> As of Fleet 4.59.0, there is a known bug in which, if GitOps runs while a new Mac is going through Setup Assistant, the script will not run. Follow the [GitHub issue](https://github.com/fleetdm/fleet/issues/35309) to learn more.
+
 The `macos_setup` section lets you control the out-of-the-box macOS [setup experience](https://fleetdm.com/guides/macos-setup-experience) for hosts that use Automated Device Enrollment (ADE).
 
 > **Experimental feature.** The `manual_agent_install` feature is undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.


### PR DESCRIPTION
Add caveat to macOS setup experience and GitOps docs re: 🪲 #35309
<img width="828" height="306" alt="Screenshot 2025-11-08 at 1 05 11 PM" src="https://github.com/user-attachments/assets/ca6a04f6-bea6-4863-839e-65a004bad932" />

