### PR TITLE
Improve UX for email fields on mobile

### DIFF
--- a/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
+++ b/frontend/components/forms/ForgotPasswordForm/ForgotPasswordForm.jsx
@@ -24,7 +24,12 @@ class ForgotPasswordForm extends Component {
     const { baseError, fields, handleSubmit, isLoading } = this.props;
 
     return (
-      <form onSubmit={handleSubmit} className={baseClass} autoComplete="off">
+      <form
+        onSubmit={handleSubmit}
+        className={baseClass}
+        autoComplete="off"
+        noValidate
+      >
         {baseError && <div className="form__base-error">{baseError}</div>}
         <p>
           Enter your email below to receive an email with instructions to reset
@@ -35,6 +40,7 @@ class ForgotPasswordForm extends Component {
           autofocus
           label="Email"
           placeholder="Email"
+          type="email"
         />
         <div className="button-wrap">
           <Button

--- a/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
+++ b/frontend/components/forms/RegistrationForm/AdminDetails/AdminDetails.jsx
@@ -42,7 +42,12 @@ class AdminDetails extends Component {
     const tabIndex = currentPage ? 0 : -1;
 
     return (
-      <form onSubmit={handleSubmit} className={className} autoComplete="off">
+      <form
+        onSubmit={handleSubmit}
+        className={className}
+        autoComplete="off"
+        noValidate
+      >
         <p>Additional admins can be designated within the Fleet app.</p>
         <InputField
           {...fields.name}
@@ -56,7 +61,12 @@ class AdminDetails extends Component {
             maxLength: "80",
           }}
         />
-        <InputField {...fields.email} label="Email" tabIndex={tabIndex} />
+        <InputField
+          {...fields.email}
+          label="Email"
+          tabIndex={tabIndex}
+          type="email"
+        />
         <InputField
           {...fields.password}
           label="Password"

--- a/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/IntegrationForm/IntegrationForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Integrations/components/IntegrationForm/IntegrationForm.tsx
@@ -175,6 +175,7 @@ const IntegrationForm = ({
           className={`${baseClass}__form`}
           onSubmit={onFormSubmit}
           autoComplete="off"
+          noValidate
         >
           <InputField
             autofocus
@@ -211,6 +212,7 @@ const IntegrationForm = ({
               parseTarget
               value={email}
               disabled={gitOpsModeEnabled}
+              type="email"
             />
           )}
           <InputField

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -552,6 +552,7 @@ const UserForm = ({
         label="Email"
         error={formErrors.email}
         name="email"
+        type="email"
         onChange={onInputChange}
         onBlur={onInputBlur}
         parseTarget


### PR DESCRIPTION
## Follow-up to https://github.com/fleetdm/fleet/pull/36172

- Set `type="email"` for email inputs in Fleet forms
- Bypass native HTML form validation as needed to preserve Fleet-specific logic

## Confirmed that on mobile, 1) email-specific keyboard is presented and 2) first letter is not automatically capitalized on:

### Sign up form:
![IMG_0733](https://github.com/user-attachments/assets/439bec45-4796-484d-b769-688a71d729f1)

### Forgot password form:
![IMG_0734](https://github.com/user-attachments/assets/e8be6c62-4dea-4f06-8d1b-276c5b8c9048)

### Add/edit user form:
![IMG_0735](https://github.com/user-attachments/assets/91d52b4c-864b-4c1c-bf41-6161a0b65954)

### Add integration (webhook) form:
![IMG_0736](https://github.com/user-attachments/assets/559dd07b-6b67-4ba3-8a1e-3b40eedc8823)


- [x] QA'd all new/changed functionality manually