### PR TITLE
updated activity filter sort dropdown values

### DIFF
--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityFeedFilters/ActivityFeedFilters.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ActivityFeedFilters/ActivityFeedFilters.tsx
@@ -37,8 +37,8 @@ TYPE_FILTER_OPTIONS.unshift({
 });
 
 const SORT_OPTIONS = [
-  { label: "Newest", value: "desc" },
-  { label: "Oldest", value: "asc" },
+  { label: "Sort by newest", value: "desc" },
+  { label: "Sort by oldest", value: "asc" },
 ];
 
 interface ActivityFeedFiltersProps {
@@ -65,7 +65,7 @@ const ActivityFeedFilters = ({
   setPageIndex,
 }: ActivityFeedFiltersProps) => {
   const onChangeActivityType = (value: string) => {
-    setTypeFilter((prev: string[]) => [value]);
+    setTypeFilter(() => [value]);
     setPageIndex(0);
   };
 


### PR DESCRIPTION
**Related issue:** Resolves #33987

Quick change to update the activity sort filter. Changes the names of the display labels to `Sort by newest` and `Sort by oldest`.

