### PR TITLE
Add enroll OTA and windows TOS to go test CI triggers

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -15,6 +15,8 @@ on:
       - 'tools/osquery/in-a-box/osquery/docker-compose.yml'
       - 'server/authz/policy.rego'
       - 'docker-compose.yml'
+      - 'frontend/templates/enroll-ota.html'
+      - 'frontend/templates/windowsTOS.html'
   pull_request:
     paths:
       - '**.go'
@@ -25,6 +27,8 @@ on:
       - 'tools/osquery/in-a-box/osquery/docker-compose.yml'
       - 'server/authz/policy.rego'
       - 'docker-compose.yml'
+      - 'frontend/templates/enroll-ota.html'
+      - 'frontend/templates/windowsTOS.html'
   workflow_dispatch: # Manual
   schedule:
     - cron: '0 4 * * *'


### PR DESCRIPTION
This is to avoid a similar issue that we just faced in the future.

The issue was this PR https://github.com/fleetdm/fleet/pull/37118 was merged, but all checks passed since it was a html file only PR, go tests did not run. So we did not catch the integration tests asserting content in these files was broken.

The following PR fixed it: https://github.com/fleetdm/fleet/pull/37196

This PR proposes to add those two files to GO test triggers in CI to avoid breaking the tests accidentally in the future.