### PR TITLE
Use writer for reads for software icon activity population

### DIFF
--- a/ee/server/service/software_title_icons.go
+++ b/ee/server/service/software_title_icons.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 
 	"github.com/fleetdm/fleet/v4/pkg/file"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -126,7 +127,7 @@ func (svc *Service) UploadSoftwareTitleIcon(ctx context.Context, payload *fleet.
 	// if anything on the icon has changed, we need to generate a new activity
 	if icon == nil || icon.StorageID != softwareTitleIcon.StorageID || icon.Filename != softwareTitleIcon.Filename {
 		iconUrl := fmt.Sprintf("/api/latest/fleet/software/titles/%d/icon?team_id=%d", softwareTitleIcon.SoftwareTitleID, softwareTitleIcon.TeamID)
-		activityDetailsForSoftwareTitleIcon, err := svc.ds.ActivityDetailsForSoftwareTitleIcon(ctx, payload.TeamID, payload.TitleID)
+		activityDetailsForSoftwareTitleIcon, err := svc.ds.ActivityDetailsForSoftwareTitleIcon(ctxdb.RequirePrimary(ctx, true), payload.TeamID, payload.TitleID)
 		if err != nil {
 			return fleet.SoftwareTitleIcon{}, ctxerr.Wrap(ctx, err, "fetching software title icon activity details")
 		}
@@ -150,7 +151,7 @@ func (svc *Service) DeleteSoftwareTitleIcon(ctx context.Context, teamID uint, ti
 		return fleet.ErrNoContext
 	}
 	user := vc.User
-	activityDetailsForSoftwareTitleIcon, err := svc.ds.ActivityDetailsForSoftwareTitleIcon(ctx, teamID, titleID)
+	activityDetailsForSoftwareTitleIcon, err := svc.ds.ActivityDetailsForSoftwareTitleIcon(ctxdb.RequirePrimary(ctx, true), teamID, titleID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "fetching software title icon activity details")
 	}

--- a/server/datastore/mysql/software_title_icons.go
+++ b/server/datastore/mysql/software_title_icons.go
@@ -166,7 +166,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 		LEFT JOIN vpp_apps_teams ON vpp_apps_teams.adam_id = vpp_apps.adam_id AND vpp_apps_teams.platform = vpp_apps.platform
 		WHERE software_title_icons.team_id = ? AND software_title_icons.software_title_id = ?
 	`
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &details, query, teamID, titleID)
+	err := sqlx.GetContext(ctx, ds.writer(ctx), &details, query, teamID, titleID)
 	if err != nil {
 		return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting activity details for software title icon")
 	}
@@ -187,7 +187,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON software_installer_labels.label_id = labels.id
 			WHERE software_installer_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.SoftwareInstallerID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.SoftwareInstallerID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}
@@ -201,7 +201,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON vpp_app_team_labels.label_id = labels.id
 			WHERE vpp_app_team_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.VPPAppTeamID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.VPPAppTeamID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}
@@ -215,7 +215,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON in_house_app_labels.label_id = labels.id
 			WHERE in_house_app_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.InHouseAppID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.InHouseAppID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}

--- a/server/datastore/mysql/software_title_icons.go
+++ b/server/datastore/mysql/software_title_icons.go
@@ -166,7 +166,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 		LEFT JOIN vpp_apps_teams ON vpp_apps_teams.adam_id = vpp_apps.adam_id AND vpp_apps_teams.platform = vpp_apps.platform
 		WHERE software_title_icons.team_id = ? AND software_title_icons.software_title_id = ?
 	`
-	err := sqlx.GetContext(ctx, ds.writer(ctx), &details, query, teamID, titleID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &details, query, teamID, titleID)
 	if err != nil {
 		return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting activity details for software title icon")
 	}
@@ -187,7 +187,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON software_installer_labels.label_id = labels.id
 			WHERE software_installer_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.SoftwareInstallerID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.SoftwareInstallerID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}
@@ -201,7 +201,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON vpp_app_team_labels.label_id = labels.id
 			WHERE vpp_app_team_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.VPPAppTeamID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.VPPAppTeamID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}
@@ -215,7 +215,7 @@ func (ds *Datastore) ActivityDetailsForSoftwareTitleIcon(ctx context.Context, te
 			INNER JOIN labels ON in_house_app_labels.label_id = labels.id
 			WHERE in_house_app_id = ?
 		`
-		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &labels, labelQuery, details.InHouseAppID); err != nil {
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &labels, labelQuery, details.InHouseAppID); err != nil {
 			return fleet.DetailsForSoftwareIconActivity{}, ctxerr.Wrap(ctx, err, "getting labels for software title icon")
 		}
 	}


### PR DESCRIPTION
Fixes #36090. Probably overkill to read both queries from the writer but given that this isn't a hot path it doesn't really hurt, and ensures consistency even in higher replica-lag situations where a software title is added/updated immediately before the associated icon is uploaded.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results