### PR TITLE
Update icon for Company Portal

### DIFF
--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -51,7 +51,6 @@ import Claude from "./Claude";
 import ClickUp from "./ClickUp";
 import ClockifyDesktop from "./ClockifyDesktop";
 import Cloudflare from "./Cloudflare";
-import CompanyPortal from "./CompanyPortal";
 import CotEditor from "./CotEditor";
 import CreativeCloud from "./AdobeCreativeCloud";
 import Cursor from "./Cursor";


### PR DESCRIPTION
This pull request makes a minor update to the icon imports on the Software Page by removing the unused `CompanyPortal` import from the `icons/index.ts` file.