### PR TITLE
Fleet UI: .exe and .tar.gz add software clues fix

### DIFF
--- a/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -232,7 +232,7 @@ const PackageAdvancedOptions = ({
         disabled={!selectedPackage || requiresAdvancedOptions}
         disabledTooltipContent={
           requiresAdvancedOptions ? (
-            <>Install script is required for .{ext} packages.</>
+            <>Install and uninstall scripts are required for .{ext} packages.</>
           ) : (
             <>
               Choose a file to modify <br />

--- a/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -218,6 +218,8 @@ const PackageAdvancedOptions = ({
     );
   };
 
+  const requiresAdvancedOptions = ext === "exe" || ext === "tar.gz";
+
   return (
     <div className={baseClass}>
       <RevealButton
@@ -227,12 +229,16 @@ const PackageAdvancedOptions = ({
         hideText="Advanced options"
         caretPosition="after"
         onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
-        disabled={!selectedPackage}
+        disabled={!selectedPackage || requiresAdvancedOptions}
         disabledTooltipContent={
-          <>
-            Choose a file to modify <br />
-            advanced options.
-          </>
+          requiresAdvancedOptions ? (
+            <>Install script is required for .{ext} packages.</>
+          ) : (
+            <>
+              Choose a file to modify <br />
+              advanced options.
+            </>
+          )
         }
       />
       {(showAdvancedOptions || ext === "exe" || ext === "tar.gz") &&

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -50,7 +50,10 @@ const FORM_VALIDATION_CONFIG: Record<
       {
         name: "requiredForExe",
         isValid: (formData) => {
-          if (formData.software?.type === "exe") {
+          if (
+            formData.software?.type === "exe" ||
+            getExtensionFromFileName(formData.software?.name || "") === "exe"
+          ) {
             // Handle undefined safely with nullish coalescing
             return (formData.installScript ?? "").trim().length > 0;
           }
@@ -66,7 +69,7 @@ const FORM_VALIDATION_CONFIG: Record<
             getExtensionFromFileName(formData.software.name) === "tar.gz"
           ) {
             // Handle undefined safely with nullish coalescing
-            return (formData.uninstallScript ?? "").trim().length > 0;
+            return (formData.installScript ?? "").trim().length > 0;
           }
           return true;
         },
@@ -79,7 +82,10 @@ const FORM_VALIDATION_CONFIG: Record<
       {
         name: "requiredForExe",
         isValid: (formData) => {
-          if (formData.software?.type === "exe") {
+          if (
+            formData.software?.type === "exe" ||
+            getExtensionFromFileName(formData.software?.name || "") === "exe"
+          ) {
             // Handle undefined safely with nullish coalescing
             return (formData.uninstallScript ?? "").trim().length > 0;
           }


### PR DESCRIPTION
## Issue
Closes #34537 

## Description
- Update advanced option dropdown that stays open to look disabled with the appropriate tooltip
- Fix "Add software" button to be disabled if criteria to save is not met for .exe and .tar.gz

## Screen recording of fix


https://github.com/user-attachments/assets/c5734104-94d6-4961-b3fb-61c7cb87d569


## Testing
- [x] QA'd all new/changed functionality manually
