### PR TITLE
Fix VLC media player FMA grouping

### DIFF
--- a/ee/maintained-apps/inputs/winget/vlc.json
+++ b/ee/maintained-apps/inputs/winget/vlc.json
@@ -1,5 +1,5 @@
 {
-  "name": "VLC",
+  "name": "VLC media player",
   "slug": "vlc/windows",
   "package_identifier": "VideoLAN.VLC",
   "unique_identifier": "VLC media player",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1038,7 +1038,7 @@
       "description": "VLC media player is a free and open-source media player software."
     },
     {
-      "name": "VLC",
+      "name": "VLC media player",
       "slug": "vlc/windows",
       "platform": "windows",
       "unique_identifier": "VLC media player",


### PR DESCRIPTION
This pull request updates the naming conventions for the VLC app in both input and output configuration files to ensure consistency and clarity. The most important changes are:

Naming consistency updates:

* Changed the `name` field from "VLC" to "VLC media player" in `ee/maintained-apps/inputs/winget/vlc.json` to better reflect the application's full name.
* Updated the `name` field from "VLC" to "VLC media player" in `ee/maintained-apps/outputs/apps.json` for the Windows platform entry, ensuring the output matches the input and provides a more descriptive app name.