### PR TITLE
account for commands being dequeued in list query

### DIFF
--- a/changes/36748-win-mdm-cmd
+++ b/changes/36748-win-mdm-cmd
@@ -1,0 +1,1 @@
+- Updated query behind `fleetctl get mdm-commands` to correctly get completed Windows MDM commands.

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -235,14 +235,31 @@ WHERE
 	}
 
 	if len(winUUIDs) > 0 {
-		winParams = []any{winUUIDs}
+		winParams = []any{winUUIDs, winUUIDs}
 		winStmt = `
-SELECT
-	mwe.host_uuid,
-	wq.command_uuid,
-	COALESCE(wcr.updated_at, wc.created_at) AS updated_at,
-	COALESCE(NULLIF(wcr.status_code, ''), '101') AS status,
-	CASE
+	SELECT
+		mwe.host_uuid,
+		wq.command_uuid,
+		wc.created_at AS updated_at,
+		'101' AS status,
+		'pending' AS command_status,
+		wc.target_loc_uri AS request_type
+	FROM
+		windows_mdm_command_queue wq
+		JOIN mdm_windows_enrollments mwe ON mwe.id = wq.enrollment_id
+		JOIN windows_mdm_commands wc ON wc.command_uuid = wq.command_uuid
+
+	WHERE
+		mwe.host_uuid IN (?)
+
+	UNION
+
+	SELECT
+		mwe.host_uuid,
+		wcr.command_uuid,
+		COALESCE(wcr.updated_at, wc.created_at) AS updated_at,
+		COALESCE(NULLIF(wcr.status_code, ''), '101') AS status,
+		CASE
         WHEN COALESCE(
             NULLIF(wcr.status_code, ''),
             '101'
@@ -252,7 +269,7 @@ SELECT
                 NULLIF(wcr.status_code, ''),
                 '101'
             ) AS UNSIGNED
-        ) BETWEEN 200 AND 399  THEN 'ran'
+        ) BETWEEN 200 AND 399 THEN 'ran'
         WHEN CAST(
             COALESCE(
                 NULLIF(wcr.status_code, ''),
@@ -260,15 +277,15 @@ SELECT
             ) AS UNSIGNED
         ) >= 400 THEN 'failed'
     END AS command_status,
-	wc.target_loc_uri AS request_type
-FROM
-	windows_mdm_command_queue wq
-	JOIN mdm_windows_enrollments mwe ON mwe.id = wq.enrollment_id
-	JOIN windows_mdm_commands wc ON wc.command_uuid = wq.command_uuid
-	LEFT JOIN windows_mdm_command_results wcr ON wcr.command_uuid = wq.command_uuid
-		AND wcr.enrollment_id = wq.enrollment_id
-WHERE
-	mwe.host_uuid IN (?)`
+		wc.target_loc_uri AS request_type
+	FROM
+		windows_mdm_command_results wcr
+		JOIN mdm_windows_enrollments mwe ON mwe.id = wcr.enrollment_id
+		JOIN windows_mdm_commands wc ON wc.command_uuid = wcr.command_uuid
+	WHERE
+		mwe.host_uuid IN (?)
+
+	`
 
 		winStmt, winParams = addRequestTypeFilter(winStmt, &listOpts.Filters, winParams)
 		winStmt, winParams, err = sqlx.In(winStmt, winParams...)

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -274,6 +274,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 		identifier    string
 		commandStatus *fleet.MDMCommandStatusFilter
 		expected      []string
+		requestType   string
 	}{
 		{
 			name:       "windows host by hostname ambiguous with macOS host",
@@ -287,6 +288,12 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 			name:       "windows host by UUID",
 			identifier: windowsH.UUID,
 			expected:   []string{winCmd.CommandUUID, winCmd2.CommandUUID, winCmd3.CommandUUID},
+		},
+		{
+			name:        "windows host by UUID, filter by request type",
+			identifier:  windowsH.UUID,
+			expected:    []string{winCmd2.CommandUUID},
+			requestType: "./test/uri2",
 		},
 		{
 			name:       "windows host by hardware serial",
@@ -325,6 +332,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 					Filters: fleet.MDMCommandFilters{
 						HostIdentifier:  tc.identifier,
 						CommandStatuses: commandStatuses,
+						RequestType:     tc.requestType,
 					},
 				},
 			)

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -328,11 +328,7 @@ func testMDMCommands(t *testing.T, ds *Datastore) {
 					},
 				},
 			)
-			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-				DumpTable(t, q, "windows_mdm_command_queue")
-				DumpTable(t, q, "windows_mdm_command_results")
-				return nil
-			})
+
 			require.NoError(t, err)
 			require.Len(t, cmds, len(tc.expected))
 			var got []string

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -2467,7 +2467,7 @@ func (ds *Datastore) GetWindowsMDMCommandsForResending(ctx context.Context, fail
 		return []*fleet.MDMWindowsCommand{}, nil
 	}
 
-	stmt := `SELECT command_uuid, raw_command, target_loc_uri, created_at, updated_at 
+	stmt := `SELECT command_uuid, raw_command, target_loc_uri, created_at, updated_at
 		FROM windows_mdm_commands WHERE`
 
 	args := []any{}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36748

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually

