### PR TITLE
Website: add edit button to software pages

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1305,12 +1305,22 @@ module.exports = {
         let appLibrary = [];
         // Get app library json
         let appsJsonData = await sails.helpers.fs.readJson(path.join(topLvlRepoPath, '/ee/maintained-apps/outputs/apps.json'));
+        // Read the same file as text. This is so we can determine the line number of apps to use in the edit page link.
+        let appsJsonDataAsAString = await sails.helpers.fs.read(path.join(topLvlRepoPath, '/ee/maintained-apps/outputs/apps.json'));
+        let linesInAppsJsonFile = appsJsonDataAsAString.split('\n');
         // Then for each item in the json, build a configuration object to add to the sails.builtStaticContent.appLibrary array.
         await sails.helpers.flow.simultaneouslyForEach(appsJsonData.apps, async(app)=>{
           // FUTURE: add support for windows apps once the page is updated to be multi-platform.
           if(app.platform !== 'darwin'){
             return;
           }
+
+          // Determine the line in the JSON that the object for this app starts on.
+          // this will allow us to link users directly to the app's position in the JSON file when users want to make a change.
+          let lineWithTheAppsNameKey = _.find(linesInAppsJsonFile, (line)=>{
+            return line.includes(`"name": "${app.name}"`);
+          });
+          let lineNumberForEdittingThisApp = linesInAppsJsonFile.indexOf(lineWithTheAppsNameKey);
 
           let appInformation = {
             name: app.name,
@@ -1319,6 +1329,7 @@ module.exports = {
             bundleIdentifier: app.unique_identifier,
             description: app.description,
             platform: app.platform,
+            lineNumberInJson: lineNumberForEdittingThisApp,
           };
 
           // Grab the latest information about these apps from the the ee/maintained-apps folder in the repo.

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -1317,10 +1317,10 @@ module.exports = {
 
           // Determine the line in the JSON that the object for this app starts on.
           // this will allow us to link users directly to the app's position in the JSON file when users want to make a change.
-          let lineWithTheAppsNameKey = _.find(linesInAppsJsonFile, (line)=>{
-            return line.includes(`"name": "${app.name}"`);
+          let lineWithTheAppsSlugKey = _.find(linesInAppsJsonFile, (line)=>{
+            return line.includes(`"slug": "${app.slug}"`);
           });
-          let lineNumberForEdittingThisApp = linesInAppsJsonFile.indexOf(lineWithTheAppsNameKey);
+          let lineNumberForEdittingThisApp = linesInAppsJsonFile.indexOf(lineWithTheAppsSlugKey);
 
           let appInformation = {
             name: app.name,

--- a/website/views/pages/app-details.ejs
+++ b/website/views/pages/app-details.ejs
@@ -61,7 +61,7 @@
               <a href="/docs">Docs</a>
               <a href="/docs/rest-api">REST API</a>
               <a href="/guides">Guides</a>
-              <!-- <a purpose="edit-button" class="d-flex align-items-center text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/edit/main/'+queryLibraryYmlRepoPath"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a> -->
+              <a purpose="edit-button" class="d-flex align-items-center text-nowrap" target="_blank" :href="'https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps/outputs/apps.json#L'+thisApp.lineNumberInJson"><img alt="A pencil icon" src="/images/pencil-16x16@2x.png">Edit page</a>
             </div>
           </div>
       </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/12276

Changes:
- updated the build-static-content script to add the line number of software items in apps.json to the website's Fleet-maintained apps configuration.
- Added an edit page button to software pages that links directly to the app's location in the apps.json file on GitHub.