### PR TITLE
Fix index to ChromeOS tab

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -371,7 +371,7 @@ const PlatformWrapper = ({
               Chromebooks,&nbsp;
               <Button
                 variant="text-link-dark"
-                onClick={() => setSelectedTabIndex(4)}
+                onClick={() => setSelectedTabIndex(3)}
               >
                 click here
               </Button>


### PR DESCRIPTION
In `Advanced` when clicking on `click here` in `This works for macOS, Windows, and Linux hosts. To add Chromebooks, click here` it currently sends you to the `iOS & iPadOS` tab.