### PR TITLE
Add incremental lint run, with modernize as the linter.

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -65,11 +65,49 @@ jobs:
       - name: Run go lint
         run: |
           # Don't forget to update
-          # docs/Contributing/Testing-and-local-development.md when this
-          # version changes
+          # docs/Contributing/Testing-and-local-development.md when this version changes
           go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@a4b55ebc3471c9fbb763fd56eefede8050f99887 # v2.7.1
-          make lint-go
+          SKIP_INCREMENTAL=1 make lint-go
 
       - name: Run cloner-check tool
         run: |
           go run ./tools/cloner-check/main.go -check
+
+  golangci-incremental:
+    # Only run on pull requests (needs base branch for incremental comparison)
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: read
+    name: lint-incremental
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          fetch-depth: 0  # Fetch full history for accurate diff
+
+      - name: Install Go
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install dependencies (Linux)
+        run: |
+          sudo apt update -y && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
+
+      - name: Run incremental go lint
+        run: |
+          # Don't forget to update
+          # docs/Contributing/Testing-and-local-development.md when this version changes
+          go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@a4b55ebc3471c9fbb763fd56eefede8050f99887 # v2.7.1
+          golangci-lint run -c .golangci-incremental.yml --new-from-rev=origin/${{ github.base_ref }} --timeout 15m ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,10 +8,15 @@ on:
       - prepare-*
     paths:
       - '**.go'
+      - '.github/workflows/golangci-lint.yml'
+      - '.golangci.yml'
+      - '.golangci-incremental.yml'
   pull_request:
     paths:
       - '**.go'
       - '.github/workflows/golangci-lint.yml'
+      - '.golangci.yml'
+      - '.golangci-incremental.yml'
   workflow_dispatch: # Manual
 
 # This allows a subsequently queued workflow run to interrupt previous runs

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -102,7 +102,9 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Install dependencies (Linux)
+        if: matrix.os == 'ubuntu-latest'
         run: |
+          # The following packages are needed to build Fleet Desktop on Ubuntu.
           sudo apt update -y && sudo apt install -y gcc libgtk-3-dev libayatana-appindicator3-dev
 
       - name: Run incremental go lint

--- a/.golangci-incremental.yml
+++ b/.golangci-incremental.yml
@@ -1,0 +1,16 @@
+# This configuration is for incremental linting of new/experimental linters.
+# It is used with --new-from-rev to only lint changed code.
+# See .golangci.yml for the main linter configuration.
+version: "2"
+
+issues:
+  max-issues-per-linter: 0 # show all issues
+  max-same-issues: 0 # show all issues
+
+linters:
+  default: none
+  enable:
+    - modernize
+
+exclusions:
+  generated: strict

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,9 @@ lint-js:
 	@echo "Run the Go linters"
 lint-go:
 	golangci-lint run --timeout 15m
+ifndef SKIP_INCREMENTAL
+	golangci-lint run -c .golangci-incremental.yml --new-from-rev=origin/main --timeout 15m ./...
+endif
 
 .help-short--lint:
 	@echo "Run linters"

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ lint-js:
 lint-go:
 	golangci-lint run --timeout 15m
 ifndef SKIP_INCREMENTAL
-	golangci-lint run -c .golangci-incremental.yml --new-from-rev=origin/main --timeout 15m ./...
+	golangci-lint run -c .golangci-incremental.yml --new-from-merge-base=origin/main --timeout 15m ./...
 endif
 
 .help-short--lint:

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -568,7 +568,7 @@ func (e *CommonEndpointer[H]) handleEndpoint(path string, f H, v interface{}, ve
 	e.HandleHTTPHandler(path, endpoint, verb)
 }
 
-func (e *CommonEndpointer[H]) makeEndpoint(f H, vwhyV interface{}) http.Handler {
+func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
 	next := func(ctx context.Context, request interface{}) (interface{}, error) {
 		return e.EP.CallHandlerFunc(f, ctx, request, e.EP.Service())
 	}
@@ -591,7 +591,7 @@ func (e *CommonEndpointer[H]) makeEndpoint(f H, vwhyV interface{}) http.Handler 
 		endp = mw(endp)
 	}
 
-	return newServer(endp, e.MakeDecoderFn(vwhyV), e.EncodeFn, e.Opts)
+	return newServer(endp, e.MakeDecoderFn(v), e.EncodeFn, e.Opts)
 }
 
 func newServer(e endpoint.Endpoint, decodeFn kithttp.DecodeRequestFunc, encodeFn kithttp.EncodeResponseFunc,

--- a/server/service/middleware/endpoint_utils/endpoint_utils.go
+++ b/server/service/middleware/endpoint_utils/endpoint_utils.go
@@ -568,7 +568,7 @@ func (e *CommonEndpointer[H]) handleEndpoint(path string, f H, v interface{}, ve
 	e.HandleHTTPHandler(path, endpoint, verb)
 }
 
-func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
+func (e *CommonEndpointer[H]) makeEndpoint(f H, vwhyV interface{}) http.Handler {
 	next := func(ctx context.Context, request interface{}) (interface{}, error) {
 		return e.EP.CallHandlerFunc(f, ctx, request, e.EP.Service())
 	}
@@ -591,7 +591,7 @@ func (e *CommonEndpointer[H]) makeEndpoint(f H, v interface{}) http.Handler {
 		endp = mw(endp)
 	}
 
-	return newServer(endp, e.MakeDecoderFn(v), e.EncodeFn, e.Opts)
+	return newServer(endp, e.MakeDecoderFn(vwhyV), e.EncodeFn, e.Opts)
 }
 
 func newServer(e endpoint.Endpoint, decodeFn kithttp.DecodeRequestFunc, encodeFn kithttp.EncodeResponseFunc,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32999

The `modernize` linter was discussed some time ago in the backend sync. We wanted to add it but it was not possible.

Now that it has been added to golangci-lint, we are adding it.

golangci-lint has incremental mode, where only changes vs the base branch are linted. This is nice when adding new linters without needing to fix the whole codebase. That said, it would be nice to `modernize` the whole codebase.
