### PR TITLE
Add Wireshark as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/wireshark.json
+++ b/ee/maintained-apps/inputs/winget/wireshark.json
@@ -1,0 +1,10 @@
+{
+  "name": "Wireshark",
+  "slug": "wireshark/windows",
+  "package_identifier": "WiresharkFoundation.Wireshark",
+  "unique_identifier": "Wireshark",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1105,7 +1105,7 @@
       "slug": "wireshark/windows",
       "platform": "windows",
       "unique_identifier": "Wireshark",
-      "description": ""
+      "description": "Wireshark is a network protocol analyzer."
     },
     {
       "name": "Wrike",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1101,6 +1101,13 @@
       "description": "Wireshark is a network protocol analyzer."
     },
     {
+      "name": "Wireshark",
+      "slug": "wireshark/windows",
+      "platform": "windows",
+      "unique_identifier": "Wireshark",
+      "description": ""
+    },
+    {
       "name": "Wrike",
       "slug": "wrike/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/wireshark/windows.json
+++ b/ee/maintained-apps/outputs/wireshark/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "4.6.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org';"
+      },
+      "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.2-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "eb44b865",
+      "sha256": "fa979913b8caceaec071156b50be0b4a999bb0c21d29f05e1a8ee61ed90c1b45",
+      "default_categories": [
+        "Developer tools"
+      ],
+      "upgrade_code": "{0D67AACE-269A-4264-81A3-DA8055C1C79C}"
+    }
+  ],
+  "refs": {
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "eb44b865": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{0D67AACE-269A-4264-81A3-DA8055C1C79C}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for managing Wireshark on Windows to the maintained apps system. The main changes include introducing new input and output files for Wireshark, updating the central apps manifest, and providing installation and uninstallation scripts.

**Wireshark Windows support:**

* Added a new input manifest for Wireshark in `winget` format at `ee/maintained-apps/inputs/winget/wireshark.json`.
* Created an output manifest for Wireshark on Windows at `ee/maintained-apps/outputs/wireshark/windows.json`, including version info, installer details, install/uninstall scripts, and metadata.
* Updated the central apps manifest `ee/maintained-apps/outputs/apps.json` to include Wireshark for Windows as a managed app.