### PR TITLE
CP Bugfix: Filter out in-house apps when listing software for setup experience

### DIFF
--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -502,6 +502,10 @@ WHERE
 		{{end}}
 		AND ({{$defFilter}})
 	{{end}}
+	-- If for setup experience, exclude any installers that are not supported
+	{{if .ForSetupExperience}}
+		AND iha.id IS NULL
+	{{end}}
 GROUP BY
 	st.id
 	{{if hasTeamID .}}

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -377,6 +377,12 @@ type SoftwareTitleListOptions struct {
 	MaximumCVSS         float64 `query:"max_cvss_score,optional"`
 	PackagesOnly        bool    `query:"packages_only,optional"`
 	Platform            string  `query:"platform,optional"`
+
+	// ForSetupExperience is an internal flag set when listing software via the
+	// setup experience endpoint, so that it filters out any software available
+	// for install that is not supported for setup experience. It cannot be set
+	// via the query parameters.
+	ForSetupExperience bool
 }
 
 type HostSoftwareTitleListOptions struct {


### PR DESCRIPTION
Cherry-pick to `main` of PR https://github.com/fleetdm/fleet/pull/35619 that targeted 4.77.0 RC branch.