### PR TITLE
Update FMA workflows to only uninstall Google Chrome when required

### DIFF
--- a/.github/workflows/test-fma-darwin-pr-only.yml
+++ b/.github/workflows/test-fma-darwin-pr-only.yml
@@ -77,6 +77,7 @@ jobs:
         run: |
           if [ "${{ steps.check-changes.outputs.has_changes }}" != "true" ]; then
             echo "has_darwin_apps=false" >> $GITHUB_OUTPUT
+            echo "has_google_chrome=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
@@ -85,6 +86,7 @@ jobs:
 
           if [ -z "$DARWIN_SLUGS" ]; then
             echo "has_darwin_apps=false" >> $GITHUB_OUTPUT
+            echo "has_google_chrome=false" >> $GITHUB_OUTPUT
             echo "No darwin apps changed, skipping Darwin workflow"
           else
             echo "has_darwin_apps=true" >> $GITHUB_OUTPUT
@@ -92,6 +94,14 @@ jobs:
             echo "$DARWIN_SLUGS" | while read -r slug; do
               echo "  - $slug"
             done
+
+            # Check if google-chrome/darwin is in the changed apps
+            if echo "$DARWIN_SLUGS" | grep -q "^google-chrome/darwin$"; then
+              echo "has_google_chrome=true" >> $GITHUB_OUTPUT
+              echo "Google Chrome detected in changed apps"
+            else
+              echo "has_google_chrome=false" >> $GITHUB_OUTPUT
+            fi
           fi
         shell: bash
 
@@ -107,7 +117,7 @@ jobs:
           sudo ln -sf /opt/osquery/lib/osquery.app/Contents/Resources/osqueryctl /usr/local/bin/osqueryctl
 
       - name: Remove pre-installed google chrome mac
-        if: steps.check-darwin-apps.outputs.has_darwin_apps == 'true'
+        if: steps.check-darwin-apps.outputs.has_darwin_apps == 'true' && steps.check-darwin-apps.outputs.has_google_chrome == 'true'
         run: |
           ls /Applications | grep -i "Chrome"
           find /Applications -name "*Chrome*.app" -type d | while read app;
@@ -122,7 +132,7 @@ jobs:
           cd fleet
           # Set GITHUB_WORKSPACE to current directory so scripts can find files
           export GITHUB_WORKSPACE="$PWD"
-          
+
           # Filter changed apps to only include darwin platform
           DARWIN_SLUGS=$(echo '${{ steps.detect-changed.outputs.CHANGED_APPS }}' | jq -r '.[] | select(endswith("/darwin"))')
           DARWIN_SLUGS_JSON=$(echo "$DARWIN_SLUGS" | jq -R -s -c 'split("\n") | map(select(length > 0))')

--- a/.github/workflows/test-fma-windows-pr-only.yml
+++ b/.github/workflows/test-fma-windows-pr-only.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           if ("${{ steps.check-changes.outputs.has_changes }}" -ne "true") {
             "has_windows_apps=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "has_google_chrome=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             exit 0
           }
 
@@ -93,11 +94,21 @@ jobs:
 
           if ($null -eq $windowsSlugs -or $windowsSlugs.Count -eq 0) {
             "has_windows_apps=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            "has_google_chrome=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             Write-Host "No windows apps changed, skipping Windows workflow"
           } else {
             "has_windows_apps=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
             Write-Host "Windows apps detected:"
             $windowsSlugs | ForEach-Object { Write-Host "  - $_" }
+
+            # Check if google-chrome/windows is in the changed apps
+            # Use -in operator which works for both arrays and single values
+            if ("google-chrome/windows" -in $windowsSlugs) {
+              "has_google_chrome=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+              Write-Host "Google Chrome detected in changed apps"
+            } else {
+              "has_google_chrome=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+            }
           }
         shell: pwsh
 
@@ -114,7 +125,7 @@ jobs:
         shell: pwsh
 
       - name: Remove pre-installed google chrome
-        if: steps.check-windows-apps.outputs.has_windows_apps == 'true'
+        if: steps.check-windows-apps.outputs.has_windows_apps == 'true' && steps.check-windows-apps.outputs.has_google_chrome == 'true'
         run: |
           Write-Host "Listing all installed packages containing 'Chrome':"
           Get-Package | Where-Object { $_.Name -like "*Chrome*" } | ForEach-Object {
@@ -143,7 +154,7 @@ jobs:
           cd fleet
           # Set GITHUB_WORKSPACE to current directory so scripts can find files
           $env:GITHUB_WORKSPACE = (Get-Location).Path
-          
+
           # Filter changed apps to only include windows platform
           $changedAppsJson = '${{ steps.detect-changed.outputs.CHANGED_APPS }}'
           $windowsSlugs = ($changedAppsJson | ConvertFrom-Json | Where-Object { $_ -like "*/windows" })


### PR DESCRIPTION
- Updating the FMA workflows to only uninstall Google Chrome if a new version of Google Chrome is getting tested. Otherwise this step in the workflow is unnecessary and makes the workflow take longer to finish. 