### PR TITLE
Fleet UI: Return pre-install query output in Install Details modal

### DIFF
--- a/changes/33733-install-details-modal
+++ b/changes/33733-install-details-modal
@@ -1,0 +1,1 @@
+* Fleet UI: Return pre-install query output in Install Details modal

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -261,6 +261,10 @@ export const SoftwareInstallDetailsModal = ({
   const renderInstallDetailsSection = () => {
     const outputs = [
       {
+        label: "Pre-install query output:",
+        value: swInstallResult?.pre_install_query_output,
+      },
+      {
         label: "Install script output:",
         value: swInstallResult?.output,
       },
@@ -273,7 +277,8 @@ export const SoftwareInstallDetailsModal = ({
     // Only show details button if there's details to display
     const showDetailsButton =
       (!!swInstallResult?.post_install_script_output ||
-        !!swInstallResult?.output) &&
+        !!swInstallResult?.output ||
+        !!swInstallResult?.pre_install_query_output) &&
       swInstallResult?.status !== "pending_install";
 
     return (

--- a/frontend/test/handlers/software-handlers.ts
+++ b/frontend/test/handlers/software-handlers.ts
@@ -64,6 +64,44 @@ export const getSoftwareInstallResultHandler = http.get(
   }
 );
 
+// ---- Pre install query output ----
+
+// Installed, outputs for pre-install, install, and post-install
+export const getSoftwareInstallHandlerWithPreInstall = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: {
+        ...createMockSoftwareInstallResult({
+          install_uuid: params.install_uuid as string,
+          status: "installed",
+          output: "Install script ran",
+          post_install_script_output: "Post-install success",
+          pre_install_query_output: "Pre-install check passed",
+        }),
+      },
+    });
+  }
+);
+
+// Failed install, only pre-install output
+export const getSoftwareInstallHandlerOnlyPreInstallOutput = http.get(
+  baseUrl("/software/install/:install_uuid/results"),
+  ({ params }) => {
+    return HttpResponse.json({
+      results: {
+        ...createMockSoftwareInstallResult({
+          install_uuid: params.install_uuid as string,
+          status: "failed_install",
+          output: "",
+          post_install_script_output: "",
+          pre_install_query_output: "Pre-install only",
+        }),
+      },
+    });
+  }
+);
+
 // ---- MDM Command Handlers ----
 
 /** This is used for testing command results of IPA custom packages */


### PR DESCRIPTION
## Issue
Closes #33733 

## Description
- Install details modal returns the pre-install query output if available

## Screenshot of fix
- Shows in the install details modal in the library section, the install details modal in the activity feed, and the install details modal on the self-service page

<img width="1474" height="875" alt="Screenshot 2025-11-14 at 10 56 19 AM" src="https://github.com/user-attachments/assets/1e6cc5ae-41be-4573-9ad6-d5791a5831c8" />
<img width="1345" height="934" alt="Screenshot 2025-11-14 at 10 56 46 AM" src="https://github.com/user-attachments/assets/40303266-ae99-4114-bfc9-78a8827b3e08" />
<img width="1058" height="818" alt="Screenshot 2025-11-14 at 10 58 34 AM" src="https://github.com/user-attachments/assets/6d857e0b-8c8f-494c-a425-323a8d528f10" />




## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
