### PR TITLE
Allow saving Fleet Queries with invalid* SQL, update error text, some JS –> TS housekeeping 

### DIFF
--- a/changes/35058-allow-saving-queries-with-invalid-sql
+++ b/changes/35058-allow-saving-queries-with-invalid-sql
@@ -1,0 +1,1 @@
+- Allow users to save Fleet Queries even if their SQL is deemed invalid by the Fleet UI

--- a/frontend/components/forms/validators/validate_query/index.js
+++ b/frontend/components/forms/validators/validate_query/index.js
@@ -17,9 +17,7 @@ export const validateQuery = (queryText) => {
     parser.astify(queryText, { database: "sqlite" });
     return validQueryResponse;
   } catch (error) {
-    return invalidQueryResponse(
-      "There is a syntax error in your query; please resolve in order to save."
-    );
+    return invalidQueryResponse("Syntax error. Please review before saving.");
   }
 };
 

--- a/frontend/components/forms/validators/validate_query/index.js
+++ b/frontend/components/forms/validators/validate_query/index.js
@@ -1,5 +1,7 @@
 import { Parser } from "utilities/node-sql-parser/sqlite";
 
+export const EMPTY_QUERY_ERR = "Query text must be present";
+
 const invalidQueryResponse = (message) => {
   return { valid: false, error: message };
 };
@@ -8,7 +10,7 @@ const parser = new Parser();
 
 export const validateQuery = (queryText) => {
   if (!queryText) {
-    return invalidQueryResponse("Query text must be present");
+    return invalidQueryResponse(EMPTY_QUERY_ERR);
   }
 
   try {
@@ -21,4 +23,4 @@ export const validateQuery = (queryText) => {
   }
 };
 
-export default validateQuery;
+export default { EMPTY_QUERY_ERR, validateQuery };

--- a/frontend/components/forms/validators/validate_query/index.ts
+++ b/frontend/components/forms/validators/validate_query/index.ts
@@ -1,14 +1,16 @@
+// @ts-ignore
 import { Parser } from "utilities/node-sql-parser/sqlite";
 
 export const EMPTY_QUERY_ERR = "Query text must be present";
+export const INVALID_SYNTAX_ERR = "Syntax error. Please review before saving.";
 
-const invalidQueryResponse = (message) => {
+const invalidQueryResponse = (message: string) => {
   return { valid: false, error: message };
 };
 const validQueryResponse = { valid: true, error: null };
 const parser = new Parser();
 
-export const validateQuery = (queryText) => {
+export const validateQuery = (queryText?: string) => {
   if (!queryText) {
     return invalidQueryResponse(EMPTY_QUERY_ERR);
   }
@@ -17,8 +19,6 @@ export const validateQuery = (queryText) => {
     parser.astify(queryText, { database: "sqlite" });
     return validQueryResponse;
   } catch (error) {
-    return invalidQueryResponse("Syntax error. Please review before saving.");
+    return invalidQueryResponse(INVALID_SYNTAX_ERR);
   }
 };
-
-export default { EMPTY_QUERY_ERR, validateQuery };

--- a/frontend/components/forms/validators/validate_query/validate_query.tests.ts
+++ b/frontend/components/forms/validators/validate_query/validate_query.tests.ts
@@ -1,4 +1,4 @@
-import validateQuery from "./index";
+import { validateQuery, EMPTY_QUERY_ERR, INVALID_SYNTAX_ERR } from ".";
 
 const malformedQueries = ["this is not a thing", "SELECT * FROM foo bar baz"];
 const validQueries = [
@@ -22,9 +22,7 @@ describe("validateQuery", () => {
       const { error, valid } = validateQuery(query);
 
       expect(valid).toEqual(false);
-      expect(error).toMatch(
-        "There is a syntax error in your query; please resolve in order to save."
-      );
+      expect(error).toMatch(INVALID_SYNTAX_ERR);
     });
   });
 
@@ -32,13 +30,13 @@ describe("validateQuery", () => {
     const { error, valid } = validateQuery();
 
     expect(valid).toEqual(false);
-    expect(error).toEqual("Query text must be present");
+    expect(error).toEqual(EMPTY_QUERY_ERR);
   });
 
   it("accepts valid queries", () => {
     validQueries.forEach((query) => {
       const { error, valid } = validateQuery(query);
-      expect(valid).toEqual(true, query);
+      expect(valid).toEqual(true);
       expect(error).toBeFalsy();
     });
   });

--- a/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
+++ b/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
@@ -2,8 +2,7 @@ import React, { useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 import { IAceEditor } from "react-ace/lib/types";
 
-// @ts-ignore
-import validateQuery from "components/forms/validators/validate_query";
+import { validateQuery } from "components/forms/validators/validate_query";
 import SQLEditor from "components/SQLEditor";
 import Button from "components/buttons/Button";
 import Icon from "components/Icon";

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -10,7 +10,6 @@ import createMockUser from "__mocks__/userMock";
 import createMockConfig from "__mocks__/configMock";
 
 import { ILabelSummary } from "interfaces/label";
-import PolicyProvider from "context/policy";
 import PolicyForm from "./PolicyForm";
 
 const baseUrl = (path: string) => {

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -29,7 +29,7 @@ import {
 import Avatar from "components/Avatar";
 import SQLEditor from "components/SQLEditor";
 // @ts-ignore
-import validateQuery from "components/forms/validators/validate_query";
+import { validateQuery } from "components/forms/validators/validate_query";
 import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
 import Checkbox from "components/forms/fields/Checkbox";

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -54,7 +54,6 @@ import SQLEditor from "components/SQLEditor";
 import {
   validateQuery,
   EMPTY_QUERY_ERR,
-  // @ts-ignore
 } from "components/forms/validators/validate_query";
 import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
@@ -107,7 +106,8 @@ const validateQuerySQL = (query: string) => {
   const { error: queryError, valid: queryValid } = validateQuery(query);
 
   if (!queryValid) {
-    errors.query = queryError;
+    // queryError should be truthy at this point
+    errors.query = queryError ?? "Invalid query";
   }
 
   const valid = !size(errors);

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -378,9 +378,12 @@ const EditQueryForm = ({
       });
     }
 
-    const { valid } = validateQuerySQL(lastEditedQueryBody);
+    const { valid, errors: newErrs } = validateQuerySQL(lastEditedQueryBody);
 
-    if (valid) {
+    // allow save when invalid sqlite syntax
+    const canSave = valid || (!valid && newErrs.query !== EMPTY_QUERY_ERR);
+
+    if (canSave) {
       if (!savedQueryMode) {
         platformSelector.setSelectedPlatforms(
           platformCompatibility.getCompatiblePlatforms()

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -14,9 +14,6 @@ import { size } from "lodash";
 import classnames from "classnames";
 import { useDebouncedCallback } from "use-debounce";
 import { IAceEditor } from "react-ace/lib/types";
-import ReactTooltip from "react-tooltip";
-
-import { COLORS } from "styles/var/colors";
 
 import PATHS from "router/paths";
 
@@ -28,6 +25,7 @@ import {
   getCustomDropdownOptions,
   secondsToDhms,
 } from "utilities/helpers";
+
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
   MIN_OSQUERY_VERSION_OPTIONS,
@@ -53,8 +51,11 @@ import labelsAPI, {
 
 import Avatar from "components/Avatar";
 import SQLEditor from "components/SQLEditor";
-// @ts-ignore
-import validateQuery from "components/forms/validators/validate_query";
+import {
+  validateQuery,
+  EMPTY_QUERY_ERR,
+  // @ts-ignore
+} from "components/forms/validators/validate_query";
 import Button from "components/buttons/Button";
 import RevealButton from "components/buttons/RevealButton";
 import Checkbox from "components/forms/fields/Checkbox";
@@ -377,10 +378,7 @@ const EditQueryForm = ({
       });
     }
 
-    let valid = true;
-    const { valid: isValidated } = validateQuerySQL(lastEditedQueryBody);
-
-    valid = isValidated;
+    const { valid } = validateQuerySQL(lastEditedQueryBody);
 
     if (valid) {
       if (!savedQueryMode) {
@@ -680,7 +678,7 @@ const EditQueryForm = ({
     // Save and save as new disabled for query name blank on existing query or sql errors
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
-      !!size(errors) ||
+      (!!errors.query && errors.query === EMPTY_QUERY_ERR) ||
       (savedQueryMode && !platformSelector.isAnyPlatformSelected) ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {

--- a/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
@@ -213,6 +213,7 @@ const SaveAsNewQueryModal = ({
             type="submit"
             className="save-as-new-query"
             isLoading={isSaving}
+            // empty SQL error handled by parent
             disabled={Object.keys(formErrors).length > 0 || isSaving}
           >
             Save


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35058 

- Open the Query save or save-as-new-ing flows in the UI even when a syntax error is found in the Query's SQL.
- Continue blocking save when the query is empty
- Update tests
- JS –> TS housekeeping

<img width="1162" height="1248" alt="Screenshot 2025-12-02 at 4 31 47 PM" src="https://github.com/user-attachments/assets/23b4e70d-f104-4b0e-b316-c03fb6492f59" />

<img width="1162" height="1248" alt="Screenshot 2025-12-02 at 4 31 50 PM" src="https://github.com/user-attachments/assets/5b5ad0b7-36f0-4c5e-a2ff-e9665263c8f1" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

* "invalid" according to Fleet's UI. Though we make efforts to fix false negatives here as we become aware of them, that parsing is imperfectly aligned with SQL that osquery considers valid 