### PR TITLE
update text assertion in integration test

### DIFF
--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -18551,7 +18551,7 @@ func (s *integrationMDMTestSuite) TestBYODEnrollmentWithIdPEnabled() {
 		map[string]string{"Cookie": shared_mdm.BYODIdpCookieName + "=abc"}, "enroll_secret", "idp", "enrollment_reference", "abc")
 	page, err = io.ReadAll(res.Body)
 	require.NoError(t, err)
-	require.Contains(t, string(page), "Enroll your Android device in Fleet")
+	require.Contains(t, string(page), "How to enroll your Android device to Fleet")
 
 	// try to BYOD-enroll with invalid enroll secret, should redirect to SSO
 	// login as at least one team has it enabled

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -11719,7 +11719,6 @@ func (s *integrationMDMTestSuite) TestBatchAssociateAppStoreApps() {
 
 			return nil
 		})
-
 	}
 
 	// Run worker to set apps available to device
@@ -11804,7 +11803,6 @@ func (s *integrationMDMTestSuite) TestBatchAssociateAppStoreApps() {
 
 	setDisplayNames("VPPAppUpdatedName2", "DriveUpdatedName2")
 	setDisplayNames("", "")
-
 }
 
 func (s *integrationMDMTestSuite) TestInvalidCommandUUID() {
@@ -18523,7 +18521,7 @@ func (s *integrationMDMTestSuite) TestBYODEnrollmentWithIdPEnabled() {
 	res := s.DoRawNoAuth("GET", "/enroll", nil, http.StatusOK, "enroll_secret", "noidp")
 	page, err := io.ReadAll(res.Body)
 	require.NoError(t, err)
-	require.Contains(t, string(page), "Enroll your Android device in Fleet")
+	require.Contains(t, string(page), "How to enroll your Android device to Fleet")
 
 	// try to BYOD-enroll in team with IdP enabled, should redirect to SSO login
 	res = s.DoRawNoAuth("GET", "/enroll", nil, http.StatusSeeOther, "enroll_secret", "idp")


### PR DESCRIPTION
Fixes a copy change happened on .html page, that did not trigger integration tests so this test started failing after merge.

https://github.com/fleetdm/fleet/pull/37118