### PR TITLE
Add PUT endpoint for setup experience script

### DIFF
--- a/changes/35309-setup-experience-script
+++ b/changes/35309-setup-experience-script
@@ -1,0 +1,1 @@
+* Added an endpoint to allow updating the macOS setup experience script in-place, and modified gitops to utilize it

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -452,7 +452,7 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 	ds.DeleteSetupExperienceScriptFunc = func(ctx context.Context, teamID *uint) error {
 		return nil
 	}
-	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error {
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script, allowUpdate bool) error {
 		return nil
 	}
 	ds.ExpandEmbeddedSecretsAndUpdatedAtFunc = func(ctx context.Context, document string) (string, *time.Time, error) {

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -95,7 +95,15 @@ func (svc *Service) GetSetupExperienceScript(ctx context.Context, teamID *uint, 
 	return script, content, nil
 }
 
-func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+func (svc *Service) CreateSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+	return svc.SetSetupExperienceScript(ctx, teamID, name, r, false)
+}
+
+func (svc *Service) PutSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+	return svc.SetSetupExperienceScript(ctx, teamID, name, r, true)
+}
+
+func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader, allowUpdate bool) error {
 	if err := svc.authz.Authorize(ctx, &fleet.Script{TeamID: teamID}, fleet.ActionWrite); err != nil {
 		return err
 	}
@@ -143,7 +151,7 @@ func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, 
 		return fleet.NewInvalidArgumentError("script", err.Error())
 	}
 
-	if err := svc.ds.SetSetupExperienceScript(ctx, script); err != nil {
+	if err := svc.ds.SetSetupExperienceScript(ctx, script, allowUpdate); err != nil {
 		var (
 			existsErr fleet.AlreadyExistsError
 			fkErr     fleet.ForeignKeyError

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -96,14 +96,14 @@ func (svc *Service) GetSetupExperienceScript(ctx context.Context, teamID *uint, 
 }
 
 func (svc *Service) CreateSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
-	return svc.SetSetupExperienceScript(ctx, teamID, name, r, false)
+	return svc.setSetupExperienceScript(ctx, teamID, name, r, false)
 }
 
 func (svc *Service) PutSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
-	return svc.SetSetupExperienceScript(ctx, teamID, name, r, true)
+	return svc.setSetupExperienceScript(ctx, teamID, name, r, true)
 }
 
-func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader, allowUpdate bool) error {
+func (svc *Service) setSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader, allowUpdate bool) error {
 	if err := svc.authz.Authorize(ctx, &fleet.Script{TeamID: teamID}, fleet.ActionWrite); err != nil {
 		return err
 	}

--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -244,7 +244,7 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 		return nil
 	}
 
-	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error {
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script, allowUpdate bool) error {
 		return nil
 	}
 
@@ -258,7 +258,7 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 	require.NoError(t, err)
 
 	scriptReader := bytes.NewReader([]byte("hello"))
-	err = svc.SetSetupExperienceScript(ctx, nil, "potato.sh", scriptReader)
+	err = svc.CreateSetupExperienceScript(ctx, nil, "potato.sh", scriptReader)
 	require.NoError(t, err)
 	_, _ = scriptReader.Seek(0, io.SeekStart)
 
@@ -266,7 +266,7 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 	err = svc.SetSetupExperienceSoftware(ctx, "darwin", 1, []uint{1, 2})
 	require.NoError(t, err)
 
-	err = svc.SetSetupExperienceScript(ctx, ptr.Uint(1), "potato.sh", scriptReader)
+	err = svc.CreateSetupExperienceScript(ctx, ptr.Uint(1), "potato.sh", scriptReader)
 	require.NoError(t, err)
 	_, _ = scriptReader.Seek(0, io.SeekStart)
 
@@ -278,7 +278,7 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 	err = svc.SetSetupExperienceSoftware(ctx, "darwin", 0, []uint{1, 2})
 	require.ErrorContains(t, err, "Couldn’t add setup experience software. To add software, first disable manual_agent_install.")
 
-	err = svc.SetSetupExperienceScript(ctx, nil, "potato.sh", scriptReader)
+	err = svc.CreateSetupExperienceScript(ctx, nil, "potato.sh", scriptReader)
 	require.ErrorContains(t, err, "Couldn’t add setup experience script. To add script, first disable manual_agent_install.")
 	_, _ = scriptReader.Seek(0, io.SeekStart)
 
@@ -286,7 +286,7 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 	err = svc.SetSetupExperienceSoftware(ctx, "darwin", 1, []uint{1, 2})
 	require.ErrorContains(t, err, "Couldn’t add setup experience software. To add software, first disable manual_agent_install.")
 
-	err = svc.SetSetupExperienceScript(ctx, ptr.Uint(1), "potato.sh", scriptReader)
+	err = svc.CreateSetupExperienceScript(ctx, ptr.Uint(1), "potato.sh", scriptReader)
 	require.ErrorContains(t, err, "Couldn’t add setup experience script. To add script, first disable manual_agent_install.")
 	_, _ = scriptReader.Seek(0, io.SeekStart)
 

--- a/server/datastore/mysql/activities_test.go
+++ b/server/datastore/mysql/activities_test.go
@@ -565,7 +565,7 @@ func testListHostUpcomingActivities(t *testing.T, ds *Datastore) {
 	t.Log("h2SelfService", h2SelfService)
 
 	setupExpScript := &fleet.Script{Name: "setup_experience_script", ScriptContents: "setup_experience"}
-	err = ds.SetSetupExperienceScript(ctx, setupExpScript)
+	err = ds.SetSetupExperienceScript(ctx, setupExpScript, false)
 	require.NoError(t, err)
 	ses, err := ds.GetSetupExperienceScript(ctx, h2.TeamID)
 	require.NoError(t, err)

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -8404,7 +8404,7 @@ func testHostsDeleteHosts(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Add a setup experience status result
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "test.sh", ScriptContents: "echo foo"})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "test.sh", ScriptContents: "echo foo"}, false)
 	require.NoError(t, err)
 
 	added, err := ds.EnqueueSetupExperienceItems(ctx, host.Platform, host.UUID, 0)

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -606,7 +606,7 @@ func (ds *Datastore) SetSetupExperienceScript(ctx context.Context, script *fleet
 		// - existing setup script with same content -> no-op
 		if allowUpdate {
 			gotSetupExperienceScript, err := ds.getSetupExperienceScript(ctx, tx, script.TeamID)
-			if err != nil && !errors.Is(err, notFound("SetupExperienceScript")) {
+			if err != nil && !fleet.IsNotFound(err) {
 				return err
 			}
 			// fall through on notFound err - nothing to do

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -609,9 +609,9 @@ func (ds *Datastore) SetSetupExperienceScript(ctx context.Context, script *fleet
 			if err != nil && !fleet.IsNotFound(err) {
 				return err
 			}
-			// fall through on notFound err - nothing to do
+			// We will fall through on a notFound err - nothing to do here
 			if err == nil {
-				if gotSetupExperienceScript.ScriptContentID != uint(id) {
+				if gotSetupExperienceScript.ScriptContentID != uint(id) { // nolint:gosec // dismiss G115 - low risk here
 					err = ds.deleteSetupExperienceScript(ctx, tx, script.TeamID)
 					if err != nil {
 						return err

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -1303,6 +1303,7 @@ func testUpdateSetupExperienceScriptWhileEnqueued(t *testing.T, ds *Datastore) {
 	require.NotEqual(t, team1OriginalScript.ID, team1UpdatedScript.ID)
 
 	host1NewItems, err = ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam1UUID)
+	require.NoError(t, err)
 	require.Len(t, host1NewItems, 0)
 
 	// Should not have affected host 2's enqueued execution

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -304,9 +304,9 @@ func testEnqueueSetupExperienceItems(t *testing.T, ds *Datastore) {
 	})
 
 	// Create some scripts and add them to setup experience
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script1", ScriptContents: "SCRIPT 1", TeamID: &team1.ID})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script1", ScriptContents: "SCRIPT 1", TeamID: &team1.ID}, false)
 	require.NoError(t, err)
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script2", ScriptContents: "SCRIPT 2", TeamID: &team2.ID})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script2", ScriptContents: "SCRIPT 2", TeamID: &team2.ID}, false)
 	require.NoError(t, err)
 
 	script1, err := ds.GetSetupExperienceScript(ctx, &team1.ID)
@@ -653,7 +653,7 @@ func testGetSetupExperienceTitles(t *testing.T, ds *Datastore) {
 		TeamID:         &team1.ID,
 		Name:           "the script.sh",
 		ScriptContents: "hello",
-	})
+	}, false)
 	require.NoError(t, err)
 
 	sec, err := ds.GetSetupExperienceCount(ctx, "darwin", &team1.ID)
@@ -1079,7 +1079,7 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 		ScriptContents: "echo foo",
 	}
 
-	err = ds.SetSetupExperienceScript(ctx, wantScript1)
+	err = ds.SetSetupExperienceScript(ctx, wantScript1, false)
 	require.NoError(t, err)
 
 	// get the script for team1
@@ -1101,7 +1101,7 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 		ScriptContents: "echo bar",
 	}
 
-	err = ds.SetSetupExperienceScript(ctx, wantScript2)
+	err = ds.SetSetupExperienceScript(ctx, wantScript2, false)
 	require.NoError(t, err)
 
 	// get the script for team2
@@ -1123,7 +1123,7 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 		ScriptContents: "echo bar",
 	}
 
-	err = ds.SetSetupExperienceScript(ctx, wantScriptNoTeam)
+	err = ds.SetSetupExperienceScript(ctx, wantScriptNoTeam, false)
 	require.NoError(t, err)
 
 	// get the script nil team id is equivalent to team id 0
@@ -1141,18 +1141,18 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 
 	// try to create another with name "script" and no team id
 	var existsErr fleet.AlreadyExistsError
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script", ScriptContents: "echo baz"})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script", ScriptContents: "echo baz"}, false)
 	require.Error(t, err)
 	require.ErrorAs(t, err, &existsErr)
 
 	// try to create another script with no team id and a different name
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script2", ScriptContents: "echo baz"})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{Name: "script2", ScriptContents: "echo baz"}, false)
 	require.Error(t, err)
 	require.ErrorAs(t, err, &existsErr)
 
 	// try to add a script for a team that doesn't exist
 	var fkErr fleet.ForeignKeyError
-	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{TeamID: ptr.Uint(42), Name: "script", ScriptContents: "echo baz"})
+	err = ds.SetSetupExperienceScript(ctx, &fleet.Script{TeamID: ptr.Uint(42), Name: "script", ScriptContents: "echo baz"}, false)
 	require.Error(t, err)
 	require.ErrorAs(t, err, &fkErr)
 
@@ -1174,7 +1174,7 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 	require.NoError(t, err) // TODO: confirm if we want to return not found on deletes
 
 	// add same script for team1 again
-	err = ds.SetSetupExperienceScript(ctx, wantScript1)
+	err = ds.SetSetupExperienceScript(ctx, wantScript1, false)
 	require.NoError(t, err)
 
 	// get the script for team1
@@ -1221,7 +1221,7 @@ func testGetSetupExperienceScriptByID(t *testing.T, ds *Datastore) {
 		ScriptContents: "echo hello",
 	}
 
-	err := ds.SetSetupExperienceScript(ctx, script)
+	err := ds.SetSetupExperienceScript(ctx, script, false)
 	require.NoError(t, err)
 
 	scriptByTeamID, err := ds.GetSetupExperienceScript(ctx, nil)

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -31,6 +31,7 @@ func TestSetupExperience(t *testing.T) {
 		{"SetupExperienceScriptCRUD", testSetupExperienceScriptCRUD},
 		{"TestHostInSetupExperience", testHostInSetupExperience},
 		{"TestGetSetupExperienceScriptByID", testGetSetupExperienceScriptByID},
+		{"TestUpdateSetupExperienceScriptWhileEnqueued", testUpdateSetupExperienceScriptWhileEnqueued},
 	}
 
 	for _, c := range cases {
@@ -1173,8 +1174,8 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 	err = ds.DeleteSetupExperienceScript(ctx, ptr.Uint(42))
 	require.NoError(t, err) // TODO: confirm if we want to return not found on deletes
 
-	// add same script for team1 again
-	err = ds.SetSetupExperienceScript(ctx, wantScript1, false)
+	// add same script for team1 again but with "allowUpdate" set(even though there will be no update since it doesn't exist)
+	err = ds.SetSetupExperienceScript(ctx, wantScript1, true)
 	require.NoError(t, err)
 
 	// get the script for team1
@@ -1188,6 +1189,137 @@ func testSetupExperienceScriptCRUD(t *testing.T, ds *Datastore) {
 	// script contents are deleted by CleanupUnusedScriptContents not by DeleteSetupExperienceScript
 	// so the content id should be the same as the old
 	require.Equal(t, oldScript1.ScriptContentID, newScript1.ScriptContentID)
+
+	// add same script for team1 again with "allowUpdate" set.
+	err = ds.SetSetupExperienceScript(ctx, wantScript1, true)
+	require.NoError(t, err)
+
+	// Verify that the script contents remained the same
+	newScript1, err = ds.GetSetupExperienceScript(ctx, &team1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, newScript1)
+	require.Equal(t, wantScript1.Name, newScript1.Name)
+	require.Equal(t, wantScript1.TeamID, newScript1.TeamID)
+	require.NotZero(t, newScript1.ScriptContentID)
+	// script contents are deleted by CleanupUnusedScriptContents not by DeleteSetupExperienceScript
+	// so the content id should be the same as the old
+	require.Equal(t, oldScript1.ScriptContentID, newScript1.ScriptContentID)
+}
+
+func testUpdateSetupExperienceScriptWhileEnqueued(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team2"})
+	require.NoError(t, err)
+
+	// create scripts for team1 and team2
+	initialScript1 := &fleet.Script{
+		Name:           "script",
+		TeamID:         &team1.ID,
+		ScriptContents: "echo foo",
+	}
+
+	initialScript2 := &fleet.Script{
+		Name:           "script",
+		TeamID:         &team2.ID,
+		ScriptContents: "echo bar",
+	}
+
+	// and an "updated" script for team1
+	updatedScript1 := &fleet.Script{
+		Name:           "script",
+		TeamID:         &team1.ID,
+		ScriptContents: "echo updated foo",
+	}
+
+	err = ds.SetSetupExperienceScript(ctx, initialScript1, true)
+	require.NoError(t, err)
+	team1OriginalScript, err := ds.GetSetupExperienceScript(ctx, &team1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, team1OriginalScript)
+
+	err = ds.SetSetupExperienceScript(ctx, initialScript2, true)
+	require.NoError(t, err)
+	team2OriginalScript, err := ds.GetSetupExperienceScript(ctx, &team2.ID)
+	require.NoError(t, err)
+	require.NotNil(t, team2OriginalScript)
+
+	hostTeam1UUID := "123"
+	hostTeam2UUID := "456"
+
+	anythingEnqueued, err := ds.EnqueueSetupExperienceItems(ctx, "darwin", hostTeam1UUID, team1.ID)
+	require.NoError(t, err)
+	require.True(t, anythingEnqueued)
+
+	anythingEnqueued, err = ds.EnqueueSetupExperienceItems(ctx, "darwin", hostTeam2UUID, team2.ID)
+	require.NoError(t, err)
+	require.True(t, anythingEnqueued)
+
+	host1OriginalItems, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam1UUID)
+	require.NoError(t, err)
+	require.Len(t, host1OriginalItems, 1)
+	require.Equal(t, fleet.SetupExperienceStatusPending, host1OriginalItems[0].Status)
+	require.NotNil(t, host1OriginalItems[0].SetupExperienceScriptID)
+	require.Equal(t, team1OriginalScript.ID, *host1OriginalItems[0].SetupExperienceScriptID)
+
+	host2OriginalItems, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam2UUID)
+	require.NoError(t, err)
+	require.Len(t, host2OriginalItems, 1)
+	require.Equal(t, fleet.SetupExperienceStatusPending, host2OriginalItems[0].Status)
+	require.NotNil(t, host2OriginalItems[0].SetupExperienceScriptID)
+	require.Equal(t, team2OriginalScript.ID, *host2OriginalItems[0].SetupExperienceScriptID)
+
+	// "Update" the script for team1 with its original contents which should cause no change to the enqueued execution
+	err = ds.SetSetupExperienceScript(ctx, initialScript1, true)
+	require.NoError(t, err)
+
+	team1UpdatedScript, err := ds.GetSetupExperienceScript(ctx, &team1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, team1UpdatedScript)
+	require.Equal(t, team1OriginalScript.ScriptContentID, team1UpdatedScript.ScriptContentID)
+	require.Equal(t, team1OriginalScript.ID, team1UpdatedScript.ID)
+
+	host1NewItems, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam1UUID)
+	require.NoError(t, err)
+	require.Len(t, host1NewItems, 1)
+	require.Equal(t, team1OriginalScript.ID, *host1NewItems[0].SetupExperienceScriptID)
+
+	// Should not have perturbed Host 2's enqueued execution either
+	host2NewItems, err := ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam2UUID)
+	require.NoError(t, err)
+	require.Len(t, host2NewItems, 1)
+	require.Equal(t, team2OriginalScript.ID, *host2NewItems[0].SetupExperienceScriptID)
+
+	// update script for team1 which should delete the enqueued execution
+	err = ds.SetSetupExperienceScript(ctx, updatedScript1, true)
+	require.NoError(t, err)
+
+	team1UpdatedScript, err = ds.GetSetupExperienceScript(ctx, &team1.ID)
+	require.NoError(t, err)
+	require.NotNil(t, team1UpdatedScript)
+	require.NotEqual(t, team1OriginalScript.ScriptContentID, team1UpdatedScript.ScriptContentID)
+	require.NotEqual(t, team1OriginalScript.ID, team1UpdatedScript.ID)
+
+	host1NewItems, err = ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam1UUID)
+	require.Len(t, host1NewItems, 0)
+
+	// Should not have affected host 2's enqueued execution
+	host2NewItems, err = ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam2UUID)
+	require.NoError(t, err)
+	require.Len(t, host2NewItems, 1)
+	require.Equal(t, team2OriginalScript.ID, *host2NewItems[0].SetupExperienceScriptID)
+
+	// re-enqueue items for host 1, should enqueue the updated script
+	anythingEnqueued, err = ds.EnqueueSetupExperienceItems(ctx, "darwin", hostTeam1UUID, team1.ID)
+	require.NoError(t, err)
+	require.True(t, anythingEnqueued)
+
+	host1NewItems, err = ds.ListSetupExperienceResultsByHostUUID(ctx, hostTeam1UUID)
+	require.NoError(t, err)
+	require.Len(t, host1NewItems, 1)
+	require.Equal(t, team1UpdatedScript.ID, *host1NewItems[0].SetupExperienceScriptID)
 }
 
 func testHostInSetupExperience(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2201,7 +2201,7 @@ type Datastore interface {
 	GetSetupExperienceScriptByID(ctx context.Context, scriptID uint) (*Script, error)
 
 	// SetSetupExperienceScript sets the setup experience script to the given script.
-	SetSetupExperienceScript(ctx context.Context, script *Script) error
+	SetSetupExperienceScript(ctx context.Context, script *Script, allowUpdate bool) error
 
 	// DeleteSetupExperienceScript deletes the setup experience script for the given team.
 	DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1275,8 +1275,13 @@ type Service interface {
 	GetOrbitSetupExperienceStatus(ctx context.Context, orbitNodeKey string, forceRelease bool, resetFailedSetupSteps bool) (*SetupExperienceStatusPayload, error)
 	// GetSetupExperienceScript gets the current setup experience script for the given team.
 	GetSetupExperienceScript(ctx context.Context, teamID *uint, downloadRequested bool) (*Script, []byte, error)
-	// SetSetupExperienceScript sets the setup experience script for the given team.
-	SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error
+	// CreateSetupExperienceScript creates the setup experience script for the given team. An error is returned if a
+	// script already exists for the given team
+	CreateSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error
+	// PutSetupExperienceScript sets the setup experience script for a given team, deleting the existing one if it exists
+	// and is different and replacing it with a new one. Effectively an upsert operation which does nothing if the contents
+	// do not change
+	PutSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error
 	// DeleteSetupExperienceScript deletes the setup experience script for the given team.
 	DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error
 	// SetupExperienceNextStep is a callback that processes the

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1401,7 +1401,7 @@ type GetSetupExperienceScriptFunc func(ctx context.Context, teamID *uint) (*flee
 
 type GetSetupExperienceScriptByIDFunc func(ctx context.Context, scriptID uint) (*fleet.Script, error)
 
-type SetSetupExperienceScriptFunc func(ctx context.Context, script *fleet.Script) error
+type SetSetupExperienceScriptFunc func(ctx context.Context, script *fleet.Script, allowUpdate bool) error
 
 type DeleteSetupExperienceScriptFunc func(ctx context.Context, teamID *uint) error
 
@@ -8800,11 +8800,11 @@ func (s *DataStore) GetSetupExperienceScriptByID(ctx context.Context, scriptID u
 	return s.GetSetupExperienceScriptByIDFunc(ctx, scriptID)
 }
 
-func (s *DataStore) SetSetupExperienceScript(ctx context.Context, script *fleet.Script) error {
+func (s *DataStore) SetSetupExperienceScript(ctx context.Context, script *fleet.Script, allowUpdate bool) error {
 	s.mu.Lock()
 	s.SetSetupExperienceScriptFuncInvoked = true
 	s.mu.Unlock()
-	return s.SetSetupExperienceScriptFunc(ctx, script)
+	return s.SetSetupExperienceScriptFunc(ctx, script, allowUpdate)
 }
 
 func (s *DataStore) DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -788,7 +788,9 @@ type GetOrbitSetupExperienceStatusFunc func(ctx context.Context, orbitNodeKey st
 
 type GetSetupExperienceScriptFunc func(ctx context.Context, teamID *uint, downloadRequested bool) (*fleet.Script, []byte, error)
 
-type SetSetupExperienceScriptFunc func(ctx context.Context, teamID *uint, name string, r io.Reader) error
+type CreateSetupExperienceScriptFunc func(ctx context.Context, teamID *uint, name string, r io.Reader) error
+
+type PutSetupExperienceScriptFunc func(ctx context.Context, teamID *uint, name string, r io.Reader) error
 
 type DeleteSetupExperienceScriptFunc func(ctx context.Context, teamID *uint) error
 
@@ -2002,8 +2004,11 @@ type Service struct {
 	GetSetupExperienceScriptFunc        GetSetupExperienceScriptFunc
 	GetSetupExperienceScriptFuncInvoked bool
 
-	SetSetupExperienceScriptFunc        SetSetupExperienceScriptFunc
-	SetSetupExperienceScriptFuncInvoked bool
+	CreateSetupExperienceScriptFunc        CreateSetupExperienceScriptFunc
+	CreateSetupExperienceScriptFuncInvoked bool
+
+	PutSetupExperienceScriptFunc        PutSetupExperienceScriptFunc
+	PutSetupExperienceScriptFuncInvoked bool
 
 	DeleteSetupExperienceScriptFunc        DeleteSetupExperienceScriptFunc
 	DeleteSetupExperienceScriptFuncInvoked bool
@@ -4787,11 +4792,18 @@ func (s *Service) GetSetupExperienceScript(ctx context.Context, teamID *uint, do
 	return s.GetSetupExperienceScriptFunc(ctx, teamID, downloadRequested)
 }
 
-func (s *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+func (s *Service) CreateSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
 	s.mu.Lock()
-	s.SetSetupExperienceScriptFuncInvoked = true
+	s.CreateSetupExperienceScriptFuncInvoked = true
 	s.mu.Unlock()
-	return s.SetSetupExperienceScriptFunc(ctx, teamID, name, r)
+	return s.CreateSetupExperienceScriptFunc(ctx, teamID, name, r)
+}
+
+func (s *Service) PutSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+	s.mu.Lock()
+	s.PutSetupExperienceScriptFuncInvoked = true
+	s.mu.Unlock()
+	return s.PutSetupExperienceScriptFunc(ctx, teamID, name, r)
 }
 
 func (s *Service) DeleteSetupExperienceScript(ctx context.Context, teamID *uint) error {

--- a/server/service/client_scripts.go
+++ b/server/service/client_scripts.go
@@ -168,16 +168,7 @@ func (c *Client) deleteMacOSSetupScript(teamID *uint) error {
 }
 
 func (c *Client) uploadMacOSSetupScript(filename string, data []byte, teamID *uint) error {
-	// there is no "replace setup experience script" endpoint, and none was
-	// planned, so to avoid delaying the feature I'm doing DELETE then SET, but
-	// that's not ideal (will always re-create the script when apply/gitops is
-	// run with the same yaml). Note though that we also redo software installers
-	// downloads on each run, so the churn of this one is minor in comparison.
-	if err := c.deleteMacOSSetupScript(teamID); err != nil {
-		return err
-	}
-
-	verb, path := "POST", "/api/latest/fleet/setup_experience/script"
+	verb, path := "PUT", "/api/latest/fleet/setup_experience/script"
 
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -406,9 +406,11 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// Setup experience software endpoints:
 	ue.PUT("/api/_version_/fleet/setup_experience/software", putSetupExperienceSoftware, putSetupExperienceSoftwareRequest{})
 	ue.GET("/api/_version_/fleet/setup_experience/software", getSetupExperienceSoftware, getSetupExperienceSoftwareRequest{})
+
 	// Setup experience script endpoints:
 	ue.GET("/api/_version_/fleet/setup_experience/script", getSetupExperienceScriptEndpoint, getSetupExperienceScriptRequest{})
-	ue.POST("/api/_version_/fleet/setup_experience/script", setSetupExperienceScriptEndpoint, setSetupExperienceScriptRequest{})
+	ue.POST("/api/_version_/fleet/setup_experience/script", createSetupExperienceScriptEndpoint, setSetupExperienceScriptRequest{})
+	ue.PUT("/api/_version_/fleet/setup_experience/script", putSetupExperienceScriptEndpoint, setSetupExperienceScriptRequest{})
 	ue.DELETE("/api/_version_/fleet/setup_experience/script", deleteSetupExperienceScriptEndpoint, deleteSetupExperienceScriptRequest{})
 
 	// Fleet-maintained apps

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -92,7 +92,7 @@ func (s *integrationMDMTestSuite) TestSetupExperienceScript() {
 	// update with a different name and contents via PUT endpoint, should suceed
 	body, headers = generateNewScriptMultipartRequest(t,
 		"different.sh", []byte(`echo "hello2"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
-	res = s.DoRawWithHeaders("POST", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+	res = s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
 
 	// create no-team script
 	body, headers = generateNewScriptMultipartRequest(t,

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -84,6 +84,16 @@ func (s *integrationMDMTestSuite) TestSetupExperienceScript() {
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "already exists") // TODO: confirm expected error message with product/frontend
 
+	// try to update script with same name via PUT endpoint, should not fail because this is allowed
+	body, headers = generateNewScriptMultipartRequest(t,
+		"script42.sh", []byte(`echo "hello"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
+	res = s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+
+	// update with a different name and contents via PUT endpoint, should suceed
+	body, headers = generateNewScriptMultipartRequest(t,
+		"different.sh", []byte(`echo "hello2"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
+	res = s.DoRawWithHeaders("POST", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+
 	// create no-team script
 	body, headers = generateNewScriptMultipartRequest(t,
 		"script42.sh", []byte(`echo "hello"`), s.token, nil)
@@ -987,6 +997,196 @@ func (s *integrationMDMTestSuite) TestSetupExperienceVPPInstallError() {
 	}
 	require.Equal(t, 1, deviceConfiguredCount)
 	require.Equal(t, 0, otherCount)
+}
+
+func (s *integrationMDMTestSuite) TestSetupExperienceFlowUpdateScript() {
+	t := s.T()
+	ctx := context.Background()
+
+	device, host, tm := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
+
+	// enroll the host
+	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
+	mdmDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken)
+	mdmDevice.SerialNumber = device.SerialNumber
+	err := mdmDevice.Enroll()
+	require.NoError(t, err)
+
+	// run the worker to process the DEP enroll request
+	s.runWorker()
+	// run the worker to assign configuration profiles
+	s.awaitTriggerProfileSchedule(t)
+
+	var cmds []*micromdm.CommandPayload
+	cmd, err := mdmDevice.Idle()
+	require.NoError(t, err)
+	for cmd != nil {
+		var fullCmd micromdm.CommandPayload
+		require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
+
+		cmds = append(cmds, &fullCmd)
+		cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+
+	// expected commands: install fleetd (install enterprise), install profiles
+	// (custom one, fleetd configuration, fleet CA root)
+	require.Len(t, cmds, 4)
+
+	// simulate fleetd being installed and the host being orbit-enrolled now
+	host.OsqueryHostID = ptr.String(mdmDevice.UUID)
+	host.UUID = mdmDevice.UUID
+	orbitKey := setOrbitEnrollment(t, host, s.ds)
+	host.OrbitNodeKey = &orbitKey
+
+	// call the /status endpoint, the software and script should be pending
+	var statusResp getOrbitSetupExperienceStatusResponse
+	s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &statusResp)
+	require.Nil(t, statusResp.Results.BootstrapPackage)         // no bootstrap package involved
+	require.Nil(t, statusResp.Results.AccountConfiguration)     // no SSO involved
+	require.Len(t, statusResp.Results.ConfigurationProfiles, 3) // fleetd config, root CA, custom profile
+
+	// the software and script are pending
+	require.NotNil(t, statusResp.Results.Script)
+	require.Equal(t, "script.sh", statusResp.Results.Script.Name)
+	require.Equal(t, fleet.SetupExperienceStatusPending, statusResp.Results.Script.Status)
+	require.Len(t, statusResp.Results.Software, 1)
+	require.Equal(t, "DummyApp", statusResp.Results.Software[0].Name)
+	require.Equal(t, fleet.SetupExperienceStatusPending, statusResp.Results.Software[0].Status)
+	require.NotNil(t, statusResp.Results.Software[0].SoftwareTitleID)
+	require.NotZero(t, *statusResp.Results.Software[0].SoftwareTitleID)
+
+	// The /setup_experience/status endpoint doesn't return the various IDs for executions, so pull
+	// it out manually (for now only the software install has its execution id)
+	results, err := s.ds.ListSetupExperienceResultsByHostUUID(ctx, host.UUID)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	var swExecID string
+	for _, r := range results {
+		if r.HostSoftwareInstallsExecutionID != nil {
+			swExecID = *r.HostSoftwareInstallsExecutionID
+		}
+	}
+	require.NotEmpty(t, swExecID)
+
+	// Check upcoming activities: we should only have the software upcoming because we don't run the
+	// script until after the software is done
+	var hostActivitiesResp listHostUpcomingActivitiesResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities/upcoming", host.ID),
+		nil, http.StatusOK, &hostActivitiesResp)
+	require.Len(t, hostActivitiesResp.Activities, 1)
+	require.Equal(t, swExecID, hostActivitiesResp.Activities[0].UUID)
+
+	// no MDM command got enqueued due to the /status call (device not released yet)
+	cmd, err = mdmDevice.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// call the /status endpoint, the software is now running and script should be pending
+	statusResp = getOrbitSetupExperienceStatusResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &statusResp)
+	require.Nil(t, statusResp.Results.BootstrapPackage)         // no bootstrap package involved
+	require.Nil(t, statusResp.Results.AccountConfiguration)     // no SSO involved
+	require.Len(t, statusResp.Results.ConfigurationProfiles, 3) // fleetd config, root CA, custom profile
+
+	// the software is running and script is pending
+	require.NotNil(t, statusResp.Results.Script)
+	require.Equal(t, "script.sh", statusResp.Results.Script.Name)
+	require.Equal(t, fleet.SetupExperienceStatusPending, statusResp.Results.Script.Status)
+	require.Len(t, statusResp.Results.Software, 1)
+	require.Equal(t, "DummyApp", statusResp.Results.Software[0].Name)
+	require.Equal(t, fleet.SetupExperienceStatusRunning, statusResp.Results.Software[0].Status)
+	require.NotNil(t, statusResp.Results.Software[0].SoftwareTitleID)
+	require.NotZero(t, *statusResp.Results.Software[0].SoftwareTitleID)
+
+	// no MDM command got enqueued due to the /status call (device not released yet)
+	cmd, err = mdmDevice.Idle()
+	require.NoError(t, err)
+	require.Nil(t, cmd)
+
+	// PUT update the script, no changes, it does not get cancelled
+	body, headers := generateNewScriptMultipartRequest(t,
+		"script.sh", []byte(`echo "hello"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
+	s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+
+	// call the /status endpoint, the software is still running and script should still be pending
+	statusResp = getOrbitSetupExperienceStatusResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &statusResp)
+	require.Nil(t, statusResp.Results.BootstrapPackage)         // no bootstrap package involved
+	require.Nil(t, statusResp.Results.AccountConfiguration)     // no SSO involved
+	require.Len(t, statusResp.Results.ConfigurationProfiles, 3) // fleetd config, root CA, custom profile
+
+	// the software is still running and script is pending
+	require.NotNil(t, statusResp.Results.Script)
+	require.Equal(t, "script.sh", statusResp.Results.Script.Name)
+	require.Equal(t, fleet.SetupExperienceStatusPending, statusResp.Results.Script.Status)
+	require.Len(t, statusResp.Results.Software, 1)
+	require.Equal(t, "DummyApp", statusResp.Results.Software[0].Name)
+	require.Equal(t, fleet.SetupExperienceStatusRunning, statusResp.Results.Software[0].Status)
+	require.NotNil(t, statusResp.Results.Software[0].SoftwareTitleID)
+	require.NotZero(t, *statusResp.Results.Software[0].SoftwareTitleID)
+
+	// PUT update the script with changes, see it get cancelled
+	body, headers = generateNewScriptMultipartRequest(t,
+		"script2.sh", []byte(`echo "foobar"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
+	s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+
+	// call the /status endpoint, software is running, script is removed as it got cancelled by the update
+	statusResp = getOrbitSetupExperienceStatusResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &statusResp)
+	require.Nil(t, statusResp.Results.BootstrapPackage)         // no bootstrap package involved
+	require.Nil(t, statusResp.Results.AccountConfiguration)     // no SSO involved
+	require.Len(t, statusResp.Results.ConfigurationProfiles, 3) // fleetd config, root CA, custom profile
+
+	require.Len(t, statusResp.Results.Software, 1)
+	require.Equal(t, "DummyApp", statusResp.Results.Software[0].Name)
+	require.Equal(t, fleet.SetupExperienceStatusRunning, statusResp.Results.Software[0].Status)
+	require.NotNil(t, statusResp.Results.Software[0].SoftwareTitleID)
+	require.NotZero(t, *statusResp.Results.Software[0].SoftwareTitleID)
+
+	require.Nil(t, statusResp.Results.Script)
+
+	// The /setup_experience/status endpoint doesn't return the various IDs for executions, so pull
+	// them out manually
+	results, err = s.ds.ListSetupExperienceResultsByHostUUID(ctx, host.UUID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	var installUUIDs []string
+	for _, r := range results {
+		if r.HostSoftwareInstallsExecutionID != nil {
+			installUUIDs = append(installUUIDs, *r.HostSoftwareInstallsExecutionID)
+		}
+	}
+	require.Equal(t, len(installUUIDs), 1)
+
+	// record a result for software installation
+	s.Do("POST", "/api/fleet/orbit/software_install/result",
+		json.RawMessage(fmt.Sprintf(`{
+					"orbit_node_key": %q,
+					"install_uuid": %q,
+					"install_script_exit_code": 0,
+					"install_script_output": "ok"
+				}`, *host.OrbitNodeKey, installUUIDs[0])), http.StatusNoContent)
+
+	// Check the setup experience status endpoint to advance the status
+	statusResp = getOrbitSetupExperienceStatusResponse{}
+	s.DoJSON("POST", "/api/fleet/orbit/setup_experience/status", json.RawMessage(fmt.Sprintf(`{"orbit_node_key": %q}`, *host.OrbitNodeKey)), http.StatusOK, &statusResp)
+
+	// check that the host received the device configured command automatically
+	cmd, err = mdmDevice.Idle()
+	require.NoError(t, err)
+	cmds = cmds[:0]
+	for cmd != nil {
+		var fullCmd micromdm.CommandPayload
+		require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
+		cmds = append(cmds, &fullCmd)
+		cmd, err = mdmDevice.Acknowledge(cmd.CommandUUID)
+		require.NoError(t, err)
+	}
+
+	require.Len(t, cmds, 1)
+	require.Equal(t, "DeviceConfigured", cmds[0].Command.RequestType)
 }
 
 func (s *integrationMDMTestSuite) TestSetupExperienceFlowCancelScript() {

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -88,11 +88,15 @@ func (s *integrationMDMTestSuite) TestSetupExperienceScript() {
 	body, headers = generateNewScriptMultipartRequest(t,
 		"script42.sh", []byte(`echo "hello"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
 	res = s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+	err = json.NewDecoder(res.Body).Decode(&newScriptResp)
+	require.NoError(t, err)
 
 	// update with a different name and contents via PUT endpoint, should suceed
 	body, headers = generateNewScriptMultipartRequest(t,
 		"different.sh", []byte(`echo "hello2"`), s.token, map[string][]string{"team_id": {fmt.Sprintf("%d", tm.ID)}})
 	res = s.DoRawWithHeaders("PUT", "/api/latest/fleet/setup_experience/script", body.Bytes(), http.StatusOK, headers)
+	err = json.NewDecoder(res.Body).Decode(&newScriptResp)
+	require.NoError(t, err)
 
 	// create no-team script
 	body, headers = generateNewScriptMultipartRequest(t,

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -169,7 +169,8 @@ type setSetupExperienceScriptResponse struct {
 
 func (r setSetupExperienceScriptResponse) Error() error { return r.Err }
 
-func setSetupExperienceScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+// EJM TODO EJM Rename this createSetupExperienceScript????
+func createSetupExperienceScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*setSetupExperienceScriptRequest)
 
 	scriptFile, err := req.Script.Open()
@@ -178,14 +179,38 @@ func setSetupExperienceScriptEndpoint(ctx context.Context, request interface{}, 
 	}
 	defer scriptFile.Close()
 
-	if err := svc.SetSetupExperienceScript(ctx, req.TeamID, filepath.Base(req.Script.Filename), scriptFile); err != nil {
+	if err := svc.CreateSetupExperienceScript(ctx, req.TeamID, filepath.Base(req.Script.Filename), scriptFile); err != nil {
 		return setSetupExperienceScriptResponse{Err: err}, nil
 	}
 
 	return setSetupExperienceScriptResponse{}, nil
 }
 
-func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+func (svc *Service) CreateSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
+	// skipauth: No authorization check needed due to implementation returning
+	// only license error.
+	svc.authz.SkipAuthorization(ctx)
+
+	return fleet.ErrMissingLicense
+}
+
+func putSetupExperienceScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*setSetupExperienceScriptRequest)
+
+	scriptFile, err := req.Script.Open()
+	if err != nil {
+		return setSetupExperienceScriptResponse{Err: err}, nil
+	}
+	defer scriptFile.Close()
+
+	if err := svc.PutSetupExperienceScript(ctx, req.TeamID, filepath.Base(req.Script.Filename), scriptFile); err != nil {
+		return setSetupExperienceScriptResponse{Err: err}, nil
+	}
+
+	return setSetupExperienceScriptResponse{}, nil
+}
+
+func (svc *Service) PutSetupExperienceScript(ctx context.Context, teamID *uint, name string, r io.Reader) error {
 	// skipauth: No authorization check needed due to implementation returning
 	// only license error.
 	svc.authz.SkipAuthorization(ctx)

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -169,7 +169,6 @@ type setSetupExperienceScriptResponse struct {
 
 func (r setSetupExperienceScriptResponse) Error() error { return r.Err }
 
-// EJM TODO EJM Rename this createSetupExperienceScript????
 func createSetupExperienceScriptEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*setSetupExperienceScriptRequest)
 

--- a/server/service/setup_experience_test.go
+++ b/server/service/setup_experience_test.go
@@ -199,7 +199,7 @@ func TestSetupExperienceAuth(t *testing.T) {
 			ctx = viewer.NewContext(ctx, viewer.Viewer{User: tt.user})
 
 			t.Run("setup experience script", func(t *testing.T) {
-				err := svc.SetSetupExperienceScript(ctx, nil, "test.sh", strings.NewReader("echo"))
+				err := svc.CreateSetupExperienceScript(ctx, nil, "test.sh", strings.NewReader("echo"))
 				checkAuthErr(t, tt.shouldFailGlobalWrite, err)
 				err = svc.DeleteSetupExperienceScript(ctx, nil)
 				checkAuthErr(t, tt.shouldFailGlobalWrite, err)
@@ -208,7 +208,7 @@ func TestSetupExperienceAuth(t *testing.T) {
 				_, _, err = svc.GetSetupExperienceScript(ctx, nil, true)
 				checkAuthErr(t, tt.shouldFailGlobalRead, err)
 
-				err = svc.SetSetupExperienceScript(ctx, &teamID, "test.sh", strings.NewReader("echo"))
+				err = svc.CreateSetupExperienceScript(ctx, &teamID, "test.sh", strings.NewReader("echo"))
 				checkAuthErr(t, tt.shouldFailTeamWrite, err)
 				err = svc.DeleteSetupExperienceScript(ctx, &teamID)
 				checkAuthErr(t, tt.shouldFailTeamWrite, err)

--- a/server/service/setup_experience_test.go
+++ b/server/service/setup_experience_test.go
@@ -25,7 +25,7 @@ func TestSetupExperienceAuth(t *testing.T) {
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{}, nil
 	}
-	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script) error {
+	ds.SetSetupExperienceScriptFunc = func(ctx context.Context, script *fleet.Script, allowUpdate bool) error {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35309

Related doc update #35736 

Adds a PUT endpoint for setting setup experience scripts, as opposed to the current POST implementation(which errors if the script is already set, which is why gitops calls DELETE first every time). If the contents change, the new endpoint has the same effect as DELETE then POST today, however if the contents are unchanged no changes occur, allowing gitops runs to avoid cancelling script executions.

Also switched gitops over to the new PUT endpoint and removed the DELETE in the "set" path.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [ ] QA'd all new/changed functionality manually

