### PR TITLE
Dogfood `FLEET_SERVER_VPP_VERIFY_TIMEOUT` and Inconsistent Plan Fix

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -72,7 +72,7 @@ locals {
     FLEET_WEBHOOK_STATUS_URL        = var.webhook_url
     FLEET_WEBHOOK_RESULT_URL        = var.webhook_url
     FLEET_OSQUERY_RESULT_LOG_PLUGIN = var.webhook_url != "" ? "webhook" : ""
-
+    FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"
 
     # Load TLS Certificate for RDS Authentication
     FLEET_MYSQL_TLS_CA              = local.cert_path
@@ -507,7 +507,7 @@ module "monitoring" {
     mysql_host                 = module.main.byo-vpc.rds.cluster_reader_endpoint
     mysql_database             = module.main.byo-vpc.rds.cluster_database_name
     mysql_user                 = module.main.byo-vpc.rds.cluster_master_username
-    mysql_password_secret_name = module.main.byo-vpc.secrets.secret_ids["${local.customer}-database-password"]
+    mysql_password_secret_name = "${local.customer}-database-password"
     rds_security_group_id      = module.main.byo-vpc.rds.security_group_id
     subnet_ids                 = module.main.vpc.private_subnets
     vpc_id                     = module.main.vpc.vpc_id


### PR DESCRIPTION
- Adds `FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"`
- Updates `mysql_password_secret_name` to search by a string, rather than the ID being forced by the AWS Terraform provider (v6) to Fix inconsistent final plan errors