### PR TITLE
Update Company Portal icon matching

### DIFF
--- a/frontend/pages/SoftwarePage/components/icons/index.ts
+++ b/frontend/pages/SoftwarePage/components/icons/index.ts
@@ -278,6 +278,7 @@ export const SOFTWARE_NAME_TO_ICON_MAP = {
   cloudflare: Cloudflare,
   code: VisualStudioCode,
   "company portal": IntuneCompanyPortal,
+  "microsoft.companyportal": IntuneCompanyPortal,
   coteditor: CotEditor,
   cursor: Cursor,
   cyberduck: Cyberduck,
@@ -525,6 +526,8 @@ const matchStrictNameSourceToIcon = ({
       return Zoom;
     case name.startsWith("zoom workplace"):
       return Zoom;
+    case name === "microsoft.companyportal":
+      return IntuneCompanyPortal;
     default:
       return null;
   }


### PR DESCRIPTION
This pull request enhances the icon mapping logic for software names in the `SoftwarePage` component, specifically ensuring that the Microsoft Company Portal app is correctly associated with its icon, even when referenced by its package name.

**Icon mapping improvements:**

* Added `"microsoft.companyportal"` to the `SOFTWARE_NAME_TO_ICON_MAP` so that this package name is mapped to the `IntuneCompanyPortal` icon.
* Updated the `matchStrictNameSourceToIcon` function to explicitly return the `IntuneCompanyPortal` icon when the software name is exactly `"microsoft.companyportal"`.