### PR TITLE
Fleet UI: Fix self-service tooltips for iOS/iPadOS and Android

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -129,6 +129,7 @@ const generateTableHeaders = (
             automaticInstallPoliciesCount={
               nameCellData.automaticInstallPoliciesCount
             }
+            isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(nameCellData.source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
           />
         );

--- a/frontend/pages/SoftwarePage/helpers.tests.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tests.tsx
@@ -1,3 +1,6 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
 import { ISoftwareInstallPolicy } from "interfaces/software";
 
 import {
@@ -10,7 +13,59 @@ import {
   createMockHostAppStoreApp,
   createMockHostSoftware,
 } from "__mocks__/hostMock";
-import { getAutomaticInstallPoliciesCount } from "./helpers";
+import {
+  getSelfServiceTooltip,
+  getAutomaticInstallPoliciesCount,
+} from "./helpers";
+
+describe("getSelfServiceTooltip", () => {
+  it("returns Play Store tooltip content when isAndroidPlayStoreApp is true", () => {
+    const tooltip = getSelfServiceTooltip(false, true);
+
+    render(tooltip as React.ReactElement);
+
+    expect(
+      screen.getByText(/End users can install from the/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Play Store/i)).toBeInTheDocument();
+    expect(screen.getByText(/in their work profile\./i)).toBeInTheDocument();
+  });
+
+  it("returns iOS self-service tooltip content when isIosOrIpadosApp is true and isAndroidPlayStoreApp is false", () => {
+    const tooltip = getSelfServiceTooltip(true, false);
+
+    render(tooltip as React.ReactElement);
+
+    expect(
+      screen.getByText(/End users can install from self-service\./i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Learn how to deploy self-service/i })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Learn how to deploy self-service/i })
+    ).toHaveAttribute(
+      "href",
+      expect.stringContaining("/deploy-self-service-to-ios")
+    );
+  });
+
+  it("returns Fleet Desktop self-service tooltip when both flags are false", () => {
+    const tooltip = getSelfServiceTooltip(false, false);
+
+    render(tooltip as React.ReactElement);
+
+    expect(screen.getByText(/End users can install from/i)).toBeInTheDocument();
+    expect(screen.getByText(/Fleet Desktop/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: /Learn more/i })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Learn more/i })).toHaveAttribute(
+      "href",
+      expect.stringContaining("/self-service-software")
+    );
+  });
+});
 
 // Helper to create an array of dummy policies
 const makePolicies = (count: number): ISoftwareInstallPolicy[] =>

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -175,10 +175,12 @@ export const getSelfServiceTooltip = (
   isAndroidPlayStoreApp: boolean
 ) => {
   if (isAndroidPlayStoreApp) {
-    <>
-      End users can install from the <strong>Play Store</strong> <br />
-      in their work profile.
-    </>;
+    return (
+      <>
+        End users can install from the <strong>Play Store</strong> <br />
+        in their work profile.
+      </>
+    );
   }
   if (isIosOrIpadosApp)
     return (

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
@@ -7,13 +7,13 @@ import {
   IHostAppStoreApp,
   IHostSoftware,
   IVPPHostSoftware,
+  isIpadOrIphoneSoftwareSource,
 } from "interfaces/software";
 import { IHeaderProps, IStringCellProps } from "interfaces/datatable_config";
 
 import PATHS from "router/paths";
 import { getPathWithQueryParams } from "utilities/url";
 import { getAutomaticInstallPoliciesCount } from "pages/SoftwarePage/helpers";
-
 import HeaderCell from "components/TableContainer/DataTable/HeaderCell/HeaderCell";
 
 import { ISWUninstallDetailsParentState } from "components/ActivityDetails/InstallDetails/SoftwareUninstallDetailsModal/SoftwareUninstallDetailsModal";
@@ -115,6 +115,8 @@ export const generateHostSWLibraryTableHeaders = ({
         const isAndroidPlayStoreApp =
           !!app_store_app && source === "android_apps";
 
+        const isIosOrIpadosApp = isIpadOrIphoneSoftwareSource(source);
+
         return (
           <SoftwareNameCell
             name={name}
@@ -127,6 +129,7 @@ export const generateHostSWLibraryTableHeaders = ({
             isSelfService={isSelfService}
             automaticInstallPoliciesCount={automaticInstallPoliciesCount}
             pageContext="hostDetailsLibrary"
+            isIosOrIpadosApp={isIosOrIpadosApp}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
           />
         );

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -102,6 +102,7 @@ export const generateSoftwareTableHeaders = ({
             isSelfService={isSelfService}
             automaticInstallPoliciesCount={automaticInstallPoliciesCount}
             pageContext="hostDetails"
+            isIosOrIpadosApp={isIpadOrIphoneSoftwareSource(source)}
             isAndroidPlayStoreApp={isAndroidPlayStoreApp}
           />
         );


### PR DESCRIPTION
## Issue
Closes #37071 

## Description
- Properly adds missing `return` for android tooltip that was causing default tooltip
- Properly passes missing isIosOrIpadosApp argument in 2 places that was causing default tooltip
- Add test for helper function

> Note: Not everything is QA-able as the BE needs to add some self_service info on the API to see self service icon on host details > software table and on software table > ipados/ios apps (separate unreleased ticket #36809)
# Checklist for submitter

## Screenshots of fixes in certain places
<img width="1200" height="412" alt="Screenshot 2025-12-11 at 2 43 52 PM" src="https://github.com/user-attachments/assets/14aaf235-9871-4baa-ae2e-978365e2a964" />
<img width="742" height="461" alt="Screenshot 2025-12-11 at 2 44 02 PM" src="https://github.com/user-attachments/assets/2b3a8c35-47d9-443e-97ae-207ca5fa2b2b" />
<img width="637" height="444" alt="Screenshot 2025-12-11 at 2 44 25 PM" src="https://github.com/user-attachments/assets/161ba3a1-c95d-4999-90c2-e971ed7091e7" />



## Testing

- [x] QA'd all new/changed functionality manually
