### PR TITLE
Fix failing test due to merge inaccuracies

### DIFF
--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -1614,6 +1614,14 @@ func TestMDMTokenUpdateIOS(t *testing.T) {
 		}, nil
 	}
 
+	ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+
+	ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails, details []byte, createdAt time.Time) error {
+		return nil
+	}
+
 	ds.NewJobFunc = func(ctx context.Context, j *fleet.Job) (*fleet.Job, error) {
 		return j, nil
 	}


### PR DESCRIPTION
We merged #35685, but since it was hanging for some time another PR made it in, and that PR was not updated to use latest main so the test failure was not caught in CI.