### PR TITLE
move where we are creating the mdm enrollment activity into the turn on apple lifecycle

### DIFF
--- a/changes/issue-32009-change-where-mdm_enrollment_activity_happens
+++ b/changes/issue-32009-change-where-mdm_enrollment_activity_happens
@@ -1,0 +1,1 @@
+- change where mdm_enrolled activity is created so it occures after the inital Token Update command. This allows the webhook to fire after the host can recieve additonal commands from fleet MDM.

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -50,6 +50,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/cryptoutil"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+
 	nano_service "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/service"
 	"github.com/fleetdm/fleet/v4/server/mdm/profiles"
 	"github.com/fleetdm/fleet/v4/server/ptr"

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3554,6 +3554,7 @@ func (svc *MDMAppleCheckinAndCommandService) TokenUpdate(r *mdm.Request, m *mdm.
 		UUID:                    r.ID,
 		EnrollReference:         acctUUID,
 		HasSetupExperienceItems: hasSetupExpItems,
+		UserEnrollmentID:        m.EnrollmentID,
 	})
 }
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3455,6 +3455,17 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 		return err
 	}
 
+	if !scepRenewalInProgress {
+		if svc.keyValueStore != nil {
+			// Set sticky key for MDM enrollments to avoid updating team id on orbit enrollments
+			err = svc.keyValueStore.Set(r.Context, fleet.StickyMDMEnrollmentKeyPrefix+r.ID, "1", fleet.StickyMDMEnrollmentTTL)
+			if err != nil {
+				// We do not want to fail here, just log the error to notify
+				level.Error(svc.logger).Log("msg", "failed to set sticky mdm enrollment key", "err", err, "host_uuid", r.ID)
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Related issue:** Resolves #32009

This updates where we fire off the mdm_enrolled activity. We had it in the Authenticate method in the mdm checking and commands struct and move it into our lifecycle module. In the lifecycle module we place it in the turnOnApple method which already had checks to see if we were on the first TokenUpdate command. This means this activity should only 
fire on the initial TokenUpdate command the host gets.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
