### PR TITLE
Fleet UI: Fix mobile error to be based on navigator.userAgent

### DIFF
--- a/frontend/components/DeviceUserError/DeviceUserError.tests.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tests.tsx
@@ -1,0 +1,41 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import DeviceUserError from "./DeviceUserError";
+
+describe("DeviceUserError", () => {
+  it("renders default error message when no props given", () => {
+    render(<DeviceUserError />);
+    expect(screen.getByTestId("error-icon")).toBeInTheDocument();
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("Please contact your IT admin.")
+    ).toBeInTheDocument();
+  });
+
+  it("applies mobile view class when isMobileView prop is true", () => {
+    const { container } = render(<DeviceUserError isMobileView />);
+    expect(container.firstChild).toHaveClass("device-user-error__mobile-view");
+  });
+
+  it("renders authentication error message on desktop device", () => {
+    render(<DeviceUserError isAuthenticationError />);
+    expect(
+      screen.getByText("This URL is invalid or expired.")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/To access your device information, please click/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders authentication error message on mobile device", () => {
+    render(<DeviceUserError isAuthenticationError isMobileDevice />);
+    expect(
+      screen.getByText("Invalid or missing certificate")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Couldn't authenticate this device. Please contact your IT admin."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/components/DeviceUserError/DeviceUserError.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tsx
@@ -5,12 +5,16 @@ import classNames from "classnames";
 const baseClass = "device-user-error";
 
 interface IDeviceUserErrorProps {
+  /** Modifies styling for mobile width (<768px) */
   isMobileView?: boolean;
+  /** Modifies error message for iPhone/iPad/Android */
+  isMobileDevice?: boolean;
   isAuthenticationError?: boolean;
 }
 
 const DeviceUserError = ({
   isMobileView = false,
+  isMobileDevice = false,
   isAuthenticationError = false,
 }: IDeviceUserErrorProps): JSX.Element => {
   const wrapperClassnames = classNames(baseClass, {
@@ -29,12 +33,12 @@ const DeviceUserError = ({
     headerContent = (
       <>
         <Icon name="error" />
-        {isMobileView
+        {isMobileDevice
           ? "Invalid or missing certificate"
           : "This URL is invalid or expired."}
       </>
     );
-    bodyContent = isMobileView ? (
+    bodyContent = isMobileDevice ? (
       "Couldn't authenticate this device. Please contact your IT admin."
     ) : (
       <>

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -64,6 +64,9 @@ import {
   getErrorMessage,
   hasRemainingSetupSteps,
   isSoftwareScriptSetup,
+  isIPhone,
+  isIPad,
+  isAndroid,
 } from "./helpers";
 
 import PolicyDetailsModal from "../cards/Policies/HostPoliciesTable/PolicyDetailsModal";
@@ -134,6 +137,8 @@ const DeviceUserPage = ({
 }: IDeviceUserPageProps): JSX.Element => {
   const deviceAuthToken = device_auth_token;
   const isMobileView = useIsMobileWidth();
+  const isMobileDevice =
+    isIPhone(navigator) || isIPad(navigator) || isAndroid(navigator);
 
   const { renderFlash, notification, hideFlash } = useContext(
     NotificationContext
@@ -862,6 +867,7 @@ const DeviceUserPage = ({
       {isDeviceUserError || enrollUrlError ? (
         <DeviceUserError
           isMobileView={isMobileView}
+          isMobileDevice={isMobileDevice}
           isAuthenticationError={!!isAuthenticationError}
         />
       ) : (

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -46,3 +46,17 @@ export const isSoftwareScriptSetup = (s: ISetupStep) => {
 
   return s.source === "sh_packages" || s.source === "ps1_packages";
 };
+
+// Same solution as defined in /templates/enroll-ota.html (https://github.com/fleetdm/fleet/pull/26592)
+export const isIPhone = (navigator: Navigator) =>
+  /iPhone/i.test(navigator.userAgent);
+export const isIPad = (navigator: Navigator) =>
+  /iPad/i.test(navigator.userAgent) ||
+  (/Macintosh/i.test(navigator.userAgent) &&
+    navigator.maxTouchPoints !== undefined &&
+    navigator.maxTouchPoints > 1);
+export const isAndroid = (navigator: Navigator) =>
+  /Android/i.test(navigator.userAgent);
+export const isMac = (navigator: Navigator) =>
+  (/Macintosh/i.test(navigator.userAgent) && !isIPad) ||
+  /Mac OS X/i.test(navigator.userAgent);


### PR DESCRIPTION
## Issue
Closes #35547 

- Fix mobile error to be based on navigator.userAgent
- Authentication errors will vary depending if the user is mobile (iphone/ipad/android) or not
- Add unit tests

## Testing

- [x] Added/updated automated tests
