### PR TITLE
Add Aircall as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/aircall.json
+++ b/ee/maintained-apps/inputs/winget/aircall.json
@@ -1,0 +1,10 @@
+{
+  "name": "Aircall",
+  "slug": "aircall/windows",
+  "package_identifier": "Aircall.Aircall",
+  "unique_identifier": "Aircall",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Communicatio"]
+}

--- a/ee/maintained-apps/outputs/aircall/windows.json
+++ b/ee/maintained-apps/outputs/aircall/windows.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "3.1.66",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Aircall' AND publisher = 'Aircall';"
+      },
+      "installer_url": "https://download-electron.aircall.io/Aircall-3.1.66.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "08c272d5",
+      "sha256": "42e747bbeefb791ab6dca212c5b8f823bf90d6e6e6d3b0ab5db1bcd6d83bb268",
+      "default_categories": [
+        "Communicatio"
+      ]
+    }
+  ],
+  "refs": {
+    "08c272d5": "$product_code = \"{3BC9C19D-57CC-4C33-9D0F-199A90C445EB}\"\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_UNINSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -97,7 +97,7 @@
       "slug": "aircall/windows",
       "platform": "windows",
       "unique_identifier": "Aircall",
-      "description": ""
+      "description": "Aircall is cloud-based call center and phone system software."
     },
     {
       "name": "Amazon Chime",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -93,6 +93,13 @@
       "description": "Aircall is cloud-based call center and phone system software."
     },
     {
+      "name": "Aircall",
+      "slug": "aircall/windows",
+      "platform": "windows",
+      "unique_identifier": "Aircall",
+      "description": ""
+    },
+    {
       "name": "Amazon Chime",
       "slug": "amazon-chime/darwin",
       "platform": "darwin",


### PR DESCRIPTION
This pull request adds support for the Aircall application on Windows to the maintained apps ecosystem. It introduces the necessary input and output configuration files, as well as versioning and installation/uninstallation scripts. Additionally, it updates the main app listing to include Aircall for Windows.

**New Aircall Windows app support:**

* Added a new input definition for Aircall in `winget/aircall.json`, specifying metadata such as package identifier, installer type, and architecture.
* Created a new output file `aircall/windows.json` with version details, installation and uninstallation scripts, download URL, and SHA256 checksum for Aircall version 3.1.66.
* Updated `apps.json` to list Aircall for Windows as a maintained app, including its name, slug, platform, and unique identifier.