### PR TITLE
Incrementing Helm chart version (and Fleet image tag version) for 4.76.1

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.7.1
+version: v6.7.2
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.76.0
+appVersion: v4.76.1
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -3,7 +3,7 @@
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 imageRepository: fleetdm/fleet
-imageTag: v4.76.0 # Version of Fleet to deploy
+imageTag: v4.76.1 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker


### PR DESCRIPTION
- Increments Fleet image version to `4.76.1` in the Fleet Helm chart
- Increments Helm chart version to `6.7.2`