### PR TITLE
Disable calendar events for enrollment profile policy

### DIFF
--- a/it-and-security/lib/macos/policies/enrollment-profile-up-to-date.yml
+++ b/it-and-security/lib/macos/policies/enrollment-profile-up-to-date.yml
@@ -15,4 +15,4 @@
 
     If you encounter any issues, please reach out via #help-dogfooding. 
   platform: darwin
-  calendar_events_enabled: true
+  calendar_events_enabled: false


### PR DESCRIPTION
This pull request makes a minor change to the `enrollment-profile-up-to-date.yml` policy by disabling calendar events for the macOS platform.