### PR TITLE
Align create/delete android cert activity names

### DIFF
--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -3220,17 +3220,17 @@ func (a ActivityTypeEditedHostIdpData) Documentation() (activity, details, detai
 }`
 }
 
-type ActivityTypeCreatedCertificateTemplate struct {
+type ActivityTypeCreatedCertificate struct {
 	Name     string  `json:"name"`
 	TeamID   *uint   `json:"team_id"`
 	TeamName *string `json:"team_name"`
 }
 
-func (a ActivityTypeCreatedCertificateTemplate) ActivityName() string {
-	return "created_certificate_template"
+func (a ActivityTypeCreatedCertificate) ActivityName() string {
+	return "created_certificate"
 }
 
-func (a ActivityTypeCreatedCertificateTemplate) Documentation() (activity string, details string, detailsExample string) {
+func (a ActivityTypeCreatedCertificate) Documentation() (activity string, details string, detailsExample string) {
 	return `Generated when an user creates a Certificate Template.`,
 		`This activity contains the following fields:
 - "name": Name of the certificate.

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -3242,17 +3242,17 @@ func (a ActivityTypeCreatedCertificate) Documentation() (activity string, detail
 }`
 }
 
-type ActivityTypeDeletedCertificateTemplate struct {
+type ActivityTypeDeletedCertificate struct {
 	Name     string  `json:"name"`
 	TeamID   *uint   `json:"team_id"`
 	TeamName *string `json:"team_name"`
 }
 
-func (a ActivityTypeDeletedCertificateTemplate) ActivityName() string {
-	return "deleted_certificate_template"
+func (a ActivityTypeDeletedCertificate) ActivityName() string {
+	return "deleted_certificate"
 }
 
-func (a ActivityTypeDeletedCertificateTemplate) Documentation() (activity string, details string, detailsExample string) {
+func (a ActivityTypeDeletedCertificate) Documentation() (activity string, details string, detailsExample string) {
 	return `Generated when an user deletes a Certificate Template.`,
 		`This activity contains the following fields:
 - "name"": Name of the certificate.

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -78,7 +78,7 @@ func (svc *Service) CreateCertificateTemplate(ctx context.Context, name string, 
 		return nil, ctxerr.Wrap(ctx, err, "creating pending certificate templates for existing hosts")
 	}
 
-	activity := fleet.ActivityTypeCreatedCertificateTemplate{
+	activity := fleet.ActivityTypeCreatedCertificate{
 		Name: name,
 	}
 	if teamID != 0 {

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -283,7 +283,7 @@ func (svc *Service) DeleteCertificateTemplate(ctx context.Context, certificateTe
 		return ctxerr.Wrap(ctx, err, "deleting certificate template")
 	}
 
-	activity := fleet.ActivityTypeDeletedCertificateTemplate{
+	activity := fleet.ActivityTypeDeletedCertificate{
 		Name: certificate.Name,
 	}
 	if certificate.TeamID != 0 {

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -198,7 +198,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateLifecycle() {
 	certificateTemplateID := createResp.ID
 
 	s.lastActivityOfTypeMatches(
-		fleet.ActivityTypeCreatedCertificateTemplate{}.ActivityName(),
+		fleet.ActivityTypeCreatedCertificate{}.ActivityName(),
 		fmt.Sprintf(
 			`{"team_id": %d, "team_name": %q, "name": %q}`,
 			teamID,

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -265,7 +265,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateLifecycle() {
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/certificates/%d", certificateTemplateID), nil, http.StatusOK)
 
 	s.lastActivityOfTypeMatches(
-		fleet.ActivityTypeDeletedCertificateTemplate{}.ActivityName(),
+		fleet.ActivityTypeDeletedCertificate{}.ActivityName(),
 		fmt.Sprintf(
 			`{"team_id": %d, "team_name": %q, "name": %q}`,
 			teamID,


### PR DESCRIPTION
**Related issue:** Current activity names don't match https://github.com/fleetdm/fleet/pull/35199/files#diff-455bb344f5cd8c35e2ee02d663d5bdfc9c1f98aaa4bcf77d5762b8824e49f6a9R1357, while UI expects those names, so this fixes the mismatch


- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually