### PR TITLE
Fleet UI: Delete Okta conditional access copy

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tests.tsx
@@ -396,7 +396,7 @@ BAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEwHwYDVQQKDBhJbnRlcm5ldCBX
       // Should show delete confirmation modal
       await waitFor(() => {
         expect(
-          screen.getByText(/Fleet will be disconnected from Okta/)
+          screen.getByText(/Before you delete, first unblock all end users/)
         ).toBeInTheDocument();
       });
 

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -105,10 +105,20 @@ const DeleteConditionalAccessModal = ({
         </p>
       </>
     ) : (
-      <p>
-        Fleet will be disconnected from Okta and will stop blocking end users
-        from logging in with single sign-on.
-      </p>
+      <>
+        <p>
+          Before you delete, first unblock all end users.{" "}
+          <CustomLink
+            text="Learn how"
+            url={`${LEARN_MORE_ABOUT_BASE_LINK}/disable-okta-conditional-access`}
+            newTab
+          />
+        </p>
+        <p>
+          If you don&apos;t, end users will stay blocked even after deleting
+          Okta.
+        </p>
+      </>
     );
 
   return (


### PR DESCRIPTION
Deleting Okta from Fleet won't unblock users.

New website redirect is in a separate PR: https://github.com/fleetdm/fleet/pull/36015/files#diff-0c6120927d3e65309562b5b15b261d3298d05fcb0ff18e5b6512ee683b7ad6b3

Context: https://github.com/fleetdm/fleet/pull/35204#discussion_r2550609592
