### PR TITLE
add ability to resend window profiles on host details and my device pages

### DIFF
--- a/changes/issue-35509-ui-resend-window-profile
+++ b/changes/issue-35509-ui-resend-window-profile
@@ -1,0 +1,1 @@
+- add ability to resend windows profiles on the host details and my device pages

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -33,6 +33,7 @@ import {
   isMacOS,
   isAppleDevice,
   isLinuxLike,
+  isWindows,
 } from "interfaces/platform";
 import { IHostSoftware } from "interfaces/software";
 import { ISetupStep } from "interfaces/setup";
@@ -822,7 +823,9 @@ const DeviceUserPage = ({
         )}
         {!!host && showOSSettingsModal && (
           <OSSettingsModal
-            canResendProfiles={host.platform === "darwin"}
+            canResendProfiles={
+              isMacOS(host.platform) || isWindows(host.platform)
+            }
             platform={host.platform}
             hostMDMData={host.mdm}
             resendRequest={resendProfile}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -55,7 +55,14 @@ import {
   DEFAULT_USE_QUERY_OPTIONS,
 } from "utilities/constants";
 
-import { isAndroid, isIPadOrIPhone, isLinuxLike } from "interfaces/platform";
+import {
+  isAppleDevice,
+  isMacOS,
+  isAndroid,
+  isIPadOrIPhone,
+  isLinuxLike,
+  isWindows,
+} from "interfaces/platform";
 
 import Spinner from "components/Spinner";
 import TabNav from "components/TabNav";
@@ -1019,12 +1026,13 @@ const HostDetailsPage = ({
     name: host?.mdm.macos_setup?.bootstrap_package_name,
   };
 
-  const isDarwinHost = host.platform === "darwin";
+  const isMacOSHost = isMacOS(host.platform);
   const isIosOrIpadosHost = isIPadOrIPhone(host.platform);
   const isAndroidHost = isAndroid(host.platform);
+  const isWindowsHost = isWindows(host.platform);
 
   const canResendProfiles =
-    isDarwinHost &&
+    (isMacOSHost || isWindowsHost) &&
     (isGlobalAdmin ||
       isGlobalMaintainer ||
       isHostTeamAdmin ||
@@ -1036,8 +1044,7 @@ const HostDetailsPage = ({
   const showAgentOptionsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showLocalUserAccountsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showCertificatesCard =
-    (isIosOrIpadosHost || isDarwinHost) &&
-    !!hostCertificates?.certificates.length;
+    isAppleDevice(host.platform) && !!hostCertificates?.certificates.length;
 
   const renderSoftwareCard = () => {
     return (
@@ -1070,7 +1077,7 @@ const HostDetailsPage = ({
                 hostTeamId={host.team_id || 0}
                 hostMdmEnrollmentStatus={host.mdm.enrollment_status}
               />
-              {isDarwinHost && macadmins?.munki?.version && (
+              {isMacOSHost && macadmins?.munki?.version && (
                 <MunkiIssuesCard
                   isLoading={isLoadingHost}
                   munkiIssues={macadmins.munki_issues}
@@ -1144,7 +1151,7 @@ const HostDetailsPage = ({
               onShowInventoryVersions={onSetSelectedHostSWForInventoryVersions}
               hostTeamId={host.team_id || 0}
             />
-            {isDarwinHost && macadmins?.munki?.version && (
+            {isMacOSHost && macadmins?.munki?.version && (
               <MunkiIssuesCard
                 isLoading={isLoadingHost}
                 munkiIssues={macadmins.munki_issues}

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -83,9 +83,14 @@ const generateTableConfig = (
 
         const isMacOSMobileConfigProfile =
           platform === "darwin" && !isDDMProfile(cellProps.row.original);
+        const isWindowsProfile = platform === "windows";
+
         return (
           <OSSettingsErrorCell
-            canResendProfiles={canResendProfiles && isMacOSMobileConfigProfile}
+            canResendProfiles={
+              canResendProfiles &&
+              (isWindowsProfile || isMacOSMobileConfigProfile)
+            }
             profile={cellProps.row.original}
             resendRequest={resendRequest}
             onProfileResent={onProfileResent}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35509

This adds the ability in the UI to resend windows profiles in the OS settings modal on both the host details and my device pages

- [x] Changefile
- [x] QA'd all new/changed functionality manually
