### PR TITLE
Fleet UI: Disable host action buttons on click (noticeable on slow connections)

### DIFF
--- a/changes/36345-disable-action-buttons-onclick
+++ b/changes/36345-disable-action-buttons-onclick
@@ -1,0 +1,1 @@
+* Fleet UI: Fixed software action buttons to disable immediately on click to prevent multiple clicks

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -21,6 +21,10 @@
     justify-content: space-between;
     gap: $pad-medium;
     align-items: center;
+
+    .search-field__tooltip-container {
+      width: 100%;
+    }
   }
 
   &__table {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/TileActionStatus.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/TileActionStatus.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import {
   IDeviceSoftwareWithUiStatus,
   IHostSoftwareUiStatus,
@@ -68,12 +68,30 @@ const TileActionStatus = ({
   software,
   onActionClick,
 }: TileActionStatusProps) => {
+  // Local “clicked” state so the button disables immediately
+  const [disableAction, setDisableAction] = useState(false);
+
   const actionLabel = getTileActionLabel(software.ui_status);
   const isError = isSoftwareErrorStatus(software.ui_status);
+
+  useEffect(() => {
+    if (
+      !isSoftwareInProgressStatus(software.ui_status) &&
+      !isSoftwarePendingStatus(software.ui_status)
+    ) {
+      setDisableAction(false);
+    }
+  }, [software.ui_status]);
 
   const isActiveAction =
     isSoftwareInProgressStatus(software.ui_status) ||
     isSoftwarePendingStatus(software.ui_status);
+
+  // Wrap handler to disable action button immediately, important for slow connections/APIs
+  const handleClick = () => {
+    setDisableAction(true);
+    onActionClick(software);
+  };
 
   const renderActiveActionStatus = () => {
     return (
@@ -94,7 +112,11 @@ const TileActionStatus = ({
           </div>
         )}
         {actionLabel && (
-          <Button variant="inverse" onClick={() => onActionClick(software)}>
+          <Button
+            variant="inverse"
+            onClick={handleClick}
+            disabled={disableAction}
+          >
             {actionLabel}
           </Button>
         )}


### PR DESCRIPTION
## Issue
Closes #36345 
Closes #36728 

## Description
- When clicking an install/uninstall button, the button wasn't disabled until the API returned information
- Update the buttons to disable on click which prevents users from clicking it multiple times or seeing a stale clickable button
- Also update search by name field to be width 100%

## Screenrecording of fix

> Note: I updated install and uninstall button to both disable at the same time since this recording (i.e. at 0:27 of the recording, you see reinstall grey out after the API responds lag, that is now iterated upon for both buttons to be disabled immediately)


https://github.com/user-attachments/assets/cb8fe3ed-a4f2-4bf5-bb80-eb44367531e3



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
