### PR TITLE
Ingest Windows host certificates via osquery

### DIFF
--- a/changes/32746-windows-custom-scep
+++ b/changes/32746-windows-custom-scep
@@ -1,1 +1,3 @@
+- Added support for resending Windows MDM profiles.
+- Added support for renewal of custom SCEP profiles for Windows.
 - Added support for ingesting Windows certificates via osquery.

--- a/changes/32746-windows-custom-scep
+++ b/changes/32746-windows-custom-scep
@@ -1,0 +1,1 @@
+- Added support for ingesting Windows certificates via osquery.

--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -46,6 +46,24 @@ SELECT
 		path LIKE '/Users/%/Library/Keychains/login.keychain-db';
 ```
 
+## certificates_windows
+
+- Platforms: windows
+
+- Query:
+```sql
+SELECT
+		ca, common_name, subject, issuer,
+		key_algorithm, key_strength, key_usage, signing_algorithm,
+		not_valid_after, not_valid_before,
+		serial, sha1, username,
+		path
+	FROM
+		certificates
+	WHERE
+		store = 'Personal';
+```
+
 ## chromeos_profile_user_info
 
 - Platforms: chrome

--- a/server/datastore/mysql/host_certificates.go
+++ b/server/datastore/mysql/host_certificates.go
@@ -341,6 +341,17 @@ func replaceHostCertsSourcesDB(ctx context.Context, tx sqlx.ExtContext, toReplac
 		return nil
 	}
 
+	// FIXME: It is entirely possible for the caller to pass duplicates in the toReplaceSources slice
+	// (e.g. multiple elements with the same source and username for the same certificate ID).
+	// Although this function checks against duplicates in the database, it does not deduplicate the
+	// slice itself. This can lead to unique constraint violations when ths function inserts new sources.
+	//
+	// For Apple, it was implicitly assumed that there would be no incoming duplicates (likely based
+	// on Apple KeyChain behavior). But for Windows, duplicates are commonly reported by osquery. We
+	// should consider the best pattern for ensuring deduplication happens here or up the call
+	// stack. For now, we are deduping Windows certs in the upstream osqquery directIngest function,
+	// but that may not be the best approach if we want to guard against other potential issues.
+
 	// Sort by host_certificate_id to ensure consistent lock ordering and prevent deadlocks
 	slices.SortFunc(toReplaceSources, func(a, b *fleet.HostCertificateRecord) int {
 		if a.ID != b.ID {

--- a/server/fleet/host_certificates_test.go
+++ b/server/fleet/host_certificates_test.go
@@ -162,7 +162,7 @@ func TestExtractHostCertificateNameDetails(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			actual, err := ExtractDetailsFromOsqueryDistinguishedName(tc.input)
+			actual, err := ExtractDetailsFromOsqueryDistinguishedName("darwin", tc.input)
 			if tc.err {
 				require.Error(t, err)
 			} else {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -804,7 +804,6 @@ var extraDetailQueries = map[string]DetailQuery{
 		Platforms:        []string{"darwin"},
 		DirectIngestFunc: directIngestHostCertificates,
 	},
-	// TODO: confirm how we want to denote source for Windows certs
 	"certificates_windows": {
 		Query: `
 	SELECT

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2460,7 +2460,7 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 		return nil
 	}
 
-	err := directIngestHostCertificates(ctx, logger, host, ds, []map[string]string{row1, row2})
+	err := directIngestHostCertificatesDarwin(ctx, logger, host, ds, []map[string]string{row1, row2})
 	require.NoError(t, err)
 	require.True(t, ds.UpdateHostCertificatesFuncInvoked)
 }
@@ -2547,7 +2547,7 @@ func TestDirectIngestHostCertificatesWindows(t *testing.T) {
 			require.True(t, ok, "unexpected cert SHA1+username combination: %s + %s", s, cert.Username)
 			seenSha1Users[s+cert.Username] = true
 
-			// validate fields that differ between the cert examples
+			// Validate fields that differ between the cert examples
 			switch s {
 			case "1A395245953C61AE12657704FF45F31A1E7BC1E8":
 				require.Equal(t, "CERT_KEY_ENCIPHERMENT_KEY_USAGE,CERT_DIGITAL_SIGNATURE_KEY_USAGE", cert.KeyUsage)
@@ -2575,7 +2575,7 @@ func TestDirectIngestHostCertificatesWindows(t *testing.T) {
 				t.Fatalf("unexpected cert SHA1: %s", s)
 			}
 
-			// validate fields common across all Windows certs in this test
+			// Validate fields common across all Windows certs in this test
 			require.Equal(t, "RSA", cert.KeyAlgorithm)
 			require.Equal(t, "sha256RSA", cert.SigningAlgorithm)
 			require.False(t, cert.CertificateAuthority)
@@ -2585,7 +2585,7 @@ func TestDirectIngestHostCertificatesWindows(t *testing.T) {
 				require.Equal(t, fleet.UserHostCertificate, cert.Source)
 			}
 
-			// osquery squeezes all distinguished name fields for Windows certs into
+			// For Windows certs, osquery squeezes all distinguished name fields into
 			// the comma-separated list that we store as Issuer/SubjectCommonName and
 			// we leave all other fields empty for now (see fleet.ExtractDetailsFromOsqueryDistinguishedName)
 			require.Empty(t, cert.SubjectOrganization)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2375,7 +2375,7 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 	ds := new(mock.Store)
 	ctx := context.Background()
 	logger := log.NewNopLogger()
-	host := &fleet.Host{ID: 1, UUID: "host-uuid"}
+	host := &fleet.Host{ID: 1, UUID: "host-uuid", Platform: "darwin"}
 
 	row1 := map[string]string{
 		"ca":                "0",

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -2464,6 +2464,147 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 	require.True(t, ds.UpdateHostCertificatesFuncInvoked)
 }
 
+func TestDirectIngestHostCertificatesWindows(t *testing.T) {
+	ds := new(mock.Store)
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+	host := &fleet.Host{ID: 1, UUID: "host-uuid", Platform: "windows"}
+
+	// Fleet SCEP cert example based on data from a real Windows host
+	c1 := map[string]string{
+		"ca":                "-1",
+		"common_name":       "494FE0F794940E21C757B790494B0FAFD97CFA4D5E9CC75856DB00DE78F3958D",
+		"subject":           "Fleet, 494FE0F794940E21C757B790494B0FAFD97CFA4D5E9CC75856DB00DE78F3958D",
+		"issuer":            "\"\", scep-ca, SCEP CA, FleetDM",
+		"key_algorithm":     "RSA",
+		"key_strength":      "2160",
+		"key_usage":         "CERT_KEY_ENCIPHERMENT_KEY_USAGE,CERT_DIGITAL_SIGNATURE_KEY_USAGE",
+		"signing_algorithm": "sha256RSA",
+		"not_valid_after":   "1780784467",
+		"not_valid_before":  "1749248467",
+		"serial":            "05",
+		"sha1":              "1A395245953C61AE12657704FF45F31A1E7BC1E8",
+		"username":          "Admin",
+		"path":              "Users\\S-1-5-21-1043593016-4249271388-1765263865-1000\\Personal",
+	}
+	// Custom SCEP cert example based on data from a real Windows host
+	c2 := map[string]string{
+		"ca":                "-1",
+		"common_name":       "wc215384b-5a6e-4ca5-a2a3-1289734a5a71 User\n            CN",
+		"subject":           "fleet-w2a6fd2c4-0018-4bdc-8046-c7342962b576, \"wc215384b-5a6e-4ca5-a2a3-1289734a5a71 User\n            CN\"",
+		"issuer":            "US, scep-ca, SCEP CA, MICROMDM SCEP CA",
+		"key_algorithm":     "RSA",
+		"key_strength":      "1120",
+		"key_usage":         "CERT_DIGITAL_SIGNATURE_KEY_USAGE",
+		"signing_algorithm": "sha256RSA",
+		"not_valid_after":   "1796430423",
+		"not_valid_before":  "1764893823",
+		"serial":            "23",
+		"sha1":              "EE5E756CC1A0782078C7C45180A4544A37D0F6D7",
+		"username":          "Admin",
+		"path":              "Users\\S-1-5-21-1043593016-4249271388-1765263865-1000\\Personal",
+	}
+
+	// We'll use the examples above to create rows with minor variations, similar to what
+	// we would get from a real Windows host.
+	c3 := maps.Clone(c1)
+	c3["username"] = "SYSTEM"
+	c3["path"] = "Users\\S-1-5-18\\Personal"
+
+	c4 := maps.Clone(c1)
+	c4["username"] = "SYSTEM"
+	c4["path"] = "CurrentUser\\Personal"
+
+	c5 := maps.Clone(c1)
+	c5["username"] = "SYSTEM"
+	c5["path"] = "Users\\S-1-5-18\\Personal"
+
+	c6 := maps.Clone(c1)
+	c6["path"] = "Users\\S-1-5-21-1043593016-4249271388-1765263865-1000_Classes\\Personal"
+
+	c7 := maps.Clone(c2)
+	c7["path"] = "Users\\S-1-5-21-1043593016-4249271388-1765263865-1000_Classes\\Personal"
+
+	rows := []map[string]string{c1, c2, c3, c4, c5, c6, c7}
+
+	ds.UpdateHostCertificatesFunc = func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord) error {
+		require.Equal(t, host.ID, hostID)
+		require.Equal(t, host.UUID, hostUUID)
+		require.Len(t, certs, 3)
+
+		// We expect that the ingest function will deduplicate certs based on SHA1+username
+		// so we should see only 3 unique combinations from the 7 rows above.
+		expectSha1Users := map[string]bool{
+			"1A395245953C61AE12657704FF45F31A1E7BC1E8" + "Admin":  true, // c1, c6
+			"1A395245953C61AE12657704FF45F31A1E7BC1E8" + "SYSTEM": true, // c3, c4, c5
+			"EE5E756CC1A0782078C7C45180A4544A37D0F6D7" + "Admin":  true, // c2, c7
+		}
+		seenSha1Users := map[string]bool{}
+		for _, cert := range certs {
+			s := strings.ToUpper(hex.EncodeToString(cert.SHA1Sum))
+			_, ok := expectSha1Users[s+cert.Username]
+			require.True(t, ok, "unexpected cert SHA1+username combination: %s + %s", s, cert.Username)
+			seenSha1Users[s+cert.Username] = true
+
+			// validate fields that differ between the cert examples
+			switch s {
+			case "1A395245953C61AE12657704FF45F31A1E7BC1E8":
+				require.Equal(t, "CERT_KEY_ENCIPHERMENT_KEY_USAGE,CERT_DIGITAL_SIGNATURE_KEY_USAGE", cert.KeyUsage)
+				require.Equal(t, "05", cert.Serial)
+				require.Equal(t, int64(1780784467), cert.NotValidAfter.Unix())
+				require.Equal(t, int64(1749248467), cert.NotValidBefore.Unix())
+				require.Equal(t, 2160, cert.KeyStrength)
+				require.Equal(t, "494FE0F794940E21C757B790494B0FAFD97CFA4D5E9CC75856DB00DE78F3958D", cert.CommonName)
+				require.Equal(t, "Fleet, 494FE0F794940E21C757B790494B0FAFD97CFA4D5E9CC75856DB00DE78F3958D", cert.SubjectCommonName)
+				require.Equal(t, "\"\", scep-ca, SCEP CA, FleetDM", cert.IssuerCommonName)
+				require.Contains(t, []string{"Admin", "SYSTEM"}, cert.Username)
+
+			case "EE5E756CC1A0782078C7C45180A4544A37D0F6D7":
+				require.Equal(t, "CERT_DIGITAL_SIGNATURE_KEY_USAGE", cert.KeyUsage)
+				require.Equal(t, "23", cert.Serial)
+				require.Equal(t, int64(1796430423), cert.NotValidAfter.Unix())
+				require.Equal(t, int64(1764893823), cert.NotValidBefore.Unix())
+				require.Equal(t, 1120, cert.KeyStrength)
+				require.Equal(t, "wc215384b-5a6e-4ca5-a2a3-1289734a5a71 User\n            CN", cert.CommonName)
+				require.Equal(t, "fleet-w2a6fd2c4-0018-4bdc-8046-c7342962b576, \"wc215384b-5a6e-4ca5-a2a3-1289734a5a71 User\n            CN\"", cert.SubjectCommonName)
+				require.Equal(t, "US, scep-ca, SCEP CA, MICROMDM SCEP CA", cert.IssuerCommonName)
+				require.Equal(t, "Admin", cert.Username)
+
+			default:
+				t.Fatalf("unexpected cert SHA1: %s", s)
+			}
+
+			// validate fields common across all Windows certs in this test
+			require.Equal(t, "RSA", cert.KeyAlgorithm)
+			require.Equal(t, "sha256RSA", cert.SigningAlgorithm)
+			require.False(t, cert.CertificateAuthority)
+			if cert.Username == "SYSTEM" {
+				require.Equal(t, fleet.SystemHostCertificate, cert.Source)
+			} else {
+				require.Equal(t, fleet.UserHostCertificate, cert.Source)
+			}
+
+			// osquery squeezes all distinguished name fields for Windows certs into
+			// the comma-separated list that we store as Issuer/SubjectCommonName and
+			// we leave all other fields empty for now (see fleet.ExtractDetailsFromOsqueryDistinguishedName)
+			require.Empty(t, cert.SubjectOrganization)
+			require.Empty(t, cert.SubjectOrganizationalUnit)
+			require.Empty(t, cert.SubjectCountry)
+			require.Empty(t, cert.IssuerOrganization)
+			require.Empty(t, cert.IssuerOrganizationalUnit)
+			require.Empty(t, cert.IssuerCountry)
+
+		}
+		require.Equal(t, expectSha1Users, seenSha1Users)
+
+		return nil
+	}
+
+	err := directIngestHostCertificatesWindows(ctx, logger, host, ds, rows)
+	require.NoError(t, err)
+	require.True(t, ds.UpdateHostCertificatesFuncInvoked)
+}
+
 func TestGenerateSQLForAllExists(t *testing.T) {
 	// Combine two queries
 	query1 := "SELECT 1 WHERE foo = bar"

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -398,13 +398,14 @@ func TestGetDetailQueries(t *testing.T) {
 		"disk_encryption_windows",
 		"chromeos_profile_user_info",
 		"certificates_darwin",
+		"certificates_windows",
 	}
 
 	require.Len(t, queriesNoConfig, len(baseQueries))
 	sortedKeysCompare(t, queriesNoConfig, baseQueries)
 
 	queriesWithoutWinOSVuln := GetDetailQueries(context.Background(), config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, nil, nil, Integrations{}, nil)
-	require.Len(t, queriesWithoutWinOSVuln, 26)
+	require.Len(t, queriesWithoutWinOSVuln, 27)
 
 	queriesWithUsers := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true}, Integrations{}, nil)
 	qs := baseQueries


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35614 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)


## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

