### PR TITLE
Ensure we only return a single result for a given MDM command

### DIFF
--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -551,7 +551,7 @@ FROM
     windows_mdm_commands wmc
     LEFT JOIN windows_mdm_command_results wmcr ON wmcr.command_uuid = wmc.command_uuid
     LEFT JOIN windows_mdm_responses wmr ON wmr.id = wmcr.response_id
-    LEFT JOIN windows_mdm_command_queue wmcq ON wmcq.command_uuid = wmc.command_uuid
+    LEFT JOIN windows_mdm_command_queue wmcq ON wmcq.command_uuid = wmc.command_uuid AND wmcr.command_uuid IS NULL
     LEFT JOIN mdm_windows_enrollments mwe ON mwe.id = COALESCE(
         wmcr.enrollment_id,
         wmcq.enrollment_id

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -1435,6 +1435,25 @@ func testMDMWindowsCommandResults(t *testing.T, ds *Datastore) {
 	_, err = insertDB(t, `INSERT INTO windows_mdm_command_results (enrollment_id, command_uuid, raw_result, response_id, status_code) VALUES (?, ?, ?, ?, ?)`, enrollmentID, cmdUUID, rawResult, responseID, statusCode)
 	require.NoError(t, err)
 
+	// Create multiple command queue entries to ensure no duplicated rows.
+	dev2 := createEnrolledDevice(t, ds)
+	dev3 := createEnrolledDevice(t, ds)
+	var enrollmentID2 uint
+	var enrollmentID3 uint
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &enrollmentID2,
+		`SELECT id FROM mdm_windows_enrollments WHERE mdm_device_id = ?`, dev2.MDMDeviceID))
+	require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &enrollmentID3,
+		`SELECT id FROM mdm_windows_enrollments WHERE mdm_device_id = ?`, dev3.MDMDeviceID))
+
+	// Insert queue entry for BOTH enrollments
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid)
+         VALUES (?, ?), (?, ?)`,
+		enrollmentID2, cmdUUID,
+		enrollmentID3, cmdUUID,
+	)
+	require.NoError(t, err)
+
 	p, err := ds.GetMDMCommandPlatform(ctx, cmdUUID)
 	require.NoError(t, err)
 	require.Equal(t, "windows", p)


### PR DESCRIPTION
A later fix for an issue discovered while working on Windows resending, that the GetMDMCommandResults could return multiple rows if certain conditions were met.