### PR TITLE
Moved lint rules to .editorconfig for Android Studio

### DIFF
--- a/android/.editorconfig
+++ b/android/.editorconfig
@@ -1,0 +1,25 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{kt,kts}]
+ktlint_code_style = android_studio
+indent_size = 4
+indent_style = space
+max_line_length = 140
+
+# Jetpack Compose requires Composable functions to start with uppercase (PascalCase)
+ktlint_standard_function-naming = disabled
+# Android conventionally uses uppercase TAG constants for logging
+ktlint_standard_property-naming = disabled
+
+# Android Studio IDE settings (prefixed with ij_)
+# Allow trailing commas (cleaner diffs + easier reordering)
+ij_kotlin_allow_trailing_comma = true
+ij_kotlin_allow_trailing_comma_on_call_site = true
+# Import ordering: prioritize Android
+ij_kotlin_imports_layout = *,android.**,androidx.**,com.**,org.**,java.**,kotlin.**,kotlinx.**,^

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -83,14 +83,7 @@ spotless {
     kotlin {
         target("**/*.kt")
         targetExclude("**/build/**/*.kt")
-        ktlint().editorConfigOverride(
-            mapOf(
-                // Jetpack Compose requires Composable functions to start with uppercase (PascalCase)
-                "ktlint_standard_function-naming" to "disabled",
-                // Android conventionally uses uppercase TAG constants for logging
-                "ktlint_standard_property-naming" to "disabled",
-            ),
-        )
+        ktlint()
     }
     kotlinGradle {
         target("*.gradle.kts")

--- a/android/app/src/main/java/com/fleetdm/agent/CertificateService.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/CertificateService.kt
@@ -6,14 +6,13 @@ import android.content.Context
 import android.content.Intent
 import android.os.IBinder
 import android.util.Log
+import org.json.JSONObject
+import java.security.PrivateKey
+import java.security.cert.Certificate
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
-import org.json.JSONObject
-import java.security.PrivateKey
-import java.security.cert.Certificate
-import java.security.cert.X509Certificate
 
 /**
  * Service to handle SCEP enrollment and silent certificate installation using DevicePolicyManager.
@@ -35,10 +34,7 @@ class CertificateService : Service() {
     )
 
     // Structure for SCEP result, holding the key and certificate(s)
-    data class ScepResult(
-        val privateKey: PrivateKey,
-        val certificateChain: Array<Certificate>,
-    )
+    data class ScepResult(val privateKey: PrivateKey, val certificateChain: Array<Certificate>)
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         val certDataJson = intent?.getStringExtra("CERT_DATA")
@@ -118,11 +114,7 @@ class CertificateService : Service() {
      * Performs a silent installation of the KeyPair using the delegated CERT_INSTALL scope.
      * This method requires NO user interaction on modern managed devices (API 18+).
      */
-    private fun installCertificateSilently(
-        alias: String,
-        privateKey: PrivateKey,
-        certificateChain: Array<Certificate>,
-    ) {
+    private fun installCertificateSilently(alias: String, privateKey: PrivateKey, certificateChain: Array<Certificate>) {
         val dpm = getSystemService(Context.DEVICE_POLICY_SERVICE) as DevicePolicyManager
 
         // The admin component is null because the caller is a DELEGATED application,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36202

`./gradlew spotlessCheck` and Android Studio should use the same style rules. The `.editorconfig` Code Style option was enabled by default in my Android Studio.
