### PR TITLE
Fleet UI: Mobile self service preview + no advanced options

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -526,7 +526,6 @@ const EditIconModal = ({
     </Card>
   );
 
-  // TODO: Confirm design with designer as this was a missed spec and not on Figma
   const renderPreviewSelfServiceMobileCard = () => (
     <Card
       borderRadiusSize="medium"
@@ -567,7 +566,7 @@ const EditIconModal = ({
           className={`${baseClass}__self-service-preview-name-version--mobile`}
         >
           <div className={`${baseClass}__self-service-preview-name--mobile`}>
-            <TooltipTruncatedText value={previewInfo.name} />
+            <TooltipTruncatedText value={displayName || previewInfo.name} />
           </div>
           <div className={`${baseClass}__self-service-preview-version--mobile`}>
             {"latest_version" in software

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -387,6 +387,7 @@ const SoftwareInstallerCard = ({
           softwarePackage={softwareInstaller as ISoftwarePackage}
           onExit={onToggleViewYaml}
           isScriptPackage={isScriptPackage}
+          isIosOrIpadosApp={isIosOrIpadosApp}
         />
       )}
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -30,6 +30,7 @@ interface IViewYamlModalProps {
   softwarePackage: ISoftwarePackage;
   onExit: () => void;
   isScriptPackage?: boolean;
+  isIosOrIpadosApp?: boolean;
 }
 
 interface HandleDownloadParams {
@@ -49,6 +50,7 @@ const ViewYamlModal = ({
   softwarePackage,
   onExit,
   isScriptPackage = false,
+  isIosOrIpadosApp = false,
 }: IViewYamlModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { config } = useContext(AppContext);
@@ -236,7 +238,7 @@ const ViewYamlModal = ({
               ? onDownloadUninstallScript
               : undefined,
             onClickIcon: iconUrl ? onDownloadIcon : undefined,
-            hasAdvancedOptionsAvailable: !isScriptPackage,
+            hasAdvancedOptionsAvailable: !isScriptPackage && !isIosOrIpadosApp,
             isScriptPackage,
           })}
         </p>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -154,9 +154,7 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ios" });
 
     expect(
-      screen.getByText(
-        /Currently, automatic installation are not available for iOS and iPadOS/i
-      )
+      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
     ).toBeInTheDocument();
   });
 
@@ -164,9 +162,7 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ipados" });
 
     expect(
-      screen.getByText(
-        /Currently, automatic installation are not available for iOS and iPadOS/i
-      )
+      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -154,8 +154,8 @@ const SoftwareOptionsSelector = ({
     // Render unavailable description for iOS or iPadOS add software form only
     return isPlatformIosOrIpados && !isEditingSoftware ? (
       <p>
-        Currently, automatic installation are not available for iOS and iPadOS.
-        Manually install on the <b>Host details</b> page for each host.
+        Automatic install for iOS and iPadOS is coming soon. Today, you can
+        manually install the <strong>Host details</strong> page for each host.
       </p>
     ) : null;
   };


### PR DESCRIPTION
## Issue
Unreleased fixes for #34012 

More unreleased bugs found by @jmwatts 

## Description 
- Updates preview text in real time for mobile when updating display name
- Hides advanced options messaging for ipa apps
- Update copy to new text specified by designer 

## Screenshot of fixes

https://github.com/user-attachments/assets/5f32efbe-9b40-4892-a2a7-dcdba88fa9d6

<img width="1128" height="677" alt="Screenshot 2025-11-12 at 11 31 38 AM" src="https://github.com/user-attachments/assets/eacdd4ac-e164-4c9e-b492-7dd1b825401a" />

<img width="773" height="598" alt="Screenshot 2025-11-12 at 12 05 41 PM" src="https://github.com/user-attachments/assets/7ef91ed9-a696-4eca-8bec-1ba02d2e7a6f" />





## Testing

- [x] QA'd all new/changed functionality manually
