### PR TITLE
Fleet v4.76 apple profile query performance hotfix  plus godep debug logging

### DIFF
--- a/changes/35601-optimize-cleanup-apple-profiles-query
+++ b/changes/35601-optimize-cleanup-apple-profiles-query
@@ -1,0 +1,1 @@
+* Optimized the cleanup Apple host profiles query to reduce probability of DB locking.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6757,13 +6757,23 @@ func (ds *Datastore) CleanupHostMDMAppleProfiles(ctx context.Context) error {
 	// This could also occur due to errors (i.e., large server/DB load) or server being stopped while processing the profiles.
 	// After the entry is deleted, the mdm_apple_profile_manager job will try to requeue the profile.
 	stmt := fmt.Sprintf(`
-		DELETE hmap FROM host_mdm_apple_profiles AS hmap
-        -- ANTIJOIN: Delete rows that don't have a corresponding entry in nano_enrollment_queue
-		-- Note that a given host may have multiple nano_enrollments(device and user) and thus we
-		-- need to account for the use of either of them in the join
-		LEFT JOIN (nano_enrollment_queue neq INNER JOIN nano_enrollments ne ON neq.id = ne.id AND ne.enabled = 1)
-		ON ne.device_id = hmap.host_uuid AND hmap.command_uuid = neq.command_uuid AND neq.active = 1
-		WHERE neq.id IS NULL AND (hmap.status IS NULL OR hmap.status = '%s') AND hmap.updated_at < NOW() - INTERVAL 1 HOUR`,
+	DELETE hmap FROM host_mdm_apple_profiles AS hmap
+WHERE (
+        hmap.status IS NULL
+        OR hmap.status = '%s'
+    )
+    AND hmap.updated_at < NOW() - INTERVAL 1 HOUR
+    AND NOT EXISTS (
+        SELECT 1
+        FROM
+            nano_enrollments ne
+            STRAIGHT_JOIN nano_enrollment_queue neq ON neq.id = ne.id
+            AND neq.command_uuid = hmap.command_uuid
+            AND neq.active = 1
+        WHERE
+            ne.device_id = hmap.host_uuid
+            AND ne.enabled = 1
+    );`,
 		fleet.MDMDeliveryPending)
 	if _, err := ds.writer(ctx).ExecContext(ctx, stmt); err != nil {
 		return ctxerr.Wrap(ctx, err, "delete from host_mdm_apple_profiles")

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1026,7 +1026,7 @@ func NewDEPClient(storage godep.ClientStorage, updater fleet.ABMTermsUpdater, lo
 			}
 		}
 		return reqErr
-	}))
+	}), godep.WithLogger(logging.NewNanoDEPLogger(kitlog.With(logger, "component", "godep-syncer"))))
 }
 
 var funcMap = map[string]any{

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -206,13 +206,13 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 		return req, err
 	}
 
-	limit20KiB := 20 * 1024
+	limit30KiB := 30 * 1024
 	if c.logger != nil {
 		responseBodyString := ""
 		// This should cover large DEP requests without overwhelming the logs and get the data needed
 		// for the most important ones like assign profile responses
-		if len(bodyBytes) > limit20KiB {
-			responseBodyString = string(bodyBytes[:limit20KiB]) + "...[truncated]"
+		if len(bodyBytes) > limit30KiB {
+			responseBodyString = string(bodyBytes[:limit30KiB]) + "...[truncated]"
 		} else {
 			responseBodyString = string(bodyBytes)
 		}

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -178,7 +178,9 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		fmt.Printf("DEP RESP ERR: %s\n", err)
+		if c.logger != nil {
+			c.logger.Debug("msg", "error sending request to Apple DEP", "url", req.URL.String(), "error", err)
+		}
 		return req, err
 	}
 	defer resp.Body.Close()

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -206,8 +206,17 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 		return req, err
 	}
 
+	limit20KiB := 20 * 1024
 	if c.logger != nil {
-		c.logger.Debug("msg", "Apple DEP Request returned 200 status", "url", req.URL.String(), "apple_request_uuid", appleRequestUUID, "body", string(bodyBytes))
+		responseBodyString := ""
+		// This should cover large DEP requests without overwhelming the logs and get the data needed
+		// for the most important ones like assign profile responses
+		if len(bodyBytes) > limit20KiB {
+			responseBodyString = string(bodyBytes[:limit20KiB]) + "...[truncated]"
+		} else {
+			responseBodyString = string(bodyBytes)
+		}
+		c.logger.Debug("msg", "Apple DEP Request returned 200 status", "url", req.URL.String(), "apple_request_uuid", appleRequestUUID, "body", responseBodyString)
 	}
 
 	if out != nil {


### PR DESCRIPTION
Adds additional debug logging to godep to try and track down some of `customer-numa`'s DEP enrollment issues
Also includes hotfix on top of 4.76 for Apple query performance from https://github.com/fleetdm/fleet/pull/36410

Tested locally and verified I was getting expected output from DEP requests. This will generate a decent bit of logging(at least once a minute + hourly cooldowns) but is all debug level so once we're done we can turn it back down