### PR TITLE
Fleet UI: handle displayname for vpp

### DIFF
--- a/frontend/services/entities/mdm_apple.ts
+++ b/frontend/services/entities/mdm_apple.ts
@@ -41,6 +41,7 @@ export interface IEditVppAppPostBody {
   labels_include_any?: string[];
   labels_exclude_any?: string[];
   categories?: SoftwareCategory[];
+  display_name?: string;
 }
 
 export interface IGetVppAppsResponse {
@@ -62,9 +63,8 @@ const handleDisplayNameVppForm = (
   teamId: number
 ): IEditVppAppPostBody => {
   return {
-    self_service: false, // or some default as needed
+    display_name: formData.displayName,
     team_id: teamId,
-    // you might not need categories/labels with this form
   };
 };
 


### PR DESCRIPTION
## Issue
Follow up in #33779 

## Description
- Allows the FE to properly call the app store app api to update `display_name`
- The fix for this code as [this helper function](https://github.com/fleetdm/fleet/pull/35177/files#r2515105403) `handleDisplayNameAppStoreAppForm` will be in another file and accept both vpp + google play store apps. It was already approved for 4.77 but google play store apps  #34393 is now being pushed to 4.78
  - This is the interim fix
