### PR TITLE
Added OTEL span for worker jobs.

### DIFF
--- a/server/worker/worker.go
+++ b/server/worker/worker.go
@@ -10,6 +10,9 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	kitlog "github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -205,6 +208,14 @@ func (w *Worker) ProcessJobs(ctx context.Context) error {
 }
 
 func (w *Worker) processJob(ctx context.Context, job *fleet.Job) error {
+	// Create OTEL span for job processing (parent span should be: cron.scheduled_tick.integrations)
+	ctx, span := otel.Tracer("github.com/fleetdm/fleet/v4/server/worker").Start(ctx, fmt.Sprintf("worker.process_job.%s", job.Name),
+		trace.WithAttributes(
+			attribute.Int64("job.id", int64(job.ID)), // nolint:gosec,G115
+		),
+	)
+	defer span.End()
+
 	j, ok := w.registry[job.Name]
 	if !ok {
 		if w.TestIgnoreUnknownJobs {
@@ -218,7 +229,11 @@ func (w *Worker) processJob(ctx context.Context, job *fleet.Job) error {
 		args = *job.Args
 	}
 
-	return j.Run(ctx, args)
+	err := j.Run(ctx, args)
+	if err != nil {
+		span.RecordError(err)
+	}
+	return err
 }
 
 type failingPoliciesTplArgs struct {

--- a/server/worker/worker.go
+++ b/server/worker/worker.go
@@ -210,6 +210,7 @@ func (w *Worker) ProcessJobs(ctx context.Context) error {
 func (w *Worker) processJob(ctx context.Context, job *fleet.Job) error {
 	// Create OTEL span for job processing (parent span should be: cron.scheduled_tick.integrations)
 	ctx, span := otel.Tracer("github.com/fleetdm/fleet/v4/server/worker").Start(ctx, fmt.Sprintf("worker.process_job.%s", job.Name),
+		trace.WithSpanKind(trace.SpanKindConsumer),
 		trace.WithAttributes(
 			attribute.Int64("job.id", int64(job.ID)), // nolint:gosec,G115
 		),


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35434

- added child span for worker jobs
- removed getTracer since that is no longer needed with the modern OTEL library, which caches the tracers itself

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually
