### PR TITLE
fixing integration test route for android certs

### DIFF
--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8143,7 +8143,7 @@ func (s *integrationTestSuite) TestCertificatesSpecs() {
 	noTeamCertID := savedNoTeamCertTemplates[0].ID
 
 	var getNoTeamCertResp getDeviceCertificateTemplateResponse
-	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleetd/certificates/%d?node_key=%s", noTeamCertID, *noTeamHost.NodeKey), nil, http.StatusOK, &getNoTeamCertResp)
+	s.DoJSON("GET", fmt.Sprintf("/api/fleetd/certificates/%d?node_key=%s", noTeamCertID, *noTeamHost.NodeKey), nil, http.StatusOK, &getNoTeamCertResp)
 	require.NotNil(t, getNoTeamCertResp.Certificate)
 	assert.Contains(t, getNoTeamCertResp.Certificate.SubjectName, "no.team.user@example.com")
 	assert.Contains(t, getNoTeamCertResp.Certificate.SubjectName, "test-no-team-uuid-12345")


### PR DESCRIPTION
Fixing test failure due to route change:
https://github.com/fleetdm/fleet/actions/runs/19917302253/job/57098874551

```
level=debug user=admin1@example.com method=GET uri=/api/latest/fleet/certificates took=4.878111ms
    http.go:49: Error trying to decode response body as Fleet jsonError: json: cannot unmarshal number into Go value of type endpoint_utils.JsonError
    http.go:50: 
        	Error Trace:	/home/runner/work/fleet/fleet/server/test/httptest/http.go:50
        	            				/home/runner/work/fleet/fleet/server/service/testing_client.go:275
        	            				/home/runner/work/fleet/fleet/server/service/testing_client.go:283
        	            				/home/runner/work/fleet/fleet/server/service/testing_client.go:259
        	            				/home/runner/work/fleet/fleet/server/service/testing_client.go:293
        	            				/home/runner/work/fleet/fleet/server/service/integration_core_test.go:8146
        	            				/opt/hostedtoolcache/go/1.25.3/x64/src/reflect/value.go:581
        	            				/opt/hostedtoolcache/go/1.25.3/x64/src/reflect/value.go:365
        	            				/home/runner/go/pkg/mod/github.com/stretchr/testify@v1.11.1/suite/suite.go:196
        	Error:      	Not equal: 
        	            	expected: 200
        	            	actual  : 404
        	Test:       	TestIntegrations/TestCertificatesSpecs
        	Messages:   	response: &{Status:404 Not Found StatusCode:404 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Content-Length:[19] Content-Type:[text/plain; charset=utf-8] Date:[Thu, 04 Dec 2025 04:11:18 GMT] X-Content-Type-Options:[nosniff]] Body:0xc00172e980 ContentLength:19 TransferEncoding:[] Close:false Uncompressed:false Trailer:map[] Request:0xc0007a1180 TLS:<nil>}
```