### PR TITLE
Update macOS maturity assessment from 🦆 to 🐥

### DIFF
--- a/handbook/company/product-maturity-assessment.md
+++ b/handbook/company/product-maturity-assessment.md
@@ -162,7 +162,7 @@ Fleet provides comprehensive device management across the entire computing lifec
 
 | Platform | Current | Q1 2026 | Q2 2026 | Q3 2026 | Q4 2026 |
 | :---- | :---- | :---- | :---- | :---- | :---- |
-| macOS | 🦆 | 🦆 | 🦆 | 🦆 | 🦆 |
+| macOS | 🐥 | 🐥 | 🐥 | 🐥 | 🐥 |
 | Windows | 🐥 | 🐥 | 🐥 | 🐥 | 🐥 |
 | Linux (Ubuntu) | 🦆 | 🦆 | 🦆 | 🦆 | 🦆 |
 | Linux (RHEL) | 🦆 | 🦆 | 🦆 | 🦆 | 🦆 |


### PR DESCRIPTION
This pull request makes a minor update to the product maturity assessment documentation. The macOS platform maturity indicator has been changed from the duck emoji (🦆) to the chick emoji (🐥) for all listed quarters.

- Updated the macOS maturity status in the product maturity table from 🦆 to 🐥 for all quarters in `handbook/company/product-maturity-assessment.md`.