### PR TITLE
Cherry pick: Return icon in in-house app metadata (#35568)

### DIFF
--- a/server/datastore/mysql/software_title_icons_test.go
+++ b/server/datastore/mysql/software_title_icons_test.go
@@ -775,7 +775,6 @@ func testDeleteIconsAssociatedWithTitlesWithoutInstallers(t *testing.T, ds *Data
 				require.NoError(t, err)
 				require.Len(t, softwareInstallerTitleIds, 2) // iha create 2 titles
 				require.Equal(t, titleID, softwareInstallerTitleIds[1].ID)
-
 				_, err = ds.CreateOrUpdateSoftwareTitleIcon(ctx, &fleet.UploadSoftwareTitleIconPayload{
 					TeamID:    team.ID,
 					TitleID:   titleID,
@@ -783,6 +782,10 @@ func testDeleteIconsAssociatedWithTitlesWithoutInstallers(t *testing.T, ds *Data
 					Filename:  "test-icon-updated.png",
 				})
 				require.NoError(t, err)
+
+				meta, err := ds.GetInHouseAppMetadataByTeamAndTitleID(ctx, &team.ID, titleID)
+				require.NoError(t, err)
+				require.NotEmpty(t, meta.IconUrl)
 
 				result, err := ds.writer(ctx).ExecContext(ctx, `
 					INSERT INTO software_titles (name, source, bundle_identifier) VALUES (?, ?, ?)


### PR DESCRIPTION
Merged into main in #35568 
Fixes in-house app icon not being deleted when title is deleted #35559