### PR TITLE
Fix Windows app icon mapping for generic programs

### DIFF
--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -336,7 +336,7 @@ export const SOFTWARE_SOURCE_TO_ICON_MAP = {
   apps: AppleApp,
   ios_apps: AppleApp,
   ipados_apps: AppleApp,
-  programs: WindowsAppRemote,
+  programs: WindowsOS,
   android_apps: AndroidApp,
   chrome_extensions: Extension,
   safari_extensions: Extension,

--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -336,7 +336,7 @@ export const SOFTWARE_SOURCE_TO_ICON_MAP = {
   apps: AppleApp,
   ios_apps: AppleApp,
   ipados_apps: AppleApp,
-  programs: WindowsApp,
+  programs: WindowsAppRemote,
   android_apps: AndroidApp,
   chrome_extensions: Extension,
   safari_extensions: Extension,


### PR DESCRIPTION
This pull request updates the icon mapping for software sources in the `SoftwarePage` component. The most important change is that the icon for `programs` is now set to `WindowsAppRemote` instead of `WindowsApp`.

* Updated the `SOFTWARE_SOURCE_TO_ICON_MAP` in `frontend/pages/SoftwarePage/components/icons/index.ts` to use `WindowsAppRemote` for the `programs` key instead of `WindowsApp`.