### PR TITLE
Product design kickoff

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -16,7 +16,7 @@
   task: "Product design sprint kickoff" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "Review stories for feature requests prioritized during Feature fest, align on priorities, and create an upcoming reference docs release branch."
+  description: "1. Pull up all contributors' calendars to review time off and, if needed, schedule design reviews. 2. Review stories for feature requests prioritized during Feature fest, align on priorities, and create an upcoming reference docs release branch."
   moreInfoUrl: 
   dri: "noahtalerman"
 -


### PR DESCRIPTION
- When @noahtalerman is out, other Product Designers fill in as reviewer during design review. Schedule meetings ahead of time so that they happen and we keep up velocity
