### PR TITLE
Add Twingate as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/twingate.json
+++ b/ee/maintained-apps/inputs/winget/twingate.json
@@ -1,0 +1,10 @@
+{
+  "name": "Twingate",
+  "slug": "twingate/windows",
+  "package_identifier": "Twingate.Client",
+  "unique_identifier": "Twingate",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1017,6 +1017,13 @@
       "description": "Twingate is a zero trust network access platform."
     },
     {
+      "name": "Twingate",
+      "slug": "twingate/windows",
+      "platform": "windows",
+      "unique_identifier": "Twingate",
+      "description": "Twingate is a zero trust network access platform."
+    },
+    {
       "name": "Microsoft Visual Studio Code",
       "slug": "visual-studio-code/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/twingate/windows.json
+++ b/ee/maintained-apps/outputs/twingate/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "20.25.322.1319",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Twingate' AND publisher = 'Twingate Inc.';"
+      },
+      "installer_url": "https://binaries.twingate.com/client/windows/versions/2025.322.1319/TwingateWindowsInstaller.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "0684eac9",
+      "sha256": "104d5868868ab63c90777c992a93e74bab7498c64a61cebba76d9d6a84f56374",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{11BA3B45-D8FA-4524-A085-80FB0A7CFC8C}"
+    }
+  ],
+  "refs": {
+    "0684eac9": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{11BA3B45-D8FA-4524-A085-80FB0A7CFC8C}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Twingate Windows application to the maintained apps system. The main changes include adding metadata and installer information for Twingate on Windows, updating the aggregated apps list, and providing install/uninstall scripts.

**Addition of Twingate Windows app:**

* Added a new input file `winget/twingate.json` with metadata for the Twingate Windows app, including installer details and categorization.
* Created an output file `twingate/windows.json` specifying the available version, installer URL, SHA256 hash, upgrade code, and PowerShell scripts for install and uninstall operations.

**Updates to app listings:**

* Updated `apps.json` to include Twingate for Windows, with platform information and description.