### PR TITLE
Fleet UI: Update all button queues another refetch if an update finishes during a refetch

### DIFF
--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -468,7 +468,6 @@ const DeviceUserPage = ({
 
   // User-initiated refetch always starts a new timer!
   const onRefetchHost = useCallback(async () => {
-    console.log("onRefetchHost called");
     if (!host) return;
     setShowRefetchSpinner(true);
     try {
@@ -493,7 +492,6 @@ const DeviceUserPage = ({
   // Handles the queue: If there's a queued refetch and not actively refetching, run refetch
   useEffect(() => {
     if (queuedSelfServiceRefetch && !showRefetchSpinner) {
-      console.log("unqueue refetch from queued effect");
       setQueuedSelfServiceRefetch(false);
       onRefetchHost();
     }
@@ -504,11 +502,9 @@ const DeviceUserPage = ({
     // If a refetch is already happening, queue this refetch
     if (showRefetchSpinner) {
       setQueuedSelfServiceRefetch(true);
-      console.log("queue refetch");
     } else {
       // Otherwise, run it now
       onRefetchHost();
-      console.log("direct refetch from requestRefetch");
     }
   };
 

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -181,6 +181,10 @@ const DeviceUserPage = ({
   const [sortCerts, setSortCerts] = useState<IListSort>({
     ...CERTIFICATES_DEFAULT_SORT,
   });
+  const [queuedSelfServiceRefetch, setQueuedSelfServiceRefetch] = useState(
+    false
+  );
+  const [selfServiceRefreshKey, setSelfServiceRefreshKey] = useState(0);
 
   const { data: deviceMacAdminsData } = useQuery(
     ["macadmins", deviceAuthToken],
@@ -275,6 +279,13 @@ const DeviceUserPage = ({
       refetchOnWindowFocus: false,
       retry: false,
       onSuccess: ({ host: responseHost }) => {
+        // Queued refetch logic to guarantee that install completions are reflected
+        if (queuedSelfServiceRefetch) {
+          setQueuedSelfServiceRefetch(false); // Clear the flag
+          refetchHostDetails(); // Trigger the queued extra fetch
+          console.log("unqueue refetch!");
+        }
+
         // If we're just showing the setup screen,
         // we don't need to refetch or alert on offline hosts.
         if (location.query.setup_only) {
@@ -627,6 +638,7 @@ const DeviceUserPage = ({
               hostSoftwareUpdatedAt={host.software_updated_at}
               hostDisplayName={host?.hostname || ""}
               isMobileView={shouldShowMobileUI}
+              setQueuedSelfServiceRefetch={setQueuedSelfServiceRefetch}
             />
           </div>
         </div>
@@ -703,6 +715,7 @@ const DeviceUserPage = ({
                     isHostDetailsPolling={showRefetchSpinner}
                     hostSoftwareUpdatedAt={host.software_updated_at}
                     hostDisplayName={host?.hostname || ""}
+                    setQueuedSelfServiceRefetch={setQueuedSelfServiceRefetch}
                   />
                 </TabPanel>
               )}

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -497,7 +497,7 @@ const DeviceUserPage = ({
     }
   }, [queuedSelfServiceRefetch, showRefetchSpinner, onRefetchHost]);
 
-  // Triggered when a software update finishes and a refetch might be busy
+  // Triggered when a software update finishes
   const requestRefetch = () => {
     // If a refetch is already happening, queue this refetch
     if (showRefetchSpinner) {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -84,8 +84,6 @@ export interface ISoftwareSelfServiceProps {
   hostSoftwareUpdatedAt?: string | null;
   hostDisplayName: string;
   isMobileView?: boolean;
-  queuedSelfServiceRefetch?: boolean;
-  setQueuedSelfServiceRefetch: (queue: boolean) => void;
 }
 
 export const parseSelfServiceQueryParams = (queryParams: {
@@ -142,8 +140,6 @@ const SoftwareSelfService = ({
   hostSoftwareUpdatedAt,
   hostDisplayName,
   isMobileView = false,
-  queuedSelfServiceRefetch,
-  setQueuedSelfServiceRefetch,
 }: ISoftwareSelfServiceProps) => {
   const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
 
@@ -277,23 +273,7 @@ const SoftwareSelfService = ({
           // Some pending installs finished during the last refresh
           // Trigger an additional refetch to ensure UI status is up-to-date
           // If already refetching, queue another refetch
-          if (isHostDetailsPolling) {
-            setQueuedSelfServiceRefetch(true);
-            console.log("queued refetch!!!");
-          } else {
-            refetchHostDetails();
-          }
-        }
-
-        // Refresh host details if the number of pending installs or uninstalls has decreased
-        // To update the software library information
-        if (newPendingSet.size < pendingSoftwareSetRef.current.size) {
-          if (isHostDetailsPolling) {
-            setQueuedSelfServiceRefetch(true);
-            console.log("queued refetch!!!");
-          } else {
-            refetchHostDetails();
-          }
+          refetchHostDetails();
         }
 
         // Compare new set with the previous set

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -143,7 +143,9 @@ const SoftwareSelfService = ({
 }: ISoftwareSelfServiceProps) => {
   const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
 
+  /** Used to track software IDs for which the user has initiated an action (install/uninstall) */
   const userActionIdsRef = useRef<Set<number>>(new Set());
+  /** Registers a software ID as user-initiated action */
   const registerUserAction = useCallback((id: number) => {
     userActionIdsRef.current.add(id);
   }, []);
@@ -195,7 +197,7 @@ const SoftwareSelfService = ({
         recentlyUpdatedIds
       ),
     }));
-  }, [selfServiceData, hostSoftwareUpdatedAt]);
+  }, [selfServiceData, recentlyUpdatedIds, hostSoftwareUpdatedAt]);
 
   const selectedSoftwareForUninstall = useRef<{
     softwareId: number;
@@ -295,7 +297,9 @@ const SoftwareSelfService = ({
                 next.add(id);
                 // Remove from the userActionIdsRef
                 userActionIdsRef.current.delete(id);
-                // Also schedule auto‑removal after 2 minutes
+                // Schedule auto‑removal after 2 minutes so the "recently updated" status is not permanent
+                // It's only surfaced to user as a ui_status if this action completed prior to a
+                // host details refresh but may not be reflected in host details data returned
                 setTimeout(() => {
                   setRecentlyUpdatedIds((latest) => {
                     const cleared = new Set(latest);

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -171,8 +171,13 @@ const getNewerDate = (dateStr1: string, dateStr2: string) => {
 export const getUiStatus = (
   software: IHostSoftware,
   isHostOnline: boolean,
-  hostSoftwareUpdatedAt?: string | null
+  hostSoftwareUpdatedAt?: string | null,
+  recentlyUpdatedIds?: Set<number>
 ): IHostSoftwareUiStatus => {
+  console.log(
+    "Recently updated IDs used for getUiStatus to show recent update instead of Update button",
+    recentlyUpdatedIds
+  );
   const { status, installed_versions, source } = software;
 
   const lastInstallDate = getLastInstall(software)?.installed_at;
@@ -247,7 +252,10 @@ export const getUiStatus = (
   // **Recently_uninstalled check comes BEFORE update_available**
   if (software.status === null && lastUninstallDate && hostSoftwareUpdatedAt) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastUninstallDate);
-    if (newerDate === lastUninstallDate) {
+    if (
+      newerDate === lastUninstallDate ||
+      recentlyUpdatedIds?.has(software.id)
+    ) {
       return "recently_uninstalled";
     }
   }
@@ -266,7 +274,8 @@ export const getUiStatus = (
     const newerDate = hostSoftwareUpdatedAt
       ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)
       : lastInstallDate;
-    return newerDate === lastInstallDate
+    return newerDate === lastInstallDate ||
+      (recentlyUpdatedIds && recentlyUpdatedIds.has(software.id))
       ? "recently_updated"
       : "update_available";
   }
@@ -278,7 +287,10 @@ export const getUiStatus = (
     hostSoftwareUpdatedAt
   ) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastInstallDate);
-    if (newerDate === lastInstallDate) {
+    if (
+      newerDate === lastInstallDate ||
+      (recentlyUpdatedIds && recentlyUpdatedIds.has(software.id))
+    ) {
       return "recently_installed";
     }
   }

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -174,16 +174,15 @@ export const getUiStatus = (
   hostSoftwareUpdatedAt?: string | null,
   recentlyUpdatedIds?: Set<number>
 ): IHostSoftwareUiStatus => {
-  console.log(
-    "Recently updated IDs used for getUiStatus to show recent update instead of Update button",
-    recentlyUpdatedIds
-  );
   const { status, installed_versions, source } = software;
 
   const lastInstallDate = getLastInstall(software)?.installed_at;
   const lastUninstallDate = getLastUninstall(software)?.uninstalled_at;
   const installerVersion = getInstallerVersion(software);
   const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(source);
+  /** True if a recent user-initiated action (install/uninstall) was detected for this software */
+  const recentUserActionDetected =
+    recentlyUpdatedIds && recentlyUpdatedIds.has(software.id);
 
   // 0. Script Packages states
   if (isScriptPackage) {
@@ -252,10 +251,7 @@ export const getUiStatus = (
   // **Recently_uninstalled check comes BEFORE update_available**
   if (software.status === null && lastUninstallDate && hostSoftwareUpdatedAt) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastUninstallDate);
-    if (
-      newerDate === lastUninstallDate ||
-      recentlyUpdatedIds?.has(software.id)
-    ) {
+    if (newerDate === lastUninstallDate || recentUserActionDetected) {
       return "recently_uninstalled";
     }
   }
@@ -274,8 +270,7 @@ export const getUiStatus = (
     const newerDate = hostSoftwareUpdatedAt
       ? getNewerDate(hostSoftwareUpdatedAt, lastInstallDate)
       : lastInstallDate;
-    return newerDate === lastInstallDate ||
-      (recentlyUpdatedIds && recentlyUpdatedIds.has(software.id))
+    return newerDate === lastInstallDate || recentUserActionDetected
       ? "recently_updated"
       : "update_available";
   }
@@ -287,10 +282,7 @@ export const getUiStatus = (
     hostSoftwareUpdatedAt
   ) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastInstallDate);
-    if (
-      newerDate === lastInstallDate ||
-      (recentlyUpdatedIds && recentlyUpdatedIds.has(software.id))
-    ) {
+    if (newerDate === lastInstallDate || recentUserActionDetected) {
       return "recently_installed";
     }
   }


### PR DESCRIPTION
## Issue
Closes #32203 

## Description
- Queue up another refetch if an update finishes during a current refetch
- Store pending IDs in the FE to ensure "Updated" `recently_updated` UI status does not accidentally revert to "Update available" UI status for an update that finishes during a current refetch
- Increase refetch timeout from 1 minute to 3 minutes which is less likely to hit (randomly would hit 1 minute limit during QA)

## Screen recordings
8 minute explanation of behavior on this page (including most of the solution)
https://fleetdm.zoom.us/clips/share/hBELkTrtRnCtdafulP0QsQ

4 minute of the actual solution working
https://fleetdm.zoom.us/clips/share/Eo-GeD3WQ9Sy-jnVmdCUIg

## Testing

- [x] QA'd all new/changed functionality manually
