### PR TITLE
Ignore `.DS_Store` files in FMA ingesters

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/ingester.go
+++ b/ee/maintained-apps/ingesters/homebrew/ingester.go
@@ -42,6 +42,11 @@ func IngestApps(ctx context.Context, logger kitlog.Logger, inputsPath, slugFilte
 			continue
 		}
 
+		// Skip non-JSON files (e.g., .DS_Store on macOS)
+		if !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
+
 		fileBytes, err := os.ReadFile(path.Join(inputsPath, f.Name()))
 		if err != nil {
 			return nil, ctxerr.WrapWithData(ctx, err, "reading app input file", map[string]any{"fileName": f.Name()})

--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -50,6 +50,11 @@ func IngestApps(ctx context.Context, logger kitlog.Logger, inputsPath string, sl
 			continue
 		}
 
+		// Skip non-JSON files (e.g., .DS_Store on macOS)
+		if !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
+
 		fileBytes, err := os.ReadFile(path.Join(inputsPath, f.Name()))
 		if err != nil {
 			return nil, ctxerr.WrapWithData(ctx, err, "reading app input file", map[string]any{"file_name": f.Name()})


### PR DESCRIPTION
This pull request improves the robustness of the app ingestion process by ensuring that only JSON files are processed, preventing potential errors from non-JSON files (such as `.DS_Store` on macOS) being read.

File filtering improvements:

* Added a check in `ingester.go` for both the Homebrew and Winget ingesters to skip any files that do not have a `.json` extension, ensuring that only valid JSON files are ingested. [[1]](diffhunk://#diff-abd7db4bef16a062c1bd81f54a7c846f1e91b913a9fe9f87976c8075f39b8cd2R45-R49) [[2]](diffhunk://#diff-eb6c4ae7be41e61a2292c4240de750809d40c0686fb01f80f52df056ebc9c2a8R53-R57)