### PR TITLE
Missed steps from 4.77.0 release

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -8,7 +8,7 @@ version: v6.7.2
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.76.1
+appVersion: v4.77.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.7.2
+version: v6.7.3
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -3,7 +3,7 @@
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 imageRepository: fleetdm/fleet
-imageTag: v4.76.1 # Version of Fleet to deploy
+imageTag: v4.77.0 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker

--- a/docs/Contributing/workflows/releasing-fleet.md
+++ b/docs/Contributing/workflows/releasing-fleet.md
@@ -21,7 +21,6 @@ Note: Please prefix versions with `fleet-v` (e.g., `fleet-v4.0.0`) in git tags, 
 - [fleetctl package.json](https://github.com/fleetdm/fleet/blob/main/tools/fleetctl-npm/package.json) (do not yet `npm publish`)
 - [Helm chart.yaml](https://github.com/fleetdm/fleet/blob/main/charts/fleet/Chart.yaml) and [values file](https://github.com/fleetdm/fleet/blob/main/charts/fleet/values.yaml)
 - GCP Terraform [variables](https://github.com/fleetdm/fleet/blob/main/infrastructure/dogfood/terraform/gcp/variables.tf)
-- [Kubernetes `fleet-deployment.yml` file](https://github.com/fleetdm/fleet/blob/main/docs/Deploy/kubernetes/fleet-deployment.yml)
 - All Terraform (*.tf) files referencing the previous version of Fleet.
 - The full list can be found by using git grep:
     % git grep "4\.3\.0"

--- a/docs/Contributing/workflows/releasing-fleet.md
+++ b/docs/Contributing/workflows/releasing-fleet.md
@@ -21,6 +21,7 @@ Note: Please prefix versions with `fleet-v` (e.g., `fleet-v4.0.0`) in git tags, 
 - [fleetctl package.json](https://github.com/fleetdm/fleet/blob/main/tools/fleetctl-npm/package.json) (do not yet `npm publish`)
 - [Helm chart.yaml](https://github.com/fleetdm/fleet/blob/main/charts/fleet/Chart.yaml) and [values file](https://github.com/fleetdm/fleet/blob/main/charts/fleet/values.yaml)
 - GCP Terraform [variables](https://github.com/fleetdm/fleet/blob/main/infrastructure/dogfood/terraform/gcp/variables.tf)
+- Kubernetes [Helm chart](https://github.com/fleetdm/fleet/blob/main/charts/fleet/Chart.yaml)
 - All Terraform (*.tf) files referencing the previous version of Fleet.
 - The full list can be found by using git grep:
     % git grep "4\.3\.0"

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,7 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.76.1"
+  default = "fleetdm/fleet:v4.77.0"
 
 variable "software_installers_bucket_name" {
   default = "fleet-software-installers"

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.76.1",
+  "version": "v4.77.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"


### PR DESCRIPTION
Looks like we [missed this step](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/releasing-fleet.md#:~:text=Update%20version%20numbers%20in%20the%20relevant%20files%3A) during the 4.77.0 release.

We're still following these steps every Fleet release right?

Context: https://github.com/fleetdm/fleet/issues/36631#issuecomment-3612582388
