### PR TITLE
Support operation type in android cert status API

### DIFF
--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -51,9 +51,13 @@ func (ds *Datastore) ListCertificateTemplatesForHosts(ctx context.Context, hostU
 			hosts.uuid AS host_uuid,
 			certificate_templates.id AS certificate_template_id,
 			host_certificate_templates.fleet_challenge AS fleet_challenge,
-			host_certificate_templates.status AS status
+			host_certificate_templates.status AS status,
+			host_certificate_templates.operation_type AS operation_type,
+			certificate_authorities.type AS ca_type,
+			certificate_authorities.name AS ca_name
 		FROM certificate_templates
 		INNER JOIN hosts ON hosts.team_id = certificate_templates.team_id
+		INNER JOIN certificate_authorities ON certificate_authorities.id = certificate_templates.certificate_authority_id
 		LEFT JOIN host_certificate_templates
 			ON host_certificate_templates.host_uuid = hosts.uuid
 			AND host_certificate_templates.certificate_template_id = certificate_templates.id
@@ -81,6 +85,7 @@ func (ds *Datastore) GetCertificateTemplateForHost(ctx context.Context, hostUUID
 			certificate_templates.id AS certificate_template_id,
 			host_certificate_templates.fleet_challenge AS fleet_challenge,
 			host_certificate_templates.status AS status,
+			host_certificate_templates.operation_type AS operation_type,
 			certificate_authorities.type AS ca_type,
 			certificate_authorities.name AS ca_name
 		FROM certificate_templates

--- a/server/datastore/mysql/host_certificate_templates_test.go
+++ b/server/datastore/mysql/host_certificate_templates_test.go
@@ -366,6 +366,15 @@ func testUpsertHostCertificateTemplateStatus(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
+	// Create a third template for testing insert with operation type
+	templateThree, err := ds.CreateCertificateTemplate(ctx, &fleet.CertificateTemplate{
+		Name:                   "Cert3",
+		TeamID:                 setup.team.ID,
+		CertificateAuthorityID: setup.ca.ID,
+		SubjectName:            "CN=Test Subject 3",
+	})
+	require.NoError(t, err)
+
 	hostUUID := uuid.New().String()
 	_, err = ds.NewHost(ctx, &fleet.Host{
 		UUID:     hostUUID,
@@ -377,55 +386,82 @@ func testUpsertHostCertificateTemplateStatus(t *testing.T, ds *Datastore) {
 	// Create an initial record for the first template
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err = q.ExecContext(ctx,
-			"INSERT INTO host_certificate_templates (host_uuid, certificate_template_id, status, fleet_challenge) VALUES (?, ?, ?, ?)",
-			hostUUID, setup.template.ID, "pending", "some_challenge_value")
+			"INSERT INTO host_certificate_templates (host_uuid, certificate_template_id, status, fleet_challenge, operation_type) VALUES (?, ?, ?, ?, ?)",
+			hostUUID, setup.template.ID, fleet.MDMDeliveryPending, "some_challenge_value", fleet.MDMOperationTypeInstall)
 		return err
 	})
 
 	cases := []struct {
-		name             string
-		templateID       uint
-		newStatus        string
-		expectedErrorMsg string
-		detail           *string
+		name                  string
+		templateID            uint
+		newStatus             string
+		expectedErrorMsg      string
+		detail                *string
+		operationType         fleet.MDMOperationType
+		expectedOperationType string
 	}{
 		{
-			name:       "valid update",
-			templateID: setup.template.ID,
-			newStatus:  "verified",
+			name:                  "valid update with install operation type",
+			templateID:            setup.template.ID,
+			newStatus:             "verified",
+			operationType:         fleet.MDMOperationTypeInstall,
+			expectedOperationType: "install",
 		},
 		{
-			name:       "valid update with details",
-			templateID: setup.template.ID,
-			newStatus:  "failed",
-			detail:     ptr.String("some details"),
+			name:                  "valid update with details",
+			templateID:            setup.template.ID,
+			newStatus:             "failed",
+			detail:                ptr.String("some details"),
+			operationType:         fleet.MDMOperationTypeInstall,
+			expectedOperationType: "install",
 		},
 		{
 			name:             "invalid status",
 			templateID:       setup.template.ID,
 			newStatus:        "invalid_status",
+			operationType:    fleet.MDMOperationTypeInstall,
 			expectedErrorMsg: "Invalid status 'invalid_status'",
 		},
 		{
-			name:       "creates new record if does not exist",
-			templateID: templateTwo.ID,
-			newStatus:  "verified",
-			detail:     ptr.String("some details"),
+			name:                  "creates new record with install operation type",
+			templateID:            templateTwo.ID,
+			newStatus:             "verified",
+			detail:                ptr.String("some details"),
+			operationType:         fleet.MDMOperationTypeInstall,
+			expectedOperationType: "install",
+		},
+		{
+			name:                  "update operation type to remove",
+			templateID:            setup.template.ID,
+			newStatus:             "pending",
+			operationType:         fleet.MDMOperationTypeRemove,
+			expectedOperationType: "remove",
+		},
+		{
+			name:                  "creates new record with remove operation type",
+			templateID:            templateThree.ID,
+			newStatus:             "pending",
+			operationType:         fleet.MDMOperationTypeRemove,
+			expectedOperationType: "remove",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := ds.UpsertCertificateStatus(ctx, hostUUID, tc.templateID, fleet.MDMDeliveryStatus(tc.newStatus), tc.detail)
+			err := ds.UpsertCertificateStatus(ctx, hostUUID, tc.templateID, fleet.MDMDeliveryStatus(tc.newStatus), tc.detail, tc.operationType)
 			if tc.expectedErrorMsg == "" {
 				require.NoError(t, err)
-				var status string
+				var result struct {
+					Status        string `db:"status"`
+					OperationType string `db:"operation_type"`
+				}
 				ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-					return sqlx.GetContext(ctx, q, &status,
-						"SELECT status FROM host_certificate_templates WHERE host_uuid = ? AND certificate_template_id = ?",
+					return sqlx.GetContext(ctx, q, &result,
+						"SELECT status, operation_type FROM host_certificate_templates WHERE host_uuid = ? AND certificate_template_id = ?",
 						hostUUID, tc.templateID)
 				})
-				require.Equal(t, tc.newStatus, status)
+				require.Equal(t, tc.newStatus, result.Status)
+				require.Equal(t, tc.expectedOperationType, result.OperationType)
 			} else {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tc.expectedErrorMsg)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2541,7 +2541,7 @@ type Datastore interface {
 	// processed together as upserts using INSERT...ON DUPLICATE KEY UPDATE.
 	BatchApplyCertificateAuthorities(ctx context.Context, ops CertificateAuthoritiesBatchOperations) error
 	// UpdateCertificateStatus allows a host to update the installation status of a certificate given its template.
-	UpsertCertificateStatus(ctx context.Context, hostUUID string, certificateTemplateID uint, status MDMDeliveryStatus, detail *string) error
+	UpsertCertificateStatus(ctx context.Context, hostUUID string, certificateTemplateID uint, status MDMDeliveryStatus, detail *string, operationType MDMOperationType) error
 
 	// BatchUpsertCertificateTemplates upserts a batch of certificates.
 	BatchUpsertCertificateTemplates(ctx context.Context, certificates []*CertificateTemplate) error

--- a/server/fleet/host_certificate_template.go
+++ b/server/fleet/host_certificate_template.go
@@ -42,6 +42,7 @@ type CertificateTemplateForHost struct {
 	CertificateTemplateID uint                       `db:"certificate_template_id"`
 	FleetChallenge        *string                    `db:"fleet_challenge"`
 	Status                *CertificateTemplateStatus `db:"status"`
+	OperationType         MDMOperationType           `db:"operation_type"`
 	CAType                CAConfigAssetType          `db:"ca_type"`
 	CAName                string                     `db:"ca_name"`
 }

--- a/server/fleet/host_certificate_template.go
+++ b/server/fleet/host_certificate_template.go
@@ -42,7 +42,7 @@ type CertificateTemplateForHost struct {
 	CertificateTemplateID uint                       `db:"certificate_template_id"`
 	FleetChallenge        *string                    `db:"fleet_challenge"`
 	Status                *CertificateTemplateStatus `db:"status"`
-	OperationType         *MDMOperationType           `db:"operation_type"`
+	OperationType         *MDMOperationType          `db:"operation_type"`
 	CAType                CAConfigAssetType          `db:"ca_type"`
 	CAName                string                     `db:"ca_name"`
 }

--- a/server/fleet/host_certificate_template.go
+++ b/server/fleet/host_certificate_template.go
@@ -42,7 +42,7 @@ type CertificateTemplateForHost struct {
 	CertificateTemplateID uint                       `db:"certificate_template_id"`
 	FleetChallenge        *string                    `db:"fleet_challenge"`
 	Status                *CertificateTemplateStatus `db:"status"`
-	OperationType         MDMOperationType           `db:"operation_type"`
+	OperationType         *MDMOperationType           `db:"operation_type"`
 	CAType                CAConfigAssetType          `db:"ca_type"`
 	CAName                string                     `db:"ca_name"`
 }

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -545,6 +545,15 @@ const (
 	MDMOperationTypeRemove  MDMOperationType = "remove"
 )
 
+func (o MDMOperationType) IsValid() bool {
+	switch o {
+	case MDMOperationTypeInstall, MDMOperationTypeRemove:
+		return true
+	default:
+		return false
+	}
+}
+
 // MDMConfigProfileAuthz is used to check user authorization to read/write an
 // MDM configuration profile.
 type MDMConfigProfileAuthz struct {

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -648,7 +648,7 @@ type Service interface {
 	DeleteCertificateTemplate(ctx context.Context, id uint) error
 	ApplyCertificateTemplateSpecs(ctx context.Context, specs []*CertificateRequestSpec) error
 	DeleteCertificateTemplateSpecs(ctx context.Context, certificateTemplateIDs []uint, teamID uint) error
-	UpdateCertificateStatus(ctx context.Context, certificateTemplateID uint, status MDMDeliveryStatus, detail *string) error
+	UpdateCertificateStatus(ctx context.Context, certificateTemplateID uint, status MDMDeliveryStatus, detail *string, operationType *string) error
 
 	// /////////////////////////////////////////////////////////////////////////////
 	// GlobalScheduleService

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1655,7 +1655,7 @@ type UpdateCertificateAuthorityByIDFunc func(ctx context.Context, id uint, certi
 
 type BatchApplyCertificateAuthoritiesFunc func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error
 
-type UpsertCertificateStatusFunc func(ctx context.Context, hostUUID string, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string) error
+type UpsertCertificateStatusFunc func(ctx context.Context, hostUUID string, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string, operationType fleet.MDMOperationType) error
 
 type BatchUpsertCertificateTemplatesFunc func(ctx context.Context, certificates []*fleet.CertificateTemplate) error
 
@@ -9929,11 +9929,11 @@ func (s *DataStore) BatchApplyCertificateAuthorities(ctx context.Context, ops fl
 	return s.BatchApplyCertificateAuthoritiesFunc(ctx, ops)
 }
 
-func (s *DataStore) UpsertCertificateStatus(ctx context.Context, hostUUID string, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string) error {
+func (s *DataStore) UpsertCertificateStatus(ctx context.Context, hostUUID string, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string, operationType fleet.MDMOperationType) error {
 	s.mu.Lock()
 	s.UpsertCertificateStatusFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpsertCertificateStatusFunc(ctx, hostUUID, certificateTemplateID, status, detail)
+	return s.UpsertCertificateStatusFunc(ctx, hostUUID, certificateTemplateID, status, detail, operationType)
 }
 
 func (s *DataStore) BatchUpsertCertificateTemplates(ctx context.Context, certificates []*fleet.CertificateTemplate) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -407,7 +407,7 @@ type ApplyCertificateTemplateSpecsFunc func(ctx context.Context, specs []*fleet.
 
 type DeleteCertificateTemplateSpecsFunc func(ctx context.Context, certificateTemplateIDs []uint, teamID uint) error
 
-type UpdateCertificateStatusFunc func(ctx context.Context, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string) error
+type UpdateCertificateStatusFunc func(ctx context.Context, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string, operationType *string) error
 
 type GlobalScheduleQueryFunc func(ctx context.Context, sq *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error)
 
@@ -3511,11 +3511,11 @@ func (s *Service) DeleteCertificateTemplateSpecs(ctx context.Context, certificat
 	return s.DeleteCertificateTemplateSpecsFunc(ctx, certificateTemplateIDs, teamID)
 }
 
-func (s *Service) UpdateCertificateStatus(ctx context.Context, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string) error {
+func (s *Service) UpdateCertificateStatus(ctx context.Context, certificateTemplateID uint, status fleet.MDMDeliveryStatus, detail *string, operationType *string) error {
 	s.mu.Lock()
 	s.UpdateCertificateStatusFuncInvoked = true
 	s.mu.Unlock()
-	return s.UpdateCertificateStatusFunc(ctx, certificateTemplateID, status, detail)
+	return s.UpdateCertificateStatusFunc(ctx, certificateTemplateID, status, detail, operationType)
 }
 
 func (s *Service) GlobalScheduleQuery(ctx context.Context, sq *fleet.ScheduledQuery) (*fleet.ScheduledQuery, error) {

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -182,6 +182,7 @@ func (svc *Service) GetDeviceCertificateTemplate(ctx context.Context, id uint) (
 			certificate.ID,
 			fleet.MDMDeliveryFailed,
 			&errorMsg,
+			fleet.MDMOperationTypeInstall,
 		); err != nil {
 			return nil, err
 		}
@@ -456,5 +457,5 @@ func (svc *Service) UpdateCertificateStatus(
 		return fleet.NewInvalidArgumentError("status", string(status))
 	}
 
-	return svc.ds.UpsertCertificateStatus(ctx, host.UUID, certificateTemplateID, status, detail)
+	return svc.ds.UpsertCertificateStatus(ctx, host.UUID, certificateTemplateID, status, detail, fleet.MDMOperationTypeInstall)
 }

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -473,8 +473,7 @@ func (svc *Service) UpdateCertificateStatus(
 
 	certificate, err := svc.ds.GetCertificateTemplateForHost(ctx, host.UUID, certificateTemplateID)
 	if err != nil {
-		level.Error(svc.logger).Log("msg", "error getting certificate template for host", "host_uuid", host.UUID, "certificate_template_id", certificateTemplateID, "err", err)
-		return nil
+		return err
 	}
 
 	if certificate.Status != nil && *certificate.Status != fleet.CertificateTemplateDelivered {
@@ -482,7 +481,7 @@ func (svc *Service) UpdateCertificateStatus(
 		return nil
 	}
 
-	if certificate.OperationType != opType {
+	if certificate.OperationType != nil && *certificate.OperationType != opType {
 		level.Info(svc.logger).Log("msg", "ignoring certificate status update for different operation type", "host_uuid", host.UUID, "certificate_template_id", certificateTemplateID, "current_operation_type", certificate.OperationType, "new_operation_type", opType)
 		return nil
 	}

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -234,7 +234,8 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateLifecycle() {
 	// Step: Verify the status is 'verified'
 	s.verifyCertificateStatus(t, host, orbitNodeKey, certificateTemplateID, certTemplateName, caID, fleet.CertificateTemplateVerified, successDetail)
 
-	// Step: Host updates the certificate status to 'failed' via fleetd API
+	// Step: Host attempts to update the certificate status to 'failed' via fleetd API
+	// This should be ignored since the current status is not 'delivered'
 	failedDetail := "Certificate installation failed: invalid challenge"
 	updateReq, err = json.Marshal(updateCertificateStatusRequest{
 		Status: string(fleet.CertificateTemplateFailed),
@@ -247,8 +248,8 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateLifecycle() {
 	})
 	_ = resp.Body.Close()
 
-	// Step: Verify the status is 'failed' with details
-	s.verifyCertificateStatus(t, host, orbitNodeKey, certificateTemplateID, certTemplateName, caID, fleet.CertificateTemplateFailed, failedDetail)
+	// Step: Verify the status is still 'verified' with details
+	s.verifyCertificateStatus(t, host, orbitNodeKey, certificateTemplateID, certTemplateName, caID, fleet.CertificateTemplateVerified, successDetail)
 }
 
 // TestCertificateTemplateSpecEndpointAndAMAPIFailure tests:

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -14896,6 +14896,7 @@ INSERT INTO host_certificate_templates (
 		name                    string
 		templateID              uint
 		newStatus               string
+		newOperationType        *string
 		detail                  *string
 		expectedResponseStatus  int
 		expectedResponseMessage string
@@ -14948,13 +14949,55 @@ INSERT INTO host_certificate_templates (
 				"Authorization": fmt.Sprintf("Node key %s", orbitNodeKey),
 			},
 		},
+		{
+			name:                   "with operation_type install",
+			templateID:             certificateTemplateID,
+			newStatus:              "verified",
+			expectedResponseStatus: http.StatusOK,
+			newOperationType:       ptr.String("install"),
+			headers: map[string]string{
+				"Authorization": fmt.Sprintf("Node key %s", orbitNodeKey),
+			},
+		},
+		{
+			name:                   "with operation_type remove",
+			templateID:             certificateTemplateID,
+			newStatus:              "verified",
+			expectedResponseStatus: http.StatusOK,
+			newOperationType:       ptr.String("remove"),
+			headers: map[string]string{
+				"Authorization": fmt.Sprintf("Node key %s", orbitNodeKey),
+			},
+		},
+		{
+			name:                   "with operation_type empty string",
+			templateID:             certificateTemplateID,
+			newStatus:              "verified",
+			expectedResponseStatus: http.StatusOK,
+			newOperationType:       ptr.String(""),
+			headers: map[string]string{
+				"Authorization": fmt.Sprintf("Node key %s", orbitNodeKey),
+			},
+		},
+		{
+			name:                    "with invalid operation_type",
+			templateID:              certificateTemplateID,
+			newStatus:               "verified",
+			expectedResponseStatus:  http.StatusUnprocessableEntity,
+			expectedResponseMessage: "must be 'install' or 'remove'",
+			newOperationType:        ptr.String("invalid_operation"),
+			headers: map[string]string{
+				"Authorization": fmt.Sprintf("Node key %s", orbitNodeKey),
+			},
+		},
 	}
 
 	for _, tc := range cases {
 		t.Run(fmt.Sprintf("TestUpdateHostCertificateTemplate:%s", tc.name), func(t *testing.T) {
 			req, err := json.Marshal(updateCertificateStatusRequest{
-				Status: tc.newStatus,
-				Detail: tc.detail,
+				Status:        tc.newStatus,
+				Detail:        tc.detail,
+				OperationType: tc.newOperationType,
 			})
 			require.NoError(t, err)
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37391 

- Added optional `operation_type` (install|remove) param (defaults to "install" for backwards compatibility with the customer RC) to the /status API
- Added validation to only update status if the operation type matches and the status is in a "delivered" state

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests

