### PR TITLE
Fleet UI copy tweak

### DIFF
--- a/frontend/components/MDM/SSOError/SSOError.tsx
+++ b/frontend/components/MDM/SSOError/SSOError.tsx
@@ -15,8 +15,7 @@ const SSOError = ({ className }: ISSOErrorProps) => {
   return (
     <DataError className={classNames}>
       <p>
-        Please try again. If this keeps happening,
-        please contact IT support.
+        Please try again. If this keeps happening, please contact IT support.
       </p>
     </DataError>
   );

--- a/frontend/components/MDM/SSOError/SSOError.tsx
+++ b/frontend/components/MDM/SSOError/SSOError.tsx
@@ -15,7 +15,7 @@ const SSOError = ({ className }: ISSOErrorProps) => {
   return (
     <DataError className={classNames}>
       <p>
-        Select <strong>Cancel</strong> and try again. If this keeps happening,
+        Please try again. If this keeps happening,
         please contact IT support.
       </p>
     </DataError>


### PR DESCRIPTION
- @noahtalerman: My understanding is that we use this error message for all platforms. "Select Cancel..." doesn't help the end user on Android because there's no cancel button. The copy could be more helpful but with this tweak at least it's not confusing.

This came up when testing Android enrollment w/ `customer-pingali`
