### PR TITLE
testing

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -638,7 +638,7 @@ Object with the following structure:
 | Name                              | Type    | Description   |
 | ---------------------             | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | url | string | **Required**. The URL of the NDES SCEP endpoint. |
-| admin_url | string | **Required**. The URL of the NDES admin endpoint. |
+| admin_url | string | **Optional**. The URL of the NDES admin endpoint. |
 | password | string | **Required**. The password for the NDES admin endpoint. |
 | username | string | **Required**. The username for the NDES admin endpoint. |
 

--- a/frontend/interfaces/certificates.ts
+++ b/frontend/interfaces/certificates.ts
@@ -44,7 +44,7 @@ export interface ICertificatesNDES {
   id?: number;
   type?: "ndes_scep_proxy";
   url: string;
-  admin_url: string;
+  admin_url?: string;
   username: string;
   password: string;
 }

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/helpers.ts
@@ -48,15 +48,10 @@ const FORM_VALIDATIONS: Record<
   adminURL: {
     validations: [
       {
-        name: "required",
-        isValid: (formData: INDESFormData) => {
-          return formData.adminURL.length > 0;
-        },
-      },
-      {
         name: "validUrl",
         isValid: (formData: INDESFormData) => {
-          return valid_url({ url: formData.adminURL });
+          // Only validate URL format if adminURL is provided
+          return formData.adminURL.length === 0 || valid_url({ url: formData.adminURL });
         },
         message: "Must be a valid URL",
       },

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/helpers.ts
@@ -51,7 +51,10 @@ const FORM_VALIDATIONS: Record<
         name: "validUrl",
         isValid: (formData: INDESFormData) => {
           // Only validate URL format if adminURL is provided
-          return formData.adminURL.length === 0 || valid_url({ url: formData.adminURL });
+          return (
+            formData.adminURL.length === 0 ||
+            valid_url({ url: formData.adminURL })
+          );
         },
         message: "Must be a valid URL",
       },


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
