### PR TITLE
Fix unbound variable error in detect-new-fmas-in-pr.sh

### DIFF
--- a/.github/scripts/detect-new-fmas-in-pr.sh
+++ b/.github/scripts/detect-new-fmas-in-pr.sh
@@ -50,7 +50,11 @@ extract_slugs_from_changed_manifests() {
     done <<< "$changed_files"
     
     # Remove duplicates and sort
-    printf '%s\n' "${slugs[@]}" | sort -u
+    if [ ${#slugs[@]} -eq 0 ]; then
+        echo ""
+    else
+        printf '%s\n' "${slugs[@]}" | sort -u
+    fi
 }
 
 # Get changed files in outputs directory


### PR DESCRIPTION
The script was failing with "slugs[@]: unbound variable" when no manifest files matched the pattern in changed files. This occurred because bash's `set -u` (nounset) option treats accessing an empty array as an error.

Added a check to handle empty arrays gracefully by checking the array length before accessing it, preventing the script from failing when there are no matching manifest files.