### PR TITLE
Fix issue where backend was only sending new pending certs to Android app

### DIFF
--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -289,7 +289,7 @@ func (ds *Datastore) GetAndTransitionCertificateTemplatesToDelivering(
 				pendingIDs = append(pendingIDs, r.ID)
 				result.DeliveringTemplateIDs = append(result.DeliveringTemplateIDs, r.CertificateTemplateID)
 			case fleet.CertificateTemplateDelivering:
-				// Already delivering (from a previous failed run), include in delivering list
+				// Already delivering (from a previous failed run), include in delivering list; should be very rare
 				result.DeliveringTemplateIDs = append(result.DeliveringTemplateIDs, r.CertificateTemplateID)
 			default:
 				// delivered, verified, failed

--- a/server/datastore/mysql/host_certificate_templates_test.go
+++ b/server/datastore/mysql/host_certificate_templates_test.go
@@ -619,10 +619,12 @@ func testCertificateTemplateFullStateMachine(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, hostUUIDs, 0)
 
-	// Second call should return empty delivering (no more pending templates)
+	// Second call should return the already-delivering templates (no new pending ones to transition)
 	certTemplates, err = ds.GetAndTransitionCertificateTemplatesToDelivering(ctx, "android-host")
 	require.NoError(t, err)
-	require.Empty(t, certTemplates.DeliveringTemplateIDs)
+	require.Len(t, certTemplates.DeliveringTemplateIDs, 2) // Already delivering from previous call
+	require.ElementsMatch(t, []uint{setup.template.ID, templateTwo.ID}, certTemplates.DeliveringTemplateIDs)
+	require.Empty(t, certTemplates.OtherTemplateIDs) // No delivered/verified/failed yet
 
 	// Verify database shows delivering status
 	records, err := ds.ListCertificateTemplatesForHosts(ctx, []string{"android-host"})

--- a/server/fleet/certificate_templates.go
+++ b/server/fleet/certificate_templates.go
@@ -67,3 +67,14 @@ func CertificateTemplateStatusToMDMDeliveryStatus(s CertificateTemplateStatus) M
 		return MDMDeliveryPending
 	}
 }
+
+// HostCertificateTemplatesForDelivery contains the result of preparing certificate templates
+// for delivery to a host. It includes both the templates being transitioned to delivering
+// status and the templates that are already installed (verified/delivered).
+type HostCertificateTemplatesForDelivery struct {
+	// DeliveringTemplateIDs are the certificate template IDs that were transitioned
+	// from pending to delivering status in this operation.
+	DeliveringTemplateIDs []uint
+	// OtherTemplateIDs are other certificate template IDs.
+	OtherTemplateIDs []uint
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2575,9 +2575,10 @@ type Datastore interface {
 	// certificate templates in 'pending' status ready for delivery.
 	ListAndroidHostUUIDsWithPendingCertificateTemplates(ctx context.Context, offset int, limit int) ([]string, error)
 
-	// TransitionCertificateTemplatesToDelivering atomically transitions certificate templates
-	// from 'pending' to 'delivering' status. Returns the certificate template IDs that were transitioned.
-	TransitionCertificateTemplatesToDelivering(ctx context.Context, hostUUID string) ([]uint, error)
+	// GetAndTransitionCertificateTemplatesToDelivering retrieves all certificate templates
+	// with operation_type='install' for a host, transitions any pending ones to 'delivering' status.
+	// If there are no pending certificate templates, then nothing is returned.
+	GetAndTransitionCertificateTemplatesToDelivering(ctx context.Context, hostUUID string) (*HostCertificateTemplatesForDelivery, error)
 
 	// TransitionCertificateTemplatesToDelivered transitions templates from 'delivering' to 'delivered'
 	// and sets the fleet_challenge for each template.

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1685,7 +1685,7 @@ type DeleteHostCertificateTemplatesFunc func(ctx context.Context, hostCertTempla
 
 type ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc func(ctx context.Context, offset int, limit int) ([]string, error)
 
-type TransitionCertificateTemplatesToDeliveringFunc func(ctx context.Context, hostUUID string) ([]uint, error)
+type GetAndTransitionCertificateTemplatesToDeliveringFunc func(ctx context.Context, hostUUID string) (*fleet.HostCertificateTemplatesForDelivery, error)
 
 type TransitionCertificateTemplatesToDeliveredFunc func(ctx context.Context, hostUUID string, challenges map[uint]string) error
 
@@ -4193,8 +4193,8 @@ type DataStore struct {
 	ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc        ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc
 	ListAndroidHostUUIDsWithPendingCertificateTemplatesFuncInvoked bool
 
-	TransitionCertificateTemplatesToDeliveringFunc        TransitionCertificateTemplatesToDeliveringFunc
-	TransitionCertificateTemplatesToDeliveringFuncInvoked bool
+	GetAndTransitionCertificateTemplatesToDeliveringFunc        GetAndTransitionCertificateTemplatesToDeliveringFunc
+	GetAndTransitionCertificateTemplatesToDeliveringFuncInvoked bool
 
 	TransitionCertificateTemplatesToDeliveredFunc        TransitionCertificateTemplatesToDeliveredFunc
 	TransitionCertificateTemplatesToDeliveredFuncInvoked bool
@@ -10034,11 +10034,11 @@ func (s *DataStore) ListAndroidHostUUIDsWithPendingCertificateTemplates(ctx cont
 	return s.ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc(ctx, offset, limit)
 }
 
-func (s *DataStore) TransitionCertificateTemplatesToDelivering(ctx context.Context, hostUUID string) ([]uint, error) {
+func (s *DataStore) GetAndTransitionCertificateTemplatesToDelivering(ctx context.Context, hostUUID string) (*fleet.HostCertificateTemplatesForDelivery, error) {
 	s.mu.Lock()
-	s.TransitionCertificateTemplatesToDeliveringFuncInvoked = true
+	s.GetAndTransitionCertificateTemplatesToDeliveringFuncInvoked = true
 	s.mu.Unlock()
-	return s.TransitionCertificateTemplatesToDeliveringFunc(ctx, hostUUID)
+	return s.GetAndTransitionCertificateTemplatesToDeliveringFunc(ctx, hostUUID)
 }
 
 func (s *DataStore) TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, challenges map[uint]string) error {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36684

Fix issue where sometimes backend doesn't send all certs to Android app. Specifically, if a cert was previously sent (but was not installed by Android), we will not resend it if a new one came in. This is fixed. Now we always send all type=install certs.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
