### PR TITLE
Add malicious package checking (Shai-Halud only) to website CI/CD test script

### DIFF
--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -67,12 +67,12 @@ jobs:
       - run: cd website/ && npm test
 
       # Scan for malicious packages
-      - name: Security Scan with Shai-Hulud Detector
-        run: |
-          git clone https://github.com/Cobenian/shai-hulud-detect
-          cd shai-hulud-detect
-          chmod +x shai-hulud-detector.sh
-          ./shai-hulud-detector.sh --paranoid ../ # Pipeline will automatically fail on exit codes 1 or 2
+      # - name: Security Scan with Shai-Hulud Detector
+#         run: |
+          # git clone https://github.com/Cobenian/shai-hulud-detect
+#          cd shai-hulud-detect
+#          chmod +x shai-hulud-detector.sh
+# #          ./shai-hulud-detector.sh --paranoid ../ # Pipeline will automatically fail on exit codes 1 or 2
 
       # Compile assets
       - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -66,5 +66,11 @@ jobs:
       # Run sanity checks
       - run: cd website/ && npm test
 
+      # Scan for malicious packages
+      - name: Security Scan with Shai-Hulud Detector
+        run: |
+          chmod +x ./shai-hulud-detector.sh
+          ./shai-hulud-detector.sh .
+
       # Compile assets
       - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -69,8 +69,10 @@ jobs:
       # Scan for malicious packages
       - name: Security Scan with Shai-Hulud Detector
         run: |
-          chmod +x ./shai-hulud-detector.sh
-          ./shai-hulud-detector.sh .
+          git clone https://github.com/Cobenian/shai-hulud-detect
+          cd shai-hulud-detect
+          chmod +x shai-hulud-detector.sh
+          ./shai-hulud-detector.sh --paranoid ../../../website/ # Pipeline will automatically fail on exit codes 1 or 2
 
       # Compile assets
       - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod

--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -72,7 +72,7 @@ jobs:
           git clone https://github.com/Cobenian/shai-hulud-detect
           cd shai-hulud-detect
           chmod +x shai-hulud-detector.sh
-          ./shai-hulud-detector.sh --paranoid ../../../website/ # Pipeline will automatically fail on exit codes 1 or 2
+          ./shai-hulud-detector.sh --paranoid ../ # Pipeline will automatically fail on exit codes 1 or 2
 
       # Compile assets
       - run: cd website/ && BUILD_SCRIPT_ARGS="--githubAccessToken=${{ secrets.FLEET_GITHUB_TOKEN_FOR_WEBSITE_TEST }}" npm run build-for-prod


### PR DESCRIPTION
For the Shai-Hulud attack: Check for malicious npm packages from nested deps in the Fleet website code base (and ttps)

EDIT: This is so incredibly slow it is impractical to run every time.  But I ran it on this branch, results below. 

(TODO: paste results when finished)
<img width="635" height="459" alt="image" src="https://github.com/user-attachments/assets/e3224e32-d454-41da-add6-a7b73800f4b0" />
<img width="546" height="260" alt="image" src="https://github.com/user-attachments/assets/ebf0951e-c093-4870-bc19-8f70ad3c409e" />


Finally, I'll comment this out so we have it as an example for next time we need to check something like this, but also so that this can be merged without slowing down build time for everybody.



