### PR TITLE
add external link icon to turn on mdm button on device banner

### DIFF
--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -17,7 +17,7 @@ export interface IInfoBannerProps {
   borderRadius?: "medium" | "xlarge";
   pageLevel?: boolean;
   /** Add this element to the end of the banner message. Mutually exclusive with `link`. */
-  cta?: JSX.Element;
+  cta?: React.ReactNode;
   /** closable and link are mutually exclusive */
   closable?: boolean;
   icon?: IconNames; // TODO: This is unused but several banners have icons within children that can be refactored to use this for consistent styling

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/DeviceUserBanners.tsx
@@ -1,17 +1,21 @@
 import React from "react";
 
+import { isDiskEncryptionSupportedLinuxPlatform } from "interfaces/platform";
+import { MacDiskEncryptionActionRequired } from "interfaces/host";
+
+import CustomLink from "components/CustomLink";
+import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";
 import Button from "components/buttons/Button";
-import { MacDiskEncryptionActionRequired } from "interfaces/host";
+
 import { IHostBannersBaseProps } from "pages/hosts/details/HostDetailsPage/components/HostDetailsBanners/HostDetailsBanners";
-import CustomLink from "components/CustomLink";
-import { isDiskEncryptionSupportedLinuxPlatform } from "interfaces/platform";
 
 const baseClass = "device-user-banners";
 
 interface IDeviceUserBannersProps extends IHostBannersBaseProps {
   mdmEnabledAndConfigured: boolean;
   diskEncryptionActionRequired: MacDiskEncryptionActionRequired | null;
+  deviceAssignedToFleetABM?: boolean;
   onClickCreatePIN: () => void;
   onClickTurnOnMdm: () => void;
   onTriggerEscrowLinuxKey: () => void;
@@ -30,6 +34,7 @@ const DeviceUserBanners = ({
   diskEncryptionOSSetting,
   diskIsEncrypted,
   diskEncryptionKeyAvailable,
+  deviceAssignedToFleetABM = false,
   onTriggerEscrowLinuxKey,
 }: IDeviceUserBannersProps) => {
   const isMdmUnenrolled =
@@ -45,16 +50,22 @@ const DeviceUserBanners = ({
     macDiskEncryptionStatus === "action_required" &&
     diskEncryptionActionRequired === "rotate_key";
 
-  const turnOnMdmButton = (
+  const turnOnMdmCTA = (
     <Button variant="text-link-dark" onClick={onClickTurnOnMdm}>
-      Turn on MDM
+      <span>Turn on MDM</span>
+      {!deviceAssignedToFleetABM && (
+        <Icon
+          name="external-link"
+          className={`${baseClass}__external-link-icon`}
+        />
+      )}
     </Button>
   );
 
   const renderBanner = () => {
     if (showTurnOnAppleMdmBanner) {
       return (
-        <InfoBanner color="yellow" cta={turnOnMdmButton}>
+        <InfoBanner color="yellow" cta={turnOnMdmCTA}>
           Mobile device management (MDM) is off. MDM allows your organization to
           change settings and install software. This lets your organization keep
           your device up to date so you don&apos;t have to.

--- a/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
+++ b/frontend/pages/hosts/details/DeviceUserPage/components/DeviceUserBanners/_styles.scss
@@ -3,4 +3,12 @@
     color: $core-fleet-black;
     font-weight: $bold;
   }
+  
+  // this is currently only used in the device user banner component
+  // so we do these one off styles here. If we start using this
+  // link style with icon elsewhere we should move it into the Button component
+  &__external-link-icon {
+    margin-left: $pad-xsmall;
+    margin-top: $pad-xxsmall; 
+  }
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Fixes #34268

This a quick fix for showing an external link icon with the Turn on MDM button on the device banner if the device is assigned to Fleet in the ABM

