### PR TITLE
Don't delete Android agent when transferring teams.

### DIFF
--- a/server/mdm/android/service.go
+++ b/server/mdm/android/service.go
@@ -28,6 +28,7 @@ type Service interface {
 	// not additive/PATCH semantics.
 	SetAppsForAndroidPolicy(ctx context.Context, enterpriseName string, appPolicies []*androidmanagement.ApplicationPolicy, hostUUIDs map[string]string) error
 	AddFleetAgentToAndroidPolicy(ctx context.Context, enterpriseName string, hostConfigs map[string]AgentManagedConfiguration) error
+	BuildFleetAgentApplicationPolicy(ctx context.Context, hostUUID string) (*androidmanagement.ApplicationPolicy, error)
 	// BuildAndSendFleetAgentConfig builds the complete AgentManagedConfiguration for the given hosts
 	// (including certificate templates) and sends it to the Android Management API.
 	// This is the centralized function that should be used by all callers to avoid race conditions.

--- a/server/worker/software_worker.go
+++ b/server/worker/software_worker.go
@@ -491,6 +491,14 @@ func (v *SoftwareWorker) bulkSetAndroidAppsAvailableForHosts(ctx context.Context
 			return ctxerr.Wrap(ctx, err, "building application policies with config")
 		}
 
+		// Include the Fleet Agent in the app list so it's not removed when we replace the apps.
+		fleetAgentPolicy, err := v.AndroidModule.BuildFleetAgentApplicationPolicy(ctx, uuid)
+		if err != nil {
+			level.Error(v.Log).Log("msg", "failed to build Fleet Agent policy, Fleet Agent may be removed", "host_uuid", uuid, "err", err)
+		} else if fleetAgentPolicy != nil {
+			appPolicies = append(appPolicies, fleetAgentPolicy)
+		}
+
 		err = v.AndroidModule.SetAppsForAndroidPolicy(ctx, enterpriseName, appPolicies, map[string]string{uuid: uuid})
 
 		if err != nil {

--- a/server/worker/software_worker_test.go
+++ b/server/worker/software_worker_test.go
@@ -1,9 +1,18 @@
 package worker
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/androidmanagement/v1"
 )
 
 func TestSoftwareWorker(t *testing.T) {
@@ -13,4 +22,84 @@ func TestSoftwareWorker(t *testing.T) {
 
 	mysql.SetTestABMAssets(t, ds, "fleet")
 
+}
+
+// mockAndroidModule is a mock implementation of the android.Service interface for testing.
+type mockAndroidModule struct {
+	android.Service
+
+	buildFleetAgentApplicationPolicyFunc func(ctx context.Context, hostUUID string) (*androidmanagement.ApplicationPolicy, error)
+	setAppsForAndroidPolicyFunc          func(ctx context.Context, enterpriseName string, appPolicies []*androidmanagement.ApplicationPolicy, hostUUIDs map[string]string) error
+}
+
+func (m *mockAndroidModule) BuildFleetAgentApplicationPolicy(ctx context.Context, hostUUID string) (*androidmanagement.ApplicationPolicy, error) {
+	if m.buildFleetAgentApplicationPolicyFunc != nil {
+		return m.buildFleetAgentApplicationPolicyFunc(ctx, hostUUID)
+	}
+	return nil, nil
+}
+
+func (m *mockAndroidModule) SetAppsForAndroidPolicy(ctx context.Context, enterpriseName string, appPolicies []*androidmanagement.ApplicationPolicy, hostUUIDs map[string]string) error {
+	if m.setAppsForAndroidPolicyFunc != nil {
+		return m.setAppsForAndroidPolicyFunc(ctx, enterpriseName, appPolicies, hostUUIDs)
+	}
+	return nil
+}
+
+// TestBulkSetAndroidAppsAvailableForHostsPreservesFleetAgent verifies that the Fleet Agent
+// is preserved when an Android host is transferred between teams. This prevents the agent
+// from being uninstalled (and losing state) during team transfers.
+func TestBulkSetAndroidAppsAvailableForHostsPreservesFleetAgent(t *testing.T) {
+	ctx := t.Context()
+	hostUUID := "test-host-uuid"
+	hostID := uint(1)
+	teamID := uint(2)
+
+	ds := new(mock.Store)
+	ds.AndroidHostLiteByHostUUIDFunc = func(ctx context.Context, uuid string) (*fleet.AndroidHost, error) {
+		return &fleet.AndroidHost{
+			Host: &fleet.Host{
+				ID:     hostID,
+				UUID:   hostUUID,
+				TeamID: ptr.Uint(teamID),
+			},
+		}, nil
+	}
+	ds.GetAndroidAppsInScopeForHostFunc = func(ctx context.Context, hostID uint) ([]string, error) {
+		return []string{"com.example.teamapp"}, nil
+	}
+	ds.BulkGetAndroidAppConfigurationsFunc = func(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error) {
+		return map[string]json.RawMessage{}, nil
+	}
+
+	var capturedAppPolicies []*androidmanagement.ApplicationPolicy
+	androidModule := &mockAndroidModule{
+		buildFleetAgentApplicationPolicyFunc: func(ctx context.Context, hostUUID string) (*androidmanagement.ApplicationPolicy, error) {
+			return &androidmanagement.ApplicationPolicy{
+				PackageName: "com.fleetdm.agent",
+				InstallType: "FORCE_INSTALLED",
+			}, nil
+		},
+		setAppsForAndroidPolicyFunc: func(ctx context.Context, enterpriseName string, appPolicies []*androidmanagement.ApplicationPolicy, hostUUIDs map[string]string) error {
+			capturedAppPolicies = appPolicies
+			return nil
+		},
+	}
+
+	worker := &SoftwareWorker{
+		Datastore:     ds,
+		AndroidModule: androidModule,
+		Log:           kitlog.NewNopLogger(),
+	}
+
+	err := worker.bulkSetAndroidAppsAvailableForHosts(ctx, map[string]uint{hostUUID: hostID}, "enterprises/test")
+	require.NoError(t, err)
+
+	// Verify both the team app and Fleet Agent are in the policy
+	require.Len(t, capturedAppPolicies, 2, "expected team app + Fleet Agent")
+	capturedPackageNames := make([]string, len(capturedAppPolicies))
+	for i, policy := range capturedAppPolicies {
+		capturedPackageNames[i] = policy.PackageName
+	}
+	require.ElementsMatch(t, []string{"com.example.teamapp", "com.fleetdm.agent"}, capturedPackageNames)
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37440 

Note, from manual testing, when moving host to a new team, it does NOT get the certs for the new team. We could fix this as part of this fix or in a separate PR.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Fleet Agent integration for Android MDM devices
  * Fleet Agent policies are now automatically constructed and applied to managed Android devices
  * Fleet Agent configuration includes server URL, enrollment secrets, and certificate templates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->