### PR TITLE
Fleet UI: Add software links go to relevant platform add software page

### DIFF
--- a/changes/37074-add-sw-links
+++ b/changes/37074-add-sw-links
@@ -1,0 +1,1 @@
+- Fleet UI: Setup experience links point to add software page relevant to platform

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -70,7 +70,7 @@ interface IAddInstallSoftwareProps {
   softwareTitles: ISoftwareTitle[] | null;
   onAddSoftware: () => void;
   platform: SetupExperiencePlatform;
-  savedRequireAllSoftwareMacOS?: boolean;
+  savedRequireAllSoftwareMacOS?: boolean | null;
 }
 
 const AddInstallSoftware = ({
@@ -112,7 +112,7 @@ const AddInstallSoftware = ({
   const renderAddedText = () => {
     if (noSoftwareUploaded) {
       return (
-        <span className={`${baseClass}__added-text`}>
+        <>
           No {getPlatformLabel(platform)} software available. You can add
           software on the{" "}
           <CustomLink
@@ -120,7 +120,7 @@ const AddInstallSoftware = ({
             text="Software page"
           />
           .
-        </span>
+        </>
       );
     }
 
@@ -158,7 +158,7 @@ const AddInstallSoftware = ({
           Install software on hosts that automatically enroll to Fleet.
         </p>
       </div>
-      {renderAddedText()}
+      <span className={`${baseClass}__added-text`}>{renderAddedText()}</span>
       {!noSoftwareUploaded && (
         <div>
           <GitOpsModeTooltipWrapper

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -2,17 +2,17 @@ import React, { useContext, useState } from "react";
 import { capitalize } from "lodash";
 
 import PATHS from "router/paths";
-
+import { buildQueryStringFromParams } from "utilities/url";
 import { SetupExperiencePlatform } from "interfaces/platform";
+import { ISoftwareTitle } from "interfaces/software";
 
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import mdmAPI from "services/entities/mdm";
+
 import Button from "components/buttons/Button";
-import { ISoftwareTitle } from "interfaces/software";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
-
 import RevealButton from "components/buttons/RevealButton";
 import TooltipWrapper from "components/TooltipWrapper";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
@@ -24,13 +24,53 @@ import {
 
 const baseClass = "add-install-software";
 
+const getPlatformLabel = (platform: SetupExperiencePlatform) => {
+  switch (platform) {
+    case "macos":
+      return "macOS";
+    case "ios":
+      return "iOS";
+    case "ipados":
+      return "iPadOS";
+    default:
+      return capitalize(platform);
+  }
+};
+
+const getAddSoftwareUrl = (
+  platform: SetupExperiencePlatform,
+  teamId: number
+) => {
+  let path = "";
+  switch (platform) {
+    case "ios":
+    case "ipados":
+    case "android":
+      path = PATHS.SOFTWARE_ADD_APP_STORE;
+      break;
+    case "linux":
+      path = PATHS.SOFTWARE_ADD_PACKAGE;
+      break;
+    default:
+      path = PATHS.SOFTWARE_ADD_FLEET_MAINTAINED;
+  }
+
+  const params = {
+    team_id: teamId,
+    // Add android param to preselect Android dropdown on the Add App store page
+    ...(platform === "android" && { platform }),
+  };
+
+  return `${path}?${buildQueryStringFromParams(params)}`;
+};
+
 interface IAddInstallSoftwareProps {
   currentTeamId: number;
   hasManualAgentInstall: boolean;
   softwareTitles: ISoftwareTitle[] | null;
   onAddSoftware: () => void;
   platform: SetupExperiencePlatform;
-  savedRequireAllSoftwareMacOS: boolean | null | undefined;
+  savedRequireAllSoftwareMacOS?: boolean;
 }
 
 const AddInstallSoftware = ({
@@ -69,33 +109,18 @@ const AddInstallSoftware = ({
     }
   };
 
-  const getAddedText = () => {
-    let platformText = "";
-
-    switch (platform) {
-      case "macos":
-        platformText = "macOS";
-        break;
-      case "ios":
-        platformText = "iOS";
-        break;
-      case "ipados":
-        platformText = "iPadOS";
-        break;
-      default:
-        platformText = capitalize(platform); // e.g. Windows, Android
-    }
-
+  const renderAddedText = () => {
     if (noSoftwareUploaded) {
       return (
-        <>
-          No {platformText} software available. You can add software on the{" "}
+        <span className={`${baseClass}__added-text`}>
+          No {getPlatformLabel(platform)} software available. You can add
+          software on the{" "}
           <CustomLink
-            url={`${PATHS.SOFTWARE_ADD_FLEET_MAINTAINED}?team_id=${currentTeamId}`}
+            url={getAddSoftwareUrl(platform, currentTeamId)}
             text="Software page"
           />
           .
-        </>
+        </span>
       );
     }
 
@@ -118,7 +143,6 @@ const AddInstallSoftware = ({
     );
   };
 
-  const addedText = getAddedText();
   const manuallyInstallTooltipText = (
     <>
       Disabled because you manually install Fleet&apos;s agent (
@@ -134,7 +158,7 @@ const AddInstallSoftware = ({
           Install software on hosts that automatically enroll to Fleet.
         </p>
       </div>
-      <span className={`${baseClass}__added-text`}>{addedText}</span>
+      {renderAddedText()}
       {!noSoftwareUploaded && (
         <div>
           <GitOpsModeTooltipWrapper


### PR DESCRIPTION
## Issue
Closes #37074 

## Description
Setup experience platform tabs now link to the specific Add software page related to the currently selected platform.


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
