### PR TITLE
Fleet UI: Set dropdown font size to 14px

### DIFF
--- a/frontend/components/buttons/DropdownButton/_styles.scss
+++ b/frontend/components/buttons/DropdownButton/_styles.scss
@@ -41,7 +41,7 @@
       padding: 0 10px;
       white-space: nowrap;
       width: 100%;
-      font-size: 15px;
+      font-size: 14px;
       height: 32px;
       letter-spacing: -0.5px;
 


### PR DESCRIPTION
Chatted w/ @mike-j-thomas and we want 14px font size in the dropdown:

<img width="163" height="332" alt="Screenshot 2025-12-01 at 5 50 13 PM" src="https://github.com/user-attachments/assets/d6cd3c95-3fc9-47c2-ba0d-64d74eb9fcef" />

Addresses the following issue:
- https://github.com/fleetdm/fleet/issues/34983