### PR TITLE
Add ClickUp as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/clickup.json
+++ b/ee/maintained-apps/inputs/winget/clickup.json
@@ -1,0 +1,10 @@
+{
+  "name": "ClickUp",
+  "slug": "clickup/windows",
+  "package_identifier": "ClickUp.ClickUp",
+  "unique_identifier": "ClickUp",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -212,6 +212,13 @@
       "description": "ClickUp is a productivity platform for tasks, docs, goals, and chat."
     },
     {
+      "name": "ClickUp",
+      "slug": "clickup/windows",
+      "platform": "windows",
+      "unique_identifier": "ClickUp",
+      "description": "ClickUp is a productivity platform for tasks, docs, goals, and chat."
+    },
+    {
       "name": "CLion",
       "slug": "clion/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/clickup/windows.json
+++ b/ee/maintained-apps/outputs/clickup/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "3.5.154",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'ClickUp' AND publisher = 'ClickUp';"
+      },
+      "installer_url": "https://download.todesktop.com/221003ra4tebclw/ClickUp-3.5.154-build-251111ehyopedtu-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "d40f06cf",
+      "sha256": "e11d7fdafc120a127b5e90f8c79b24e30bf7512cdfee44224056bb7825203feb",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{95C04A28-5736-505A-91E3-9132CDC33800}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "d40f06cf": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{95C04A28-5736-505A-91E3-9132CDC33800}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Windows version of ClickUp to the maintained apps system. The changes introduce new metadata, installer information, and management scripts for ClickUp on Windows, ensuring it can be properly discovered, installed, and uninstalled through the platform.

**Addition of ClickUp for Windows:**

* Added a new input manifest `clickup.json` for ClickUp in `ee/maintained-apps/inputs/winget`, specifying package details and default categories.
* Updated `apps.json` to include ClickUp for Windows, with platform information and a descriptive entry for discoverability.

**Installer and management scripts:**

* Created `clickup/windows.json` in outputs, defining the available version, installer URL, install/uninstall PowerShell scripts, SHA256 hash, and upgrade code for ClickUp on Windows.