### PR TITLE
Validate CA existence and type when creating cert templates

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3733,6 +3733,18 @@ func setupAndroidCertificatesTestMocks(t *testing.T, ds *mock.Store) []*fleet.Ce
 			URL:       ptr.String("https://ca2.example.com"),
 			Challenge: ptr.String("challenge2"),
 		},
+		{
+			ID:                            3,
+			Name:                          ptr.String("Test CA 3"),
+			Type:                          string(fleet.CATypeDigiCert),
+			URL:                           ptr.String("https://ca3.example.com"),
+			Challenge:                     ptr.String("challenge3"),
+			CertificateCommonName:         ptr.String("foo"),
+			CertificateSeatID:             ptr.String("foo"),
+			CertificateUserPrincipalNames: &[]string{"foo"},
+			APIToken:                      ptr.String("foo"),
+			ProfileID:                     ptr.String("foo"),
+		},
 	}
 
 	ds.BatchSetMDMProfilesFunc = func(
@@ -3818,10 +3830,10 @@ controls:
   android_settings:
     certificates:
       - name: "Certificate 1"
-        certificate_authority_name: "Test CA 1"
+        certificate_authority_name: "Test CA %d"
         subject_name: "CN=Device Certificate 1"
       - name: "Certificate 2"
-        certificate_authority_name: "Test CA 2"
+        certificate_authority_name: "Test CA %d"
         subject_name: "CN=Device Certificate 2"
 policies: []
 queries: []
@@ -3831,7 +3843,7 @@ software: null
 	tmpDir := t.TempDir()
 	teamFile, err := os.CreateTemp(tmpDir, "team-*.yml")
 	require.NoError(t, err)
-	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName))
+	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName, 1, 2))
 	require.NoError(t, err)
 
 	// Run GitOps
@@ -3849,6 +3861,20 @@ software: null
 
 	// Verify team was created
 	require.Contains(t, savedTeams, teamName)
+
+	// Try the same with a cert that uses a DigiCert CA
+	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName, 2, 3))
+	require.NoError(t, err)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Currently, only the custom_scep_proxy certificate authority is supported")
+
+	// Try the same with a non-existent CA
+	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName, 2, 4))
+	require.NoError(t, err)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "not found")
 }
 
 // TestGitOpsAndroidCertificatesChange tests changing existing Android certificates via GitOps

--- a/server/service/certificate_templates_test.go
+++ b/server/service/certificate_templates_test.go
@@ -1,0 +1,174 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateCertificateTemplate(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	type TestCAID uint
+
+	const (
+		InvalidCATypeID TestCAID = iota + 1
+		ValidCATypeID
+	)
+
+	const TeamID = 1
+
+	ds.GetCertificateAuthorityByIDFunc = func(ctx context.Context, id uint, includeSecrets bool) (*fleet.CertificateAuthority, error) {
+		if id == uint(InvalidCATypeID) {
+			ca := fleet.CertificateAuthority{
+				ID:   id,
+				Type: string(fleet.CATypeDigiCert),
+			}
+			return &ca, nil
+		}
+		if id == uint(ValidCATypeID) {
+			ca := fleet.CertificateAuthority{
+				ID:   id,
+				Type: string(fleet.CATypeCustomSCEPProxy),
+			}
+			return &ca, nil
+		}
+		return nil, errors.New("not found")
+	}
+
+	ds.CreateCertificateTemplateFunc = func(ctx context.Context, certificateTemplate *fleet.CertificateTemplate) (*fleet.CertificateTemplateResponseFull, error) {
+		return nil, nil
+	}
+	t.Run("Invalid CA type", func(t *testing.T) {
+		_, err := svc.CreateCertificateTemplate(ctx, "my template", TeamID, uint(InvalidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+		require.Error(t, err)
+		// Check that the error is about invalid CA type
+		require.Contains(t, err.Error(), "Currently, only the custom_scep_proxy certificate authority is supported")
+	})
+
+	t.Run("Valid CA type", func(t *testing.T) {
+		_, err := svc.CreateCertificateTemplate(ctx, "my template", TeamID, uint(ValidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+		require.NoError(t, err)
+	})
+
+	t.Run("Missing CA", func(t *testing.T) {
+		_, err := svc.CreateCertificateTemplate(ctx, "my template", TeamID, 999, "CN=$FLEET_VAR_HOST_UUID")
+		require.Error(t, err)
+		// Check that the error is about invalid CA type
+		require.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestApplyCertificateTemplateSpecs(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	// Set up certificate authority mocks
+	certAuthorities := []*fleet.CertificateAuthority{
+		{
+			ID:        1,
+			Name:      ptr.String("Test CA 1"),
+			Type:      string(fleet.CATypeCustomSCEPProxy),
+			URL:       ptr.String("https://ca1.example.com"),
+			Challenge: ptr.String("challenge1"),
+		},
+		{
+			ID:        2,
+			Name:      ptr.String("Test CA 2"),
+			Type:      string(fleet.CATypeCustomSCEPProxy),
+			URL:       ptr.String("https://ca2.example.com"),
+			Challenge: ptr.String("challenge2"),
+		},
+		{
+			ID:                            3,
+			Name:                          ptr.String("Test CA 3"),
+			Type:                          string(fleet.CATypeDigiCert),
+			URL:                           ptr.String("https://ca3.example.com"),
+			Challenge:                     ptr.String("challenge3"),
+			CertificateCommonName:         ptr.String("foo"),
+			CertificateSeatID:             ptr.String("foo"),
+			CertificateUserPrincipalNames: &[]string{"foo"},
+			APIToken:                      ptr.String("foo"),
+			ProfileID:                     ptr.String("foo"),
+		},
+	}
+
+	ds.ListCertificateAuthoritiesFunc = func(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error) {
+		summaries := make([]*fleet.CertificateAuthoritySummary, 0, len(certAuthorities))
+		for _, ca := range certAuthorities {
+			summaries = append(summaries, &fleet.CertificateAuthoritySummary{
+				ID:   ca.ID,
+				Name: *ca.Name,
+				Type: ca.Type,
+			})
+		}
+		return summaries, nil
+	}
+
+	// Track certificate templates that are created
+	var createdCertificates []fleet.CertificateTemplate
+
+	ds.BatchUpsertCertificateTemplatesFunc = func(ctx context.Context, certificates []*fleet.CertificateTemplate) error {
+		createdCertificates = nil
+		for _, cert := range certificates {
+			createdCertificates = append(createdCertificates, *cert)
+		}
+		return nil
+	}
+
+	t.Run("Valid CA types", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "Template 1",
+				CertificateAuthorityId: 1,
+				SubjectName:            "foo",
+			},
+			{
+				Name:                   "Template 2",
+				CertificateAuthorityId: 2,
+				SubjectName:            "bar",
+			},
+		})
+		require.NoError(t, err)
+		require.Len(t, createdCertificates, 2)
+		require.Equal(t, "Template 1", createdCertificates[0].Name)
+		require.Equal(t, uint(1), createdCertificates[0].CertificateAuthorityID)
+		require.Equal(t, "Template 2", createdCertificates[1].Name)
+		require.Equal(t, uint(2), createdCertificates[1].CertificateAuthorityID)
+	})
+
+	t.Run("Invalid CA type", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "Template 3",
+				CertificateAuthorityId: 3,
+				SubjectName:            "baz",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Currently, only the custom_scep_proxy certificate authority is supported")
+	})
+
+	t.Run("Missing CA", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "Template 4",
+				CertificateAuthorityId: 4,
+				SubjectName:            "baz",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "not found")
+	})
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36560 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

* Tested `fleetctl gitops` with and without `--dry-run`, with valid and invalid CA types
* Automated tests for public and contributor endpoints.