### PR TITLE
Bump alpine to 3.23.0 in `fleet/tools/fleet-docker/Dockerfile`

### DIFF
--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
+FROM alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375
 LABEL maintainer="Fleet Developers"
 
 RUN apk --update add ca-certificates


### PR DESCRIPTION
- Updates alpine from `alpine:3.22.2@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412` -> `alpine:3.23.0@sha256:51183f2cfa6320055da30872f211093f9ff1d3cf06f39a0bdb212314c5dc7375` in `fleet/tools/fleet-docker/Dockerfile`