### PR TITLE
Support nested app targets in Homebrew cask artifacts

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -247,7 +247,7 @@ type brewCask struct {
 
 // brew artifacts are objects that have one and only one of their fields set.
 type brewArtifact struct {
-	App []string `json:"app"`
+	App []optjson.StringOr[*brewAppTarget] `json:"app"`
 	// Pkg is a bit like Binary, it is an array with a string and an object as
 	// first two elements. The object has a choices field with an array of
 	// objects. See Microsoft Edge.
@@ -261,6 +261,12 @@ type brewArtifact struct {
 	// Binary is an array with a string and an object as first two elements. See
 	// the "docker" and "firefox" casks.
 	Binary []optjson.StringOr[*brewBinaryTarget] `json:"binary"`
+}
+
+// brewAppTarget handles both string app names and objects with target redirects
+// Example: "Grammarly Installer.app" or {"target":"Grammarly Desktop.app"}
+type brewAppTarget struct {
+	Target string `json:"target"`
 }
 
 // The choiceChanges file is a property list containing an array of dictionaries. Each dictionary has the following three keys:

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -279,7 +279,7 @@
       "slug": "yubico-yubikey-manager/darwin",
       "platform": "darwin",
       "unique_identifier": "com.yubico.ykman",
-      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: \u003ca target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\"\u003ehttps://www.yubico.com/support/download/yubikey-manager\u003c/a\u003e"
+      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: <a target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\">https://www.yubico.com/support/download/yubikey-manager</a>"
     },
     {
       "name": "Zoom",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -279,7 +279,7 @@
       "slug": "yubico-yubikey-manager/darwin",
       "platform": "darwin",
       "unique_identifier": "com.yubico.ykman",
-      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: <a target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\">https://www.yubico.com/support/download/yubikey-manager</a>"
+      "description": "YubiKey Manager is an application for configuring any YubiKey. Requires Rosetta 2. YubiKey Manager won't get security updates or bug fixes. It's End of Life: \u003ca target=\"_blank\" href=\"https://www.yubico.com/support/download/yubikey-manager/\"\u003ehttps://www.yubico.com/support/download/yubikey-manager\u003c/a\u003e"
     },
     {
       "name": "Zoom",


### PR DESCRIPTION
When adding Grammarly, discovered Homebrew casks can have nested app artifacts:


```
  "artifacts": [
    {
      "app": [
        "Grammarly Installer.app",
        {
          "target": "Grammarly Desktop.app"
        }
      ]
    },
```
Updated the app field to use `optjson.StringOr[*brewAppTarget]` to support both simple strings and objects.