### PR TITLE
🤖 Pass through name when creating a named datastore for Android tests

### DIFF
--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -245,6 +245,6 @@ func CreateNamedMySQLDS(t *testing.T, name string) *mysql.Datastore {
 	if _, ok := os.LookupEnv("MYSQL_TEST"); !ok {
 		t.Skip("MySQL tests are disabled")
 	}
-	// use the standard Fleet datastore for Android integration tests
-	return mysql.CreateMySQLDS(t)
+	// Use a named Fleet datastore for Android integration tests to ensure the expected database exists
+	return mysql.CreateNamedMySQLDS(t, name)
 }


### PR DESCRIPTION
Related to #35847. Flagged by both Junie Pro and Zed + Sonnet 4.5.

Prompt for Junie:

Sometime on Thursday, a code change caused database errors relating to the database server_mdm_android_tests_CreateNamedMySQLDS not being found to show up in integration tests, particularly TestServiceEnterprise and TestServiceSoftware/TestAndroidSoftwareIngestion. Find the cause for this failure.

Prompt for Zed:

Sometime on Thursday, a code change caused database errors relating to the database server_mdm_android_tests_CreateNamedMySQLDS not being found to show up in integration tests, particularly TestServiceEnterprise and TestServiceSoftware/TestAndroidSoftwareIngestion. Find the cause for this failure. https://github.com/fleetdm/fleet/issues/35847 has some more detail.