### PR TITLE
remove product group guides mentions in contributing docs

### DIFF
--- a/docs/Contributing/architecture/mdm/README.md
+++ b/docs/Contributing/architecture/mdm/README.md
@@ -18,4 +18,3 @@ Fleet's MDM architecture is designed to manage devices across different platform
 ## Related resources
 
 - [MDM Product Group Documentation](../../product-groups/mdm/) - Documentation for the MDM product group
-- [MDM Development Guides](../../guides/mdm/) - Guides for MDM development

--- a/docs/Contributing/architecture/orchestration/README.md
+++ b/docs/Contributing/architecture/orchestration/README.md
@@ -18,4 +18,3 @@ Fleet's Orchestration architecture is designed to manage and query devices at sc
 ## Related resources
 
 - [Orchestration Product Group Documentation](../../product-groups/orchestration/) - Documentation for the Orchestration product group
-- [Orchestration Development Guides](../../guides/orchestration/) - Guides for Orchestration development

--- a/docs/Contributing/architecture/software/README.md
+++ b/docs/Contributing/architecture/software/README.md
@@ -15,4 +15,3 @@ Fleet's software architecture is designed to manage software across the device f
 ## Related resources
 
 - [Software Product Group Documentation](../../product-groups/software/) - Documentation for the Software product group
-- [Software Development Guides](../../guides/software/) - Guides for Software development

--- a/docs/Contributing/guides/README.md
+++ b/docs/Contributing/guides/README.md
@@ -27,11 +27,3 @@ This directory contains guides for common development tasks in Fleet.
 
 - [SCIM Integration](integrations/scim-integration.md) - Guide for integrating Fleet with SCIM
 - [Digicert Integration](integrations/digicert-integration.md) - Guide for integrating Fleet with Digicert
-
-## Product group guides
-
-Each product group has its own set of guides:
-
-- [MDM Guides](mdm/README.md) - Guides for MDM development
-- [Orchestration Guides](orchestration/README.md) - Guides for Orchestration development
-- [Software Guides](software/README.md) - Guides for Software development


### PR DESCRIPTION
I was just browsing around and saw the concept of product group guides is gone, so just cleaning up some old links