### PR TITLE
Add note about Windows profile verification using CDATA to use escaped XML

### DIFF
--- a/articles/creating-windows-csps.md
+++ b/articles/creating-windows-csps.md
@@ -232,6 +232,8 @@ Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-DeviceManagement-Ente
 
 [This](https://blog.mindcore.dk/2022/09/intune-error-codes-and-solutions/) blog post can also help you translate error codes that are present here.
 
+> If you are seeing the following error with verification: `The MDM protocol returned a success but the result couldn’t be verified by osquery`, and the profile uses [!CDATA []] sections, then you can try to [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. This means the following: `[!CDATA[<enabled/>]]>` becomes `&lt;enabled/&gt;`.
+
 
 ## Conclusion
 

--- a/articles/creating-windows-csps.md
+++ b/articles/creating-windows-csps.md
@@ -232,7 +232,7 @@ Get-WinEvent -FilterHashtable @{LogName='Microsoft-Windows-DeviceManagement-Ente
 
 [This](https://blog.mindcore.dk/2022/09/intune-error-codes-and-solutions/) blog post can also help you translate error codes that are present here.
 
-> If you are seeing the following error with verification: `The MDM protocol returned a success but the result couldn’t be verified by osquery`, and the profile uses [!CDATA []] sections, then you can try to [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. This means the following: `[!CDATA[<enabled/>]]>` becomes `&lt;enabled/&gt;`.
+> If you encounter the error: "The MDM protocol returned a success but the result couldn’t be verified by osquery", and the profile includes `[!CDATA []]` sections, [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. For example, `[!CDATA[<enabled/>]]>` should be changed to `&lt;enabled/&gt;`.
 
 
 ## Conclusion

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -72,7 +72,6 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings. Android hosts are "Verified" after Fleet verifies that the settings is applied in the next [status report](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices).
 
-> If you are seeing the following error with verification: `The MDM protocol returned a success but the result couldn’t be verified by osquery`, and the profile uses [!CDATA []] sections, then you can try to [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. This means the following: `[!CDATA[<enabled/>]]>` becomes `&lt;enabled/&gt;`.
 
 * **Verifying**: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying. If the profile wasn't delivered, Fleet will redeliver the profile.
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -72,6 +72,8 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings. Android hosts are "Verified" after Fleet verifies that the settings is applied in the next [status report](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices).
 
+> If you are seeing the following error with verification: `The MDM protocol returned a success but the result couldn’t be verified by osquery`, and the profile uses [!CDATA []] sections, then you can try to [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. This means the following: `[!CDATA[<enabled/>]]>` becomes `&lt;enabled/&gt;`.
+
 * **Verifying**: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying. If the profile wasn't delivered, Fleet will redeliver the profile.
 
 * **Pending**: hosts that are running MDM commands or will run MDM commands to apply OS settings when they come online.

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -72,7 +72,6 @@ In the top box, with "Verified," "Verifying," "Pending," and "Failed" statuses, 
 
 * **Verified**: hosts that applied all OS settings. Fleet verified by running an osquery query on Windows and macOS hosts (declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport)). Currently, iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings. Android hosts are "Verified" after Fleet verifies that the settings is applied in the next [status report](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices).
 
-
 * **Verifying**: hosts that acknowledged all MDM commands to apply OS settings. Fleet is verifying. If the profile wasn't delivered, Fleet will redeliver the profile.
 
 * **Pending**: hosts that are running MDM commands or will run MDM commands to apply OS settings when they come online.

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -102,6 +102,8 @@ To verify that the OS setting is applied, run the following osquery query:
 SELECT data FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\employee\Attributes\Subteam';
 ```
 
+> If your Windows profile fails with the following error: "The MDM protocol returned a success but the result couldn’t be verified by osquery", and the profile includes `[!CDATA []]` sections, [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. For example, `[!CDATA[<enabled/>]]>` should be changed to `&lt;enabled/&gt;`.
+
 ### Broken profiles
 
 If one or more labels included in the profile's scope are deleted, the profile will not apply to new hosts that enroll.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33350 

This is solely a docs change, since I've verified it works by escaping instead of using CDATA.

Could also solve/close: https://github.com/fleetdm/fleet/issues/33731