### PR TITLE
Update instructions for installing golangci-lint in dev environments

### DIFF
--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -72,8 +72,10 @@ Check out [`/tools/osquery` directory instructions](https://github.com/fleetdm/f
 You must install the [`golangci-lint`](https://golangci-lint.run/) command to run `make test[-go]` or `make lint[-go]`, using:
 
 ```sh
-go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@43d03392d7dc3746fa776dbddd66dfcccff70651
 ```
+
+This installs the version of `golangci-lint` used in our CI environment (currently 2.4.0)
 
 Make sure it is available in your `PATH`. To execute the basic unit and integration tests, run the following from the root of the repository:
 

--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -75,9 +75,7 @@ You must install the [`golangci-lint`](https://golangci-lint.run/) command to ru
 go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@43d03392d7dc3746fa776dbddd66dfcccff70651
 ```
 
-This installs the version of `golangci-lint` used in our CI environment (currently 2.4.0)
-
-Make sure it is available in your `PATH`. To execute the basic unit and integration tests, run the following from the root of the repository:
+This installs the version of `golangci-lint` used in our CI environment (currently 2.4.0). Make sure it is available in your `PATH`. To execute the basic unit and integration tests, run the following from the root of the repository:
 
 ```sh
 REDIS_TEST=1 MYSQL_TEST=1 make test


### PR DESCRIPTION
Updates the testing-and-local-development to reference the `golangci-lint` version as of https://github.com/fleetdm/fleet/issues/33251.