### PR TITLE
Use auth header for android end-points

### DIFF
--- a/changes/36287-android-cert-crud-use-auth-header
+++ b/changes/36287-android-cert-crud-use-auth-header
@@ -1,0 +1,1 @@
+* Updated 'fleetd/certificates/<id>' and 'fleetd/certificates/<id>/status' to authenticate using the orbit_node_key provided in the 'Authentication' header.

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
@@ -102,12 +103,12 @@ func (svc *Service) ListCertificateTemplates(ctx context.Context, teamID uint, p
 }
 
 type getDeviceCertificateTemplateRequest struct {
-	ID      uint   `url:"id"`
-	NodeKey string `query:"node_key"`
+	ID                 uint   `url:"id"`
+	OrbitNodeKeyHeader string `header:"Authorization"`
 }
 
-func (r *getDeviceCertificateTemplateRequest) hostNodeKey() string {
-	return r.NodeKey
+func (r *getDeviceCertificateTemplateRequest) orbitHostNodeKey() string {
+	return strings.TrimPrefix(r.OrbitNodeKeyHeader, "Node key ")
 }
 
 type getDeviceCertificateTemplateResponse struct {
@@ -336,15 +337,15 @@ func (svc *Service) DeleteCertificateTemplateSpecs(ctx context.Context, certific
 
 type updateCertificateStatusRequest struct {
 	CertificateTemplateID uint   `url:"id"`
-	NodeKey               string `json:"node_key"`
 	Status                string `json:"status"`
 	// Detail provides additional information about the status change.
 	// For example, it can be used to provide a reason for a failed status change.
-	Detail *string `json:"detail,omitempty"`
+	Detail             *string `json:"detail,omitempty"`
+	OrbitNodeKeyHeader string  `header:"Authorization"`
 }
 
-func (r *updateCertificateStatusRequest) hostNodeKey() string {
-	return r.NodeKey
+func (r *updateCertificateStatusRequest) orbitHostNodeKey() string {
+	return strings.TrimPrefix(r.OrbitNodeKeyHeader, "Node key ")
 }
 
 type updateCertificateStatusResponse struct {

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
@@ -103,12 +102,7 @@ func (svc *Service) ListCertificateTemplates(ctx context.Context, teamID uint, p
 }
 
 type getDeviceCertificateTemplateRequest struct {
-	ID                 uint   `url:"id"`
-	OrbitNodeKeyHeader string `header:"Authorization"`
-}
-
-func (r *getDeviceCertificateTemplateRequest) orbitHostNodeKey() string {
-	return strings.TrimPrefix(r.OrbitNodeKeyHeader, "Node key ")
+	ID uint `url:"id"`
 }
 
 type getDeviceCertificateTemplateResponse struct {
@@ -340,12 +334,7 @@ type updateCertificateStatusRequest struct {
 	Status                string `json:"status"`
 	// Detail provides additional information about the status change.
 	// For example, it can be used to provide a reason for a failed status change.
-	Detail             *string `json:"detail,omitempty"`
-	OrbitNodeKeyHeader string  `header:"Authorization"`
-}
-
-func (r *updateCertificateStatusRequest) orbitHostNodeKey() string {
-	return strings.TrimPrefix(r.OrbitNodeKeyHeader, "Node key ")
+	Detail *string `json:"detail,omitempty"`
 }
 
 type updateCertificateStatusResponse struct {

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -217,11 +217,39 @@ func newHostAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts [
 	}
 }
 
+func androidAuthenticatedEndpointer(
+	svc fleet.Service,
+	logger log.Logger,
+	opts []kithttp.ServerOption,
+	r *mux.Router,
+	versions ...string,
+) *eu.CommonEndpointer[eu.HandlerFunc] {
+	// Inject the fleet.Capabilities header to the response for Orbit hosts
+	opts = append(opts, capabilitiesResponseFunc(fleet.GetServerOrbitCapabilities()))
+	// Add the capabilities reported by Orbit to the request context
+	opts = append(opts, capabilitiesContextFunc())
+
+	return &eu.CommonEndpointer[eu.HandlerFunc]{
+		EP: &endpointer{
+			svc: svc,
+		},
+		MakeDecoderFn: makeDecoder,
+		EncodeFn:      encodeResponse,
+		Opts:          opts,
+		AuthFunc: func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint {
+			return authenticatedOrbitHost(svc, logger, next, authHeaderValue("Node key "))
+		},
+		FleetService: svc,
+		Router:       r,
+		Versions:     versions,
+	}
+}
+
 func newOrbitAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
 ) *eu.CommonEndpointer[eu.HandlerFunc] {
 	authFunc := func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint {
-		return authenticatedOrbitHost(svc, logger, next)
+		return authenticatedOrbitHost(svc, logger, next, getOrbitNodeKey)
 	}
 
 	// Inject the fleet.Capabilities header to the response for Orbit hosts

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -914,8 +914,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// These end-points are here because we want to use the orbit_node_key as the authentication mechanism.
 	// For android clients, the orbit_node_key is the only thing we have available when the device gets enrolled
 	// after the MDM setup.
-	oe.GET("/api/fleetd/certificates/{id:[0-9]+}", getDeviceCertificateTemplateEndpoint, getDeviceCertificateTemplateRequest{})
-	oe.PUT("/api/fleetd/certificates/{id:[0-9]+}/status", updateCertificateStatusEndpoint, updateCertificateStatusRequest{})
+	androidEndpoints := newOrbitAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
+	androidEndpoints.GET("/api/fleetd/certificates/{id:[0-9]+}", getDeviceCertificateTemplateEndpoint, getDeviceCertificateTemplateRequest{})
+	androidEndpoints.PUT("/api/fleetd/certificates/{id:[0-9]+}/status", updateCertificateStatusEndpoint, updateCertificateStatusRequest{})
 
 	oe.POST("/api/fleet/orbit/device_token", setOrUpdateDeviceTokenEndpoint, setOrUpdateDeviceTokenRequest{})
 	oe.POST("/api/fleet/orbit/config", getOrbitConfigEndpoint, orbitGetConfigRequest{})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -907,17 +907,16 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	he.WithAltPaths("/api/v1/osquery/yara/{name}").
 		POST("/api/osquery/yara/{name}", getYaraEndpoint, getYaraRequest{})
 
-	// orbit authenticated endpoints
-	oe := newOrbitAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
-
-	// android related end-points
-	// These end-points are here because we want to use the orbit_node_key as the authentication mechanism.
-	// For android clients, the orbit_node_key is the only thing we have available when the device gets enrolled
-	// after the MDM setup.
-	androidEndpoints := newOrbitAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
+	// android authenticated end-points
+	// Authentication is implemented using the orbit_node_key from the 'Authentication' header.
+	// The 'orbit_node_key' is used because it's the only thing we have available when the device gets enrolled
+	// after the MDM setup is complete.
+	androidEndpoints := androidAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
 	androidEndpoints.GET("/api/fleetd/certificates/{id:[0-9]+}", getDeviceCertificateTemplateEndpoint, getDeviceCertificateTemplateRequest{})
 	androidEndpoints.PUT("/api/fleetd/certificates/{id:[0-9]+}/status", updateCertificateStatusEndpoint, updateCertificateStatusRequest{})
 
+	// orbit authenticated endpoints
+	oe := newOrbitAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
 	oe.POST("/api/fleet/orbit/device_token", setOrUpdateDeviceTokenEndpoint, setOrUpdateDeviceTokenRequest{})
 	oe.POST("/api/fleet/orbit/config", getOrbitConfigEndpoint, orbitGetConfigRequest{})
 	// using POST to get a script execution request since all authenticated orbit

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -906,13 +906,17 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		POST("/api/osquery/log", submitLogsEndpoint, submitLogsRequest{})
 	he.WithAltPaths("/api/v1/osquery/yara/{name}").
 		POST("/api/osquery/yara/{name}", getYaraEndpoint, getYaraRequest{})
-	he.WithAltPaths("/api/v1/fleetd/certificates/{id:[0-9]+}").
-		GET("/api/fleetd/certificates/{id:[0-9]+}", getDeviceCertificateTemplateEndpoint, getDeviceCertificateTemplateRequest{})
-	he.WithAltPaths("/api/v1/fleetd/certificates/{id:[0-9]+}/status").
-		PUT("/api/fleetd/certificates/{id:[0-9]+}/status", updateCertificateStatusEndpoint, updateCertificateStatusRequest{})
 
 	// orbit authenticated endpoints
 	oe := newOrbitAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)
+
+	// android related end-points
+	// These end-points are here because we want to use the orbit_node_key as the authentication mechanism.
+	// For android clients, the orbit_node_key is the only thing we have available when the device gets enrolled
+	// after the MDM setup.
+	oe.GET("/api/fleetd/certificates/{id:[0-9]+}", getDeviceCertificateTemplateEndpoint, getDeviceCertificateTemplateRequest{})
+	oe.PUT("/api/fleetd/certificates/{id:[0-9]+}/status", updateCertificateStatusEndpoint, updateCertificateStatusRequest{})
+
 	oe.POST("/api/fleet/orbit/device_token", setOrUpdateDeviceTokenEndpoint, setOrUpdateDeviceTokenRequest{})
 	oe.POST("/api/fleet/orbit/config", getOrbitConfigEndpoint, orbitGetConfigRequest{})
 	// using POST to get a script execution request since all authenticated orbit

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -413,6 +413,11 @@ func MakeDecoder(
 		for _, fp := range fields {
 			field := fp.V
 
+			if headerTagValue, ok := fp.Sf.Tag.Lookup("header"); ok {
+				field.SetString(r.Header.Get(headerTagValue))
+				continue
+			}
+
 			urlTagValue, ok := fp.Sf.Tag.Lookup("url")
 
 			var err error

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -413,11 +413,6 @@ func MakeDecoder(
 		for _, fp := range fields {
 			field := fp.V
 
-			if headerTagValue, ok := fp.Sf.Tag.Lookup("header"); ok {
-				field.SetString(r.Header.Get(headerTagValue))
-				continue
-			}
-
 			urlTagValue, ok := fp.Sf.Tag.Lookup("url")
 
 			var err error


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36287 

Updated 'fleetd/certificates/<id>' and 'fleetd/certificates/<id>/status' to authenticate using the orbit_node_key provided in the 'Authentication' header.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests