### PR TITLE
Fleet UI: Improve edit software upload UX

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ConfirmSaveChangesModal/ConfirmSaveChangesModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ConfirmSaveChangesModal/ConfirmSaveChangesModal.tsx
@@ -12,6 +12,7 @@ export interface IConfirmSaveChangesModalProps {
   softwareInstallerName?: string;
   installerType: InstallerType;
   onClose: () => void;
+  isLoading: boolean;
 }
 
 const ConfirmSaveChangesModal = ({
@@ -19,6 +20,7 @@ const ConfirmSaveChangesModal = ({
   softwareInstallerName,
   installerType,
   onClose,
+  isLoading,
 }: IConfirmSaveChangesModalProps) => {
   const warningText =
     installerType === "package" ? (
@@ -55,6 +57,7 @@ const ConfirmSaveChangesModal = ({
             type="button"
             onClick={onSaveChanges}
             className="save-loading"
+            isLoading={isLoading}
           >
             Save
           </Button>

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -117,6 +117,7 @@ const EditSoftwareModal = ({
     categories: [],
   });
   const [uploadProgress, setUploadProgress] = useState(0);
+  const [showFileProgressModal, setShowFileProgressModal] = useState(false);
 
   const { data: labels } = useQuery<ILabelSummary[], Error>(
     ["custom_labels"],
@@ -144,7 +145,14 @@ const EditSoftwareModal = ({
     isUpdatingSoftware,
   ]);
 
+  /* 1. Delays showing the file progress modal until isUpdatingSoftware
+   * has been true for 3 seconds to prevent flashing modal on quick uploads
+   * 2. Prevents page unload during the upload
+   * 3. Cleans both up when uploading stops or the component unmounts */
   useEffect(() => {
+    // Timer for delayed modal
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
     const beforeUnloadHandler = (e: BeforeUnloadEvent) => {
       e.preventDefault();
       // Next line with e.returnValue is included for legacy support
@@ -152,18 +160,34 @@ const EditSoftwareModal = ({
       e.returnValue = true;
     };
 
-    // set up event listener to prevent user from leaving page while uploading
     if (isUpdatingSoftware) {
+      // only show modal if still uploading after 3 seconds
+      timeoutId = setTimeout(() => {
+        setShowFileProgressModal(true);
+      }, 3000);
+
+      // Prevents user from leaving page while uploading
       addEventListener("beforeunload", beforeUnloadHandler);
     } else {
-      removeEventListener("beforeunload", beforeUnloadHandler);
+      // upload finished: hide modal and reset
+      setShowFileProgressModal(false);
     }
 
-    // clean up event listener and timeout on component unmount
+    // Cleanup that runs when isUpdatingSoftware changes or component unmounts
     return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
       removeEventListener("beforeunload", beforeUnloadHandler);
     };
   }, [isUpdatingSoftware]);
+
+  // Close confirm modal when file progress modal opens
+  useEffect(() => {
+    if (showFileProgressModal) {
+      setShowConfirmSaveChangesModal(false);
+    }
+  }, [showFileProgressModal]);
 
   const toggleConfirmSaveChangesModal = () => {
     setShowConfirmSaveChangesModal(!showConfirmSaveChangesModal);
@@ -374,6 +398,7 @@ const EditSoftwareModal = ({
           softwareInstallerName={softwareInstaller?.name}
           installerType={installerType}
           onSaveChanges={onClickConfirmChanges}
+          isLoading={isUpdatingSoftware}
         />
       )}
       {showPreviewEndUserExperienceModal && (
@@ -386,7 +411,7 @@ const EditSoftwareModal = ({
           isIosOrIpadosApp={isIosOrIpadosApp}
         />
       )}
-      {!!pendingPackageUpdates.software && isUpdatingSoftware && (
+      {!!pendingPackageUpdates.software && showFileProgressModal && (
         <FileProgressModal
           fileDetails={getFileDetails(pendingPackageUpdates.software, true)}
           fileProgress={uploadProgress}


### PR DESCRIPTION
## Issue
Closes #36740 

## Description
- Code shows the "only show on new file upload" is already implemented
- Shows loading spinner on save button for up to 3 seconds
- Only if the new file upload takes more than 3 seconds, the file progress modal will be shown instead

## Screen recording of fix

Video recording shows
1. If you don't edit the software file, it will only show a loading spinner on the button
2. If you edit a software file, it will show a loading spinner on the button for up to 3 seconds, if it takes longer than 3 seconds, it will open the file progress modal.

https://github.com/user-attachments/assets/f8b4bfa6-5d98-4d29-b8a3-7b8d8b9d0ad9



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually
