### PR TITLE
Revert iOS/iPadOS self-service API changes

### DIFF
--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_valid_ipa.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_valid_ipa.yml
@@ -15,4 +15,4 @@ queries:
 software:
   packages:
     - url: ${SOFTWARE_INSTALLER_URL}/ipa_test.ipa
-      self_service: true
+      self_service: false

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -2044,7 +2044,7 @@ team_settings:
 	require.NoError(t, err)
 	_, err = noTeamFile.WriteString(fmt.Sprintf(noTeamTemplate, `
       - url: ${SOFTWARE_INSTALLER_URL}/ipa_test.ipa
-        self_service: true
+        self_service: false
 `))
 	require.NoError(t, err)
 	err = noTeamFile.Close()
@@ -2081,7 +2081,7 @@ team_settings:
 
 		meta, err := s.DS.GetInHouseAppMetadataByTeamAndTitleID(ctx, nil, title.ID)
 		require.NoError(t, err)
-		require.True(t, meta.SelfService)
+		require.False(t, meta.SelfService)
 		require.Empty(t, meta.LabelsExcludeAny)
 		require.Empty(t, meta.LabelsIncludeAny)
 	}

--- a/ee/server/service/in_house_apps.go
+++ b/ee/server/service/in_house_apps.go
@@ -47,6 +47,9 @@ func (svc *Service) updateInHouseAppInstaller(ctx context.Context, payload *flee
 	}
 	selfService := existingInstaller.SelfService
 	if payload.SelfService != nil {
+		if *payload.SelfService {
+			return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
+		}
 		selfService = *payload.SelfService
 	}
 	displayName := ptr.ValOrZero(payload.DisplayName)
@@ -223,7 +226,6 @@ func (svc *Service) GetInHouseAppManifest(ctx context.Context, titleID uint, tea
 		Name     string
 		URL      string
 	}{meta.BundleIdentifier, meta.Version, meta.SoftwareTitle, downloadUrl})
-
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "rendering app manifest")
 	}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2346,6 +2346,11 @@ func (svc *Service) softwareBatchUpload(
 				installer.Title = installer.Filename
 			}
 
+			// Validate self-service is not enabled for IPA files
+			if installer.Extension == "ipa" && installer.SelfService {
+				return fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
+			}
+
 			// if this is an .ipa and there is no extra installer, create it here
 			if installer.Extension == "ipa" && len(extraInstallers) == 0 {
 				extraPayload := *installer

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -411,9 +411,6 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 	}
 
 	if payload.SelfService != nil && *payload.SelfService != existingInstaller.SelfService {
-		if existingInstaller.Extension == "ipa" && *payload.SelfService {
-			return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
-		}
 		dirty["SelfService"] = true
 		activity.SelfService = *payload.SelfService
 	}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -87,12 +87,8 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 		return nil, ctxerr.Wrap(ctx, err, "adding metadata to payload")
 	}
 
-	if payload.Extension == "ipa" {
-		if payload.SelfService {
-			return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
-		}
-		// Ensure it's false even if not set (though bool defaults to false)
-		payload.SelfService = false
+	if payload.Extension == "ipa" && payload.SelfService {
+		return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
 	}
 
 	if payload.AutomaticInstall && payload.AutomaticInstallQuery == "" {

--- a/ee/server/service/software_installers_self_service_test.go
+++ b/ee/server/service/software_installers_self_service_test.go
@@ -20,19 +20,6 @@ func TestSoftwareInstallerSelfServiceRestrictions(t *testing.T) {
 	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
 	ctx = authz_ctx.NewContext(ctx, &authz_ctx.AuthorizationContext{})
 
-	t.Run("UploadSoftwareInstaller", func(t *testing.T) {
-		t.Run("fails for ipa with self-service", func(t *testing.T) {
-			// We mock addMetadataToSoftwarePayload to return "ipa" extension
-			// But since we can't easily mock private methods, we'll rely on the fact that
-			// UploadSoftwareInstaller calls addMetadataToSoftwarePayload which we can't mock directly
-			// However, we can construct a payload that would result in extension being "ipa"
-			// if we could control it.
-			// Since we can't easily mock the private method, we might need to rely on integration tests
-			// or just test the logic we added if we could.
-			// Actually, we can test UpdateSoftwareInstaller more easily as it uses existing metadata.
-		})
-	})
-
 	t.Run("UpdateSoftwareInstaller", func(t *testing.T) {
 		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
 			return &fleet.SoftwareTitle{
@@ -65,7 +52,6 @@ func TestSoftwareInstallerSelfServiceRestrictions(t *testing.T) {
 	})
 
 	t.Run("updateInHouseAppInstaller", func(t *testing.T) {
-		// This is called via UpdateSoftwareInstaller when InHouseAppCount == 1
 		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
 			return &fleet.SoftwareTitle{
 				InHouseAppCount: 1,

--- a/ee/server/service/software_installers_self_service_test.go
+++ b/ee/server/service/software_installers_self_service_test.go
@@ -1,0 +1,92 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSoftwareInstallerSelfServiceRestrictions(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+	ctx = authz_ctx.NewContext(ctx, &authz_ctx.AuthorizationContext{})
+
+	t.Run("UploadSoftwareInstaller", func(t *testing.T) {
+		t.Run("fails for ipa with self-service", func(t *testing.T) {
+			// We mock addMetadataToSoftwarePayload to return "ipa" extension
+			// But since we can't easily mock private methods, we'll rely on the fact that
+			// UploadSoftwareInstaller calls addMetadataToSoftwarePayload which we can't mock directly
+			// However, we can construct a payload that would result in extension being "ipa"
+			// if we could control it.
+			// Since we can't easily mock the private method, we might need to rely on integration tests
+			// or just test the logic we added if we could.
+			// Actually, we can test UpdateSoftwareInstaller more easily as it uses existing metadata.
+		})
+	})
+
+	t.Run("UpdateSoftwareInstaller", func(t *testing.T) {
+		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
+			return &fleet.SoftwareTitle{
+				SoftwareInstallersCount: 1,
+				Name:                    "Test App",
+			}, nil
+		}
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			return &fleet.SoftwareInstaller{
+				Extension:   "ipa",
+				SelfService: false,
+			}, nil
+		}
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, scripts []string) error {
+			return nil
+		}
+		ds.TeamWithoutExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: "team"}, nil
+		}
+
+		t.Run("fails for ipa with self-service", func(t *testing.T) {
+			_, err := svc.UpdateSoftwareInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{
+				TitleID:     1,
+				TeamID:      ptr.Uint(1),
+				SelfService: ptr.Bool(true),
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
+		})
+	})
+
+	t.Run("updateInHouseAppInstaller", func(t *testing.T) {
+		// This is called via UpdateSoftwareInstaller when InHouseAppCount == 1
+		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
+			return &fleet.SoftwareTitle{
+				InHouseAppCount: 1,
+				Name:            "Test App",
+			}, nil
+		}
+		ds.GetInHouseAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.SoftwareInstaller, error) {
+			return &fleet.SoftwareInstaller{
+				Extension:   "ipa",
+				SelfService: false,
+			}, nil
+		}
+
+		t.Run("fails for ipa with self-service", func(t *testing.T) {
+			_, err := svc.UpdateSoftwareInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{
+				TitleID:     1,
+				TeamID:      ptr.Uint(1),
+				SelfService: ptr.Bool(true),
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
+		})
+	})
+}

--- a/ee/server/service/software_installers_self_service_test.go
+++ b/ee/server/service/software_installers_self_service_test.go
@@ -20,37 +20,6 @@ func TestSoftwareInstallerSelfServiceRestrictions(t *testing.T) {
 	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
 	ctx = authz_ctx.NewContext(ctx, &authz_ctx.AuthorizationContext{})
 
-	t.Run("UpdateSoftwareInstaller", func(t *testing.T) {
-		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
-			return &fleet.SoftwareTitle{
-				SoftwareInstallersCount: 1,
-				Name:                    "Test App",
-			}, nil
-		}
-		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
-			return &fleet.SoftwareInstaller{
-				Extension:   "ipa",
-				SelfService: false,
-			}, nil
-		}
-		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, scripts []string) error {
-			return nil
-		}
-		ds.TeamWithoutExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
-			return &fleet.Team{ID: 1, Name: "team"}, nil
-		}
-
-		t.Run("fails for ipa with self-service", func(t *testing.T) {
-			_, err := svc.UpdateSoftwareInstaller(ctx, &fleet.UpdateSoftwareInstallerPayload{
-				TitleID:     1,
-				TeamID:      ptr.Uint(1),
-				SelfService: ptr.Bool(true),
-			})
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
-		})
-	})
-
 	t.Run("updateInHouseAppInstaller", func(t *testing.T) {
 		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, filter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
 			return &fleet.SoftwareTitle{
@@ -63,6 +32,12 @@ func TestSoftwareInstallerSelfServiceRestrictions(t *testing.T) {
 				Extension:   "ipa",
 				SelfService: false,
 			}, nil
+		}
+		ds.TeamWithoutExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: "team"}, nil
+		}
+		ds.ValidateEmbeddedSecretsFunc = func(ctx context.Context, scripts []string) error {
+			return nil
 		}
 
 		t.Run("fails for ipa with self-service", func(t *testing.T) {

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -602,10 +602,9 @@ func (svc *Service) UpdateAppStoreApp(ctx context.Context, titleID uint, teamID 
 	selfServiceVal := meta.SelfService
 	if selfService != nil {
 		selfServiceVal = *selfService
-	}
-
-	if selfServiceVal && (meta.Platform == fleet.IOSPlatform || meta.Platform == fleet.IPadOSPlatform) {
-		return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
+		if selfServiceVal && (meta.Platform == fleet.IOSPlatform || meta.Platform == fleet.IPadOSPlatform) {
+			return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
+		}
 	}
 
 	appToWrite := &fleet.VPPApp{

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -74,7 +74,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 		// import vpp apps as self-service for ios or ipados
 		payloadsWithPlatform = append(payloadsWithPlatform, []fleet.VPPBatchPayloadWithPlatform{{
 			AppStoreID:         payload.AppStoreID,
-			SelfService:        payload.SelfService,
+			SelfService:        false,
 			InstallDuringSetup: payload.InstallDuringSetup,
 			Platform:           fleet.IOSPlatform,
 			LabelsExcludeAny:   payload.LabelsExcludeAny,
@@ -82,7 +82,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 			Categories:         payload.Categories,
 		}, {
 			AppStoreID:         payload.AppStoreID,
-			SelfService:        payload.SelfService,
+			SelfService:        false,
 			InstallDuringSetup: payload.InstallDuringSetup,
 			Platform:           fleet.IPadOSPlatform,
 			LabelsExcludeAny:   payload.LabelsExcludeAny,
@@ -356,6 +356,10 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 			fmt.Sprintf("platform must be one of '%s', '%s', or '%s", fleet.IOSPlatform, fleet.IPadOSPlatform, fleet.MacOSPlatform))
 	}
 
+	if appID.SelfService && (appID.Platform == fleet.IOSPlatform || appID.Platform == fleet.IPadOSPlatform) {
+		return 0, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
+	}
+
 	validatedLabels, err := ValidateSoftwareLabels(ctx, svc, appID.LabelsIncludeAny, appID.LabelsExcludeAny)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "validating software labels for adding vpp app")
@@ -598,6 +602,10 @@ func (svc *Service) UpdateAppStoreApp(ctx context.Context, titleID uint, teamID 
 	selfServiceVal := meta.SelfService
 	if selfService != nil {
 		selfServiceVal = *selfService
+	}
+
+	if selfServiceVal && (meta.Platform == fleet.IOSPlatform || meta.Platform == fleet.IPadOSPlatform) {
+		return nil, fleet.NewInvalidArgumentError("self_service", "Self-service is not supported for iOS and iPadOS apps.")
 	}
 
 	appToWrite := &fleet.VPPApp{

--- a/ee/server/service/vpp_self_service_test.go
+++ b/ee/server/service/vpp_self_service_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVPPSelfServiceRestrictions(t *testing.T) {
+	t.Parallel()
+	ds := new(mock.Store)
+	svc := newTestService(t, ds)
+
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	t.Run("AddAppStoreApp", func(t *testing.T) {
+		t.Run("fails for iOS with self-service", func(t *testing.T) {
+			_, err := svc.AddAppStoreApp(ctx, ptr.Uint(1), fleet.VPPAppTeam{
+				VPPAppID: fleet.VPPAppID{
+					Platform: fleet.IOSPlatform,
+				},
+				SelfService: true,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
+		})
+
+		t.Run("fails for iPadOS with self-service", func(t *testing.T) {
+			_, err := svc.AddAppStoreApp(ctx, ptr.Uint(1), fleet.VPPAppTeam{
+				VPPAppID: fleet.VPPAppID{
+					Platform: fleet.IPadOSPlatform,
+				},
+				SelfService: true,
+			})
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
+		})
+	})
+
+	t.Run("UpdateAppStoreApp", func(t *testing.T) {
+		ds.GetVPPAppMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, titleID uint) (*fleet.VPPAppStoreApp, error) {
+			return &fleet.VPPAppStoreApp{
+				VPPAppID: fleet.VPPAppID{
+					Platform: fleet.IOSPlatform,
+				},
+				SelfService: false,
+			}, nil
+		}
+		ds.TeamFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
+			return &fleet.Team{ID: 1, Name: "team"}, nil
+		}
+
+		t.Run("fails for iOS with self-service", func(t *testing.T) {
+			_, err := svc.UpdateAppStoreApp(ctx, 1, ptr.Uint(1), ptr.Bool(true), nil, nil, nil, nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Self-service is not supported for iOS and iPadOS apps")
+		})
+	})
+}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -22306,7 +22306,7 @@ func (s *integrationEnterpriseTestSuite) TestInHouseAppCRUD() {
 			Filename:    "ipa_test2.ipa",
 			Version:     "1.0.0",
 			StorageID:   uuid.New().String(),
-			SelfService: true,
+			SelfService: false, // self-service not supported for iOS/iPadOS apps
 		}
 		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
 
@@ -22323,7 +22323,7 @@ func (s *integrationEnterpriseTestSuite) TestInHouseAppCRUD() {
 
 		// check activity
 		activityData := fmt.Sprintf(
-			`{"software_title": "ipa_test", "software_package": "ipa_test2.ipa", "team_name": "%s", "team_id": %d, "self_service": true, "software_title_id": %d}`,
+			`{"software_title": "ipa_test", "software_package": "ipa_test2.ipa", "team_name": "%s", "team_id": %d, "self_service": false, "software_title_id": %d}`,
 			createTeamResp.Team.Name,
 			createTeamResp.Team.ID,
 			titleID+1, // iOS title is created first and returned, so the latest title is the iPadOS one
@@ -22355,7 +22355,7 @@ func (s *integrationEnterpriseTestSuite) TestInHouseAppCRUD() {
 
 		// check activity
 		s.lastActivityOfTypeMatches(fleet.ActivityTypeDeletedSoftware{}.ActivityName(),
-			fmt.Sprintf(`{"labels_exclude_any":  [{"id": %d, "name": "%s"}], "software_title": "ipa_test", "software_package": "ipa_test2.ipa", "software_icon_url": null, "team_name": "%s", "team_id": %d, "self_service": true}`,
+			fmt.Sprintf(`{"labels_exclude_any":  [{"id": %d, "name": "%s"}], "software_title": "ipa_test", "software_package": "ipa_test2.ipa", "software_icon_url": null, "team_name": "%s", "team_id": %d, "self_service": false}`,
 				labelResp.Label.ID, labelResp.Label.Name, createTeamResp.Team.Name, createTeamResp.Team.ID), 0)
 
 		// download the installer, not found anymore

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -22348,7 +22348,7 @@ func (s *integrationEnterpriseTestSuite) TestInHouseAppCRUD() {
 		require.NoError(t, err)
 		require.Equal(t, expectedPayload.Filename, meta.Name)
 		require.Equal(t, expectedPayload.LabelsExcludeAny[0], meta.LabelsExcludeAny[0].LabelName)
-		require.Equal(t, expectedPayload.Categories, meta.Categories)
+		require.ElementsMatch(t, expectedPayload.Categories, meta.Categories)
 
 		// delete the installer
 		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", fmt.Sprintf("%d", *payload.TeamID))

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12133,10 +12133,10 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 	// Insert/deletion flow for iPadOS app
 	addedApp = expectedApps[1]
 	addAppResp = addAppStoreAppResponse{}
-	// Accepts self-service for iPadOS
+	// Self-service is not supported for iPadOS
 	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",
 		&addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: addedApp.AdamID, Platform: addedApp.Platform, SelfService: true},
-		http.StatusOK, &addAppResp)
+		http.StatusUnprocessableEntity, &addAppResp)
 	// No auto-install for iPadOS
 	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps",
 		&addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: addedApp.AdamID, Platform: addedApp.Platform, AutomaticInstall: true},

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -410,11 +410,11 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 		}
 	}
 
+	// Note: self-service is not supported for iOS/iPadOS apps (in-house apps)
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
 		TitleID:     titleID,
 		TeamID:      &team.ID,
 		DisplayName: ptr.String("InHouseAppUpdate2"),
-		SelfService: ptr.Bool(true),
 		Categories:  []string{"Developer tools", "Browsers"},
 	}, http.StatusOK, "")
 
@@ -438,7 +438,7 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 			"software_icon_url": null,
 			"team_name": "%s",
 		    "team_id": %d,
-			"self_service": true,
+			"self_service": false,
 			"software_title_id": %d,
 			"software_display_name": "%s"
 		}`,
@@ -454,8 +454,7 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 	// Entity has display name
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d", titleID), getSoftwareTitleRequest{}, http.StatusOK, &stResp, "team_id", fmt.Sprint(team.ID))
 	s.Assert().Equal("InHouseAppUpdate2", stResp.SoftwareTitle.DisplayName)
-	// PATCH semantics, so we shouldn't overwrite self service or categories
-	s.Assert().True(stResp.SoftwareTitle.SoftwarePackage.SelfService)
+	// PATCH semantics, so we shouldn't overwrite categories
 	s.Assert().ElementsMatch([]string{"Developer tools", "Browsers"}, stResp.SoftwareTitle.SoftwarePackage.Categories)
 
 	// List software titles has display name
@@ -464,8 +463,6 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 	for _, t := range resp.SoftwareTitles {
 		if t.ID == titleID {
 			s.Assert().Equal("InHouseAppUpdate2", t.DisplayName)
-			// PATCH semantics, so we shouldn't overwrite self service
-			s.Assert().True(*t.SoftwarePackage.SelfService)
 		}
 	}
 

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1558,16 +1558,11 @@ func (s *integrationMDMTestSuite) TestInHouseAppInstall() {
 	require.WithinDuration(t, time.Now(), st.SoftwareTitle.SoftwarePackage.UploadedAt, time.Hour)
 }
 
-func (s *integrationMDMTestSuite) TestInHouseAppSelfInstall() {
+func (s *integrationMDMTestSuite) TestInHouseAppSelfInstallNotSupported() {
 	t := s.T()
 	s.setSkipWorkerJobs(t)
-	ctx := context.Background()
 
-	// Enroll iPhone
-	iosHost, iosDevice := s.createAppleMobileHostThenEnrollMDM("ios")
-	s.appleVPPConfigSrvConfig.SerialNumbers = append(s.appleVPPConfigSrvConfig.SerialNumbers, iosDevice.SerialNumber)
-
-	// Upload in-house app for iOS, not available in self-service for now
+	// Upload in-house app for iOS, not available in self-service
 	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{Filename: "ipa_test.ipa"}, http.StatusOK, "")
 
 	// get its title ID
@@ -1583,128 +1578,10 @@ func (s *integrationMDMTestSuite) TestInHouseAppSelfInstall() {
 		"team_id": null, "self_service": false, "software_title_id": %d}`, titleID)
 	s.lastActivityMatches(fleet.ActivityTypeAddedSoftware{}.ActivityName(), activityData, 0)
 
-	// Add certificate authentication for iPhone
-	iosHost, err := s.ds.Host(ctx, iosHost.ID)
-	require.NoError(t, err)
-	certSerial := uint64(123456789)
-	headers := map[string]string{
-		"X-Client-Cert-Serial": fmt.Sprintf("%d", certSerial),
-	}
-	s.addHostIdentityCertificate(iosHost.UUID, certSerial)
-
-	// self-install with no authentication
-	s.DoRawNoAuth("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, 999), nil, http.StatusUnauthorized)
-
-	// self-install a non-existing title
-	res := s.DoRawWithHeaders("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, 999), nil, http.StatusBadRequest, headers)
-	errMsg := extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Software title is not available for install.")
-
-	// self-install an existing title not available for self-install
-	res = s.DoRawWithHeaders("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, titleID), nil, http.StatusBadRequest, headers)
-	errMsg = extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Software title is not available through self-service")
-
-	// update the in-house app to make it self-service
+	// Attempting to update the in-house app to make it self-service should fail
+	// because self-service is not supported for iOS/iPadOS apps
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{SelfService: ptr.Bool(true), TitleID: titleID, TeamID: nil},
-		http.StatusOK, "")
-	activityData = fmt.Sprintf(`{"software_title": "ipa_test", "software_package": "ipa_test.ipa", "software_display_name": "", "software_icon_url": null, "team_name": null,
-		"team_id": null, "self_service": true, "software_title_id": %d}`, titleID)
-	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), activityData, 0)
-
-	// self-install request is accepted
-	s.DoRawWithHeaders("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, titleID), nil, http.StatusAccepted, headers)
-
-	var installCmdUUID string
-	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &installCmdUUID, "SELECT command_uuid FROM host_in_house_software_installs WHERE host_id = ?", iosHost.ID)
-	})
-	require.NotEmpty(t, installCmdUUID)
-
-	// last activity is still "edited software" as the installed activity is created only when
-	// the install is verified
-	s.lastActivityMatches(fleet.ActivityTypeEditedSoftware{}.ActivityName(), "", 0)
-
-	// Process the InstallApplication command
-	s.runWorker()
-	cmd, err := iosDevice.Idle()
-	require.NoError(t, err)
-
-	for cmd != nil {
-		var fullCmd micromdm.CommandPayload
-		if cmd.Command.RequestType == "InstallApplication" {
-			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			assert.Equal(t, installCmdUUID, cmd.CommandUUID)
-
-			// Points at the expected manifest URL
-			expectedManifestURL := fmt.Sprintf("%s/api/latest/fleet/software/titles/%d/in_house_app/manifest?team_id=%d", s.server.URL, titleID, 0)
-			assert.Contains(t, string(cmd.Raw), expectedManifestURL)
-
-			cmd, err = iosDevice.Acknowledge(cmd.CommandUUID)
-			require.NoError(t, err)
-		}
-	}
-
-	// Install verification command should be sent, acknowledge it
-	cmd, err = iosDevice.Idle()
-	require.NoError(t, err)
-	assert.NotNil(t, cmd)
-	for cmd != nil {
-		var fullCmd micromdm.CommandPayload
-		switch cmd.Command.RequestType {
-		case "InstalledApplicationList":
-			require.NoError(t, plist.Unmarshal(cmd.Raw, &fullCmd))
-			require.Contains(t, cmd.CommandUUID, fleet.VerifySoftwareInstallVPPPrefix)
-			cmd, err = iosDevice.AcknowledgeInstalledApplicationList(
-				iosDevice.UUID,
-				cmd.CommandUUID,
-				[]fleet.Software{
-					{Name: "test", BundleIdentifier: "com.ipa-test.ipa-test", Version: "1.0", Installed: true},
-				},
-			)
-			require.NoError(t, err)
-		default:
-			require.Fail(t, "unexpected MDM command on client", cmd.Command.RequestType)
-		}
-	}
-
-	// installed activity is now created
-	activityData = fmt.Sprintf(`{"host_id": %d, "host_display_name": %q, "command_uuid": %q, "install_uuid": "",
-	"software_title": "ipa_test", "software_package": "", "self_service": true, "status": "installed",
-	"policy_id": null, "policy_name": null}`, iosHost.ID, iosHost.DisplayName(), installCmdUUID)
-	s.lastActivityMatches(fleet.ActivityTypeInstalledSoftware{}.ActivityName(), activityData, 0)
-
-	// host has no more upcoming activities
-	var listUpcomingAct listHostUpcomingActivitiesResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities/upcoming", iosHost.ID), nil, http.StatusOK, &listUpcomingAct)
-	require.Len(t, listUpcomingAct.Activities, 0)
-
-	// host has the past activity for the installed app
-	var listPastResp listActivitiesResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d/activities", iosHost.ID), nil, http.StatusOK, &listPastResp)
-	require.Len(t, listPastResp.Activities, 1)
-
-	// update the app to have a label condition
-	clr := createLabelResponse{}
-	s.DoJSON("POST", "/api/latest/fleet/labels", createLabelRequest{
-		LabelPayload: fleet.LabelPayload{Name: "L1", HostIDs: []uint{}}}, http.StatusOK, &clr)
-
-	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
-		TitleID: titleID, TeamID: nil, LabelsIncludeAny: []string{"L1"},
-	}, http.StatusOK, "")
-
-	// self-install request is rejected
-	res = s.DoRawWithHeaders("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, titleID), nil, http.StatusBadRequest, headers)
-	errMsg = extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "This software is not available for this host.")
-
-	// add the label to the host, so it can be installed
-	var addLabelsToHostResp addLabelsToHostResponse
-	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/labels", iosHost.ID), addLabelsToHostRequest{
-		Labels: []string{"L1"}}, http.StatusOK, &addLabelsToHostResp)
-
-	// self-install request is now accepted
-	s.DoRawWithHeaders("POST", fmt.Sprintf("/api/v1/fleet/device/%s/software/install/%d", iosHost.UUID, titleID), nil, http.StatusAccepted, headers)
+		http.StatusUnprocessableEntity, "Self-service is not supported for iOS and iPadOS apps")
 }
 
 func (s *integrationMDMTestSuite) addHostIdentityCertificate(hostUUID string, certSerial uint64) {


### PR DESCRIPTION
Fixes #36360.

This PR Temporarily blocks self-service for iOS/iPadOS at all key API entry points. 