### PR TITLE
Fleet UI: Fix removed display name message

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tsx
@@ -684,7 +684,7 @@ const EditIconModal = ({
       }
 
       // Process display name change
-      if (displayName !== previewInfo.name) {
+      if (canSaveDisplayName) {
         try {
           await (installerType === "package"
             ? softwareAPI.editSoftwarePackage({
@@ -699,12 +699,18 @@ const EditIconModal = ({
             id: "name-edited",
             alertType: "success",
             isVisible: true,
-            message: (
-              <>
-                Successfully renamed <b>{previewInfo.name}</b> to{" "}
-                <b>{displayName}</b>.
-              </>
-            ),
+            message:
+              displayName === "" ? (
+                <>
+                  Successfully removed custom name for <b>{previewInfo.name}</b>
+                  .
+                </>
+              ) : (
+                <>
+                  Successfully renamed <b>{previewInfo.name}</b> to{" "}
+                  <b>{displayName}</b>.
+                </>
+              ),
             persistOnPageChange: false,
           });
         } catch (e) {


### PR DESCRIPTION
## Issue
Redo of https://github.com/fleetdm/fleet/pull/35429

Somehow I merged the RC cherry pick to main again

Caught in QA by magnus https://github.com/fleetdm/fleet/issues/34012#issuecomment-3564149170

Merge to `main`
<img width="1082" height="940" alt="Screenshot 2025-11-21 at 1 24 38 PM" src="https://github.com/user-attachments/assets/f253dd16-e74c-43cc-9d7b-149ab90c3f16" />
Somehow I re-merged to main again instead of to 4.77 RC 
<img width="996" height="961" alt="Screenshot 2025-11-21 at 1 24 04 PM" src="https://github.com/user-attachments/assets/3ddc3146-e462-4a55-9e48-0b149ed3c786" />


