### PR TITLE
Do not output unknown error msg if label is built in

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -261,6 +261,8 @@ func gitopsCommand() *cli.Command {
 				// Check if any used labels are not in the proposed labels list.
 				// If there are, we'll bail out with helpful error messages.
 				unknownLabelsUsed := false
+				builtInLabelsUsed := false
+
 				for labelUsed := range labelsUsed {
 					if slices.Index(proposedLabelNames, labelUsed) == -1 {
 						if _, ok := storedLabelNames[fleet.LabelTypeBuiltIn][labelUsed]; ok {
@@ -270,16 +272,20 @@ func gitopsCommand() *cli.Command {
 									labelUsed,
 								),
 							)
+							builtInLabelsUsed = true
 						} else {
 							for _, labelUser := range labelsUsed[labelUsed] {
 								logf("[!] Unknown label '%s' is referenced by %s '%s'\n", labelUsed, labelUser.Type, labelUser.Name)
 							}
+							unknownLabelsUsed = true
 						}
-						unknownLabelsUsed = true
 					}
 				}
 				if unknownLabelsUsed {
 					return errors.New("Please create the missing labels, or update your settings to not refer to these labels.")
+				}
+				if builtInLabelsUsed {
+					return errors.New("Please update your settings to not refer to built-in labels.")
 				}
 
 				// Special handling for tokens is required because they link to teams (by


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32776 

When validating labels on gitops, if the label is built-in, do not display "Please create the missing labels..." error message.

## Testing

- [X] QA'd all new/changed functionality manually