### PR TITLE
Clean up Windows profile preprocess parameter passing in advance of adding additional profile variables

### DIFF
--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -498,6 +498,15 @@ type GroupedCertificateAuthorities struct {
 	Smallstep       []SmallstepSCEPProxyCA `json:"smallstep"`
 }
 
+// ToCustomSCEPProxyCAMap converts the CustomScepProxy slice to a map keyed by CA name
+func (g *GroupedCertificateAuthorities) ToCustomSCEPProxyCAMap() map[string]*CustomSCEPProxyCA {
+	customSCEPCAs := make(map[string]*CustomSCEPProxyCA, len(g.CustomScepProxy))
+	for _, ca := range g.CustomScepProxy {
+		customSCEPCAs[ca.Name] = &ca
+	}
+	return customSCEPCAs
+}
+
 func GroupCertificateAuthoritiesByType(cas []*CertificateAuthority) (*GroupedCertificateAuthorities, error) {
 	grouped := &GroupedCertificateAuthorities{
 		DigiCert:        []DigiCertCA{},

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -59,11 +59,10 @@ func LoopOverExpectedHostProfiles(
 			HostIDForUUIDCache: hostIDForUUIDCache,
 			CustomSCEPCAs:      nil,
 		}
-		params := ProfilePreprocessParamsForVerify{
+		processedContent := PreprocessWindowsProfileContentsForVerification(deps, ProfilePreprocessParamsForVerify{
 			HostUUID:    host.UUID,
 			ProfileUUID: expectedProf.ProfileUUID,
-		}
-		processedContent := PreprocessWindowsProfileContentsForVerification(deps, params, expanded)
+		}, expanded)
 		expectedProf.RawProfile = []byte(processedContent)
 
 		var prof fleet.SyncMLCmd

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -42,7 +42,12 @@ func LoopOverExpectedHostProfiles(
 		return fmt.Errorf("getting host profiles for verification: %w", err)
 	}
 
-	hostIDForUUIDCache := make(map[string]uint)
+	deps := ProfilePreprocessDependenciesForVerify{
+		Context:            ctx,
+		Logger:             logger,
+		DataStore:          ds,
+		HostIDForUUIDCache: make(map[string]uint),
+	}
 
 	for _, expectedProf := range profileMap {
 		expanded, err := ds.ExpandEmbeddedSecrets(ctx, string(expectedProf.RawProfile))
@@ -52,12 +57,6 @@ func LoopOverExpectedHostProfiles(
 
 		// Process Fleet variables if present (similar to how it's done during profile deployment)
 		// This ensures we compare what was actually sent to the device
-		deps := ProfilePreprocessDependenciesForVerify{
-			Context:            ctx,
-			Logger:             logger,
-			DataStore:          ds,
-			HostIDForUUIDCache: hostIDForUUIDCache,
-		}
 		processedContent := PreprocessWindowsProfileContentsForVerification(deps, ProfilePreprocessParamsForVerify{
 			HostUUID:    host.UUID,
 			ProfileUUID: expectedProf.ProfileUUID,

--- a/server/mdm/microsoft/profile_verifier.go
+++ b/server/mdm/microsoft/profile_verifier.go
@@ -41,9 +41,7 @@ func LoopOverExpectedHostProfiles(
 		return fmt.Errorf("getting host profiles for verification: %w", err)
 	}
 
-	params := PreprocessingParameters{
-		HostIDForUUIDCache: make(map[string]uint),
-	}
+	hostIDForUUIDCache := make(map[string]uint)
 
 	for _, expectedProf := range profileMap {
 		expanded, err := ds.ExpandEmbeddedSecrets(ctx, string(expectedProf.RawProfile))
@@ -53,7 +51,7 @@ func LoopOverExpectedHostProfiles(
 
 		// Process Fleet variables if present (similar to how it's done during profile deployment)
 		// This ensures we compare what was actually sent to the device
-		processedContent := PreprocessWindowsProfileContentsForVerification(ctx, logger, ds, host.UUID, expectedProf.ProfileUUID, expanded, params)
+		processedContent := PreprocessWindowsProfileContentsForVerification(ctx, logger, ds, host.UUID, expectedProf.ProfileUUID, expanded, hostIDForUUIDCache)
 		expectedProf.RawProfile = []byte(processedContent)
 
 		var prof fleet.SyncMLCmd
@@ -292,20 +290,27 @@ func IsWin32OrDesktopBridgeADMXCSP(locURI string) bool {
 	return false
 }
 
-// PreprocessingParameters holds parameters needed for preprocessing Windows profiles, for both verification and deployment only.
-// It should only contain helper stuff, and not core values such as hostUUID, profileUUID, etc.
-type PreprocessingParameters struct {
-	// a lookup map to avoid repeated datastore calls for hostID from hostUUID
-	HostIDForUUIDCache map[string]uint
-}
-
 // PreprocessWindowsProfileContentsForVerification processes Windows configuration profiles to replace Fleet variables
 // with the given host UUID for verification purposes.
 //
 // This function is similar to PreprocessWindowsProfileContentsForDeployment, but it does not require
 // a datastore or logger since it only replaces certain fleet variables to avoid datastore unnecessary work.
-func PreprocessWindowsProfileContentsForVerification(ctx context.Context, logger kitlog.Logger, ds fleet.Datastore, hostUUID string, profileUUID string, profileContents string, params PreprocessingParameters) string {
-	replacedContents, _ := preprocessWindowsProfileContents(ctx, logger, ds, nil, true, hostUUID, profileUUID, nil, profileContents, nil, params)
+func PreprocessWindowsProfileContentsForVerification(ctx context.Context, logger kitlog.Logger, ds fleet.Datastore, hostUUID string, profileUUID string, profileContents string, hostIDForUUIDCache map[string]uint) string {
+	deps := preprocessDependencies{
+		ctx:                ctx,
+		logger:             logger,
+		ds:                 ds,
+		appConfig:          nil,
+		HostIDForUUIDCache: hostIDForUUIDCache,
+		customSCEPCAs:      nil,
+	}
+	preprocessParams := preprocessParams{
+		isVerifying:                true,
+		hostUUID:                   hostUUID,
+		profileUUID:                profileUUID,
+		managedCertificatePayloads: nil,
+	}
+	replacedContents, _ := preprocessWindowsProfileContents(deps, preprocessParams, profileContents)
 	// ^ We ignore the error here, and rely on the fact that the function will return the original contents if no replacements were made.
 	// So verification fails on individual profile level, instead of entire verification failing.
 	return replacedContents
@@ -314,10 +319,10 @@ func PreprocessWindowsProfileContentsForVerification(ctx context.Context, logger
 // PreprocessWindowsProfileContentsForDeployment processes Windows configuration profiles to replace Fleet variables
 // with their actual values for each host during profile deployment.
 func PreprocessWindowsProfileContentsForDeployment(ctx context.Context, logger kitlog.Logger, ds fleet.Datastore,
-	appConfig *fleet.AppConfig, hostCmdUUID string, profileUUID string,
+	appConfig *fleet.AppConfig, hostUUID string, profileUUID string,
 	groupedCAs *fleet.GroupedCertificateAuthorities, profileContents string,
 	managedCertificatePayloads *[]*fleet.MDMManagedCertificate,
-	params PreprocessingParameters,
+	hostIDForUUIDCache map[string]uint,
 ) (string, error) {
 	// TODO: Should we avoid iterating this list for every profile?
 	customSCEPCAs := make(map[string]*fleet.CustomSCEPProxyCA, len(groupedCAs.CustomScepProxy))
@@ -325,7 +330,21 @@ func PreprocessWindowsProfileContentsForDeployment(ctx context.Context, logger k
 		customSCEPCAs[ca.Name] = &ca
 	}
 
-	return preprocessWindowsProfileContents(ctx, logger, ds, appConfig, false, hostCmdUUID, profileUUID, customSCEPCAs, profileContents, managedCertificatePayloads, params)
+	deps := preprocessDependencies{
+		ctx:                ctx,
+		logger:             logger,
+		ds:                 ds,
+		appConfig:          appConfig,
+		HostIDForUUIDCache: hostIDForUUIDCache,
+		customSCEPCAs:      customSCEPCAs,
+	}
+	preprocessParams := preprocessParams{
+		isVerifying:                false,
+		hostUUID:                   hostUUID,
+		profileUUID:                profileUUID,
+		managedCertificatePayloads: managedCertificatePayloads,
+	}
+	return preprocessWindowsProfileContents(deps, preprocessParams, profileContents)
 }
 
 // This error type is used to indicate errors during Microsoft profile processing, such as variable replacement failures.
@@ -336,6 +355,22 @@ type MicrosoftProfileProcessingError struct {
 
 func (e *MicrosoftProfileProcessingError) Error() string {
 	return e.message
+}
+
+type preprocessDependencies struct {
+	ctx                context.Context
+	logger             kitlog.Logger
+	ds                 fleet.Datastore
+	appConfig          *fleet.AppConfig
+	HostIDForUUIDCache map[string]uint
+	customSCEPCAs      map[string]*fleet.CustomSCEPProxyCA
+}
+
+type preprocessParams struct {
+	isVerifying                bool
+	hostUUID                   string
+	profileUUID                string
+	managedCertificatePayloads *[]*fleet.MDMManagedCertificate
 }
 
 // preprocessWindowsProfileContents processes Windows configuration profiles to replace Fleet variables
@@ -360,12 +395,7 @@ func (e *MicrosoftProfileProcessingError) Error() string {
 //     thousands of host profiles. Direct string replacement is more efficient for our use case.
 //  4. XML escaping: We need XML-specific escaping for values, which is simpler to control with direct
 //     string replacement rather than template functions.
-func preprocessWindowsProfileContents(ctx context.Context, logger kitlog.Logger, ds fleet.Datastore, appConfig *fleet.AppConfig,
-	isVerifying bool, hostUUID string, profileUUID string,
-	customSCEPCAs map[string]*fleet.CustomSCEPProxyCA, profileContents string,
-	managedCertificatePayloads *[]*fleet.MDMManagedCertificate,
-	params PreprocessingParameters,
-) (string, error) {
+func preprocessWindowsProfileContents(deps preprocessDependencies, params preprocessParams, profileContents string) (string, error) {
 	// Check if Fleet variables are present
 	fleetVars := variables.Find(profileContents)
 	if len(fleetVars) == 0 {
@@ -377,40 +407,40 @@ func preprocessWindowsProfileContents(ctx context.Context, logger kitlog.Logger,
 	result := profileContents
 	for _, fleetVar := range fleetVars {
 		if fleetVar == string(fleet.FleetVarHostUUID) {
-			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostUUIDRegexp, result, hostUUID)
+			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarHostUUIDRegexp, result, params.hostUUID)
 		} else if slices.Contains(fleet.IDPFleetVariables, fleet.FleetVarName(fleetVar)) {
-			replacedContents, replacedVariable, err := profiles.ReplaceHostEndUserIDPVariables(ctx, ds, fleetVar, result, hostUUID, params.HostIDForUUIDCache, func(errMsg string) error {
+			replacedContents, replacedVariable, err := profiles.ReplaceHostEndUserIDPVariables(deps.ctx, deps.ds, fleetVar, result, params.hostUUID, deps.HostIDForUUIDCache, func(errMsg string) error {
 				return &MicrosoftProfileProcessingError{message: errMsg}
 			})
 			if err != nil {
 				return profileContents, err
 			}
 			if !replacedVariable {
-				return profileContents, ctxerr.Wrap(ctx, err, "host end user IDP variable replacement failed for variable")
+				return profileContents, ctxerr.Wrap(deps.ctx, err, "host end user IDP variable replacement failed for variable")
 			}
 			result = replacedContents
 		}
 
 		// We skip some variables during verification, to avoid unnecessary datastore calls
 		// or processing that is not needed for verification.
-		if isVerifying {
+		if params.isVerifying {
 			continue
 		}
 
 		switch {
 		case fleetVar == string(fleet.FleetVarSCEPWindowsCertificateID):
-			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarSCEPWindowsCertificateIDRegexp, result, profileUUID)
+			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarSCEPWindowsCertificateIDRegexp, result, params.profileUUID)
 		case strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPChallengePrefix)):
 			caName := strings.TrimPrefix(fleetVar, string(fleet.FleetVarCustomSCEPChallengePrefix))
-			err := profiles.IsCustomSCEPConfigured(ctx, customSCEPCAs, caName, fleetVar, func(errMsg string) error {
+			err := profiles.IsCustomSCEPConfigured(deps.ctx, deps.customSCEPCAs, caName, fleetVar, func(errMsg string) error {
 				return &MicrosoftProfileProcessingError{message: errMsg}
 			})
 			if err != nil {
 				return profileContents, err
 			}
-			replacedContents, replacedVariable, err := profiles.ReplaceCustomSCEPChallengeVariable(ctx, logger, fleetVar, customSCEPCAs, result)
+			replacedContents, replacedVariable, err := profiles.ReplaceCustomSCEPChallengeVariable(deps.ctx, deps.logger, fleetVar, deps.customSCEPCAs, result)
 			if err != nil {
-				return profileContents, ctxerr.Wrap(ctx, err, "replacing custom SCEP challenge variable")
+				return profileContents, ctxerr.Wrap(deps.ctx, err, "replacing custom SCEP challenge variable")
 			}
 			if !replacedVariable {
 				return profileContents, &MicrosoftProfileProcessingError{message: fmt.Sprintf("Custom SCEP challenge variable replacement failed for variable %s", fleetVar)}
@@ -418,22 +448,22 @@ func preprocessWindowsProfileContents(ctx context.Context, logger kitlog.Logger,
 			result = replacedContents
 		case strings.HasPrefix(fleetVar, string(fleet.FleetVarCustomSCEPProxyURLPrefix)):
 			caName := strings.TrimPrefix(fleetVar, string(fleet.FleetVarCustomSCEPProxyURLPrefix))
-			err := profiles.IsCustomSCEPConfigured(ctx, customSCEPCAs, caName, fleetVar, func(errMsg string) error {
+			err := profiles.IsCustomSCEPConfigured(deps.ctx, deps.customSCEPCAs, caName, fleetVar, func(errMsg string) error {
 				return &MicrosoftProfileProcessingError{message: errMsg}
 			})
 			if err != nil {
 				return profileContents, err
 			}
-			replacedContents, managedCertificate, replacedVariable, err := profiles.ReplaceCustomSCEPProxyURLVariable(ctx, logger, ds, appConfig, fleetVar, customSCEPCAs, result, hostUUID, profileUUID)
+			replacedContents, managedCertificate, replacedVariable, err := profiles.ReplaceCustomSCEPProxyURLVariable(deps.ctx, deps.logger, deps.ds, deps.appConfig, fleetVar, deps.customSCEPCAs, result, params.hostUUID, params.profileUUID)
 			if err != nil {
-				return profileContents, ctxerr.Wrap(ctx, err, "replacing custom SCEP challenge variable")
+				return profileContents, ctxerr.Wrap(deps.ctx, err, "replacing custom SCEP challenge variable")
 			}
 			if !replacedVariable {
 				return profileContents, &MicrosoftProfileProcessingError{message: fmt.Sprintf("Custom SCEP challenge variable replacement failed for variable %s", fleetVar)}
 			}
 			result = replacedContents
 
-			*managedCertificatePayloads = append(*managedCertificatePayloads, managedCertificate)
+			*params.managedCertificatePayloads = append(*params.managedCertificatePayloads, managedCertificate)
 		}
 
 		// Add other Fleet variables here as they are implemented, identify if it can be skipped for verification.

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -928,13 +928,11 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 		},
 	}
 
-	params := PreprocessingParameters{
-		HostIDForUUIDCache: make(map[string]uint),
-	}
+	hostIDForUUIDCache := make(map[string]uint)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := PreprocessWindowsProfileContentsForVerification(t.Context(), log.NewNopLogger(), ds, tt.hostUUID, uuid.NewString(), tt.profileContents, params)
+			result := PreprocessWindowsProfileContentsForVerification(t.Context(), log.NewNopLogger(), ds, tt.hostUUID, uuid.NewString(), tt.profileContents, hostIDForUUIDCache)
 			require.Equal(t, tt.expectedContents, result)
 		})
 	}
@@ -1143,9 +1141,7 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 		},
 	}
 
-	params := PreprocessingParameters{
-		HostIDForUUIDCache: make(map[string]uint),
-	}
+	hostIDForUUIDCache := make(map[string]uint)
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1174,7 +1170,7 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 
 			managedCertificates := &[]*fleet.MDMManagedCertificate{}
 
-			result, err := PreprocessWindowsProfileContentsForDeployment(ctx, log.NewNopLogger(), ds, appConfig, tt.hostUUID, profileUUID, groupedCAs, tt.profileContents, managedCertificates, params)
+			result, err := PreprocessWindowsProfileContentsForDeployment(ctx, log.NewNopLogger(), ds, appConfig, tt.hostUUID, profileUUID, groupedCAs, tt.profileContents, managedCertificates, hostIDForUUIDCache)
 			if tt.expectError {
 				require.Error(t, err)
 				if tt.processingError != "" {

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -932,13 +932,11 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deps := ProfilePreprocessDependencies{
+			deps := ProfilePreprocessDependenciesForVerify{
 				Context:            t.Context(),
 				Logger:             log.NewNopLogger(),
 				DataStore:          ds,
-				AppConfig:          nil,
 				HostIDForUUIDCache: hostIDForUUIDCache,
-				CustomSCEPCAs:      nil,
 			}
 			result := PreprocessWindowsProfileContentsForVerification(deps, ProfilePreprocessParamsForVerify{
 				HostUUID:    tt.hostUUID,
@@ -1183,13 +1181,15 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 
 			managedCertificates := &[]*fleet.MDMManagedCertificate{}
 
-			deps := ProfilePreprocessDependencies{
-				Context:            ctx,
-				Logger:             log.NewNopLogger(),
-				DataStore:          ds,
-				AppConfig:          appConfig,
-				HostIDForUUIDCache: hostIDForUUIDCache,
-				CustomSCEPCAs:      customSCEPCAs,
+			deps := ProfilePreprocessDependenciesForDeploy{
+				ProfilePreprocessDependenciesForVerify: ProfilePreprocessDependenciesForVerify{
+					Context:            ctx,
+					Logger:             log.NewNopLogger(),
+					DataStore:          ds,
+					HostIDForUUIDCache: hostIDForUUIDCache,
+				},
+				AppConfig:     appConfig,
+				CustomSCEPCAs: customSCEPCAs,
 			}
 
 			result, err := PreprocessWindowsProfileContentsForDeployment(deps, ProfilePreprocessParamsForDeploy{

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -940,11 +940,10 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      nil,
 			}
-			params := ProfilePreprocessParamsForVerify{
+			result := PreprocessWindowsProfileContentsForVerification(deps, ProfilePreprocessParamsForVerify{
 				HostUUID:    tt.hostUUID,
 				ProfileUUID: uuid.NewString(),
-			}
-			result := PreprocessWindowsProfileContentsForVerification(deps, params, tt.profileContents)
+			}, tt.profileContents)
 			require.Equal(t, tt.expectedContents, result)
 		})
 	}
@@ -1192,15 +1191,14 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      customSCEPCAs,
 			}
-			params := ProfilePreprocessParamsForDeploy{
+
+			result, err := PreprocessWindowsProfileContentsForDeployment(deps, ProfilePreprocessParamsForDeploy{
 				ProfilePreprocessParamsForVerify: ProfilePreprocessParamsForVerify{
 					HostUUID:    tt.hostUUID,
 					ProfileUUID: profileUUID,
 				},
 				ManagedCertificatePayloads: managedCertificates,
-			}
-
-			result, err := PreprocessWindowsProfileContentsForDeployment(deps, params, tt.profileContents)
+			}, tt.profileContents)
 			if tt.expectError {
 				require.Error(t, err)
 				if tt.processingError != "" {

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -1216,4 +1216,6 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 			}
 		})
 	}
+
+	require.Len(t, hostIDForUUIDCache, 3) // make sure cache is populated by IdP var host UUID lookups
 }

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -928,16 +928,15 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 		},
 	}
 
-	hostIDForUUIDCache := make(map[string]uint)
+	deps := ProfilePreprocessDependenciesForVerify{
+		Context:            t.Context(),
+		Logger:             log.NewNopLogger(),
+		DataStore:          ds,
+		HostIDForUUIDCache: make(map[string]uint),
+	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deps := ProfilePreprocessDependenciesForVerify{
-				Context:            t.Context(),
-				Logger:             log.NewNopLogger(),
-				DataStore:          ds,
-				HostIDForUUIDCache: hostIDForUUIDCache,
-			}
 			result := PreprocessWindowsProfileContentsForVerification(deps, ProfilePreprocessParamsForVerify{
 				HostUUID:    tt.hostUUID,
 				ProfileUUID: uuid.NewString(),

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -940,11 +940,9 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      nil,
 			}
-			params := ProfilePreprocessParams{
-				IsVerifying:                true,
-				HostUUID:                   tt.hostUUID,
-				ProfileUUID:                uuid.NewString(),
-				ManagedCertificatePayloads: nil,
+			params := ProfilePreprocessParamsForVerify{
+				HostUUID:    tt.hostUUID,
+				ProfileUUID: uuid.NewString(),
 			}
 			result := PreprocessWindowsProfileContentsForVerification(deps, params, tt.profileContents)
 			require.Equal(t, tt.expectedContents, result)
@@ -1194,10 +1192,11 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      customSCEPCAs,
 			}
-			params := ProfilePreprocessParams{
-				IsVerifying:                false,
-				HostUUID:                   tt.hostUUID,
-				ProfileUUID:                profileUUID,
+			params := ProfilePreprocessParamsForDeploy{
+				ProfilePreprocessParamsForVerify: ProfilePreprocessParamsForVerify{
+					HostUUID:    tt.hostUUID,
+					ProfileUUID: profileUUID,
+				},
 				ManagedCertificatePayloads: managedCertificates,
 			}
 

--- a/server/mdm/microsoft/profile_verifier_test.go
+++ b/server/mdm/microsoft/profile_verifier_test.go
@@ -932,15 +932,15 @@ func TestPreprocessWindowsProfileContentsForVerification(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			deps := PreprocessDependencies{
-				Ctx:                t.Context(),
+			deps := ProfilePreprocessDependencies{
+				Context:            t.Context(),
 				Logger:             log.NewNopLogger(),
-				Ds:                 ds,
+				DataStore:          ds,
 				AppConfig:          nil,
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      nil,
 			}
-			params := PreprocessParams{
+			params := ProfilePreprocessParams{
 				IsVerifying:                true,
 				HostUUID:                   tt.hostUUID,
 				ProfileUUID:                uuid.NewString(),
@@ -1186,15 +1186,15 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 
 			managedCertificates := &[]*fleet.MDMManagedCertificate{}
 
-			deps := PreprocessDependencies{
-				Ctx:                ctx,
+			deps := ProfilePreprocessDependencies{
+				Context:            ctx,
 				Logger:             log.NewNopLogger(),
-				Ds:                 ds,
+				DataStore:          ds,
 				AppConfig:          appConfig,
 				HostIDForUUIDCache: hostIDForUUIDCache,
 				CustomSCEPCAs:      customSCEPCAs,
 			}
-			params := PreprocessParams{
+			params := ProfilePreprocessParams{
 				IsVerifying:                false,
 				HostUUID:                   tt.hostUUID,
 				ProfileUUID:                profileUUID,

--- a/server/mdm/profiles/profile_variables.go
+++ b/server/mdm/profiles/profile_variables.go
@@ -135,7 +135,6 @@ func getHostEndUserIDPUser(ctx context.Context, ds fleet.Datastore,
 			return nil, false, onError(fmt.Sprintf("Unexpected number of hosts (%d) for UUID %s. ", len(ids), hostUUID))
 		}
 		hostID = ids[0]
-		// TODO figure out whether we should be passing a ref around here, as this looks like the cache doesn't persist
 		hostIDForUUIDCache[hostUUID] = hostID
 	}
 

--- a/server/mdm/profiles/profile_variables.go
+++ b/server/mdm/profiles/profile_variables.go
@@ -135,6 +135,7 @@ func getHostEndUserIDPUser(ctx context.Context, ds fleet.Datastore,
 			return nil, false, onError(fmt.Sprintf("Unexpected number of hosts (%d) for UUID %s. ", len(ids), hostUUID))
 		}
 		hostID = ids[0]
+		// TODO figure out whether we should be passing a ref around here, as this looks like the cache doesn't persist
 		hostIDForUUIDCache[hostUUID] = hostID
 	}
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2350,15 +2350,15 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 				}
 
 				// Preprocess the profile content for this specific host
-				deps := microsoft_mdm.PreprocessDependencies{
-					Ctx:                ctx,
+				deps := microsoft_mdm.ProfilePreprocessDependencies{
+					Context:            ctx,
 					Logger:             logger,
-					Ds:                 ds,
+					DataStore:          ds,
 					AppConfig:          appConfig,
 					HostIDForUUIDCache: hostIDForUUIDCache,
 					CustomSCEPCAs:      customSCEPCAs,
 				}
-				params := microsoft_mdm.PreprocessParams{
+				params := microsoft_mdm.ProfilePreprocessParams{
 					IsVerifying:                false,
 					HostUUID:                   hostUUID,
 					ProfileUUID:                profUUID,

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2358,10 +2358,11 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 					HostIDForUUIDCache: hostIDForUUIDCache,
 					CustomSCEPCAs:      customSCEPCAs,
 				}
-				params := microsoft_mdm.ProfilePreprocessParams{
-					IsVerifying:                false,
-					HostUUID:                   hostUUID,
-					ProfileUUID:                profUUID,
+				params := microsoft_mdm.ProfilePreprocessParamsForDeploy{
+					ProfilePreprocessParamsForVerify: microsoft_mdm.ProfilePreprocessParamsForVerify{
+						HostUUID:    hostUUID,
+						ProfileUUID: profUUID,
+					},
 					ManagedCertificatePayloads: managedCertificatePayloads,
 				}
 				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(deps, params, string(p.SyncML))

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2358,14 +2358,17 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 					HostIDForUUIDCache: hostIDForUUIDCache,
 					CustomSCEPCAs:      customSCEPCAs,
 				}
-				params := microsoft_mdm.ProfilePreprocessParamsForDeploy{
-					ProfilePreprocessParamsForVerify: microsoft_mdm.ProfilePreprocessParamsForVerify{
-						HostUUID:    hostUUID,
-						ProfileUUID: profUUID,
+				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(
+					deps,
+					microsoft_mdm.ProfilePreprocessParamsForDeploy{
+						ProfilePreprocessParamsForVerify: microsoft_mdm.ProfilePreprocessParamsForVerify{
+							HostUUID:    hostUUID,
+							ProfileUUID: profUUID,
+						},
+						ManagedCertificatePayloads: managedCertificatePayloads,
 					},
-					ManagedCertificatePayloads: managedCertificatePayloads,
-				}
-				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(deps, params, string(p.SyncML))
+					string(p.SyncML),
+				)
 				var profileProcessingError *microsoft_mdm.MicrosoftProfileProcessingError
 				if err != nil && !errors.As(err, &profileProcessingError) {
 					return ctxerr.Wrapf(ctx, err, "preprocessing profile contents for host %s and profile %s", hostUUID, profUUID)

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2350,13 +2350,15 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 				}
 
 				// Preprocess the profile content for this specific host
-				deps := microsoft_mdm.ProfilePreprocessDependencies{
-					Context:            ctx,
-					Logger:             logger,
-					DataStore:          ds,
-					AppConfig:          appConfig,
-					HostIDForUUIDCache: hostIDForUUIDCache,
-					CustomSCEPCAs:      customSCEPCAs,
+				deps := microsoft_mdm.ProfilePreprocessDependenciesForDeploy{
+					ProfilePreprocessDependenciesForVerify: microsoft_mdm.ProfilePreprocessDependenciesForVerify{
+						Context:            ctx,
+						Logger:             logger,
+						DataStore:          ds,
+						HostIDForUUIDCache: hostIDForUUIDCache,
+					},
+					AppConfig:     appConfig,
+					CustomSCEPCAs: customSCEPCAs,
 				}
 				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(
 					deps,

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2315,9 +2315,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
-	params := microsoft_mdm.PreprocessingParameters{
-		HostIDForUUIDCache: make(map[string]uint),
-	}
+	hostIDForUUIDCache := make(map[string]uint)
 
 	managedCertificatePayloads := &[]*fleet.MDMManagedCertificate{}
 
@@ -2350,7 +2348,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger ki
 				}
 
 				// Preprocess the profile content for this specific host
-				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(ctx, logger, ds, appConfig, hostUUID, profUUID, groupedCAs, string(p.SyncML), managedCertificatePayloads, params)
+				processedContent, err := microsoft_mdm.PreprocessWindowsProfileContentsForDeployment(ctx, logger, ds, appConfig, hostUUID, profUUID, groupedCAs, string(p.SyncML), managedCertificatePayloads, hostIDForUUIDCache)
 				var profileProcessingError *microsoft_mdm.MicrosoftProfileProcessingError
 				if err != nil && !errors.As(err, &profileProcessingError) {
 					return ctxerr.Wrapf(ctx, err, "preprocessing profile contents for host %s and profile %s", hostUUID, profUUID)


### PR DESCRIPTION
Should be no functional changes, though in a few cases I was able to pull some dep declarations outside of loops. Setting this as a separate PR so refactors can be evaluated without worrying about functional changes, and vice versa. Functional changes on #34364 will be stacked on top of this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced Windows profile preprocessing logic and certificate authority handling through improved dependency management for better code maintainability and testability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->