### PR TITLE
check MDM enrolled status in profile reconciler to not queue new profile installs for unenrolled hosts that hasn't checked in yet

### DIFF
--- a/changes/31516-dont-queue-profiles-for-unenrolled-hosts
+++ b/changes/31516-dont-queue-profiles-for-unenrolled-hosts
@@ -1,0 +1,1 @@
+* Fixed a case where a profile could be left on an Apple device after unenrolling.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2527,6 +2527,9 @@ type Datastore interface {
 	GetCurrentTime(ctx context.Context) (time.Time, error)
 
 	UpdateOrDeleteHostMDMWindowsProfile(ctx context.Context, profile *HostMDMWindowsProfile) error
+
+	// ListHostsMDM retrieves MDM information (from the host_mdm table) for the given host UUIDs.
+	ListHostsMDM(ctx context.Context, hostUUIDs []string) ([]*HostMDMWithUUID, error)
 }
 
 type AndroidDatastore interface {

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1147,15 +1147,15 @@ type HostMDM struct {
 
 // HostMDMWithUUID represents a host_mdm row without any additional joins other than host UUID.
 type HostMDMWithUUID struct {
-	HostID               uint   `db:"host_id" json:"-" csv:"-"`
-	Enrolled             bool   `db:"enrolled" json:"-" csv:"-"`
-	ServerURL            string `db:"server_url" json:"-" csv:"-"`
-	InstalledFromDep     bool   `db:"installed_from_dep" json:"-" csv:"-"`
-	IsServer             bool   `db:"is_server" json:"-" csv:"-"`
-	IsPersonalEnrollment bool   `db:"is_personal_enrollment" json:"-" csv:"-"`
-	MDMID                *uint  `db:"mdm_id" json:"-" csv:"-"`
-	HostUUID             string `db:"host_uuid" json:"host_uuid"`
-	EnrollmentStatus     string `db:"enrollment_status" json:"-" csv:"-"`
+	HostID               uint    `db:"host_id" json:"-" csv:"-"`
+	Enrolled             bool    `db:"enrolled" json:"-" csv:"-"`
+	ServerURL            string  `db:"server_url" json:"-" csv:"-"`
+	InstalledFromDep     bool    `db:"installed_from_dep" json:"-" csv:"-"`
+	IsServer             bool    `db:"is_server" json:"-" csv:"-"`
+	IsPersonalEnrollment bool    `db:"is_personal_enrollment" json:"-" csv:"-"`
+	MDMID                *uint   `db:"mdm_id" json:"-" csv:"-"`
+	HostUUID             string  `db:"host_uuid" json:"host_uuid"`
+	EnrollmentStatus     *string `db:"enrollment_status" json:"-" csv:"-"`
 }
 
 // HasJSONProfileAssigned returns true if Fleet has assigned an ADE/DEP JSON

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1145,6 +1145,19 @@ type HostMDM struct {
 	DEPProfileAssignStatus *string `db:"dep_profile_assign_status" json:"-" csv:"-"`
 }
 
+// HostMDMWithUUID represents a host_mdm row without any additional joins other than host UUID.
+type HostMDMWithUUID struct {
+	HostID               uint   `db:"host_id" json:"-" csv:"-"`
+	Enrolled             bool   `db:"enrolled" json:"-" csv:"-"`
+	ServerURL            string `db:"server_url" json:"-" csv:"-"`
+	InstalledFromDep     bool   `db:"installed_from_dep" json:"-" csv:"-"`
+	IsServer             bool   `db:"is_server" json:"-" csv:"-"`
+	IsPersonalEnrollment bool   `db:"is_personal_enrollment" json:"-" csv:"-"`
+	MDMID                *uint  `db:"mdm_id" json:"-" csv:"-"`
+	HostUUID             string `db:"host_uuid" json:"host_uuid"`
+	EnrollmentStatus     string `db:"enrollment_status" json:"-" csv:"-"`
+}
+
 // HasJSONProfileAssigned returns true if Fleet has assigned an ADE/DEP JSON
 // profile to the host, and it'll be enrolled into Fleet the next time the host
 // performs automatic enrollment.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1639,6 +1639,8 @@ type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
 type UpdateOrDeleteHostMDMWindowsProfileFunc func(ctx context.Context, profile *fleet.HostMDMWindowsProfile) error
 
+type ListHostsMDMFunc func(ctx context.Context, hostUUIDs []string) ([]*fleet.HostMDMWithUUID, error)
+
 type DataStore struct {
 	HealthCheckFunc        HealthCheckFunc
 	HealthCheckFuncInvoked bool
@@ -4063,6 +4065,9 @@ type DataStore struct {
 
 	UpdateOrDeleteHostMDMWindowsProfileFunc        UpdateOrDeleteHostMDMWindowsProfileFunc
 	UpdateOrDeleteHostMDMWindowsProfileFuncInvoked bool
+
+	ListHostsMDMFunc        ListHostsMDMFunc
+	ListHostsMDMFuncInvoked bool
 
 	mu sync.Mutex
 }
@@ -9721,4 +9726,11 @@ func (s *DataStore) UpdateOrDeleteHostMDMWindowsProfile(ctx context.Context, pro
 	s.UpdateOrDeleteHostMDMWindowsProfileFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateOrDeleteHostMDMWindowsProfileFunc(ctx, profile)
+}
+
+func (s *DataStore) ListHostsMDM(ctx context.Context, hostUUIDs []string) ([]*fleet.HostMDMWithUUID, error) {
+	s.mu.Lock()
+	s.ListHostsMDMFuncInvoked = true
+	s.mu.Unlock()
+	return s.ListHostsMDMFunc(ctx, hostUUIDs)
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5001,7 +5001,6 @@ func filterOutMDMUnenrolledHosts(ctx context.Context, installTargets map[string]
 			if hmdm, ok := hostMDMsByUUID[hostUUID]; ok && hmdm.Enrolled {
 				filtered = append(filtered, eid)
 			} else {
-				// mark the corresponding host profile as failed (or leave nil) and clear command
 				if hp, ok := hostProfilesToInstallMap[hostProfileUUID{HostUUID: hostUUID, ProfileUUID: profUUID}]; ok {
 					// Do not enqueue the profile, and set status to nil for it to be picked up again.
 					// Next time around we expect to have a checkout call which updates nano tables that we pull profiles based on.

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2708,6 +2708,13 @@ func TestMDMAppleReconcileAppleProfiles(t *testing.T) {
 		return baseProfilesToInstall, baseProfilesToRemove, nil
 	}
 
+	ds.ListHostsMDMFunc = func(ctx context.Context, hostUUIDs []string) ([]*fleet.HostMDMWithUUID, error) {
+		return []*fleet.HostMDMWithUUID{
+			{HostUUID: hostUUID1, Enrolled: true},
+			{HostUUID: hostUUID2, Enrolled: true},
+		}, nil
+	}
+
 	ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, profileUUIDs []string) (map[string]mobileconfig.Mobileconfig, error) {
 		require.ElementsMatch(t, []string{p1, p2, p4, p5}, profileUUIDs)
 		// only those profiles that are to be installed


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31516 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
