### PR TITLE
Update how we version Google Chrome for macOS

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
@@ -23,7 +23,8 @@ var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps
 }
 
 func ChromePKGInstaller(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
-	app.Version = "latest"
+	// Override installer URL to use Google's PKG installer instead of Homebrew's DMG
+	// Version is kept from Homebrew (not set to "latest")
 	app.InstallerURL = "https://dl.google.com/dl/chrome/mac/universal/stable/gcem/GoogleChrome.pkg"
 
 	return app, nil

--- a/ee/maintained-apps/outputs/google-chrome/darwin.json
+++ b/ee/maintained-apps/outputs/google-chrome/darwin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "version": "latest",
+      "version": "142.0.7444.176",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';"
       },


### PR DESCRIPTION
- Updating how we version Google Chrome for macOS. The current process of using "latest" as the version number means we are never validating the pkg we are installing. It also doesn't display a good pkg version for admins to track. This change may introduce a small window where the pkg that gets installed is newer than the version we represent on our website or in our library. This is an accepted risk since we can say we have validated up to that version.