### PR TITLE
Fleet UI: GitOps mode icon color

### DIFF
--- a/frontend/components/icons/GitOpsMode.tsx
+++ b/frontend/components/icons/GitOpsMode.tsx
@@ -10,7 +10,7 @@ interface IGitOpsModeIconProps {
 
 const GitOpsMode = ({
   // size = "small",
-  color = "core-fleet-white",
+  color = "ui-fleet-black-75",
 }: IGitOpsModeIconProps) => {
   // const iconSize = ICON_SIZES[size];
   return (


### PR DESCRIPTION
For the following bug:
- https://github.com/fleetdm/fleet/issues/34557
