### PR TITLE
Fix UI bug in OS settings modal that caused status tooltip to flicker when refetching host details

### DIFF
--- a/changes/25787-ui-bugfix
+++ b/changes/25787-ui-bugfix
@@ -1,0 +1,2 @@
+- Fixed UI bug in OS settings modal that caused status tooltip to flicker when refetching host
+  details.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -541,12 +541,12 @@ const DeviceUserPage = ({
     setSelectedCertificate(certificate);
   };
 
-  const resendProfile = (profileUUID: string): Promise<void> => {
-    if (!host) {
-      return new Promise(() => undefined);
-    }
-    return deviceUserAPI.resendProfile(deviceAuthToken, profileUUID);
-  };
+  const resendProfile = useCallback(
+    (profileUUID: string): Promise<void> => {
+      return deviceUserAPI.resendProfile(deviceAuthToken, profileUUID);
+    },
+    [deviceAuthToken]
+  );
 
   const renderDeviceUserPage = () => {
     const failingPoliciesCount = host?.issues?.failing_policies_count || 0;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -669,12 +669,15 @@ const HostDetailsPage = ({
     }
   };
 
-  const resendProfile = (profileUUID: string): Promise<void> => {
-    if (!host) {
-      return new Promise(() => undefined);
-    }
-    return hostAPI.resendProfile(host.id, profileUUID);
-  };
+  const resendProfile = useCallback(
+    (profileUUID: string): Promise<void> => {
+      if (!host?.id) {
+        return new Promise(() => undefined);
+      }
+      return hostAPI.resendProfile(host.id, profileUUID);
+    },
+    [host?.id]
+  );
 
   const onChangeActivityTab = (tabIndex: number) => {
     setActiveActivityTab(tabIndex === 0 ? "past" : "upcoming");


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #25787 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually

