### PR TITLE
Add missing FMAs and `end_user_auth` to 🧪 Testing & QA team

### DIFF
--- a/it-and-security/teams/testing-and-qa.yml
+++ b/it-and-security/teams/testing-and-qa.yml
@@ -27,6 +27,13 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
+  macos_setup:
+    bootstrap_package: ""
+    enable_end_user_authentication: true
+    macos_setup_assistant: 
+  macos_updates:
+    deadline:
+    minimum_version:
   enable_disk_encryption: true
   scripts:
     # macOS scripts
@@ -117,6 +124,8 @@ software:
       self_service: true
     - slug: microsoft-excel/darwin # Microsoft Excel for macOS
       self_service: true
+    - slug: microsoft-office/darwin # Microsoft Office for macOS
+      self_service: true
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true
     - slug: microsoft-word/darwin # Microsoft Word for macOS
@@ -146,6 +155,8 @@ software:
     - slug: vnc-viewer/darwin # VNC Viewer for macOS
       self_service: true
     - slug: whatsapp/darwin # WhatsApp for macOS
+      self_service: true
+    - slug: windows-app/darwin # Windows App for macOS
       self_service: true
     - slug: yubico-yubikey-manager/darwin # Yubikey Manager for macOS
       self_service: true

--- a/it-and-security/teams/testing-and-qa.yml
+++ b/it-and-security/teams/testing-and-qa.yml
@@ -124,7 +124,7 @@ software:
       self_service: true
     - slug: microsoft-excel/darwin # Microsoft Excel for macOS
       self_service: true
-    - slug: microsoft-office/darwin # Microsoft Office for macOS
+    - slug: microsoft-outlook/darwin # Microsoft Outlook for macOS
       self_service: true
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true

--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -129,7 +129,7 @@ controls:
           - "Microsoft AutoUpdate installed"
   macos_setup:
     bootstrap_package: ""
-    enable_end_user_authentication: false
+    enable_end_user_authentication: true
     macos_setup_assistant: null
   macos_updates:
     deadline:


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
