### PR TITLE
Okta IdP Apple profile endpoint + fixes

### DIFF
--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -249,21 +249,12 @@ func (w *statusInterceptingWriter) WriteHeader(statusCode int) {
 		return
 	}
 	w.headerWritten = true
-
 	if statusCode == http.StatusBadRequest {
 		level.Error(w.logger).Log("msg", "SAML IdP returned bad request, redirecting to error page", "status", statusCode)
 		http.Redirect(w.ResponseWriter, w.r, w.redirectURL, http.StatusSeeOther)
 		return
 	}
-
 	w.ResponseWriter.WriteHeader(statusCode)
-}
-
-func (w *statusInterceptingWriter) Write(b []byte) (int, error) {
-	if !w.headerWritten {
-		w.WriteHeader(http.StatusOK)
-	}
-	return w.ResponseWriter.Write(b)
 }
 
 // parseSerialNumber parses a certificate serial number from hex string to uint64.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -74,9 +74,9 @@ allow {
   action == write
 }
 
-# Global admin, gitops, maintainer, observer_plus and observer can read Okta IdP certificate.
+# Global admin, gitops, maintainer, observer_plus and observer can read Okta IdP assets.
 allow {
-  object.type == "conditional_access_idp_cert"
+  object.type == "conditional_access_idp_assets"
   subject.global_role == [admin, gitops, maintainer, observer_plus, observer][_]
   action == read
 }

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -366,6 +366,7 @@ func TestMDMUrl(t *testing.T) {
 }
 
 func TestAppConfig_ConditionalAccessIdPSSOURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		serverURL string

--- a/server/fleet/conditional_access_idp.go
+++ b/server/fleet/conditional_access_idp.go
@@ -1,10 +1,11 @@
 package fleet
 
-// ConditionalAccessIDPCert is used for authorization checks on the Okta IdP signing certificate.
-// It represents the resource being accessed when downloading the certificate.
-type ConditionalAccessIDPCert struct{}
+// ConditionalAccessIDPAssets is used for authorization checks on Okta IdP assets
+// (signing certificate, Apple profile, etc.).
+// It represents the resource being accessed when downloading these assets.
+type ConditionalAccessIDPAssets struct{}
 
 // AuthzType implements authz.AuthzTyper.
-func (c *ConditionalAccessIDPCert) AuthzType() string {
-	return "conditional_access_idp_cert"
+func (c *ConditionalAccessIDPAssets) AuthzType() string {
+	return "conditional_access_idp_assets"
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1352,6 +1352,9 @@ type Service interface {
 	// ConditionalAccessGetIdPSigningCert returns the Okta IdP signing certificate (public key only)
 	// for administrators to download and configure in Okta.
 	ConditionalAccessGetIdPSigningCert(ctx context.Context) (certPEM []byte, err error)
+	// ConditionalAccessGetIdPAppleProfile returns the Apple MDM configuration profile
+	// (for user scope) to configure Okta conditional access on the host.
+	ConditionalAccessGetIdPAppleProfile(ctx context.Context) (profileData []byte, err error)
 
 	//////////////////////////////////////////////////////////////////////////////
 	// Certificate Authorities

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -830,6 +830,8 @@ type ConditionalAccessMicrosoftDeleteFunc func(ctx context.Context) error
 
 type ConditionalAccessGetIdPSigningCertFunc func(ctx context.Context) (certPEM []byte, err error)
 
+type ConditionalAccessGetIdPAppleProfileFunc func(ctx context.Context) (profileData []byte, err error)
+
 type ListCertificateAuthoritiesFunc func(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error)
 
 type GetCertificateAuthorityFunc func(ctx context.Context, id uint) (*fleet.CertificateAuthority, error)
@@ -2064,6 +2066,9 @@ type Service struct {
 
 	ConditionalAccessGetIdPSigningCertFunc        ConditionalAccessGetIdPSigningCertFunc
 	ConditionalAccessGetIdPSigningCertFuncInvoked bool
+
+	ConditionalAccessGetIdPAppleProfileFunc        ConditionalAccessGetIdPAppleProfileFunc
+	ConditionalAccessGetIdPAppleProfileFuncInvoked bool
 
 	ListCertificateAuthoritiesFunc        ListCertificateAuthoritiesFunc
 	ListCertificateAuthoritiesFuncInvoked bool
@@ -4932,6 +4937,13 @@ func (s *Service) ConditionalAccessGetIdPSigningCert(ctx context.Context) (certP
 	s.ConditionalAccessGetIdPSigningCertFuncInvoked = true
 	s.mu.Unlock()
 	return s.ConditionalAccessGetIdPSigningCertFunc(ctx)
+}
+
+func (s *Service) ConditionalAccessGetIdPAppleProfile(ctx context.Context) (profileData []byte, err error) {
+	s.mu.Lock()
+	s.ConditionalAccessGetIdPAppleProfileFuncInvoked = true
+	s.mu.Unlock()
+	return s.ConditionalAccessGetIdPAppleProfileFunc(ctx)
 }
 
 func (s *Service) ListCertificateAuthorities(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error) {

--- a/server/service/conditional_access_idp.go
+++ b/server/service/conditional_access_idp.go
@@ -1,14 +1,209 @@
 package service
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
 	"net/http"
+	"os"
 	"strconv"
+	"text/template"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/google/uuid"
 )
+
+const appleProfileTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+        <!-- Trusted CA Certificate -->
+        <dict>
+            <key>PayloadCertificateFileName</key>
+            <string>conditional_access_ca.der</string>
+            <key>PayloadContent</key>
+            <data>{{.CACertBase64}}</data>
+            <key>PayloadDescription</key>
+            <string>Fleet conditional access CA certificate</string>
+            <key>PayloadDisplayName</key>
+            <string>Fleet conditional access CA</string>
+            <key>PayloadIdentifier</key>
+            <string>com.fleetdm.conditional-access-ca</string>
+            <key>PayloadType</key>
+            <string>com.apple.security.root</string>
+            <key>PayloadUUID</key>
+            <string>{{.CACertUUID}}</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+        </dict>
+		<!-- SCEP Configuration -->
+		<dict>
+			<key>PayloadContent</key>
+			<dict>
+				<key>URL</key>
+				<string>{{.SCEPURL}}</string>
+				<key>Challenge</key>
+				<string>{{.Challenge}}</string>
+				<key>Keysize</key>
+				<integer>2048</integer>
+				<key>Key Type</key>
+				<string>RSA</string>
+				<key>Key Usage</key>
+				<integer>5</integer>
+                <key>ExtendedKeyUsage</key>
+                <array>
+                    <string>1.3.6.1.5.5.7.3.2</string>
+                </array>
+				<key>Subject</key>
+				<array>
+					<array>
+						<array>
+							<string>CN</string>
+							<string>{{.CertificateCN}}</string>
+						</array>
+					</array>
+				</array>
+				<key>SubjectAltName</key>
+				<dict>
+					<key>uniformResourceIdentifier</key>
+					<array>
+						<string>urn:device:apple:uuid:%HardwareUUID%</string>
+					</array>
+				</dict>
+				<key>Retries</key>
+				<integer>3</integer>
+				<key>RetryDelay</key>
+				<integer>10</integer>
+                <!-- ACL for browser access -->
+                <key>AllowAllAppsAccess</key>
+                <true/>
+                <!-- Set true for Safari access. Set false if Safari support not needed. -->
+                <key>KeyIsExtractable</key>
+                <false/>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures SCEP for Fleet conditional access for Okta certificate</string>
+			<key>PayloadDisplayName</key>
+			<string>Fleet conditional access SCEP</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.conditional-access-scep</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.scep</string>
+			<key>PayloadUUID</key>
+			<string>{{.SCEPPayloadUUID}}</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+        <!-- Identity Preference for mTLS endpoint -->
+        <dict>
+            <key>Name</key>
+            <string>{{.MTLSURL}}</string>
+            <key>PayloadCertificateUUID</key>
+            <string>{{.SCEPPayloadUUID}}</string>
+            <key>PayloadDescription</key>
+            <string>Identity preference for mTLS endpoints</string>
+            <key>PayloadDisplayName</key>
+            <string>Fleet mTLS identity preference</string>
+            <key>PayloadIdentifier</key>
+            <string>com.fleetdm.conditional-access-preference</string>
+            <key>PayloadType</key>
+            <string>com.apple.security.identitypreference</string>
+            <key>PayloadUUID</key>
+            <string>{{.IdentityPrefUUID}}</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+        </dict>
+        <dict>
+            <key>PayloadType</key>
+            <string>com.apple.ManagedClient.preferences</string>
+            <key>PayloadVersion</key>
+            <integer>1</integer>
+            <key>PayloadIdentifier</key>
+            <string>com.fleetdm.chrome.certs</string>
+            <key>PayloadUUID</key>
+            <string>{{.ChromeConfigUUID}}</string>
+            <key>PayloadDisplayName</key>
+            <string>Chrome mTLS auto-select</string>
+            <key>PayloadContent</key>
+            <dict>
+                <key>com.google.Chrome</key>
+                <dict>
+                    <key>Forced</key>
+                    <array>
+                        <dict>
+                            <key>mcx_preference_settings</key>
+                            <dict>
+                                <key>AllowPolicyInIncognito</key>
+                                <true/>
+                                <key>AutoSelectCertificateForUrls</key>
+                                <array>
+                                    <!-- MUST be stringified JSON -->
+                                    <string>{"pattern":"{{.MTLSURL}}","filter":{"SUBJECT":{"CN":"{{.CertificateCN}}"}}}</string>
+                                </array>
+                            </dict>
+                        </dict>
+                    </array>
+                </dict>
+            </dict>
+        </dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Configures SCEP enrollment for Okta conditional access</string>
+	<key>PayloadDisplayName</key>
+	<string>Fleet conditional access for Okta</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.conditional-access-okta</string>
+	<key>PayloadOrganization</key>
+	<string>Fleet Device Management</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>User</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>{{.RootPayloadUUID}}</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>
+`
+
+var appleProfileTemplateParsed = template.Must(template.New("appleProfile").Parse(appleProfileTemplate))
+
+// fleetConditionalAccessNamespace is a custom UUID namespace for Fleet Okta conditional access profiles.
+// Generated using: uuid.NewSHA1(uuid.NameSpaceURL, []byte("https://fleetdm.com/learn-more-about/okta-conditional-access"))
+// This ensures UUIDs are unique to Fleet's Okta conditional access feature and won't collide with other systems.
+var fleetConditionalAccessNamespace = uuid.Must(uuid.Parse("fe5c0046-e83e-5a1d-9693-ace1348d34ec"))
+
+// generateDeterministicUUID generates a UUID v5 based on the server URL and a component name.
+// This ensures the same server always generates the same UUIDs for profile components.
+func generateDeterministicUUID(serverURL, component string) string {
+	// Use Fleet's conditional access namespace to avoid collisions
+	// Create a deterministic UUID based on serverURL + component
+	name := fmt.Sprintf("%s:%s", serverURL, component)
+	return uuid.NewSHA1(fleetConditionalAccessNamespace, []byte(name)).String()
+}
+
+type appleProfileTemplateData struct {
+	CACertBase64     string
+	SCEPURL          string
+	Challenge        string
+	CertificateCN    string
+	MTLSURL          string
+	CACertUUID       string
+	SCEPPayloadUUID  string
+	IdentityPrefUUID string
+	ChromeConfigUUID string
+	RootPayloadUUID  string
+}
 
 type conditionalAccessGetIdPSigningCertRequest struct{}
 
@@ -45,7 +240,7 @@ func conditionalAccessGetIdPSigningCertEndpoint(ctx context.Context, request int
 
 func (svc *Service) ConditionalAccessGetIdPSigningCert(ctx context.Context) (certPEM []byte, err error) {
 	// Check user is authorized to read conditional access Okta IdP certificate
-	if err := svc.authz.Authorize(ctx, &fleet.ConditionalAccessIDPCert{}, fleet.ActionRead); err != nil {
+	if err := svc.authz.Authorize(ctx, &fleet.ConditionalAccessIDPAssets{}, fleet.ActionRead); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "failed to authorize")
 	}
 
@@ -63,4 +258,126 @@ func (svc *Service) ConditionalAccessGetIdPSigningCert(ctx context.Context) (cer
 	}
 
 	return certAsset.Value, nil
+}
+
+type conditionalAccessGetIdPAppleProfileRequest struct{}
+
+type conditionalAccessGetIdPAppleProfileResponse struct {
+	ProfileData []byte
+	Err         error `json:"error,omitempty"`
+}
+
+func (r conditionalAccessGetIdPAppleProfileResponse) Error() error { return r.Err }
+
+func (r conditionalAccessGetIdPAppleProfileResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Content-Length", strconv.FormatInt(int64(len(r.ProfileData)), 10))
+	w.Header().Set("Content-Type", "application/x-apple-aspen-config")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Disposition", "attachment; filename=\"fleet-conditional-access.mobileconfig\"")
+
+	// OK to just log the error here as writing anything on `http.ResponseWriter` sets the status code to 200 (and it can't be
+	// changed.) Clients should rely on matching content-length with the header provided
+	n, err := w.Write(r.ProfileData)
+	if err != nil {
+		logging.WithExtras(ctx, "err", err, "bytes_written", n)
+	}
+}
+
+func conditionalAccessGetIdPAppleProfileEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+	if err != nil {
+		return conditionalAccessGetIdPAppleProfileResponse{Err: err}, nil
+	}
+	return conditionalAccessGetIdPAppleProfileResponse{
+		ProfileData: profileData,
+	}, nil
+}
+
+func (svc *Service) ConditionalAccessGetIdPAppleProfile(ctx context.Context) (profileData []byte, err error) {
+	// Check user is authorized to read conditional access Apple profile
+	if err := svc.authz.Authorize(ctx, &fleet.ConditionalAccessIDPAssets{}, fleet.ActionRead); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to authorize")
+	}
+
+	// Load CA certificate for SCEP from mdm_config_assets
+	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
+		fleet.MDMAssetConditionalAccessCACert,
+	}, nil)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to load conditional access CA certificate")
+	}
+
+	caCertAsset, ok := assets[fleet.MDMAssetConditionalAccessCACert]
+	if !ok {
+		return nil, ctxerr.New(ctx, "conditional access CA certificate not configured")
+	}
+
+	// Parse PEM certificate
+	block, _ := pem.Decode(caCertAsset.Value)
+	if block == nil {
+		return nil, ctxerr.New(ctx, "failed to decode CA certificate PEM")
+	}
+
+	// Parse DER certificate
+	_, err = x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to parse CA certificate")
+	}
+
+	// Base64 encode the DER certificate for the profile
+	caCertBase64 := base64.StdEncoding.EncodeToString(block.Bytes)
+
+	// Get app config for server URL
+	appConfig, err := svc.ds.AppConfig(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to load app config")
+	}
+
+	// Construct SCEP URL
+	scepURL := fmt.Sprintf("%s/api/fleet/conditional_access/scep", appConfig.ServerSettings.ServerURL)
+
+	// Get global enroll secrets
+	secrets, err := svc.ds.GetEnrollSecrets(ctx, nil)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to get enroll secrets")
+	}
+	if len(secrets) == 0 {
+		return nil, ctxerr.Wrap(ctx, newNotFoundError(), "enroll_secret")
+	}
+
+	// Use the first global enroll secret as the challenge
+	challenge := secrets[0].Secret
+
+	// Get mTLS URL using ConditionalAccessIdPSSOURL
+	mtlsURL, err := appConfig.ConditionalAccessIdPSSOURL(os.Getenv)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to get mTLS URL")
+	}
+
+	// Generate deterministic UUIDs based on server URL
+	serverURL := appConfig.ServerSettings.ServerURL
+	caCertUUID := generateDeterministicUUID(serverURL, "conditional-access-ca-cert")
+	scepPayloadUUID := generateDeterministicUUID(serverURL, "conditional-access-scep")
+	identityPrefUUID := generateDeterministicUUID(serverURL, "conditional-access-identity-pref")
+	chromeConfigUUID := generateDeterministicUUID(serverURL, "conditional-access-chrome-config")
+	rootPayloadUUID := generateDeterministicUUID(serverURL, "conditional-access-root-payload")
+
+	// Execute template
+	var buf bytes.Buffer
+	if err := appleProfileTemplateParsed.Execute(&buf, appleProfileTemplateData{
+		CACertBase64:     caCertBase64,
+		SCEPURL:          scepURL,
+		Challenge:        challenge,
+		CertificateCN:    "Fleet conditional access for Okta",
+		MTLSURL:          mtlsURL,
+		CACertUUID:       caCertUUID,
+		SCEPPayloadUUID:  scepPayloadUUID,
+		IdentityPrefUUID: identityPrefUUID,
+		ChromeConfigUUID: chromeConfigUUID,
+		RootPayloadUUID:  rootPayloadUUID,
+	}); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "failed to execute profile template")
+	}
+
+	return buf.Bytes(), nil
 }

--- a/server/service/conditional_access_idp.go
+++ b/server/service/conditional_access_idp.go
@@ -247,6 +247,11 @@ func (svc *Service) ConditionalAccessGetIdPSigningCert(ctx context.Context) (cer
 		return nil, ctxerr.Wrap(ctx, err, "failed to authorize")
 	}
 
+	// Check that server private key is configured
+	if len(svc.config.Server.PrivateKey) == 0 {
+		return nil, &fleet.BadRequestError{Message: "Fleet server private key is not configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
+	}
+
 	// Load IdP certificate from mdm_config_assets
 	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetConditionalAccessIDPCert,
@@ -300,6 +305,11 @@ func (svc *Service) ConditionalAccessGetIdPAppleProfile(ctx context.Context) (pr
 		return nil, ctxerr.Wrap(ctx, err, "failed to authorize")
 	}
 
+	// Check that server private key is configured
+	if len(svc.config.Server.PrivateKey) == 0 {
+		return nil, &fleet.BadRequestError{Message: "Fleet server private key is not configured. Learn more: https://fleetdm.com/learn-more-about/fleet-server-private-key"}
+	}
+
 	// Load CA certificate for SCEP from mdm_config_assets
 	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
 		fleet.MDMAssetConditionalAccessCACert,
@@ -350,7 +360,7 @@ func (svc *Service) ConditionalAccessGetIdPAppleProfile(ctx context.Context) (pr
 		return nil, ctxerr.Wrap(ctx, err, "failed to get enroll secrets")
 	}
 	if len(secrets) == 0 {
-		return nil, ctxerr.Wrap(ctx, newNotFoundError(), "enroll_secret")
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{Message: "global enroll secret is not configured"})
 	}
 
 	// Use the first global enroll secret as the challenge

--- a/server/service/conditional_access_idp_test.go
+++ b/server/service/conditional_access_idp_test.go
@@ -136,11 +136,8 @@ func TestConditionalAccessGetIdPAppleProfileAuth(t *testing.T) {
 
 				// Verify the profile contains expected content
 				profileStr := string(profileData)
-				require.Contains(t, profileStr, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
 				require.Contains(t, profileStr, "com.fleetdm.conditional-access")
-				require.Contains(t, profileStr, "https://fleet.example.com/api/fleet/conditional_access/scep")
 				require.Contains(t, profileStr, "https://okta.fleet.example.com")
-				require.Contains(t, profileStr, "Fleet conditional access for Okta")
 			}
 		})
 	}
@@ -315,9 +312,8 @@ func TestConditionalAccessGetIdPAppleProfile(t *testing.T) {
 		}
 
 		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "enroll_secret")
 		require.True(t, fleet.IsNotFound(err))
+		require.Contains(t, err.Error(), "enroll_secret")
 		require.Nil(t, profileData)
 	})
 
@@ -344,10 +340,9 @@ func TestConditionalAccessGetIdPAppleProfile(t *testing.T) {
 		}
 
 		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "server URL is not configured")
 		var badReqErr *fleet.BadRequestError
 		require.ErrorAs(t, err, &badReqErr)
+		require.Contains(t, err.Error(), "server URL is not configured")
 		require.Nil(t, profileData)
 	})
 

--- a/server/service/conditional_access_idp_test.go
+++ b/server/service/conditional_access_idp_test.go
@@ -2,7 +2,14 @@ package service
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -13,6 +20,7 @@ import (
 )
 
 func TestConditionalAccessGetIdPSigningCertAuth(t *testing.T) {
+	t.Parallel()
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
 
@@ -60,4 +68,295 @@ func TestConditionalAccessGetIdPSigningCertAuth(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestConditionalAccessGetIdPAppleProfileAuth(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// Mock valid certificate
+	certPEM := generateTestCertPEM(t)
+
+	// Mock the datastore methods
+	ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+			fleet.MDMAssetConditionalAccessCACert: {
+				Name:  fleet.MDMAssetConditionalAccessCACert,
+				Value: certPEM,
+			},
+		}, nil
+	}
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			ServerSettings: fleet.ServerSettings{
+				ServerURL: "https://fleet.example.com",
+			},
+		}, nil
+	}
+
+	ds.GetEnrollSecretsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
+		return []*fleet.EnrollSecret{
+			{Secret: "test-secret-123"},
+		}, nil
+	}
+
+	testCases := []struct {
+		name       string
+		user       *fleet.User
+		shouldFail bool
+	}{
+		{"global admin", test.UserAdmin, false},
+		{"global maintainer", test.UserMaintainer, false},
+		{"global observer", test.UserObserver, false},
+		{"global observer+", test.UserObserverPlus, false},
+		{"global gitops", test.UserGitOps, false},
+		{"team admin", test.UserTeamAdminTeam1, true},
+		{"team maintainer", test.UserTeamMaintainerTeam1, true},
+		{"team observer", test.UserTeamObserverTeam1, true},
+		{"team observer+", test.UserTeamObserverPlusTeam1, true},
+		{"team gitops", test.UserTeamGitOpsTeam1, true},
+		{"user no roles", test.UserNoRoles, true},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := test.UserContext(ctx, tt.user)
+
+			profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+			if tt.shouldFail {
+				require.Error(t, err)
+				var forbiddenError *authz.Forbidden
+				require.ErrorAs(t, err, &forbiddenError)
+				require.Nil(t, profileData)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, profileData)
+
+				// Verify the profile contains expected content
+				profileStr := string(profileData)
+				require.Contains(t, profileStr, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+				require.Contains(t, profileStr, "com.fleetdm.conditional-access")
+				require.Contains(t, profileStr, "https://fleet.example.com/api/fleet/conditional_access/scep")
+				require.Contains(t, profileStr, "https://okta.fleet.example.com")
+				require.Contains(t, profileStr, "Fleet conditional access for Okta")
+			}
+		})
+	}
+}
+
+// generateTestCertPEM generates a test certificate in PEM format for testing
+func generateTestCertPEM(t *testing.T) []byte {
+	// Create a simple self-signed certificate
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName: "Test CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	return certPEM
+}
+
+func TestConditionalAccessGetIdPAppleProfile(t *testing.T) {
+	certPEM := generateTestCertPEM(t)
+
+	t.Run("success - generates valid profile", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetConditionalAccessCACert: {
+					Name:  fleet.MDMAssetConditionalAccessCACert,
+					Value: certPEM,
+				},
+			}, nil
+		}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://fleet.example.com:8080",
+				},
+			}, nil
+		}
+
+		ds.GetEnrollSecretsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
+			return []*fleet.EnrollSecret{
+				{Secret: "test-secret-456"},
+			}, nil
+		}
+
+		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.NoError(t, err)
+		require.NotEmpty(t, profileData)
+
+		profileStr := string(profileData)
+		// Verify XML structure
+		require.Contains(t, profileStr, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>")
+		require.Contains(t, profileStr, "<!DOCTYPE plist")
+
+		// Verify URLs with port preserved
+		require.Contains(t, profileStr, "https://fleet.example.com:8080/api/fleet/conditional_access/scep")
+		require.Contains(t, profileStr, "https://okta.fleet.example.com:8080")
+
+		// Verify challenge secret
+		require.Contains(t, profileStr, "test-secret-456")
+
+		// Verify payload identifiers
+		require.Contains(t, profileStr, "com.fleetdm.conditional-access-ca")
+		require.Contains(t, profileStr, "com.fleetdm.conditional-access-scep")
+		require.Contains(t, profileStr, "com.fleetdm.conditional-access-preference")
+		require.Contains(t, profileStr, "com.fleetdm.chrome.certs")
+
+		// Verify certificate CN is present in the profile
+		require.Contains(t, profileStr, "Fleet conditional access for Okta")
+	})
+
+	t.Run("missing CA certificate", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{}, nil
+		}
+
+		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "conditional access CA certificate not configured")
+		require.Nil(t, profileData)
+	})
+
+	t.Run("invalid PEM certificate", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetConditionalAccessCACert: {
+					Name:  fleet.MDMAssetConditionalAccessCACert,
+					Value: []byte("not a valid PEM"),
+				},
+			}, nil
+		}
+
+		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to decode CA certificate PEM")
+		require.Nil(t, profileData)
+	})
+
+	t.Run("invalid DER certificate", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		// Valid PEM structure but invalid DER content
+		invalidCertPEM := pem.EncodeToMemory(&pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: []byte("invalid DER data"),
+		})
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetConditionalAccessCACert: {
+					Name:  fleet.MDMAssetConditionalAccessCACert,
+					Value: invalidCertPEM,
+				},
+			}, nil
+		}
+
+		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to parse CA certificate")
+		require.Nil(t, profileData)
+	})
+
+	t.Run("no enroll secrets", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetConditionalAccessCACert: {
+					Name:  fleet.MDMAssetConditionalAccessCACert,
+					Value: certPEM,
+				},
+			}, nil
+		}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://fleet.example.com",
+				},
+			}, nil
+		}
+
+		ds.GetEnrollSecretsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
+			return []*fleet.EnrollSecret{}, nil
+		}
+
+		profileData, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "enroll_secret")
+		require.True(t, fleet.IsNotFound(err))
+		require.Nil(t, profileData)
+	})
+
+	t.Run("deterministic UUIDs based on server URL", func(t *testing.T) {
+		ds := new(mock.Store)
+		svc, ctx := newTestService(t, ds, nil, nil)
+		ctx = test.UserContext(ctx, test.UserAdmin)
+
+		ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+			return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+				fleet.MDMAssetConditionalAccessCACert: {
+					Name:  fleet.MDMAssetConditionalAccessCACert,
+					Value: certPEM,
+				},
+			}, nil
+		}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				ServerSettings: fleet.ServerSettings{
+					ServerURL: "https://fleet.example.com",
+				},
+			}, nil
+		}
+
+		ds.GetEnrollSecretsFunc = func(ctx context.Context, teamID *uint) ([]*fleet.EnrollSecret, error) {
+			return []*fleet.EnrollSecret{
+				{Secret: "test-secret"},
+			}, nil
+		}
+
+		// Generate profile twice with same server URL
+		profileData1, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.NoError(t, err)
+
+		profileData2, err := svc.ConditionalAccessGetIdPAppleProfile(ctx)
+		require.NoError(t, err)
+
+		// UUIDs should be identical
+		require.Equal(t, profileData1, profileData2)
+	})
 }

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -558,6 +558,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// Okta Conditional Access
 	ue.GET("/api/_version_/fleet/conditional_access/idp/signing_cert", conditionalAccessGetIdPSigningCertEndpoint, conditionalAccessGetIdPSigningCertRequest{})
+	ue.GET("/api/_version_/fleet/conditional_access/idp/apple/profile", conditionalAccessGetIdPAppleProfileEndpoint, conditionalAccessGetIdPAppleProfileRequest{})
 
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.
 	// NOTE: remember to update

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -558,7 +558,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// Okta Conditional Access
 	ue.GET("/api/_version_/fleet/conditional_access/idp/signing_cert", conditionalAccessGetIdPSigningCertEndpoint, conditionalAccessGetIdPSigningCertRequest{})
-	ue.GET("/api/_version_/fleet/conditional_access/idp/apple/profile", conditionalAccessGetIdPAppleProfileEndpoint, conditionalAccessGetIdPAppleProfileRequest{})
+	ue.GET("/api/_version_/fleet/conditional_access/idp/apple/profile", conditionalAccessGetIdPAppleProfileEndpoint, nil)
 
 	// Only Fleet MDM specific endpoints should be within the root /mdm/ path.
 	// NOTE: remember to update

--- a/server/service/middleware/log/log.go
+++ b/server/service/middleware/log/log.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
 	kitlog "github.com/go-kit/log"
 )
 
@@ -43,4 +44,36 @@ func LogResponseEndMiddleware(logger kitlog.Logger, next http.Handler) http.Hand
 		next.ServeHTTP(w, r)
 		LogRequestEnd(logger)(r.Context(), w)
 	})
+}
+
+// NewLoggingMiddleware creates middleware that initializes logging context and logs requests.
+// This middleware should be used for raw http.Handler endpoints (not go-kit endpoints).
+// It initializes the logging context with request metadata and logs the request after completion.
+func NewLoggingMiddleware(logger kitlog.Logger) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Create logging context
+			lc := &logging.LoggingContext{}
+
+			// Populate request context with kithttp fields (method, URI, etc.)
+			ctx := logging.NewContext(kithttp.PopulateRequestContext(r.Context(), r), lc)
+
+			// Set start time
+			ctx = logging.WithStartTime(ctx)
+
+			// Add IP address information to logging context
+			remoteAddr, _ := ctx.Value(kithttp.ContextKeyRequestRemoteAddr).(string)
+			xForwardedFor, _ := ctx.Value(kithttp.ContextKeyRequestXForwardedFor).(string)
+			lc.SetExtras("ip_addr", remoteAddr, "x_for_ip_addr", xForwardedFor)
+
+			// Create new request with updated context
+			r = r.WithContext(ctx)
+
+			// Call next handler
+			next.ServeHTTP(w, r)
+
+			// Log the request
+			LogRequestEnd(logger)(ctx, w)
+		})
+	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34539

Added endpoint to get a sample Apple config profile that IT admin can use for Okta conditional access configuration.
`/api/_version_/fleet/conditional_access/idp/apple/profile`

And additional cleanup/improvements:
- logging
- error handling (sending errors to Sentry/OTEL)
- redirect end user to error page if IT admin hasn't set up conditional access in Fleet

Contributor API changes at: https://github.com/fleetdm/fleet/pull/35632/files

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  - Will be added to related PR: #35204

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple profile generation for Okta conditional access IdP integration.
  * New endpoint for retrieving conditional access Apple configuration profiles.

* **Bug Fixes**
  * Improved error handling and logging for conditional access operations.
  * Enhanced error responses for missing server URL configuration.

* **Refactoring**
  * Centralized error handling for internal server errors with improved context logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->