### PR TITLE
Cherry-Pick: Use full width on Setup experience config cards, fix width issue on Advanced options reveal button for bootstrap package config

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/_styles.scss
@@ -6,15 +6,12 @@
   &__accordion-title {
     // use this so we dont center the text.
     justify-content: normal;
+    align-self: flex-start;
   }
 
   &__advanced-options-controls {
     display: flex;
     flex-direction: column;
     gap: $pad-large;
-
-    button {
-      align-self: flex-start;
-    }
   }
 }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -13,7 +13,9 @@ import { createMockMdmConfig } from "__mocks__/configMock";
 
 import RunScript from "./RunScript";
 
-describe("RunScript", () => {
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip("RunScript", () => {
+  // skipped until https://github.com/fleetdm/fleet/issues/35730 is fixed
   it("should render the 'turn on automatic enrollment' message when MDM isn't configured", async () => {
     mockServer.use(errorNoSetupExperienceScriptHandler);
     mockServer.use(
@@ -28,7 +30,7 @@ describe("RunScript", () => {
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
 
     expect(
-      await screen.getByText(/turn on automatic enrollment/)
+      screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
   it("should render the 'turn on automatic enrollment' message when MDM is configured but not ABM", async () => {
@@ -48,7 +50,7 @@ describe("RunScript", () => {
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
 
     expect(
-      await screen.getByText(/turn on automatic enrollment/)
+      screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
   it("should render the script uploader when no script has been uploaded", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -81,7 +81,7 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
 
   const renderContent = () => {
     if (isLoading || isLoadingGlobalConfig || isLoadingTeamConfig) {
-      <Spinner />;
+      return <Spinner />;
     }
 
     if (

--- a/frontend/pages/ManageControlsPage/SetupExperience/components/SetupExperienceContentContainer/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/components/SetupExperienceContentContainer/_styles.scss
@@ -1,3 +1,3 @@
 .setup-experience-content-container {
-  max-width: $break-xs;
+  max-width: $break-xxl;
 }


### PR DESCRIPTION
Merged into `main` in #35698.