### PR TITLE
Add mdatp status table, schema

### DIFF
--- a/orbit/pkg/table/msft_defender/msft_defender_status.go
+++ b/orbit/pkg/table/msft_defender/msft_defender_status.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/osquery/osquery-go"
+	"github.com/osquery/osquery-go/plugin/table"
+)
+
+var (
+	socket   = flag.String("socket", "", "Path to the extensions UNIX domain socket")
+	timeout  = flag.Int("timeout", 3, "Seconds to wait for autoloaded extensions")
+	interval = flag.Int("interval", 3, "Seconds delay between connectivity checks")
+
+	// Compiled regex for parsing mdatp health output - handles "key : value" format with variable whitespace
+	// Format: "key                                     : value" (key has trailing spaces, colon, then value)
+	healthOutputRegex = regexp.MustCompile(`^([^:]+?)\s*:\s*(.+)$`)
+)
+
+func main() {
+	flag.Parse()
+	if *socket == "" {
+		log.Fatalln("Missing required --socket argument")
+	}
+
+	serverTimeout := osquery.ServerTimeout(
+		time.Second * time.Duration(*timeout),
+	)
+	serverPingInterval := osquery.ServerPingInterval(
+		time.Second * time.Duration(*interval),
+	)
+
+	server, err := osquery.NewExtensionManagerServer(
+		"mdatp_extension",
+		*socket,
+		serverTimeout,
+		serverPingInterval,
+	)
+	if err != nil {
+		log.Fatalf("Error creating extension: %s\n", err)
+	}
+
+	server.RegisterPlugin(table.NewPlugin("mdatp_status", mdatpStatusColumns(), generateMDATPStatus))
+
+	if err := server.Run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// mdatpStatusColumns returns the column definitions for the mdatp_status table
+func mdatpStatusColumns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("healthy"),
+		table.TextColumn("health_issues"),
+		table.TextColumn("licensed"),
+		table.TextColumn("engine_version"),
+		table.TextColumn("engine_load_status"),
+		table.TextColumn("app_version"),
+		table.TextColumn("org_id"),
+		table.TextColumn("log_level"),
+		table.TextColumn("machine_guid"),
+		table.TextColumn("release_ring"),
+		table.TextColumn("product_expiration"),
+		table.TextColumn("cloud_enabled"),
+		table.TextColumn("cloud_automatic_sample_submission_consent"),
+		table.TextColumn("cloud_diagnostic_enabled"),
+		table.TextColumn("cloud_pin_certificate_thumbs"),
+		table.TextColumn("passive_mode_enabled"),
+		table.TextColumn("behavior_monitoring"),
+		table.TextColumn("real_time_protection_enabled"),
+		table.TextColumn("real_time_protection_available"),
+		table.TextColumn("real_time_protection_subsystem"),
+		table.TextColumn("network_events_subsystem"),
+		table.TextColumn("device_control_enforcement_level"),
+		table.TextColumn("tamper_protection"),
+		table.TextColumn("automatic_definition_update_enabled"),
+		table.TextColumn("definitions_updated"),
+		table.TextColumn("definitions_updated_minutes_ago"),
+		table.TextColumn("definitions_version"),
+		table.TextColumn("definitions_status"),
+		table.TextColumn("edr_early_preview_enabled"),
+		table.TextColumn("edr_device_tags"),
+		table.TextColumn("edr_group_ids"),
+		table.TextColumn("edr_configuration_version"),
+		table.TextColumn("edr_machine_id"),
+		table.TextColumn("conflicting_applications"),
+		table.TextColumn("network_protection_status"),
+		table.TextColumn("network_protection_enforcement_level"),
+		table.TextColumn("data_loss_prevention_status"),
+		table.TextColumn("full_disk_access_enabled"),
+		table.TextColumn("troubleshooting_mode"),
+		table.TextColumn("ecs_configuration_ids"),
+		table.TextColumn("error"),
+	}
+}
+
+// generateMDATPStatus generates rows for the mdatp_status table
+func generateMDATPStatus(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	mdatpPath, err := findMDATPPath()
+	if err != nil {
+		return []map[string]string{
+			{"error": err.Error()},
+		}, nil
+	}
+
+	output, err := executeMDATPCommand(mdatpPath)
+	result := parseMDATPHealthOutput(output)
+
+	if err != nil {
+		result["error"] = err.Error()
+	}
+
+	return []map[string]string{result}, nil
+}
+
+// findMDATPPath locates the mdatp binary by checking common installation paths
+func findMDATPPath() (string, error) {
+	possiblePaths := []string{
+		"/usr/local/bin/mdatp",
+		"/opt/microsoft/mdatp/bin/mdatp",
+	}
+
+	for _, path := range possiblePaths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+
+	return "", fmt.Errorf("mdatp binary not found at %s or %s", possiblePaths[0], possiblePaths[1])
+}
+
+// executeMDATPCommand calls mdatp with the health flag
+func executeMDATPCommand(mdatpPath string) (string, error) {
+	cmd := exec.Command(mdatpPath, "health")
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+// parseMDATPHealthOutput parses the output from 'mdatp health'
+func parseMDATPHealthOutput(output string) map[string]string {
+	result := make(map[string]string)
+
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if line == "" || strings.HasPrefix(line, "ATTENTION:") {
+			continue
+		}
+
+		matches := healthOutputRegex.FindStringSubmatch(line)
+		if len(matches) == 3 {
+			// Extract and trim the key (removes trailing spaces from keys like "healthy                                     ")
+			key := strings.TrimSpace(matches[1])
+			// Extract and trim the value
+			value := strings.TrimSpace(matches[2])
+
+			// Remove surrounding quotes if present - cleans up the values returned
+			if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+				value = value[1 : len(value)-1]
+			}
+
+			// Convert key to lowercase and replace spaces with underscores - standardizes the keys
+			key = strings.ToLower(strings.ReplaceAll(key, " ", "_"))
+
+			// Only store if we successfully extracted both key and value
+			if key != "" && value != "" {
+				result[key] = value
+			}
+		}
+	}
+
+	return result
+}

--- a/orbit/pkg/table/msft_defender/msft_defender_status_test.go
+++ b/orbit/pkg/table/msft_defender/msft_defender_status_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/osquery/osquery-go/plugin/table"
 )
 
 func TestParseMDATPHealthOutput(t *testing.T) {
@@ -264,7 +266,7 @@ func TestHealthOutputRegexPattern(t *testing.T) {
 
 func TestGenerateMDATPStatusWithoutBinary(t *testing.T) {
 	// This test ensures generateMDATPStatus handles the case where mdatp binary is not found
-	result, err := generateMDATPStatus(context.Background(), nil)
+	result, err := generateMDATPStatus(context.Background(), table.QueryContext{})
 
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)

--- a/orbit/pkg/table/msft_defender/msft_defender_status_test.go
+++ b/orbit/pkg/table/msft_defender/msft_defender_status_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestParseMDATPHealthOutput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected map[string]string
+	}{
+		{
+			name: "Basic health output",
+			input: `Healthy                                     : true
+Licensed                                    : true
+App version                                 : 101.23.45
+Engine version                              : 1.1.19600.2`,
+			expected: map[string]string{
+				"healthy":        "true",
+				"licensed":       "true",
+				"app_version":    "101.23.45",
+				"engine_version": "1.1.19600.2",
+			},
+		},
+		{
+			name: "Values with quotes",
+			input: `Healthy                                     : "true"
+Licensed                                    : "false"
+Release ring                                : "beta"`,
+			expected: map[string]string{
+				"healthy":      "true",
+				"licensed":     "false",
+				"release_ring": "beta",
+			},
+		},
+		{
+			name: "Multi-word keys with spaces",
+			input: `Real Time Protection Enabled                : true
+Behavior Monitoring                         : enabled
+Tamper Protection                           : managed`,
+			expected: map[string]string{
+				"real_time_protection_enabled": "true",
+				"behavior_monitoring":          "enabled",
+				"tamper_protection":            "managed",
+			},
+		},
+		{
+			name: "Ignores empty lines and ATTENTION",
+			input: `Healthy                                     : true
+
+ATTENTION: Some warning message here
+
+Licensed                                    : true`,
+			expected: map[string]string{
+				"healthy":  "true",
+				"licensed": "true",
+			},
+		},
+		{
+			name: "Complex values with special characters",
+			input: `Machine GUID                                : "12345-abcde-67890-fghij"
+Definitions Version                         : "1.387.123"
+Conflicting Applications                    : "Office 365, Slack"`,
+			expected: map[string]string{
+				"machine_guid":             "12345-abcde-67890-fghij",
+				"definitions_version":      "1.387.123",
+				"conflicting_applications": "Office 365, Slack",
+			},
+		},
+		{
+			name:     "Empty input",
+			input:    "",
+			expected: map[string]string{},
+		},
+		{
+			name:     "Only whitespace and empty lines",
+			input:    "\n\n   \n\t\n",
+			expected: map[string]string{},
+		},
+		{
+			name: "Mixed case keys",
+			input: `HEALTHY                                     : true
+Licensed                                    : true
+Engine Version                              : 1.1.19600.2`,
+			expected: map[string]string{
+				"healthy":        "true",
+				"licensed":       "true",
+				"engine_version": "1.1.19600.2",
+			},
+		},
+		{
+			name: "Values with leading/trailing whitespace",
+			input: `Healthy                                     :    true   
+Licensed                                    :   false  `,
+			expected: map[string]string{
+				"healthy":  "true",
+				"licensed": "false",
+			},
+		},
+		{
+			name: "Malformed lines are skipped",
+			input: `Healthy                                     : true
+This line has no colon
+Licensed                                    : false
+Another bad line`,
+			expected: map[string]string{
+				"healthy":  "true",
+				"licensed": "false",
+			},
+		},
+		{
+			name: "Values with colons",
+			input: `Last Updated                                : 2024-01-15 10:30:45
+Time Zone                                   : UTC-05:00`,
+			expected: map[string]string{
+				"last_updated": "2024-01-15 10:30:45",
+				"time_zone":    "UTC-05:00",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseMDATPHealthOutput(tt.input)
+
+			// Check all expected keys are present
+			for key, expectedValue := range tt.expected {
+				value, exists := result[key]
+				if !exists {
+					t.Errorf("Expected key %q not found in result", key)
+					continue
+				}
+				if value != expectedValue {
+					t.Errorf("For key %q: expected %q, got %q", key, expectedValue, value)
+				}
+			}
+
+			// Check no unexpected keys are present
+			for key := range result {
+				if _, exists := tt.expected[key]; !exists {
+					t.Errorf("Unexpected key %q in result with value %q", key, result[key])
+				}
+			}
+		})
+	}
+}
+
+func TestMdatpStatusColumns(t *testing.T) {
+	columns := mdatpStatusColumns()
+
+	if len(columns) == 0 {
+		t.Error("Expected non-empty columns list")
+	}
+
+	expectedColumnNames := []string{
+		"healthy",
+		"health_issues",
+		"licensed",
+		"engine_version",
+		"app_version",
+		"org_id",
+		"error",
+	}
+
+	columnNameMap := make(map[string]bool)
+	for _, col := range columns {
+		columnNameMap[col.Name] = true
+	}
+
+	for _, expected := range expectedColumnNames {
+		if !columnNameMap[expected] {
+			t.Errorf("Expected column %q not found", expected)
+		}
+	}
+
+	// Verify all columns are TextColumn type
+	for _, col := range columns {
+		if col.Type != "TEXT" {
+			t.Errorf("Column %q has unexpected type %q, expected TEXT", col.Name, col.Type)
+		}
+	}
+}
+
+func TestHealthOutputRegexPattern(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		shouldMatch   bool
+		expectedKey   string
+		expectedValue string
+	}{
+		{
+			name:          "Standard format",
+			input:         "Healthy                                     : true",
+			shouldMatch:   true,
+			expectedKey:   "Healthy",
+			expectedValue: "true",
+		},
+		{
+			name:          "Minimal spacing",
+			input:         "Key:value",
+			shouldMatch:   true,
+			expectedKey:   "Key",
+			expectedValue: "value",
+		},
+		{
+			name:          "Extra spaces around colon",
+			input:         "Key   :   value",
+			shouldMatch:   true,
+			expectedKey:   "Key",
+			expectedValue: "value",
+		},
+		{
+			name:          "Quoted value",
+			input:         `Value with spaces                           : "hello world"`,
+			shouldMatch:   true,
+			expectedKey:   "Value with spaces",
+			expectedValue: `"hello world"`,
+		},
+		{
+			name:        "No colon",
+			input:       "This line has no separator",
+			shouldMatch: false,
+		},
+		{
+			name:        "Empty line",
+			input:       "",
+			shouldMatch: false,
+		},
+		{
+			name:          "Numeric value",
+			input:         "Count                                       : 42",
+			shouldMatch:   true,
+			expectedKey:   "Count",
+			expectedValue: "42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matches := healthOutputRegex.FindStringSubmatch(tt.input)
+			if tt.shouldMatch {
+				if len(matches) != 3 {
+					t.Errorf("Expected match with 3 groups, got %d", len(matches))
+					return
+				}
+				if strings.TrimSpace(matches[1]) != tt.expectedKey {
+					t.Errorf("Expected key %q, got %q", tt.expectedKey, strings.TrimSpace(matches[1]))
+				}
+				if strings.TrimSpace(matches[2]) != tt.expectedValue {
+					t.Errorf("Expected value %q, got %q", tt.expectedValue, strings.TrimSpace(matches[2]))
+				}
+			} else {
+				if len(matches) > 0 {
+					t.Errorf("Expected no match but got: %v", matches)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateMDATPStatusWithoutBinary(t *testing.T) {
+	// This test ensures generateMDATPStatus handles the case where mdatp binary is not found
+	result, err := generateMDATPStatus(context.Background(), nil)
+
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+
+	if len(result) != 1 {
+		t.Errorf("Expected 1 result row, got %d", len(result))
+	}
+
+	// Should contain an error field since the binary won't be found
+	if row := result[0]; row["error"] == "" {
+		t.Error("Expected error field to be populated when mdatp binary is not found")
+	}
+}
+
+func BenchmarkParseMDATPHealthOutput(b *testing.B) {
+	input := `Healthy                                     : true
+Licensed                                    : true
+Engine version                              : 1.1.19600.2
+App version                                 : 101.23.45
+Org Id                                      : 00000000-0000-0000-0000-000000000000
+Log level                                   : "warning"
+Machine GUID                                : "12345-67890"
+Release ring                                : "beta"
+Product expiration                          : "2025-12-31"
+Cloud enabled                               : true
+Passive mode enabled                        : false
+Behavior monitoring                         : enabled
+Real Time Protection Enabled                : true
+Real Time Protection Available              : true
+Tamper Protection                           : managed
+Automatic definition update enabled         : true
+Definitions updated                         : "2024-01-15 10:30:45"
+Definitions version                         : "1.387.123"
+EDR Device Tags                             : "tag1,tag2,tag3"
+Network Protection Status                   : enabled
+Data Loss Prevention Status                 : enabled
+Full Disk Access Enabled                    : true
+Troubleshooting mode                        : disabled`
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		parseMDATPHealthOutput(input)
+	}
+}

--- a/schema/tables/msft_defender_status.yml
+++ b/schema/tables/msft_defender_status.yml
@@ -1,0 +1,131 @@
+name: santa_status
+description: The output of `santactl status --json` showing current Santa statistics and configuration.
+platforms: 
+  - darwin
+evented: false
+examples: |-
+  Confirm Santa is running in lockdown mode across all macOS hosts.
+  ```
+  SELECT mode FROM santa_status;
+  ```
+columns:
+  - name: last_successful_rule
+    description: Last successful rule sync
+    required: false
+    type: text
+  - name: push_notifications
+    description: Push notifications status
+    required: false
+    type: text
+  - name: bundle_scanning
+    description: Whether bundle scanning is enabled (1=true, 0=false)
+    required: false
+    type: integer
+  - name: clean_required
+    description: Whether a clean is required (1=true, 0=false)
+    required: false
+    type: integer
+  - name: server
+    description: Sync server address
+    required: false
+    type: text
+  - name: last_successful_full
+    description: Last successful full sync
+    required: false
+    type: text
+  - name: file_logging
+    description: File logging enabled (1=true, 0=false)
+    required: false
+    type: integer
+  - name: watchdog_ram_events
+    description: Number of watchdog RAM events
+    required: false
+    type: integer
+  - name: driver_connected
+    description: Whether the driver is connected (1=true, 0=false)
+    required: false
+    type: integer
+  - name: log_type
+    description: Log type (e.g., file)
+    required: false
+    type: text
+  - name: watchdog_cpu_events
+    description: Number of watchdog CPU events
+    required: false
+    type: integer
+  - name: mode
+    description: Santa mode (e.g., Monitor)
+    required: false
+    type: text
+  - name: watchdog_cpu_peak
+    description: Peak CPU usage
+    required: false
+    type: double
+  - name: watchdog_ram_peak
+    description: Peak RAM usage
+    required: false
+    type: double
+  - name: transitive_rules_enabled
+    description: Transitive rules enabled (1=true, 0=false)
+    required: false
+    type: integer
+  - name: remount_usb_mode
+    description: Remount USB mode
+    required: false
+    type: text
+  - name: block_usb
+    description: Block USB enabled (1=true, 0=false)
+    required: false
+    type: integer
+  - name: on_start_usb_options
+    description: USB options on start
+    required: false
+    type: text
+  - name: root_cache_count
+    description: Root cache count
+    required: false
+    type: integer
+  - name: non_root_cache_count
+    description: Non-root cache count
+    required: false
+    type: integer
+  - name: static_rule_count
+    description: Static rule count
+    required: false
+    type: integer
+  - name: certificate_rules
+    description: Certificate rules count
+    required: false
+    type: integer
+  - name: cdhash_rules
+    description: CDHash rules count
+    required: false
+    type: integer
+  - name: transitive_rules_count
+    description: Transitive rules count
+    required: false
+    type: integer
+  - name: teamid_rules
+    description: Team ID rules count
+    required: false
+    type: integer
+  - name: signingid_rules
+    description: Signing ID rules count
+    required: false
+    type: integer
+  - name: compiler_rules
+    description: Compiler rules count
+    required: false
+    type: integer
+  - name: binary_rules
+    description: Binary rules count
+    required: false
+    type: integer
+  - name: events_pending_upload
+    description: Events pending upload
+    required: false
+    type: integer
+  - name: watch_items_enabled
+    description: Watch items enabled (1=true, 0=false)
+    required: false
+    type: integer

--- a/schema/tables/msft_defender_status.yml
+++ b/schema/tables/msft_defender_status.yml
@@ -1,131 +1,158 @@
-name: santa_status
-description: The output of `santactl status --json` showing current Santa statistics and configuration.
+name: mdatp_status
+description: The output of `mdatp health` showing current Microsoft Defender for Endpoint statistics and configuration.
 platforms: 
   - darwin
 evented: false
 examples: |-
-  Confirm Santa is running in lockdown mode across all macOS hosts.
+  Confirm Microsoft Defender for Endpoint is running and healthy.
   ```
-  SELECT mode FROM santa_status;
+  SELECT healthy FROM mdatp_status;
   ```
+  
+  Check if real-time protection is enabled.
+  ```
+  SELECT real_time_protection_enabled, real_time_protection_available FROM mdatp_status;
+  ```
+  
+  View the current antivirus engine and definitions version.
+  ```
+  SELECT engine_version, definitions_version, definitions_updated FROM mdatp_status;
+  ```
+
 columns:
-  - name: last_successful_rule
-    description: Last successful rule sync
+  - name: app_version
+    description: Microsoft Defender application version.
     required: false
     type: text
-  - name: push_notifications
-    description: Push notifications status
+  - name: automatic_definition_update_enabled
+    description: True if automatic antivirus definition updates are enabled; otherwise, false.
     required: false
     type: text
-  - name: bundle_scanning
-    description: Whether bundle scanning is enabled (1=true, 0=false)
-    required: false
-    type: integer
-  - name: clean_required
-    description: Whether a clean is required (1=true, 0=false)
-    required: false
-    type: integer
-  - name: server
-    description: Sync server address
+  - name: behavior_monitoring
+    description: Feature to detect real-time threats and prevention by monitoring the behavior of applications, services, and files. Values can be 'disabled' (default) or 'enabled'.
     required: false
     type: text
-  - name: last_successful_full
-    description: Last successful full sync
+  - name: cloud_automatic_sample_submission_consent
+    description: Current sample submission level. Can be 'None' (no submission), 'safe' (default, only non-personal data), or 'All' (all samples submitted).
     required: false
     type: text
-  - name: file_logging
-    description: File logging enabled (1=true, 0=false)
-    required: false
-    type: integer
-  - name: watchdog_ram_events
-    description: Number of watchdog RAM events
-    required: false
-    type: integer
-  - name: driver_connected
-    description: Whether the driver is connected (1=true, 0=false)
-    required: false
-    type: integer
-  - name: log_type
-    description: Log type (e.g., file)
+  - name: cloud_diagnostic_enabled
+    description: True if optional diagnostic data collection is enabled; otherwise, false.
     required: false
     type: text
-  - name: watchdog_cpu_events
-    description: Number of watchdog CPU events
-    required: false
-    type: integer
-  - name: mode
-    description: Santa mode (e.g., Monitor)
+  - name: cloud_enabled
+    description: True if cloud-delivered protection is enabled; otherwise, false.
     required: false
     type: text
-  - name: watchdog_cpu_peak
-    description: Peak CPU usage
-    required: false
-    type: double
-  - name: watchdog_ram_peak
-    description: Peak RAM usage
-    required: false
-    type: double
-  - name: transitive_rules_enabled
-    description: Transitive rules enabled (1=true, 0=false)
-    required: false
-    type: integer
-  - name: remount_usb_mode
-    description: Remount USB mode
+  - name: conflicting_applications
+    description: List of applications that are possibly conflicting with Microsoft Defender for Endpoint. Includes other security products and applications known to cause compatibility issues.
     required: false
     type: text
-  - name: block_usb
-    description: Block USB enabled (1=true, 0=false)
-    required: false
-    type: integer
-  - name: on_start_usb_options
-    description: USB options on start
+  - name: definitions_status
+    description: Status of antivirus definitions. Can be 'up_to_date', 'updating', or 'unavailable'.
     required: false
     type: text
-  - name: root_cache_count
-    description: Root cache count
+  - name: definitions_updated
+    description: Date and time of last antivirus definition update.
     required: false
-    type: integer
-  - name: non_root_cache_count
-    description: Non-root cache count
+    type: text
+  - name: definitions_updated_minutes_ago
+    description: Number of minutes since last antivirus definition update.
     required: false
-    type: integer
-  - name: static_rule_count
-    description: Static rule count
+    type: text
+  - name: definitions_version
+    description: Antivirus definition version.
     required: false
-    type: integer
-  - name: certificate_rules
-    description: Certificate rules count
+    type: text
+  - name: edr_client_version
+    description: Version of the EDR client running on the device.
     required: false
-    type: integer
-  - name: cdhash_rules
-    description: CDHash rules count
+    type: text
+  - name: edr_configuration_version
+    description: EDR configuration version.
     required: false
-    type: integer
-  - name: transitive_rules_count
-    description: Transitive rules count
+    type: text
+  - name: edr_device_tags
+    description: List of tags associated with the device in the EDR system.
     required: false
-    type: integer
-  - name: teamid_rules
-    description: Team ID rules count
+    type: text
+  - name: edr_early_preview_enabled
+    description: Setting of EDR early preview. Can be 'disabled' or 'enabled'.
     required: false
-    type: integer
-  - name: signingid_rules
-    description: Signing ID rules count
+    type: text
+  - name: edr_group_ids
+    description: Group ID that the device is associated with.
     required: false
-    type: integer
-  - name: compiler_rules
-    description: Compiler rules count
+    type: text
+  - name: edr_machine_id
+    description: Device identifier used in the Microsoft Defender portal.
     required: false
-    type: integer
-  - name: binary_rules
-    description: Binary rules count
+    type: text
+  - name: engine_load_status
+    description: Status of antivirus engine. Can be 'Engine not loaded' (process down) or 'Engine load succeeded' (process up and running).
     required: false
-    type: integer
-  - name: events_pending_upload
-    description: Events pending upload
+    type: text
+  - name: engine_version
+    description: Version of the antivirus engine.
     required: false
-    type: integer
-  - name: watch_items_enabled
-    description: Watch items enabled (1=true, 0=false)
+    type: text
+  - name: healthy
+    description: True if the product is healthy; otherwise, false.
     required: false
-    type: integer
+    type: text
+  - name: health_issues
+    description: Lists health issues if any exist.
+    required: false
+    type: text
+  - name: licensed
+    description: True if the device is onboarded to a tenant; otherwise, false.
+    required: false
+    type: text
+  - name: log_level
+    description: Current log level for the product. Can be 'info' or 'debug'.
+    required: false
+    type: text
+  - name: machine_guid
+    description: Unique machine identifier used by the antivirus component.
+    required: false
+    type: text
+  - name: network_protection_enforcement_level
+    description: Mode of network protection. Can be 'disabled' (all components disabled), 'block' (prevents connection to malicious websites), or 'audit' (check how blocks occur).
+    required: false
+    type: text
+  - name: network_protection_status
+    description: Status of the network protection component. Can be 'starting', 'failed_to_start', 'started', 'restarting', 'stopping', or 'stopped'.
+    required: false
+    type: text
+  - name: org_id
+    description: Organization that the device is onboarded to. Shows 'unavailable' if not yet onboarded.
+    required: false
+    type: text
+  - name: passive_mode_enabled
+    description: True if the antivirus component is set to run in passive mode; otherwise, false.
+    required: false
+    type: text
+  - name: product_expiration
+    description: Date and time when the current product version reaches end of support.
+    required: false
+    type: text
+  - name: real_time_protection_available
+    description: True if the real-time protection component is healthy; otherwise, false.
+    required: false
+    type: text
+  - name: real_time_protection_enabled
+    description: True if real-time antivirus protection is enabled; otherwise, false.
+    required: false
+    type: text
+  - name: real_time_protection_subsystem
+    description: Subsystem used to serve real-time protection. Shows 'unavailable' if real-time protection isn't operating as expected.
+    required: false
+    type: text
+  - name: release_ring
+    description: Release ring for the product deployment.
+    required: false
+    type: text
+  - name: supplementary_events_subsystem
+    description: Subsystem that provides supplementary event data. Can be 'ebpf' (default from app version 101.2408.0000 onwards) or 'auditd'.
+    required: false
+    type: text


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
