### PR TITLE
Support direct path to images in generate-icons script

### DIFF
--- a/tools/software/icons/README.md
+++ b/tools/software/icons/README.md
@@ -5,16 +5,23 @@ App icons for the Fleet server and [fleetdm.com software catalog](https://fleetd
 ## Usage
 
 ```bash
-bash tools/software/icons/generate-icons.sh -a /path/to/App.app -s slug-name
+bash tools/software/icons/generate-icons.sh -s slug-name [-a /path/to/App.app | -i /path/to/icon.png]
 ```
 
-- `-a`: Path to the `.app` bundle (e.g. `/Applications/Safari.app`)
-- `-s`: Slug name for the Fleet-maintained app.  The portion before the slash will be used in the output filenames.
+- `-s`: Slug name for the Fleet-maintained app (required). The portion before the slash will be used in the output filenames.
+- `-a`: Path to the `.app` bundle (e.g. `/Applications/Safari.app`). Required if `-i` is not provided.
+- `-i`: Path to a PNG icon file. Required if `-a` is not provided. The icon will be resized to 128x128 if larger.
 
-## Example
+## Examples
 
+Using an app bundle:
 ```bash
 bash tools/software/icons/generate-icons.sh -a /Applications/Google\ Chrome.app -s "google-chrome/darwin"
+```
+
+Using a PNG file directly:
+```bash
+bash tools/software/icons/generate-icons.sh -i /path/to/icon.png -s "company-portal/windows"
 ```
 
 This will generate two files:


### PR DESCRIPTION
This pull request adds support for generating app icons from a PNG file in addition to the existing `.app` bundle method. The changes update both the documentation and the `generate-icons.sh` script to allow users to specify either an app bundle or a PNG file, improving flexibility for icon generation.

**Documentation and usage improvements:**

* Updated `README.md` to document the new `-i` option for PNG input, clarified required arguments, and added usage examples for both `.app` bundles and PNG files.

**Script enhancements for PNG support:**

* Modified argument parsing in `generate-icons.sh` to accept a new `-i` option for PNG files, and added validation to ensure either `-a` or `-i` is provided (but not both). [[1]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44R295-R302) [[2]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L312-R381)
* Added logic to handle PNG input: verifies the PNG file, derives component and display names from the slug, and integrates PNG processing alongside the existing `.app` bundle workflow. [[1]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L312-R381) [[2]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L412) [[3]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44R508-R519)
* Adjusted SVG and component name generation to work appropriately for both input methods, ensuring correct naming and file output. [[1]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L465-R548) [[2]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L481-L483) [[3]](diffhunk://#diff-3efaab61495d01f6ff77a1e75195bd8b009e71c9ea53e3278274cb5edf929c44L501-L507)