### PR TITLE
Use UTC timestamps for DB migrations

### DIFF
--- a/server/goose/create.go
+++ b/server/goose/create.go
@@ -8,7 +8,7 @@ import (
 
 // Create writes a new blank migration file.
 func Create(db *sql.DB, dir, name, migrationType string) error {
-	paths, err := CreateMigration(name, migrationType, dir, time.Now())
+	paths, err := CreateMigration(name, migrationType, dir, time.Now().UTC())
 	if err != nil {
 		return err
 	}

--- a/tools/bump-migration/main.go
+++ b/tools/bump-migration/main.go
@@ -56,7 +56,7 @@ func main() {
 	if _, err := time.Parse(timeFormat, oldTimestamp); err != nil {
 		log.Fatalf("Bad filename pattern, '%s' is not a valid timestamp in '%s'", oldTimestamp, sourceFilename)
 	}
-	newTimestamp := time.Now().Format(timeFormat)
+	newTimestamp := time.Now().UTC().Format(timeFormat)
 
 	newMig, newTest, err := renameMigrationFiles(migrationsDir, sourceFilename, oldTimestamp, newTimestamp)
 	if err != nil {


### PR DESCRIPTION
No changes file because this is just a tooling change rather than a functionality change.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually