### PR TITLE
Website: Add API rate limit alert to Android proxy endpoints

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -75,6 +75,10 @@ module.exports = {
         requestBody: this.req.body,
       });
       return enrollmentTokenCreateResponse.data;
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to create an enrollment token for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     }).intercept((err)=>{
       return new Error(`When attempting to create an enrollment token for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     });

--- a/website/api/controllers/android-proxy/create-android-enterprise.js
+++ b/website/api/controllers/android-proxy/create-android-enterprise.js
@@ -173,6 +173,10 @@ module.exports = {
     }).intercept({status: 403}, (err)=>{
       sails.log.warn('Error details when creating Android enterprise with Android Management API (from 403):', require('util').inspect(err));
       return {'invalidEnterpriseToken': 'Access forbidden to Android Management API.'};
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to create a new Android enterprise, an error occurred. Error: ${require('util').inspect(err)}`);
     }).intercept((err)=>{
       // For all other errors (5XX, network errors, etc.), maintain existing behavior
       return new Error(`When attempting to create a new Android enterprise, an error occurred. Error: ${require('util').inspect(err)}`);

--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -75,6 +75,10 @@ module.exports = {
       return createSignupUrlResponse.data;
     }).intercept({status: 400}, (unusedErr)=>{
       return {'invalidCallbackUrl': 'The provided Callback Url could not be used to create an Android enterprise signup URL.'};
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
     }).intercept((err)=>{
       return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
     });

--- a/website/api/controllers/android-proxy/delete-android-device.js
+++ b/website/api/controllers/android-proxy/delete-android-device.js
@@ -79,7 +79,11 @@ module.exports = {
       await androidmanagement.enterprises.devices.delete({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });
-    }).intercept((err) => {
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to delete a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    }).intercept((err)=>{
       return new Error(`When attempting to delete a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     });
 

--- a/website/api/controllers/android-proxy/delete-one-android-enterprise.js
+++ b/website/api/controllers/android-proxy/delete-one-android-enterprise.js
@@ -83,8 +83,12 @@ module.exports = {
           subscription: thisAndroidEnterprise.pubsubSubscriptionName,
         });
         return;
+      }).intercept({status: 429}, (err)=>{
+        // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+        sails.log.warn(`p1: Android management API rate limit exceeded! Error: ${require('util').inspect(err)}`);
+        return new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${err}`);
       }).intercept((err)=>{
-        throw new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+        return new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${err}`);
       });
     } catch (unusedErr) {
       // If Google API deletion fails (e.g., enterprise already deleted), continue with proxy cleanup

--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -81,7 +81,11 @@ module.exports = {
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
       });
       return getDeviceResult.data;
-    }).intercept((err) => {
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to get a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {
         return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};

--- a/website/api/controllers/android-proxy/get-android-enterprises.js
+++ b/website/api/controllers/android-proxy/get-android-enterprises.js
@@ -92,7 +92,7 @@ module.exports = {
         return allEnterprises;
       }).intercept({status: 429}, (err)=>{
         // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
-        sails.log.warn(`p1: Android management API rate limit exceeded! Error: ${require('util').inspect(err)}`);
+        sails.log.warn(`p1: Android management API rate limit exceeded!`);
         return err;
       }).intercept((err)=>{
         // Re-throw the error for handling outside the intercept

--- a/website/api/controllers/android-proxy/get-android-enterprises.js
+++ b/website/api/controllers/android-proxy/get-android-enterprises.js
@@ -90,6 +90,10 @@ module.exports = {
         });
 
         return allEnterprises;
+      }).intercept({status: 429}, (err)=>{
+        // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+        sails.log.warn(`p1: Android management API rate limit exceeded! Error: ${require('util').inspect(err)}`);
+        return err;
       }).intercept((err)=>{
         // Re-throw the error for handling outside the intercept
         return err;

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -82,7 +82,11 @@ module.exports = {
         requestBody: this.req.body,
       });
       return patchDeviceResponse.data;
-    }).intercept((err) => {
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to update a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    }).intercept((err)=>{
       let errorString = err.toString();
       if (errorString.includes('Device is no longer being managed')) {
         return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -81,7 +81,11 @@ module.exports = {
         requestBody: this.req.body,
       });
       return patchPoliciesResponse.data;
-    }).intercept((err) => {
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to update a policy for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    }).intercept((err)=>{
       return new Error(`When attempting to update a policy for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     });
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/34358

Changes:
- Updated Android enterprise proxy endpoints to log an additional warning to alert us if we exceed the Android management API rate limit.