### PR TITLE
Add Cyberduck as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/cyberduck.json
+++ b/ee/maintained-apps/inputs/winget/cyberduck.json
@@ -1,0 +1,10 @@
+{
+  "name": "Cyberduck",
+  "slug": "cyberduck/windows",
+  "package_identifier": "Iterate.Cyberduck",
+  "unique_identifier": "Cyberduck",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -261,6 +261,13 @@
       "description": "Cyberduck is a server and cloud storage browser."
     },
     {
+      "name": "Cyberduck",
+      "slug": "cyberduck/windows",
+      "platform": "windows",
+      "unique_identifier": "Cyberduck",
+      "description": "Cyberduck is a server and cloud storage browser."
+    },
+    {
       "name": "DataGrip",
       "slug": "datagrip/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/cyberduck/windows.json
+++ b/ee/maintained-apps/outputs/cyberduck/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "9.3.0.44071",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Cyberduck' AND publisher = 'iterate GmbH';"
+      },
+      "installer_url": "https://update.cyberduck.io//Cyberduck-Installer-9.3.0.44071.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "5afbd60e",
+      "sha256": "01123311a1aeadc81906857ac4bd63dc78f4057832baef3dd70ab44f24851e52",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{B9C33495-4B77-4863-9A40-4E767388647E}"
+    }
+  ],
+  "refs": {
+    "5afbd60e": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{B9C33495-4B77-4863-9A40-4E767388647E}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Cyberduck application on Windows to the maintained apps system. The changes introduce Cyberduck's metadata, installation details, and scripts for managing the app lifecycle.

**Addition of Cyberduck for Windows:**

* Added a new input manifest for Cyberduck in `winget/cyberduck.json`, specifying package identifiers, installer details, and default categories.
* Created an output manifest `cyberduck/windows.json` with version info, install/uninstall scripts, installer URL, SHA256 hash, and upgrade code for reliable management.
* Updated `apps.json` to include Cyberduck as a supported Windows app, with platform, identifier, and description.