### PR TITLE
Update CODEOWNERS for documentation ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -71,9 +71,7 @@ go.mod @fleetdm/go
 /docs/Contributing                                      @lukeheath @georgekarrv @sharon-fdm # « Contributing guidelines
 /docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @sgress454 @getvictor # software ingestion is security & compliance
 /docs/REST\ API/rest-api.md                             @noahtalerman # « REST API reference documentation
-/docs/Contributing/reference/api-for-contributors.md    @noahtalerman @lukeheath # « Advanced / contributors-only API reference documentation
-/docs/Contributing/reference/audit-logs.md              @noahtalerman @lukeheath # « Advanced / contributors-only audit log documentation
-/docs/Contributing/reference/configuration-for-contributors.md @noahtalerman @lukeheath # « Advanced / contributors-only configuration documentation
+/docs/Contributing/reference                            @noahtalerman
 /schema                                                 @eashaw # « Data tables (osquery/fleetd schema) documentation
 /render.yaml                                            @edwardsb
 /it-and-security                                        @allenhouchins


### PR DESCRIPTION
- @noahtalerman: I think we only need one CODEOWNER for `/docs/Contributing/reference`: the API design DRI
  - @noahtalerman is interim API design DRI while @rachaelshaw is OOO
