### PR TITLE
Fleet UI: Disable save button by default until edit vpp form has been used

### DIFF
--- a/changes/36283-disable-edit
+++ b/changes/36283-disable-edit
@@ -1,0 +1,1 @@
+- Fleet UI: Improve Edit VPP UX by disabling a form that hasn't been edited

--- a/changes/36740-remove-blinky-progress-bar-modal
+++ b/changes/36740-remove-blinky-progress-bar-modal
@@ -1,0 +1,1 @@
+- Fleet UI: Improved software upload progress modal

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
@@ -154,7 +154,7 @@ const SoftwareVppForm = ({
   );
 
   const [formValidation, setFormValidation] = useState<IFormValidation>({
-    isValid: !!softwareVppForEdit, // Disables submit before VPP to add is selected
+    isValid: false, // Disables submit before VPP to add is selected and before edit VPP is edited
   });
 
   const onFormSubmit = (evt: React.FormEvent<HTMLFormElement>) => {
@@ -184,6 +184,7 @@ const SoftwareVppForm = ({
   const onToggleSelfServiceCheckbox = (value: boolean) => {
     const newData = { ...formData, selfService: value };
     setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const onSelectCategory = ({
@@ -217,6 +218,7 @@ const SoftwareVppForm = ({
   const onToggleAutomaticInstall = (value: boolean) => {
     const newData = { ...formData, automaticInstall: value };
     setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const onSelectTargetType = (value: string) => {
@@ -228,6 +230,7 @@ const SoftwareVppForm = ({
   const onSelectCustomTargetOption = (value: string) => {
     const newData = { ...formData, customTarget: value };
     setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
   };
 
   const onSelectLabel = ({ name, value }: { name: string; value: boolean }) => {


### PR DESCRIPTION
## Issue
Closes #36283 

## Description
- Disable Edit VPP modal save button until formData is dirty

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
