### PR TITLE
Fleet UI: Fixed click area of edit software file button

### DIFF
--- a/changes/36215-button-click-area-fix
+++ b/changes/36215-button-click-area-fix
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed click area of edit software file button

--- a/frontend/components/FileDetails/FileDetails.tests.tsx
+++ b/frontend/components/FileDetails/FileDetails.tests.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { fireEvent } from "@testing-library/react";
+import { renderWithSetup } from "test/test-utils";
+import { IFileDetails } from "utilities/file/fileUtils";
+
+import FileDetails from "./FileDetails";
+
+const defaultFileDetails = {
+  name: "config.yaml",
+  description: "File description",
+} as IFileDetails;
+
+const setup = (props = {}) =>
+  renderWithSetup(
+    <FileDetails
+      graphicNames="file-pkg"
+      fileDetails={defaultFileDetails}
+      canEdit
+      onFileSelect={jest.fn()}
+      {...props}
+    />
+  );
+
+describe("FileDetails", () => {
+  it("renders file name and description and calls input.click when edit button is clicked (non-GitOps path)", async () => {
+    const { user, container } = setup();
+
+    expect(
+      container.querySelector(".file-details__name")?.textContent
+    ).toContain("config.yaml");
+    expect(
+      container.querySelector(".file-details__description")?.textContent
+    ).toContain("File description");
+
+    const fileInput = container.querySelector(
+      "input[type='file']"
+    ) as HTMLInputElement;
+    const clickSpy = jest.spyOn(fileInput, "click");
+
+    const editButton = container.querySelector(
+      ".file-details__edit-button"
+    ) as HTMLButtonElement;
+    await user.click(editButton);
+
+    expect(clickSpy).toHaveBeenCalled();
+  });
+
+  it("calls onFileSelect when a file is selected", () => {
+    const onFileSelect = jest.fn();
+    const { container } = setup({
+      gitopsCompatible: false,
+      onFileSelect,
+    });
+
+    const fileInput = container.querySelector(
+      "input[type='file']"
+    ) as HTMLInputElement;
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File(["content"], "config.yaml", { type: "text/yaml" })],
+      },
+    });
+
+    expect(onFileSelect).toHaveBeenCalled();
+  });
+
+  it("renders delete button and calls onDeleteFile on click", async () => {
+    const onDeleteFile = jest.fn();
+    const { user, container } = setup({ onDeleteFile });
+
+    const deleteButton = container.querySelector(
+      ".file-details__delete-button"
+    ) as HTMLButtonElement;
+    await user.click(deleteButton);
+
+    expect(onDeleteFile).toHaveBeenCalled();
+  });
+
+  it("renders progress bar and hides edit/delete when progress is present", () => {
+    const { container } = setup({ progress: 0.5 });
+
+    expect(
+      container.querySelector(".file-details__progress-bar--uploaded")
+    ).toBeInTheDocument();
+    expect(container.querySelector(".file-details__edit-button")).toBeNull();
+    expect(container.querySelector(".file-details__delete-button")).toBeNull();
+  });
+});

--- a/frontend/components/FileDetails/FileDetails.tsx
+++ b/frontend/components/FileDetails/FileDetails.tsx
@@ -43,10 +43,41 @@ const FileDetails = ({
   gitopsCompatible = true,
   gitOpsModeEnabled = false,
 }: IFileDetailsProps) => {
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+
+  const handleClickEdit = (disabled?: boolean) => {
+    if (disabled) return;
+    inputRef.current?.click();
+  };
+
   const infoClasses = classnames(`${baseClass}__info`, {
     [`${baseClass}__info--disabled-by-gitops-mode`]:
       gitOpsModeEnabled && gitopsCompatible,
   });
+
+  const renderEditButton = (disabled?: boolean) => {
+    return (
+      <div className={`${baseClass}__edit`}>
+        <Button
+          disabled={disabled}
+          className={`${baseClass}__edit-button`}
+          variant="icon"
+          onClick={() => handleClickEdit(disabled)}
+          title="Replace file"
+        >
+          <Icon name="pencil" color="ui-fleet-black-75" />
+        </Button>
+        <input
+          ref={inputRef}
+          type="file"
+          accept={accept}
+          onChange={onFileSelect}
+          className="file-input-visually-hidden"
+        />
+      </div>
+    );
+  };
+
   return (
     <div className={baseClass}>
       {/* disabling at this level preserves funcitonality of GitOpsModeTooltipWrapper around the edit icon */}
@@ -72,41 +103,12 @@ const FileDetails = ({
           <GitOpsModeTooltipWrapper
             position="left"
             tipOffset={4}
-            renderChildren={(disableChildren) => (
-              <div className={`${baseClass}__edit`}>
-                <Button
-                  disabled={disableChildren}
-                  className={`${baseClass}__edit-button`}
-                  variant="icon"
-                >
-                  <label htmlFor="edit-file">
-                    <Icon name="pencil" color="ui-fleet-black-75" />
-                  </label>
-                </Button>
-                <input
-                  disabled={disableChildren}
-                  accept={accept}
-                  id="edit-file"
-                  type="file"
-                  onChange={onFileSelect}
-                />
-              </div>
-            )}
+            renderChildren={(disableChildren) =>
+              renderEditButton(disableChildren)
+            }
           />
         ) : (
-          <div className={`${baseClass}__edit`}>
-            <Button className={`${baseClass}__edit-button`} variant="icon">
-              <label htmlFor="edit-file">
-                <Icon name="pencil" color="ui-fleet-black-75" />
-              </label>
-            </Button>
-            <input
-              accept={accept}
-              id="edit-file"
-              type="file"
-              onChange={onFileSelect}
-            />
-          </div>
+          renderEditButton()
         ))}
       {!progress && onDeleteFile && (
         <div className={`${baseClass}__delete`}>


### PR DESCRIPTION
## Issue
Closes #36215 

## Description
- Something with the file select input not having the same click pixels as the button
- Fixed so the button does the same click handler as the input component
- Also now keyboard accessible :)

## Screen recording of fix

https://github.com/user-attachments/assets/aba03ff6-2a32-4e75-b5e2-a4aa9371434e

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually
