### PR TITLE
UI tweak: "macOS Setup Assistant"

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/SetupExperienceNavItems.tsx
@@ -42,7 +42,7 @@ const SETUP_EXPERIENCE_NAV_ITEMS: ISideNavItem<ISetupExperienceCardProps>[] = [
     Card: RunScript,
   },
   {
-    title: "5. Setup assistant",
+    title: "5. macOS Setup Assistant",
     urlSection: "setup-assistant",
     path: PATHS.CONTROLS_SETUP_ASSISTANT,
     Card: SetupAssistant,

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
@@ -143,7 +143,7 @@ const SetupAssistant = ({
   return (
     <section className={baseClass}>
       <SectionHeader
-        title="Setup assistant"
+        title="macOS Setup Assistant"
         details={
           <CustomLink
             url="https://fleetdm.com/learn-more-about/setup-assistant"


### PR DESCRIPTION
- Setup Assistant is a proper noun: https://support.apple.com/guide/deployment/manage-setup-assistant-depdeff4a547/web
- Add "macOS" to clarify this is macOS only
