### PR TITLE
API docs: Add clarification to "Update device mapping" example

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4083,7 +4083,8 @@ Updates the email for the data source in the human-device mapping. This source c
 
 ```json
 {
-  "email": "user@example.com"
+  "email": "user@example.com",
+  "source": "idp"
 }
 ```
 


### PR DESCRIPTION
Clarify that passing in `"source": "idp"` when manually updating device mapping should result in a user with `"source": "mdm_idp_accounts"`.