### PR TITLE
Add simple dbutils tool to quickly set migration table status

### DIFF
--- a/tools/dbutils/update-migration-status
+++ b/tools/dbutils/update-migration-status
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if we have at least 2 arguments
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <is_applied_value> <version_id1> [version_id2] [version_id3] ..."
+    exit 1
+fi
+
+is_applied=$1
+shift  # Remove first argument, leaving only version IDs
+
+# Check if we have only one remaining argument and it contains commas
+if [ $# -eq 1 ] && [[ "$1" == *","* ]]; then
+    # Single argument with commas - use as is
+    version_ids="$1"
+else
+    # Multiple arguments or single argument without commas - join with commas
+    version_ids=$(IFS=','; echo "$*")
+fi
+
+docker compose exec mysql mysql -uroot -ptoor -Dfleet -e "UPDATE migration_status_tables SET is_applied = $is_applied WHERE version_id IN ($version_ids);"


### PR DESCRIPTION
I wrote this small utility tool to quickly help switch migrations off or on, when switching between versions.

It fits this workflow:

- You build fleet
- Start and see missing or unknown migrations: `Missing migrations: tables=[20251207050413 20251208215800].`
- Copy all values inside the `[]` and run the tool:
    - `./tools/dbutils/update-migration-status 1 20251207050413 20251208215800` if you already have the migrations.
- Or when going to older versions:
    - `./tools/dbutils/update-migration-status 0 20251207050413 20251208215800` to disable them.

Feel free to reject if deemed unnecessary, I've found it be helpful for me, so wanted to put it up for potential merge if others could see the benefit.