### PR TITLE
Improve Fleet Desktop tray description in Windows

### DIFF
--- a/orbit/changes/37459-update-fleet-desktop-description-taskbar
+++ b/orbit/changes/37459-update-fleet-desktop-description-taskbar
@@ -1,0 +1,1 @@
+* Improve "Fleet Desktop" description in Windows' system tray.

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -123,10 +123,10 @@ for system in $SYSTEMS; do
        ORBIT_BINARY_PATH=$orbit_target \
        go run ./orbit/tools/build/build.go
     elif [ $system == "windows" ]; then
-        ORBIT_VERSION=$ORBIT_VERSION make orbit-windows
+        CGO_ENABLED=0 ORBIT_VERSION=$ORBIT_VERSION make orbit-windows
         mv orbit.exe orbit-windows.exe
     elif [ $system == "windows-arm64" ]; then
-        ORBIT_VERSION=$ORBIT_VERSION make orbit-windows-arm64
+        CGO_ENABLED=0 ORBIT_VERSION=$ORBIT_VERSION make orbit-windows-arm64
         mv orbit.exe orbit-windows-arm64.exe
     else
       race_value=false

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -122,6 +122,12 @@ for system in $SYSTEMS; do
        ORBIT_COMMIT=$ORBIT_COMMIT \
        ORBIT_BINARY_PATH=$orbit_target \
        go run ./orbit/tools/build/build.go
+    elif [ $system == "windows" ]; then
+        ORBIT_VERSION=$ORBIT_VERSION make orbit-windows
+        mv orbit.exe orbit-windows.exe
+    elif [ $system == "windows-arm64" ]; then
+        ORBIT_VERSION=$ORBIT_VERSION make orbit-windows-arm64
+        mv orbit.exe orbit-windows-arm64.exe
     else
       race_value=false
       # Enable race on macOS Intel at least.


### PR DESCRIPTION
Resolves #37459.

Screenshot of the new system tray description for Fleet Desktop:
<img width="1017" height="826" alt="Screenshot 2025-12-30 at 4 45 58 PM" src="https://github.com/user-attachments/assets/d45b75dd-b7f7-4a64-a3b0-5a4083d385b1" />
Description for orbit and Fleet Desktop as seen in Task Manager (stays the same):
<img width="1075" height="170" alt="Screenshot 2025-12-30 at 4 47 20 PM" src="https://github.com/user-attachments/assets/6fb7fb19-2a11-4998-904a-ff8e95279273" />

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
