### PR TITLE
Better error message for user scoped profile on iOS/iPadOS

### DIFF
--- a/changes/34960-better-error-message-for-user-scope-on-device-enrollments
+++ b/changes/34960-better-error-message-for-user-scope-on-device-enrollments
@@ -1,0 +1,1 @@
+- Improved error message for user-scoped profiles on iOS/iPadOS hosts

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsTableConfig.tsx
@@ -12,6 +12,7 @@ import {
   MdmProfileStatus,
 } from "interfaces/mdm";
 import { isDDMProfile } from "services/entities/mdm";
+import { isIPadOrIPhone } from "interfaces/platform";
 
 import OSSettingsNameCell from "./OSSettingsNameCell";
 import OSSettingStatusCell from "./OSSettingStatusCell";
@@ -51,10 +52,16 @@ const generateTableConfig = (
       disableSortBy: true,
       accessor: "name",
       Cell: (cellProps: ITableStringCellProps) => {
+        let scope = cellProps.row.original.scope;
+
+        if (isIPadOrIPhone(cellProps.row.original.platform)) {
+          scope = null; // Don't show user-scoped icon for iOS/iPadOS profiles, since we don't support user channels.
+        }
+
         return (
           <OSSettingsNameCell
             profileName={cellProps.cell.value}
-            scope={cellProps.row.original.scope}
+            scope={scope}
             managedAccount={cellProps.row.original.managed_local_account}
           />
         );

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1057,6 +1057,11 @@ func IsApplePlatform(hostPlatform string) bool {
 	return hostPlatform == "darwin" || hostPlatform == "ios" || hostPlatform == "ipados"
 }
 
+// Return true if the platform is either iOS or iPadOS
+func IsAppleMobilePlatform(hostPlatform string) bool {
+	return hostPlatform == "ios" || hostPlatform == "ipados"
+}
+
 func IsAndroidPlatform(hostPlatform string) bool {
 	return hostPlatform == "android"
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4665,7 +4665,6 @@ func ReconcileAppleProfiles(
 						"host_uuid", p.HostUUID, "profile_uuid", p.ProfileUUID, "profile_identifier", p.ProfileIdentifier)
 				}
 
-				fmt.Println("Skipping empty user enrollment", p.ProfileIdentifier, p.HostUUID)
 
 				hostProfile := &fleet.MDMAppleBulkUpsertHostProfilePayload{
 					ProfileUUID:       p.ProfileUUID,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4657,7 +4657,7 @@ func ReconcileAppleProfiles(
 			}
 			if userEnrollmentID == "" {
 				var errorDetail string
-				if p.HostPlatform == "ios" || p.HostPlatform == "ipados" {
+				if fleet.IsAppleMobilePlatform(p.HostPlatform) {
 					errorDetail = "This setting couldn't be enforced because the user channel isn't available on iOS and iPadOS hosts."
 				} else {
 					errorDetail = "This setting couldn't be enforced because the user channel doesn't exist for this host. Currently, Fleet creates the user channel for hosts that automatically enroll."

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4665,7 +4665,6 @@ func ReconcileAppleProfiles(
 						"host_uuid", p.HostUUID, "profile_uuid", p.ProfileUUID, "profile_identifier", p.ProfileIdentifier)
 				}
 
-
 				hostProfile := &fleet.MDMAppleBulkUpsertHostProfilePayload{
 					ProfileUUID:       p.ProfileUUID,
 					HostUUID:          p.HostUUID,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #34960 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

To test with a newly enrolled device, go and update the `authenticate_at` in `nano_devices` to more than 2 hours ago.

<img width="744" height="141" alt="image" src="https://github.com/user-attachments/assets/82cc492c-55aa-4ee7-abda-3d5aed8aee3a" />
