### PR TITLE
Move the report clipped check to happen sooner

### DIFF
--- a/changes/fix-clipped-host-query-reports
+++ b/changes/fix-clipped-host-query-reports
@@ -1,0 +1,1 @@
+* Fixed host query report to display "Report clipped" when a query has reached the 1k result limit.

--- a/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HQRTable/HQRTable.tsx
@@ -87,6 +87,16 @@ const HQRTable = ({
   const renderEmptyState = useCallback(() => {
     // rows.length === 0
 
+    if (reportClipped) {
+      return (
+        <EmptyTable
+          className={`${baseClass}__report-clipped`}
+          graphicName="empty-software"
+          header="Report clipped"
+          info="This query has paused reporting in Fleet, and no results were saved for this host."
+        />
+      );
+    }
     if (!lastFetched) {
       // collecting results
       return (
@@ -95,16 +105,6 @@ const HQRTable = ({
           graphicName="collecting-results"
           header="Collecting results..."
           info={`Fleet is collecting query results from ${hostName}. Check back later.`}
-        />
-      );
-    }
-    if (reportClipped) {
-      return (
-        <EmptyTable
-          className={`${baseClass}__report-clipped`}
-          graphicName="empty-software"
-          header="Report clipped"
-          info="This query has paused reporting in Fleet, and no results were saved for this host."
         />
       );
     }


### PR DESCRIPTION
Resolves #36566.

I was attempting to estimate the bug and saw that it involved just a move of the `if` clause to fix.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually.