### PR TITLE
Placeholder for Okta conditional access guide

### DIFF
--- a/articles/okta-conditional-access-integration.md
+++ b/articles/okta-conditional-access-integration.md
@@ -1,0 +1,12 @@
+# Conditional access: Okta
+
+> This page is a stub for an upcoming feature guide.
+
+Okta conditional access is coming soon. You can follow its progress in [GitHub](https://github.com/fleetdm/fleet/issues/31909).
+
+<meta name="articleTitle" value="Conditional access: Okta">
+<meta name="authorFullName" value="Rachael Shaw">
+<meta name="authorGitHubUsername" value="rachaelshaw">
+<meta name="category" value="guides">
+<meta name="publishedOn" value="2025-12-04">
+<meta name="description" value="Learn how to enforce conditional access with Fleet and Okta.">

--- a/articles/okta-conditional-access-integration.md
+++ b/articles/okta-conditional-access-integration.md
@@ -1,6 +1,6 @@
 # Conditional access: Okta
 
-> This page is a stub for an upcoming feature guide.
+> This page is a placeholder for an upcoming feature guide.
 
 Okta conditional access is coming soon. You can follow its progress in [GitHub](https://github.com/fleetdm/fleet/issues/31909).
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1129,6 +1129,8 @@ module.exports.routes = {
   'GET /learn-more-about/microsoft-compliance-partner': '/guides/entra-conditional-access-integration',
   'GET /learn-more-about/microsoft-entra-setup': 'https://entra.microsoft.com/#view/Microsoft_AAD_IAM/TenantProperties.ReactView',
   'GET /learn-more-about/conditional-access': '/guides/entra-conditional-access-integration',
+  'GET /learn-more-about/entra-conditional-access': '/guides/entra-conditional-access-integration',
+  'GET /learn-more-about/okta-conditional-access': '/guides/okta-conditional-access-integration',
   'GET /learn-more-about/organization-logo-size': '/docs/configuration/yaml-files#org-info',
   'GET /learn-more-about/byod-hosts-vpp-install': 'https://github.com/fleetdm/fleet/issues/31138',
   'GET /learn-more-about/install-google-play-apps': 'https://github.com/fleetdm/fleet/issues/25595',


### PR DESCRIPTION
This creates a stub for the upcoming Okta conditional access feature guide, and gets the redirects in place so QA can test the links.

<img width="1624" height="1060" alt="Screenshot 2025-12-04 at 5 27 17 PM" src="https://github.com/user-attachments/assets/f277ac39-93da-4a28-a7a1-5a7998700e63" />
