### PR TITLE
Freeze versioning on Adobe Acrobat Pro (macOS)

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
+++ b/ee/maintained-apps/inputs/homebrew/adobe-acrobat-pro.json
@@ -4,5 +4,6 @@
   "token": "adobe-acrobat-pro",
   "installer_format": "dmg",
   "slug": "adobe-acrobat-pro/darwin",
-  "default_categories": ["Productivity"]
+  "default_categories": ["Productivity"],
+  "frozen": true
 }

--- a/ee/maintained-apps/inputs/homebrew/adobe-acrobat-reader.json
+++ b/ee/maintained-apps/inputs/homebrew/adobe-acrobat-reader.json
@@ -6,6 +6,5 @@
   "slug": "adobe-acrobat-reader/darwin",
   "default_categories": [
     "Productivity"
-  ],
-  "frozen": true
+  ]
 }


### PR DESCRIPTION
Freezing Adobe Acrobat Pro on macOS. They recently updated the product but did not update the installer leading to validation issues on our end. I am freezing this and will check back in a few days to see if it has been updated or if we need to update our validation. 