### PR TITLE
Don't nuke built container images before testing them for vulns

### DIFF
--- a/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af
+          docker system prune -af --filter "label!=fleetdm/bomutils"
           df -h
 
       - name: List VEX files

--- a/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-bomutils-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af --filter "label!=fleetdm/bomutils"
+          docker builder prune -af
           df -h
 
       - name: List VEX files

--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af --filter "label!=fleetdm/fleetctl"
+          docker builder prune -af
           df -h
 
       - name: List VEX files

--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af
+          docker system prune -af --filter "label!=fleetdm/fleetctl"
           df -h
 
       - name: List VEX files

--- a/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af --filter "label!=fleetdm/wix"
+          docker builder prune -af
           df -h
 
       - name: List VEX files

--- a/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-wix-check-vulnerabilities.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Clean up Docker build cache
         run: |
-          docker system prune -af
+          docker system prune -af --filter "label!=fleetdm/wix"
           df -h
 
       - name: List VEX files


### PR DESCRIPTION
Otherwise we're just pulling the currently published Docker images and checking *those* rather than what's on `main`.