### PR TITLE
certificate gitops fixes

### DIFF
--- a/server/fleet/certificate_templates.go
+++ b/server/fleet/certificate_templates.go
@@ -2,7 +2,7 @@ package fleet
 
 type CertificateRequestSpec struct {
 	Name                   string `json:"name"`
-	Team                   string `json:"team"`
+	Team                   string `json:"team,omitempty"`
 	CertificateAuthorityId uint   `json:"certificate_authority_id"`
 	SubjectName            string `json:"subject_name"`
 }

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -289,7 +289,6 @@ func (svc *Service) resolveTeamNamesForSpecs(ctx context.Context, specs []*fleet
 
 		team, err := svc.ds.TeamByName(ctx, spec.Team)
 		if err != nil {
-			svc.authz.SkipAuthorization(ctx)
 			return nil, ctxerr.Wrap(ctx, err, "getting team by name")
 		}
 		teamNameToID[spec.Team] = team.ID
@@ -311,6 +310,7 @@ func (svc *Service) checkCertificateTemplateSpecAuthorization(ctx context.Contex
 func (svc *Service) ApplyCertificateTemplateSpecs(ctx context.Context, specs []*fleet.CertificateRequestSpec) error {
 	teamNameToID, err := svc.resolveTeamNamesForSpecs(ctx, specs)
 	if err != nil {
+		svc.authz.SkipAuthorization(ctx)
 		return err
 	}
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2902,16 +2902,7 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 		teamName = "No team"
 		teamID = "0"
 	case config.TeamID != nil:
-		if config.TeamName != nil {
-			teamName = *config.TeamName
-		} else {
-			// Team name should already be provided in yml, but fetch it if not.
-			team, err := c.GetTeam(*config.TeamID)
-			if err != nil {
-				return fmt.Errorf("getting team by ID: %w", err)
-			}
-			teamName = team.Name
-		}
+		teamName = *config.TeamName
 		teamID = fmt.Sprintf("%d", *config.TeamID)
 	default:
 		// global config, ignore

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2275,6 +2275,21 @@ func (c *Client) DoGitOps(
 			if ok && teamID == 0 {
 				if dryRun {
 					logFn("[+] would've added any policies/queries to new team %s\n", *incoming.TeamName)
+
+					numCerts := 0
+					if incoming.Controls.AndroidSettings != nil {
+						if androidSettings, ok := incoming.Controls.AndroidSettings.(fleet.AndroidSettings); ok {
+							if androidSettings.Certificates.Valid {
+								numCerts = len(androidSettings.Certificates.Value)
+							}
+						}
+					}
+					if numCerts > 0 {
+						logFn("[+] would've added %s to new team %s\n",
+							numberWithPluralization(numCerts, "Android certificate", "Android certificates"),
+							*incoming.TeamName)
+					}
+
 					return nil, postOps, nil
 				}
 				return nil, nil, fmt.Errorf("team %s not created", *incoming.TeamName)
@@ -2881,12 +2896,23 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 	numCerts := len(certificates)
 
 	teamID := ""
+	teamName := ""
 	switch {
-	case config.TeamID != nil:
-		teamID = fmt.Sprintf("%d", *config.TeamID)
 	case config.IsNoTeam():
-		//  "No team"
+		teamName = "No team"
 		teamID = "0"
+	case config.TeamID != nil:
+		if config.TeamName != nil {
+			teamName = *config.TeamName
+		} else {
+			// Team name should already be provided in yml, but fetch it if not.
+			team, err := c.GetTeam(*config.TeamID)
+			if err != nil {
+				return fmt.Errorf("getting team by ID: %w", err)
+			}
+			teamName = team.Name
+		}
+		teamID = fmt.Sprintf("%d", *config.TeamID)
 	default:
 		// global config, ignore
 		return nil
@@ -2902,7 +2928,9 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 		return nil
 	}
 
-	if numCerts > 0 {
+	if dryRun {
+		logFn("[+] would have attempted to apply %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
+	} else {
 		logFn("[+] attempting to apply %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
 	}
 
@@ -2944,7 +2972,7 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 
 		certRequests[i] = &fleet.CertificateRequestSpec{
 			Name:                   certificates[i].Name,
-			Team:                   teamID,
+			Team:                   teamName,
 			CertificateAuthorityId: ca.ID,
 			SubjectName:            certificates[i].SubjectName,
 		}
@@ -2984,15 +3012,15 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 		}
 	}
 
-	if numCerts > 0 {
-		if dryRun {
-			logFn("[+] would've applied %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
-		} else {
+	if dryRun {
+		logFn("[+] would've applied %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
+	} else {
+		if numCerts > 0 {
 			if err := c.ApplyCertificateSpecs(certRequests); err != nil {
 				return fmt.Errorf("applying Android certificates: %w", err)
 			}
-			logFn("[+] applied %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
 		}
+		logFn("[+] applied %s\n", numberWithPluralization(numCerts, "Android certificate", "Android certificates"))
 	}
 
 	return nil


### PR DESCRIPTION
**Related issue:** Resolves #36649

Cleaned up some gitops messaging

Changed the team parameter to accept a name rather than an id. 
the certificate_template is still using an id. This matches what other entities in gitops.
Here is a sample post to the spec endpoint for a certificate_template
```
{
  specs: [
    {
       "name": "certificate template",
       "team": "workstations",
       "certificate_authority_id": 1,
       "subject_name": "CN:hello"
    }
  ]
}
```

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually