### PR TITLE
Fix RunScript tests and update mock server domain 

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -79,6 +79,7 @@ describe("RunScript", () => {
 
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
     expect(screen.getByTestId("spinner")).toBeVisible();
+    expect(screen.queryByLabelText("Upload")).not.toBeInTheDocument();
     await waitFor(async () => {
       expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
     });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -39,6 +39,7 @@ describe("RunScript", () => {
       screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
+
   it("should render the 'turn on automatic enrollment' message when MDM is configured but not ABM", async () => {
     mockServer.use(errorNoSetupExperienceScriptHandler);
     mockServer.use(
@@ -67,6 +68,7 @@ describe("RunScript", () => {
       screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
+
   it("should render the script uploader when no script has been uploaded", async () => {
     mockServer.use(errorNoSetupExperienceScriptHandler);
     mockServer.use(createGetConfigHandler());
@@ -94,6 +96,9 @@ describe("RunScript", () => {
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
 
     expect(screen.getByTestId("spinner")).toBeVisible();
+    expect(
+      screen.queryByText("Script will run during setup:")
+    ).not.toBeInTheDocument();
     await waitFor(async () => {
       expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
     });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 
 import mockServer from "test/mock-server";
 import { createCustomRenderer, createMockRouter } from "test/test-utils";
@@ -8,6 +8,7 @@ import {
   errorNoSetupExperienceScriptHandler,
 } from "test/handlers/setup-experience-handlers";
 import { createGetConfigHandler } from "test/handlers/config-handlers";
+import { createGetTeamHandler } from "test/handlers/team-handlers";
 
 import { createMockMdmConfig } from "__mocks__/configMock";
 
@@ -21,14 +22,21 @@ describe("RunScript", () => {
         mdm: createMockMdmConfig({ enabled_and_configured: false }),
       })
     );
+    mockServer.use(createGetTeamHandler({}));
     const render = createCustomRenderer({
       withBackendMock: true,
     });
 
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
-
+    expect(screen.getByTestId("spinner")).toBeVisible();
     expect(
-      await screen.getByText(/turn on automatic enrollment/)
+      screen.queryByText(/turn on automatic enrollment/)
+    ).not.toBeInTheDocument();
+    await waitFor(async () => {
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
   it("should render the 'turn on automatic enrollment' message when MDM is configured but not ABM", async () => {
@@ -41,37 +49,54 @@ describe("RunScript", () => {
         }),
       })
     );
+    mockServer.use(createGetTeamHandler({}));
     const render = createCustomRenderer({
       withBackendMock: true,
     });
 
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
 
+    expect(screen.getByTestId("spinner")).toBeVisible();
     expect(
-      await screen.getByText(/turn on automatic enrollment/)
+      screen.queryByText(/turn on automatic enrollment/)
+    ).not.toBeInTheDocument();
+    await waitFor(async () => {
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/turn on automatic enrollment/)
     ).toBeInTheDocument();
   });
   it("should render the script uploader when no script has been uploaded", async () => {
     mockServer.use(errorNoSetupExperienceScriptHandler);
     mockServer.use(createGetConfigHandler());
+    mockServer.use(createGetTeamHandler({}));
     const render = createCustomRenderer({
       withBackendMock: true,
     });
 
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
-
+    expect(screen.getByTestId("spinner")).toBeVisible();
+    await waitFor(async () => {
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+    });
     expect(await screen.findByRole("button", { name: "Upload" })).toBeVisible();
   });
 
   it("should render the uploaded script uploader when a script has been uploaded", async () => {
     mockServer.use(createSetupExperienceScriptHandler());
     mockServer.use(createGetConfigHandler());
+    mockServer.use(createGetTeamHandler({}));
     const render = createCustomRenderer({
       withBackendMock: true,
     });
 
     render(<RunScript router={createMockRouter()} currentTeamId={1} />);
 
+    expect(screen.getByTestId("spinner")).toBeVisible();
+    await waitFor(async () => {
+      expect(screen.queryByTestId("spinner")).not.toBeInTheDocument();
+    });
     expect(
       await screen.findByText("Script will run during setup:")
     ).toBeVisible();

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/RunScript/RunScript.tsx
@@ -81,7 +81,7 @@ const RunScript = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
 
   const renderContent = () => {
     if (isLoading || isLoadingGlobalConfig || isLoadingTeamConfig) {
-      <Spinner />;
+      return <Spinner />;
     }
 
     if (

--- a/frontend/test/jest.config.ts
+++ b/frontend/test/jest.config.ts
@@ -39,7 +39,7 @@ const config: Config = {
   setupFilesAfterEnv: ["<rootDir>/frontend/test/test-setup.ts"],
   clearMocks: true,
   testEnvironmentOptions: {
-    url: "http://localhost:8080",
+    url: "http://fleettest.test:9876",
     customExportConditions: [""],
   },
   transformIgnorePatterns: [`/node_modules/(?!(${esModules})/)`],


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35730 

# Details

* Unskipped and updated the RunScript (setup experience scripts UI) tests to check for loading spinner, wait for it to disappear, and then check for relevant items for test.
* Updated the mock server URL so that if a handler is missing in a test, it won't accidentally be served by a local Fleet server (unless someone intentionally starts a server on `fleettest.test:9876`).

# Checklist for submitter

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
* Ran all tests locally without Fleet server running, verified they passed.
* Removed one of the "get team" handlers from the RunScript tests, verified that it now fails even with Fleet server running.
