### PR TITLE
Added additional icon mapping for Zoom

### DIFF
--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -351,6 +351,8 @@ const matchStrictNameSourceToIcon = ({
       return Zoom;
     case name === "zoom":
       return Zoom;
+    case name === "zoom.us":
+      return Zoom;
     case name.startsWith("zoom workplace"):
       return Zoom;
     default:


### PR DESCRIPTION
Icon mapping was explicitly looking for `zoom.us.app`. It also needs to match on `zoom.us`. I am holding off on matching anything that starts with `zoom` since this might interfere with the other Zoom apps. 