### PR TITLE
make failed and ran use their status value in mdm command feed

### DIFF
--- a/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandItem/CommandItem.tsx
@@ -28,7 +28,7 @@ const CommandItem = ({ command, onShowDetails }: ICommandItemProps) => {
       break;
     case "ran":
     case "failed":
-      statusVerb = "ran";
+      statusVerb = command_status;
       break;
     default:
       statusVerb = "ran";


### PR DESCRIPTION
<img width="537" height="282" alt="image" src="https://github.com/user-attachments/assets/88bacc63-7707-4bc1-81d2-cb52e1c0f2eb" />

Shows failed now for failed commands