### PR TITLE
fix dropdown wrapper value wrapping down to new line

### DIFF
--- a/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
+++ b/frontend/components/forms/fields/DropdownWrapper/DropdownWrapper.tsx
@@ -368,6 +368,7 @@ export const generateCustomDropdownStyles = (
       padding: 0,
       display: "flex",
       gap: PADDING[variant === "button" ? "pad-xsmall" : "pad-small"],
+      flexWrap: "nowrap", // This ensures the value is on a single line and truncated
     }),
     option: (provided, state) => ({
       ...provided,


### PR DESCRIPTION
**Related issue:** Resolves #33987

quick fix to fix truncation for the value section on dropdown wrapper component 
