### PR TITLE
Add filter param and count to MDM commands endpoint

### DIFF
--- a/changes/34704-past-upcoming-mdm-commands
+++ b/changes/34704-past-upcoming-mdm-commands
@@ -1,0 +1,1 @@
+- Added feature for viewing past and upcoming MDM commands for a host in Fleet.

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -3013,13 +3013,13 @@ func TestGetMDMCommands(t *testing.T) {
 	var noHostErr error
 	var expectIdentifier bool
 	var expectRequestType bool
-	ds.ListMDMCommandsFunc = func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error) {
+	ds.ListMDMCommandsFunc = func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
 		if empty || listErr != nil {
-			return nil, listErr
+			return nil, nil, listErr
 		}
 
 		if noHostErr != nil {
-			return nil, errors.New(fleet.HostIdentiferNotFound)
+			return nil, nil, errors.New(fleet.HostIdentiferNotFound)
 		}
 
 		if expectIdentifier {
@@ -3055,7 +3055,7 @@ func TestGetMDMCommands(t *testing.T) {
 				Status:      "200",
 				Hostname:    "host2",
 			},
-		}, nil
+		}, nil, nil
 	}
 
 	listErr = io.ErrUnexpectedEOF

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -108,7 +108,7 @@ func (svc *Service) GetOrbitSetupExperienceStatus(ctx context.Context, orbitNode
 	adminTeamFilter := fleet.TeamFilter{
 		User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
 	}
-	acctCmds, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
+	acctCmds, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
 		Filters: fleet.MDMCommandFilters{
 			HostIdentifier: host.UUID,
 			RequestType:    "AccountConfiguration",

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -348,7 +348,7 @@ func addRequestTypeFilter(stmt string, filter *fleet.MDMCommandFilters, params [
 	return stmt, params
 }
 
-func addAppleCommandStatusFilter(stmt string, filter *fleet.MDMCommandFilters, params []interface{}) (string, []interface{}) {
+func addAppleCommandStatusFilter(stmt string, filter *fleet.MDMCommandFilters, params []any) (string, []any) {
 	if len(filter.CommandStatuses) > 0 {
 		stmt += " AND ("
 		for i, status := range filter.CommandStatuses {

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -93,7 +93,7 @@ func (ds *Datastore) ListMDMCommands(
 	ctx context.Context,
 	tmFilter fleet.TeamFilter,
 	listOpts *fleet.MDMCommandListOptions,
-) ([]*fleet.MDMCommand, error) {
+) ([]*fleet.MDMCommand, *int64, error) {
 	if listOpts != nil && listOpts.Filters.HostIdentifier != "" {
 		// separate codepath for more performant query by host identifier
 		return ds.listMDMCommandsByHostIdentifier(ctx, tmFilter, listOpts)
@@ -105,9 +105,9 @@ func (ds *Datastore) ListMDMCommands(
 	jointStmt, params = appendListOptionsWithCursorToSQL(jointStmt, params, &listOpts.ListOptions)
 	var results []*fleet.MDMCommand
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, jointStmt, params...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list commands")
+		return nil, nil, ctxerr.Wrap(ctx, err, "list commands")
 	}
-	return results, nil
+	return results, nil, nil
 }
 
 // listMDMCommandsByHostIdentifier retrieves MDM commands by host identifier. It is implemented as a
@@ -122,9 +122,9 @@ func (ds *Datastore) listMDMCommandsByHostIdentifier(
 	ctx context.Context,
 	teamFilter fleet.TeamFilter,
 	listOpts *fleet.MDMCommandListOptions,
-) ([]*fleet.MDMCommand, error) {
+) ([]*fleet.MDMCommand, *int64, error) {
 	if listOpts == nil || listOpts.Filters.HostIdentifier == "" {
-		return nil, ctxerr.Wrap(ctx, errors.New("listMDMCommandsByHostIdentifier requires non-empty listOpts.Filters.HostIdentifier"))
+		return nil, nil, ctxerr.Wrap(ctx, errors.New("listMDMCommandsByHostIdentifier requires non-empty listOpts.Filters.HostIdentifier"))
 	}
 
 	// First, search for host by identifier (hostname, uuid, or hardware_serial).
@@ -161,15 +161,21 @@ WHERE ` + whereTeam
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &dest, stmt, args...)
 	switch {
 	case err != nil:
-		return nil, ctxerr.Wrap(ctx, err, "get host by identifier for mdm")
+		return nil, nil, ctxerr.Wrap(ctx, err, "get host by identifier for mdm")
 	case len(dest) == 0:
 		// TODO: should we return an empty slice or an error?
-		return []*fleet.MDMCommand{}, nil
+		return []*fleet.MDMCommand{}, nil, nil
 	case len(dest) > 1:
 		// TODO: how should we handle this unexpected case?
 		level.Debug(ds.logger).Log("msg", "list mdm commands: multiple hosts found for identifier",
 			"identifier", identifier, "count", len(dest),
 		)
+	}
+
+	if dest[0].Platform == "windows" && len(listOpts.Filters.CommandStatuses) > 0 {
+		return nil, nil, &fleet.BadRequestError{
+			Message: `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`,
+		}
 	}
 
 	// Next, build the query to list MDM commands. If the found host(s) are on the same platform,
@@ -205,6 +211,12 @@ SELECT
 	nc.command_uuid,
 	COALESCE(ncr.updated_at, nc.created_at) AS updated_at,
 	COALESCE(NULLIF(ncr.status, ''), 'Pending') AS status,
+	CASE
+        WHEN COALESCE(NULLIF(ncr.status, ''), 'Pending') IN ('Pending', 'NotNow') THEN 'pending'
+        WHEN COALESCE(NULLIF(ncr.status, ''), 'Pending') = 'Acknowledged' THEN 'ran'
+        WHEN COALESCE(NULLIF(ncr.status, ''), 'Pending') = 'Error' THEN 'failed'
+        ELSE 'pending'
+    END AS command_status,
 	request_type
 FROM
 	nano_enrollment_queue nq
@@ -215,9 +227,10 @@ WHERE
 	nq.id IN(?) AND nq.active = 1`
 
 		appleStmt, appleParams = addRequestTypeFilter(appleStmt, &listOpts.Filters, appleParams)
+		appleStmt, appleParams = addAppleCommandStatusFilter(appleStmt, &listOpts.Filters, appleParams)
 		appleStmt, appleParams, err = sqlx.In(appleStmt, appleParams...)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Apple devices")
+			return nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Apple devices")
 		}
 	}
 
@@ -229,6 +242,24 @@ SELECT
 	wq.command_uuid,
 	COALESCE(wcr.updated_at, wc.created_at) AS updated_at,
 	COALESCE(NULLIF(wcr.status_code, ''), '101') AS status,
+	CASE
+        WHEN COALESCE(
+            NULLIF(wcr.status_code, ''),
+            '101'
+        ) = '101' THEN 'pending'
+        WHEN CAST(
+            COALESCE(
+                NULLIF(wcr.status_code, ''),
+                '101'
+            ) AS UNSIGNED
+        ) BETWEEN 200 AND 399  THEN 'ran'
+        WHEN CAST(
+            COALESCE(
+                NULLIF(wcr.status_code, ''),
+                '101'
+            ) AS UNSIGNED
+        ) >= 400 THEN 'failed'
+    END AS command_status,
 	wc.target_loc_uri AS request_type
 FROM
 	windows_mdm_command_queue wq
@@ -242,23 +273,26 @@ WHERE
 		winStmt, winParams = addRequestTypeFilter(winStmt, &listOpts.Filters, winParams)
 		winStmt, winParams, err = sqlx.In(winStmt, winParams...)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Windows devices")
+			return nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Windows devices")
 		}
 	}
 
-	var listStmt string
+	var listStmt, countStmt string
 	var params []any
 	switch {
 	case len(appleUUIDs) > 0 && len(winUUIDs) > 0:
 		listStmt = fmt.Sprintf(`SELECT * FROM ((%s) UNION ALL (%s)) u`,
 			appleStmt, winStmt)
+		countStmt = fmt.Sprintf(`SELECT COUNT(1) FROM ((%s) UNION ALL (%s)) u`, appleStmt, winStmt)
 		params = append(params, appleParams...)
 		params = append(params, winParams...)
 	case len(appleUUIDs) > 0:
 		listStmt = appleStmt
+		countStmt = `SELECT COUNT(1) FROM (` + appleStmt + `) u`
 		params = appleParams
 	case len(winUUIDs) > 0:
 		listStmt = winStmt
+		countStmt = `SELECT COUNT(1) FROM (` + winStmt + `) u`
 		params = winParams
 	}
 
@@ -283,7 +317,15 @@ WHERE
 
 	var results []*fleet.MDMCommand
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, listStmt, params...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "list commands")
+		return nil, nil, ctxerr.Wrap(ctx, err, "list commands")
+	}
+
+	var total *int64
+	if len(listOpts.Filters.CommandStatuses) == 1 && listOpts.Filters.CommandStatuses[0] == fleet.MDMCommandStatusFilterPending {
+		// Only get count if we only filter by pending
+		if err := sqlx.GetContext(ctx, ds.reader(ctx), &total, countStmt, params...); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "count commands")
+		}
 	}
 
 	// Add hostname and team info to the results based on the host UUIDs.
@@ -294,7 +336,7 @@ WHERE
 		}
 	}
 
-	return results, nil
+	return results, total, nil
 }
 
 func addRequestTypeFilter(stmt string, filter *fleet.MDMCommandFilters, params []interface{}) (string, []interface{}) {
@@ -303,6 +345,28 @@ func addRequestTypeFilter(stmt string, filter *fleet.MDMCommandFilters, params [
 		params = append(params, filter.RequestType)
 	}
 
+	return stmt, params
+}
+
+func addAppleCommandStatusFilter(stmt string, filter *fleet.MDMCommandFilters, params []interface{}) (string, []interface{}) {
+	if len(filter.CommandStatuses) > 0 {
+		stmt += " AND ("
+		for i, status := range filter.CommandStatuses {
+			if i > 0 {
+				stmt += " OR "
+			}
+			switch status {
+			case fleet.MDMCommandStatusFilterPending:
+				stmt += " COALESCE(NULLIF(ncr.status, ''), 'Pending') IN ('Pending', 'NotNow')"
+			case fleet.MDMCommandStatusFilterRan:
+				stmt += " COALESCE(NULLIF(ncr.status, ''), 'Pending') = 'Acknowledged'"
+			case fleet.MDMCommandStatusFilterFailed:
+				stmt += " COALESCE(NULLIF(ncr.status, ''), 'Pending') = 'Error'"
+			}
+
+		}
+		stmt += ")"
+	}
 	return stmt, params
 }
 

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -404,6 +404,22 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, cmds, 1)
 	require.Equal(t, appleCmdUUID2, cmds[0].CommandUUID)
+
+	// filter by command status for windows host
+	cmds, total, err = ds.ListMDMCommands(
+		ctx,
+		fleet.TeamFilter{User: test.UserAdmin},
+		&fleet.MDMCommandListOptions{
+			Filters: fleet.MDMCommandFilters{
+				HostIdentifier:  "123456",
+				CommandStatuses: []fleet.MDMCommandStatusFilter{fleet.MDMCommandStatusFilterPending},
+			},
+		},
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`)
+	require.Nil(t, cmds)
+	require.Nil(t, total)
 }
 
 // testListMDMCommandsWithTeamFilter tests listing MDM commands with team filters

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1768,7 +1768,8 @@ type Datastore interface {
 
 	// ListMDMCommands returns a list of MDM Apple commands that have been
 	// executed, based on the provided options.
-	ListMDMCommands(ctx context.Context, tmFilter TeamFilter, listOpts *MDMCommandListOptions) ([]*MDMCommand, error)
+	// returns a non-nil count if filtering by command_status = pending
+	ListMDMCommands(ctx context.Context, tmFilter TeamFilter, listOpts *MDMCommandListOptions) ([]*MDMCommand, *int64, error)
 
 	// GetMDMWindowsBitLockerSummary summarizes the current state of Windows disk encryption on
 	// each Windows host in the specified team (or, if no team is specified, each host that is not assigned

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -372,6 +372,9 @@ type MDMCommand struct {
 	// to authorize the user to see the command, it is not returned as part of
 	// the response payload.
 	TeamID *uint `json:"-" db:"team_id"`
+	// CommandStatus is the fleet computed field representing the status of the command
+	// based on the MDM protocol status
+	CommandStatus MDMCommandStatusFilter `json:"command_status" db:"command_status"`
 }
 
 // MDMCommandListOptions defines the options to control the list of MDM
@@ -384,9 +387,24 @@ type MDMCommandListOptions struct {
 	Filters MDMCommandFilters
 }
 
+type MDMCommandStatusFilter string
+
+const (
+	MDMCommandStatusFilterPending MDMCommandStatusFilter = "pending"
+	MDMCommandStatusFilterRan     MDMCommandStatusFilter = "ran"
+	MDMCommandStatusFilterFailed  MDMCommandStatusFilter = "failed"
+)
+
+var AllMDMCommandStatusFilters = []MDMCommandStatusFilter{
+	MDMCommandStatusFilterPending,
+	MDMCommandStatusFilterRan,
+	MDMCommandStatusFilterFailed,
+}
+
 type MDMCommandFilters struct {
-	HostIdentifier string
-	RequestType    string
+	HostIdentifier  string
+	RequestType     string
+	CommandStatuses []MDMCommandStatusFilter
 }
 
 type MDMPlatformsCounts struct {
@@ -438,7 +456,6 @@ func (mdmPS *MDMProfilesSummary) Add(other *MDMProfilesSummary) *MDMProfilesSumm
 		Pending:   s1.Pending + s2.Pending,
 		Failed:    s1.Failed + s2.Failed,
 	}
-
 }
 
 // HostMDMProfile is the status of an MDM profile on a host. It can be used to represent either

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1107,7 +1107,7 @@ type Service interface {
 	GetMDMCommandResults(ctx context.Context, commandUUID string) ([]*MDMCommandResult, error)
 
 	// ListMDMCommands returns MDM commands based on the provided options.
-	ListMDMCommands(ctx context.Context, opts *MDMCommandListOptions) ([]*MDMCommand, error)
+	ListMDMCommands(ctx context.Context, opts *MDMCommandListOptions) ([]*MDMCommand, *int64, error)
 
 	// Set or update the disk encryption key for a host.
 	SetOrUpdateDiskEncryptionKey(ctx context.Context, encryptionKey, clientError string) error

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1161,7 +1161,7 @@ type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (
 
 type GetMDMCommandPlatformFunc func(ctx context.Context, commandUUID string) (string, error)
 
-type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error)
+type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error)
 
 type GetMDMWindowsBitLockerSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMWindowsBitLockerSummary, error)
 
@@ -8130,7 +8130,7 @@ func (s *DataStore) GetMDMCommandPlatform(ctx context.Context, commandUUID strin
 	return s.GetMDMCommandPlatformFunc(ctx, commandUUID)
 }
 
-func (s *DataStore) ListMDMCommands(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error) {
+func (s *DataStore) ListMDMCommands(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
 	s.mu.Lock()
 	s.ListMDMCommandsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -692,7 +692,7 @@ type RunMDMCommandFunc func(ctx context.Context, rawBase64Cmd string, deviceIDs 
 
 type GetMDMCommandResultsFunc func(ctx context.Context, commandUUID string) ([]*fleet.MDMCommandResult, error)
 
-type ListMDMCommandsFunc func(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error)
+type ListMDMCommandsFunc func(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error)
 
 type SetOrUpdateDiskEncryptionKeyFunc func(ctx context.Context, encryptionKey string, clientError string) error
 
@@ -4506,7 +4506,7 @@ func (s *Service) GetMDMCommandResults(ctx context.Context, commandUUID string) 
 	return s.GetMDMCommandResultsFunc(ctx, commandUUID)
 }
 
-func (s *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, error) {
+func (s *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
 	s.mu.Lock()
 	s.ListMDMCommandsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -846,7 +846,9 @@ func (r listMDMCommandsResponse) Error() error { return r.Err }
 // We the DecodeBody method to perform custom validation before hitting the service layer.
 func (req listMDMCommandsRequest) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {
 	if req.CommandStatus != "" && req.HostIdentifier == "" {
-		return errors.New(`"host_identifier" must be specified when filtering by "command_status".`)
+		return &fleet.BadRequestError{
+			Message: `"host_identifier" must be specified when filtering by "command_status".`,
+		}
 	}
 
 	if req.CommandStatus != "" {
@@ -865,7 +867,9 @@ func (req listMDMCommandsRequest) DecodeBody(ctx context.Context, r io.Reader, u
 			for i, v := range fleet.AllMDMCommandStatusFilters {
 				allowed[i] = string(v)
 			}
-			return fleet.NewInvalidArgumentError("command_status", fmt.Sprintf("command_status only accepts the following values: %s", strings.Join(allowed, ", ")))
+			return &fleet.BadRequestError{
+				Message: fmt.Sprintf("command_status only accepts the following values: %s", strings.Join(allowed, ", ")),
+			}
 		}
 	}
 

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -582,7 +582,7 @@ func (svc *Service) processReleaseDeviceForOldFleetd(ctx context.Context, host *
 		adminTeamFilter := fleet.TeamFilter{
 			User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
 		}
-		acctCmds, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
+		acctCmds, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
 			Filters: fleet.MDMCommandFilters{
 				HostIdentifier: host.UUID,
 				RequestType:    "AccountConfiguration",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36868 

Returning the count does not seem to really affect the performance with my data set, but let us see what the load test shows.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually