### PR TITLE
Update Santa package URL to version 2025.11

### DIFF
--- a/it-and-security/lib/macos/software/santa.yml
+++ b/it-and-security/lib/macos/software/santa.yml
@@ -1,1 +1,1 @@
-url: https://github.com/northpolesec/santa/releases/download/2025.6/santa-2025.6.pkg
+url: https://github.com/northpolesec/santa/releases/download/2025.11/santa-2025.11.pkg


### PR DESCRIPTION
This pull request updates the Santa software package to a newer version in the configuration file.

- Updated the Santa package URL in `it-and-security/lib/macos/software/santa.yml` to point to version `2025.11` instead of `2025.6`.