### PR TITLE
Fleet UI: Nuances between platform and last opened time

### DIFF
--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -146,6 +146,9 @@ export const isAppleDevice = (platform = "") => {
   );
 };
 
+export const isWindows = (platform: string | HostPlatform) =>
+  platform === "windows";
+
 export const isMacOS = (platform: string | HostPlatform) =>
   platform === "darwin";
 

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -7,7 +7,13 @@ import {
   IHostSoftware,
   isIpadOrIphoneSoftwareSource,
 } from "interfaces/software";
-import { HostPlatform, isLinuxLike } from "interfaces/platform";
+import {
+  HostPlatform,
+  isIPadOrIPhone,
+  isLinuxLike,
+  isMacOS,
+  isWindows,
+} from "interfaces/platform";
 import { IHeaderProps, IStringCellProps } from "interfaces/datatable_config";
 
 import PATHS from "router/paths";
@@ -125,15 +131,20 @@ export const generateSoftwareTableHeaders = ({
     },
     {
       Header: (): JSX.Element => {
-        const lastOpenedHeader = isLinuxLike(platform) ? (
-          <TooltipWrapper
-            tipContent={
-              <>
-                The last time the package was opened by the end user <br />
-                or accessed by any process on the host.
-              </>
-            }
-          >
+        let tooltipContent = <></>;
+
+        if (isMacOS(platform)) {
+          tooltipContent = (
+            <>When the version installed most recently was last opened.</>
+          );
+        } else if (isLinuxLike(platform) || isWindows(platform)) {
+          tooltipContent = <>When any version was last opened.</>;
+        } else if (isIPadOrIPhone(platform)) {
+          tooltipContent = <>Date and time of last opened.</>;
+        }
+
+        const lastOpenedHeader = tooltipContent ? (
+          <TooltipWrapper tipContent={tooltipContent}>
             Last opened
           </TooltipWrapper>
         ) : (


### PR DESCRIPTION
## Issue
Closes #32064

## Description
- Surface nuance between last open time for each platform to the admin user
# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually
