### PR TITLE
Update quality assurance and bug handling sections

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -631,7 +631,7 @@ If a bug meets the criteria for a [critical bug](https://fleetdm.com/handbook/co
 
 A bug is in engineering after it has gone through product drafting, has received an estimation, and has been moved to a release board during sprint planning.
 
-If this is a customer-reported bug that is related to performance at scale, it must be reproduced in a load test environment before a Fleet release can be published containing a fix. Request review of relevant production data to determine what changes are necessary in our load test environment's data set to reproduce the bug.
+If this is a customer-reported bug that is related to performance at scale, it must be reproduced in a load test environment before a Fleet release can be published containing a fix. Request review of relevant production data to determine what changes are necessary in our load test environment's data set to reproduce the bug. If there is an ongoing outage, a hotfix branch may be deployed without load testing reproduction if approved by the relevant EM.
 
 
 #### Awaiting QA

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -553,6 +553,7 @@ Just as when a feature request is not accepted in the 🎁🗣 Feature Fest meet
 
 
 ## Quality
+
 The goal of quality assurance is to identify corrections and optimizations before release by verifying;
 - Bugs
 - Fixes for bugs
@@ -629,6 +630,8 @@ If a bug meets the criteria for a [critical bug](https://fleetdm.com/handbook/co
 #### In engineering
 
 A bug is in engineering after it has gone through product drafting, has received an estimation, and has been moved to a release board during sprint planning.
+
+If this is a customer-reported bug that is related to performance at scale, it must be reproduced in a load test environment before a Fleet release can be published containing a fix. Request review of relevant production data to determine what changes are necessary in our load test environment's data set to reproduce the bug.
 
 
 #### Awaiting QA


### PR DESCRIPTION
FYI adding a note that customer-reported bugs that are related to performance at scale must be reproduced in a load test environment before we publish a release containing the fix. It also specifies that reviewing relevant production data for the affected customer should be a first step when unable to reproduce using our default load testing data set. 