### PR TITLE
Remove expensive "get labels" subquery

### DIFF
--- a/changes/35376-remove-expensive-label-host-counts-query
+++ b/changes/35376-remove-expensive-label-host-counts-query
@@ -1,0 +1,1 @@
+- Removed "host counts" data from the GET /labels API to improve performance.

--- a/frontend/interfaces/label.ts
+++ b/frontend/interfaces/label.ts
@@ -73,7 +73,6 @@ export interface ILabel extends ILabelSummary {
   created_at: string;
   updated_at: string;
   uuid?: string;
-  host_count?: number; // returned for built-in labels but not custom labels
   display_text: string;
   count: number; // seems to be a repeat of hosts_count issue #1618
   type?: "custom" | "platform" | "status" | "all";

--- a/server/datastore/mysql/labels.go
+++ b/server/datastore/mysql/labels.go
@@ -512,16 +512,6 @@ func (ds *Datastore) ListLabels(ctx context.Context, filter fleet.TeamFilter, op
 	}
 
 	query := "SELECT * FROM labels l "
-	// If a team filter is provided, filter host membership by team and return counts with the labels.
-	if filter.User != nil {
-		query = fmt.Sprintf(`
-				SELECT *,
-					(SELECT COUNT(1) FROM label_membership lm JOIN hosts h ON (lm.host_id = h.id) WHERE label_id = l.id AND %s) AS host_count
-				FROM labels l
-			`, ds.whereFilterHostsByTeams(filter, "h"),
-		)
-	}
-
 	query, params := appendListOptionsToSQL(query, &opt)
 	labels := []*fleet.Label{}
 

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -81,7 +81,6 @@ func TestLabels(t *testing.T) {
 		{"ListHostsInLabelAndTeamFilterDeferred", func(t *testing.T, ds *Datastore) { testLabelsListHostsInLabelAndTeamFilter(true, t, ds) }},
 		{"ListHostsInLabelAndTeamFilterNotDeferred", func(t *testing.T, ds *Datastore) { testLabelsListHostsInLabelAndTeamFilter(false, t, ds) }},
 		{"BuiltIn", testLabelsBuiltIn},
-		{"ListUniqueHostsInLabels", testLabelsListUniqueHostsInLabels},
 		{"ChangeDetails", testLabelsChangeDetails},
 		{"GetSpec", testLabelsGetSpec},
 		{"ApplySpecsRoundtrip", testLabelsApplySpecsRoundtrip},
@@ -583,118 +582,6 @@ func testLabelsBuiltIn(t *testing.T, db *Datastore) {
 	assert.Equal(t, 2, len(hits))
 	assert.Equal(t, fleet.LabelTypeBuiltIn, hits[0].LabelType)
 	assert.Equal(t, fleet.LabelTypeBuiltIn, hits[1].LabelType)
-}
-
-func testLabelsListUniqueHostsInLabels(t *testing.T, db *Datastore) {
-	hosts := make([]*fleet.Host, 4)
-	for i := range hosts {
-		h, err := db.NewHost(context.Background(), &fleet.Host{
-			DetailUpdatedAt: time.Now(),
-			LabelUpdatedAt:  time.Now(),
-			PolicyUpdatedAt: time.Now(),
-			SeenTime:        time.Now(),
-			OsqueryHostID:   ptr.String(strconv.Itoa(i)),
-			NodeKey:         ptr.String(strconv.Itoa(i)),
-			UUID:            strconv.Itoa(i),
-			Hostname:        fmt.Sprintf("host_%d", i),
-		})
-		require.Nil(t, err)
-		hosts[i] = h
-	}
-
-	team1, err := db.NewTeam(context.Background(), &fleet.Team{Name: "team1"})
-	require.NoError(t, err)
-	require.NoError(t, db.AddHostsToTeam(context.Background(), fleet.NewAddHostsToTeamParams(&team1.ID, []uint{hosts[0].ID})))
-
-	l1 := fleet.LabelSpec{
-		ID:    1,
-		Name:  "label foo",
-		Query: "query1",
-	}
-	l2 := fleet.LabelSpec{
-		ID:    2,
-		Name:  "label bar",
-		Query: "query2",
-	}
-	require.NoError(t, db.ApplyLabelSpecs(context.Background(), []*fleet.LabelSpec{&l1, &l2}))
-
-	for i := 0; i < 3; i++ {
-		err = db.RecordLabelQueryExecutions(context.Background(), hosts[i], map[uint]*bool{l1.ID: ptr.Bool(true)}, time.Now(), false)
-		assert.Nil(t, err)
-	}
-	// host 2 executes twice
-	for i := 2; i < len(hosts); i++ {
-		err = db.RecordLabelQueryExecutions(context.Background(), hosts[i], map[uint]*bool{l2.ID: ptr.Bool(true)}, time.Now(), false)
-		assert.Nil(t, err)
-	}
-
-	filter := fleet.TeamFilter{User: test.UserAdmin}
-
-	uniqueHosts, err := db.ListUniqueHostsInLabels(context.Background(), filter, []uint{l1.ID, l2.ID})
-	assert.Nil(t, err)
-	assert.Equal(t, len(hosts), len(uniqueHosts))
-
-	labels, err := db.ListLabels(context.Background(), filter, fleet.ListOptions{})
-	require.Nil(t, err)
-	require.Len(t, labels, 2)
-	for _, l := range labels {
-		assert.True(t, l.HostCount > 0)
-	}
-
-	// If an empty team filter is used, all hosts should be returned.
-	labelsNoTeamFilter, err := db.ListLabels(context.Background(), fleet.TeamFilter{}, fleet.ListOptions{})
-	require.Nil(t, err)
-	require.Len(t, labelsNoTeamFilter, 2)
-	for _, l := range labelsNoTeamFilter {
-		assert.True(t, l.HostCount == 0)
-	}
-
-	userObs := &fleet.User{GlobalRole: ptr.String(fleet.RoleObserver)}
-	filter = fleet.TeamFilter{User: userObs}
-
-	// observer not included
-	uniqueHosts, err = db.ListUniqueHostsInLabels(context.Background(), filter, []uint{l1.ID, l2.ID})
-	require.Nil(t, err)
-	assert.Len(t, uniqueHosts, 0)
-
-	labels, err = db.ListLabels(context.Background(), filter, fleet.ListOptions{})
-	require.Nil(t, err)
-	require.Len(t, labels, 2)
-	for _, l := range labels {
-		assert.Equal(t, 0, l.HostCount)
-	}
-
-	// observer included
-	filter.IncludeObserver = true
-	uniqueHosts, err = db.ListUniqueHostsInLabels(context.Background(), filter, []uint{l1.ID, l2.ID})
-	require.Nil(t, err)
-	assert.Len(t, uniqueHosts, len(hosts))
-
-	labels, err = db.ListLabels(context.Background(), filter, fleet.ListOptions{})
-	require.Nil(t, err)
-	require.Len(t, labels, 2)
-	for _, l := range labels {
-		assert.True(t, l.HostCount > 0)
-	}
-
-	userTeam1 := &fleet.User{Teams: []fleet.UserTeam{{Team: *team1, Role: fleet.RoleAdmin}}}
-	filter = fleet.TeamFilter{User: userTeam1}
-
-	uniqueHosts, err = db.ListUniqueHostsInLabels(context.Background(), filter, []uint{l1.ID, l2.ID})
-	require.Nil(t, err)
-	require.Len(t, uniqueHosts, 1) // only host 0 associated with this team
-	assert.Equal(t, hosts[0].ID, uniqueHosts[0].ID)
-
-	labels, err = db.ListLabels(context.Background(), filter, fleet.ListOptions{})
-	require.Nil(t, err)
-	require.Len(t, labels, 2)
-	for _, l := range labels {
-		if l.ID == l1.ID {
-			assert.Equal(t, 1, l.HostCount)
-		} else {
-			assert.Equal(t, 0, l.HostCount)
-		}
-	}
 }
 
 func testLabelsChangeDetails(t *testing.T, db *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35376

# Details

This PR removes a subquery that runs in the `GET /labels` endpoint handler code, which returns the number of hosts that are members of each label. I'm removing it because:

1. This is an N+1 query pattern which scales poorly as the # of labels and hosts increases (see associated ticket as well as https://github.com/fleetdm/fleet/issues/4890)
2. _We don't use this data anywhere_. At least no where I could find in the front end or back end (besides a test specifically for this functionality). So we're doing this work for nothing.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [X] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [X] QA'd all new/changed functionality manually
The only place that I could find that lists host counts for labels is the Packs UI, which uses a different endpoint and database method (`GET /targets` and `SearchLabels()`