### PR TITLE
Fleet UI: Fix 2 instances of software name not showing display_name  (#35918)

### DIFF
--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTiles/SelfServiceTiles.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTiles/SelfServiceTiles.tsx
@@ -67,7 +67,10 @@ const SelfServiceTiles = ({
             </div>
             <div className={`${tileBaseClass}__item-name-version`}>
               <div className={`${tileBaseClass}__item-name`}>
-                <TooltipTruncatedText isMobileView value={software.name} />
+                <TooltipTruncatedText
+                  isMobileView
+                  value={software.display_name || software.name}
+                />
               </div>
               <div className={`${tileBaseClass}__item-version`}>
                 {software.software_package?.version ||

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/UpdatesCard/UpdateSoftwareItem/UpdateSoftwareItem.tsx
@@ -61,6 +61,7 @@ interface IInstallerInfoProps {
 const InstallerInfo = ({ software }: IInstallerInfoProps) => {
   const {
     name,
+    display_name,
     source,
     icon_url: iconUrl,
     software_package: installerPackage,
@@ -73,7 +74,9 @@ const InstallerInfo = ({ software }: IInstallerInfoProps) => {
       </div>
       <div className={`${baseClass}__item-name-version`}>
         <div className={`${baseClass}__item-name`}>
-          <TooltipTruncatedText value={name || installerPackage?.name} />
+          <TooltipTruncatedText
+            value={display_name || name || installerPackage?.name}
+          />
         </div>
         <div className={`${baseClass}__item-version`}>
           {installerPackage?.version || vppApp?.version || ""}


### PR DESCRIPTION
## Issue
Unreleased bug fix for #33779 

## Description
Previously merged into main with 35918
This is for the 4.77.0 RC
