### PR TITLE
Update bookmark name from 'Roadmap' to 'Sprint planning'

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -561,7 +561,7 @@
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>🗺️ Roadmap</string>
+                            <string>🗺️ Sprint planning</string>
                             <key>url</key>
                             <string>https://github.com/orgs/fleetdm/projects/87</string>
                         </dict>


### PR DESCRIPTION
We re-named the project: https://github.com/orgs/fleetdm/projects/87
