### PR TITLE
Fleet 4.76: Vulnerabilities (CVEs) are supported for Cursor, Windsurf, and VSCode-forks

### DIFF
--- a/articles/fleet.4.76.0.md
+++ b/articles/fleet.4.76.0.md
@@ -1,4 +1,4 @@
-# Fleet 4.76.0 | Self-service scripts, JetBrains/Cursor/Windsurf inventory, and more...
+# Fleet 4.76.0 | Self-service scripts, JetBrains/Cursor/Windsurf vulnerabilities, and more...
 
 <div purpose="embedded-content">
    <iframe src="https://www.youtube.com/embed/2hJ7yZTBaVY?si=11HG8r-mS1iF9fma" frameborder="0" allowfullscreen></iframe>
@@ -9,7 +9,7 @@ Fleet 4.76.0 is now available. See the complete [changelog](https://github.com/f
 ## Highlights
 
 - Self-service scripts
-- Cursor, Windsurf, and JetBrains extensions
+- Vulnerabilities for Cursor, Windsurf, and JetBrains extensions
 - Improved macOS, iOS, and iPadOS setup experience
 - Android software inventory
 - Lock (Lost Mode) for iOS and iPadOS
@@ -19,9 +19,9 @@ Fleet 4.76.0 is now available. See the complete [changelog](https://github.com/f
 
 You can now create custom Linux and Windows packages that include just a script (aka payload-free packages). In Fleet, head to **Software** page and select **Add software > Custom package**. This is perfect for self-service utilities or bundling multiple scripts as part of your out-of-the-box setup experience. macOS self-service scripts are coming soon.
 
-### JetBrains, Cursor, and Windsurf extensions
+### Vulnerabilities for JetBrains, Cursor, and Windsurf extensions
 
-All Cursor, Windsurf, other VSCode forks, and JetBrains IDE extensions now show up in the **Software**, **Host details**, and **My device** pages. Vulnerabilities (CVEs) are detected for JetBrains IDE extenions. CVEs for Cursor, Windsurf, and other VSCode forks are coming soon. Learn more about CVEs in the [vulnerabilities guide](https://fleetdm.com/guides/vulnerability-processing#basic-article).
+Vulnerabilities (CVEs) in all Cursor, Windsurf, other VSCode forks, and JetBrains IDE extensions now show up in the **Software**, **Host details**, and **My device** pages. Gain better coverage of high-risk developer tools. Learn more about CVEs in the [vulnerabilities guide](https://fleetdm.com/guides/vulnerability-processing#basic-article).
 
 ### Improved macOS, iOS, and iPadOS setup experience
 


### PR DESCRIPTION
We learned that CVEs work: https://github.com/fleetdm/fleet/issues/35523#issuecomment-3523047239