### PR TITLE
Fixed invalid props on Custom EST certs edits

### DIFF
--- a/changes/35729-custom-est-certificate-edit-bug
+++ b/changes/35729-custom-est-certificate-edit-bug
@@ -1,0 +1,1 @@
+- Fixed bug that prevented users from editing custom EST certificates URLs.

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -190,11 +190,11 @@ export const generateEditCertAuthorityData = (
     case "custom_est_proxy": {
       const {
         name: customESTName,
-        scepURL: customESTUrl,
+        url: customESTUrl,
         username: customESTUsername,
         password: customESTPassword,
-      } = formData as ISmallstepFormData;
-      return {
+      } = formData as ICustomESTFormData;
+      const diff = {
         custom_est_proxy: deepDifference(
           {
             name: customESTName,
@@ -205,6 +205,16 @@ export const generateEditCertAuthorityData = (
           certAuthWithoutType
         ),
       };
+      // Make sure credentials are included if we are modifying the url
+      if (diff.custom_est_proxy.url) {
+        if (!diff.custom_est_proxy.username) {
+          diff.custom_est_proxy.username = customESTUsername;
+        }
+        if (!diff.custom_est_proxy.password) {
+          diff.custom_est_proxy.password = customESTPassword;
+        }
+      }
+      return diff;
     }
     default:
       throw new Error(


### PR DESCRIPTION
**Related issue:** Resolves #35729 

- Fixed url prop mapping rule on Custom EST certs form.
- When editing the url field, include credentials to PATH end-point.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually