### PR TITLE
Disable iOS/iPadOS self-service in the UI

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/SoftwareNameCell.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { InjectedRouter } from "react-router";
 
-import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 
 import TooltipWrapper from "components/TooltipWrapper";
 import Icon from "components/Icon";
@@ -23,7 +23,6 @@ export type PageContext = "deviceUser" | "hostDetails" | "hostDetailsLibrary";
 interface InstallIconTooltip {
   automaticInstallPoliciesCount?: number;
   pageContext?: PageContext;
-  isIosOrIpados?: boolean;
 }
 
 interface InstallIconConfig {
@@ -51,8 +50,7 @@ const installIconMap: Record<InstallType, InstallIconConfig> = {
   },
   selfService: {
     iconName: "user",
-    tooltip: ({ isIosOrIpados = false }) =>
-      getSelfServiceTooltip(isIosOrIpados),
+    tooltip: () => SELF_SERVICE_TOOLTIP,
   },
   automatic: {
     iconName: "refresh",
@@ -78,7 +76,6 @@ interface IInstallIconWithTooltipProps {
   isSelfService: boolean;
   automaticInstallPoliciesCount?: number;
   pageContext?: PageContext;
-  isIosOrIpados?: boolean;
 }
 
 const getInstallIconType = (
@@ -95,7 +92,6 @@ const InstallIconWithTooltip = ({
   isSelfService,
   automaticInstallPoliciesCount,
   pageContext,
-  isIosOrIpados = false,
 }: IInstallIconWithTooltipProps) => {
   const iconType = getInstallIconType(
     isSelfService,
@@ -111,7 +107,6 @@ const InstallIconWithTooltip = ({
   const tipContent = tooltip({
     automaticInstallPoliciesCount,
     pageContext,
-    isIosOrIpados,
   });
 
   return (

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -13,7 +13,7 @@ import {
 import { Platform } from "interfaces/platform";
 import softwareAPI from "services/entities/software";
 
-import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 
 import Card from "components/Card";
 
@@ -308,7 +308,7 @@ const SoftwareInstallerCard = ({
                 <TooltipWrapper
                   showArrow
                   position="top"
-                  tipContent={getSelfServiceTooltip(isIosOrIpadosApp)}
+                  tipContent={SELF_SERVICE_TOOLTIP}
                   underline={false}
                 >
                   <Tag icon="user" text="Self-service" />

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -61,7 +61,7 @@ describe("SoftwareOptionsSelector", () => {
     expect(onToggleAutomaticInstall).toHaveBeenCalledWith(true);
   });
 
-  it("enables self-service and disables automatic install checkboxes for iOS", () => {
+  it("disables self-service and automatic install checkboxes for iOS", () => {
     renderComponent({ platform: "ios" });
 
     // Targeting the checkbox elements directly
@@ -72,11 +72,11 @@ describe("SoftwareOptionsSelector", () => {
       .getByText("Automatic install")
       .closest('[role="checkbox"]');
 
-    expect(selfServiceCheckbox).toHaveAttribute("aria-disabled", "false");
+    expect(selfServiceCheckbox).toHaveAttribute("aria-disabled", "true");
     expect(automaticInstallCheckbox).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("enables self-service and disables automatic install checkboxes for iPadOS", () => {
+  it("disables self-service and automatic install checkboxes for iPadOS", () => {
     renderComponent({ platform: "ipados" });
 
     // Targeting the checkbox elements directly
@@ -87,7 +87,7 @@ describe("SoftwareOptionsSelector", () => {
       .getByText("Automatic install")
       .closest('[role="checkbox"]');
 
-    expect(selfServiceCheckbox).toHaveAttribute("aria-disabled", "false");
+    expect(selfServiceCheckbox).toHaveAttribute("aria-disabled", "true");
     expect(automaticInstallCheckbox).toHaveAttribute("aria-disabled", "true");
   });
 
@@ -154,7 +154,9 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ios" });
 
     expect(
-      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
+      screen.getByText(
+        /Automatic install and self-service for iOS and iPadOS are coming soon./i
+      )
     ).toBeInTheDocument();
   });
 
@@ -162,7 +164,9 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ platform: "ipados" });
 
     expect(
-      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
+      screen.getByText(
+        /Automatic install and self-service for iOS and iPadOS are coming soon./i
+      )
     ).toBeInTheDocument();
   });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -6,7 +6,7 @@ import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
-import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
+import { SELF_SERVICE_TOOLTIP } from "pages/SoftwarePage/helpers";
 import { ISoftwareVppFormData } from "pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm";
 import { IFleetMaintainedAppFormData } from "pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm";
 import { IPackageFormData } from "pages/SoftwarePage/components/forms/PackageForm/PackageForm";
@@ -106,7 +106,7 @@ const SoftwareOptionsSelector = ({
 
   const isPlatformIosOrIpados =
     platform === "ios" || platform === "ipados" || isIpaPackage;
-  const isSelfServiceDisabled = disableOptions;
+  const isSelfServiceDisabled = disableOptions || isPlatformIosOrIpados;
   const isAutomaticInstallDisabled =
     disableOptions ||
     isPlatformIosOrIpados ||
@@ -154,9 +154,9 @@ const SoftwareOptionsSelector = ({
     // Render unavailable description for iOS or iPadOS add software form only
     return isPlatformIosOrIpados && !isEditingSoftware ? (
       <p>
-        Automatic install for iOS and iPadOS is coming soon. Today, you can
-        manually install it from the <strong>Host details</strong> page for each
-        host.
+        Automatic install and self-service for iOS and iPadOS are coming soon.
+        Today, you can manually install from the <strong>Host details</strong>{" "}
+        page for each host.
       </p>
     ) : null;
   };
@@ -170,12 +170,7 @@ const SoftwareOptionsSelector = ({
           value={formData.selfService}
           onChange={(newVal: boolean) => onToggleSelfService(newVal)}
           className={`${baseClass}__self-service-checkbox`}
-          labelTooltipContent={
-            !isSelfServiceDisabled &&
-            getSelfServiceTooltip(
-              isIpaPackage || isPlatformIosOrIpados || false
-            )
-          }
+          labelTooltipContent={!isSelfServiceDisabled && SELF_SERVICE_TOOLTIP}
           labelTooltipClickable // Allow interaction with link in tooltip
           disabled={isSelfServiceDisabled}
         >

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -170,31 +170,18 @@ export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
   },
 ];
 
-export const getSelfServiceTooltip = (isIosOrIpadosApp: boolean) => {
-  return isIosOrIpadosApp ? (
-    <>
-      End users can install from self-service.
-      <br />
-      <CustomLink
-        newTab
-        text="Learn how to deploy self-service"
-        variant="tooltip-link"
-        url={`${LEARN_MORE_ABOUT_BASE_LINK}/deploy-self-service-to-ios`}
-      />
-    </>
-  ) : (
-    <>
-      End users can install from <br />
-      <strong>Fleet Desktop</strong> &gt; <strong>Self-service</strong>. <br />
-      <CustomLink
-        newTab
-        text="Learn more"
-        variant="tooltip-link"
-        url={`${LEARN_MORE_ABOUT_BASE_LINK}/self-service-software`}
-      />
-    </>
-  );
-};
+export const SELF_SERVICE_TOOLTIP = (
+  <>
+    End users can install from <br />
+    <b>Fleet Desktop</b> &gt; <b>Self-service</b>. <br />
+    <CustomLink
+      newTab
+      text="Learn more"
+      variant="tooltip-link"
+      url={`${LEARN_MORE_ABOUT_BASE_LINK}/self-service-software`}
+    />
+  </>
+);
 
 export const getAutomaticInstallPoliciesCount = (
   softwareTitle: ISoftwareTitle | IHostSoftware


### PR DESCRIPTION
Fixes #36347. This PR temporarily disables self-service for iOS/iPadOS in the UI.