### PR TITLE
Update product groups expertise areas

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -66,7 +66,7 @@ The goal of the MDM group is to increase and exceed [Fleet's product maturity go
 - New device onboarding
 - Scripts
 - Setup experience
-- OS updates
+- OS configuration & updates
 
 > The [Slack channel](https://fleetdm.slack.com/archives/C03C41L5YEL), [kanban release board](https://github.com/orgs/fleetdm/projects/58), and [GitHub label](https://github.com/fleetdm/fleet/issues?q=is%3Aopen+is%3Aissue+label%3A%23g-mdm) for this product group is `#g-mdm`.
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -62,10 +62,9 @@ The goal of the MDM group is to increase and exceed [Fleet's product maturity go
 
 **Areas of expertise**:
 - MDM protocol & configuration
+- Configuration profiles
 - New device onboarding
 - Scripts
-- Certificate Authorities (CAs)
-- Certificate delivery & renewal
 - Setup experience
 - OS updates
 
@@ -139,10 +138,11 @@ The goal of the security and compliance group is to increase and exceed Fleet's 
 - Software inventory ingestion
 - CVE/CPE ingestion & matching
 - Vulnerability reporting
-- CIS benchmarks 
-- PCI ASV
-- Application blocking
+- Conditional access
+- Certificate Authorities (CAs)
+- Certificate delivery & renewal
 - Encryption
+- CIS benchmarks 
 
 
 ### Product group capacity 


### PR DESCRIPTION
Fleet is going to continue to focus on IT maturity in Q1 and Q2, so we need to reallocate areas of expertise so that workload is more evenly distributed to the product groups. Right now, MDM has more workload than they can cover, which leads to S&C assisting them. Rather than continue with the "assisting" method, I'd like to reassign CAs and certificate lifecycle to S&C. 