### PR TITLE
Add `no_check` to Google Chrome FMA for Windows

### DIFF
--- a/ee/maintained-apps/inputs/winget/google-chrome.json
+++ b/ee/maintained-apps/inputs/winget/google-chrome.json
@@ -6,5 +6,6 @@
   "installer_arch": "x64",
   "installer_type": "msi",
   "installer_scope": "machine",
+  "ignore_hash": true,
   "default_categories": ["Browsers"]
 }

--- a/ee/maintained-apps/outputs/google-chrome/windows.json
+++ b/ee/maintained-apps/outputs/google-chrome/windows.json
@@ -8,7 +8,7 @@
       "installer_url": "https://dl.google.com/dl/chrome/install/googlechromestandaloneenterprise64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "7a2f151e",
-      "sha256": "7781b948073d8b6cc33b1c33afe3f03c566f86cfa51e960d633da2d448845e19",
+      "sha256": "no_check",
       "default_categories": [
         "Browsers"
       ],


### PR DESCRIPTION
This pull request updates the configuration for the Google Chrome maintained app on Windows to bypass hash checking for the installer. This change ensures that installations will proceed even if the installer hash changes, which can help avoid issues with frequent upstream updates.

Configuration changes for hash checking:

* Added `"ignore_hash": true` to the `winget/google-chrome.json` input file to instruct the system to skip hash verification during installation.
* Set `"sha256": "no_check"` in the `outputs/google-chrome/windows.json` output file to explicitly indicate that the installer hash should not be checked.