### PR TITLE
Link newly-enrolled Windows/Linux host with SCIM user

### DIFF
--- a/changes/37271-link-linux-win-users-to-scim
+++ b/changes/37271-link-linux-win-users-to-scim
@@ -1,0 +1,1 @@
+- Fixed an issue where newly-enrolled Windows or Linux hosts were not automatically linked with existing SCIM user account data.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2223,7 +2223,6 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 		Hostname:       hostInfo.Hostname,
 		HardwareModel:  hostInfo.HardwareModel,
 		HardwareSerial: hostInfo.HardwareSerial,
-		UUID:           hostInfo.HardwareUUID,
 	}
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		serialToMatch := hostInfo.HardwareSerial

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -2223,6 +2223,7 @@ func (ds *Datastore) EnrollOrbit(ctx context.Context, opts ...fleet.DatastoreEnr
 		Hostname:       hostInfo.Hostname,
 		HardwareModel:  hostInfo.HardwareModel,
 		HardwareSerial: hostInfo.HardwareSerial,
+		UUID:           hostInfo.HardwareUUID,
 	}
 	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		serialToMatch := hostInfo.HardwareSerial
@@ -4400,6 +4401,45 @@ WHERE %s`
 	}
 
 	return nil
+}
+
+func (ds *Datastore) MaybeAssociateHostWithScimUser(ctx context.Context, host *fleet.Host) error {
+	// Validate that host is not nil.
+	if host == nil {
+		return ctxerr.New(ctx, "MaybeAssociateHostWithScimUser: host is nil")
+	}
+
+	// First, get the SCIM user ID associated with the host's MDM IdP account.
+	getSCIMUserIDSQL := `
+SELECT
+    scim_users.id
+FROM
+	scim_users
+JOIN mdm_idp_accounts ON 
+	mdm_idp_accounts.email = scim_users.user_name OR mdm_idp_accounts.username = scim_users.user_name
+JOIN host_mdm_idp_accounts ON
+	host_mdm_idp_accounts.account_uuid = mdm_idp_accounts.uuid
+WHERE
+	host_mdm_idp_accounts.host_uuid = ?`
+	var scimUserID uint
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &scimUserID, getSCIMUserIDSQL, host.UUID)
+	if err != nil {
+		if fleet.IsNotFound(err) {
+			// No MDM IdP account found for this host, nothing to do
+			return nil
+		}
+		return ctxerr.Wrap(ctx, err, "MaybeAssociateHostWithScimUser: get mdm idp account for host")
+	}
+
+	// Now that we have the SCIM user ID, associate it with the host.
+	linkSQL := `INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE scim_user_id = VALUES(scim_user_id)`
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		_, err := tx.ExecContext(ctx, linkSQL, host.ID, scimUserID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "MaybeAssociateHostWithScimUser: link host with scim user")
+		}
+		return nil
+	})
 }
 
 func maybeAssociateHostMDMIdPWithScimUser(ctx context.Context, tx sqlx.ExtContext, logger log.Logger, hostID uint, idp *fleet.MDMIdPAccount) error {

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4410,7 +4410,7 @@ func (ds *Datastore) MaybeAssociateHostWithScimUser(ctx context.Context, host *f
 		return ctxerr.New(ctx, "MaybeAssociateHostWithScimUser: host is nil")
 	}
 
-	// If an existing SCIM user association exists for this host, nothing to do.
+	// Check for an existing SCIM user association for the host.
 	var existingSCIMUserID uint
 	checkExistingSQL := `SELECT scim_user_id FROM host_scim_user WHERE host_id = ?`
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &existingSCIMUserID, checkExistingSQL, host.ID)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4429,7 +4429,7 @@ WHERE
 	var idpAccount fleet.MDMIdPAccount
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &idpAccount, getMDMIDPSQL, host.ID)
 	if err != nil {
-		if fleet.IsNotFound(err) {
+		if errors.Is(err, sql.ErrNoRows) {
 			// No MDM IdP account for this host, nothing to do.
 			return nil
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4413,7 +4413,10 @@ func (ds *Datastore) MaybeAssociateHostWithScimUser(ctx context.Context, host *f
 	// Get any existing MDM IdP record for the host.
 	getMDMIDPSQL := `
 SELECT
-    mdm_idp_accounts.*
+    mdm_idp_accounts.uuid,
+	mdm_idp_accounts.username,
+	mdm_idp_accounts.email,
+	mdm_idp_accounts.fullname
 FROM
 	mdm_idp_accounts
 JOIN host_mdm_idp_accounts ON

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4473,7 +4473,7 @@ func (ds *Datastore) associateHostWithScimUser(ctx context.Context, hostID uint,
 func associateHostWithScimUser(ctx context.Context, tx sqlx.ExtContext, hostID uint, scimUserID uint) error {
 	_, err := tx.ExecContext(
 		ctx,
-		`INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?, ?)`,
+		`INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?, ?) ON DUPLICATE KEY UPDATE scim_user_id = VALUES(scim_user_id)`,
 		hostID, scimUserID,
 	)
 	if err != nil {

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -12029,7 +12029,7 @@ func testMaybeAssociateHostWithScimUser(t *testing.T, ds *Datastore) {
 		createIdPRecords()
 		createScimUserRecord()
 
-		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host.ID)
 		require.NoError(t, err)
 
 		var scimUserID uint
@@ -12039,7 +12039,7 @@ func testMaybeAssociateHostWithScimUser(t *testing.T, ds *Datastore) {
 	})
 	t.Run("no mdm idp account record", func(t *testing.T) {
 		defer cleanup()
-		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host.ID)
 		require.NoError(t, err)
 
 		var scimUserID uint
@@ -12051,7 +12051,7 @@ func testMaybeAssociateHostWithScimUser(t *testing.T, ds *Datastore) {
 		defer cleanup()
 		// Create MDM IDP account record and host MDM IDP account mapping
 		createIdPRecords()
-		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host.ID)
 		require.NoError(t, err)
 
 		var scimUserID uint
@@ -12076,7 +12076,7 @@ func testMaybeAssociateHostWithScimUser(t *testing.T, ds *Datastore) {
 			return err
 		})
 
-		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host.ID)
 		require.NoError(t, err)
 	})
 }

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -186,6 +186,7 @@ func TestHosts(t *testing.T) {
 		{"TestGetMatchingHostSerialsMarkedDeleted", testGetMatchingHostSerialsMarkedDeleted},
 		{"ListHostsByProfileUUIDAndStatus", testListHostsProfileUUIDAndStatus},
 		{"SetOrUpdateHostDiskTpmPIN", testSetOrUpdateHostDiskTpmPIN},
+		{"TestMaybeAssociateHostWithScimUser", testMaybeAssociateHostWithScimUser},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -11975,4 +11976,119 @@ func testSetOrUpdateHostDiskTpmPIN(t *testing.T, ds *Datastore) {
 		)
 		require.NotEqual(t, expected, tpmPINSet)
 	}
+}
+
+func testMaybeAssociateHostWithScimUser(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	host, err := ds.NewHost(context.Background(), &fleet.Host{
+		UUID: uuid.NewString(),
+	})
+	require.NoError(t, err)
+	cleanup := func() {
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM mdm_idp_accounts`)
+			return err
+		})
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM host_mdm_idp_accounts`)
+			return err
+		})
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM scim_users`)
+			return err
+		})
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `DELETE FROM host_scim_user`)
+			return err
+		})
+	}
+	createIdPRecords := func() {
+		// Create MDM IDP account record, host MDM IDP account mapping, and SCIM user record
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `INSERT INTO mdm_idp_accounts (uuid, username, fullname, email) VALUES (?,?,?,?)`, "mdm_account_uuid", "testuser", "Test User", "testuser@example.com")
+			return err
+		})
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `INSERT INTO host_mdm_idp_accounts (host_uuid, account_uuid) VALUES (?,?)`, host.UUID, "mdm_account_uuid")
+			return err
+		})
+	}
+	createScimUserRecord := func(email ...string) {
+		userEmail := "testuser@example.com"
+		if len(email) > 0 {
+			userEmail = email[0]
+		}
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `INSERT INTO scim_users (user_name) VALUES (?)`, userEmail)
+			return err
+		})
+	}
+	t.Run("happy path", func(t *testing.T) {
+		defer cleanup()
+		// Create MDM IDP account record, host MDM IDP account mapping, and SCIM user record
+		createIdPRecords()
+		createScimUserRecord()
+
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		require.NoError(t, err)
+
+		var scimUserID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &scimUserID, `SELECT scim_user_id FROM host_scim_user WHERE host_id = ?`, host.ID)
+		require.NoError(t, err)
+		require.NotZero(t, scimUserID)
+	})
+	t.Run("no mdm idp account record", func(t *testing.T) {
+		defer cleanup()
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		require.NoError(t, err)
+
+		var scimUserID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &scimUserID, `SELECT scim_user_id FROM host_scim_user WHERE host_id = ?`, host.ID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sql.ErrNoRows))
+	})
+	t.Run("no scim user record", func(t *testing.T) {
+		defer cleanup()
+		// Create MDM IDP account record and host MDM IDP account mapping
+		createIdPRecords()
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		require.NoError(t, err)
+
+		var scimUserID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &scimUserID, `SELECT scim_user_id FROM host_scim_user WHERE host_id = ?`, host.ID)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, sql.ErrNoRows))
+	})
+	t.Run("duplicate scim user records", func(t *testing.T) {
+		defer cleanup()
+		// Create MDM IDP account record, host MDM IDP account mapping, and SCIM user record
+		createIdPRecords()
+		createScimUserRecord()
+		createScimUserRecord("testuser2@example.com")
+
+		var scimUser1ID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &scimUser1ID, `SELECT id FROM scim_users WHERE user_name = ?`, "testuser@example.com")
+		require.NoError(t, err)
+		require.NotZero(t, scimUser1ID)
+		var scimUser2ID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &scimUser2ID, `SELECT id FROM scim_users WHERE user_name = ?`, "testuser2@example.com")
+		require.NoError(t, err)
+		require.NotZero(t, scimUser2ID)
+
+		// Create host_scim_user mapping to simulate duplicate records.
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `INSERT INTO host_scim_user (host_id, scim_user_id) VALUES (?,?)`, host.ID, scimUser2ID)
+			return err
+		})
+
+		// This should update the existing mapping to point to scimUser1ID, since it matches the host's MDM IDP account email.
+		err := ds.MaybeAssociateHostWithScimUser(ctx, host)
+		require.NoError(t, err)
+
+		var hostScimUserID uint
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &hostScimUserID, `SELECT scim_user_id FROM host_scim_user WHERE host_id = ?`, host.ID)
+		require.NoError(t, err)
+		require.NotZero(t, hostScimUserID)
+		require.Equal(t, scimUser1ID, hostScimUserID)
+	})
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2452,7 +2452,7 @@ type Datastore interface {
 	// UpdateScimLastRequest updates the last SCIM request info
 	UpdateScimLastRequest(ctx context.Context, lastRequest *ScimLastRequest) error
 	// MaybeAssociateHostWithScimUser links a host with a SCIM user based on MDM IdP and IdP user ID
-	MaybeAssociateHostWithScimUser(ctx context.Context, host *Host) error
+	MaybeAssociateHostWithScimUser(ctx context.Context, hostID uint) error
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Challenges

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2451,7 +2451,7 @@ type Datastore interface {
 	ScimLastRequest(ctx context.Context) (*ScimLastRequest, error)
 	// UpdateScimLastRequest updates the last SCIM request info
 	UpdateScimLastRequest(ctx context.Context, lastRequest *ScimLastRequest) error
-	// AssociateHostMDMIdPWithScimUser links a host with a SCIM user based on MDM IdP and IdP user ID
+	// MaybeAssociateHostWithScimUser links a host with a SCIM user based on MDM IdP and IdP user ID
 	MaybeAssociateHostWithScimUser(ctx context.Context, host *Host) error
 
 	// /////////////////////////////////////////////////////////////////////////////

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2451,6 +2451,8 @@ type Datastore interface {
 	ScimLastRequest(ctx context.Context) (*ScimLastRequest, error)
 	// UpdateScimLastRequest updates the last SCIM request info
 	UpdateScimLastRequest(ctx context.Context, lastRequest *ScimLastRequest) error
+	// AssociateHostMDMIdPWithScimUser links a host with a SCIM user based on MDM IdP and IdP user ID
+	MaybeAssociateHostWithScimUser(ctx context.Context, host *Host) error
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// Challenges

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -196,10 +196,10 @@ type ABMTermsUpdater interface {
 // MDMIdPAccount contains account information of a third-party IdP that can be
 // later used for MDM operations like creating local accounts.
 type MDMIdPAccount struct {
-	UUID     string
-	Username string
-	Fullname string
-	Email    string
+	UUID     string `db:"uuid"`
+	Username string `db:"username"`
+	Fullname string `db:"fullname"`
+	Email    string `db:"email"`
 }
 
 type MDMAppleBootstrapPackage struct {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1601,7 +1601,7 @@ type ScimLastRequestFunc func(ctx context.Context) (*fleet.ScimLastRequest, erro
 
 type UpdateScimLastRequestFunc func(ctx context.Context, lastRequest *fleet.ScimLastRequest) error
 
-type MaybeAssociateHostWithScimUserFunc func(ctx context.Context, host *fleet.Host) error
+type MaybeAssociateHostWithScimUserFunc func(ctx context.Context, hostID uint) error
 
 type NewChallengeFunc func(ctx context.Context) (string, error)
 
@@ -9735,11 +9735,11 @@ func (s *DataStore) UpdateScimLastRequest(ctx context.Context, lastRequest *flee
 	return s.UpdateScimLastRequestFunc(ctx, lastRequest)
 }
 
-func (s *DataStore) MaybeAssociateHostWithScimUser(ctx context.Context, host *fleet.Host) error {
+func (s *DataStore) MaybeAssociateHostWithScimUser(ctx context.Context, hostID uint) error {
 	s.mu.Lock()
 	s.MaybeAssociateHostWithScimUserFuncInvoked = true
 	s.mu.Unlock()
-	return s.MaybeAssociateHostWithScimUserFunc(ctx, host)
+	return s.MaybeAssociateHostWithScimUserFunc(ctx, hostID)
 }
 
 func (s *DataStore) NewChallenge(ctx context.Context) (string, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1601,6 +1601,8 @@ type ScimLastRequestFunc func(ctx context.Context) (*fleet.ScimLastRequest, erro
 
 type UpdateScimLastRequestFunc func(ctx context.Context, lastRequest *fleet.ScimLastRequest) error
 
+type MaybeAssociateHostWithScimUserFunc func(ctx context.Context, host *fleet.Host) error
+
 type NewChallengeFunc func(ctx context.Context) (string, error)
 
 type ConsumeChallengeFunc func(ctx context.Context, challenge string) error
@@ -4062,6 +4064,9 @@ type DataStore struct {
 
 	UpdateScimLastRequestFunc        UpdateScimLastRequestFunc
 	UpdateScimLastRequestFuncInvoked bool
+
+	MaybeAssociateHostWithScimUserFunc        MaybeAssociateHostWithScimUserFunc
+	MaybeAssociateHostWithScimUserFuncInvoked bool
 
 	NewChallengeFunc        NewChallengeFunc
 	NewChallengeFuncInvoked bool
@@ -9728,6 +9733,13 @@ func (s *DataStore) UpdateScimLastRequest(ctx context.Context, lastRequest *flee
 	s.UpdateScimLastRequestFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateScimLastRequestFunc(ctx, lastRequest)
+}
+
+func (s *DataStore) MaybeAssociateHostWithScimUser(ctx context.Context, host *fleet.Host) error {
+	s.mu.Lock()
+	s.MaybeAssociateHostWithScimUserFuncInvoked = true
+	s.mu.Unlock()
+	return s.MaybeAssociateHostWithScimUserFunc(ctx, host)
 }
 
 func (s *DataStore) NewChallenge(ctx context.Context) (string, error) {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -238,8 +238,13 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	}
 
 	// Associate the newly-enrolled host with a SCIM user if applicable.
-	if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host); err != nil {
-		level.Error(svc.logger).Log("msg", "failed to associate enrolled host with SCIM user", "err", err, "host_id", host.ID)
+	// Do this only for linux and windows devices, as macOS devices
+	// are associated during MDM enrollment.
+	platform := host.FleetPlatform()
+	if platform == "linux" || platform == "windows" {
+		if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host); err != nil {
+			level.Error(svc.logger).Log("msg", "failed to associate enrolled host with SCIM user", "err", err, "host_id", host.ID)
+		}
 	}
 
 	if err := svc.NewActivity(

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -237,6 +237,11 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 		return "", fleet.OrbitError{Message: "failed to enroll " + err.Error()}
 	}
 
+	// Associate the newly-enrolled host with a SCIM user if applicable.
+	if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host); err != nil {
+		level.Error(svc.logger).Log("msg", "failed to associate enrolled host with SCIM user", "err", err, "host_id", host.ID)
+	}
+
 	if err := svc.NewActivity(
 		ctx,
 		nil,

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -242,7 +242,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 	// are associated during MDM enrollment.
 	platform := host.FleetPlatform()
 	if platform == "linux" || platform == "windows" {
-		if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host); err != nil {
+		if err := svc.ds.MaybeAssociateHostWithScimUser(ctx, host.ID); err != nil {
 			level.Error(svc.logger).Log("msg", "failed to associate enrolled host with SCIM user", "err", err, "host_id", host.ID)
 		}
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37271

# Details

This PR addresses a gap where Windows or Linux hosts enrolling via end-user authentication were not linked to existing SCIM user data.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

Tested on a Linux VM using Okta, verified that after enrolling it populated SCIM attributes for the user:
<img width="858" height="299" alt="image" src="https://github.com/user-attachments/assets/dc3bf70e-62cb-40a6-aebe-fef3db6d8f53" />

