### PR TITLE
Fleet UI: Android app fallback icon and name

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -60,29 +60,6 @@ const SoftwareAppStoreAndroid = ({
     setIsLoading(true);
 
     try {
-      // HANDLED SERVER SIDE?
-      // // Validate app ID exists using AMAPI
-      // const appId = formData.applicationID; // e.g. "us.zoom.videomeetings"
-      // const appApiUrl = `${AMAPI_BASE_URL}enterprises/${ENTERPRISE_ID}/applications/${appId}`;
-      // // Requires OAuth access token with the required scopes
-      // const accessToken = "<your_oauth_access_token>";
-
-      // const appApiRes = await axios.get(appApiUrl, {
-      //   headers: {
-      //     Authorization: `Bearer ${accessToken}`,
-      //   },
-      // });
-
-      // // If successful, app metadata is present
-      // if (!appApiRes.data || !appApiRes.data.name) {
-      //   renderFlash(
-      //     "error",
-      //     `${ADD_SOFTWARE_ERROR_PREFIX} The application ID isn't available in Play Store. Please find ID on the Play Store and try again.`
-      //   );
-      //   setIsLoading(false);
-      //   return;
-      // }
-
       const {
         software_title_id: softwareAppStoreTitleId,
         // Maybe this will return name and can render success message with the name?
@@ -93,7 +70,8 @@ const SoftwareAppStoreAndroid = ({
         "success",
         <>
           {/* <strong>{appApiRes.data.name}</strong> successfully added. */}
-          <strong>{softwareTitleName}</strong> successfully added.
+          <strong>{softwareTitleName || "Android app"}</strong> successfully
+          added.
         </>,
         { persistOnPageChange: true }
       );

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
@@ -73,7 +73,7 @@ const SoftwareAndroidForm = ({
       : {
           applicationID: "",
           selfService: true, // Default to true for new Android apps
-          automaticInstall: false, // 4.77 Currently navailable for Android apps
+          automaticInstall: false, // 4.77 Currently not available for Android apps
           targetType: "All hosts",
           customTarget: "labelsIncludeAny",
           labelTargets: {},

--- a/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/SoftwareIcon.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/SoftwareIcon.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { useQuery } from "react-query";
 import classnames from "classnames";
 import { SOFTWARE_ICON_SIZES, SoftwareIconSizes } from "styles/var/icon_sizes";
@@ -30,6 +30,8 @@ const SoftwareIcon = ({
   uploadedAt,
 }: ISoftwareIconProps) => {
   const classNames = classnames(baseClass, `${baseClass}__${size}`);
+
+  const [imgFailed, setImgFailed] = useState(false);
 
   const isApiUrl =
     (typeof url === "string" && url?.startsWith("/api/")) || false;
@@ -69,10 +71,16 @@ const SoftwareIcon = ({
     iconSrc = url;
   }
 
-  if (iconSrc) {
+  // Only use direct image URL if it hasn't failed, if it has, skip and go to matched icons
+  if (iconSrc && !imgFailed) {
     return (
       <div className={classNames}>
-        <img className={imgClasses} src={iconSrc} alt="" />
+        <img
+          className={imgClasses}
+          src={iconSrc}
+          alt=""
+          onError={() => setImgFailed(true)} // e.g. 429 rate limit
+        />
       </div>
     );
   }


### PR DESCRIPTION
## Issue
Part of #34393

## Description
Pair Testing with Jahziel 11/14/25
- API doesn't return name and there's no fallback, so success message looked silly and broken.
- Icon is being rate-limited (429) and doesn't push to a fallback icon, also looked silly and broke.
- I left some commented out code in the codebase that needs to be removed

> Note: @jahzielv will be doing BE fixes to these, but these are the FE catches

## Testing

- [x] QA'd all new/changed functionality manually

