### PR TITLE
Cherry-pick: Incrementing Fleet helm chart release version from 6.7.0 to 6.7.1 (#35520)

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.7.0
+version: v6.7.1
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git


### PR DESCRIPTION
- Increments Fleet helm chart version from `6.7.0` to `6.7.1`
