### PR TITLE
Windows and Linux setup experience

### DIFF
--- a/articles/windows-linux-setup-experience.md
+++ b/articles/windows-linux-setup-experience.md
@@ -8,7 +8,7 @@ Here's what you can configure, and in what order each happen, to your Windows an
 
 1. Require [end users to authenticate](#end-user-authentication) with your identity provider (IdP).
 
-2. [Install software](#install-software) (App Store apps, custom packages, and Fleet-maintained apps). 
+2. [Install software](#install-software) inclduing [app store apps](https://fleetdm.com/guides/install-app-store-apps), [custom packages](https://fleetdm.com/guides/deploy-software-packages) (e.g. a bootstrap package), and [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps). 
 
 ## End user authentication
 


### PR DESCRIPTION
Mention "bootstrap package" to help Mac admins, who are familiar with the term, realize that they can install a bootstrap package when new Windows workstations first boot

