### PR TITLE
Fleet UI: Fix removed display name message

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -619,7 +619,7 @@ const EditIconModal = ({
       }
 
       // Process display name change
-      if (displayName !== previewInfo.name) {
+      if (canSaveDisplayName) {
         try {
           await (installerType === "package"
             ? softwareAPI.editSoftwarePackage({
@@ -634,12 +634,18 @@ const EditIconModal = ({
             id: "name-edited",
             alertType: "success",
             isVisible: true,
-            message: (
-              <>
-                Successfully renamed <b>{previewInfo.name}</b> to{" "}
-                <b>{displayName}</b>.
-              </>
-            ),
+            message:
+              displayName === "" ? (
+                <>
+                  Successfully removed custom name for <b>{previewInfo.name}</b>
+                  .
+                </>
+              ) : (
+                <>
+                  Successfully renamed <b>{previewInfo.name}</b> to{" "}
+                  <b>{displayName}</b>.
+                </>
+              ),
             persistOnPageChange: false,
           });
         } catch (e) {


### PR DESCRIPTION
## Issue
Follow up for #33779 

## Description

2 fixes:
- Only call the edit software API for display name if the display name has been modified
- Update the success message for if a display name is removed

## Testing

- [x] QA'd all new/changed functionality manually
