### PR TITLE
Website: Update create-compliance-partner-tenant error handling

### DIFF
--- a/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
+++ b/website/api/controllers/microsoft-proxy/create-compliance-partner-tenant.js
@@ -47,7 +47,9 @@ module.exports = {
       entraTenantId: entraTenantId,
       fleetInstanceUrl: this.req.get('origin'),
       setupCompleted: false,
-    }).fetch();
+    })
+    .fetch()
+    .tolerate('E_UNIQUE', 'connectionAlreadyExists');
 
 
     return {


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/36356

Changes:
- updated the website's `create-compliance-partner-tenant` microsoft proxy endpoint to return a `connectionAlreadyExists` response when a uniqueness error is returned by the database adapter.