### PR TITLE
Support opening end-user auth window on MacOS

### DIFF
--- a/changes/37127-fix-macos-manual-enroll-with-end-user-auth
+++ b/changes/37127-fix-macos-manual-enroll-with-end-user-auth
@@ -1,1 +1,1 @@
-- Fixed issue where MacOS devices were blocked from enrolling when Orbit was installed manually.
+- Fixed an issue where MacOS devices were blocked from enrolling when Orbit was installed manually.

--- a/changes/37127-fix-macos-manual-enroll-with-end-user-auth
+++ b/changes/37127-fix-macos-manual-enroll-with-end-user-auth
@@ -1,0 +1,1 @@
+- Fixed issue where MacOS devices were blocked from enrolling when Orbit was installed manually.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -2472,7 +2472,7 @@ func openBrowserWindow(browserURL string) error {
 		var opts []execuser.Option
 		opts = append(opts, execuser.WithUser(*loggedInUser))
 		opts = append(opts, execuser.WithArg(browserURL, ""))
-		log.Debug().Str("browser", browserBin).Str("url", browserURL).Str("user", *loggedInUser).Msg("opening browser for setup experience")
+		log.Debug().Str("browser", browserBin).Str("url", browserURL).Str("user", *loggedInUser).Msg("opening linux browser")
 		if _, err := execuser.Run(browserBin, opts...); err != nil {
 			return fmt.Errorf("opening browser with %s: %w", browserBin, err)
 		}
@@ -2487,8 +2487,24 @@ func openBrowserWindow(browserURL string) error {
 			return fmt.Errorf("opening windows browser: %w", err)
 		}
 	default:
-		log.Debug().Msg("could not open browser, unsupported OS: " + runtime.GOOS)
-		return errors.New("opening setup experience browser page not supported on " + runtime.GOOS)
+		loggedInUser, err := user.UserLoggedInViaGui()
+		if err != nil {
+			return fmt.Errorf("get logged in user: %w", err)
+		}
+
+		if loggedInUser == nil {
+			return errors.New("no user logged in")
+		}
+
+		browserBin := "open"
+
+		var opts []execuser.Option
+		opts = append(opts, execuser.WithUser(*loggedInUser))
+		opts = append(opts, execuser.WithArg(browserURL, ""))
+		log.Debug().Str("browser", browserBin).Str("url", browserURL).Str("user", *loggedInUser).Msg("opening macos browser")
+		if _, err := execuser.Run(browserBin, opts...); err != nil {
+			return fmt.Errorf("opening browser with %s: %w", browserBin, err)
+		}
 	}
 	return nil
 }

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -2496,13 +2496,12 @@ func openBrowserWindow(browserURL string) error {
 			return errors.New("no user logged in")
 		}
 
-		browserBin := "open"
+		browserBin := "/usr/bin/open"
+		var cmd *exec.Cmd
+		arg := []string{"-u", *loggedInUser, "/usr/bin/open", browserURL}
+		cmd = exec.Command("sudo", arg...)
 
-		var opts []execuser.Option
-		opts = append(opts, execuser.WithUser(*loggedInUser))
-		opts = append(opts, execuser.WithArg(browserURL, ""))
-		log.Debug().Str("browser", browserBin).Str("url", browserURL).Str("user", *loggedInUser).Msg("opening macos browser")
-		if _, err := execuser.Run(browserBin, opts...); err != nil {
+		if err := cmd.Run(); err != nil {
 			return fmt.Errorf("opening browser with %s: %w", browserBin, err)
 		}
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37127 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
