### PR TITLE
36332 Omit Android app configuration

### DIFF
--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -49,7 +49,7 @@ type VPPAppTeam struct {
 	AddedAutomaticInstallPolicy *Policy `json:"-"`
 	DisplayName                 *string `json:"display_name"`
 	// Configuration is a json file used to customize Android app
-	// behavior/settings. Relevant to Android only.
+	// behavior/settings. Applicable to Android apps only.
 	Configuration json.RawMessage `json:"configuration,omitempty"`
 }
 
@@ -106,9 +106,11 @@ type VPPAppStoreApp struct {
 	AddedAt time.Time `db:"added_at" json:"created_at"`
 	// Categories is the list of categories to which this software belongs: e.g. "Productivity",
 	// "Browsers", etc.
-	Categories    []string        `json:"categories"`
-	DisplayName   string          `json:"display_name"`
-	Configuration json.RawMessage `json:"configuration"`
+	Categories  []string `json:"categories"`
+	DisplayName string   `json:"display_name"`
+	// Configuration is a json file used to customize Android app
+	// behavior/settings. Applicable to Android apps only.
+	Configuration json.RawMessage `json:"configuration,omitempty"`
 }
 
 // VPPAppStatusSummary represents aggregated status metrics for a VPP app.

--- a/server/service/integration_android_software_test.go
+++ b/server/service/integration_android_software_test.go
@@ -224,6 +224,14 @@ func (s *integrationMDMTestSuite) TestAndroidAppSelfService() {
 
 	// Test Android app configurations
 
+	// Title with no configuration should omit it from response
+	var getAppResp map[string]any
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", addAppResp.TitleID), &getSoftwareTitleRequest{
+		ID:     addAppResp.TitleID,
+		TeamID: nil,
+	}, http.StatusOK, &getAppResp)
+	require.Nil(t, getAppResp["configuration"])
+
 	// Android app with configuration
 	appConfiguration := json.RawMessage(`{"workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED"}`)
 	androidAppWithConfig := &fleet.VPPApp{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36332
This is a small followup to to #35493

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
Testing the `GET /api/v1/fleet/software/titles/:id` endpoint
- android title, team id: shows configuration
- android title, no team id: doesn't show configuration at all
- ipados title, with/without team id: doesn't show configuration at all