### PR TITLE
Website: add missing exit to get-android-devices

### DIFF
--- a/website/api/controllers/android-proxy/get-android-devices.js
+++ b/website/api/controllers/android-proxy/get-android-devices.js
@@ -33,6 +33,7 @@ module.exports = {
     success: { description: 'Android devices list was successfully retrieved.' },
     missingAuthHeader: { description: 'This request was missing an authorization header.', responseType: 'unauthorized'},
     missingOriginHeader: { description: 'The request was missing an Origin header', responseType: 'badRequest'},
+    notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
   },
 


### PR DESCRIPTION
Changes:
- Added a missing `notFound` exit to the `get-android-devices` action used by the website's Android Enterprise proxy.