### PR TITLE
UI expect "delivering" and "delivered" statuses when removing Android certs

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tests.tsx
@@ -108,4 +108,46 @@ describe("OS setting status cell", () => {
       screen.getByText(/The host is running the command/)
     ).toBeInTheDocument();
   });
+  it("Displays Pending UI for 'delivering' status with optype 'remove'", async () => {
+    const customRender = createCustomRenderer();
+
+    const { user } = customRender(
+      <OSSettingStatusCell
+        profileName="Test cert"
+        status="delivering"
+        operationType="remove"
+        hostPlatform="android"
+        profileUUID={FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID}
+      />
+    );
+
+    const statusText = screen.getByText("Removing enforcement (pending)");
+    expect(statusText).toBeInTheDocument();
+
+    await user.hover(statusText);
+    expect(
+      screen.getByText(/The host is running the command/)
+    ).toBeInTheDocument();
+  });
+  it("Displays Pending UI for 'delivered' status with optype 'remove'", async () => {
+    const customRender = createCustomRenderer();
+
+    const { user } = customRender(
+      <OSSettingStatusCell
+        profileName="Test cert"
+        status="delivered"
+        operationType="remove"
+        hostPlatform="android"
+        profileUUID={FLEET_ANDROID_CERTIFICATE_TEMPLATE_PROFILE_ID}
+      />
+    );
+
+    const statusText = screen.getByText("Removing enforcement (pending)");
+    expect(statusText).toBeInTheDocument();
+
+    await user.hover(statusText);
+    expect(
+      screen.getByText(/The host is running the command/)
+    ).toBeInTheDocument();
+  });
 });

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingStatusCell/OSSettingStatusCell.tsx
@@ -54,6 +54,8 @@ const OSSettingStatusCell = ({
   ) {
     switch (status) {
       case "pending":
+      case "delivering":
+      case "delivered":
         if (operationType === "install") {
           displayOption = {
             statusText: "Enforcing (pending)",
@@ -68,23 +70,6 @@ const OSSettingStatusCell = ({
             tooltip:
               "The host is running the command to remove settings or will run it when the host comes online.",
           };
-        }
-        break;
-      case "delivering":
-      case "delivered":
-        if (operationType === "install") {
-          // note that thise case is identical to the "pending" case above for install operation
-          // separation allows catching the below error case
-          displayOption = {
-            statusText: "Enforcing (pending)",
-            iconName: "pending-outline",
-            tooltip:
-              "The host is running the command to apply settings or will run it when the host comes online.",
-          };
-        } else {
-          throw new Error(
-            "Received unexpected 'delivering' or 'delivered' status for remove operation"
-          );
         }
         break;
       case "verified":


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/36683#issuecomment-3671505923

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually