### PR TITLE
4.77.0 plus dep debug logging

### DIFF
--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1026,7 +1026,7 @@ func NewDEPClient(storage godep.ClientStorage, updater fleet.ABMTermsUpdater, lo
 			}
 		}
 		return reqErr
-	}))
+	}), godep.WithLogger(logging.NewNanoDEPLogger(kitlog.With(logger, "component", "godep-syncer"))))
 }
 
 var funcMap = map[string]any{

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -206,13 +206,13 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 		return req, err
 	}
 
-	limit20KiB := 20 * 1024
+	limit30KiB := 30 * 1024
 	if c.logger != nil {
 		responseBodyString := ""
 		// This should cover large DEP requests without overwhelming the logs and get the data needed
 		// for the most important ones like assign profile responses
-		if len(bodyBytes) > limit20KiB {
-			responseBodyString = string(bodyBytes[:limit20KiB]) + "...[truncated]"
+		if len(bodyBytes) > limit30KiB {
+			responseBodyString = string(bodyBytes[:limit30KiB]) + "...[truncated]"
 		} else {
 			responseBodyString = string(bodyBytes)
 		}

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -178,7 +178,9 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		fmt.Printf("DEP RESP ERR: %s\n", err)
+		if c.logger != nil {
+			c.logger.Debug("msg", "error sending request to Apple DEP", "url", req.URL.String(), "error", err)
+		}
 		return req, err
 	}
 	defer resp.Body.Close()

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -206,13 +206,13 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 		return req, err
 	}
 
-	limit30KiB := 30 * 1024
+	limit50KiB := 50 * 1024
 	if c.logger != nil {
 		responseBodyString := ""
 		// This should cover large DEP requests without overwhelming the logs and get the data needed
 		// for the most important ones like assign profile responses
-		if len(bodyBytes) > limit30KiB {
-			responseBodyString = string(bodyBytes[:limit30KiB]) + "...[truncated]"
+		if len(bodyBytes) > limit50KiB {
+			responseBodyString = string(bodyBytes[:limit50KiB]) + "...[truncated]"
 		} else {
 			responseBodyString = string(bodyBytes)
 		}

--- a/server/mdm/nanodep/godep/client.go
+++ b/server/mdm/nanodep/godep/client.go
@@ -206,8 +206,17 @@ func (c *Client) do(ctx context.Context, name, method, path string, in interface
 		return req, err
 	}
 
+	limit20KiB := 20 * 1024
 	if c.logger != nil {
-		c.logger.Debug("msg", "Apple DEP Request returned 200 status", "url", req.URL.String(), "apple_request_uuid", appleRequestUUID, "body", string(bodyBytes))
+		responseBodyString := ""
+		// This should cover large DEP requests without overwhelming the logs and get the data needed
+		// for the most important ones like assign profile responses
+		if len(bodyBytes) > limit20KiB {
+			responseBodyString = string(bodyBytes[:limit20KiB]) + "...[truncated]"
+		} else {
+			responseBodyString = string(bodyBytes)
+		}
+		c.logger.Debug("msg", "Apple DEP Request returned 200 status", "url", req.URL.String(), "apple_request_uuid", appleRequestUUID, "body", responseBodyString)
 	}
 
 	if out != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
