### PR TITLE
Remove unnecessary code from react template, add condition to swap viewport for mobile-friendly URLs

### DIFF
--- a/frontend/templates/react.ejs
+++ b/frontend/templates/react.ejs
@@ -1,60 +1,18 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <!-- isProduction comes from build time webpack config -->
-    <% if (isProduction) { %>
-    <!-- ServerType comes from runtime server -->
-    {{ if (eq .ServerType "sandbox") }}
-    <!-- these scripts are to add google analytics on production sandbox instances -->
-    <script
-      async
-      type="text/javascript"
-      src="https://www.googletagmanager.com/gtag/js?id=G-JC3DRNY1GV"
-    ></script>
-    <script type="text/javascript">
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
-      gtag("config", "G-JC3DRNY1GV");
-    </script>
-
-    <!-- adds pendo client for production sandbox instances -->
-    <script>
-      (function (apiKey) {
-        (function (p, e, n, d, o) {
-          var v, w, x, y, z;
-          o = p[d] = p[d] || {};
-          o._q = o._q || [];
-          v = ["initialize", "identify", "updateOptions", "pageLoad", "track"];
-          for (w = 0, x = v.length; w < x; ++w)
-            (function (m) {
-              o[m] =
-                o[m] ||
-                function () {
-                  o._q[m === v[0] ? "unshift" : "push"](
-                    [m].concat([].slice.call(arguments, 0))
-                  );
-                };
-            })(v[w]);
-          y = e.createElement(n);
-          y.async = !0;
-          y.src = "https://cdn.pendo.io/agent/static/" + apiKey + "/pendo.js";
-          z = e.getElementsByTagName(n)[0];
-          z.parentNode.insertBefore(y, z);
-        })(window, document, "script", "pendo");
-      })("b323499a-2a2e-43eb-5c83-56882bda486f");
-    </script>
-    {{
-      end
-    }}
-    <% } %>
-
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=768">
-
     <meta name="robots" content="noindex" />
+    <meta name="viewport" content="width=768" id="viewport-meta-tag" />
+
+    <script>
+      // If URL contains /device/, set mobile-friendly viewport
+      if (window.location.pathname.includes("/device/")) {
+        document
+          .getElementById("viewport-meta-tag")
+          .setAttribute("content", "width=device-width, initial-scale=1.0");
+      }
+    </script>
 
     <link
       rel="stylesheet"
@@ -75,10 +33,5 @@
       defer
       src="{{.URLPrefix}}<%= htmlWebpackPlugin.files.js[0] %>"
     ></script>
-    <!-- Because iOS hates interactive stuff, we have to kill it with fire -->
-    <script>
-      document.addEventListener("touchstart", function () {}, false);
-    </script>
-    <!-- End Apple Hate -->
   </body>
 </html>


### PR DESCRIPTION
For #36281 

We had a bunch of old code in the react template for sandbox, along with a touch event override from 9 years ago. I figured iOS has come a long way in 9 years so probably not needed (given we don't support iOS in the admin app). Didn't seem to have an affect on the self servce page on my iphone. 

Instead of adding complexity with multiple react templates, I'm just going the ismpl route and swapping out the viewport for a mobile-friendly one anytime the url contains `/device/`.