### PR TITLE
Update dogfood-update-testing-qa-apps.yml

### DIFF
--- a/.github/workflows/dogfood-update-testing-qa-apps.yml
+++ b/.github/workflows/dogfood-update-testing-qa-apps.yml
@@ -87,6 +87,11 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
 
+      - name: Get current date and time
+        if: steps.update-apps.outputs.changed == 'true'
+        id: date
+        run: echo "date=$(date +'%y%m%d%H%M')" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         if: steps.update-apps.outputs.changed == 'true'
         id: create-pr
@@ -102,7 +107,7 @@ jobs:
             This PR automatically updates the `fleet_maintained_apps` list in `testing-and-qa.yml` with any new apps from Fleet's maintained apps library.
 
             The changes were generated automatically by the [dogfood-update-testing-qa-apps workflow](https://github.com/${{ github.repository }}/actions/workflows/dogfood-update-testing-qa-apps.yml).
-          branch: update-testing-qa-apps-$(date +%s)
+          branch: update-testing-qa-apps-${{ steps.date.outputs.date }}
           delete-branch: true
           assignees: allenhouchins
 


### PR DESCRIPTION
Updated the workflow to use `$GITHUB_OUTPUT` instead of `::set-output` which follows the pattern used by other workflows in our repo. 

The issue was that `$(date +%s)` was treated as a literal string in YAML which resulted in the branch name `update-testing-qa-apps-$(date +%s)`, which Git rejected because `$` and parentheses are invalid in branch names.




<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
