### PR TITLE
Cherry pick: Fixed bug with the Android Cert Template OS Status modal (#37068)

### DIFF
--- a/frontend/interfaces/mdm.ts
+++ b/frontend/interfaces/mdm.ts
@@ -233,6 +233,8 @@ export const isLinuxDiskEncryptionStatus = (
   ["verified", "failed", "action_required"].includes(status);
 
 export const FLEET_FILEVAULT_PROFILE_DISPLAY_NAME = "Disk encryption";
+export const FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID =
+  "fleet-host-certificate-template";
 
 export interface IMdmSSOReponse {
   url: string;

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -5,6 +5,7 @@ import { uniqueId } from "lodash";
 import Icon from "components/Icon";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import {
+  FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID,
   LinuxDiskEncryptionStatus,
   ProfileOperationType,
   ProfilePlatform,
@@ -28,6 +29,7 @@ interface IOSSettingStatusCellProps {
   operationType: ProfileOperationType | null;
   profileName: string;
   hostPlatform?: ProfilePlatform;
+  profileUUID?: string;
 }
 
 const OSSettingStatusCell = ({
@@ -35,12 +37,50 @@ const OSSettingStatusCell = ({
   operationType,
   profileName = "",
   hostPlatform,
+  profileUUID,
 }: IOSSettingStatusCellProps) => {
   let displayOption: ProfileDisplayOption = null;
-
   if (hostPlatform === "linux") {
     displayOption =
       LINUX_DISK_ENCRYPTION_DISPLAY_CONFIG[status as LinuxDiskEncryptionStatus];
+  }
+
+  // Android host certificate templates.
+  else if (
+    hostPlatform === "android" &&
+    profileUUID === FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID
+  ) {
+    switch (status) {
+      case "pending":
+        displayOption = {
+          statusText:
+            operationType === "install"
+              ? "Enforcing (pending)"
+              : "Removing enforcement (pending)",
+          iconName: "pending-outline",
+          tooltip: () =>
+            operationType === "install"
+              ? "The host is running the command to apply settings or will run it when the host comes online."
+              : "The host is running the command to remove settings or will run it when the host comes online.",
+        };
+        break;
+      case "verified":
+        displayOption = {
+          statusText: "Verified",
+          iconName: "success",
+          tooltip: () => "The host applied the setting. Fleet verified",
+        };
+        break;
+      case "failed":
+        displayOption = {
+          statusText: "Failed",
+          iconName: "error",
+          tooltip: null,
+        };
+        break;
+      default:
+        displayOption = null;
+    }
   }
 
   // windows hosts do not have an operation type at the moment and their display options are

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -6,10 +6,10 @@ import { IHostMdmData } from "interfaces/host";
 import {
   FLEET_FILEVAULT_PROFILE_DISPLAY_NAME,
   IHostMdmProfile,
-  MdmDDMProfileStatus,
-  MdmProfileStatus,
   isLinuxDiskEncryptionStatus,
   isWindowsDiskEncryptionStatus,
+  MdmDDMProfileStatus,
+  MdmProfileStatus,
 } from "interfaces/mdm";
 import { isDDMProfile } from "services/entities/mdm";
 
@@ -70,6 +70,7 @@ const generateTableConfig = (
             operationType={cellProps.row.original.operation_type}
             profileName={cellProps.row.original.name}
             hostPlatform={cellProps.row.original.platform}
+            profileUUID={cellProps.row.original.profile_uuid}
           />
         );
       },

--- a/server/fleet/certificate_templates_test.go
+++ b/server/fleet/certificate_templates_test.go
@@ -36,6 +36,8 @@ func TestHostCertificateTemplate(t *testing.T) {
 					require.Equal(t, "HostCertificate", profile.Name)
 					require.Equal(t, "android", profile.Platform)
 					require.Equal(t, MDMDeliveryVerified, *profile.Status)
+					require.Equal(t, MDMOperationTypeInstall, profile.OperationType)
+					require.Equal(t, AndroidCertificateTemplateProfileID, profile.ProfileUUID)
 					require.Empty(t, profile.Detail)
 				},
 			},

--- a/server/fleet/host_certificate_template.go
+++ b/server/fleet/host_certificate_template.go
@@ -1,5 +1,8 @@
 package fleet
 
+// AndroidCertificateTemplateProfileID Used by the front-end for determining the displaying logic.
+const AndroidCertificateTemplateProfileID = "fleet-host-certificate-template"
+
 type HostCertificateTemplate struct {
 	ID                    uint              `db:"id"`
 	Name                  string            `db:"name"`
@@ -19,10 +22,12 @@ func (p *HostCertificateTemplate) ToHostMDMProfile() HostMDMProfile {
 	}
 
 	profile := HostMDMProfile{
-		HostUUID: p.HostUUID,
-		Name:     p.Name,
-		Platform: "android",
-		Status:   &p.Status,
+		HostUUID:      p.HostUUID,
+		Name:          p.Name,
+		Platform:      "android",
+		Status:        &p.Status,
+		OperationType: p.OperationType,
+		ProfileUUID:   AndroidCertificateTemplateProfileID,
 	}
 	if p.Detail != nil {
 		profile.Detail = *p.Detail

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1366,7 +1366,6 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				p.Detail = fleet.HostMDMProfileDetail(p.Detail).Message()
 				profiles = append(profiles, p.ToHostMDMProfile())
 			}
-
 		case "android":
 			if !ac.MDM.AndroidEnabledAndConfigured {
 				break

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -14841,6 +14841,32 @@ INSERT INTO host_certificate_templates (
 		return nil
 	})
 
+	// Enable Android MDM and verify GetHost returns operation_type for certificate templates
+	appCfg, err := s.ds.AppConfig(ctx)
+	require.NoError(t, err)
+	origAndroidEnabled := appCfg.MDM.AndroidEnabledAndConfigured
+	appCfg.MDM.AndroidEnabledAndConfigured = true
+	err = s.ds.SaveAppConfig(ctx, appCfg)
+	require.NoError(t, err)
+	err = s.ds.SetAndroidEnabledAndConfigured(ctx, true)
+	require.NoError(t, err)
+	defer func() {
+		appCfg.MDM.AndroidEnabledAndConfigured = origAndroidEnabled
+		_ = s.ds.SaveAppConfig(ctx, appCfg)
+		_ = s.ds.SetAndroidEnabledAndConfigured(ctx, origAndroidEnabled)
+	}()
+
+	// Verify GetHost returns operation_type for certificate templates
+	var getHostResp getHostResponse
+	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
+	require.NotNil(t, getHostResp.Host)
+	require.NotNil(t, getHostResp.Host.MDM.Profiles)
+	require.Len(t, *getHostResp.Host.MDM.Profiles, 1)
+	profile := (*getHostResp.Host.MDM.Profiles)[0]
+	require.Equal(t, savedTemplate.Name, profile.Name)
+	require.Equal(t, fleet.AndroidCertificateTemplateProfileID, profile.ProfileUUID)
+	require.Equal(t, fleet.MDMOperationTypeInstall, profile.OperationType, "operation_type should be populated for certificate templates")
+
 	// Test cases
 	cases := []struct {
 		name                    string


### PR DESCRIPTION
**Related issue:** Resolves #37018

Make sure the proper tooltip is displayed on the OS Settings modal when rendering Host Certificate Template entries.