### PR TITLE
Add iOS Self-service apps

### DIFF
--- a/it-and-security/lib/ios/configuration-profiles/self-service.mobileconfig
+++ b/it-and-security/lib/ios/configuration-profiles/self-service.mobileconfig
@@ -114,7 +114,7 @@
 		</dict>
 	</array>
 	<key>PayloadDisplayName</key>
-	<string>iOS self-service</string>
+	<string>iOS Self-service</string>
 	<key>PayloadIdentifier</key>
 	<string>com.fleetdm.self-service.webclip</string>
 	<key>PayloadType</key>

--- a/it-and-security/teams/company-owned-mobile-devices.yml
+++ b/it-and-security/teams/company-owned-mobile-devices.yml
@@ -32,11 +32,16 @@ software:
   app_store_apps:
     - app_store_id: '618783545' # Slack
       setup_experience: true
+      self_service: true
     - app_store_id: '546505307' # Zoom
       setup_experience: true
+      self_service: true
     - app_store_id: '842842640' # Google Docs
       setup_experience: true
+      self_service: true
     - app_store_id: '842849113' # Google Sheets
       setup_experience: true
+      self_service: true
     - app_store_id: '507874739' # Google Drive
       setup_experience: true
+      self_service: true

--- a/it-and-security/teams/personal-mobile-devices.yml
+++ b/it-and-security/teams/personal-mobile-devices.yml
@@ -29,7 +29,12 @@ queries:
 software:
   app_store_apps:
     - app_store_id: '618783545' # Slack
+      self_service: true
     - app_store_id: '546505307' # Zoom
+      self_service: true
     - app_store_id: '842842640' # Google Docs
+      self_service: true
     - app_store_id: '842849113' # Google Sheets
+      self_service: true
     - app_store_id: '507874739' # Google Drive
+      self_service: true


### PR DESCRIPTION
This pull request updates the self-service configuration for iOS devices by enabling self-service installation for several key apps in both company-owned and personal mobile device configurations. Additionally, it makes a minor improvement to the display name in the iOS self-service configuration profile.

Self-service app enablement:

* Enabled the `self_service` flag for Slack, Zoom, Google Docs, Google Sheets, and Google Drive in both `company-owned-mobile-devices.yml` and `personal-mobile-devices.yml`, allowing users to install these apps via self-service. [[1]](diffhunk://#diff-b86f7c2a3c8266d5f17dc1cbb37b248bee72ce749c7e0c7f7d16f69c7265b821R35-R47) [[2]](diffhunk://#diff-ac1234902debdea911a540bc3423aa5ae74ae532d5cea9c9ed3128a07873b925R32-R40)

Configuration profile update:

* Updated the `PayloadDisplayName` in `self-service.mobileconfig` to use "iOS Self-service" (capitalized "Self-service") for improved consistency and presentation.