### PR TITLE
Fleet UI: Remove unsupported url params when switching to all teams

### DIFF
--- a/changes/37973-sw-filters
+++ b/changes/37973-sw-filters
@@ -1,0 +1,1 @@
+- Fleet UI: Software table viewing a team and switching to All teams will remove any unsupported url params for the All teams view

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState, useEffect } from "react";
+import React, { useCallback, useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 import { Tab, TabList, Tabs } from "react-tabs";

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -191,6 +191,13 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     router,
     includeAllTeams: true,
     includeNoTeam: true,
+    // When switching to "All teams" context, remove any unsupported query params that might be set
+    overrideParamsOnTeamChange: {
+      available_for_install: (newTeamId: number | undefined) =>
+        newTeamId === APP_CONTEXT_ALL_TEAMS_ID,
+      self_service: (newTeamId: number | undefined) =>
+        newTeamId === APP_CONTEXT_ALL_TEAMS_ID,
+    },
   });
 
   // softwareConfig is either the global config or the team config of the
@@ -218,24 +225,6 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       select: (data) => ("team" in data ? data.team : data),
     }
   );
-
-  // When switching to "All teams" context, remove only unsupported query params in URL
-  useEffect(() => {
-    // teamIdForApi is undefined for "All teams"
-    if (teamIdForApi === undefined) {
-      const { available_for_install, self_service, ...rest } = location.query;
-
-      if (available_for_install !== undefined || self_service !== undefined) {
-        router.replace(
-          getNextLocationPath({
-            pathPrefix: location.pathname,
-            routeTemplate: "",
-            queryParams: rest,
-          })
-        );
-      }
-    }
-  }, [teamIdForApi, location.pathname, location.query, router]);
 
   const isSoftwareConfigLoaded =
     !isFetchingSoftwareConfig && !softwareConfigError && !!softwareConfig;

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useState } from "react";
+import React, { useCallback, useContext, useState, useEffect } from "react";
 import { InjectedRouter } from "react-router";
 import { useQuery } from "react-query";
 import { Tab, TabList, Tabs } from "react-tabs";
@@ -103,6 +103,7 @@ interface ISoftwarePageProps {
     query: {
       team_id?: string;
       available_for_install?: string;
+      self_service?: string;
       vulnerable?: string;
       exploit?: string;
       min_cvss_score?: string;
@@ -217,6 +218,24 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
       select: (data) => ("team" in data ? data.team : data),
     }
   );
+
+  // When switching to "All teams" context, remove only unsupported query params in URL
+  useEffect(() => {
+    // teamIdForApi is undefined for "All teams"
+    if (teamIdForApi === undefined) {
+      const { available_for_install, self_service, ...rest } = location.query;
+
+      if (available_for_install !== undefined || self_service !== undefined) {
+        router.replace(
+          getNextLocationPath({
+            pathPrefix: location.pathname,
+            routeTemplate: "",
+            queryParams: rest,
+          })
+        );
+      }
+    }
+  }, [teamIdForApi, location.pathname, location.query, router]);
 
   const isSoftwareConfigLoaded =
     !isFetchingSoftwareConfig && !softwareConfigError && !!softwareConfig;

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -134,11 +134,14 @@ const SoftwareTable = ({
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
         ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
       };
-      if (softwareFilter === "installableSoftware") {
-        newQueryParam.available_for_install = true.toString();
-      }
-      if (softwareFilter === "selfServiceSoftware") {
-        newQueryParam.self_service = true.toString();
+      // Only include these filters when not on “All teams”
+      if (teamId !== undefined) {
+        if (softwareFilter === "installableSoftware") {
+          newQueryParam.available_for_install = "true";
+        }
+        if (softwareFilter === "selfServiceSoftware") {
+          newQueryParam.self_service = "true";
+        }
       }
 
       return newQueryParam;
@@ -153,11 +156,8 @@ const SoftwareTable = ({
       // reset the page index to 0 if any other param has changed.
       const changedParam = determineQueryParamChange(newTableQuery);
 
-      // if nothing has changed, don't update the route. this can happen when
-      // this handler is called on the inital render. Can also happen when
-      // the filter dropdown is changed. That is handled on the onChange handler
-      // for the dropdown.
-      if (changedParam === "") return;
+      // Note: There may be no changedParam on initial render, but we still may need
+      // to strip unwanted params with generateNewQueryParams so do NOT early return
 
       const newRoute = getNextLocationPath({
         pathPrefix: currentPath,
@@ -367,7 +367,8 @@ const SoftwareTable = ({
         // additionalQueries serves as a trigger for the useDeepEffect hook
         // to fire onQueryChange for events happening outside of
         // the TableContainer.
-        // additionalQueries={softwareFilter}
+        // This is necessary to remove unwanted query params from the URL
+        additionalQueries={softwareFilter}
         customControl={showFilterHeaders ? renderCustomControls : undefined}
         customFiltersButton={
           showFilterHeaders ? renderCustomFiltersButton : undefined


### PR DESCRIPTION
## Issue
Closes #37073 

## Description
- When looking at a team view of available for install or self service software, switching to all teams clears these unsupported filters

2 Fixes:
- At the URL level, strip all unsupported params (in the same manner as the manage host page)
- At the onTeamChange level, strip 2 unsupported params for All teams only


## Screen recording
Watch in 1.5x
https://fleetdm.zoom.us/clips/share/f7prtKMZRxKgcjzGqkaugA

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
