### PR TITLE
Fleet UI: Fix package form preinstall sql to handle invalid sql as savable

### DIFF
--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 
-// @ts-ignore
-import validateQuery from "components/forms/validators/validate_query";
+import { validateQuery } from "components/forms/validators/validate_query";
 
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
 import { IPackageFormData, IPackageFormValidation } from "./PackageForm";
@@ -35,16 +34,22 @@ const FORM_VALIDATION_CONFIG: Record<
     validations: [
       {
         name: "invalidQuery",
-        isValid: (formData) => {
+        // Allow all SQL including empty SQL: this field never blocks form submission Request: #35058
+        isValid: () => true,
+        message: (formData) => {
           const query = formData.preInstallQuery;
-          return (
-            query === undefined || query === "" || validateQuery(query).valid
-          );
+          if (!query) {
+            return "";
+          }
+
+          const { error } = validateQuery(query);
+          // Return error text (or empty string)
+          return error || "";
         },
-        message: (formData) => validateQuery(formData.preInstallQuery).error,
       },
     ],
   },
+
   installScript: {
     validations: [
       {
@@ -154,6 +159,14 @@ export const generateFormValidation = (formData: IPackageFormData) => {
     if (!failedValidation) {
       formValidation[objKey] = {
         isValid: true,
+        // still compute error message for preInstallQuery since it can have warnings
+        // of bad SQL but still allow form submission
+        ...(objKey === "preInstallQuery" && {
+          message: getErrorMessage(
+            formData,
+            FORM_VALIDATION_CONFIG[objKey].validations[0].message
+          ),
+        }),
       };
     } else {
       formValidation.isValid = false;


### PR DESCRIPTION
## Issue
Closes #36787 

## Description
- #35058 solution didn't play nice with the existin validation handler for this form
- Update this form to follow guideline of #35058 which allows invalid SQL to be saved

## Screen recording of fix

https://github.com/user-attachments/assets/d2fe1a11-ce83-4598-97cb-dee64f3fb6b1


## Testing

- [x] QA'd all new/changed functionality manually
