### PR TITLE
Fix dashes so the formatting will show correctly on GitHub

### DIFF
--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -3,10 +3,10 @@
 
 ## General
 
-– Name the file what the profile does.
+- Name the file what the profile does.
   - For example, instead of `googlePlayProtectVerifyApps.json` (the name of the
     Android policy for this control), describe what it does:
     `enforce-google-play-protect.json`.
-– Use kebab case in file names, with all letters in lowercase.
+- Use kebab case in file names, with all letters in lowercase.
   - Instead of `passwordPolicy.json`, use `password-policy.json`.
-– Be sure to end files with an empty newline.
+- Be sure to end files with an empty newline.

--- a/docs/solutions/README.md
+++ b/docs/solutions/README.md
@@ -4,9 +4,7 @@
 ## General
 
 - Name the file what the profile does.
-  - For example, instead of `googlePlayProtectVerifyApps.json` (the name of the
-    Android policy for this control), describe what it does:
-    `enforce-google-play-protect.json`.
+  - For example, instead of `googlePlayProtectVerifyApps.json` (the name of the Android policy for this control), describe what it does: `enforce-google-play-protect.json`.
 - Use kebab case in file names, with all letters in lowercase.
   - Instead of `passwordPolicy.json`, use `password-policy.json`.
 - Be sure to end files with an empty newline.


### PR DESCRIPTION
Sorry for opening another PR on this! Not sure how, but some weird dashes snuck in and it threw off the formatting.

Screenshots of the rich text before and after below.

<img width="1049" height="276" alt="Screenshot 2025-12-18 at 12 19 15" src="https://github.com/user-attachments/assets/1fefafda-0b94-4f20-a39a-ace4fa874457" />
<img width="1077" height="322" alt="Screenshot 2025-12-18 at 12 20 38" src="https://github.com/user-attachments/assets/ef7274d2-501a-4394-8c34-78a9a30c43c2" />