### PR TITLE
Handbook: Add section about deleting contact information

### DIFF
--- a/handbook/customer-success/README.md
+++ b/handbook/customer-success/README.md
@@ -299,6 +299,22 @@ Refunds for Fleet Premium licenses purchased on the self-service license dispens
 
 Once you submit the form, Stripe will refund the user's payment and cancel their subscription.
 
+
+### Respond to a data-deletion request
+
+When a user requests that we delete all data we have stored about them, their data will need to be removed from the following places:
+1. **fleetdm.com**
+    - Create a confidential website request issue
+    - If the user signed up for an account on fleetdm.com, you will need to create a confidential website request issue. A member of the #g-website working group will delete the account and let you know in a comment when the user account is deleted.
+2.  **Salesforce**
+    1. Search Salesforce for the user's email address, delete the contact record, and any related historical event records associated with the user's contact record.
+3. **Stripe** 
+    - If the user created an account on the Fleet website, a Stripe customer profile will have been created for their email address.
+    - Follow these steps to delete the profile: 
+        1. Log in to Stripe using the shared credentials in 1Password 
+        2. Search for the user's email address
+        3. Select the user's Stripe customer record
+        4. Click the "Actions" dropdown in the upper right corner of the customer profile page and select delete.
  
 ## Rituals
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/10409

Changes:
- Added a section to the handbook about deleting information related to users on the Fleet website, Stripe, and Salesforce.