### PR TITLE
Always return fields for Windows MDM command result even if pending

### DIFF
--- a/changes/31819-always-return-object-for-pending-windows-commands
+++ b/changes/31819-always-return-object-for-pending-windows-commands
@@ -1,0 +1,1 @@
+* Improve MDM command result endpoint response for pending windows commands

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -85,6 +85,8 @@ WHERE TRUE
 		appleStmtWithFilter, windowsStmtWithFilter,
 	)
 
+	fmt.Println(stmt)
+
 	return stmt, params
 }
 
@@ -227,7 +229,7 @@ SELECT
 	mwe.host_uuid,
 	wq.command_uuid,
 	COALESCE(wcr.updated_at, wc.created_at) AS updated_at,
-	COALESCE(NULLIF(wcr.status_code, ''), 'Pending') AS status,
+	COALESCE(NULLIF(wcr.status_code, ''), '101') AS status,
 	wc.target_loc_uri AS request_type
 FROM
 	windows_mdm_command_queue wq

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -63,7 +63,7 @@ WHERE
 SELECT
     mwe.host_uuid,
     wmc.command_uuid,
-    COALESCE(NULLIF(wmcr.status_code, ''), 'Pending') as status,
+    COALESCE(NULLIF(wmcr.status_code, ''), '101') as status,
     COALESCE(wmc.updated_at, wmc.created_at) as updated_at,
     wmc.target_loc_uri as request_type,
     h.hostname,

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -85,8 +85,6 @@ WHERE TRUE
 		appleStmtWithFilter, windowsStmtWithFilter,
 	)
 
-	fmt.Println(stmt)
-
 	return stmt, params
 }
 

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -151,7 +151,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Len(t, cmds, 1)
 	require.Equal(t, winCmd.CommandUUID, cmds[0].CommandUUID)
 	require.Equal(t, winCmd.TargetLocURI, cmds[0].RequestType)
-	require.Equal(t, "Pending", cmds[0].Status)
+	require.Equal(t, "101", cmds[0].Status)
 
 	appleCmdUUID := uuid.New().String()
 	appleCmd := createRawAppleCmd("ProfileList", appleCmdUUID)
@@ -173,7 +173,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Pending", cmds[0].Status)
 	require.Equal(t, winCmd.CommandUUID, cmds[1].CommandUUID)
 	require.Equal(t, winCmd.TargetLocURI, cmds[1].RequestType)
-	require.Equal(t, "Pending", cmds[1].Status)
+	require.Equal(t, "101", cmds[1].Status)
 
 	// store results for both commands
 	err = appleCommanderStorage.StoreCommandReport(&mdm.Request{

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -32,6 +32,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestMDMWindowsInsertCommandForHosts", testMDMWindowsInsertCommandForHosts},
 		{"TestMDMWindowsGetPendingCommands", testMDMWindowsGetPendingCommands},
 		{"TestMDMWindowsCommandResults", testMDMWindowsCommandResults},
+		{"TestMDMWindowsCommandResultsWithPendingResult", testMDMWindowsCommandResultsWithPendingResult},
 		{"TestMDMWindowsProfileManagement", testMDMWindowsProfileManagement},
 		{"TestBulkOperationsMDMWindowsHostProfiles", testBulkOperationsMDMWindowsHostProfiles},
 		{"TestBulkOperationsMDMWindowsHostProfilesBatch2", testBulkOperationsMDMWindowsHostProfilesBatch2},
@@ -1446,6 +1447,81 @@ func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {
 	require.Equal(t, rawResponse, results[0].Result)
 	require.Equal(t, cmdTarget, results[0].RequestType)
 	require.Equal(t, statusCode, results[0].Status)
+	require.Empty(t, results[0].Hostname) // populated only at the service layer
+	require.Equal(t, rawCmd, string(results[0].Payload))
+
+	p, err = ds.GetMDMCommandPlatform(ctx, "unknown-cmd-uuid")
+	require.True(t, fleet.IsNotFound(err))
+	require.Empty(t, p)
+
+	results, err = ds.GetMDMWindowsCommandResults(ctx, "unknown-cmd-uuid")
+	require.NoError(t, err) // expect no error here, just no results
+	require.Empty(t, results)
+}
+
+func testMDMWindowsCommandResultsWithPendingResult(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	insertDB := func(t *testing.T, query string, args ...interface{}) (int64, error) {
+		t.Helper()
+		res, err := ds.writer(ctx).Exec(query, args...)
+		if err != nil {
+			return 0, err
+		}
+		return res.LastInsertId()
+	}
+
+	h, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:      "test-win-host-name",
+		OsqueryHostID: ptr.String("1337"),
+		NodeKey:       ptr.String("1337"),
+		UUID:          "test-win-host-uuid",
+		Platform:      "windows",
+	})
+	require.NoError(t, err)
+
+	dev := &fleet.MDMWindowsEnrolledDevice{
+		MDMDeviceID:            "test-device-id",
+		MDMHardwareID:          "test-hardware-id",
+		MDMDeviceState:         microsoft_mdm.MDMDeviceStateEnrolled,
+		MDMDeviceType:          "dt",
+		MDMDeviceName:          "dn",
+		MDMEnrollType:          "et",
+		MDMEnrollUserID:        "euid",
+		MDMEnrollProtoVersion:  "epv",
+		MDMEnrollClientVersion: "ecv",
+		MDMNotInOOBE:           false,
+		HostUUID:               h.UUID,
+	}
+
+	require.NoError(t, ds.MDMWindowsInsertEnrolledDevice(ctx, dev))
+	var enrollmentID uint
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &enrollmentID, `SELECT id FROM mdm_windows_enrollments WHERE mdm_device_id = ?`, dev.MDMDeviceID))
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE mdm_windows_enrollments SET host_uuid = ? WHERE id = ?`, dev.HostUUID, enrollmentID)
+	require.NoError(t, err)
+
+	rawCmd := "some-command"
+	cmdUUID := "some-uuid"
+	cmdTarget := "some-target-loc-uri"
+	_, err = insertDB(t, `INSERT INTO windows_mdm_commands (command_uuid, raw_command, target_loc_uri) VALUES (?, ?, ?)`, cmdUUID, rawCmd, cmdTarget)
+	require.NoError(t, err)
+
+	_, err = insertDB(t, `INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid) VALUES (?, ? )`, enrollmentID, cmdUUID)
+	require.NoError(t, err)
+
+	p, err := ds.GetMDMCommandPlatform(ctx, cmdUUID)
+	require.NoError(t, err)
+	require.Equal(t, "windows", p)
+
+	results, err := ds.GetMDMWindowsCommandResults(ctx, cmdUUID)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.Equal(t, dev.HostUUID, results[0].HostUUID)
+	require.Equal(t, cmdUUID, results[0].CommandUUID)
+	require.Equal(t, []byte{}, results[0].Result)
+	require.Equal(t, cmdTarget, results[0].RequestType)
+	require.Equal(t, "101", results[0].Status)
 	require.Empty(t, results[0].Hostname) // populated only at the service layer
 	require.Equal(t, rawCmd, string(results[0].Payload))
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31819 

I also ended up tweaking the return value for windows commands in the `commands` endpoint, so it aligns everywhere.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

MDM Command result with a pending command:
<img width="770" height="334" alt="Screenshot 2025-12-01 at 12 36 55" src="https://github.com/user-attachments/assets/51adb4bd-cc07-455c-8255-e1ec654521d2" />

MDM comman result with a result:
<img width="764" height="517" alt="Screenshot 2025-12-01 at 12 36 07" src="https://github.com/user-attachments/assets/dec2f1c1-e756-4170-a1d0-5496dc8039b9" />

