### PR TITLE
Turn off end-user auth capability for macos (#37151)

### DIFF
--- a/orbit/changes/37134-fix-issue-with-end-user-auth-on-macos
+++ b/orbit/changes/37134-fix-issue-with-end-user-auth-on-macos
@@ -1,0 +1,1 @@
+- Fixed an issue where macOS devices would fail to enroll when end-user authentication was configured.

--- a/server/fleet/capabilities.go
+++ b/server/fleet/capabilities.go
@@ -2,6 +2,7 @@ package fleet
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"sync"
 )
@@ -121,11 +122,15 @@ func GetServerDeviceCapabilities() CapabilityMap {
 }
 
 func GetOrbitClientCapabilities() CapabilityMap {
-	return CapabilityMap{
+	capabilities := CapabilityMap{
 		CapabilityEscrowBuddy:     {},
 		CapabilitySetupExperience: {},
-		CapabilityEndUserAuth:     {},
 	}
+	// On non-macOS systems, include end user auth capability.
+	if runtime.GOOS != "darwin" {
+		capabilities[CapabilityEndUserAuth] = struct{}{}
+	}
+	return capabilities
 }
 
 // CapabilitiesHeader is the header name used to communicate the capabilities.

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -203,7 +203,8 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 			if !ok {
 				level.Error(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but fleet could not determine whether orbit supports end-user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
 			} else if !mp.Has(fleet.CapabilityEndUserAuth) {
-				level.Error(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but connected with an orbit version that does not support end user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
+				// Quieting this error until https://github.com/fleetdm/fleet/issues/37134 has a proper fix.
+				level.Debug(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but connected with an orbit version that does not support end user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
 			} else {
 				// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
 				return "", fleet.NewOrbitIDPAuthRequiredError()


### PR DESCRIPTION
Cherry-pick to release fleetd v1.50.2 to `edge`