### PR TITLE
helm: Add namespace for ingress and revisionHistoryLimit for deployment

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.7.3
+version: v6.7.4
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -11,6 +11,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.replicas }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: fleet

--- a/charts/fleet/templates/ingress.yaml
+++ b/charts/fleet/templates/ingress.yaml
@@ -17,6 +17,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "fleet.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -2,6 +2,7 @@
 # All settings related to how Fleet is deployed in Kubernetes
 hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
+revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
 imageTag: v4.77.0 # Version of Fleet to deploy
 # imagePullSecrets is optional.


### PR DESCRIPTION
- Bump helm chart version to v6.7.4
- Add `metadata.namespace` to the ingress template to ensure that ingress is deployed in the same namespace as all other resources
- Add `spec.revisionHistoryLimit` to the deployment template (`.Values.revisionHistoryLimit`)