### PR TITLE
Removing dependencies from endpoint_utils

### DIFF
--- a/server/mdm/android/service/endpoint_utils.go
+++ b/server/mdm/android/service/endpoint_utils.go
@@ -11,6 +11,7 @@ import (
 	eu "github.com/fleetdm/fleet/v4/server/service/middleware/endpoint_utils"
 	"github.com/go-json-experiment/json"
 	"github.com/go-json-experiment/json/jsontext"
+	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
 )
@@ -54,10 +55,11 @@ func newUserAuthenticatedEndpointer(fleetSvc fleet.Service, svc android.Service,
 		MakeDecoderFn: makeDecoder,
 		EncodeFn:      encodeResponse,
 		Opts:          opts,
-		AuthFunc:      auth.AuthenticatedUser,
-		FleetService:  fleetSvc,
-		Router:        r,
-		Versions:      versions,
+		AuthMiddleware: func(next endpoint.Endpoint) endpoint.Endpoint {
+			return auth.AuthenticatedUser(fleetSvc, next)
+		},
+		Router:   r,
+		Versions: versions,
 	}
 }
 
@@ -70,9 +72,10 @@ func newNoAuthEndpointer(fleetSvc fleet.Service, svc android.Service, opts []kit
 		MakeDecoderFn: makeDecoder,
 		EncodeFn:      encodeResponse,
 		Opts:          opts,
-		AuthFunc:      auth.UnauthenticatedRequest,
-		FleetService:  fleetSvc,
-		Router:        r,
-		Versions:      versions,
+		AuthMiddleware: func(next endpoint.Endpoint) endpoint.Endpoint {
+			return auth.UnauthenticatedRequest(fleetSvc, next)
+		},
+		Router:   r,
+		Versions: versions,
 	}
 }

--- a/server/mdm/android/service/endpoint_utils.go
+++ b/server/mdm/android/service/endpoint_utils.go
@@ -30,14 +30,17 @@ func makeDecoder(iface interface{}) kithttp.DecodeRequestFunc {
 	}, nil, nil, nil)
 }
 
+// handlerFunc is the handler function type for Android service endpoints.
+type handlerFunc func(ctx context.Context, request any, svc android.Service) fleet.Errorer
+
 // Compile-time check to ensure that endpointer implements Endpointer.
-var _ eu.Endpointer[eu.AndroidFunc] = &endpointer{}
+var _ eu.Endpointer[handlerFunc] = &endpointer{}
 
 type endpointer struct {
 	svc android.Service
 }
 
-func (e *endpointer) CallHandlerFunc(f eu.AndroidFunc, ctx context.Context, request interface{},
+func (e *endpointer) CallHandlerFunc(f handlerFunc, ctx context.Context, request interface{},
 	svc interface{}) (fleet.Errorer, error) {
 	return f(ctx, request, svc.(android.Service)), nil
 }
@@ -47,8 +50,8 @@ func (e *endpointer) Service() interface{} {
 }
 
 func newUserAuthenticatedEndpointer(fleetSvc fleet.Service, svc android.Service, opts []kithttp.ServerOption, r *mux.Router,
-	versions ...string) *eu.CommonEndpointer[eu.AndroidFunc] {
-	return &eu.CommonEndpointer[eu.AndroidFunc]{
+	versions ...string) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -64,8 +67,8 @@ func newUserAuthenticatedEndpointer(fleetSvc fleet.Service, svc android.Service,
 }
 
 func newNoAuthEndpointer(fleetSvc fleet.Service, svc android.Service, opts []kithttp.ServerOption, r *mux.Router,
-	versions ...string) *eu.CommonEndpointer[eu.AndroidFunc] {
-	return &eu.CommonEndpointer[eu.AndroidFunc]{
+	versions ...string) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},

--- a/server/service/endpoint_utils.go
+++ b/server/service/endpoint_utils.go
@@ -88,14 +88,17 @@ func isBodyDecoder(v reflect.Value) bool {
 	return ok
 }
 
+// handlerFunc is the handler function type for the main Fleet service endpoints.
+type handlerFunc func(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error)
+
 // Compile-time check to ensure that endpointer implements Endpointer.
-var _ eu.Endpointer[eu.HandlerFunc] = &endpointer{}
+var _ eu.Endpointer[handlerFunc] = &endpointer{}
 
 type endpointer struct {
 	svc fleet.Service
 }
 
-func (e *endpointer) CallHandlerFunc(f eu.HandlerFunc, ctx context.Context, request interface{},
+func (e *endpointer) CallHandlerFunc(f handlerFunc, ctx context.Context, request interface{},
 	svc interface{},
 ) (fleet.Errorer, error) {
 	return f(ctx, request, svc.(fleet.Service))
@@ -107,8 +110,8 @@ func (e *endpointer) Service() interface{} {
 
 func newUserAuthenticatedEndpointer(svc fleet.Service, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -125,8 +128,8 @@ func newUserAuthenticatedEndpointer(svc fleet.Service, opts []kithttp.ServerOpti
 
 func newNoAuthEndpointer(svc fleet.Service, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -143,11 +146,11 @@ func newNoAuthEndpointer(svc fleet.Service, opts []kithttp.ServerOption, r *mux.
 
 func newOrbitNoAuthEndpointer(svc fleet.Service, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
+) *eu.CommonEndpointer[handlerFunc] {
 	// Add the capabilities reported by Orbit to the request context
 	opts = append(opts, capabilitiesContextFunc())
 
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -174,7 +177,7 @@ func badRequestf(format string, a ...any) error {
 
 func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
+) *eu.CommonEndpointer[handlerFunc] {
 	// Extract certificate serial from X-Client-Cert-Serial header for certificate-based auth
 	opts = append(opts, kithttp.ServerBefore(extractCertSerialFromHeader))
 	// Inject the fleet.CapabilitiesHeader header to the response for device endpoints
@@ -182,7 +185,7 @@ func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts
 	// Add the capabilities reported by the device to the request context
 	opts = append(opts, capabilitiesContextFunc())
 
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -199,8 +202,8 @@ func newDeviceAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts
 
 func newHostAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -221,13 +224,13 @@ func androidAuthenticatedEndpointer(
 	opts []kithttp.ServerOption,
 	r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
+) *eu.CommonEndpointer[handlerFunc] {
 	// Inject the fleet.Capabilities header to the response for Orbit hosts
 	opts = append(opts, capabilitiesResponseFunc(fleet.GetServerOrbitCapabilities()))
 	// Add the capabilities reported by Orbit to the request context
 	opts = append(opts, capabilitiesContextFunc())
 
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},
@@ -244,13 +247,13 @@ func androidAuthenticatedEndpointer(
 
 func newOrbitAuthenticatedEndpointer(svc fleet.Service, logger log.Logger, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
-) *eu.CommonEndpointer[eu.HandlerFunc] {
+) *eu.CommonEndpointer[handlerFunc] {
 	// Inject the fleet.Capabilities header to the response for Orbit hosts
 	opts = append(opts, capabilitiesResponseFunc(fleet.GetServerOrbitCapabilities()))
 	// Add the capabilities reported by Orbit to the request context
 	opts = append(opts, capabilitiesContextFunc())
 
-	return &eu.CommonEndpointer[eu.HandlerFunc]{
+	return &eu.CommonEndpointer[handlerFunc]{
 		EP: &endpointer{
 			svc: svc,
 		},

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -576,6 +576,10 @@ func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
 			endp = mw(endp)
 		}
 	}
+	if e.AuthMiddleware == nil {
+		// This panic catches potential security issues during development.
+		panic("AuthMiddleware must be set on CommonEndpointer")
+	}
 	endp = e.AuthMiddleware(endp)
 
 	// Apply "before auth" middleware (in reverse order so that the first wraps

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -513,19 +513,18 @@ type HandlerFunc func(ctx context.Context, request interface{}, svc fleet.Servic
 
 type AndroidFunc func(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer
 
-type CommonEndpointer[H HandlerFunc | AndroidFunc] struct {
-	EP            Endpointer[H]
-	MakeDecoderFn func(iface interface{}) kithttp.DecodeRequestFunc
-	EncodeFn      kithttp.EncodeResponseFunc
-	Opts          []kithttp.ServerOption
-	AuthFunc      func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint
-	FleetService  fleet.Service
-	Router        *mux.Router
-	Versions      []string
+type CommonEndpointer[H any] struct {
+	EP             Endpointer[H]
+	MakeDecoderFn  func(iface interface{}) kithttp.DecodeRequestFunc
+	EncodeFn       kithttp.EncodeResponseFunc
+	Opts           []kithttp.ServerOption
+	AuthMiddleware endpoint.Middleware
+	Router         *mux.Router
+	Versions       []string
 
-	// CustomMiddleware are middlewares that run before AuthFunc.
+	// CustomMiddleware are middlewares that run before AuthMiddleware.
 	CustomMiddleware []endpoint.Middleware
-	// CustomMiddlewareAfterAuth are middlewares that run after AuthFunc.
+	// CustomMiddlewareAfterAuth are middlewares that run after AuthMiddleware.
 	CustomMiddlewareAfterAuth []endpoint.Middleware
 
 	startingAtVersion string
@@ -534,7 +533,7 @@ type CommonEndpointer[H HandlerFunc | AndroidFunc] struct {
 	usePathPrefix     bool
 }
 
-type Endpointer[H HandlerFunc | AndroidFunc] interface {
+type Endpointer[H any] interface {
 	CallHandlerFunc(f H, ctx context.Context, request interface{}, svc interface{}) (fleet.Errorer, error)
 	Service() interface{}
 }
@@ -582,7 +581,7 @@ func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
 			endp = mw(endp)
 		}
 	}
-	endp = e.AuthFunc(e.FleetService, endp)
+	endp = e.AuthMiddleware(endp)
 
 	// Apply "before auth" middleware (in reverse order so that the first wraps
 	// the second wraps the third etc.)

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/authzcheck"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/ratelimit"
 	"github.com/go-kit/kit/endpoint"
@@ -508,10 +507,6 @@ func WriteBrowserSecurityHeaders(w http.ResponseWriter) {
 	// Referer.
 	w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 }
-
-type HandlerFunc func(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error)
-
-type AndroidFunc func(ctx context.Context, request interface{}, svc android.Service) fleet.Errorer
 
 type CommonEndpointer[H any] struct {
 	EP             Endpointer[H]

--- a/server/service/middleware/endpoint_utils/endpoint_utils_test.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils_test.go
@@ -31,7 +31,7 @@ func TestCustomMiddlewareAfterAuth(t *testing.T) {
 		}
 	}
 
-	authFunc := func(svc fleet.Service, next endpoint.Endpoint) endpoint.Endpoint {
+	authMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, req interface{}) (interface{}, error) {
 			i++
 			authIndex = i
@@ -69,7 +69,7 @@ func TestCustomMiddlewareAfterAuth(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 			return nil
 		},
-		AuthFunc: authFunc,
+		AuthMiddleware: authMiddleware,
 		CustomMiddleware: []endpoint.Middleware{
 			beforeAuthMiddleware,
 		},

--- a/server/service/middleware/endpoint_utils/endpoint_utils_test.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils_test.go
@@ -15,6 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testHandlerFunc is a handler function type used for testing.
+type testHandlerFunc func(ctx context.Context, request any, svc any) (fleet.Errorer, error)
+
 func TestCustomMiddlewareAfterAuth(t *testing.T) {
 	var (
 		i                = 0
@@ -58,7 +61,7 @@ func TestCustomMiddlewareAfterAuth(t *testing.T) {
 	}
 
 	r := mux.NewRouter()
-	ce := &CommonEndpointer[HandlerFunc]{
+	ce := &CommonEndpointer[testHandlerFunc]{
 		EP: nopEP{},
 		MakeDecoderFn: func(iface interface{}) kithttp.DecodeRequestFunc {
 			return func(ctx context.Context, r *http.Request) (request interface{}, err error) {
@@ -79,7 +82,7 @@ func TestCustomMiddlewareAfterAuth(t *testing.T) {
 		},
 		Router: r,
 	}
-	ce.handleEndpoint("/", func(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	ce.handleEndpoint("/", func(ctx context.Context, request interface{}, svc any) (fleet.Errorer, error) {
 		fmt.Printf("handler\n")
 		return nopResponse{}, nil
 	}, nil, "GET")
@@ -113,7 +116,7 @@ func (n nopResponse) Error() error {
 
 type nopEP struct{}
 
-func (n nopEP) CallHandlerFunc(f HandlerFunc, ctx context.Context, request interface{}, svc interface{}) (fleet.Errorer, error) {
+func (n nopEP) CallHandlerFunc(_ testHandlerFunc, _ context.Context, _ any, _ any) (fleet.Errorer, error) {
 	return nopResponse{}, nil
 }
 

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -576,7 +576,7 @@ func (r callbackSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter
 	deleteSSOCookie(w)
 }
 
-func makeCallbackSSOEndpoint(urlPrefix string) endpoint_utils.HandlerFunc {
+func makeCallbackSSOEndpoint(urlPrefix string) handlerFunc {
 	return func(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 		callbackRequest := request.(*callbackSSORequest)
 		session, userID, err := getSSOSession(ctx, svc, callbackRequest)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36670

Refactoring `middleware/endpoint_utils` package to remove direct dependencies on:
- fleet.Service
- android.Service

Specific changes are:
- replace AuthFunc+FleetService with AuthMiddleware
- Move the definition of handler functions to the respective services and use a generic `CommonEndpointer[H any] struct`

Although this was discovered as part of Activity bounded context research, this change is not directly related to bounded contexts.

In retrospect, this decoupling should have been done when creating the Android service for ADR-0001.

## Testing

- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring of endpoint handling and authentication middleware composition to improve code maintainability and type safety.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->