### PR TITLE
Fix issue where end-user sso form sometimes shows stale data

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -108,6 +108,7 @@ const IntegrationsPage = ({
               // below props used only by settings-related cards e.g. SSO
               appConfig={appConfig}
               handleSubmit={onUpdateSettings}
+              refetchConfig={refetchConfig}
               isPremiumTier={isPremiumTier}
               isUpdatingSettings={isUpdatingSettings}
               subsection={subsection}

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -116,7 +116,6 @@ const IntegrationsPage = ({
               // below props used only by settings-related cards e.g. SSO
               appConfig={appConfig}
               handleSubmit={onUpdateSettings}
-              refetchConfig={refetchConfig}
               isPremiumTier={isPremiumTier}
               isUpdatingSettings={isUpdatingSettings}
               subsection={subsection}

--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -60,9 +60,17 @@ const IntegrationsPage = ({
         return false;
       }
 
+      const diff = deepDifference(formUpdates, appConfig);
+
+      // If there's no actual change, don't make the API call to update config.
+      // Still refetch in case settings were changed inside a card (like end-user auth).
+      if (Object.keys(diff).length === 0) {
+        refetchConfig();
+        return true;
+      }
+
       setIsUpdatingSettings(true);
 
-      const diff = deepDifference(formUpdates, appConfig);
       // send all formUpdates.agent_options because diff overrides all agent options
       diff.agent_options = formUpdates.agent_options;
 

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -40,7 +40,9 @@ const EndUserAuthSection = ({
   formData,
   setFormData,
   originalFormData,
-  onSubmit: handleSubmit,
+  // Notify parent component of changes, since we're calling our own API
+  // rather than using the common config update handler.
+  onSubmit: announceChanges,
 }: IEndUserAuthSectionProps) => {
   const { config, isPremiumTier } = useContext(AppContext);
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
@@ -100,7 +102,9 @@ const EndUserAuthSection = ({
         renderFlash("success", "Successfully updated end user authentication!");
         originalFormData.current = { ...formData };
         setDirty(false);
-        handleSubmit();
+        // Notify parent component of changes, since we're calling our own API
+        // rather than using the common config update handler.
+        announceChanges();
       } catch (err) {
         const ae = (typeof err === "object" ? err : {}) as AxiosResponse;
         if (ae.status === 422) {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -32,6 +32,7 @@ export interface IEndUserAuthSectionProps {
   formData: IFormDataIdp;
   setFormData: React.Dispatch<React.SetStateAction<IFormDataIdp>>;
   originalFormData: MutableRefObject<IFormDataIdp>;
+  onSubmit: () => void;
 }
 
 const EndUserAuthSection = ({
@@ -39,6 +40,7 @@ const EndUserAuthSection = ({
   formData,
   setFormData,
   originalFormData,
+  onSubmit: handleSubmit,
 }: IEndUserAuthSectionProps) => {
   const { config, isPremiumTier } = useContext(AppContext);
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
@@ -98,6 +100,7 @@ const EndUserAuthSection = ({
         renderFlash("success", "Successfully updated end user authentication!");
         originalFormData.current = { ...formData };
         setDirty(false);
+        handleSubmit();
       } catch (err) {
         const ae = (typeof err === "object" ? err : {}) as AxiosResponse;
         if (ae.status === 422) {

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -91,6 +91,7 @@ export const AUTH_TARGETS_BY_INDEX = ["fleet-users", "end-users"];
 const Sso = ({
   appConfig,
   handleSubmit,
+  refetchConfig,
   isPremiumTier,
   isUpdatingSettings,
   router,
@@ -180,6 +181,11 @@ const Sso = ({
       originalFormData.current = { ...formData };
     }
   };
+
+  console.log(
+    "appConfig?.mdm?.end_user_authentication",
+    appConfig?.mdm?.end_user_authentication
+  );
 
   const [endUserFormData, setEndUserFormData] = useState<IFormDataIdp>(
     newFormDataIdp(appConfig?.mdm?.end_user_authentication)
@@ -334,12 +340,17 @@ const Sso = ({
     );
   };
 
+  const onSubmitEndUserSso = async () => {
+    refetchConfig && (await refetchConfig());
+  };
+
   const renderEndUserSsoTab = () => (
     <EndUserAuthSection
       setDirty={setFormDirty}
       formData={endUserFormData}
       setFormData={setEndUserFormData}
       originalFormData={originalEndUserFormData}
+      onSubmit={onSubmitEndUserSso}
     />
   );
 

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -335,6 +335,8 @@ const Sso = ({
   };
 
   const onSubmitEndUserSso = async () => {
+    // Notify parent component that it needs to re-fetch app config.
+    // No formUpdates needed because changes are made inside the card.
     await handleSubmit({});
   };
 

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -181,11 +181,6 @@ const Sso = ({
     }
   };
 
-  console.log(
-    "appConfig?.mdm?.end_user_authentication",
-    appConfig?.mdm?.end_user_authentication
-  );
-
   const [endUserFormData, setEndUserFormData] = useState<IFormDataIdp>(
     newFormDataIdp(appConfig?.mdm?.end_user_authentication)
   );

--- a/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Sso/Sso.tsx
@@ -91,7 +91,6 @@ export const AUTH_TARGETS_BY_INDEX = ["fleet-users", "end-users"];
 const Sso = ({
   appConfig,
   handleSubmit,
-  refetchConfig,
   isPremiumTier,
   isUpdatingSettings,
   router,
@@ -341,7 +340,7 @@ const Sso = ({
   };
 
   const onSubmitEndUserSso = async () => {
-    refetchConfig && (await refetchConfig());
+    await handleSubmit({});
   };
 
   const renderEndUserSsoTab = () => (

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -16,7 +16,6 @@ export interface IAppConfigFormProps {
   handleSubmit: (formUpdates: DeepPartial<IConfig>) => Promise<boolean>;
   router: InjectedRouter;
   subsection?: string;
-  refetchConfig?: () => Promise<IConfig>;
 }
 
 export const authMethodOptions = [

--- a/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
+++ b/frontend/pages/admin/OrgSettingsPage/cards/constants.ts
@@ -16,6 +16,7 @@ export interface IAppConfigFormProps {
   handleSubmit: (formUpdates: DeepPartial<IConfig>) => Promise<boolean>;
   router: InjectedRouter;
   subsection?: string;
+  refetchConfig?: () => Promise<IConfig>;
 }
 
 export const authMethodOptions = [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35322

# Details

Since the end-user auth form uses calls its own API rather than the common config update handler in the parent `IntegrationsPage`, we need to notify that parent when updates occur so that it can re-fetch the app config which serves as the base state for all of the sub-sections. 

# Checklist for submitter

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results

