### PR TITLE
optimisations and tests for mdm commands UI

### DIFF
--- a/frontend/components/FeedListItem/FeedListItem.tests.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tests.tsx
@@ -1,0 +1,118 @@
+import React from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { renderWithSetup } from "test/test-utils";
+
+import FeedListItem from "./FeedListItem";
+
+describe("FeedListItem", () => {
+  const defaultProps = {
+    useFleetAvatar: true,
+    createdAt: new Date("2024-01-01T12:00:00Z"),
+  };
+
+  it("renders the info icon when allowShowDetails is true", () => {
+    render(
+      <FeedListItem {...defaultProps} allowShowDetails>
+        Test content
+      </FeedListItem>
+    );
+
+    expect(screen.getByTestId("info-outline-icon")).toBeInTheDocument();
+  });
+
+  it("does not render the info icon when allowShowDetails is false", () => {
+    render(
+      <FeedListItem {...defaultProps} allowShowDetails={false}>
+        Test content
+      </FeedListItem>
+    );
+
+    expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
+  });
+
+  it("calls onClickFeedItem when allowShowDetails is true and the feed content is clicked", async () => {
+    const onClickFeedItem = jest.fn();
+
+    const { user } = renderWithSetup(
+      <FeedListItem
+        {...defaultProps}
+        allowShowDetails
+        onClickFeedItem={onClickFeedItem}
+      >
+        Test content
+      </FeedListItem>
+    );
+
+    const detailsWrapper = screen.getByRole("button", {
+      name: /Test content/i,
+    });
+    await user.click(detailsWrapper);
+
+    expect(onClickFeedItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the createdAt date when passed in", () => {
+    const createdAt = new Date("2024-01-01T12:00:00Z");
+    render(
+      <FeedListItem {...defaultProps} createdAt={createdAt}>
+        Test content
+      </FeedListItem>
+    );
+
+    // The dateAgo function will render something like "X days ago" or similar
+    // We can check that some date-related text is rendered
+    const dateElement = screen.getByText(/ago/i);
+    expect(dateElement).toBeInTheDocument();
+  });
+
+  it("renders the close icon when allowCancel is true", () => {
+    render(
+      <FeedListItem {...defaultProps} allowCancel>
+        Test content
+      </FeedListItem>
+    );
+
+    expect(screen.getByTestId("close-icon")).toBeInTheDocument();
+  });
+
+  it("does not render the close icon when allowCancel is false", () => {
+    render(
+      <FeedListItem {...defaultProps} allowCancel={false}>
+        Test content
+      </FeedListItem>
+    );
+
+    expect(screen.queryByTestId("close-icon")).not.toBeInTheDocument();
+  });
+
+  it("calls onClickCancel when the close icon is clicked", async () => {
+    const onClickCancel = jest.fn();
+
+    render(
+      <FeedListItem {...defaultProps} allowCancel onClickCancel={onClickCancel}>
+        Test content
+      </FeedListItem>
+    );
+
+    // there is some weirdness with userEvent.click on the cancel icon
+    // so using fireEvent.click for this test. I think it has to do with
+    // the icon not being shown until the user hovers over the button but we
+    // were not able to fix this so we use fireEvent.click instead.
+    const cancelIcon = screen.getByRole("button", { name: "cancel" });
+    await fireEvent.click(cancelIcon);
+
+    expect(onClickCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the close button when disableCancel is true", () => {
+    render(
+      <FeedListItem {...defaultProps} allowCancel disableCancel>
+        Test content
+      </FeedListItem>
+    );
+
+    const closeButton = screen.getByTestId("close-icon").closest("button");
+    expect(closeButton).toBeDisabled();
+  });
+});

--- a/frontend/components/FeedListItem/FeedListItem.tests.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tests.tsx
@@ -113,6 +113,6 @@ describe("FeedListItem", () => {
     );
 
     const cancelIcon = screen.getByRole("button", { name: "cancel action" });
-    expect(closeButton).toBeDisabled();
+    expect(cancelIcon).toBeDisabled();
   });
 });

--- a/frontend/components/FeedListItem/FeedListItem.tests.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tests.tsx
@@ -99,7 +99,7 @@ describe("FeedListItem", () => {
     // so using fireEvent.click for this test. I think it has to do with
     // the icon not being shown until the user hovers over the button but we
     // were not able to fix this so we use fireEvent.click instead.
-    const cancelIcon = screen.getByRole("button", { name: "cancel" });
+    const cancelIcon = screen.getByRole("button", { name: "cancel action" });
     await fireEvent.click(cancelIcon);
 
     expect(onClickCancel).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe("FeedListItem", () => {
       </FeedListItem>
     );
 
-    const closeButton = screen.getByTestId("close-icon").closest("button");
+    const cancelIcon = screen.getByRole("button", { name: "cancel action" });
     expect(closeButton).toBeDisabled();
   });
 });

--- a/frontend/components/FeedListItem/FeedListItem.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tsx
@@ -99,7 +99,7 @@ const FeedListItem = ({
               className={`${baseClass}__action-button`}
               variant="icon"
               onClick={onClickFeedItem}
-              ariaLabel="info"
+              ariaLabel="show info"
             >
               <Icon name="info-outline" />
             </Button>
@@ -110,7 +110,7 @@ const FeedListItem = ({
               variant="icon"
               onClick={onClickCancel}
               disabled={disableCancel}
-              ariaLabel="cancel"
+              ariaLabel="cancel action"
             >
               <Icon
                 name="close"

--- a/frontend/components/FeedListItem/FeedListItem.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tsx
@@ -102,6 +102,7 @@ const FeedListItem = ({
               className={`${baseClass}__action-button`}
               variant="icon"
               onClick={onClickFeedItem}
+              ariaLabel="info"
             >
               <Icon name="info-outline" />
             </Button>
@@ -112,6 +113,7 @@ const FeedListItem = ({
               variant="icon"
               onClick={onClickCancel}
               disabled={disableCancel}
+              ariaLabel="cancel"
             >
               <Icon
                 name="close"

--- a/frontend/components/FeedListItem/FeedListItem.tsx
+++ b/frontend/components/FeedListItem/FeedListItem.tsx
@@ -5,10 +5,7 @@ import { noop, uniqueId } from "lodash";
 
 import { COLORS } from "styles/var/colors";
 import { dateAgo } from "utilities/date_format";
-import {
-  addGravatarUrlToResource,
-  internationalTimeFormat,
-} from "utilities/helpers";
+import { internationalTimeFormat } from "utilities/helpers";
 
 import Avatar from "components/Avatar";
 import Button from "components/buttons/Button";

--- a/frontend/components/FeedListItem/_styles.scss
+++ b/frontend/components/FeedListItem/_styles.scss
@@ -136,7 +136,7 @@
    * We switch from grid to flexbox since we don't need the solid lines anymore.
    * we also dont show to actions on hover
    */
-  &__solo-activity {
+  &__solo-item {
     border: 1px solid $ui-fleet-black-10;
     border-radius: $border-radius-large;
     padding: $pad-medium;

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -51,6 +51,7 @@ export interface IButtonProps {
     | "grid"
     | "dialog";
   ariaExpanded?: boolean;
+  ariaLabel?: string;
   /** Small: 1/2 the padding */
   size?: "small" | "default";
 }
@@ -126,6 +127,7 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       iconStroke,
       ariaHasPopup,
       ariaExpanded,
+      ariaLabel,
       size,
     } = this.props;
     const fullClassName = classnames(
@@ -157,6 +159,7 @@ class Button extends React.Component<IButtonProps, IButtonState> {
         ref={setRef}
         aria-haspopup={ariaHasPopup}
         aria-expanded={ariaExpanded}
+        aria-label={ariaLabel}
       >
         <div className={isLoading ? "transparent-text" : "children-wrapper"}>
           {children}

--- a/frontend/pages/hosts/components/CommandDetailsModal/_styles.scss
+++ b/frontend/pages/hosts/components/CommandDetailsModal/_styles.scss
@@ -9,4 +9,10 @@
       gap: $pad-small;
     }
   }
+
+  // shortening the hight of the textarea
+  // so the modal height stays within the viewport
+  .textarea--code {
+    max-height: 200px;
+  }
 }

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -149,6 +149,8 @@ const BYOD_SW_INSTALL_LEARN_MORE_LINK =
 const ANDROID_SW_INSTALL_LEARN_MORE_LINK =
   "https://fleetdm.com/learn-more-about/install-google-play-apps";
 
+const ACTIVITY_CARD_DATA_STALE_TIME = 5000; // 5 seconds
+
 interface IHostDetailsProps {
   router: InjectedRouter; // v3
   location: {
@@ -524,7 +526,7 @@ const HostDetailsPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       keepPreviousData: true,
-      staleTime: 2000,
+      staleTime: ACTIVITY_CARD_DATA_STALE_TIME,
     }
   );
 
@@ -563,7 +565,7 @@ const HostDetailsPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       keepPreviousData: true,
-      staleTime: 2000,
+      staleTime: ACTIVITY_CARD_DATA_STALE_TIME,
     }
   );
 
@@ -594,6 +596,8 @@ const HostDetailsPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isAppleDevice(host?.platform),
+      keepPreviousData: true,
+      staleTime: ACTIVITY_CARD_DATA_STALE_TIME,
     }
   );
 
@@ -625,6 +629,8 @@ const HostDetailsPage = ({
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       enabled: isAppleDevice(host?.platform),
+      keepPreviousData: true,
+      staleTime: ACTIVITY_CARD_DATA_STALE_TIME,
     }
   );
 
@@ -1003,7 +1009,9 @@ const HostDetailsPage = ({
     !host ||
     isLoadingHost ||
     pastActivitiesIsLoading ||
-    upcomingActivitiesIsLoading
+    upcomingActivitiesIsLoading ||
+    pastMDMCommandsIsLoading ||
+    upcomingMDMCommandsIsLoading
   ) {
     return <Spinner />;
   }

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -22,6 +22,7 @@ import UpcomingActivityFeed from "./UpcomingActivityFeed";
 import MDMCommandsToggle from "./MDMCommandsToggle";
 import PastCommandFeed from "./PastCommandFeed";
 import UpcomingCommandFeed from "./UpcomingCommandFeed";
+import CommandFeed from "./CommandFeed";
 import { ShowCommandDetailsHandler } from "./CommandItem/CommandItem";
 
 const baseClass = "host-activity-card";
@@ -129,7 +130,7 @@ const Activity = ({
               />
             )}
             {showMDMCommands && commands ? (
-              <PastCommandFeed
+              <CommandFeed
                 commands={commands}
                 onShowDetails={onShowCommandDetails}
                 onNextPage={onNextPage}
@@ -158,7 +159,7 @@ const Activity = ({
               />
             )}
             {showMDMCommands && commands ? (
-              <UpcomingCommandFeed
+              <CommandFeed
                 commands={commands}
                 onShowDetails={onShowCommandDetails}
                 onNextPage={onNextPage}

--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -132,6 +132,7 @@ const Activity = ({
             {showMDMCommands && commands ? (
               <CommandFeed
                 commands={commands}
+                emptyDescription="Completed MDM commands will appear here."
                 onShowDetails={onShowCommandDetails}
                 onNextPage={onNextPage}
                 onPreviousPage={onPreviousPage}
@@ -161,6 +162,7 @@ const Activity = ({
             {showMDMCommands && commands ? (
               <CommandFeed
                 commands={commands}
+                emptyDescription="Pending MDM commands will appear here."
                 onShowDetails={onShowCommandDetails}
                 onNextPage={onNextPage}
                 onPreviousPage={onPreviousPage}

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockGetCommandsResponse } from "__mocks__/commandMock";
+
+import CommandFeed from "./CommandFeed";
+
+describe("CommandFeed", () => {
+  const mockOnShowDetails = jest.fn();
+  const mockOnNextPage = jest.fn();
+  const mockOnPreviousPage = jest.fn();
+
+  const defaultProps = {
+    onShowDetails: mockOnShowDetails,
+    onNextPage: mockOnNextPage,
+    onPreviousPage: mockOnPreviousPage,
+  };
+
+  it("renders empty state when results is null", () => {
+    const commands = createMockGetCommandsResponse({
+      results: null,
+    });
+
+    render(<CommandFeed commands={commands} {...defaultProps} />);
+
+    expect(screen.getByText("No MDM commands")).toBeInTheDocument();
+    expect(
+      screen.getByText("Completed MDM commands will appear here.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders empty state when results is an empty array", () => {
+    const commands = createMockGetCommandsResponse({
+      results: [],
+    });
+
+    render(<CommandFeed commands={commands} {...defaultProps} />);
+
+    expect(screen.getByText("No MDM commands")).toBeInTheDocument();
+    expect(
+      screen.getByText("Completed MDM commands will appear here.")
+    ).toBeInTheDocument();
+  });
+
+  it("does not render pagination when has_next_results and has_previous_results are both false", () => {
+    const commands = createMockGetCommandsResponse({
+      meta: {
+        has_next_results: false,
+        has_previous_results: false,
+      },
+    });
+
+    render(<CommandFeed commands={commands} {...defaultProps} />);
+
+    const prevButton = screen.queryByText("Previous");
+    const nextButton = screen.queryByText("Next");
+
+    expect(prevButton).not.toBeInTheDocument();
+    expect(nextButton).not.toBeInTheDocument();
+  });
+
+  it("renders pagination when there are more pagination items", () => {
+    const commands = createMockGetCommandsResponse({
+      meta: {
+        has_next_results: true,
+        has_previous_results: true,
+      },
+    });
+
+    render(<CommandFeed commands={commands} {...defaultProps} />);
+
+    expect(screen.getByText("Previous")).toBeInTheDocument();
+    expect(screen.getByText("Next")).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tests.tsx
@@ -11,6 +11,7 @@ describe("CommandFeed", () => {
   const mockOnPreviousPage = jest.fn();
 
   const defaultProps = {
+    emptyDescription: "Completed MDM commands will appear here.",
     onShowDetails: mockOnShowDetails,
     onNextPage: mockOnNextPage,
     onPreviousPage: mockOnPreviousPage,

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
@@ -32,7 +32,7 @@ const CommandFeed = ({
     return (
       <EmptyFeed
         title="No MDM commands"
-        message={description}
+        message={emptyDescription}
         className={`${baseClass}__empty-feed`}
       />
     );

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
@@ -14,6 +14,7 @@ const baseClass = "command-feed";
 
 interface ICommandFeedProps {
   commands: IGetCommandsResponse;
+  emptyDescription: string;
   onShowDetails: ShowCommandDetailsHandler;
   onNextPage: () => void;
   onPreviousPage: () => void;
@@ -21,6 +22,7 @@ interface ICommandFeedProps {
 
 const CommandFeed = ({
   commands,
+  emptyDescription,
   onShowDetails,
   onNextPage,
   onPreviousPage,
@@ -30,7 +32,7 @@ const CommandFeed = ({
     return (
       <EmptyFeed
         title="No MDM commands"
-        message="Completed MDM commands will appear here."
+        message={description}
         className={`${baseClass}__empty-feed`}
       />
     );

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/CommandFeed.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+import { ICommand } from "interfaces/command";
+import { IGetCommandsResponse } from "services/entities/command";
+
+import Pagination from "components/Pagination";
+
+import EmptyFeed from "../EmptyFeed/EmptyFeed";
+import CommandItem, {
+  ShowCommandDetailsHandler,
+} from "../CommandItem/CommandItem";
+
+const baseClass = "command-feed";
+
+interface ICommandFeedProps {
+  commands: IGetCommandsResponse;
+  onShowDetails: ShowCommandDetailsHandler;
+  onNextPage: () => void;
+  onPreviousPage: () => void;
+}
+
+const CommandFeed = ({
+  commands,
+  onShowDetails,
+  onNextPage,
+  onPreviousPage,
+}: ICommandFeedProps) => {
+  const { meta, results } = commands;
+  if (results === null || results.length === 0) {
+    return (
+      <EmptyFeed
+        title="No MDM commands"
+        message="Completed MDM commands will appear here."
+        className={`${baseClass}__empty-feed`}
+      />
+    );
+  }
+
+  return (
+    <div className={baseClass}>
+      <div>
+        {results.map((command: ICommand) => {
+          return (
+            <CommandItem
+              key={`${command.command_uuid}+${command.host_uuid}`}
+              command={command}
+              onShowDetails={onShowDetails}
+            />
+          );
+        })}
+      </div>
+      <Pagination
+        disablePrev={!meta.has_previous_results}
+        disableNext={!meta.has_next_results}
+        hidePagination={!meta.has_next_results && !meta.has_previous_results}
+        onPrevPage={onPreviousPage}
+        onNextPage={onNextPage}
+      />
+    </div>
+  );
+};
+
+export default CommandFeed;

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/_styles.scss
@@ -1,3 +1,0 @@
-.command-feed {
-
-}

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/_styles.scss
@@ -1,0 +1,3 @@
+.command-feed {
+
+}

--- a/frontend/pages/hosts/details/cards/Activity/CommandFeed/index.ts
+++ b/frontend/pages/hosts/details/cards/Activity/CommandFeed/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./CommandFeed";


### PR DESCRIPTION
This adds some optimisations and tests for the mdm commands UI feature. This includes:

1. optimisations to making the request for the activity card data. We add a stale time so the request is always occuring
2. consolidate PastCommandFeed and UpcomingCommandFeed to a single CommandFeed component
3. adding aria label to buttons to improve a11y when buttons dont have text (e.g. icon buttons)
4. tests for CommandFeed and FeedListItem components
5. change max-height of textarea in command details modal so it stays within the viewport
