### PR TITLE
Fleet UI: Remove ability to transfer host to current team

### DIFF
--- a/changes/33420-transfer-to-same-team
+++ b/changes/33420-transfer-to-same-team
@@ -1,0 +1,1 @@
+- Fleet UI: Hid option to transfer hosts to their current team.

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1497,6 +1497,7 @@ const ManageHostsPage = ({
         onCancel={toggleTransferHostModal}
         isUpdating={isUpdating}
         multipleHosts={selectedHostIds.length > 1}
+        hostsTeamId={currentTeamId} // Removes current team from the transfer options
       />
     );
   };

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
@@ -1,0 +1,145 @@
+// TransferHostModal.test.tsx
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import paths from "router/paths";
+
+import TransferHostModal from "./TransferHostModal";
+
+const teams = [
+  { id: 1, name: "Team Alpha" },
+  { id: 2, name: "Team Beta" },
+];
+
+const setup = (
+  props: Partial<React.ComponentProps<typeof TransferHostModal>> = {}
+) => {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+
+  const user = userEvent.setup();
+
+  render(
+    <TransferHostModal
+      isGlobalAdmin={false}
+      teams={teams as any}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+      isUpdating={false}
+      multipleHosts={false}
+      hostsTeamId={1}
+      {...props}
+    />
+  );
+
+  return { user, onSubmit, onCancel };
+};
+
+describe("TransferHostModal", () => {
+  it("renders title for single host and label", () => {
+    setup();
+
+    expect(screen.getByText("Transfer host")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Transfer host to:", { selector: "label" })
+    ).toBeInTheDocument();
+  });
+
+  it("pluralizes title and label when multipleHosts is true", () => {
+    setup({ multipleHosts: true });
+
+    expect(screen.getByText("Transfer hosts")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("Transfer selected hosts to:", { selector: "label" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows Create a team link when user is global admin", () => {
+    setup({ isGlobalAdmin: true });
+
+    expect(screen.getByText(/Create a team/i)).toBeInTheDocument();
+  });
+
+  it("does not show Create a team link when not global admin", () => {
+    setup({ isGlobalAdmin: false });
+
+    expect(screen.queryByText(/Create a team/i)).not.toBeInTheDocument();
+  });
+
+  it("disables Transfer button until a team is selected", () => {
+    setup();
+
+    const transferButton = screen.getByRole("button", { name: "Transfer" });
+    expect(transferButton).toBeDisabled();
+  });
+
+  it("filters out current host team from dropdown options and includes No team when allowed", async () => {
+    const { user } = setup({ hostsTeamId: 1 });
+
+    const dropdown = screen.getByText(/Select a team/i);
+
+    await user.click(dropdown);
+
+    expect(screen.getByText("No team")).toBeInTheDocument();
+    expect(screen.getByText("Team Beta")).toBeInTheDocument();
+    expect(screen.queryByText("Team Alpha")).not.toBeInTheDocument();
+  });
+
+  it("does not allow transferring to No team again when host is already on no team", async () => {
+    const { user } = setup({ hostsTeamId: 0 });
+
+    const dropdown = screen.getByText(/Select a team/i);
+    await user.click(dropdown);
+
+    expect(screen.queryByText("No team")).not.toBeInTheDocument();
+    expect(screen.getByText("Team Alpha")).toBeInTheDocument();
+    expect(screen.getByText("Team Beta")).toBeInTheDocument();
+  });
+
+  it("enables Transfer after selecting a team and calls onSubmit with selected team", async () => {
+    const { user, onSubmit } = setup({ hostsTeamId: 1 });
+
+    const dropdown = screen.getByText(/Select a team/i);
+
+    // Custom dropdown path: open then click an option
+    await user.click(dropdown);
+    await user.click(await screen.findByText("Team Beta"));
+
+    const transferButton = screen.getByRole("button", { name: "Transfer" });
+    expect(transferButton).not.toBeDisabled();
+
+    await user.click(transferButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("supports selecting No team and passes through the no-team object shape", async () => {
+    const { user, onSubmit } = setup({ hostsTeamId: 1 });
+
+    const dropdown = screen.getByText(/Select a team/i);
+
+    await user.click(dropdown);
+    const noTeamOption = await screen.findByRole("option", {
+      name: "No team",
+    });
+    await user.click(noTeamOption);
+
+    const transferButton = screen.getByRole("button", { name: "Transfer" });
+    expect(transferButton).not.toBeDisabled();
+
+    await user.click(transferButton);
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const { user, onCancel } = setup();
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    await user.click(cancelButton);
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
@@ -6,7 +6,7 @@ import Button from "components/buttons/Button";
 // ignore TS error for now until these are rewritten in ts.
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
-import { ITeam } from "interfaces/team";
+import { ITeam, ITeamSummary } from "interfaces/team";
 
 interface ITransferHostModal {
   isGlobalAdmin: boolean;
@@ -16,6 +16,8 @@ interface ITransferHostModal {
   isUpdating: boolean;
   /** Manage host page only */
   multipleHosts?: boolean;
+  /** Selected team's id on manage host page, or host detail's team id */
+  hostsTeamId?: number | null;
 }
 
 interface INoTeamOption {
@@ -36,6 +38,7 @@ const TransferHostModal = ({
   isGlobalAdmin,
   isUpdating,
   multipleHosts,
+  hostsTeamId,
 }: ITransferHostModal): JSX.Element => {
   const [selectedTeam, setSelectedTeam] = useState<ITeam | INoTeamOption>();
 
@@ -56,17 +59,27 @@ const TransferHostModal = ({
   }, [onSubmit, selectedTeam]);
 
   const createTeamDropdownOptions = () => {
-    const teamOptions = teams.map((team) => {
-      return {
-        value: team.id,
-        label: team.name,
-      };
-    });
-    return [NO_TEAM_OPTION, ...teamOptions];
+    const teamOptions = teams
+      .filter((team) => team.id !== hostsTeamId) // Remove current team from options
+      .map((team) => {
+        return {
+          value: team.id,
+          label: team.name,
+        };
+      });
+
+    // Hosts on no team cannot transfer to no team again
+    const canTransferToNoTeam = hostsTeamId !== 0 && hostsTeamId !== null;
+
+    return canTransferToNoTeam ? [NO_TEAM_OPTION, ...teamOptions] : teamOptions;
   };
 
   return (
-    <Modal onExit={onCancel} title="Transfer hosts" className={baseClass}>
+    <Modal
+      onExit={onCancel}
+      title={`Transfer host${multipleHosts ? "s" : ""}`}
+      className={baseClass}
+    >
       <>
         <form className={`${baseClass}__form`}>
           <Dropdown

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1399,6 +1399,7 @@ const HostDetailsPage = ({
               teams={teams || []}
               isGlobalAdmin={isGlobalAdmin as boolean}
               isUpdating={isUpdating}
+              hostsTeamId={host.team_id}
             />
           )}
           {!!host && showPolicyDetailsModal && (


### PR DESCRIPTION
## Issue
Closes #33420 

## Description
- Nerd sniped while looking for another ticket
- Removes host's current team from host details > transfer modal options
- Removes current selected team from manage host page > transfer modal options

## Screenshot of fix
<img width="1195" height="429" alt="Screenshot 2025-12-09 at 11 56 56 AM" src="https://github.com/user-attachments/assets/bb5d3a02-646e-499f-99be-32fe731287c6" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
