### PR TITLE
Add Inkscape as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/inkscape.json
+++ b/ee/maintained-apps/inputs/winget/inkscape.json
@@ -1,0 +1,10 @@
+{
+  "name": "Inkscape",
+  "slug": "inkscape/windows",
+  "package_identifier": "Inkscape.Inkscape",
+  "unique_identifier": "Inkscape",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -800,6 +800,13 @@
       "description": "Inkscape is a vector graphics editor."
     },
     {
+      "name": "Inkscape",
+      "slug": "inkscape/windows",
+      "platform": "windows",
+      "unique_identifier": "Inkscape",
+      "description": "Inkscape is a vector graphics editor."
+    },
+    {
       "name": "Insomnia",
       "slug": "insomnia/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/inkscape/windows.json
+++ b/ee/maintained-apps/outputs/inkscape/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "1.4.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Inkscape' AND publisher = 'Inkscape';"
+      },
+      "installer_url": "https://media.inkscape.org/dl/resources/file/inkscape-1.4.2_2025-05-13_f4327f4-x64.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "57fe5f4f",
+      "sha256": "cdb54ddf15fb8aba98c48072f93e5a7b9063fb30e33ccb6b1d3cb9b42ec0a508",
+      "default_categories": [
+        "Productivity"
+      ],
+      "upgrade_code": "{4D5FEDAA-84A0-48BE-BD2A-08246398361A}"
+    }
+  ],
+  "refs": {
+    "57fe5f4f": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{4D5FEDAA-84A0-48BE-BD2A-08246398361A}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for managing the Inkscape application on Windows. It introduces new configuration files and updates existing outputs to include Inkscape as a managed app, complete with installation and uninstallation scripts.

**Addition of Inkscape for Windows:**

* Added a new input configuration for Inkscape in `winget`, specifying installer details and default categories in `inkscape.json`.
* Created a new output file `inkscape/windows.json` with version information, download URL, SHA256 hash, install/uninstall scripts, and upgrade code for Inkscape 1.4.2.

**Updates to application listings:**

* Updated `apps.json` to include Inkscape for Windows as a managed app, with its platform, slug, unique identifier, and description.