### PR TITLE
Fleet UI: Fix conflict to allow clickable tooltip on mobile view

### DIFF
--- a/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
+++ b/frontend/components/TooltipTruncatedText/TooltipTruncatedText.tsx
@@ -11,7 +11,7 @@ interface ITooltipTruncatedTextCellProps {
   tooltip?: React.ReactNode;
   className?: string;
   tooltipPosition?: "top" | "bottom" | "left" | "right";
-  isMobileView?: boolean; // new prop
+  isMobileView?: boolean;
 }
 
 const baseClass = "tooltip-truncated-text";
@@ -38,6 +38,7 @@ const TooltipTruncatedText = ({
       position={tooltipPosition}
       showArrow
       tipContent={tooltip ?? value}
+      isMobileView={isMobileView}
     >
       <div className={`${baseClass}__text-value`} ref={ref}>
         {value}

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -48,6 +48,7 @@ and mouseout from the element. If a boolean, sets delay to the default below. If
    * Do this if you run into issues with `overflow: hidden` on the tooltip parent container
    * */
   fixedPositionStrategy?: boolean;
+  isMobileView?: boolean;
 }
 
 const baseClass = "component__tooltip-wrapper";
@@ -73,6 +74,7 @@ const TooltipWrapper = ({
   disableTooltip = false,
   showArrow = false,
   fixedPositionStrategy = false,
+  isMobileView = false,
 }: ITooltipWrapper) => {
   const wrapperClassNames = classnames(baseClass, className, {
     "show-arrow": showArrow,
@@ -110,9 +112,15 @@ const TooltipWrapper = ({
     [delayShowVal, delayHideVal] = [delayShowHide, delayShowHide];
   }
 
+  console.log("isMobileView in TooltipWrapper:", isMobileView);
   return (
     <span className={wrapperClassNames}>
-      <div className={elementClassNames} data-tip data-tooltip-id={tipId}>
+      <div
+        className={elementClassNames}
+        data-tip
+        data-tooltip-id={tipId}
+        style={!isMobileView ? { cursor: "pointer" } : undefined} // With mobile width, show pointer cursor on hover since tooltip won't show on hover
+      >
         {children}
       </div>
       {!disableTooltip && (
@@ -128,6 +136,11 @@ const TooltipWrapper = ({
           clickable={clickable}
           offset={tipOffset}
           positionStrategy={fixedPositionStrategy ? "fixed" : "absolute"}
+          globalCloseEvents={
+            isMobileView ? { clickOutsideAnchor: true } : undefined
+          }
+          openEvents={isMobileView ? { click: true } : { mouseenter: true }}
+          closeEvents={isMobileView ? { click: true } : { mouseleave: true }}
         >
           {tipContent}
         </ReactTooltip5>

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -112,7 +112,6 @@ const TooltipWrapper = ({
     [delayShowVal, delayHideVal] = [delayShowHide, delayShowHide];
   }
 
-  console.log("isMobileView in TooltipWrapper:", isMobileView);
   return (
     <span className={wrapperClassNames}>
       <div

--- a/frontend/components/TooltipWrapper/TooltipWrapper.tsx
+++ b/frontend/components/TooltipWrapper/TooltipWrapper.tsx
@@ -119,7 +119,9 @@ const TooltipWrapper = ({
         className={elementClassNames}
         data-tip
         data-tooltip-id={tipId}
-        style={!isMobileView ? { cursor: "pointer" } : undefined} // With mobile width, show pointer cursor on hover since tooltip won't show on hover
+        style={
+          isMobileView && !disableTooltip ? { cursor: "pointer" } : undefined
+        } // With mobile width, show pointer cursor on hover since tooltip won't show on hover
       >
         {children}
       </div>


### PR DESCRIPTION
## Issue 
Follow up of #33779 merge conflicts

## Description
- Updates to tooltip truncated text had conflicts with this solution
- During merge conflict, took Updates to tooltip truncated text knowing this would be a followup PR to apply this solution
- When viewing low width from a laptop browser, have a cursor hover to indicate it's clickable to see a tooltip

## Screen recording of fix
https://fleetdm.zoom.us/clips/share/7u2KxUn1T3C2xgLMNgHScg

Update with the cursor hover:

https://github.com/user-attachments/assets/1d7127cf-4bde-4b6b-a3ff-0f307ea31152



<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

## Testing

- [x] QA'd all new/changed functionality manually
