### PR TITLE
Refactored RDS IAM authentication logic into a dedicated `rdsauth` package

### DIFF
--- a/changes/36846-refactor-rds-iam
+++ b/changes/36846-refactor-rds-iam
@@ -1,0 +1,1 @@
+Refactored server RDS IAM authentication logic into a dedicated `rdsauth` package.

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -6,6 +6,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"regexp"
 	"strconv"
@@ -25,6 +26,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/data"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/migrations/tables"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql/rdsauth"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/goose"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
@@ -230,7 +232,7 @@ func (ds *Datastore) withReadTx(ctx context.Context, fn common_mysql.ReadTxFn) (
 }
 
 // New creates an MySQL datastore.
-func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore, error) {
+func New(conf config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore, error) {
 	options := &common_mysql.DBOptions{
 		MinLastOpenedAtDiff: defaultMinLastOpenedAtDiff,
 		MaxAttempts:         defaultMaxAttempts,
@@ -245,7 +247,7 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		}
 	}
 
-	if err := checkConfig(&config); err != nil {
+	if err := checkConfig(&conf); err != nil {
 		return nil, err
 	}
 	if options.ReplicaConfig != nil {
@@ -254,13 +256,25 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		}
 	}
 
-	dbWriter, err := NewDB(&config, options)
+	// Set up IAM authentication connector factory if needed
+	if err := setupIAMAuthIfNeeded(&conf, options); err != nil {
+		return nil, err
+	}
+
+	dbWriter, err := NewDB(&conf, options)
 	if err != nil {
 		return nil, err
 	}
 	dbReader := dbWriter
 	if options.ReplicaConfig != nil {
-		dbReader, err = NewDB(options.ReplicaConfig, options)
+		// Set up IAM auth for replica if needed (may have different region/credentials)
+		replicaOptions := *options
+		// Reset ConnectorFactory - replica may have different auth requirements than primary
+		replicaOptions.ConnectorFactory = nil
+		if err := setupIAMAuthIfNeeded(options.ReplicaConfig, &replicaOptions); err != nil {
+			return nil, fmt.Errorf("replica: %w", err)
+		}
+		dbReader, err = NewDB(options.ReplicaConfig, &replicaOptions)
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +285,7 @@ func New(config config.MysqlConfig, c clock.Clock, opts ...DBOption) (*Datastore
 		replica:             dbReader,
 		logger:              options.Logger,
 		clock:               c,
-		config:              config,
+		config:              conf,
 		readReplicaConfig:   options.ReplicaConfig,
 		writeCh:             make(chan itemToWrite),
 		stmtCache:           make(map[string]*sqlx.Stmt),
@@ -378,6 +392,28 @@ func checkConfig(conf *config.MysqlConfig) error {
 			return fmt.Errorf("register TLS config for mysql: %w", err)
 		}
 	}
+	return nil
+}
+
+// setupIAMAuthIfNeeded configures IAM authentication for RDS if the config
+// indicates it should be used (no password provided but region is set).
+func setupIAMAuthIfNeeded(conf *config.MysqlConfig, opts *common_mysql.DBOptions) error {
+	if conf.Password != "" || conf.PasswordPath != "" || conf.Region == "" {
+		return nil
+	}
+
+	// Parse host and port from address
+	host, port, err := net.SplitHostPort(conf.Address)
+	if err != nil {
+		host = conf.Address
+		port = "3306"
+	}
+
+	factory, err := rdsauth.NewConnectorFactory(conf, host, port)
+	if err != nil {
+		return fmt.Errorf("failed to create RDS IAM auth connector factory: %w", err)
+	}
+	opts.ConnectorFactory = factory
 	return nil
 }
 

--- a/server/datastore/mysql/rdsauth/connector.go
+++ b/server/datastore/mysql/rdsauth/connector.go
@@ -1,4 +1,5 @@
-package common_mysql
+// Package rdsauth provides AWS IAM authentication for RDS MySQL connections.
+package rdsauth
 
 import (
 	"context"
@@ -9,12 +10,13 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/rds/auth"
 	"github.com/fleetdm/fleet/v4/server/aws_common"
+	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/go-kit/log"
 	"github.com/go-sql-driver/mysql"
 )
 
-// awsIAMAuthTokenGenerator generates AWS IAM authentication tokens for RDS MySQL
-type awsIAMAuthTokenGenerator struct {
+// iamAuthTokenGenerator generates AWS IAM authentication tokens for RDS MySQL
+type iamAuthTokenGenerator struct {
 	dbEndpoint   string // Full endpoint with port
 	dbUsername   string
 	region       string
@@ -22,8 +24,8 @@ type awsIAMAuthTokenGenerator struct {
 	tokenManager *aws_common.IAMAuthTokenManager
 }
 
-// newAWSIAMAuthTokenGenerator creates a new IAM authentication token generator
-func newAWSIAMAuthTokenGenerator(dbEndpoint, dbUsername, dbPort, region, assumeRoleArn, stsExternalID string) (*awsIAMAuthTokenGenerator, error) {
+// newIAMAuthTokenGenerator creates a new IAM authentication token generator
+func newIAMAuthTokenGenerator(dbEndpoint, dbUsername, dbPort, region, assumeRoleArn, stsExternalID string) (*iamAuthTokenGenerator, error) {
 	// Load AWS configuration
 	cfg, err := aws_common.LoadAWSConfig(context.Background(), region, assumeRoleArn, stsExternalID)
 	if err != nil {
@@ -36,7 +38,7 @@ func newAWSIAMAuthTokenGenerator(dbEndpoint, dbUsername, dbPort, region, assumeR
 		fullEndpoint = fmt.Sprintf("%s:%s", dbEndpoint, dbPort)
 	}
 
-	g := &awsIAMAuthTokenGenerator{
+	g := &iamAuthTokenGenerator{
 		dbEndpoint:  fullEndpoint,
 		dbUsername:  dbUsername,
 		region:      region,
@@ -51,12 +53,12 @@ func newAWSIAMAuthTokenGenerator(dbEndpoint, dbUsername, dbPort, region, assumeR
 
 // getAuthToken gets an IAM authentication token for RDS
 // It uses a cache to avoid generating new tokens for every connection
-func (g *awsIAMAuthTokenGenerator) getAuthToken(ctx context.Context) (string, error) {
+func (g *iamAuthTokenGenerator) getAuthToken(ctx context.Context) (string, error) {
 	return g.tokenManager.GetToken(ctx)
 }
 
 // newToken creates a new IAM authentication token
-func (g *awsIAMAuthTokenGenerator) newToken(ctx context.Context) (string, error) {
+func (g *iamAuthTokenGenerator) newToken(ctx context.Context) (string, error) {
 	authToken, err := auth.BuildAuthToken(ctx, g.dbEndpoint, g.region, g.dbUsername, g.credentials)
 	if err != nil {
 		return "", fmt.Errorf("failed to build auth token: %w", err)
@@ -65,16 +67,16 @@ func (g *awsIAMAuthTokenGenerator) newToken(ctx context.Context) (string, error)
 	return authToken, nil
 }
 
-// awsIAMAuthConnector implements driver.Connector for IAM authentication
-type awsIAMAuthConnector struct {
+// Connector implements driver.Connector for IAM authentication
+type Connector struct {
 	driverName string
 	baseDSN    string
-	tokenGen   *awsIAMAuthTokenGenerator
+	tokenGen   *iamAuthTokenGenerator
 	logger     log.Logger
 }
 
 // Connect implements driver.Connector
-func (c *awsIAMAuthConnector) Connect(ctx context.Context) (driver.Conn, error) {
+func (c *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 	token, err := c.tokenGen.getAuthToken(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate IAM auth token: %w", err)
@@ -96,6 +98,32 @@ func (c *awsIAMAuthConnector) Connect(ctx context.Context) (driver.Conn, error) 
 }
 
 // Driver implements driver.Connector
-func (c *awsIAMAuthConnector) Driver() driver.Driver {
+func (c *Connector) Driver() driver.Driver {
 	return mysql.MySQLDriver{}
+}
+
+// NewConnectorFactory returns a factory function that creates IAM-authenticated
+// database connectors. This factory can be injected into common_mysql.NewDB
+// to enable IAM authentication without adding AWS dependencies to common_mysql.
+func NewConnectorFactory(conf *config.MysqlConfig, host, port string) (func(driverName, dsn string, logger log.Logger) (driver.Connector, error), error) {
+	tokenGen, err := newIAMAuthTokenGenerator(
+		host,
+		conf.Username,
+		port,
+		conf.Region,
+		conf.StsAssumeRoleArn,
+		conf.StsExternalID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create IAM token generator: %w", err)
+	}
+
+	return func(driverName, dsn string, logger log.Logger) (driver.Connector, error) {
+		return &Connector{
+			driverName: driverName,
+			baseDSN:    dsn,
+			tokenGen:   tokenGen,
+			logger:     logger,
+		}, nil
+	}, nil
 }


### PR DESCRIPTION
Simplified and modularized IAM auth setup for MySQL connections.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36846 

Manually QA'ed by setting up RDS with IAM and running Fleet like:
```
FLEET_MYSQL_ADDRESS=fleet-iam-test-public.xxxxxxxxx.us-east-2.rds.amazonaws.com:3306 \
  FLEET_MYSQL_USERNAME=fleet_iam \
  FLEET_MYSQL_DATABASE=fleet \
  FLEET_MYSQL_REGION=us-east-2 \
./build/fleet serve
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized IAM authentication infrastructure for RDS databases to improve code organization and maintainability.
  * Enhanced the database connection layer to support flexible authentication configuration methods while maintaining full backward compatibility with existing configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->