### PR TITLE
Removed feature image from zero-trust-attestation-with-fleet.md

### DIFF
--- a/articles/zero-trust-attestation-with-fleet.md
+++ b/articles/zero-trust-attestation-with-fleet.md
@@ -1,7 +1,5 @@
 # How to use Fleet for zero trust attestation
 
-![Using Fleet for zero trust attestation](../website/assets/images/articles/fleet-for-zero-trust-attestation-800x450@2x.jpg)
-
 ### In this article
 
 - [What is zero trust?](#what-is-zero-trust)


### PR DESCRIPTION
I removed the feature image since it adds little value and pushes the content further down the page.

Articles and guides do not require a feature image. Social sharing thumbnails can be optionally defined in the metadata, but are not required. The default thumbnail will be used if the article image is not defined in the metadata.