### PR TITLE
Website: update logged warning in deliver-contact-form-message

### DIFF
--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -122,7 +122,7 @@ Fleet Premium subscription details:
 
       // If the Contact record returned by the updateOrCreateContactAndAccount does not have a parent Account record, throw an error to stop the build helper.
       if(!recordIds.salesforceAccountId) {
-        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing an Account.`);
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing a parent account record.`);
       }
       // Create the new Fleet website page view record.
       await sails.helpers.salesforce.createHistoricalEvent.with({

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -127,7 +127,7 @@ Fleet Premium subscription details:
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {
-        sails.log.warn(`Background task failed: When a user submitted a contact form message, a contact/account/historical event could not be created/updated in the CRM for this email address: ${emailAddress}.`, err);
+        sails.log.warn(`Background task failed: When a user submitted a contact form message, a contact/account/historical event could not be created/updated in the CRM for this email address: ${emailAddress}. Full error: ${requre('util').inspect(err)}`);
       }
       return;
     });//_∏_

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -117,8 +117,13 @@ Fleet Premium subscription details:
         contactSource: 'Website - Contact forms',
         description: `Sent a contact form message: ${message}`,
       }).intercept((err)=>{
-        return new Error(`Could not create/update a contact or account. Full error: ${require('util').inspect(err)}`)
+        return new Error(`Could not create/update a contact or account. Full error: ${require('util').inspect(err)}`);
       });
+
+      // If the Contact record returned by the updateOrCreateContactAndAccount does not have a parent Account record, throw an error to stop the build helper.
+      if(!recordIds.salesforceAccountId) {
+        throw new Error(`Could not create historical event. The contact record (ID: ${recordIds.salesforceContactId}) returned by the updateOrCreateContactAndAccount helper is missing an Account.`);
+      }
       // Create the new Fleet website page view record.
       await sails.helpers.salesforce.createHistoricalEvent.with({
         salesforceAccountId: recordIds.salesforceAccountId,
@@ -127,7 +132,7 @@ Fleet Premium subscription details:
         intentSignal: 'Submitted the "Send a message" form',
         eventContent: message,
       }).intercept((err)=>{
-        return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`)
+        return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`);
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -116,6 +116,8 @@ Fleet Premium subscription details:
         lastName: lastName,
         contactSource: 'Website - Contact forms',
         description: `Sent a contact form message: ${message}`,
+      }).intercept((err)=>{
+        return new Error(`Could not create/update a contact or account. Full error: ${require('util').inspect(err)}`)
       });
       // Create the new Fleet website page view record.
       await sails.helpers.salesforce.createHistoricalEvent.with({
@@ -124,10 +126,12 @@ Fleet Premium subscription details:
         eventType: 'Intent signal',
         intentSignal: 'Submitted the "Send a message" form',
         eventContent: message,
+      }).intercept((err)=>{
+        return new Error(`Could not create an historical event. Full error: ${require('util').inspect(err)}`)
       });
     }).exec((err)=>{// Use .exec() to run the salesforce helpers in the background.
       if(err) {
-        sails.log.warn(`Background task failed: When a user submitted a contact form message, a contact/account/historical event could not be created/updated in the CRM for this email address: ${emailAddress}. Full error: ${requre('util').inspect(err)}`);
+        sails.log.warn(`Background task failed: When a user submitted a contact form message, a contact/account/historical event could not be created/updated in the CRM for this email address: ${emailAddress}. Full error: ${require('util').inspect(err)}`);
       }
       return;
     });//_∏_


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/13046

Changes:
- Updated the logged warning in deliver-contact-form-message to include the full error thrown by the `build()` helper.
- Added intercepts to the helpers called inside of the `build()` helper in deliver-contact-form-message, and updated it to throw an error if the updateOrCreateContactAndAccount helper does not return an account ID.