### PR TITLE
Product Design handbook: Changes to the activity feed are closed instead of merged

### DIFF
--- a/handbook/product-design/README.md
+++ b/handbook/product-design/README.md
@@ -61,7 +61,7 @@ At Fleet, like [GitLab](https://about.gitlab.com/handbook/product-development-fl
    - Add a link to the issue in the PR description.
    - Attach the `~api-or-yaml-design` label. (This helps the [API design DRI](https://fleetdm.com/handbook/company/communications#directly-responsible-individuals-dris) prioritize API/YAML PR review.)
    - Mark the PR ready for review. (Draft PRs do not auto-request reviews.)
-   - After your changes are approved by the API design DRI, they will merge your changes into the docs release branch.
+   - After your changes are approved by the API design DRI, they will merge your changes into the docs release branch. Changes to the activity feed (audit logs) are closed instead of merged because the [audit-logs.md file is auto-generated](https://fleetdm.com/handbook/company/communications#audit-logs).
 
 5. Add links to the user story as specified in the [issue template](https://github.com/fleetdm/fleet/issues/new?template=story.md).
 


### PR DESCRIPTION
Example: https://github.com/fleetdm/fleet/pull/32481
