### PR TITLE
Fleet UI: Fix 2 instances of software name not showing display_name 

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTiles/SelfServiceTiles.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTiles/SelfServiceTiles.tsx
@@ -67,7 +67,10 @@ const SelfServiceTiles = ({
             </div>
             <div className={`${tileBaseClass}__item-name-version`}>
               <div className={`${tileBaseClass}__item-name`}>
-                <TooltipTruncatedText isMobileView value={software.name} />
+                <TooltipTruncatedText
+                  isMobileView
+                  value={software.display_name || software.name}
+                />
               </div>
               <div className={`${tileBaseClass}__item-version`}>
                 {software.software_package?.version ||

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -61,6 +61,7 @@ interface IInstallerInfoProps {
 const InstallerInfo = ({ software }: IInstallerInfoProps) => {
   const {
     name,
+    display_name,
     source,
     icon_url: iconUrl,
     software_package: installerPackage,
@@ -73,7 +74,9 @@ const InstallerInfo = ({ software }: IInstallerInfoProps) => {
       </div>
       <div className={`${baseClass}__item-name-version`}>
         <div className={`${baseClass}__item-name`}>
-          <TooltipTruncatedText value={name || installerPackage?.name} />
+          <TooltipTruncatedText
+            value={display_name || name || installerPackage?.name}
+          />
         </div>
         <div className={`${baseClass}__item-version`}>
           {installerPackage?.version || vppApp?.version || ""}


### PR DESCRIPTION
## Issue
Unreleased bug to #33779 

This will need to be cherry-picked into 4.77

## Description
- New self-service mobile page needs `display_name` to show over `name`
- Updates card needs `display_name` to show over `name`

## Screenshot of fixes

<img width="338" height="509" alt="Screenshot 2025-11-18 at 12 57 05 PM" src="https://github.com/user-attachments/assets/c94d67dd-a157-4322-84c1-ff23d14e4eee" />
<img width="504" height="490" alt="Screenshot 2025-11-18 at 12 57 31 PM" src="https://github.com/user-attachments/assets/dbe152e4-c4b1-43d1-a5aa-046d14c44bec" />

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter



## Testing


- [x] QA'd all new/changed functionality manually
