### PR TITLE
Removed feature image from using-maintenance-windows.md

### DIFF
--- a/articles/using-maintenance-windows.md
+++ b/articles/using-maintenance-windows.md
@@ -1,7 +1,5 @@
 # Using maintenance windows (Fleet in your calendar)
 
-![Configuring maintenance windows in Fleet](../website/assets/images/articles/configuring-maintenance-windows-in-fleet-1600x900@2x.jpg)
-
 Fleet helps end users fix issues on their own by scheduling a maintenance window directly on their calendar—no IT ticket required.
 
 When a host fails a policy (e.g. MDM enrollment profile expired, disk encryption disabled, outdated software), Fleet can notify the user via a Google Calendar event. The event includes:


### PR DESCRIPTION
I removed the feature image since it adds little value and pushes the content further down the page.

Articles and guides do not require a feature image. Social sharing thumbnails can be optionally defined in the metadata, but are not required. The default thumbnail will be used if the article image is not defined in the metadata.