### PR TITLE
CP: android api usage reduction -> 4.77

### DIFF
--- a/changes/36138-reduce-android-api-usage
+++ b/changes/36138-reduce-android-api-usage
@@ -1,0 +1,1 @@
+* Reduce Android API usage by listing devices instead of getting, and checking Android Enterprise disconnects hourly.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -839,6 +839,7 @@ func newCleanupsAndAggregationSchedule(
 	softwareInstallStore fleet.SoftwareInstallerStore,
 	bootstrapPackageStore fleet.MDMBootstrapPackageStore,
 	softwareTitleIconStore fleet.SoftwareTitleIconStore,
+	androidSvc android.Service,
 ) (*schedule.Schedule, error) {
 	const (
 		name            = string(fleet.CronCleanupsThenAggregation)
@@ -1059,6 +1060,9 @@ func newCleanupsAndAggregationSchedule(
 				level.Info(logger).Log("msg", "revoked old conditional access certificates", "count", count)
 			}
 			return nil
+		}),
+		schedule.WithJob("cleanup_android_enterprise", func(ctx context.Context) error {
+			return androidSvc.VerifyExistingEnterpriseIfAny(ctx)
 		}),
 	)
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -969,7 +969,7 @@ the way that the Fleet server works.
 				func() (fleet.CronSchedule, error) {
 					commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
 					return newCleanupsAndAggregationSchedule(
-						ctx, instanceID, ds, svc, logger, redisWrapperDS, &config, commander, softwareInstallStore, bootstrapPackageStore, softwareTitleIconStore,
+						ctx, instanceID, ds, svc, logger, redisWrapperDS, &config, commander, softwareInstallStore, bootstrapPackageStore, softwareTitleIconStore, androidSvc,
 					)
 				},
 			); err != nil {

--- a/server/mdm/android/mock/client.go
+++ b/server/mdm/android/mock/client.go
@@ -25,6 +25,8 @@ type EnterprisesDevicesGetFunc func(ctx context.Context, deviceName string) (*an
 
 type EnterprisesDevicesDeleteFunc func(ctx context.Context, deviceName string) error
 
+type EnterprisesDevicesListPartialFunc func(ctx context.Context, enterpriseName string, pageToken string) (*androidmanagement.ListDevicesResponse, error)
+
 type EnterprisesEnrollmentTokensCreateFunc func(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error)
 
 type EnterpriseDeleteFunc func(ctx context.Context, enterpriseName string) error
@@ -51,6 +53,9 @@ type Client struct {
 
 	EnterprisesDevicesDeleteFunc        EnterprisesDevicesDeleteFunc
 	EnterprisesDevicesDeleteFuncInvoked bool
+
+	EnterprisesDevicesListPartialFunc        EnterprisesDevicesListPartialFunc
+	EnterprisesDevicesListPartialFuncInvoked bool
 
 	EnterprisesEnrollmentTokensCreateFunc        EnterprisesEnrollmentTokensCreateFunc
 	EnterprisesEnrollmentTokensCreateFuncInvoked bool
@@ -107,6 +112,13 @@ func (p *Client) EnterprisesDevicesDelete(ctx context.Context, deviceName string
 	p.EnterprisesDevicesDeleteFuncInvoked = true
 	p.mu.Unlock()
 	return p.EnterprisesDevicesDeleteFunc(ctx, deviceName)
+}
+
+func (p *Client) EnterprisesDevicesListPartial(ctx context.Context, enterpriseName string, pageToken string) (*androidmanagement.ListDevicesResponse, error) {
+	p.mu.Lock()
+	p.EnterprisesDevicesListPartialFuncInvoked = true
+	p.mu.Unlock()
+	return p.EnterprisesDevicesListPartialFunc(ctx, enterpriseName, pageToken)
 }
 
 func (p *Client) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken) (*androidmanagement.EnrollmentToken, error) {

--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -19,6 +19,11 @@ type Service interface {
 	// UnenrollAndroidHost triggers unenrollment (work profile removal) for the given Android host ID.
 	UnenrollAndroidHost(ctx context.Context, hostID uint) error
 	EnableAppReportsOnDefaultPolicy(ctx context.Context) error
+
+	// verifyExistingEnterpriseIfAny checks if there's an existing enterprise in the database
+	// and if so, verifies it still exists in Google API. If it doesn't exist, performs cleanup.
+	// Returns fleet.IsNotFound error if enterprise was deleted, nil if no enterprise exists or verification passed.
+	VerifyExistingEnterpriseIfAny(ctx context.Context) error
 }
 
 // /////////////////////////////////////////////

--- a/server/mdm/android/service/androidmgmt/client.go
+++ b/server/mdm/android/service/androidmgmt/client.go
@@ -38,6 +38,13 @@ type Client interface {
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/delete
 	EnterprisesDevicesDelete(ctx context.Context, deviceName string) error
 
+	// EnterprisesDevicesListPartial lists devices for the given enterprise with partial fields.
+	// Page size of 100 devices
+	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.devices/list
+	// Currently the devices has the following attributes:
+	// Name
+	EnterprisesDevicesListPartial(ctx context.Context, enterpriseName string, pageToken string) (*androidmanagement.ListDevicesResponse, error)
+
 	// EnterprisesEnrollmentTokensCreate creates an enrollment token for a given enterprise. It is used to enroll an Android device.
 	// See: https://developers.google.com/android/management/reference/rest/v1/enterprises.enrollmentTokens/create
 	EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string,

--- a/server/mdm/android/service/androidmgmt/google_client.go
+++ b/server/mdm/android/service/androidmgmt/google_client.go
@@ -212,6 +212,14 @@ func (g *GoogleClient) EnterprisesDevicesDelete(ctx context.Context, deviceName 
 	return nil
 }
 
+func (g *GoogleClient) EnterprisesDevicesListPartial(ctx context.Context, enterpriseName string, pageToken string) (*androidmanagement.ListDevicesResponse, error) {
+	ret, err := g.mgmt.Enterprises.Devices.List(enterpriseName).Context(ctx).PageToken(pageToken).PageSize(100).Fields("nextPageToken", "devices/name").Do()
+	if err != nil {
+		return nil, fmt.Errorf("listing devices: %w", err)
+	}
+	return ret, nil
+}
+
 func (g *GoogleClient) EnterprisesEnrollmentTokensCreate(ctx context.Context, enterpriseName string, token *androidmanagement.EnrollmentToken,
 ) (*androidmanagement.EnrollmentToken, error) {
 	if g == nil || g.mgmt == nil {

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -262,8 +262,8 @@ func TestGetEnterprise(t *testing.T) {
 			return nil, &notFoundError{}
 		}
 
-		activityModule := activities.NewActivityModule(fleetDS, logger)
-		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, "test-private-key", &fleetDS.DataStore, activityModule)
+		fleetSvc := mockService{}
+		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
 		enterprise, err := svc.GetEnterprise(ctx)

--- a/server/mdm/android/service/enterprises_test.go
+++ b/server/mdm/android/service/enterprises_test.go
@@ -249,8 +249,37 @@ func TestGetEnterprise(t *testing.T) {
 		enterprise, err := svc.GetEnterprise(ctx)
 		require.NoError(t, err)
 		require.NotNil(t, enterprise)
-		assert.True(t, androidAPIClient.EnterprisesListFuncInvoked)
+		assert.False(t, androidAPIClient.EnterprisesListFuncInvoked, "Should not call android API in get to avoid hitting quotas")
 	})
+
+	t.Run("enterprise not found in database", func(t *testing.T) {
+		androidAPIClient := android_mock.Client{}
+		androidAPIClient.InitCommonMocks()
+
+		// Override GetEnterpriseFunc to return not found
+		fleetDS := InitCommonDSMocks()
+		fleetDS.Store.GetEnterpriseFunc = func(ctx context.Context) (*android.Enterprise, error) {
+			return nil, &notFoundError{}
+		}
+
+		activityModule := activities.NewActivityModule(fleetDS, logger)
+		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, "test-private-key", &fleetDS.DataStore, activityModule)
+		require.NoError(t, err)
+
+		enterprise, err := svc.GetEnterprise(ctx)
+		require.Error(t, err)
+		require.Nil(t, enterprise)
+
+		// Should not call Google API if enterprise not found in database
+		assert.False(t, androidAPIClient.EnterprisesListFuncInvoked)
+		assert.Contains(t, err.Error(), "No enterprise found")
+	})
+}
+
+func TestVerifyExistingEnterpriseIfAny(t *testing.T) {
+	logger := kitlog.NewLogfmtLogger(os.Stdout)
+	user := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx := viewer.NewContext(context.Background(), viewer.Viewer{User: user})
 
 	t.Run("enterprise actually deleted - enterprise NOT in LIST", func(t *testing.T) {
 		androidAPIClient := android_mock.Client{}
@@ -283,9 +312,8 @@ func TestGetEnterprise(t *testing.T) {
 		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
-		enterprise, err := svc.GetEnterprise(ctx)
+		err = svc.VerifyExistingEnterpriseIfAny(ctx)
 		require.Error(t, err)
-		require.Nil(t, enterprise)
 
 		// Verify LIST API was called
 		assert.True(t, androidAPIClient.EnterprisesListFuncInvoked)
@@ -333,9 +361,8 @@ func TestGetEnterprise(t *testing.T) {
 		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
-		enterprise, err := svc.GetEnterprise(ctx)
-		require.NoError(t, err) // Should succeed since LIST found the enterprise
-		require.NotNil(t, enterprise)
+		err = svc.VerifyExistingEnterpriseIfAny(ctx)
+		require.NoError(t, err)
 
 		// Verify LIST API was called
 		assert.True(t, androidAPIClient.EnterprisesListFuncInvoked)
@@ -375,9 +402,8 @@ func TestGetEnterprise(t *testing.T) {
 		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
-		enterprise, err := svc.GetEnterprise(ctx)
+		err = svc.VerifyExistingEnterpriseIfAny(ctx)
 		require.Error(t, err)
-		require.Nil(t, enterprise)
 
 		// Verify LIST API was called
 		assert.True(t, androidAPIClient.EnterprisesListFuncInvoked)
@@ -417,9 +443,8 @@ func TestGetEnterprise(t *testing.T) {
 		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
-		enterprise, err := svc.GetEnterprise(ctx)
+		err = svc.VerifyExistingEnterpriseIfAny(ctx)
 		require.Error(t, err)
-		require.Nil(t, enterprise)
 
 		// Should still return 404 for deleted enterprise even if SetAndroidEnabledAndConfigured fails
 		assert.Contains(t, err.Error(), "Android Enterprise has been deleted")
@@ -485,17 +510,15 @@ func TestGetEnterprise(t *testing.T) {
 				svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 				require.NoError(t, err)
 
-				enterprise, err := svc.GetEnterprise(ctx)
+				err = svc.VerifyExistingEnterpriseIfAny(ctx)
 
 				if tc.shouldFindInList {
 					// Enterprise found in list
 					require.NoError(t, err)
-					require.NotNil(t, enterprise)
 					assert.False(t, setAndroidCalled, "Should not turn off Android when enterprise exists")
 				} else {
 					// Enterprise not found in list - should be deletion
 					require.Error(t, err)
-					require.Nil(t, enterprise)
 					assert.True(t, setAndroidCalled, "Should turn off Android when enterprise deleted")
 					assert.Contains(t, err.Error(), "Android Enterprise has been deleted")
 				}
@@ -517,12 +540,10 @@ func TestGetEnterprise(t *testing.T) {
 		svc, err := NewServiceWithClient(logger, fleetDS, &androidAPIClient, &fleetSvc, "test-private-key", &fleetDS.DataStore)
 		require.NoError(t, err)
 
-		enterprise, err := svc.GetEnterprise(ctx)
-		require.Error(t, err)
-		require.Nil(t, enterprise)
+		err = svc.VerifyExistingEnterpriseIfAny(ctx)
+		require.Nil(t, err)
 
 		// Should not call Google API if enterprise not found in database
 		assert.False(t, androidAPIClient.EnterprisesListFuncInvoked)
-		assert.Contains(t, err.Error(), "No enterprise found")
 	})
 }

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/tests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/androidmanagement/v1"

--- a/server/mdm/android/tests/enterprise/enterprise_test.go
+++ b/server/mdm/android/tests/enterprise/enterprise_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/tests"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/api/androidmanagement/v1"
@@ -133,69 +132,4 @@ func (s *enterpriseTestSuite) TestEnterpriseSSE() {
 	data, err = io.ReadAll(resp.Body)
 	assert.NoError(s.T(), err)
 	assert.Contains(s.T(), string(data), assert.AnError.Error())
-}
-
-func (s *enterpriseTestSuite) TestEnterpriseDeletedDetection() {
-	s.SetupTest()
-
-	// First, create an enterprise to test with
-	var signupResp android.EnterpriseSignupResponse
-	s.DoJSON("GET", "/api/v1/fleet/android_enterprise/signup_url", nil, http.StatusOK, &signupResp)
-
-	s.FleetSvc.On("NewActivity", mock.Anything, mock.Anything, mock.AnythingOfType("fleet.ActivityTypeEnabledAndroidMDM")).Return(nil)
-	const enterpriseToken = "enterpriseToken"
-	s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
-
-	// Update LIST mock to return the enterprise after "creation"
-	s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
-		return []*androidmanagement.Enterprise{
-			{Name: "enterprises/" + tests.EnterpriseID},
-		}, nil
-	}
-
-	// Verify enterprise exists
-	var resp android.GetEnterpriseResponse
-	s.DoJSON("GET", "/api/v1/fleet/android_enterprise", nil, http.StatusOK, &resp)
-	assert.Equal(s.T(), tests.EnterpriseID, resp.EnterpriseID)
-
-	t := s.T()
-
-	t.Run("enterprise deleted detection - 403 from GET, empty LIST", func(t *testing.T) {
-		// Mock EnterprisesListFunc to return empty list (enterprise deleted)
-		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
-			return []*androidmanagement.Enterprise{}, nil
-		}
-
-		// Attempt to get enterprise - should return 404 when enterprise is detected as deleted
-		var getResp android.GetEnterpriseResponse
-		s.DoJSON("GET", "/api/v1/fleet/android_enterprise", nil, http.StatusNotFound, &getResp)
-
-		// Verify LIST API was called
-		assert.True(t, s.AndroidAPIClient.EnterprisesListFuncInvoked)
-	})
-
-	t.Run("enterprise exists but permission issue - 403 from GET, enterprise in LIST", func(t *testing.T) {
-		// Re-create enterprise for this test since the previous test deleted it
-		var signupResp android.EnterpriseSignupResponse
-		s.DoJSON("GET", "/api/v1/fleet/android_enterprise/signup_url", nil, http.StatusOK, &signupResp)
-		s.FleetSvc.On("NewActivity", mock.Anything, mock.Anything, mock.AnythingOfType("fleet.ActivityTypeEnabledAndroidMDM")).Return(nil)
-		s.Do("GET", s.ProxyCallbackURL, nil, http.StatusOK, "enterpriseToken", "enterpriseToken2")
-
-		// Reset invocation flags for clean test
-		s.AndroidAPIClient.EnterprisesListFuncInvoked = false
-
-		// Mock EnterprisesListFunc to return the enterprise
-		s.AndroidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
-			return []*androidmanagement.Enterprise{
-				{Name: "enterprises/" + tests.EnterpriseID},
-			}, nil
-		}
-
-		// Attempt to get enterprise - should succeed since LIST found the enterprise
-		var getResp android.GetEnterpriseResponse
-		s.DoJSON("GET", "/api/v1/fleet/android_enterprise", nil, http.StatusOK, &getResp)
-
-		// Verify LIST API was called
-		assert.True(t, s.AndroidAPIClient.EnterprisesListFuncInvoked)
-	})
 }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -3100,6 +3100,15 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	testTeam, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "TestTeam"})
 	require.NoError(t, err)
 
+	// Ensure MDM is turned on
+	appConfig, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	appConfig.MDM.AndroidEnabledAndConfigured = true
+	appConfig.MDM.EnabledAndConfigured = true
+	appConfig.MDM.WindowsEnabledAndConfigured = true
+	err = s.ds.SaveAppConfig(ctx, appConfig)
+	require.NoError(t, err)
+
 	// NOTE: label names starting with "-" are sent as "labels_excluding_any"
 	// (and the leading "-" is removed from the name). Names starting with
 	// "!" are sent as the deprecated "labels" field (and the "!" is removed).

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -127,7 +127,6 @@ type integrationMDMTestSuite struct {
 	scepConfig                *eeservice.SCEPConfigService
 	androidSvc                *android_service.Service
 	androidAPIClient          *android_mock.Client
-	proxyCallbackURL          string
 }
 
 // appleVPPConfigSrvConf is used to configure the mock server that mocks Apple's VPP endpoints.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -35,6 +35,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
+
+	/* android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service" */
+	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
+	"github.com/fleetdm/fleet/v4/server/mdm/android/tests"
+	"google.golang.org/api/androidmanagement/v1"
+
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	"github.com/fleetdm/fleet/v4/pkg/fleetdbase"
@@ -99,8 +107,10 @@ type integrationMDMTestSuite struct {
 	depStorage                 nanodep_storage.AllDEPStorage
 	profileSchedule            *schedule.Schedule
 	integrationsSchedule       *schedule.Schedule
+	cleanupsSchedule           *schedule.Schedule
 	onProfileJobDone           func() // function called when profileSchedule.Trigger() job completed
 	onIntegrationsScheduleDone func() // function called when integrationsSchedule.Trigger() job completed
+	onCleanupScheduleDone      func() // function called when cleanupsSchedule.Trigger() job completed
 	mdmStorage                 *mysql.NanoMDMStorage
 	worker                     *worker.Worker
 	// Flag to skip jobs processing by worker
@@ -115,6 +125,8 @@ type integrationMDMTestSuite struct {
 	appleGDMFSrv              *httptest.Server
 	mockedDownloadFleetdmMeta fleetdbase.Metadata
 	scepConfig                *eeservice.SCEPConfigService
+	androidAPIClient          *android_mock.Client
+	proxyCallbackURL          string
 }
 
 // appleVPPConfigSrvConf is used to configure the mock server that mocks Apple's VPP endpoints.
@@ -191,6 +203,18 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
 		wlog = kitlog.NewNopLogger()
 	}
+
+	androidMockClient := &android_mock.Client{}
+	androidMockClient.SetAuthenticationSecretFunc = func(secret string) error {
+		return nil
+	}
+	/* androidSvc, err := android_service.NewServiceWithClient(wlog, s.ds, androidMockClient, svc, "test-private-key", s.ds)
+	if err != nil {
+		panic(err)
+	}
+	androidSvc.(*android_service.Service).AllowLocalhostServerURL = true */
+	// TODO: FIX ANDROID SVC INIT
+
 	macosJob := &worker.MacosSetupAssistant{
 		Datastore:  s.ds,
 		Log:        wlog,
@@ -221,6 +245,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 
 	var integrationsSchedule *schedule.Schedule
 	var profileSchedule *schedule.Schedule
+	var cleanupsSchedule *schedule.Schedule
 	cronLog := kitlog.NewJSONLogger(os.Stdout)
 	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
 		cronLog = kitlog.NewNopLogger()
@@ -337,6 +362,24 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 			},
 			func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc {
 				return func() (fleet.CronSchedule, error) {
+					const name = string(fleet.CronCleanupsThenAggregation)
+					logger := cronLog
+					cleanupsSchedule = schedule.New(
+						ctx, name, s.T().Name(), 1*time.Hour, ds, ds,
+						schedule.WithLogger(logger),
+						schedule.WithJob("cleanup_android_enterprise", func(ctx context.Context) error {
+							if s.onCleanupScheduleDone != nil {
+								defer s.onCleanupScheduleDone()
+							}
+							return nil
+							/* return androidSvc.VerifyExistingEnterpriseIfAny(ctx) */
+						}),
+					)
+					return cleanupsSchedule, nil
+				}
+			},
+			func(ctx context.Context, ds fleet.Datastore) fleet.NewCronScheduleFunc {
+				return func() (fleet.CronSchedule, error) {
 					const name = string(fleet.CronAppleMDMIPhoneIPadRefetcher)
 					logger := cronLog
 					refetcherSchedule := schedule.New(
@@ -382,6 +425,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	s.depStorage = depStorage
 	s.integrationsSchedule = integrationsSchedule
 	s.profileSchedule = profileSchedule
+	s.cleanupsSchedule = cleanupsSchedule
 	s.mdmStorage = mdmStorage
 	s.mdmCommander = mdmCommander
 	s.logger = serverLogger
@@ -756,6 +800,11 @@ func (s *integrationMDMTestSuite) TearDownTest() {
 
 	mysql.ExecAdhocSQL(t, s.ds, func(tx sqlx.ExtContext) error {
 		_, err := tx.ExecContext(ctx, "DELETE FROM vpp_apps;")
+		return err
+	})
+
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM android_enterprises`)
 		return err
 	})
 }
@@ -9361,6 +9410,27 @@ func (s *integrationMDMTestSuite) runIntegrationsSchedule() {
 	_, err := s.integrationsSchedule.Trigger()
 	require.NoError(s.T(), err)
 	<-ch
+}
+
+func (s *integrationMDMTestSuite) awaitRunCleanupSchedule() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	s.onCleanupScheduleDone = wg.Done
+	_, err := s.cleanupsSchedule.Trigger()
+	require.NoError(s.T(), err)
+	// Add timeout detection
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Completed successfully
+	case <-time.After(5 * time.Minute):
+		s.T().Fatalf("Cleanup schedule jobs timed out after 5 minutes")
+	}
 }
 
 func (s *integrationMDMTestSuite) getRawTokenValue(content string) string {
@@ -18076,4 +18146,88 @@ func (s *integrationMDMTestSuite) TestWipeWindowsReenrollAsNewHost() {
 	s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/wipe", newHost.ID), nil, http.StatusOK, &wipeResp)
 	require.Equal(t, fleet.PendingActionWipe, wipeResp.PendingAction)
 	require.Equal(t, fleet.DeviceStatusUnlocked, wipeResp.DeviceStatus)
+}
+
+func (s *integrationMDMTestSuite) TestAndroidEnterpriseDeletedDetection() {
+	t := s.T()
+	ctx := t.Context()
+
+	// ----- SETUP
+
+	appConfig, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	originalAppConfig := *appConfig
+	appConfig.MDM.AndroidEnabledAndConfigured = false
+	err = s.ds.SaveAppConfig(ctx, appConfig)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := s.ds.SaveAppConfig(context.Background(), &originalAppConfig)
+		require.NoError(t, err)
+	})
+
+	// ---- SETUP DONE
+
+	s.androidAPIClient.InitCommonMocks()
+
+	var proxyCallbackURL string
+	s.androidAPIClient.SignupURLsCreateFunc = func(_ context.Context, _, callbackURL string) (*android.SignupDetails, error) {
+		url, err := url.Parse(callbackURL)
+		require.NoError(t, err)
+		proxyCallbackURL = url.EscapedPath() + "?" + url.RawQuery
+		return &android.SignupDetails{
+			Url:  tests.EnterpriseSignupURL,
+			Name: "signupUrls/Cb0812d0999c464f",
+		}, nil
+	}
+	s.androidAPIClient.EnterprisesCreateFunc = func(_ context.Context, _ androidmgmt.EnterprisesCreateRequest) (androidmgmt.EnterprisesCreateResponse, error) {
+		return androidmgmt.EnterprisesCreateResponse{
+			EnterpriseName: "enterprises/" + tests.EnterpriseID,
+			TopicName:      "projects/android/topics/ae98ed130-5ce2-4ddb-a90a-191ec76976d5",
+		}, nil
+	}
+	s.androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
+		return []*androidmanagement.Enterprise{}, nil
+	}
+
+	// First, create an enterprise to test with
+	var signupResp android.EnterpriseSignupResponse
+	s.DoJSON("GET", "/api/latest/fleet/android_enterprise/signup_url", nil, http.StatusOK, &signupResp)
+
+	const enterpriseToken = "enterpriseToken"
+	s.Do("GET", proxyCallbackURL, nil, http.StatusOK, "enterpriseToken", enterpriseToken)
+
+	// Update LIST mock to return the enterprise after "creation"
+	s.androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
+		return []*androidmanagement.Enterprise{
+			{Name: "enterprises/" + tests.EnterpriseID},
+		}, nil
+	}
+
+	// Verify enterprise exists
+	var resp android.GetEnterpriseResponse
+	s.DoJSON("GET", "/api/latest/fleet/android_enterprise", nil, http.StatusOK, &resp)
+	assert.Equal(t, tests.EnterpriseID, resp.EnterpriseID)
+
+	t.Run("enterprise deleted detection", func(t *testing.T) {
+		// Mock EnterprisesListFunc to return empty list (enterprise deleted)
+		s.androidAPIClient.EnterprisesListFunc = func(_ context.Context, _ string) ([]*androidmanagement.Enterprise, error) {
+			return []*androidmanagement.Enterprise{}, nil
+		}
+
+		// Attempt to get enterprise - should return 200 until cron is ran
+		var getResp android.GetEnterpriseResponse
+		s.DoJSON("GET", "/api/latest/fleet/android_enterprise", nil, http.StatusOK, &getResp)
+		// Verify LIST API was not called
+		assert.False(t, s.androidAPIClient.EnterprisesListFuncInvoked)
+
+		// Trigger cron
+		s.awaitRunCleanupSchedule()
+
+		// Verify LIST API was called
+		assert.True(t, s.androidAPIClient.EnterprisesListFuncInvoked)
+
+		// Attempt to get enterprise - should now return 404 since cron detected deletion
+		s.DoJSON("GET", "/api/v1/fleet/android_enterprise", nil, http.StatusNotFound, &getResp)
+	})
 }

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -33,6 +33,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
+	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	nanodep_storage "github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
@@ -393,6 +394,7 @@ type TestServerOpts struct {
 	ConditionalAccessMicrosoftProxy ConditionalAccessMicrosoftProxy
 	HostIdentity                    *HostIdentity
 	ConditionalAccess               *ConditionalAccess
+	AndroidSvc                      *android_service.Service
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
@@ -498,6 +500,9 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	var featureRoutes []endpoint_utils.HandlerRoutesFunc
 	if len(opts) > 0 && len(opts[0].FeatureRoutes) > 0 {
 		featureRoutes = opts[0].FeatureRoutes
+	}
+	if len(opts) > 0 && opts[0].AndroidSvc != nil {
+		featureRoutes = append(featureRoutes, android_service.GetRoutes(svc, opts[0].AndroidSvc))
 	}
 	var extra []ExtraHandlerOption
 	extra = append(extra, WithLoginRateLimit(throttled.PerMin(1000)))

--- a/website/api/controllers/android-proxy/get-android-devices.js
+++ b/website/api/controllers/android-proxy/get-android-devices.js
@@ -1,0 +1,103 @@
+module.exports = {
+
+
+  friendlyName: 'Get android devices',
+
+
+  description: 'List android devices accessible to the Android enterprise.',
+
+
+  inputs: {
+    androidEnterpriseId: {
+      type: 'string',
+      required: true,
+    },
+    pageSize: {
+      type: 'number',
+      description: 'The maximum number of devices to return.',
+      min: 1,
+      defaultsTo: 100,
+      isInteger: true,
+    },
+    pageToken: {
+      type: 'string',
+    },
+    fields: {
+      type: 'string',
+      description: 'Selector specifying which fields to include in a partial response if any.',
+    }
+  },
+
+
+  exits: {
+    success: { description: 'Android devices list was successfully retrieved.' },
+    missingAuthHeader: { description: 'This request was missing an authorization header.', responseType: 'unauthorized'},
+    missingOriginHeader: { description: 'The request was missing an Origin header', responseType: 'badRequest'},
+    unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
+  },
+
+
+  fn: async function ({ androidEnterpriseId, pageSize, pageToken, fields }) {
+
+    // Extract fleetServerSecret from the Authorization header
+    let authHeader = this.req.get('authorization');
+    let fleetServerSecret;
+
+    if (authHeader && authHeader.startsWith('Bearer')) {
+      fleetServerSecret = authHeader.replace('Bearer', '').trim();
+    } else {
+      throw 'missingAuthHeader';
+    }
+
+
+    let thisAndroidEnterprise = await AndroidEnterprise.findOne({
+      androidEnterpriseId: androidEnterpriseId
+    });
+
+    if (!thisAndroidEnterprise) {
+      throw 'notFound';
+    }
+
+    if (thisAndroidEnterprise.fleetServerSecret !== fleetServerSecret) {
+      throw 'unauthorized';
+    }
+
+
+    // List android devices from an enterprises using the passed parameters
+    return await sails.helpers.flow.build(async ()=>{
+      let { google } = require('googleapis');
+      let androidmanagement = google.androidmanagement('v1');
+
+      let googleAuth = new google.auth.GoogleAuth({
+        scopes: [
+          'https://www.googleapis.com/auth/androidmanagement'
+        ],
+        credentials: {
+          client_email: sails.config.custom.androidEnterpriseServiceAccountEmailAddress,// eslint-disable-line camelcase
+          private_key: sails.config.custom.androidEnterpriseServiceAccountPrivateKey,// eslint-disable-line camelcase
+        },
+      });
+
+      // Acquire the google auth client
+      let authClient = await googleAuth.getClient();
+      google.options({auth: authClient});
+
+      // Get the Android devices list from Google
+      let devicesResponse = await androidmanagement.enterprises.devices.list({
+        parent: `enterprises/${thisAndroidEnterprise.androidEnterpriseId}`,
+        pageSize: pageSize,
+        pageToken: pageToken,
+        fields: fields,
+      });
+      // Return the devices (no filtering needed since parent parameter already filters by enterprise)
+      return devicesResponse.data;
+
+    }).intercept({status: 429}, (err)=>{
+      // If the Android management API returns a 429 response, log an additional warning that will trigger a help-p1 alert.
+      sails.log.warn(`p1: Android management API rate limit exceeded!`);
+      return new Error(`When attempting to list devices for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    }).intercept((err)=>{
+      return new Error(`When attempting to list devices for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+    });
+  }
+};

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1065,7 +1065,8 @@ module.exports.routes = {
   'POST /api/android/v1/enterprises/:androidEnterpriseId/enrollmentTokens': { action: 'android-proxy/create-android-enrollment-token', csrf: false},
   'PATCH /api/android/v1/enterprises/:androidEnterpriseId/policies/:policyId': { action: 'android-proxy/modify-android-policies', csrf: false},
   'DELETE /api/android/v1/enterprises/:androidEnterpriseId': { action: 'android-proxy/delete-one-android-enterprise', csrf: false},
-  'GET /api/android/v1/enterprises/:androidEnterpriseId/devices/:deviceId': { action: 'android-proxy/get-android-device', csrf: false},
+  'GET /api/android/v1/enterprises/:androidEnterpriseId/devices/:deviceId': { action: 'android-proxy/get-android-device', csrf: false },
+  'GET /api/android/v1/enterprises/:androidEnterpriseId/devices': { action: 'android-proxy/get-android-devices', csrf: false },
   'DELETE /api/android/v1/enterprises/:androidEnterpriseId/devices/:deviceId': { action: 'android-proxy/delete-android-device', csrf: false},
   'PATCH /api/android/v1/enterprises/:androidEnterpriseId/devices/:deviceId': { action: 'android-proxy/modify-android-device', csrf: false},
 


### PR DESCRIPTION
Cherry picks: https://github.com/fleetdm/fleet/pull/36209 into 4.77, but I had to make manual adjustments (only to tests) since the new activity work was also in, so I had to convert some of the code back to make it build and test pass.