### PR TITLE
Website: Increase MySQL service disk size for Render trial instances

### DIFF
--- a/website/scripts/manage-fleet-premium-trial-instances.js
+++ b/website/scripts/manage-fleet-premium-trial-instances.js
@@ -264,7 +264,7 @@ module.exports = {
               plan: 'standard',
               runtime: 'docker',
               disk: {
-                sizeGB: 1,
+                sizeGB: 5,
                 name: 'mysql',
                 mountPath: '/var/lib/mysql',
               },


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/35585

Changes:
 - Increased the size of the disk attached to the MySQL service created for Fleet Premium trial instances in Render. (1gb » 5gb)