### PR TITLE
Fix fast-track spelling

### DIFF
--- a/website/views/pages/fast-track.ejs
+++ b/website/views/pages/fast-track.ejs
@@ -14,7 +14,7 @@
       <div purpose="features-section">
         <div purpose="section-heading">
           <h1>What’s included</h1>
-          <p>Fast Track focuses on new device enrollments and the workflows your IT team needs on day one.</p>
+          <p>Fast-track focuses on new device enrollments and the workflows your IT team needs on day one.</p>
         </div>
         <div purpose="feature-row">
           <div purpose="feature">


### PR DESCRIPTION
For consistency; every other instance of fast-track is spelled with a hyphen.