### PR TITLE
Rename "Orbit osquery runtime and autoupdater" to "Fleet desktop" in build-windows.go

### DIFF
--- a/orbit/changes/37459-windows-system-tray-branding
+++ b/orbit/changes/37459-windows-system-tray-branding
@@ -1,0 +1,1 @@
+* Fixed Fleet Desktop display name in Windows system tray settings to show "Fleet desktop" instead of "Fleet osquery installer".

--- a/orbit/changes/37459-windows-system-tray-branding
+++ b/orbit/changes/37459-windows-system-tray-branding
@@ -1,1 +1,1 @@
-* Fixed Fleet Desktop display name in Windows system tray settings to show "Fleet desktop" instead of "Fleet osquery installer".
+* Fixed Fleet Desktop display name in Windows system tray settings to show "Fleet Desktop" instead of "Fleet osquery installer".

--- a/orbit/tools/build/build-windows.go
+++ b/orbit/tools/build/build-windows.go
@@ -145,7 +145,7 @@ func createVersionInfo(vParts []string, iconPath string, manifestPath string) (*
 		StringFileInfo: goversioninfo.StringFileInfo{
 			Comments:         "Fleet osquery",
 			CompanyName:      "Fleet Device Management (fleetdm.com)",
-			FileDescription:  "Fleet desktop",
+			FileDescription:  "Fleet Desktop",
 			FileVersion:      version,
 			InternalName:     "",
 			LegalCopyright:   copyright,

--- a/orbit/tools/build/build-windows.go
+++ b/orbit/tools/build/build-windows.go
@@ -145,7 +145,7 @@ func createVersionInfo(vParts []string, iconPath string, manifestPath string) (*
 		StringFileInfo: goversioninfo.StringFileInfo{
 			Comments:         "Fleet osquery",
 			CompanyName:      "Fleet Device Management (fleetdm.com)",
-			FileDescription:  "Orbit osquery runtime and autoupdater",
+			FileDescription:  "Fleet desktop",
 			FileVersion:      version,
 			InternalName:     "",
 			LegalCopyright:   copyright,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37459

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [X] Verified that fleetd runs on ~macOS, Linux and~ Windows

<img width="439" height="346" alt="Screenshot 2025-12-18 at 9 22 26 AM" src="https://github.com/user-attachments/assets/7533606d-1092-4d4e-97b3-4d69d3c6156a" />

<img width="1920" height="1200" alt="Screenshot 2025-12-18 at 9 28 29 AM" src="https://github.com/user-attachments/assets/9207405a-a1da-4e87-b875-c728b46a427c" />
