### PR TITLE
Fleet UI: Remove edit software option from Android

### DIFF
--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -61,14 +61,19 @@ const buildActionOptions = (
       isDisabled: !!disableEditAppearanceTooltipContent,
       tooltipContent: disableEditAppearanceTooltipContent,
     },
-    {
+  ];
+
+  // Hides edit software option only for Android installers, as they are currently non-editable
+  if (!androidSoftwareAvailableForInstall) {
+    options.push({
       label: "Edit software",
       value: "edit_software",
       isDisabled: !!disableEditSoftwareTooltipContent,
       tooltipContent: disableEditSoftwareTooltipContent,
-    },
-  ];
+    });
+  }
 
+  // Show edit configuration option only for Android installers
   if (androidSoftwareAvailableForInstall) {
     options.push({
       label: "Edit configuration",

--- a/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/SoftwareIcon.tsx
+++ b/frontend/pages/SoftwarePage/components/icons/SoftwareIcon/SoftwareIcon.tsx
@@ -29,7 +29,6 @@ const SoftwareIcon = ({
   url,
   uploadedAt,
 }: ISoftwareIconProps) => {
-  console.log("name", name, "source", source, "url", url);
   const classNames = classnames(baseClass, `${baseClass}__${size}`);
 
   const [imgFailed, setImgFailed] = useState(false);


### PR DESCRIPTION
## Issue
Part of #35666 

## Description
- Recent change to specs realizing Android users can't actually edit anything in their software so the option should be hidden ([confirmed with designer in Slack](https://fleetdm.slack.com/archives/C086V2QK76X/p1765970209686449?thread_ts=1765907699.930839&cid=C086V2QK76X))
- Remove stray log merged yesterday

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] QA'd all new/changed functionality manually
