### PR TITLE
Update replica db setup and guide

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -818,9 +818,9 @@ db-replica-setup:
 	$(eval MYSQL_REPLICATION_USER := replicator)
 	$(eval MYSQL_REPLICATION_PASSWORD := rotacilper)
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "stop slave; reset slave all;"
-	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -AN -e "drop user if exists '$(MYSQL_REPLICATION_USER)'; create user '$(MYSQL_REPLICATION_USER)'@'%' identified by '$(MYSQL_REPLICATION_PASSWORD)'; grant replication slave on *.* to '$(MYSQL_REPLICATION_USER)'@'%'; flush privileges;"
-	$(eval MAIN_POSITION := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -e 'show master status \G' | grep Position | grep -o '[0-9]*'))
-	$(eval MAIN_FILE := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -e 'show master status \G' | grep File | sed -n -e 's/^.*: //p'))
+	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot -AN -e "drop user if exists '$(MYSQL_REPLICATION_USER)'; create user '$(MYSQL_REPLICATION_USER)'@'%' identified with mysql_native_password by '$(MYSQL_REPLICATION_PASSWORD)'; grant replication slave on *.* to '$(MYSQL_REPLICATION_USER)'@'%'; flush privileges;"
+	$(eval MAIN_POSITION := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot --vertical -e 'show master status' | grep Position | grep -o '[0-9]*'))
+	$(eval MAIN_FILE := $(shell MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3308 -uroot --vertical -e 'show master status' | grep File | sed -n -e 's/^.*: //p'))
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to master_port=3306,master_host='mysql_main',master_user='$(MYSQL_REPLICATION_USER)',master_password='$(MYSQL_REPLICATION_PASSWORD)',master_log_file='$(MAIN_FILE)',master_log_pos=$(MAIN_POSITION);"
 	if [ "${FLEET_MYSQL_IMAGE}" == "mysql:8.0" ]; then MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to get_master_public_key=1;"; fi
 	MYSQL_PWD=toor mysql --host 127.0.0.1 --port 3309 -uroot -AN -e "change master to master_delay=1;"

--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -352,6 +352,11 @@ To connect via Docker:
 docker-compose exec mysql mysql -uroot -ptoor -Dfleet
 ```
 
+## MySQL replica delay
+
+To set up replication delay on a local dev setup, follow the instructions at [/tools/mysql-replica-testing](https://github.com/fleetdm/fleet/tree/main/tools/mysql-replica-testing). This will create a new primary/secondary database for testing delay issues and will not affect your existing database.
+
+
 ## Redis REPL
 
 Connect to the `redis-cli` in REPL mode to view and interact directly with the contents stored in Redis.

--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -24,6 +24,7 @@
       - [Mailpit SMTP server with plain authentication](#mailpit-smtp-server-with-plain-authentication)
   - [Development database management](#development-database-management)
   - [MySQL shell](#mysql-shell)
+  - [MySQL replica delay](#mysql-replica-delay)
   - [Redis REPL](#redis-repl)
   - [Testing SSO](#testing-sso)
     - [Configuration](#configuration)

--- a/tools/mysql-replica-testing/README.md
+++ b/tools/mysql-replica-testing/README.md
@@ -5,9 +5,11 @@ This directory contains scripts to run/test a local Fleet instance with a MySQL 
 ## Run MySQL Main and Read Replica Docker Images
 
 > Run all commands from fleet's root repository directory.
+>
+>The regular `docker compose up` command should be running for the other services to work.
 
 ```sh
-docker-compose -f ./tools/mysql-replica-testing/docker-compose.yml up
+docker compose -f ./tools/mysql-replica-testing/docker-compose.yml up
 ```
 
 ## Configure MySQL Main and Read Replica


### PR DESCRIPTION
**Related issue:** Resolves #35937
Changes:
- Fix `make db-replica-setup`
- mention the tool in `docs/contributing/getting-started/testing-and-local-development.md`.
