### PR TITLE
Grouping OTEL exceptions by type.

### DIFF
--- a/infrastructure/loadtesting/terraform/signoz/otel-collector-values.yaml
+++ b/infrastructure/loadtesting/terraform/signoz/otel-collector-values.yaml
@@ -3,6 +3,9 @@
 # retry logic, and sending queues.
 
 otelCollector:
+  # Enable low cardinality exception grouping to reduce exception noise
+  lowCardinalityExceptionGrouping: true
+
   config:
     exporters:
       # Logs exporter with increased timeout and retry/queue support

--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -323,11 +323,12 @@ func Handle(ctx context.Context, err error) {
 	if span := trace.SpanFromContext(ctx); span != nil && span.IsRecording() {
 		// Mark the current span as failed by setting the error status.
 		// This status can be overridden if we recovered from the error.
-		span.SetStatus(codes.Error, cause.Error())
+		exceptionType := fmt.Sprintf("%T", Cause(cause)) // type of root error
+		span.SetStatus(codes.Error, exceptionType)       // low-cardinality identifier
 
 		// Build attributes for the exception event
 		attrs := []attribute.KeyValue{
-			attribute.String("exception.type", fmt.Sprintf("%T", Cause(cause))),
+			attribute.String("exception.type", exceptionType),
 			attribute.String("exception.message", cause.Error()),
 			attribute.String("exception.stacktrace", strings.Join(cause.Stack(), "\n")),
 		}

--- a/server/contexts/ctxerr/ctxerr.go
+++ b/server/contexts/ctxerr/ctxerr.go
@@ -327,7 +327,7 @@ func Handle(ctx context.Context, err error) {
 
 		// Build attributes for the exception event
 		attrs := []attribute.KeyValue{
-			attribute.String("exception.type", fmt.Sprintf("%T", cause)),
+			attribute.String("exception.type", fmt.Sprintf("%T", Cause(cause))),
 			attribute.String("exception.message", cause.Error()),
 			attribute.String("exception.stacktrace", strings.Join(cause.Stack(), "\n")),
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34677 

Changing OTEL set up to group exceptions by type, which is an OTEL/industry best practice.
