### PR TITLE
Update UI styling of links on setup experience controls page

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
@@ -6,11 +6,11 @@ import classnames from "classnames";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
+import CustomLink from "components/CustomLink";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 import TooltipWrapper from "components/TooltipWrapper";
-import { Link } from "react-router";
 
 const baseClass = "end-user-auth-form";
 
@@ -66,20 +66,20 @@ const EndUserAuthForm = ({
       <form>
         <p className={classes}>
           Require end users to authenticate with your{" "}
-          <Link to={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}>
-            identity provider (IdP)
-          </Link>{" "}
+          <CustomLink
+            url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
+            text="identity provider (IdP)"
+          />{" "}
           when they set up their new hosts.
           <br />
           <TooltipWrapper tipContent={getTooltipCopy()}>
             macOS
           </TooltipWrapper>{" "}
           hosts will also be required to agree to an{" "}
-          <Link
-            to={`${PATHS.ADMIN_INTEGRATIONS_MDM}#end-user-license-agreement`}
-          >
-            end user license agreement (EULA)
-          </Link>{" "}
+          <CustomLink
+            url={`${PATHS.ADMIN_INTEGRATIONS_MDM}#end-user-license-agreement`}
+            text="end user license agreement (EULA)"
+          />{" "}
           if configured.
         </p>
         <Checkbox

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -11,7 +11,8 @@ import mdmAPI from "services/entities/mdm";
 import Button from "components/buttons/Button";
 import { ISoftwareTitle } from "interfaces/software";
 import Checkbox from "components/forms/fields/Checkbox";
-import LinkWithContext from "components/LinkWithContext";
+import CustomLink from "components/CustomLink";
+
 import RevealButton from "components/buttons/RevealButton";
 import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -89,13 +90,10 @@ const AddInstallSoftware = ({
       return (
         <>
           No {platformText} software available. You can add software on the{" "}
-          <LinkWithContext
-            to={PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}
-            currentQueryParams={{ team_id: currentTeamId }}
-            withParams={{ type: "query", names: ["team_id"] }}
-          >
-            Software page
-          </LinkWithContext>
+          <CustomLink
+            url={`${PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}?team_id=${currentTeamId}`}
+            text="Software page"
+          />
           .
         </>
       );


### PR DESCRIPTION
Resolves #34725 

- Updates links to IdP and EULA on `/controls/setup-experience/end-user-auth` page
- Updates link to software on `/controls/setup-experience/install-software` page

<img width="702" height="134" alt="Screenshot 2025-12-02 at 9 51 40 AM" src="https://github.com/user-attachments/assets/12447ea2-9b17-4dc3-9be8-1e621968c788" />
<img width="642" height="230" alt="Screenshot 2025-12-02 at 9 51 26 AM" src="https://github.com/user-attachments/assets/94121f6a-5fce-4632-bb36-23be35125d19" />


