### PR TITLE
Add Cisco Jabber as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/cisco-jabber.json
+++ b/ee/maintained-apps/inputs/winget/cisco-jabber.json
@@ -1,0 +1,10 @@
+{
+  "name": "Cisco Jabber",
+  "slug": "cisco-jabber/windows",
+  "package_identifier": "Cisco.Jabber",
+  "unique_identifier": "Cisco Jabber",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Communication"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -195,7 +195,7 @@
       "slug": "cisco-jabber/windows",
       "platform": "windows",
       "unique_identifier": "Cisco Jabber",
-      "description": ""
+      "description": "Cisco Jabber is a collaboration and communication app."
     },
     {
       "name": "Citrix Workspace",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -191,6 +191,13 @@
       "description": "Cisco Jabber is a collaboration and communication app."
     },
     {
+      "name": "Cisco Jabber",
+      "slug": "cisco-jabber/windows",
+      "platform": "windows",
+      "unique_identifier": "Cisco Jabber",
+      "description": ""
+    },
+    {
       "name": "Citrix Workspace",
       "slug": "citrix-workspace/darwin",
       "platform": "darwin",
@@ -890,7 +897,7 @@
       "unique_identifier": "com.sublimetext.4",
       "description": "Sublime Text is a text editor for code, markup, and prose."
     },
-    {  
+    {
       "name": "Sublime Text",
       "slug": "sublime-text/windows",
       "platform": "windows",
@@ -898,18 +905,18 @@
       "description": "Sublime Text is a text editor for code, markup, and prose."
     },
     {
-      "name": "TablePlus",
-      "slug": "tableplus/darwin",
-      "platform": "darwin",
-      "unique_identifier": "com.tinyapp.TablePlus",
-      "description": "TablePlus is a native GUI tool for relational databases."
-    },
-    {
       "name": "Tableau Desktop",
       "slug": "tableau/darwin",
       "platform": "darwin",
       "unique_identifier": "com.tableausoftware.Desktop.app",
       "description": "Tableau Desktop is a powerful data visualization and business intelligence platform for analyzing and presenting data insights."
+    },
+    {
+      "name": "TablePlus",
+      "slug": "tableplus/darwin",
+      "platform": "darwin",
+      "unique_identifier": "com.tinyapp.TablePlus",
+      "description": "TablePlus is a native GUI tool for relational databases."
     },
     {
       "name": "Tailscale",

--- a/ee/maintained-apps/outputs/cisco-jabber/windows.json
+++ b/ee/maintained-apps/outputs/cisco-jabber/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "15.2.0.60459",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Cisco Jabber' AND publisher = 'Cisco Systems, Inc';"
+      },
+      "installer_url": "https://binaries.webex.com/jabberclientwindows/20251117102106/CiscoJabberSetup.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "163f2357",
+      "sha256": "adf7ac006769ba1e7df82fb322c48e27df56a53c5664a989d7b5ed55ea58b4a6",
+      "default_categories": [
+        "Communication"
+      ],
+      "upgrade_code": "{6FA51B39-4177-411C-A3A3-5A81C464278B}"
+    }
+  ],
+  "refs": {
+    "163f2357": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{6FA51B39-4177-411C-A3A3-5A81C464278B}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Cisco Jabber application on Windows, including its metadata, installation, and uninstallation details. It also corrects the ordering of the TablePlus app entry in the output list. The most important changes are:

**New application support:**

* Added a new input manifest for Cisco Jabber in `winget/cisco-jabber.json`, specifying its package details and default category.
* Added Cisco Jabber to `apps.json` output, including its name, slug, platform, and unique identifier.
* Created a new output file `cisco-jabber/windows.json` with version information, installation/uninstallation scripts, installer URL, SHA256 hash, and upgrade code for Cisco Jabber.

**App list correction:**

* Corrected the ordering of the TablePlus entry in `apps.json` output to ensure proper listing.