### PR TITLE
Fleet UI: Add Android setup experience

### DIFF
--- a/frontend/components/MDM/AndroidLatestVersionWithTooltip/AndroidLatestVersionWithTooltip.tests.tsx
+++ b/frontend/components/MDM/AndroidLatestVersionWithTooltip/AndroidLatestVersionWithTooltip.tests.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { screen, waitFor } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
+import { ANDROID_PLAY_STORE_URL } from "utilities/constants";
+
+import AndroidLatestVersionWithTooltip from "./AndroidLatestVersionWithTooltip";
+
+describe("AndroidLatestVersionWithTooltip", () => {
+  const playStoreAppId = "com.example.app";
+  const playStoreUrl = `${ANDROID_PLAY_STORE_URL}?id=${playStoreAppId}`;
+
+  it('renders "Latest" text with tooltip with Play Store link', async () => {
+    const { user } = renderWithSetup(
+      <AndroidLatestVersionWithTooltip androidPlayStoreId={playStoreAppId} />
+    );
+    user.hover(screen.getByText("Latest"));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/See latest version on the/i)
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Play Store/i)).toBeInTheDocument();
+    });
+    // Looks for <a> with correct href and text
+    const playStoreLink = screen.getByRole("link", { name: /Play Store/i });
+    expect(playStoreLink).toHaveAttribute("href", playStoreUrl);
+    expect(playStoreLink).toHaveAttribute("target", "_blank");
+    expect(playStoreLink).toHaveTextContent("Play Store");
+  });
+});

--- a/frontend/components/MDM/AndroidLatestVersionWithTooltip/AndroidLatestVersionWithTooltip.tsx
+++ b/frontend/components/MDM/AndroidLatestVersionWithTooltip/AndroidLatestVersionWithTooltip.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+import CustomLink from "components/CustomLink";
+import TooltipWrapper from "components/TooltipWrapper";
+import { getPathWithQueryParams } from "utilities/url";
+import { ANDROID_PLAY_STORE_URL } from "utilities/constants";
+
+interface IAndroidLatestVersionWithTooltipProps {
+  androidPlayStoreId: string;
+}
+
+/**  For Android Play Store apps version UI, we show "Latest" with tooltip
+ * which links to the apps' play store */
+const AndroidLatestVersionWithTooltip = ({
+  androidPlayStoreId,
+}: IAndroidLatestVersionWithTooltipProps) => {
+  return (
+    <TooltipWrapper
+      tipContent={
+        <span>
+          See latest version on the{" "}
+          <CustomLink
+            text="Play Store"
+            url={getPathWithQueryParams(ANDROID_PLAY_STORE_URL, {
+              id: androidPlayStoreId,
+            })}
+            newTab
+          />
+        </span>
+      }
+    >
+      <span>Latest</span>
+    </TooltipWrapper>
+  );
+};
+
+export default AndroidLatestVersionWithTooltip;

--- a/frontend/components/MDM/AndroidLatestVersionWithTooltip/index.ts
+++ b/frontend/components/MDM/AndroidLatestVersionWithTooltip/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./AndroidLatestVersionWithTooltip";

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -233,6 +233,7 @@ export const SETUP_EXPERIENCE_PLATFORMS = [
   "linux",
   "ios",
   "ipados",
+  "android",
 ] as const;
 
 export type SetupExperiencePlatform = typeof SETUP_EXPERIENCE_PLATFORMS[number];

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1716,4 +1716,22 @@ describe("Activity Feed", () => {
     expect(screen.getByText(/Test Host/)).toBeInTheDocument();
     expect(screen.getByText(/is unenrolled from Fleet/)).toBeInTheDocument();
   });
+  it("renders an editedSetupExperienceSoftware type activity for a team", () => {
+    const activity = createMockActivity({
+      type: ActivityType.EditedSetupExperienceSoftware,
+      details: {
+        platform: "darwin", // macOS
+        team_name: "Bears",
+        team_id: 1,
+      },
+    });
+    render(<GlobalActivityItem activity={activity} isPremiumTier />);
+    expect(
+      screen.getByText(
+        /edited setup experience software for macOS hosts that enroll to the/i
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Bears/i)).toBeInTheDocument();
+    expect(screen.getByText(/team/i)).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1589,7 +1589,7 @@ const TAGGED_TEMPLATES = {
         platformText = "iPadOS";
         break;
       default:
-        platformText = capitalize(platform);
+        platformText = capitalize(platform); // e.g. Windows, Android
     }
 
     return (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -48,7 +48,7 @@ export const PLATFORM_BY_INDEX: SetupExperiencePlatform[] = [
   "linux",
   "ios",
   "ipados",
-  "macos", // Change to android
+  "android",
 ];
 export interface InstallSoftwareLocation {
   search: string;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -48,6 +48,7 @@ export const PLATFORM_BY_INDEX: SetupExperiencePlatform[] = [
   "linux",
   "ios",
   "ipados",
+  "macos", // Change to android
 ];
 export interface InstallSoftwareLocation {
   search: string;
@@ -140,6 +141,8 @@ const InstallSoftware = ({
     teamConfig
   );
 
+  const isAndroidMdmEnabled = !globalConfig?.mdm.android_enabled_and_configured;
+
   const renderTabContent = (platform: SetupExperiencePlatform) => {
     if (
       isLoadingSoftwareTitles ||
@@ -231,6 +234,11 @@ const InstallSoftware = ({
             <Tab>
               <TabText>iPadOS</TabText>
             </Tab>
+            {isAndroidMdmEnabled && (
+              <Tab>
+                <TabText>Android</TabText>
+              </Tab>
+            )}
           </TabList>
           {PLATFORM_BY_INDEX.map((platform) => {
             return (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -8,6 +8,7 @@ import {
 } from "__mocks__/softwareMock";
 
 import AddInstallSoftware from "./AddInstallSoftware";
+import { renderWithSetup } from "test/test-utils";
 
 describe("AddInstallSoftware", () => {
   it("should render the expected message if there are no software titles to select from", () => {
@@ -41,8 +42,8 @@ describe("AddInstallSoftware", () => {
     expect(screen.queryByRole("button", { name: "Add software" })).toBeNull();
   });
 
-  it("should render the correct messaging when there are software titles that have been selected to install at setup", () => {
-    render(
+  it("should render the correct messaging when there are software titles that have been selected to install at setup", async () => {
+    const { user } = renderWithSetup(
       <AddInstallSoftware
         savedRequireAllSoftwareMacOS={false}
         currentTeamId={1}
@@ -77,6 +78,60 @@ describe("AddInstallSoftware", () => {
     expect(
       screen.getByRole("button", { name: "Select software" })
     ).toBeVisible();
+
+    await user.hover(screen.getByText("installed during setup"));
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(
+        /Installation order will depend on software name, starting with 0-9 then A-Z./i
+      );
+      expect(tooltip).toBeInTheDocument();
+    });
+  });
+
+  it("should render the correct messaging for Android when there are software titles that have been selected to install at setup", async () => {
+    const { user } = renderWithSetup(
+      <AddInstallSoftware
+        savedRequireAllSoftwareMacOS={false}
+        currentTeamId={1}
+        softwareTitles={[
+          createMockSoftwareTitle({
+            software_package: createMockSoftwarePackage({
+              install_during_setup: true,
+            }),
+          }),
+          createMockSoftwareTitle(
+            createMockSoftwareTitle({
+              software_package: createMockSoftwarePackage({
+                install_during_setup: true,
+              }),
+            })
+          ),
+          createMockSoftwareTitle(),
+        ]}
+        onAddSoftware={noop}
+        hasManualAgentInstall={false}
+        platform="android"
+      />
+    );
+
+    expect(
+      screen.getByText(
+        (_, element) =>
+          element?.textContent ===
+          "2 software items will be installed during setup."
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByRole("button", { name: "Select software" })
+    ).toBeVisible();
+
+    await user.hover(screen.getByText("installed during setup"));
+
+    await waitFor(() => {
+      const tooltip = screen.getByText(/Software order will vary/i);
+      expect(tooltip).toBeInTheDocument();
+    });
   });
 
   it('should render the "Cancel setup if software install fails" form for macos platform', async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
 import { noop } from "lodash";
 
 import {
@@ -8,7 +9,6 @@ import {
 } from "__mocks__/softwareMock";
 
 import AddInstallSoftware from "./AddInstallSoftware";
-import { renderWithSetup } from "test/test-utils";
 
 describe("AddInstallSoftware", () => {
   it("should render the expected message if there are no software titles to select from", () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -81,11 +81,8 @@ const AddInstallSoftware = ({
       case "ipados":
         platformText = "iPadOS";
         break;
-      case "android":
-        platformText = "Android";
-        break;
       default:
-        platformText = capitalize(platform);
+        platformText = capitalize(platform); // e.g. Windows, Android
     }
 
     if (noSoftwareUploaded) {
@@ -104,15 +101,21 @@ const AddInstallSoftware = ({
       );
     }
 
+    const orderTooltip =
+      platform === "android"
+        ? "Software order will vary"
+        : "Installation order will depend on software name, starting with 0-9 then A-Z.";
+
     return installSoftwareDuringSetupCount === 0 ? (
       "No software selected."
     ) : (
       <>
         {installSoftwareDuringSetupCount} software item
         {installSoftwareDuringSetupCount > 1 && "s"} will be{" "}
-        <TooltipWrapper tipContent="Installation order will depend on software name, starting with 0-9 then A-Z.">
-          installed during setup.
+        <TooltipWrapper tipContent={orderTooltip}>
+          installed during setup
         </TooltipWrapper>
+        .
       </>
     );
   };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -81,6 +81,9 @@ const AddInstallSoftware = ({
       case "ipados":
         platformText = "iPadOS";
         break;
+      case "android":
+        platformText = "Android";
+        break;
       default:
         platformText = capitalize(platform);
     }

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -103,7 +103,7 @@ const AddInstallSoftware = ({
 
     const orderTooltip =
       platform === "android"
-        ? "Software order will vary"
+        ? "Software order will vary."
         : "Installation order will depend on software name, starting with 0-9 then A-Z.";
 
     return installSoftwareDuringSetupCount === 0 ? (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -3,14 +3,17 @@ import { CellProps, Column } from "react-table";
 
 import { IStringCellProps } from "interfaces/datatable_config";
 import { ISoftwareTitle, SoftwareSource } from "interfaces/software";
+import { getPathWithQueryParams } from "utilities/url";
+import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import { ANDROID_PLAY_STORE_URL } from "pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget";
 
+import CustomLink from "components/CustomLink";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 import Checkbox from "components/forms/fields/Checkbox";
+import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import { SetupExperiencePlatform } from "interfaces/platform";
-
-import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
 
 type ISelectSoftwareTableConfig = Column<ISoftwareTitle>;
 type ITableStringCellProps = IStringCellProps<ISoftwareTitle>;
@@ -80,6 +83,35 @@ const generateTableConfig = (
       Header: "Version",
       disableSortBy: true,
       Cell: (cellProps: ITableStringCellProps) => {
+        if (platform === "android") {
+          const androidPlayStoreId =
+            cellProps.row.original.app_store_app?.app_store_id;
+
+          return (
+            <TextCell
+              value={
+                // 2 usages here and softwaredetailswidget, consider making component if more common
+                <TooltipWrapper
+                  tipContent={
+                    <span>
+                      See latest version on the{" "}
+                      <CustomLink
+                        text="Play Store"
+                        url={getPathWithQueryParams(ANDROID_PLAY_STORE_URL, {
+                          id: androidPlayStoreId,
+                        })}
+                        newTab
+                      />
+                    </span>
+                  }
+                >
+                  <span>Latest</span>
+                </TooltipWrapper>
+              }
+            />
+          );
+        }
+
         const title = cellProps.row.original;
         let versionFoRender = title.software_package?.version;
         if (platform === "linux") {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -3,17 +3,14 @@ import { CellProps, Column } from "react-table";
 
 import { IStringCellProps } from "interfaces/datatable_config";
 import { ISoftwareTitle, SoftwareSource } from "interfaces/software";
-import { getPathWithQueryParams } from "utilities/url";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
-import { ANDROID_PLAY_STORE_URL } from "pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget";
 
-import CustomLink from "components/CustomLink";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
 import Checkbox from "components/forms/fields/Checkbox";
-import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import { SetupExperiencePlatform } from "interfaces/platform";
+import AndroidLatestVersionWithTooltip from "components/MDM/AndroidLatestVersionWithTooltip";
 
 type ISelectSoftwareTableConfig = Column<ISoftwareTitle>;
 type ITableStringCellProps = IStringCellProps<ISoftwareTitle>;
@@ -90,23 +87,9 @@ const generateTableConfig = (
           return (
             <TextCell
               value={
-                // 2 usages here and softwaredetailswidget, consider making component if more common
-                <TooltipWrapper
-                  tipContent={
-                    <span>
-                      See latest version on the{" "}
-                      <CustomLink
-                        text="Play Store"
-                        url={getPathWithQueryParams(ANDROID_PLAY_STORE_URL, {
-                          id: androidPlayStoreId,
-                        })}
-                        newTab
-                      />
-                    </span>
-                  }
-                >
-                  <span>Latest</span>
-                </TooltipWrapper>
+                <AndroidLatestVersionWithTooltip
+                  androidPlayStoreId={androidPlayStoreId || ""}
+                />
               }
             />
           );

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tests.tsx
@@ -105,7 +105,7 @@ describe("InstallerDetailsWidget", () => {
     expect(screen.getByText(/App Store \(VPP\)/i)).toBeInTheDocument();
   });
 
-  it("renders Google Play Store label", () => {
+  it("renders Google Play Store label and 'latest' for version", () => {
     render(
       <InstallerDetailsWidget
         {...defaultProps}
@@ -115,6 +115,7 @@ describe("InstallerDetailsWidget", () => {
     );
 
     expect(screen.getByText(/Google Play Store/i)).toBeInTheDocument();
+    expect(screen.getByText(/latest/i)).toBeInTheDocument();
   });
 
   it("InstallerName disables tooltip if not truncated", () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -20,7 +20,8 @@ import CustomLink from "components/CustomLink";
 
 const baseClass = "installer-details-widget";
 
-const ANDROID_PLAY_STORE_URL = "https://play.google.com/store/apps/details";
+export const ANDROID_PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details";
 
 interface IInstallerNameProps {
   name: string;
@@ -152,6 +153,7 @@ const InstallerDetailsWidget = ({
 
       if (androidPlayStoreId) {
         versionInfo = (
+          // 2 usages here and selectsoftwaretableconfig, consider making component if more common
           <TooltipWrapper
             tipContent={
               <span>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerDetailsWidget/InstallerDetailsWidget.tsx
@@ -8,7 +8,6 @@ import { stringToClipboard } from "utilities/copy_text";
 import { internationalTimeFormat } from "utilities/helpers";
 import { addedFromNow } from "utilities/date_format";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
-import { getPathWithQueryParams } from "utilities/url";
 import { useCheckTruncatedElement } from "hooks/useCheckTruncatedElement";
 
 import Graphic from "components/Graphic";
@@ -17,11 +16,9 @@ import TooltipWrapper from "components/TooltipWrapper";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";
 import CustomLink from "components/CustomLink";
+import AndroidLatestVersionWithTooltip from "components/MDM/AndroidLatestVersionWithTooltip";
 
 const baseClass = "installer-details-widget";
-
-export const ANDROID_PLAY_STORE_URL =
-  "https://play.google.com/store/apps/details";
 
 interface IInstallerNameProps {
   name: string;
@@ -153,23 +150,9 @@ const InstallerDetailsWidget = ({
 
       if (androidPlayStoreId) {
         versionInfo = (
-          // 2 usages here and selectsoftwaretableconfig, consider making component if more common
-          <TooltipWrapper
-            tipContent={
-              <span>
-                See latest version on the{" "}
-                <CustomLink
-                  text="Play Store"
-                  url={getPathWithQueryParams(ANDROID_PLAY_STORE_URL, {
-                    id: androidPlayStoreId,
-                  })}
-                  newTab
-                />
-              </span>
-            }
-          >
-            <span>Latest</span>
-          </TooltipWrapper>
+          <AndroidLatestVersionWithTooltip
+            androidPlayStoreId={androidPlayStoreId}
+          />
         );
       }
 

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
@@ -18,8 +18,9 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCel
 
 import { ISWUninstallDetailsParentState } from "components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal";
 import SoftwareNameCell from "components/TableContainer/DataTable/SoftwareNameCell";
-
+import TextCell from "components/TableContainer/DataTable/TextCell";
 import VersionCell from "pages/SoftwarePage/components/tables/VersionCell";
+import AndroidLatestVersionWithTooltip from "components/MDM/AndroidLatestVersionWithTooltip";
 import HostInstallerActionCell from "../HostInstallerActionCell";
 import InstallStatusCell from "../../Software/InstallStatusCell";
 import { installStatusSortType } from "../../Software/helpers";
@@ -182,9 +183,20 @@ export const generateHostSWLibraryTableHeaders = ({
           !!softwareTitle.app_store_app &&
           softwareTitle.source === "android_apps";
 
-        // For Android Play Store apps, we do not show the version in the library
+        // For Android Play Store apps, we show "Latest" in the UI
         if (isAndroidPlayStoreApp) {
-          return <span>Latest</span>;
+          const androidPlayStoreId =
+            cellProps.row.original.app_store_app?.app_store_id;
+
+          return (
+            <TextCell
+              value={
+                <AndroidLatestVersionWithTooltip
+                  androidPlayStoreId={androidPlayStoreId || ""}
+                />
+              }
+            />
+          );
         }
 
         return (

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -69,6 +69,8 @@ export const SUPPORT_LINK = `${FLEET_WEBSITE_URL}/support`;
 export const CONTACT_FLEET_LINK = `${FLEET_WEBSITE_URL}/contact`;
 export const LEARN_MORE_ABOUT_BASE_LINK = `${FLEET_WEBSITE_URL}/learn-more-about`;
 export const FLEET_GUIDES_BASE_LINK = `${FLEET_WEBSITE_URL}/guides`;
+export const ANDROID_PLAY_STORE_URL =
+  "https://play.google.com/store/apps/details";
 
 /**  July 28, 2016 is the date of the initial commit to fleet/fleet. */
 export const INITIAL_FLEET_DATE = "2016-07-28T00:00:00Z";


### PR DESCRIPTION
## Issue
For #35553 

## Description
- UI for Android Setup Experience

## Screenshots


## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
