### PR TITLE
Redact API tokens in `fleetctl config set`

### DIFF
--- a/changes/34626-redact-token
+++ b/changes/34626-redact-token
@@ -1,0 +1,1 @@
+* Redact API tokens in `fleetctl config set` to prevent accidental logging.

--- a/cmd/fleetctl/fleetctl/config.go
+++ b/cmd/fleetctl/fleetctl/config.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	configFilePerms = 0600
+	configFilePerms = 0o600
 )
 
 type configFile struct {
@@ -56,7 +56,7 @@ func contextFlag() cli.Flag {
 
 func makeConfigIfNotExists(fp string) error {
 	if _, err := os.Stat(filepath.Dir(fp)); errors.Is(err, os.ErrNotExist) {
-		if err := secure.MkdirAll(filepath.Dir(fp), 0700); err != nil {
+		if err := secure.MkdirAll(filepath.Dir(fp), 0o700); err != nil {
 			return err
 		}
 	}
@@ -300,7 +300,8 @@ func configSetCommand() *cli.Command {
 				if err := setConfigValue(configPath, context, "token", flToken); err != nil {
 					return fmt.Errorf("error setting token: %w", err)
 				}
-				fmt.Printf("[+] Set the token config key to %q in the %q context\n", flToken, c.String("context"))
+				// Redact the token from the output as this may be run in contexts where it is logged.
+				fmt.Printf("[+] Set the token config key to \"<redacted>\" in the %q context\n", c.String("context"))
 			}
 
 			if flTLSSkipVerify {


### PR DESCRIPTION
**Related issue:** Resolves #34626

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] QA'd all new/changed functionality manually
