### PR TITLE
Add 8x8 Work as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/8x8-work.json
+++ b/ee/maintained-apps/inputs/winget/8x8-work.json
@@ -1,0 +1,10 @@
+{
+  "name": "8x8 Work",
+  "slug": "8x8-work/windows",
+  "package_identifier": "8x8.Work",
+  "unique_identifier": "8x8 Work",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Communication"]
+}

--- a/ee/maintained-apps/outputs/8x8-work/windows.json
+++ b/ee/maintained-apps/outputs/8x8-work/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "8.29.1",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = '8x8 Work' AND publisher = '8x8 Inc.';"
+      },
+      "installer_url": "https://work-desktop-assets.8x8.com/prod-publish/ga/work-64-msi-v8.29.1-3.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "5ca9bb7b",
+      "sha256": "277e0b7cbba13b4602d50f92d7abb0a0c90cc66564b435ad797c61035d0fea95",
+      "default_categories": [
+        "Communication"
+      ],
+      "upgrade_code": "{66F8B350-94E0-43AF-9D26-C2385B310C96}"
+    }
+  ],
+  "refs": {
+    "5ca9bb7b": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{66F8B350-94E0-43AF-9D26-C2385B310C96}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -30,6 +30,13 @@
       "description": "8x8 Work is a communications application with voice, video, chat, and web conferencing."
     },
     {
+      "name": "8x8 Work",
+      "slug": "8x8-work/windows",
+      "platform": "windows",
+      "unique_identifier": "8x8 Work",
+      "description": "8x8 Work is a communications application with voice, video, chat, and web conferencing."
+    },
+    {
       "name": "Abstract",
       "slug": "abstract/darwin",
       "platform": "darwin",


### PR DESCRIPTION
This pull request adds support for the "8x8 Work" application on Windows to the maintained apps system. The changes introduce input and output definitions for the app, including installation and uninstallation scripts, version metadata, and an entry in the global apps listing.

**Addition of 8x8 Work (Windows) application:**

* Added a new input definition for `8x8 Work` in `winget` format, specifying package identifiers, architecture, installer type, and default categories.
* Created an output file for `8x8 Work` on Windows, including version metadata, installer and uninstaller scripts, SHA256 hash, upgrade code, and detection SQL query.
* Added `8x8 Work` (Windows) entry to the global `apps.json` file, including description and unique identifier.