### PR TITLE
Add `upgrade_code` to Cloudlfare WARP FMA

### DIFF
--- a/ee/maintained-apps/outputs/cloudflare-warp/windows.json
+++ b/ee/maintained-apps/outputs/cloudflare-warp/windows.json
@@ -9,9 +9,8 @@
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "0e3fb216",
       "sha256": "ac519bcc2937d93d67d31497d72a6262801d30cea98894a9584c0b92d0635ba2",
-      "default_categories": [
-        "Productivity"
-      ]
+      "default_categories": ["Productivity"],
+      "upgrade_code": "{1BF42825-7B65-4CA9-AFFF-B7B5E1CE27B4}"
     }
   ],
   "refs": {


### PR DESCRIPTION
This will allow testing WIP updates to FMA Windows software that depend on downloads from the Fleet repo. Once this is all confirmed working as intended, will follow-up with a PR with those server changes and adding `upgrade_code`s to the remaining Windows FMApps that have them