### PR TITLE
[WIP] 🤖 Attempted fix for #37168

### DIFF
--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3863,7 +3863,7 @@ func (ds *Datastore) SetOrUpdateIDPHostDeviceMapping(ctx context.Context, hostID
 			return ctxerr.Wrap(ctx, err, "delete existing MDM IDP device mappings")
 		}
 
-		if _, err := tx.ExecContext(ctx, insStmt, email, hostID, fleet.DeviceMappingIDP); err != nil {
+		if _, err := tx.ExecContext(ctx, insStmt, email, hostID, fleet.DeviceMappingMDMIdpAccounts); err != nil {
 			return ctxerr.Wrap(ctx, err, "insert IDP device mapping")
 		}
 

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -6811,7 +6811,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	mappings, err := ds.ListHostDeviceMapping(ctx, h1.ID)
 	require.NoError(t, err)
 	assertHostDeviceMapping(t, mappings, []*fleet.HostDeviceMapping{
-		{Email: "user1@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user1@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Test 2: Replace IDP mapping with new user (should replace, not add)
@@ -6822,7 +6822,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	mappings, err = ds.ListHostDeviceMapping(ctx, h1.ID)
 	require.NoError(t, err)
 	assertHostDeviceMapping(t, mappings, []*fleet.HostDeviceMapping{
-		{Email: "user2@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user2@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Test 3: Test idempotent behavior - setting same mapping again should not change anything
@@ -6833,7 +6833,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	mappings, err = ds.ListHostDeviceMapping(ctx, h1.ID)
 	require.NoError(t, err)
 	assertHostDeviceMapping(t, mappings, []*fleet.HostDeviceMapping{
-		{Email: "user2@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user2@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Test 4: Add IDP mapping for different host
@@ -6844,14 +6844,14 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	mappings, err = ds.ListHostDeviceMapping(ctx, h2.ID)
 	require.NoError(t, err)
 	assertHostDeviceMapping(t, mappings, []*fleet.HostDeviceMapping{
-		{Email: "user3@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user3@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Verify h1 still has its current mapping unchanged
 	mappings, err = ds.ListHostDeviceMapping(ctx, h1.ID)
 	require.NoError(t, err)
 	assertHostDeviceMapping(t, mappings, []*fleet.HostDeviceMapping{
-		{Email: "user2@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user2@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Test 5: Test coexistence with custom mappings
@@ -6862,7 +6862,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	require.Len(t, customMappings, 2)
 	assertHostDeviceMapping(t, customMappings, []*fleet.HostDeviceMapping{
 		{Email: "custom@example.com", Source: fleet.DeviceMappingCustomReplacement}, // displayed as "custom"
-		{Email: "user2@idp.com", Source: fleet.DeviceMappingIDP},
+		{Email: "user2@idp.com", Source: fleet.DeviceMappingMDMIdpAccounts},
 	})
 
 	// Test 6: Test replacement with various email formats
@@ -6882,7 +6882,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Len(t, mappings, 1, "Should have exactly one IDP mapping after email %d", i)
 		assert.Equal(t, email, mappings[0].Email, "Should have the latest email")
-		assert.Equal(t, fleet.DeviceMappingIDP, mappings[0].Source, "Should be IDP source")
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, mappings[0].Source, "Should be IDP source")
 	}
 
 	// Test 7: Test empty email (edge case)
@@ -6894,7 +6894,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	found := false
 	for _, mapping := range mappings {
-		if mapping.Email == "" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			found = true
 			break
 		}
@@ -6931,13 +6931,13 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	foundOldMdmIdp := false
 	foundEmptyEmail := false
 	for _, mapping := range mappings {
-		if mapping.Email == "new.user@example.com" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "new.user@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundNewIdp = true
 		}
 		if mapping.Email == "mdm.user@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundOldMdmIdp = true
 		}
-		if mapping.Email == "" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundEmptyEmail = true
 		}
 	}
@@ -6955,7 +6955,7 @@ func testIDPHostDeviceMapping(t *testing.T, ds *Datastore) {
 	foundIdP := false
 	foundCustom := false
 	for _, mapping := range mappings {
-		if mapping.Email == "new.user@example.com" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "new.user@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundIdP = true
 		}
 		if mapping.Email == "custom@example.com" && mapping.Source == fleet.DeviceMappingCustomReplacement {

--- a/server/datastore/mysql/migrations/tables/20251212225700_UpdateIdpSourceToMdmIdpAccounts.go
+++ b/server/datastore/mysql/migrations/tables/20251212225700_UpdateIdpSourceToMdmIdpAccounts.go
@@ -1,0 +1,27 @@
+package tables
+
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	MigrationClient.AddMigration(Up_20251212225700, Down_20251212225700)
+}
+
+func Up_20251212225700(tx *sql.Tx) error {
+	// Update existing host_emails records with source='idp' to source='mdm_idp_accounts'
+	// This fixes the inconsistency where manually updated human-device mappings
+	// were stored with source='idp' instead of 'mdm_idp_accounts'
+	// See: https://github.com/fleetdm/fleet/issues/37168
+	_, err := tx.Exec(`UPDATE host_emails SET source = 'mdm_idp_accounts' WHERE source = 'idp'`)
+	if err != nil {
+		return errors.Wrap(err, "update idp source to mdm_idp_accounts")
+	}
+	return nil
+}
+
+func Down_20251212225700(tx *sql.Tx) error {
+	return nil
+}

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1109,7 +1109,7 @@ func ExpandPlatform(platform string) []string {
 const (
 	DeviceMappingGoogleChromeProfiles = "google_chrome_profiles"
 	DeviceMappingMDMIdpAccounts       = "mdm_idp_accounts"
-	DeviceMappingIDP                  = "idp"              // set by user via PUT /hosts/{id}/device_mapping with source=idp
+	DeviceMappingIDP                  = "idp"              // accepted as API input via PUT /hosts/{id}/device_mapping, stored as mdm_idp_accounts
 	DeviceMappingCustomInstaller      = "custom_installer" // set by fleetd via device-authenticated API
 	DeviceMappingCustomOverride       = "custom_override"  // set by user via user-authenticated API
 

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -3165,7 +3165,7 @@ func TestSetHostDeviceMapping(t *testing.T) {
 			return nil
 		}
 		ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
-			return []*fleet.HostDeviceMapping{{HostID: hostID, Email: "user@example.com", Source: fleet.DeviceMappingIDP}}, nil
+			return []*fleet.HostDeviceMapping{{HostID: hostID, Email: "user@example.com", Source: fleet.DeviceMappingMDMIdpAccounts}}, nil
 		}
 		ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails, details []byte, createdAt time.Time) error {
 			return nil
@@ -3183,7 +3183,7 @@ func TestSetHostDeviceMapping(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, uint(1), result[0].HostID)
 		assert.Equal(t, "user@example.com", result[0].Email)
-		assert.Equal(t, fleet.DeviceMappingIDP, result[0].Source)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, result[0].Source)
 	})
 
 	t.Run("IDP source success with any username when SCIM user not found", func(t *testing.T) {
@@ -3203,7 +3203,7 @@ func TestSetHostDeviceMapping(t *testing.T) {
 			return nil
 		}
 		ds.ListHostDeviceMappingFunc = func(ctx context.Context, hostID uint) ([]*fleet.HostDeviceMapping, error) {
-			return []*fleet.HostDeviceMapping{{HostID: hostID, Email: "any@username.com", Source: fleet.DeviceMappingIDP}}, nil
+			return []*fleet.HostDeviceMapping{{HostID: hostID, Email: "any@username.com", Source: fleet.DeviceMappingMDMIdpAccounts}}, nil
 		}
 		ds.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails, details []byte, createdAt time.Time) error {
 			return nil
@@ -3222,7 +3222,7 @@ func TestSetHostDeviceMapping(t *testing.T) {
 		require.Len(t, result, 1)
 		assert.Equal(t, uint(1), result[0].HostID)
 		assert.Equal(t, "any@username.com", result[0].Email)
-		assert.Equal(t, fleet.DeviceMappingIDP, result[0].Source)
+		assert.Equal(t, fleet.DeviceMappingMDMIdpAccounts, result[0].Source)
 	})
 
 	t.Run("IDP source fails without premium license", func(t *testing.T) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -21901,7 +21901,7 @@ func (s *integrationEnterpriseTestSuite) TestHostDeviceMappingIDP() {
 
 	// Verify the IDP mapping was created and returned in device mappings
 	require.Equal(t, "scim.user@example.com", putResp.DeviceMapping[0].Email)
-	require.Equal(t, fleet.DeviceMappingIDP, putResp.DeviceMapping[0].Source)
+	require.Equal(t, fleet.DeviceMappingMDMIdpAccounts, putResp.DeviceMapping[0].Source)
 
 	// Verify the IDP mapping appears in the host's device mappings via getHostDeviceMapping
 	var getResp listHostDeviceMappingResponse
@@ -21909,7 +21909,7 @@ func (s *integrationEnterpriseTestSuite) TestHostDeviceMappingIDP() {
 		nil, http.StatusOK, &getResp)
 	require.Len(t, getResp.DeviceMapping, 1)
 	require.Equal(t, "scim.user@example.com", getResp.DeviceMapping[0].Email)
-	require.Equal(t, fleet.DeviceMappingIDP, getResp.DeviceMapping[0].Source)
+	require.Equal(t, fleet.DeviceMappingMDMIdpAccounts, getResp.DeviceMapping[0].Source)
 
 	// Test that IDP mapping appears correctly in host details via getHostEndpoint
 	var hostResp getHostResponse
@@ -21959,10 +21959,10 @@ func (s *integrationEnterpriseTestSuite) TestHostDeviceMappingIDP() {
 		if mapping.Email == "custom.user@example.com" && mapping.Source == fleet.DeviceMappingCustomReplacement {
 			foundCustom = true
 		}
-		if mapping.Email == "any.username@example.com" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "any.username@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundCurrentIdp = true
 		}
-		if mapping.Email == "scim.user@example.com" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "scim.user@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundOldIdp = true
 		}
 	}
@@ -22005,10 +22005,10 @@ func (s *integrationEnterpriseTestSuite) TestHostDeviceMappingIDP() {
 	foundNonScimIdp := false
 	foundPreviousIdp := false
 	for _, mapping := range putResp.DeviceMapping {
-		if mapping.Email == "nonscim@example.com" && mapping.Source == fleet.DeviceMappingIDP {
+		if mapping.Email == "nonscim@example.com" && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundNonScimIdp = true
 		}
-		if (mapping.Email == "scim.user@example.com" || mapping.Email == "any.username@example.com") && mapping.Source == fleet.DeviceMappingIDP {
+		if (mapping.Email == "scim.user@example.com" || mapping.Email == "any.username@example.com") && mapping.Source == fleet.DeviceMappingMDMIdpAccounts {
 			foundPreviousIdp = true
 		}
 	}


### PR DESCRIPTION
Zed + Opus 4.5 pointed at the issue. Untested etc.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
