### PR TITLE
Do not build fleetdm/fleetctl on every PR

### DIFF
--- a/.goreleaser-snapshot.yml
+++ b/.goreleaser-snapshot.yml
@@ -65,14 +65,3 @@ dockers:
     dockerfile: tools/fleet-docker/Dockerfile
     image_templates:
       - 'fleetdm/fleet:{{ .ShortCommit }}'
-
-  - goos: linux
-    goarch: amd64
-    ids:
-      - fleetctl
-    dockerfile: tools/fleetctl-docker/Dockerfile
-    build_flag_templates:
-      - "--build-arg=binpath=fleetctl"
-    image_templates:
-      - 'fleetdm/fleetctl:{{ .ShortCommit }}'
-


### PR DESCRIPTION
Docker publish is currently failing with no space left on device because it builds the fleetdm/fleetctl docker image which is huge (~2 GB). I propose not building it on every PR because IMO it's an overkill (the job already makes sure fleetctl can be built).