### PR TITLE
Remove width limit of `OSSettingsStatusCell`

### DIFF
--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -10,9 +10,6 @@
       .os-settings-name-cell {
         max-width: 166px;
       }
-      .os-settings-status-cell {
-        width: 200px;
-      }
       .os-settings-error-cell {
         width: 237px;
       }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves
<img width="476" height="337" alt="Screenshot 2025-12-18 at 2 49 52 PM" src="https://github.com/user-attachments/assets/4f3c927d-2e98-42c8-9c6c-34235667b6d2" />

Now:
<img width="927" height="623" alt="Screenshot 2025-12-18 at 2 48 49 PM" src="https://github.com/user-attachments/assets/5b8e45ac-b3b2-4ec4-8513-c9f07df2473e" />


- [x] QA'd all new/changed functionality manually