### PR TITLE
Changed to "delivered" status and other fixes.

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -106,7 +106,7 @@ keytool -list -v -keystore keystore.jks -alias fleet-android
 echo <SHA256> | xxd -r -p | base64
 ```
 
-Copy the fingerprint for use in `FLEET_DEV_ANDROID_AGENT_SHA256`
+Copy the fingerprint for use in `FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256`
 
 ## Deploying via Android MDM (development)
 
@@ -116,7 +116,7 @@ This feature is behind the feature flag `FLEET_DEV_ANDROID_AGENT_PACKAGE`. Requi
 
 ```bash
 export FLEET_DEV_ANDROID_AGENT_PACKAGE=com.fleetdm.agent.private.<yourname>
-export FLEET_DEV_ANDROID_AGENT_SHA256=<SHA256 fingerprint>
+export FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256=<SHA256 fingerprint>
 ```
 
 2. **Change the `applicationId` in `app/build.gradle.kts`:**

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -638,7 +638,7 @@ type Service interface {
 
 	CreateCertificateTemplate(ctx context.Context, name string, teamID uint, certificateAuthorityID uint, subjectName string) (*CertificateTemplateResponseFull, error)
 	ListCertificateTemplates(ctx context.Context, teamID uint, opts ListOptions) ([]*CertificateTemplateResponseSummary, *PaginationMetadata, error)
-	GetDeviceCertificateTemplate(ctx context.Context, id uint) (*CertificateTemplateResponseFull, error)
+	GetDeviceCertificateTemplate(ctx context.Context, id uint) (*CertificateTemplateDeviceResponseFull, error)
 	GetCertificateTemplate(ctx context.Context, id uint) (*CertificateTemplateResponseFull, error)
 	DeleteCertificateTemplate(ctx context.Context, id uint) error
 	ApplyCertificateTemplateSpecs(ctx context.Context, specs []*CertificateRequestSpec) error

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -639,7 +639,7 @@ type Service interface {
 	CreateCertificateTemplate(ctx context.Context, name string, teamID uint, certificateAuthorityID uint, subjectName string) (*CertificateTemplateResponseFull, error)
 	ListCertificateTemplates(ctx context.Context, teamID uint, opts ListOptions) ([]*CertificateTemplateResponseSummary, *PaginationMetadata, error)
 	GetDeviceCertificateTemplate(ctx context.Context, id uint) (*CertificateTemplateResponseFull, error)
-	GetCertificateTemplate(ctx context.Context, id uint, hostUUID *string) (*CertificateTemplateResponseFull, error)
+	GetCertificateTemplate(ctx context.Context, id uint) (*CertificateTemplateResponseFull, error)
 	DeleteCertificateTemplate(ctx context.Context, id uint) error
 	ApplyCertificateTemplateSpecs(ctx context.Context, specs []*CertificateRequestSpec) error
 	DeleteCertificateTemplateSpecs(ctx context.Context, certificateTemplateIDs []uint, teamID uint) error

--- a/server/mdm/android/service/profiles.go
+++ b/server/mdm/android/service/profiles.go
@@ -472,6 +472,7 @@ func (r *profileReconciler) processCertificateTemplateBatch(ctx context.Context,
 	}
 
 	svc := &Service{
+		logger:           kitlog.NewNopLogger(),
 		ds:               r.DS,
 		fleetDS:          r.DS,
 		androidAPIClient: r.Client,

--- a/server/mdm/android/service/profiles_test.go
+++ b/server/mdm/android/service/profiles_test.go
@@ -887,12 +887,12 @@ func testCertificateTemplates(t *testing.T, ds fleet.Datastore, client *mock.Cli
 	}
 
 	oldPackageValue := os.Getenv("FLEET_DEV_ANDROID_AGENT_PACKAGE")
-	oldSHA256Value := os.Getenv("FLEET_DEV_ANDROID_AGENT_SHA256")
+	oldSHA256Value := os.Getenv("FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256")
 	os.Setenv("FLEET_DEV_ANDROID_AGENT_PACKAGE", "com.fleetdm.agent")
-	os.Setenv("FLEET_DEV_ANDROID_AGENT_SHA256", "abc123def456")
+	os.Setenv("FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256", "abc123def456")
 	defer func() {
 		os.Setenv("FLEET_DEV_ANDROID_AGENT_PACKAGE", oldPackageValue)
-		os.Setenv("FLEET_DEV_ANDROID_AGENT_SHA256", oldSHA256Value)
+		os.Setenv("FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256", oldSHA256Value)
 	}()
 
 	err = reconciler.reconcileCertificateTemplates(ctx)

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -910,9 +910,9 @@ func (svc *Service) AddFleetAgentToAndroidPolicy(ctx context.Context, enterprise
 ) error {
 	var errs []error
 	if packageName := os.Getenv("FLEET_DEV_ANDROID_AGENT_PACKAGE"); packageName != "" {
-		sha256Fingerprint := os.Getenv("FLEET_DEV_ANDROID_AGENT_SHA256")
+		sha256Fingerprint := os.Getenv("FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256")
 		if sha256Fingerprint == "" {
-			return ctxerr.New(ctx, "FLEET_DEV_ANDROID_AGENT_SHA256 must be set when FLEET_DEV_ANDROID_AGENT_PACKAGE is set")
+			return ctxerr.New(ctx, "FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256 must be set when FLEET_DEV_ANDROID_AGENT_PACKAGE is set")
 		}
 		for uuid, managedConfig := range hostConfigs {
 			policyName := fmt.Sprintf("%s/policies/%s", enterpriseName, uuid)

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -394,9 +394,9 @@ type CreateCertificateTemplateFunc func(ctx context.Context, name string, teamID
 
 type ListCertificateTemplatesFunc func(ctx context.Context, teamID uint, opts fleet.ListOptions) ([]*fleet.CertificateTemplateResponseSummary, *fleet.PaginationMetadata, error)
 
-type GetDeviceCertificateTemplateFunc func(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error)
+type GetDeviceCertificateTemplateFunc func(ctx context.Context, id uint) (*fleet.CertificateTemplateDeviceResponseFull, error)
 
-type GetCertificateTemplateFunc func(ctx context.Context, id uint, hostUUID *string) (*fleet.CertificateTemplateResponseFull, error)
+type GetCertificateTemplateFunc func(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error)
 
 type DeleteCertificateTemplateFunc func(ctx context.Context, id uint) error
 
@@ -3463,18 +3463,18 @@ func (s *Service) ListCertificateTemplates(ctx context.Context, teamID uint, opt
 	return s.ListCertificateTemplatesFunc(ctx, teamID, opts)
 }
 
-func (s *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error) {
+func (s *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (*fleet.CertificateTemplateDeviceResponseFull, error) {
 	s.mu.Lock()
 	s.GetDeviceCertificateTemplateFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetDeviceCertificateTemplateFunc(ctx, id)
 }
 
-func (s *Service) GetCertificateTemplate(ctx context.Context, id uint, hostUUID *string) (*fleet.CertificateTemplateResponseFull, error) {
+func (s *Service) GetCertificateTemplate(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error) {
 	s.mu.Lock()
 	s.GetCertificateTemplateFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetCertificateTemplateFunc(ctx, id, hostUUID)
+	return s.GetCertificateTemplateFunc(ctx, id)
 }
 
 func (s *Service) DeleteCertificateTemplate(ctx context.Context, id uint) error {

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -130,8 +130,8 @@ type getDeviceCertificateTemplateRequest struct {
 }
 
 type getDeviceCertificateTemplateResponse struct {
-	Certificate *fleet.CertificateTemplateResponseFull `json:"certificate"`
-	Err         error                                  `json:"error,omitempty"`
+	Certificate *fleet.CertificateTemplateDeviceResponseFull `json:"certificate"`
+	Err         error                                        `json:"error,omitempty"`
 }
 
 func (r getDeviceCertificateTemplateResponse) Error() error { return r.Err }
@@ -145,7 +145,7 @@ func getDeviceCertificateTemplateEndpoint(ctx context.Context, request interface
 	return getDeviceCertificateTemplateResponse{Certificate: certificate}, nil
 }
 
-func (svc *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (*fleet.CertificateTemplateResponseFull, error) {
+func (svc *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (*fleet.CertificateTemplateDeviceResponseFull, error) {
 	// skipauth: This endpoint uses node key authentication instead of user authentication.
 	svc.authz.SkipAuthorization(ctx)
 
@@ -182,11 +182,11 @@ func (svc *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (
 			return nil, err
 		}
 		certificate.Status = &fleet.MDMDeliveryFailed
-		return certificate, nil
+		return certificate.ToDeviceResponse(), nil
 	}
 	certificate.SubjectName = subjectName
 
-	return certificate, nil
+	return certificate.ToDeviceResponse(), nil
 }
 
 type getCertificateTemplateRequest struct {

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8042,7 +8042,7 @@ func (s *integrationTestSuite) TestCertificatesSpecs() {
 	})
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&getCertResp))
 	require.NoError(t, resp.Body.Close())
-	require.Equal(t, *getCertResp.Certificate.Status, fleet.MDMDeliveryFailed)
+	require.Equal(t, *getCertResp.Certificate.Status, fleet.CertificateTemplateFailed)
 
 	// Add an IDP user for the host
 	err = s.ds.ReplaceHostDeviceMapping(ctx, host.ID, []*fleet.HostDeviceMapping{
@@ -8077,14 +8077,6 @@ func (s *integrationTestSuite) TestCertificatesSpecs() {
 	assert.Contains(t, getCertResp.Certificate.SubjectName, "$FLEET_VAR_HOST_END_USER_IDP_USERNAME")
 	assert.Contains(t, getCertResp.Certificate.SubjectName, "$FLEET_VAR_HOST_UUID")
 	assert.Contains(t, getCertResp.Certificate.SubjectName, "$FLEET_VAR_HOST_HARDWARE_SERIAL")
-
-	// Get certificate with host_uuid (should return replaced variables)
-	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/certificates/%d?host_uuid=%s", certID, host.UUID), nil, http.StatusOK, &getCertResp)
-	require.NotNil(t, getCertResp.Certificate)
-
-	assert.Contains(t, getCertResp.Certificate.SubjectName, "test.user@example.com")
-	assert.Contains(t, getCertResp.Certificate.SubjectName, "test-uuid-12345")
-	assert.Contains(t, getCertResp.Certificate.SubjectName, "TEST-SERIAL-67890")
 
 	// batch delete certificate templates
 	var delBatchResp deleteCertificateTemplateSpecsResponse

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -8185,7 +8185,6 @@ func (s *integrationTestSuite) TestCertificatesSpecs() {
 
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/certificates/%d", createCertResp.ID), nil, http.StatusOK, &getCertResp)
 	require.NotNil(t, getCertResp.Certificate)
-	require.Equal(t, uint(0), getCertResp.Certificate.TeamID)
 
 	var delResp deleteCertificateTemplateResponse
 	s.DoJSON("DELETE", fmt.Sprintf("/api/latest/fleet/certificates/%d", createCertResp.ID), nil, http.StatusOK, &delResp)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36795 

Flowchart update: https://github.com/fleetdm/fleet/pull/36800

`/api/fleetd/certificates/{id:[0-9]+}` to return `delivered` status instead of `pending` for future compatibility
- created a temporary `CertificateTemplateDeviceResponseFull` which should be merged with `CertificateTemplateResponseFull` in next sprint's work

Also:
- Changed `FLEET_DEV_ANDROID_AGENT_SHA256` to `FLEET_DEV_ANDROID_AGENT_SIGNING_SHA256`
- Removed host-specific code from `/api/_version_/fleet/certificates/{id:[0-9]+}`

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved certificate template status tracking with three delivery states: delivered, failed, and verified.

* **Chores**
  * Updated environment variable naming for Android agent signing configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->