### PR TITLE
Website: Update email domains in `config.custom.bannedEmailDomainsForWebsiteSubmissions`

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -385,20 +385,24 @@ module.exports.custom = {
 
   // For website signups & "Talk to us" form submissions:
   bannedEmailDomainsForWebsiteSubmissions: [
-    'gmail.com',
-    'yahoo.com',
-    'yahoo.co.uk',
-    'hotmail.com',
-    'hotmail.co.uk',
-    'hotmail.ca',
-    'outlook.com',
-    'icloud.com',
-    'proton.me',
-    'live.com',
-    'yandex.ru',
-    'ymail.com',
-    'qq.com',
-    'example.com',
+  'example.com',
+  'gmail.com',
+  'hotmail.ca',
+  'hotmail.co.uk',
+  'hotmail.com',
+  'icloud.com',
+  'live.com',
+  'mac.com',
+  'me.com',
+  'msn.com',
+  'outlook.com',
+  'proton.com',
+  'proton.me',
+  'protonmail.com'
+  'qq.com',
+  'yahoo.com',
+  'yandex.ru',
+  'ymail.com'
   ],
 
   // For contact form submissions.

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -385,24 +385,25 @@ module.exports.custom = {
 
   // For website signups & "Talk to us" form submissions:
   bannedEmailDomainsForWebsiteSubmissions: [
-  'example.com',
-  'gmail.com',
-  'hotmail.ca',
-  'hotmail.co.uk',
-  'hotmail.com',
-  'icloud.com',
-  'live.com',
-  'mac.com',
-  'me.com',
-  'msn.com',
-  'outlook.com',
-  'proton.com',
-  'proton.me',
-  'protonmail.com'
-  'qq.com',
-  'yahoo.com',
-  'yandex.ru',
-  'ymail.com'
+    'example.com',
+    'gmail.com',
+    'hotmail.ca',
+    'hotmail.co.uk',
+    'hotmail.com',
+    'icloud.com',
+    'live.com',
+    'mac.com',
+    'me.com',
+    'msn.com',
+    'outlook.com',
+    'proton.com',
+    'proton.me',
+    'protonmail.com',
+    'qq.com',
+    'yahoo.com',
+    'yahoo.co.uk',
+    'yandex.ru',
+    'ymail.com'
   ],
 
   // For contact form submissions.


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/10999

Changes:
- added domains to the list of personal email domains that cannot be used to submit forms on the Fleet website, and sorted the list alphabetically.