### PR TITLE
For R.C. - Fleet UI: display name self service preview + no advanced options text

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -526,7 +526,6 @@ const EditIconModal = ({
     </Card>
   );
 
-  // TODO: Confirm design with designer as this was a missed spec and not on Figma
   const renderPreviewSelfServiceMobileCard = () => (
     <Card
       borderRadiusSize="medium"
@@ -567,7 +566,7 @@ const EditIconModal = ({
           className={`${baseClass}__self-service-preview-name-version--mobile`}
         >
           <div className={`${baseClass}__self-service-preview-name--mobile`}>
-            <TooltipTruncatedText value={previewInfo.name} />
+            <TooltipTruncatedText value={displayName || previewInfo.name} />
           </div>
           <div className={`${baseClass}__self-service-preview-version--mobile`}>
             {"latest_version" in software

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/_styles.scss
@@ -114,6 +114,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     position: relative;
+    font-weight: $bold;
   }
 
   &__mask-overlay {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -387,6 +387,7 @@ const SoftwareInstallerCard = ({
           softwarePackage={softwareInstaller as ISoftwarePackage}
           onExit={onToggleViewYaml}
           isScriptPackage={isScriptPackage}
+          isIosOrIpadosApp={isIosOrIpadosApp}
         />
       )}
     </Card>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -30,6 +30,7 @@ interface IViewYamlModalProps {
   softwarePackage: ISoftwarePackage;
   onExit: () => void;
   isScriptPackage?: boolean;
+  isIosOrIpadosApp?: boolean;
 }
 
 interface HandleDownloadParams {
@@ -49,6 +50,7 @@ const ViewYamlModal = ({
   softwarePackage,
   onExit,
   isScriptPackage = false,
+  isIosOrIpadosApp = false,
 }: IViewYamlModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { config } = useContext(AppContext);
@@ -236,7 +238,7 @@ const ViewYamlModal = ({
               ? onDownloadUninstallScript
               : undefined,
             onClickIcon: iconUrl ? onDownloadIcon : undefined,
-            hasAdvancedOptionsAvailable: !isScriptPackage,
+            hasAdvancedOptionsAvailable: !isScriptPackage && !isIosOrIpadosApp,
             isScriptPackage,
           })}
         </p>

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -154,9 +154,7 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ios" });
 
     expect(
-      screen.getByText(
-        /Currently, automatic installation are not available for iOS and iPadOS/i
-      )
+      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
     ).toBeInTheDocument();
   });
 
@@ -164,9 +162,7 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ipados" });
 
     expect(
-      screen.getByText(
-        /Currently, automatic installation are not available for iOS and iPadOS/i
-      )
+      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -154,8 +154,8 @@ const SoftwareOptionsSelector = ({
     // Render unavailable description for iOS or iPadOS add software form only
     return isPlatformIosOrIpados && !isEditingSoftware ? (
       <p>
-        Currently, automatic installation are not available for iOS and iPadOS.
-        Manually install on the <b>Host details</b> page for each host.
+        Automatic install for iOS and iPadOS is coming soon. Today, you can
+        manually install the <strong>Host details</strong> page for each host.
       </p>
     ) : null;
   };

--- a/frontend/services/entities/mdm_apple.ts
+++ b/frontend/services/entities/mdm_apple.ts
@@ -41,6 +41,7 @@ export interface IEditVppAppPostBody {
   labels_include_any?: string[];
   labels_exclude_any?: string[];
   categories?: SoftwareCategory[];
+  display_name?: string;
 }
 
 export interface IGetVppAppsResponse {
@@ -62,9 +63,8 @@ const handleDisplayNameVppForm = (
   teamId: number
 ): IEditVppAppPostBody => {
   return {
-    self_service: false, // or some default as needed
+    display_name: formData.displayName,
     team_id: teamId,
-    // you might not need categories/labels with this form
   };
 };
 


### PR DESCRIPTION
## Issue
Unreleased fixes for #33779 and #34012

## Description
- This was merged into `main` with #35535 and #35626
- This is for the 4.77 RC branch