### PR TITLE
add pagination metadata to get mdm commands endpoint

### DIFF
--- a/changes/issue-37335-add-metadata-pagination-commands
+++ b/changes/issue-37335-add-metadata-pagination-commands
@@ -1,0 +1,1 @@
+- add pagination metadata to the GET /mdm/commands endpoint

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -3099,13 +3099,13 @@ func TestGetMDMCommands(t *testing.T) {
 	var noHostErr error
 	var expectIdentifier bool
 	var expectRequestType bool
-	ds.ListMDMCommandsFunc = func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
+	ds.ListMDMCommandsFunc = func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 		if empty || listErr != nil {
-			return nil, nil, listErr
+			return nil, nil, nil, listErr
 		}
 
 		if noHostErr != nil {
-			return nil, nil, errors.New(fleet.HostIdentiferNotFound)
+			return nil, nil, nil, errors.New(fleet.HostIdentiferNotFound)
 		}
 
 		if expectIdentifier {

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -3141,7 +3141,7 @@ func TestGetMDMCommands(t *testing.T) {
 				Status:      "200",
 				Hostname:    "host2",
 			},
-		}, nil, nil
+		}, nil, nil, nil
 	}
 
 	listErr = io.ErrUnexpectedEOF

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -108,7 +108,7 @@ func (svc *Service) GetOrbitSetupExperienceStatus(ctx context.Context, orbitNode
 	adminTeamFilter := fleet.TeamFilter{
 		User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
 	}
-	acctCmds, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
+	acctCmds, _, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
 		Filters: fleet.MDMCommandFilters{
 			HostIdentifier: host.UUID,
 			RequestType:    "AccountConfiguration",

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -93,7 +93,7 @@ func (ds *Datastore) ListMDMCommands(
 	ctx context.Context,
 	tmFilter fleet.TeamFilter,
 	listOpts *fleet.MDMCommandListOptions,
-) ([]*fleet.MDMCommand, *int64, error) {
+) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 	if listOpts != nil && listOpts.Filters.HostIdentifier != "" {
 		// separate codepath for more performant query by host identifier
 		return ds.listMDMCommandsByHostIdentifier(ctx, tmFilter, listOpts)
@@ -105,9 +105,18 @@ func (ds *Datastore) ListMDMCommands(
 	jointStmt, params = appendListOptionsWithCursorToSQL(jointStmt, params, &listOpts.ListOptions)
 	var results []*fleet.MDMCommand
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, jointStmt, params...); err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "list commands")
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "list commands")
 	}
-	return results, nil, nil
+
+	var metaData *fleet.PaginationMetadata
+	if listOpts.IncludeMetadata {
+		metaData = &fleet.PaginationMetadata{HasPreviousResults: listOpts.Page > 0}
+		if len(results) > int(listOpts.PerPage) { //nolint:gosec // dismiss G115
+			metaData.HasNextResults = true
+			results = results[:len(results)-1]
+		}
+	}
+	return results, nil, metaData, nil
 }
 
 // listMDMCommandsByHostIdentifier retrieves MDM commands by host identifier. It is implemented as a
@@ -122,9 +131,9 @@ func (ds *Datastore) listMDMCommandsByHostIdentifier(
 	ctx context.Context,
 	teamFilter fleet.TeamFilter,
 	listOpts *fleet.MDMCommandListOptions,
-) ([]*fleet.MDMCommand, *int64, error) {
+) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 	if listOpts == nil || listOpts.Filters.HostIdentifier == "" {
-		return nil, nil, ctxerr.Wrap(ctx, errors.New("listMDMCommandsByHostIdentifier requires non-empty listOpts.Filters.HostIdentifier"))
+		return nil, nil, nil, ctxerr.Wrap(ctx, errors.New("listMDMCommandsByHostIdentifier requires non-empty listOpts.Filters.HostIdentifier"))
 	}
 
 	// First, search for host by identifier (hostname, uuid, or hardware_serial).
@@ -161,10 +170,10 @@ WHERE ` + whereTeam
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &dest, stmt, args...)
 	switch {
 	case err != nil:
-		return nil, nil, ctxerr.Wrap(ctx, err, "get host by identifier for mdm")
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "get host by identifier for mdm")
 	case len(dest) == 0:
 		// TODO: should we return an empty slice or an error?
-		return []*fleet.MDMCommand{}, nil, nil
+		return []*fleet.MDMCommand{}, nil, nil, nil
 	case len(dest) > 1:
 		// TODO: how should we handle this unexpected case?
 		level.Debug(ds.logger).Log("msg", "list mdm commands: multiple hosts found for identifier",
@@ -173,7 +182,7 @@ WHERE ` + whereTeam
 	}
 
 	if dest[0].Platform == "windows" && len(listOpts.Filters.CommandStatuses) > 0 {
-		return nil, nil, &fleet.BadRequestError{
+		return nil, nil, nil, &fleet.BadRequestError{
 			Message: `Currently, "command_status" filter is only available for macOS, iOS, and iPadOS hosts.`,
 		}
 	}
@@ -230,7 +239,7 @@ WHERE
 		appleStmt, appleParams = addAppleCommandStatusFilter(appleStmt, &listOpts.Filters, appleParams)
 		appleStmt, appleParams, err = sqlx.In(appleStmt, appleParams...)
 		if err != nil {
-			return nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Apple devices")
+			return nil, nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Apple devices")
 		}
 	}
 
@@ -273,7 +282,7 @@ WHERE
 		winStmt, winParams = addRequestTypeFilter(winStmt, &listOpts.Filters, winParams)
 		winStmt, winParams, err = sqlx.In(winStmt, winParams...)
 		if err != nil {
-			return nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Windows devices")
+			return nil, nil, nil, ctxerr.Wrap(ctx, err, "prepare query to list MDM commands for Windows devices")
 		}
 	}
 
@@ -317,14 +326,14 @@ WHERE
 
 	var results []*fleet.MDMCommand
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &results, listStmt, params...); err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err, "list commands")
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "list commands")
 	}
 
 	var total *int64
 	if len(listOpts.Filters.CommandStatuses) == 1 && listOpts.Filters.CommandStatuses[0] == fleet.MDMCommandStatusFilterPending {
 		// Only get count if we only filter by pending
 		if err := sqlx.GetContext(ctx, ds.reader(ctx), &total, countStmt, params...); err != nil {
-			return nil, nil, ctxerr.Wrap(ctx, err, "count commands")
+			return nil, nil, nil, ctxerr.Wrap(ctx, err, "count commands")
 		}
 	}
 
@@ -336,7 +345,16 @@ WHERE
 		}
 	}
 
-	return results, total, nil
+	var metaData *fleet.PaginationMetadata
+	if listOpts.IncludeMetadata {
+		metaData = &fleet.PaginationMetadata{HasPreviousResults: listOpts.Page > 0}
+		if len(results) > int(listOpts.PerPage) { //nolint:gosec // dismiss G115
+			metaData.HasNextResults = true
+			results = results[:len(results)-1]
+		}
+	}
+
+	return results, total, metaData, nil
 }
 
 func addRequestTypeFilter(stmt string, filter *fleet.MDMCommandFilters, params []interface{}) (string, []interface{}) {

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -456,7 +456,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.ElementsMatch(t, []string{appleCmdUUID, failedAppleCmdUUID}, got)
 
 	// pagination and pagination meta data
-	_, _, meta, err := ds.ListMDMCommands(
+	cmds, _, meta, err := ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -70,7 +70,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
 	// no commands or devices enrolled => no results
-	cmds, _, err := ds.ListMDMCommands(ctx, fleet.TeamFilter{}, &fleet.MDMCommandListOptions{})
+	cmds, _, _, err := ds.ListMDMCommands(ctx, fleet.TeamFilter{}, &fleet.MDMCommandListOptions{})
 	require.NoError(t, err)
 	require.Empty(t, cmds)
 
@@ -124,7 +124,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	nanoEnroll(t, ds, macH, false)
 
 	// no commands => no results
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{},
@@ -142,7 +142,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// we get one result
-	cmds, total, err := ds.ListMDMCommands(
+	cmds, total, _, err := ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{},
@@ -161,7 +161,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// we get both commands
-	cmds, total, err = ds.ListMDMCommands(
+	cmds, total, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -212,7 +212,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	})
 
 	// we get both commands
-	cmds, total, err = ds.ListMDMCommands(
+	cmds, total, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -256,7 +256,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// non-existent host identifier
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -269,7 +269,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Len(t, cmds, 0)
 
 	// non-existent request type
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -330,7 +330,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 			if tc.commandStatus != nil {
 				commandStatuses = append(commandStatuses, *tc.commandStatus)
 			}
-			cmds, total, err := ds.ListMDMCommands(
+			cmds, total, _, err := ds.ListMDMCommands(
 				ctx,
 				fleet.TeamFilter{User: test.UserAdmin},
 				&fleet.MDMCommandListOptions{
@@ -375,7 +375,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// filter by request_type
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -391,7 +391,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Equal(t, appleCmdUUID2, cmds[1].CommandUUID)
 
 	// filter by request_type and host_identifier
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -406,7 +406,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 	require.Equal(t, appleCmdUUID2, cmds[0].CommandUUID)
 
 	// filter by command status for windows host
-	cmds, total, err = ds.ListMDMCommands(
+	cmds, total, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -436,7 +436,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 		Raw:         []byte(appleCmd),
 	})
 	require.NoError(t, err)
-	cmds, total, err = ds.ListMDMCommands(
+	cmds, total, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: test.UserAdmin},
 		&fleet.MDMCommandListOptions{
@@ -454,6 +454,23 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 		got = append(got, cmd.CommandUUID)
 	}
 	require.ElementsMatch(t, []string{appleCmdUUID, failedAppleCmdUUID}, got)
+
+	// pagination and pagination meta data
+	_, _, meta, err := ds.ListMDMCommands(
+		ctx,
+		fleet.TeamFilter{User: test.UserAdmin},
+		&fleet.MDMCommandListOptions{
+			ListOptions: fleet.ListOptions{Page: 0, PerPage: 1, IncludeMetadata: true},
+			Filters: fleet.MDMCommandFilters{
+				HostIdentifier:  macH.UUID,
+				CommandStatuses: []fleet.MDMCommandStatusFilter{fleet.MDMCommandStatusFilterRan, fleet.MDMCommandStatusFilterFailed},
+			},
+		},
+	)
+	require.Len(t, cmds, 1)
+	require.NoError(t, err)
+	require.Equal(t, true, meta.HasNextResults)
+	require.Equal(t, false, meta.HasPreviousResults)
 }
 
 // testListMDMCommandsWithTeamFilter tests listing MDM commands with team filters
@@ -493,7 +510,7 @@ func testListMDMCommandsWithTeamFilter(t *testing.T, ds *Datastore) {
 	}
 
 	// List commands with team filter (no host identifier) - this would trigger the bug hit by customer
-	cmds, _, err := ds.ListMDMCommands(
+	cmds, _, _, err := ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: teamUser},
 		&fleet.MDMCommandListOptions{},
@@ -503,7 +520,7 @@ func testListMDMCommandsWithTeamFilter(t *testing.T, ds *Datastore) {
 	require.Equal(t, teamCmdUUID, cmds[0].CommandUUID)
 
 	// Test with a specific team filter
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: teamUser, TeamID: &team.ID},
 		&fleet.MDMCommandListOptions{},
@@ -531,7 +548,7 @@ func testListMDMCommandsWithTeamFilter(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Team user should only see team command
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: teamUser},
 		&fleet.MDMCommandListOptions{},
@@ -542,7 +559,7 @@ func testListMDMCommandsWithTeamFilter(t *testing.T, ds *Datastore) {
 
 	// Test with admin user (should see all commands)
 	adminUser := test.UserAdmin
-	cmds, _, err = ds.ListMDMCommands(
+	cmds, _, _, err = ds.ListMDMCommands(
 		ctx,
 		fleet.TeamFilter{User: adminUser},
 		&fleet.MDMCommandListOptions{},
@@ -9031,7 +9048,7 @@ func testDeleteMDMProfilesCancelsInstalls(t *testing.T, ds *Datastore) {
 	require.False(t, active)
 
 	// listing the MDM commands does not return the inactive one
-	cmds, _, err := ds.ListMDMCommands(ctx, fleet.TeamFilter{
+	cmds, _, _, err := ds.ListMDMCommands(ctx, fleet.TeamFilter{
 		User:            test.UserAdmin,
 		IncludeObserver: true,
 	}, &fleet.MDMCommandListOptions{Filters: fleet.MDMCommandFilters{HostIdentifier: host1.UUID}})

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1774,7 +1774,7 @@ type Datastore interface {
 	// ListMDMCommands returns a list of MDM Apple commands that have been
 	// executed, based on the provided options.
 	// returns a non-nil count if filtering by command_status = pending
-	ListMDMCommands(ctx context.Context, tmFilter TeamFilter, listOpts *MDMCommandListOptions) ([]*MDMCommand, *int64, error)
+	ListMDMCommands(ctx context.Context, tmFilter TeamFilter, listOpts *MDMCommandListOptions) ([]*MDMCommand, *int64, *PaginationMetadata, error)
 
 	// GetMDMWindowsBitLockerSummary summarizes the current state of Windows disk encryption on
 	// each Windows host in the specified team (or, if no team is specified, each host that is not assigned

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1112,7 +1112,7 @@ type Service interface {
 	GetMDMCommandResults(ctx context.Context, commandUUID string, hostIdentifier string) ([]*MDMCommandResult, error)
 
 	// ListMDMCommands returns MDM commands based on the provided options.
-	ListMDMCommands(ctx context.Context, opts *MDMCommandListOptions) ([]*MDMCommand, *int64, error)
+	ListMDMCommands(ctx context.Context, opts *MDMCommandListOptions) ([]*MDMCommand, *int64, *PaginationMetadata, error)
 
 	// Set or update the disk encryption key for a host.
 	SetOrUpdateDiskEncryptionKey(ctx context.Context, encryptionKey, clientError string) error

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1163,7 +1163,7 @@ type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (
 
 type GetMDMCommandPlatformFunc func(ctx context.Context, commandUUID string) (string, error)
 
-type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error)
+type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata error)
 
 type GetMDMWindowsBitLockerSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMWindowsBitLockerSummary, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1163,7 +1163,7 @@ type GetLinuxDiskEncryptionSummaryFunc func(ctx context.Context, teamID *uint) (
 
 type GetMDMCommandPlatformFunc func(ctx context.Context, commandUUID string) (string, error)
 
-type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata error)
+type ListMDMCommandsFunc func(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error)
 
 type GetMDMWindowsBitLockerSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMWindowsBitLockerSummary, error)
 
@@ -8207,7 +8207,7 @@ func (s *DataStore) GetMDMCommandPlatform(ctx context.Context, commandUUID strin
 	return s.GetMDMCommandPlatformFunc(ctx, commandUUID)
 }
 
-func (s *DataStore) ListMDMCommands(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
+func (s *DataStore) ListMDMCommands(ctx context.Context, tmFilter fleet.TeamFilter, listOpts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 	s.mu.Lock()
 	s.ListMDMCommandsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -695,7 +695,7 @@ type RunMDMCommandFunc func(ctx context.Context, rawBase64Cmd string, deviceIDs 
 
 type GetMDMCommandResultsFunc func(ctx context.Context, commandUUID string, hostIdentifier string) ([]*fleet.MDMCommandResult, error)
 
-type ListMDMCommandsFunc func(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error)
+type ListMDMCommandsFunc func(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error)
 
 type SetOrUpdateDiskEncryptionKeyFunc func(ctx context.Context, encryptionKey string, clientError string) error
 
@@ -4519,7 +4519,7 @@ func (s *Service) GetMDMCommandResults(ctx context.Context, commandUUID string, 
 	return s.GetMDMCommandResultsFunc(ctx, commandUUID, hostIdentifier)
 }
 
-func (s *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
+func (s *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 	s.mu.Lock()
 	s.ListMDMCommandsFuncInvoked = true
 	s.mu.Unlock()

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -910,9 +910,10 @@ type listMDMCommandsRequest struct {
 }
 
 type listMDMCommandsResponse struct {
-	Count   *int64              `json:"count"`
-	Results []*fleet.MDMCommand `json:"results"`
-	Err     error               `json:"error,omitempty"`
+	Meta    *fleet.PaginationMetadata `json:"meta"`
+	Count   *int64                    `json:"count"`
+	Results []*fleet.MDMCommand       `json:"results"`
+	Err     error                     `json:"error,omitempty"`
 }
 
 func (r listMDMCommandsResponse) Error() error { return r.Err }
@@ -961,7 +962,9 @@ func listMDMCommandsEndpoint(ctx context.Context, request interface{}, svc fleet
 		}
 	}
 
-	results, total, err := svc.ListMDMCommands(ctx, &fleet.MDMCommandListOptions{
+	req.ListOptions.IncludeMetadata = true
+
+	results, total, meta, err := svc.ListMDMCommands(ctx, &fleet.MDMCommandListOptions{
 		ListOptions: req.ListOptions,
 		Filters:     fleet.MDMCommandFilters{HostIdentifier: req.HostIdentifier, RequestType: req.RequestType, CommandStatuses: commandStatuses},
 	})
@@ -975,31 +978,32 @@ func listMDMCommandsEndpoint(ctx context.Context, request interface{}, svc fleet
 	}
 
 	return listMDMCommandsResponse{
+		Meta:    meta,
 		Results: results,
 		Count:   total,
 	}, nil
 }
 
-func (svc *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, error) {
+func (svc *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandListOptions) ([]*fleet.MDMCommand, *int64, *fleet.PaginationMetadata, error) {
 	// first, authorize that the user has the right to list hosts
 	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
-		return nil, nil, ctxerr.Wrap(ctx, err)
+		return nil, nil, nil, ctxerr.Wrap(ctx, err)
 	}
 
 	vc, ok := viewer.FromContext(ctx)
 	if !ok {
-		return nil, nil, fleet.ErrNoContext
+		return nil, nil, nil, fleet.ErrNoContext
 	}
 
 	// get the list of commands so we know what hosts (and therefore what teams)
 	// we're dealing with. Including the observers as they are allowed to view
 	// MDM Apple commands.
-	results, total, err := svc.ds.ListMDMCommands(ctx, fleet.TeamFilter{
+	results, total, meta, err := svc.ds.ListMDMCommands(ctx, fleet.TeamFilter{
 		User:            vc.User,
 		IncludeObserver: true,
 	}, opts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	// collect the different team IDs and verify that the user has access to view
@@ -1057,10 +1061,10 @@ func (svc *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandL
 		_, err := svc.ds.HostLiteByIdentifier(ctx, opts.Filters.HostIdentifier)
 		var nve fleet.NotFoundError
 		if errors.As(err, &nve) {
-			return nil, nil, fleet.NewInvalidArgumentError("Invalid Host", fleet.HostIdentiferNotFound).WithStatus(http.StatusNotFound)
+			return nil, nil, nil, fleet.NewInvalidArgumentError("Invalid Host", fleet.HostIdentiferNotFound).WithStatus(http.StatusNotFound)
 		}
 	}
-	return results, total, nil
+	return results, total, meta, nil
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -593,7 +593,7 @@ func (svc *Service) processReleaseDeviceForOldFleetd(ctx context.Context, host *
 		adminTeamFilter := fleet.TeamFilter{
 			User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
 		}
-		acctCmds, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
+		acctCmds, _, _, err := svc.ds.ListMDMCommands(ctx, adminTeamFilter, &fleet.MDMCommandListOptions{
 			Filters: fleet.MDMCommandFilters{
 				HostIdentifier: host.UUID,
 				RequestType:    "AccountConfiguration",


### PR DESCRIPTION
**Related issue:** Resolves #37335

This adds pagination metadata to the `GET /mdm/commands` endpoint. 

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
