### PR TITLE
Use macOS 14 runners in GHA rather than macOS 13 since 13 is being browned out

### DIFF
--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -219,8 +219,8 @@ jobs:
   # Here we generate the Fleet Desktop and osqueryd targets for
   # macOS which can only be generated from a macOS host.
   build-macos-targets:
-    # Set macOS version to '13' for building the binary as Fleet's minimum supported macOS version.
-    runs-on: macos-13
+    # Set macOS version to '14' for building the binary as Fleet's minimum supported macOS version.
+    runs-on: macos-14
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0

--- a/.github/workflows/generate-desktop-targets.yml
+++ b/.github/workflows/generate-desktop-targets.yml
@@ -29,10 +29,10 @@ jobs:
           echo "FLEET_DESKTOP_VERSION=$VERSION" >> "$GITHUB_OUTPUT"
   
   desktop-macos:
-    # Set macOS version to '13' (previously was macos-12, and it was deprecated) for
-    # building the binary. This ensures compatibility with macOS version 13 and
-    # later, avoiding runtime errors on systems using macOS 13 or newer.
-    runs-on: macos-13
+    # Set macOS version to '14' (previously was macos-12/13 until they were deprecated) for
+    # building the binary. This ensures compatibility with macOS version 14 and
+    # later, avoiding runtime errors on systems using macOS 14 or newer.
+    runs-on: macos-14
     needs: set-version
     steps:
       - name: Harden Runner


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/13046. We already say we support >= macOS 14 on the website.