### PR TITLE
Website: Update earliest supported browser versions

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -971,7 +971,7 @@
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
           iOS: '13',//« earliest version that suppports the embedded podcast player.
-          Android: '6' // « earliest version we can test for compatibility issues with on browserstack
+          Android: '6' // « Note: the earliest version we can test for compatibility issues with on browserstack is Android 7, but Google's search crawler uses an Android 6 user agent.
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
           msedge: '84',//« earliest version to support the backdrop filter css property.

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -974,11 +974,11 @@
           Android: '6' // « Note: the earliest version we can test for compatibility issues with on browserstack is Android 7, but Google's search crawler uses an Android 6 user agent.
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '84',//« earliest version to support the backdrop filter css property.
-          safari: '14',//« earliest version that suppports the hubspot chatbot.
+          msedge: '84',//« earliest version to support the gap css property.
+          safari: '14',//« earliest version that suppports the gap css property.
           firefox: '103',//« earliest version to support the backdrop filter css property.
-          chrome: '84',//« earliest version to support the embedded podcast player.
-          opera: '70',//« earliest version to support the backdrop filter css property.
+          chrome: '84',//« earliest version to support the gap css property.
+          opera: '70',//« earliest version to support the gap css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -971,14 +971,14 @@
         // --------------------------------------------------------------------
         var LATEST_SUPPORTED_VERSION_BY_OS = {
           iOS: '13',//« earliest version that suppports the embedded podcast player.
-          Android: '7' // « earliest version we can test for compatibility issues with on browserstack
+          Android: '6' // « earliest version we can test for compatibility issues with on browserstack
         };
         var LATEST_SUPPORTED_VERSION_BY_USER_AGENT = {
-          msedge: '80',//« earliest version to support the backdrop filter css property.
-          safari: '13',//« earliest version that suppports the hubspot chatbot.
+          msedge: '84',//« earliest version to support the backdrop filter css property.
+          safari: '14',//« earliest version that suppports the hubspot chatbot.
           firefox: '103',//« earliest version to support the backdrop filter css property.
-          chrome: '80',//« earliest version to support the embedded podcast player.
-          opera: '67',//« earliest version to support the backdrop filter css property.
+          chrome: '84',//« earliest version to support the embedded podcast player.
+          opera: '70',//« earliest version to support the backdrop filter css property.
         };
         var LATEST_SUPPORTED_VERSION_BY_BROWSER_NAME = {
           'microsoft edge': LATEST_SUPPORTED_VERSION_BY_USER_AGENT.msedge,


### PR DESCRIPTION
Changes:
- Updated the website's earliest supported browser versions
   - Chrome v80 » v84
   - Microsoft edge v80 » v84
   - Opera v67 » 70
   - Safari 13 » 14
- Changed the earliest supported version of Android to v6