### PR TITLE
Bump Go to 1.25.5, Alpine to 3.23.0 where relevant, bump Trivy to current version

### DIFF
--- a/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
+++ b/.github/workflows/build-fleetdm-fleetctl-check-vulnerabilities.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           mkdir trivy-download
           cd trivy-download
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
-          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_Linux-64bit.tar.gz --output trivy_0.68.1_Linux-64bit.tar.gz
+          tar -xf trivy_0.68.1_Linux-64bit.tar.gz
           mv trivy ..
           cd ..
           chmod +x ./trivy

--- a/.github/workflows/check-bomutils-vulnerabilities.yml
+++ b/.github/workflows/check-bomutils-vulnerabilities.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           mkdir trivy-download
           cd trivy-download
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
-          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_Linux-64bit.tar.gz --output trivy_0.68.1_Linux-64bit.tar.gz
+          tar -xf trivy_0.68.1_Linux-64bit.tar.gz
           mv trivy ..
           cd ..
           chmod +x ./trivy

--- a/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
+++ b/.github/workflows/check-vulnerabilities-in-released-docker-images.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           mkdir trivy-download
           cd trivy-download
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
-          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_Linux-64bit.tar.gz --output trivy_0.68.1_Linux-64bit.tar.gz
+          tar -xf trivy_0.68.1_Linux-64bit.tar.gz
           mv trivy ..
           cd ..
           chmod +x ./trivy

--- a/.github/workflows/check-wix-vulnerabilities.yml
+++ b/.github/workflows/check-wix-vulnerabilities.yml
@@ -64,8 +64,8 @@ jobs:
         run: |
           mkdir trivy-download
           cd trivy-download
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
-          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_Linux-64bit.tar.gz --output trivy_0.68.1_Linux-64bit.tar.gz
+          tar -xf trivy_0.68.1_Linux-64bit.tar.gz
           mv trivy ..
           cd ..
           chmod +x ./trivy

--- a/.github/workflows/goreleaser-snapshot-fleet.yaml
+++ b/.github/workflows/goreleaser-snapshot-fleet.yaml
@@ -101,8 +101,8 @@ jobs:
         run: |
           mkdir trivy-download
           cd trivy-download
-          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.61.0/trivy_0.61.0_Linux-64bit.tar.gz --output trivy_0.61.0_Linux-64bit.tar.gz
-          tar -xf trivy_0.61.0_Linux-64bit.tar.gz
+          curl -L https://github.com/aquasecurity/trivy/releases/download/v0.68.1/trivy_0.68.1_Linux-64bit.tar.gz --output trivy_0.68.1_Linux-64bit.tar.gz
+          tar -xf trivy_0.68.1_Linux-64bit.tar.gz
           mv trivy ..
           cd ..
           chmod +x ./trivy

--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.25.3-bookworm@sha256:ee420c17fa013f71eca6b35c3547b854c838d4f26056a34eb6171bba5bf8ece4
+FROM --platform=linux/amd64 golang:1.25.5-bookworm@sha256:5117d68695f57faa6c2b3a49a6f3187ec1f66c75d5b080e4360bfe4c1ada398c
 LABEL maintainer="Fleet Developers"
 
 RUN mkdir -p /usr/src/fleet

--- a/changes/go-1.25.5
+++ b/changes/go-1.25.5
@@ -1,0 +1,1 @@
+- Updated Go to 1.25.5.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.25.3
+go 1.25.5
 
 require (
 	cloud.google.com/go/pubsub v1.49.0

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.3-alpine3.21@sha256:0c9f3e09a50a6c11714dbc37a6134fd0c474690030ed07d23a61755afd3a812f
+FROM golang:1.25.5-alpine3.23@sha256:26111811bc967321e7b6f852e914d14bede324cd1accb7f81811929a6a57fea9
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .
@@ -21,7 +21,7 @@ RUN cd /go/fleet/cmd/osquery-perf/software-library && \
     sqlite3 software.db "SELECT COUNT(*) FROM software;" && \
     echo "Successfully generated software.db ($(du -h software.db | cut -f1))"
 
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
 LABEL maintainer="Fleet Developers"
 
 # Create FleetDM group and user

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,9 +1,9 @@
-FROM golang:1.25.3-alpine3.21@sha256:0c9f3e09a50a6c11714dbc37a6134fd0c474690030ed07d23a61755afd3a812f
+FROM golang:1.25.5-alpine3.23@sha256:26111811bc967321e7b6f852e914d14bede324cd1accb7f81811929a6a57fea9
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .
 
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.25.3
+go 1.25.5
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.25.3
+go 1.25.5
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Fixes vulns reported in https://github.com/fleetdm/fleet/actions/runs/19999992703. We'll definitely want to at least cherry-pick this.