### PR TITLE
Prevent IT admins from adding Fleet agent manually to Software

### DIFF
--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -139,6 +139,12 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 					fmt.Sprintf("platform must be one of '%s', '%s', '%s', or '%s'", fleet.IOSPlatform, fleet.IPadOSPlatform, fleet.MacOSPlatform, fleet.AndroidPlatform))
 			}
 
+			// Block Fleet Agent apps from being added via GitOps
+			if payload.Platform == fleet.AndroidPlatform && strings.HasPrefix(payload.AppStoreID, fleetAgentPackagePrefix) {
+				return nil, fleet.NewInvalidArgumentError("app_store_id", "The Fleet agent cannot be added manually. "+
+					"It is automatically managed by Fleet when Android MDM is enabled.")
+			}
+
 			var err error
 			if payload.Platform.IsApplePlatform() && vppToken == "" {
 				vppToken, err = svc.getVPPToken(ctx, teamID)

--- a/ee/server/service/vpp_test.go
+++ b/ee/server/service/vpp_test.go
@@ -48,4 +48,43 @@ func TestBatchAssociateVPPApps(t *testing.T) {
 			require.ErrorContains(t, err, "could not retrieve vpp token")
 		})
 	})
+
+	t.Run("Fails for Fleet Agent Android apps via GitOps", func(t *testing.T) {
+		ds.GetSoftwareCategoryIDsFunc = func(ctx context.Context, names []string) ([]uint, error) {
+			return nil, nil
+		}
+
+		fleetAgentPackages := []string{
+			"com.fleetdm.agent",
+			"com.fleetdm.agent.pingali",
+			"com.fleetdm.agent.private.testuser",
+		}
+
+		for _, pkg := range fleetAgentPackages {
+			t.Run(pkg+" dry run", func(t *testing.T) {
+				_, err := svc.BatchAssociateVPPApps(ctx, "", []fleet.VPPBatchPayload{
+					{
+						AppStoreID:       pkg,
+						LabelsExcludeAny: []string{},
+						LabelsIncludeAny: []string{},
+						Categories:       []string{},
+						Platform:         fleet.AndroidPlatform,
+					},
+				}, true)
+				require.ErrorContains(t, err, "The Fleet agent cannot be added manually")
+			})
+			t.Run(pkg+" not dry run", func(t *testing.T) {
+				_, err := svc.BatchAssociateVPPApps(ctx, "", []fleet.VPPBatchPayload{
+					{
+						AppStoreID:       pkg,
+						LabelsExcludeAny: []string{},
+						LabelsIncludeAny: []string{},
+						Categories:       []string{},
+						Platform:         fleet.AndroidPlatform,
+					},
+				}, false)
+				require.ErrorContains(t, err, "The Fleet agent cannot be added manually")
+			})
+		}
+	})
 }

--- a/server/service/integration_android_software_test.go
+++ b/server/service/integration_android_software_test.go
@@ -69,6 +69,22 @@ func (s *integrationMDMTestSuite) TestAndroidAppsSelfService() {
 	)
 	require.Contains(t, extractServerErrorText(r.Body), "Application ID must be a valid Android application ID")
 
+	// Fleet agent app: should fail (cannot be added manually)
+	for _, fleetAgentPkg := range []string{
+		"com.fleetdm.agent",
+		"com.fleetdm.agent.pingali",
+		"com.fleetdm.agent.private.testuser",
+	} {
+		r = s.Do(
+			"POST",
+			"/api/latest/fleet/software/app_store_apps",
+			&addAppStoreAppRequest{AppStoreID: fleetAgentPkg, Platform: fleet.AndroidPlatform},
+			http.StatusUnprocessableEntity,
+		)
+		require.Contains(t, extractServerErrorText(r.Body), "The Fleet agent cannot be added manually",
+			"expected Fleet Agent package %s to be blocked", fleetAgentPkg)
+	}
+
 	// Missing platform: should fail
 	r = s.Do(
 		"POST",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37441

Treating this as unreleased Android certs bug.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Prevented manual addition of the Fleet agent package on Android devices. Attempting to manually add the Fleet agent through the app store configuration endpoint now returns an error message, as this package is automatically managed by the system when Android MDM is enabled. Other Android app additions remain unaffected.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->