### PR TITLE
FAF: Time format clarification

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -510,8 +510,8 @@ Returns a list of the activities that have been performed in Fleet. For a compre
 | order_direction | string  | query | **Requires `order_key`**. The direction of the order given the order key. Options include `"asc"` and `"desc"`. Default is `"asc"`. |
 | query | string | query | Search query keywords. Searchable fields include `actor_full_name` and `actor_email`.
 | activity_type | string | query | Indicates the activity `type` to filter by. See available activity types on the [Audit logs page](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/audit-logs.md).
-| start_created_at | string | query | Filters to include only activities that happened after this date. If not specified, set to the earliest possible date.
-| end_created_at | string | query | Filters to include only activities that happened before this date. If not specified, set to now.
+| start_created_at | string | query | Filters to include only activities that happened after this date. If not specified, set to the earliest possible date. Should be of the format that is yet to be aligned on
+| end_created_at | string | query | Filters to include only activities that happened before this date. If not specified, set to now. Should be of the format that is yet to be aligned on
 
 #### Example
 


### PR DESCRIPTION
This PR is to open the discussion on what time format we should accept when it goes to the server.

Currently we show all times (returned from us) in UTC ISO times. `2025-10-20T14:42:07.90149Z`

Should we accept that as the input, use unix timestamps? (Seconds or milliseconds?), another format?
One aligns inputs and outputs, but I would argue that timestamps are more manageble also since we can fail on invalid input (a time string), where if we use ISO all strings are valid in the eyes of the API, but the DB will fail if a non date string is passed.

See: https://fleetdm.slack.com/archives/C019WG4GH0A/p1764169033487539

**Side note: This doc change should be reverted (the entire filter activites, as the story is marked for 4.78, I've already tagged Marko)**