### PR TITLE
Website: uncomment warning related to missing Cloudflare headers

### DIFF
--- a/website/api/controllers/docs/view-basic-documentation.js
+++ b/website/api/controllers/docs/view-basic-documentation.js
@@ -59,10 +59,9 @@ module.exports = {
     // Due to shipping costs, we'll check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
     if(sails.config.environment === 'production') {
       // Log a warning if the cloudflare headers we use are missing in production.
-      // 2025-11-18: This warning was temporarily disabled until the website is back on Cloudflare.
-      // if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
-      //   sails.log.warn('When a user visted the docs, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
-      // }
+      if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
+        sails.log.warn('When a user visted the docs, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
+      }
     }
     if(this.req.get('cf-ipcountry') === 'US' && this.req.get('cf-iplongitude') > -125) {
       showSwagForm = true;

--- a/website/api/controllers/view-device-management.js
+++ b/website/api/controllers/view-device-management.js
@@ -62,10 +62,9 @@ module.exports = {
     // Due to shipping costs, we'll check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
     if(sails.config.environment === 'production') {
       // Log a warning if the cloudflare headers we use are missing in production.
-      // 2025-11-18: This warning was temporarily disabled until the website is back on Cloudflare.
-      // if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
-      //   sails.log.warn('When a user visted the device management page, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
-      // }
+      if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
+        sails.log.warn('When a user visted the device management page, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
+      }
     }
     if(this.req.get('cf-ipcountry') === 'US' && this.req.get('cf-iplongitude') > -125) {
       showSwagForm = true;

--- a/website/api/controllers/view-transparency.js
+++ b/website/api/controllers/view-transparency.js
@@ -21,10 +21,9 @@ module.exports = {
     // Due to shipping costs, we'll check the requesting user's cf-ipcountry to see if they're in the US, and their cf-iplongitude header to see if they're in the contiguous US.
     if(sails.config.environment === 'production') {
       // Log a warning if the cloudflare headers we use are missing in production.
-      // 2025-11-18: This warning was temporarily disabled until the website is back on Cloudflare.
-      // if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
-      //   sails.log.warn('When a user visted the transparency page, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
-      // }
+      if(!this.req.get('cf-ipcountry') || !this.req.get('cf-iplongitude')) {
+        sails.log.warn('When a user visted the transparency page, the Cloudflare header we use to determine if they are visiting from the contiguous United States is missing.');
+      }
     }
     if(this.req.get('cf-ipcountry') === 'US' && this.req.get('cf-iplongitude') > -125) {
       showSwagForm = true;


### PR DESCRIPTION
Changes:
- Uncommented a warning that is logged if certain Cloudflare headers are missing. (Reverted the changes from https://github.com/fleetdm/fleet/pull/35909)