### PR TITLE
Remove extra info callout on Wi-Fi guide

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -750,8 +750,6 @@ If an end user is on vacation (offline for more than 30 days), their certificate
 >
 > If automatic renewal fails, you can resend the configuration profile manually on the host's **Host details** page, the end user's **Fleet Desktop > My Device** page, or via [Fleet's API](https://fleetdm.com/docs/rest-api/rest-api#resend-custom-os-setting-configuration-profile).
 
-> 
-
 ## Advanced
 
 ### User scoped certificates


### PR DESCRIPTION
Removes an extra info callout

<img width="939" height="425" alt="image" src="https://github.com/user-attachments/assets/c1057014-b5cd-4892-b517-2ec3b34f4f8a" />
