### PR TITLE
Website: Update version of osquery schema used to build osquery_fleet_schema.json

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -7493,7 +7493,7 @@
   },
   {
     "name": "dns_resolvers",
-    "description": "Resolvers used by this host.",
+    "description": "Resolvers used by this host. Note: On Windows this data is available in the interface_details table.",
     "url": "https://fleetdm.com/tables/dns_resolvers",
     "platforms": [
       "darwin",
@@ -17866,7 +17866,7 @@
       },
       {
         "name": "blocks_free",
-        "description": "Mounted device free blocks",
+        "description": "Mounted device blocks available to root users, a superset of blocks_available",
         "type": "bigint",
         "notes": "",
         "hidden": false,
@@ -17875,7 +17875,7 @@
       },
       {
         "name": "blocks_available",
-        "description": "Mounted device available blocks",
+        "description": "Mounted device blocks available to non-root users",
         "type": "bigint",
         "notes": "",
         "hidden": false,

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -341,7 +341,7 @@ module.exports.custom = {
   //
   // The version of osquery to use when generating schema docs
   // (both in Fleet's query console and on fleetdm.com)
-  versionOfOsquerySchemaToUseWhenGeneratingDocumentation: '5.19.0',
+  versionOfOsquerySchemaToUseWhenGeneratingDocumentation: '5.20.0',
 
 
   //  ███╗   ███╗██╗███████╗ ██████╗


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/36620

Changes:
- Updated the website to use the osquery 5.20.0 schema when generating osquery table documentation pages and osquery_fleet_schema.json
- Regenerated osquery_fleet_schema.json