### PR TITLE
Website: Update error handling in `deliver-apple-csr`

### DIFF
--- a/website/api/controllers/deliver-apple-csr.js
+++ b/website/api/controllers/deliver-apple-csr.js
@@ -166,6 +166,8 @@ module.exports = {
     // Send a message to Slack.
     await sails.helpers.http.post(sails.config.custom.slackWebhookUrlForMDMSignups, {
       text: `An MDM CSR was generated for ${generateCertificateResult.org} - ${generateCertificateResult.email}`
+    }).tolerate((err)=>{
+      sails.log.warn(`When an MDM CSR was generated for ${generateCertificateResult.org} (email: ${generateCertificateResult.email}), an error occured when posting a notification to Slack. Full error: ${require('util').inspect(err)}`);
     });
 
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/36776

Changes:
- Updated the `deliver-apple-csr` endpoint to tolerate errors returned by the Slack API and log a warning when it happens.