### PR TITLE
Add ABM token for Mactivate LLC

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -27,6 +27,10 @@ org_settings:
       macos_team: "💻 Workstations" 
       ios_team: "📱🏢 Company-owned mobile devices"
       ipados_team: "📱🏢 Company-owned mobile devices"
+    - organization_name: Mactivate LLC
+      macos_team: "🧪 Testing & QA" 
+      ios_team: "🧪 Testing & QA"
+      ipados_team: "🧪 Testing & QA"
     volume_purchasing_program:
     - location: Fleet Device Management Inc.
       teams:


### PR DESCRIPTION
This pull request adds a new organization, Mactivate LLC, to the `org_settings` section in the `it-and-security/default.yml` configuration file. The new organization is assigned to the "🧪 Testing & QA" team for all device types.

Organizational configuration updates:

* Added `Mactivate LLC` to the list of organizations, assigning the "🧪 Testing & QA" team for `macos_team`, `ios_team`, and `ipados_team` settings in `it-and-security/default.yml`.