### PR TITLE
Update priority issue approval DRIs

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -460,13 +460,8 @@ Any fleetie can follow the process below to add a priority label to an issue.
 1. Add as much context as possible to the issue description and assign labels to help the team
    understand the problem and what is driving the urgency. 
 2. Add the `P0`, `P1`, or `P2` label based on the urgency of the issue. 
-3. Comment on the GitHub issue explaining why the issue is a priority, and assign the issue to the
-   [DRI for what goes in a
-   release](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris).
-   For immediate action, follow up via Slack DM or by phone.
-4. The DRI for what goes in a release will review the issue to determine if it meets the criteria
-   for the assigned priority label. If so, they will assign the issue to the appropriate EM and PM. If not,
-   they will comment on the issue explaining why. 
+3. Comment on the GitHub issue explaining why the issue is a priority, and assign the issue to the [Engineering Manager for the associated product group](https://fleetdm.com/handbook/company/product-groups#current-product-groups). For immediate action, follow up with the EM via Slack DM or by phone.
+4. The EM will review the issue to determine if it meets the criteria for the assigned priority label. If so, they will triage as needed based on priority level. If not, they will remove the priority label and add a comment on the issue explaining why.
 
 
 ### Making a pull request


### PR DESCRIPTION
I would like to hand over responsibility for approving/denying priority issues to the EMs. Right now, I don't typically have enough context to always make the best decision, and end up deferring to the EMs anyway. 