### PR TITLE
 Make various fixes to falconctl parsing to remove errors on selecting from the falconctl_options table

### DIFF
--- a/orbit/changes/32239-falconctl-options
+++ b/orbit/changes/32239-falconctl-options
@@ -1,0 +1,1 @@
+* Fixed handling of various parsing bugs that caused the falconctl_options table to fail to load in some circumsatances.

--- a/orbit/pkg/table/crowdstrike/falconctl/parser_test.go
+++ b/orbit/pkg/table/crowdstrike/falconctl/parser_test.go
@@ -83,12 +83,15 @@ func TestParseOptions(t *testing.T) {
 			input:    []byte(`billing is not set,`),
 			expected: map[string]any{"billing": "is not set"},
 		},
-
-		// Tags are quite tricky to parse\
 		{
 			name:     "--tags",
 			input:    []byte(`tags=kolide-test-1,kolide-test-2,`),
-			expected: map[string]any{"tags": []string{"kolide-test-1", "kolide-test-2"}},
+			expected: map[string]any{"tags": "kolide-test-1,kolide-test-2"},
+		},
+		{
+			name:     "--tags with no tags",
+			input:    []byte(`Sensor grouping tags are not set`),
+			expected: map[string]any{"tags": "is not set"},
 		},
 		{
 			name:  "--rfm-state --rfm-reason --aph --tags",
@@ -98,19 +101,19 @@ func TestParseOptions(t *testing.T) {
 				"rfm-reason":      "None",
 				"rfm-reason-code": "0x0",
 				"rfm-state":       "false",
-				"tags":            []string{"kolide-test-1", "kolide-test-2"},
+				"tags":            "kolide-test-1,kolide-test-2",
 			},
 		},
 		{
 			name:  "-rfm-state --rfm-reason --aph --tags --version",
-			input: []byte("aph is not set, rfm-state=false, rfm-reason=None, code=0x0, version = 6.45.14203.0\ntags=kolide-test-1,kolide-test-2,"),
+			input: []byte("aph is not set, rfm-state=false, rfm-reason=None, code=0x0, version = 6.45.14203.0\ntags=kolide-test-1,kolide-test-2, "),
 			expected: map[string]any{
 				"aph":             "is not set",
 				"rfm-reason":      "None",
 				"rfm-reason-code": "0x0",
 				"rfm-state":       "false",
 				"version":         "6.45.14203.0",
-				"tags":            []string{"kolide-test-1", "kolide-test-2"},
+				"tags":            "kolide-test-1,kolide-test-2",
 			},
 		},
 
@@ -139,6 +142,23 @@ func TestParseOptions(t *testing.T) {
 			name:        "cid not set",
 			input:       readTestFile(t, path.Join("test-data", "cid-error.txt")),
 			expectedErr: true,
+		},
+		{
+			name:  "all options",
+			input: []byte("cid=\"deadbeefdeadbeefdeadbeefdeadbeef\", aid is not set, apd is not set, aph is not set, app is not set, feature is not set, metadata-query=enable (unset default), version = 7.30.18306.0\ntags=foo,bar, rfm-state is not set, rfm-reason is not set,"),
+			expected: map[string]any{
+				"cid":            "deadbeefdeadbeefdeadbeefdeadbeef",
+				"aid":            "is not set",
+				"apd":            "is not set",
+				"aph":            "is not set",
+				"app":            "is not set",
+				"feature":        "is not set",
+				"metadata-query": "enable",
+				"version":        "7.30.18306.0",
+				"tags":           "foo,bar",
+				"rfm-state":      "is not set",
+				"rfm-reason":     "is not set",
+			},
 		},
 	}
 

--- a/orbit/pkg/table/crowdstrike/falconctl/table.go
+++ b/orbit/pkg/table/crowdstrike/falconctl/table.go
@@ -18,7 +18,7 @@ var (
 	falconctlPaths = []string{"/opt/CrowdStrike/falconctl"}
 
 	// allowedOptions is the list of options this table is allowed to query. Notable exceptions
-	// are `systags` (which is parsed seperatedly) and `provisioning-token` (which is a secret).
+	// are `systags` (which is parsed separately) and `provisioning-token` (which is a secret).
 	allowedOptions = []string{
 		"--aid",
 		"--apd",


### PR DESCRIPTION
Fixes #32239.

This changes tags to return a comma-delimited list on multiple tags, the single tag when there's only one, and "is not set" (similar to other values) when no tags are set.

Confirmed that this allows us to run `SELECT * FROM falconctl_options` without issue on various configurations of Crowdstrike Falcon on Linux.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
