### PR TITLE
recreate certificate templates when CA or subject name change

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -3888,8 +3889,9 @@ func TestGitOpsAndroidCertificatesChange(t *testing.T) {
 	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 	setupAndroidCertificatesTestMocks(t, ds)
 
-	// Track certificate templates
+	// Track certificate templates actions
 	var updatedCertificates []fleet.CertificateTemplate
+	var deletedCertificateIDs []uint
 
 	ds.BatchUpsertCertificateTemplatesFunc = func(ctx context.Context, certificates []*fleet.CertificateTemplate) error {
 		updatedCertificates = nil
@@ -3916,11 +3918,38 @@ func TestGitOpsAndroidCertificatesChange(t *testing.T) {
 		return existing, &fleet.PaginationMetadata{}, nil
 	}
 
+	// Simulate full certificate details for existing certificates
+	ds.GetCertificateTemplateByIdFunc = func(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error) {
+		switch id {
+		case 1:
+			return &fleet.CertificateTemplateResponseFull{
+				CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+					ID:                     1,
+					Name:                   "Certificate 1",
+					CertificateAuthorityId: 1,
+				},
+				SubjectName: "CN=Original Subject 1",
+			}, nil
+		case 2:
+			return &fleet.CertificateTemplateResponseFull{
+				CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+					ID:                     2,
+					Name:                   "Certificate 2",
+					CertificateAuthorityId: 2,
+				},
+				SubjectName: "CN=Original Subject 2",
+			}, nil
+		default:
+			return nil, errors.New("certificate not found")
+		}
+	}
+
 	ds.BatchDeleteCertificateTemplatesFunc = func(ctx context.Context, ids []uint) error {
+		deletedCertificateIDs = append(deletedCertificateIDs, ids...)
 		return nil
 	}
 
-	// Create team config with modified certificates
+	// Create team config with modified subjectNames
 	teamConfig := `
 name: %s
 team_settings:
@@ -3970,12 +3999,134 @@ software: null
 	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
 	require.NoError(t, err)
 
-	// Verify certificates were updated with new subject names
-	require.Len(t, updatedCertificates, 2)
+	// Verify both certificates were deleted because their SubjectName changed
+	require.Len(t, deletedCertificateIDs, 2, "Both certificates should be deleted due to SubjectName changes")
+	assert.Contains(t, deletedCertificateIDs, uint(1), "Certificate 1 should be deleted")
+	assert.Contains(t, deletedCertificateIDs, uint(2), "Certificate 2 should be deleted")
+
+	// Verify both certificates were recreated with new subject names
+	require.Len(t, updatedCertificates, 2, "Both certificates should be recreated")
 	assert.Equal(t, "Certificate 1", updatedCertificates[0].Name)
 	assert.Equal(t, "CN=Updated Subject 1", updatedCertificates[0].SubjectName)
 	assert.Equal(t, "Certificate 2", updatedCertificates[1].Name)
 	assert.Equal(t, "CN=Updated Subject 2", updatedCertificates[1].SubjectName)
+
+	// Create team config with modified certificate authorities (swapped CAs)
+	updatedCertificates = make([]fleet.CertificateTemplate, 0)
+	deletedCertificateIDs = make([]uint, 0)
+	teamConfig = `
+name: %s
+team_settings:
+  secrets:
+    - secret: TestSecret
+  mdm:
+    macos_updates:
+      minimum_version: null
+      deadline: null
+    macos_settings:
+      custom_settings: null
+    macos_setup:
+      bootstrap_package: null
+      enable_end_user_authentication: false
+      macos_setup_assistant: null
+    windows_updates:
+      deadline_days: null
+      grace_period_days: null
+    windows_settings:
+      custom_settings: null
+agent_options:
+  config:
+    options:
+      pack_delimiter: /
+  overrides: {}
+controls:
+  android_settings:
+    certificates:
+      - name: "Certificate 1"
+        certificate_authority_name: "Test CA 2"
+        subject_name: "CN=Original Subject 1"
+      - name: "Certificate 2"
+        certificate_authority_name: "Test CA 1"
+        subject_name: "CN=Original Subject 2"
+policies: []
+queries: []
+software: null
+`
+
+	teamFile, err = os.CreateTemp(tmpDir, "team-*.yml")
+	require.NoError(t, err)
+	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName))
+	require.NoError(t, err)
+
+	// Run GitOps
+	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
+	require.NoError(t, err)
+
+	// Verify both certificates were deleted because their SubjectName changed
+	require.Len(t, deletedCertificateIDs, 2, "Both certificates should be deleted due to SubjectName changes")
+	assert.Contains(t, deletedCertificateIDs, uint(1), "Certificate 1 should be deleted")
+	assert.Contains(t, deletedCertificateIDs, uint(2), "Certificate 2 should be deleted")
+
+	// Verify both certificates were recreated with new subject names
+	require.Len(t, updatedCertificates, 2, "Both certificates should be recreated")
+	assert.Equal(t, "Certificate 1", updatedCertificates[0].Name)
+	assert.Equal(t, uint(2), updatedCertificates[0].CertificateAuthorityID)
+	assert.Equal(t, "Certificate 2", updatedCertificates[1].Name)
+	assert.Equal(t, uint(1), updatedCertificates[1].CertificateAuthorityID)
+
+	// Create team config with no changes, make sure we don't delete
+	updatedCertificates = make([]fleet.CertificateTemplate, 0)
+	deletedCertificateIDs = make([]uint, 0)
+	teamConfig = `
+name: %s
+team_settings:
+  secrets:
+    - secret: TestSecret
+  mdm:
+    macos_updates:
+      minimum_version: null
+      deadline: null
+    macos_settings:
+      custom_settings: null
+    macos_setup:
+      bootstrap_package: null
+      enable_end_user_authentication: false
+      macos_setup_assistant: null
+    windows_updates:
+      deadline_days: null
+      grace_period_days: null
+    windows_settings:
+      custom_settings: null
+agent_options:
+  config:
+    options:
+      pack_delimiter: /
+  overrides: {}
+controls:
+  android_settings:
+    certificates:
+      - name: "Certificate 1"
+        certificate_authority_name: "Test CA 1"
+        subject_name: "CN=Original Subject 1"
+      - name: "Certificate 2"
+        certificate_authority_name: "Test CA 2"
+        subject_name: "CN=Original Subject 2"
+policies: []
+queries: []
+software: null
+`
+
+	teamFile, err = os.CreateTemp(tmpDir, "team-*.yml")
+	require.NoError(t, err)
+	_, err = teamFile.WriteString(fmt.Sprintf(teamConfig, teamName))
+	require.NoError(t, err)
+
+	// Run GitOps
+	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
+	require.NoError(t, err)
+
+	require.Len(t, deletedCertificateIDs, 0, "No certificates should be deleted when there are no changes")
+	require.Len(t, updatedCertificates, 2, "Both certificates should be present without changes")
 }
 
 // TestGitOpsAndroidCertificatesDeleteOne tests deleting one certificate while leaving others via GitOps
@@ -4015,6 +4166,32 @@ func TestGitOpsAndroidCertificatesDeleteOne(t *testing.T) {
 			},
 		}
 		return existing, &fleet.PaginationMetadata{}, nil
+	}
+
+	// Mock GetCertificateTemplateByIdFunc to return full certificate details
+	ds.GetCertificateTemplateByIdFunc = func(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error) {
+		switch id {
+		case 1:
+			return &fleet.CertificateTemplateResponseFull{
+				CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+					ID:                     1,
+					Name:                   "Certificate 1",
+					CertificateAuthorityId: 1,
+				},
+				SubjectName: "CN=Device Certificate 1",
+			}, nil
+		case 2:
+			return &fleet.CertificateTemplateResponseFull{
+				CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+					ID:                     2,
+					Name:                   "Certificate 2",
+					CertificateAuthorityId: 2,
+				},
+				SubjectName: "CN=Device Certificate 2",
+			}, nil
+		default:
+			return nil, errors.New("certificate not found")
+		}
 	}
 
 	// Create team config with only one certificate (Certificate 1 removed)

--- a/server/datastore/mysql/certificate_templates.go
+++ b/server/datastore/mysql/certificate_templates.go
@@ -162,9 +162,7 @@ func (ds *Datastore) BatchUpsertCertificateTemplates(ctx context.Context, certif
 		) VALUES %s
 		ON DUPLICATE KEY UPDATE
 			name = VALUES(name),
-			team_id = VALUES(team_id),
-			certificate_authority_id = VALUES(certificate_authority_id),
-			subject_name = VALUES(subject_name)
+			team_id = VALUES(team_id)
 	`
 
 	var placeholders strings.Builder

--- a/server/datastore/mysql/certificate_templates_test.go
+++ b/server/datastore/mysql/certificate_templates_test.go
@@ -717,7 +717,7 @@ func testBatchUpsertCertificates(t *testing.T, ds *Datastore) {
 				require.NoError(t, err)
 				require.Equal(t, 1, count)
 
-				certificates[0].SubjectName = "CN=Updated Subject 1"
+				certificates[0].SubjectName = "Updated Subject"
 				err = ds.BatchUpsertCertificateTemplates(ctx, certificates)
 				require.NoError(t, err)
 
@@ -725,10 +725,10 @@ func testBatchUpsertCertificates(t *testing.T, ds *Datastore) {
 				require.NoError(t, err)
 				require.Equal(t, 1, count)
 
-				var updatedSubject string
-				err = ds.writer(ctx).GetContext(ctx, &updatedSubject, "SELECT subject_name FROM certificate_templates WHERE name = ?", "Cert1")
+				var subjectName string
+				err = ds.writer(ctx).GetContext(ctx, &subjectName, "SELECT subject_name FROM certificate_templates WHERE name = ?", "Cert1")
 				require.NoError(t, err)
-				require.Equal(t, "CN=Updated Subject 1", updatedSubject)
+				require.Equal(t, "CN=Test Subject 1", subjectName)
 			},
 		},
 	}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2972,12 +2972,8 @@ func (c *Client) doGitOpsAndroidCertificates(config *spec.GitOps, logFn func(for
 				if err != nil {
 					return fmt.Errorf("getting certificate %q details: %w", cert.Name, err)
 				}
-				if fullCert.SubjectName != newCert.SubjectName {
-					// subjectName changed, mark for deletion (will be recreated)
-					certificatesToDelete = append(certificatesToDelete, cert.ID)
-				}
-				if fullCert.CertificateAuthorityId != newCert.CertificateAuthorityId {
-					// CA changed, mark for deletion (will be recreated)
+				if fullCert.SubjectName != newCert.SubjectName || fullCert.CertificateAuthorityId != newCert.CertificateAuthorityId {
+					// SubjectName or CA changed, mark for deletion (will be recreated)
 					certificatesToDelete = append(certificatesToDelete, cert.ID)
 				}
 			}


### PR DESCRIPTION
**Related issue:** Resolves #36717

When gitops runs and the yml for a certificate template includes a change to a certificate authority or a subject name for an existing certificate template. Do not update the certificate template, delete the old one and create a new one. This will aid in ensuring the new certificate is sent to the android device.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced certificate template comparison logic to properly detect changes in certificate authority associations and subject names, ensuring certificates are recreated when needed.

* **Tests**
  * Expanded test coverage for certificate template management scenarios, including updates to certificate authorities and subject name modifications.
  * Added validation for certificate deletion and recreation workflows under various configuration changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->