### PR TITLE
Update Google Chrome FMA for Windows

### DIFF
--- a/ee/maintained-apps/outputs/google-chrome/windows.json
+++ b/ee/maintained-apps/outputs/google-chrome/windows.json
@@ -1,14 +1,14 @@
 {
   "versions": [
     {
-      "version": "143.0.7499.110",
+      "version": "143.0.7499.147",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Google Chrome' AND publisher = 'Google LLC';"
       },
       "installer_url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "7a2f151e",
-      "sha256": "fb72a80798590a1e4973f57c551fa4fe1a350907a0614fe6a1ed62726b8d94ce",
+      "sha256": "7781b948073d8b6cc33b1c33afe3f03c566f86cfa51e960d633da2d448845e19",
       "default_categories": [
         "Browsers"
       ],


### PR DESCRIPTION
This pull request updates the Google Chrome package definition for Windows to use the latest available version.

- Dependency update:
  * Updated the `version` field for Google Chrome from `143.0.7499.110` to `143.0.7499.147` in `windows.json`, and updated the corresponding `sha256` checksum to match the new installer.