### PR TITLE
Fix FMAs on Render

### DIFF
--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -732,6 +732,10 @@ export default {
   ) => {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
 
+    // DEBUG: Log branch name to verify correct deployment
+    // eslint-disable-next-line no-console
+    console.log("[WAF-FIX-BRANCH] addFleetMaintainedApp called - branch: cdcme/fix-fleet-maintained-windows-apps-on-render");
+
     // Base64 encode script fields to bypass WAF rules that block script patterns
     const body: IAddFleetMaintainedAppPostBody = {
       team_id: teamId,

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -732,10 +732,6 @@ export default {
   ) => {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
 
-    // DEBUG: Log branch name to verify correct deployment
-    // eslint-disable-next-line no-console
-    console.log("[WAF-FIX-BRANCH] addFleetMaintainedApp called - branch: cdcme/fix-fleet-maintained-windows-apps-on-render");
-
     // Base64 encode script fields to bypass WAF rules that block script patterns
     const body: IAddFleetMaintainedAppPostBody = {
       team_id: teamId,

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -1,7 +1,15 @@
 import { AxiosProgressEvent } from "axios";
 
-import sendRequest, { sendRequestWithProgress } from "services";
+import sendRequest, {
+  sendRequestWithProgress,
+  sendRequestWithHeaders,
+  sendRequestWithProgressAndHeaders,
+} from "services";
 import endpoints from "utilities/endpoints";
+import {
+  encodeScriptBase64,
+  SCRIPTS_ENCODED_HEADER,
+} from "utilities/scripts_encoding";
 import {
   ISoftwareResponse,
   ISoftwareCountResponse,
@@ -264,10 +272,11 @@ const handleEditPackageForm = (
 ) => {
   data.software && formData.append("software", data.software);
   formData.append("self_service", data.selfService.toString());
-  formData.append("install_script", data.installScript);
-  formData.append("pre_install_query", data.preInstallQuery || "");
-  formData.append("post_install_script", data.postInstallScript || "");
-  formData.append("uninstall_script", data.uninstallScript || "");
+  // Base64 encode script fields to bypass WAF rules that block script patterns
+  formData.append("install_script", encodeScriptBase64(data.installScript) || "");
+  formData.append("pre_install_query", encodeScriptBase64(data.preInstallQuery || "") || "");
+  formData.append("post_install_script", encodeScriptBase64(data.postInstallScript || "") || "");
+  formData.append("uninstall_script", encodeScriptBase64(data.uninstallScript || "") || "");
   if (data.categories) {
     data.categories.forEach((category) => {
       formData.append("categories", category);
@@ -458,13 +467,15 @@ export default {
     const formData = new FormData();
     formData.append("software", data.software);
     formData.append("self_service", data.selfService.toString());
-    data.installScript && formData.append("install_script", data.installScript);
+    // Base64 encode script fields to bypass WAF rules that block script patterns
+    data.installScript &&
+      formData.append("install_script", encodeScriptBase64(data.installScript) || "");
     data.uninstallScript &&
-      formData.append("uninstall_script", data.uninstallScript);
+      formData.append("uninstall_script", encodeScriptBase64(data.uninstallScript) || "");
     data.preInstallQuery &&
-      formData.append("pre_install_query", data.preInstallQuery);
+      formData.append("pre_install_query", encodeScriptBase64(data.preInstallQuery) || "");
     data.postInstallScript &&
-      formData.append("post_install_script", data.postInstallScript);
+      formData.append("post_install_script", encodeScriptBase64(data.postInstallScript) || "");
     data.automaticInstall &&
       formData.append("automatic_install", data.automaticInstall.toString());
     teamId && formData.append("team_id", teamId.toString());
@@ -487,10 +498,11 @@ export default {
       });
     }
 
-    return sendRequestWithProgress({
+    return sendRequestWithProgressAndHeaders({
       method: "POST",
       path: SOFTWARE_PACKAGE_ADD,
       data: formData,
+      customHeaders: { [SCRIPTS_ENCODED_HEADER]: "base64" },
       timeout,
       skipParseError: true,
       onUploadProgress,
@@ -535,10 +547,11 @@ export default {
       );
     }
 
-    return sendRequestWithProgress({
+    return sendRequestWithProgressAndHeaders({
       method: "PATCH",
       path: EDIT_SOFTWARE_PACKAGE(softwareId),
       data: formData,
+      customHeaders: { [SCRIPTS_ENCODED_HEADER]: "base64" },
       timeout,
       skipParseError: true,
       onUploadProgress,
@@ -696,13 +709,14 @@ export default {
   ) => {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
 
+    // Base64 encode script fields to bypass WAF rules that block script patterns
     const body: IAddFleetMaintainedAppPostBody = {
       team_id: teamId,
       fleet_maintained_app_id: formData.appId,
-      pre_install_query: formData.preInstallQuery,
-      install_script: formData.installScript,
-      post_install_script: formData.postInstallScript,
-      uninstall_script: formData.uninstallScript,
+      pre_install_query: encodeScriptBase64(formData.preInstallQuery),
+      install_script: encodeScriptBase64(formData.installScript),
+      post_install_script: encodeScriptBase64(formData.postInstallScript),
+      uninstall_script: encodeScriptBase64(formData.uninstallScript),
       self_service: formData.selfService,
       automatic_install: formData.automaticInstall,
       categories: formData.categories,
@@ -717,6 +731,8 @@ export default {
       }
     }
 
-    return sendRequest("POST", SOFTWARE_FLEET_MAINTAINED_APPS, body);
+    return sendRequestWithHeaders("POST", SOFTWARE_FLEET_MAINTAINED_APPS, body, {
+      [SCRIPTS_ENCODED_HEADER]: "base64",
+    });
   },
 };

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -1,7 +1,6 @@
 import { AxiosProgressEvent } from "axios";
 
 import sendRequest, {
-  sendRequestWithProgress,
   sendRequestWithHeaders,
   sendRequestWithProgressAndHeaders,
 } from "services";
@@ -273,10 +272,22 @@ const handleEditPackageForm = (
   data.software && formData.append("software", data.software);
   formData.append("self_service", data.selfService.toString());
   // Base64 encode script fields to bypass WAF rules that block script patterns
-  formData.append("install_script", encodeScriptBase64(data.installScript) || "");
-  formData.append("pre_install_query", encodeScriptBase64(data.preInstallQuery || "") || "");
-  formData.append("post_install_script", encodeScriptBase64(data.postInstallScript || "") || "");
-  formData.append("uninstall_script", encodeScriptBase64(data.uninstallScript || "") || "");
+  formData.append(
+    "install_script",
+    encodeScriptBase64(data.installScript) || ""
+  );
+  formData.append(
+    "pre_install_query",
+    encodeScriptBase64(data.preInstallQuery || "") || ""
+  );
+  formData.append(
+    "post_install_script",
+    encodeScriptBase64(data.postInstallScript || "") || ""
+  );
+  formData.append(
+    "uninstall_script",
+    encodeScriptBase64(data.uninstallScript || "") || ""
+  );
   if (data.categories) {
     data.categories.forEach((category) => {
       formData.append("categories", category);
@@ -469,13 +480,25 @@ export default {
     formData.append("self_service", data.selfService.toString());
     // Base64 encode script fields to bypass WAF rules that block script patterns
     data.installScript &&
-      formData.append("install_script", encodeScriptBase64(data.installScript) || "");
+      formData.append(
+        "install_script",
+        encodeScriptBase64(data.installScript) || ""
+      );
     data.uninstallScript &&
-      formData.append("uninstall_script", encodeScriptBase64(data.uninstallScript) || "");
+      formData.append(
+        "uninstall_script",
+        encodeScriptBase64(data.uninstallScript) || ""
+      );
     data.preInstallQuery &&
-      formData.append("pre_install_query", encodeScriptBase64(data.preInstallQuery) || "");
+      formData.append(
+        "pre_install_query",
+        encodeScriptBase64(data.preInstallQuery) || ""
+      );
     data.postInstallScript &&
-      formData.append("post_install_script", encodeScriptBase64(data.postInstallScript) || "");
+      formData.append(
+        "post_install_script",
+        encodeScriptBase64(data.postInstallScript) || ""
+      );
     data.automaticInstall &&
       formData.append("automatic_install", data.automaticInstall.toString());
     teamId && formData.append("team_id", teamId.toString());
@@ -731,8 +754,13 @@ export default {
       }
     }
 
-    return sendRequestWithHeaders("POST", SOFTWARE_FLEET_MAINTAINED_APPS, body, {
-      [SCRIPTS_ENCODED_HEADER]: "base64",
-    });
+    return sendRequestWithHeaders(
+      "POST",
+      SOFTWARE_FLEET_MAINTAINED_APPS,
+      body,
+      {
+        [SCRIPTS_ENCODED_HEADER]: "base64",
+      }
+    );
   },
 };

--- a/frontend/services/index.ts
+++ b/frontend/services/index.ts
@@ -111,4 +111,122 @@ export const sendRequest = async (
   }
 };
 
+/**
+ * Send a request with custom headers. Used for requests that need to signal
+ * special handling (e.g., base64-encoded scripts to bypass WAF rules).
+ */
+export const sendRequestWithHeaders = async (
+  method: "GET" | "POST" | "PUT" | "PATCH" | "DELETE" | "HEAD",
+  path: string,
+  data?: unknown,
+  customHeaders?: Record<string, string>,
+  responseType: AxiosResponseType = "json",
+  timeout?: number,
+  skipParseError?: boolean,
+  returnRaw?: boolean
+) => {
+  const { origin } = global.window.location;
+
+  const url = `${origin}${URL_PREFIX}/api${path}`;
+  const token = authToken();
+
+  try {
+    const response = await axios({
+      method,
+      url,
+      data,
+      responseType,
+      timeout,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...customHeaders,
+      },
+    });
+
+    if (returnRaw) {
+      return response;
+    }
+    return response.data;
+  } catch (error) {
+    if (skipParseError) {
+      return Promise.reject(error);
+    }
+    let reason: unknown | undefined;
+    if (isAxiosError(error)) {
+      reason = error.response || error.message || error.code;
+    }
+    return Promise.reject(
+      reason || `send request: parse server error: ${error}`
+    );
+  }
+};
+
+/**
+ * Send a request with progress tracking and custom headers. Used for file uploads
+ * that need to signal special handling (e.g., base64-encoded scripts to bypass WAF rules).
+ */
+export const sendRequestWithProgressAndHeaders = async ({
+  method,
+  path,
+  data,
+  customHeaders,
+  responseType = "json",
+  timeout,
+  skipParseError,
+  returnRaw,
+  onDownloadProgress,
+  onUploadProgress,
+  signal,
+}: {
+  method: "GET" | "POST" | "PATCH" | "DELETE" | "HEAD";
+  path: string;
+  data?: unknown;
+  customHeaders?: Record<string, string>;
+  responseType?: AxiosResponseType;
+  timeout?: number;
+  skipParseError?: boolean;
+  returnRaw?: boolean;
+  onDownloadProgress?: (progressEvent: AxiosProgressEvent) => void;
+  onUploadProgress?: (progressEvent: AxiosProgressEvent) => void;
+  signal?: AbortSignal;
+}) => {
+  const { origin } = global.window.location;
+
+  const url = `${origin}${URL_PREFIX}/api${path}`;
+  const token = authToken();
+
+  try {
+    const response = await axios({
+      method,
+      url,
+      data,
+      responseType,
+      timeout,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        ...customHeaders,
+      },
+      onDownloadProgress,
+      onUploadProgress,
+      signal,
+    });
+
+    if (returnRaw) {
+      return response;
+    }
+    return response.data;
+  } catch (error) {
+    if (skipParseError) {
+      return Promise.reject(error);
+    }
+    let reason: unknown | undefined;
+    if (isAxiosError(error)) {
+      reason = error.response || error.message || error.code;
+    }
+    return Promise.reject(
+      reason || `send request: parse server error: ${error}`
+    );
+  }
+};
+
 export default sendRequest;

--- a/frontend/utilities/scripts_encoding.tests.ts
+++ b/frontend/utilities/scripts_encoding.tests.ts
@@ -1,7 +1,4 @@
-import {
-  encodeScriptBase64,
-  SCRIPTS_ENCODED_HEADER,
-} from "./scripts_encoding";
+import { encodeScriptBase64, SCRIPTS_ENCODED_HEADER } from "./scripts_encoding";
 
 describe("scripts_encoding", () => {
   describe("SCRIPTS_ENCODED_HEADER", () => {

--- a/frontend/utilities/scripts_encoding.tests.ts
+++ b/frontend/utilities/scripts_encoding.tests.ts
@@ -23,6 +23,7 @@ describe("scripts_encoding", () => {
     });
 
     it("should encode PowerShell patterns with dollar brace", () => {
+      // eslint-disable-next-line no-template-curly-in-string
       const encoded = encodeScriptBase64("${env:TEMP}");
       // "${env:TEMP}" in base64 is "JHtlbnY6VEVNUH0="
       expect(encoded).toBe("JHtlbnY6VEVNUH0=");
@@ -37,6 +38,7 @@ describe("scripts_encoding", () => {
 
     it("should encode multiline PowerShell scripts", () => {
       const script =
+        // eslint-disable-next-line no-template-curly-in-string
         '$logFile = "${env:TEMP}/fleet-install.log"\nStart-Process msiexec.exe';
       const encoded = encodeScriptBase64(script);
       // Verify it's valid base64 and decodes back correctly
@@ -53,11 +55,17 @@ describe("scripts_encoding", () => {
 
     it("should produce valid base64 that Go can decode", () => {
       // Test the specific WAF-triggering patterns
+      // eslint-disable-next-line no-template-curly-in-string
+      const envTemp = "${env:TEMP}";
+      // eslint-disable-next-line no-template-curly-in-string
+      const envInstallerPath = "${env:INSTALLER_PATH}";
+      // eslint-disable-next-line no-template-curly-in-string
+      const logFileScript = '$logFile = "${env:TEMP}/fleet-install.log"';
       const testCases = [
-        "${env:TEMP}",
-        "${env:INSTALLER_PATH}",
+        envTemp,
+        envInstallerPath,
         "Start-Process msiexec.exe",
-        '$logFile = "${env:TEMP}/fleet-install.log"',
+        logFileScript,
       ];
 
       testCases.forEach((script) => {

--- a/frontend/utilities/scripts_encoding.tests.ts
+++ b/frontend/utilities/scripts_encoding.tests.ts
@@ -1,0 +1,76 @@
+import {
+  encodeScriptBase64,
+  SCRIPTS_ENCODED_HEADER,
+} from "./scripts_encoding";
+
+describe("scripts_encoding", () => {
+  describe("SCRIPTS_ENCODED_HEADER", () => {
+    it("should have the expected value", () => {
+      expect(SCRIPTS_ENCODED_HEADER).toBe("X-Fleet-Scripts-Encoded");
+    });
+  });
+
+  describe("encodeScriptBase64", () => {
+    it("should return undefined for undefined input", () => {
+      expect(encodeScriptBase64(undefined)).toBeUndefined();
+    });
+
+    it("should return empty string for empty input", () => {
+      expect(encodeScriptBase64("")).toBe("");
+    });
+
+    it("should encode simple strings correctly", () => {
+      const encoded = encodeScriptBase64("Hello World");
+      // "Hello World" in base64 is "SGVsbG8gV29ybGQ="
+      expect(encoded).toBe("SGVsbG8gV29ybGQ=");
+    });
+
+    it("should encode PowerShell patterns with dollar brace", () => {
+      const encoded = encodeScriptBase64("${env:TEMP}");
+      // "${env:TEMP}" in base64 is "JHtlbnY6VEVNUH0="
+      expect(encoded).toBe("JHtlbnY6VEVNUH0=");
+    });
+
+    it("should encode PowerShell install script patterns", () => {
+      const script = "$installProcess = Start-Process msiexec.exe";
+      const encoded = encodeScriptBase64(script);
+      // Verify it's valid base64 and decodes back correctly
+      expect(atob(encoded!)).toBe(script);
+    });
+
+    it("should encode multiline PowerShell scripts", () => {
+      const script =
+        '$logFile = "${env:TEMP}/fleet-install.log"\nStart-Process msiexec.exe';
+      const encoded = encodeScriptBase64(script);
+      // Verify it's valid base64 and decodes back correctly
+      expect(atob(encoded!)).toBe(script);
+    });
+
+    it("should handle unicode characters correctly", () => {
+      const script = 'echo "Hello World"';
+      const encoded = encodeScriptBase64(script);
+      // Decode and verify using TextDecoder for proper UTF-8 handling
+      const decoded = atob(encoded!);
+      expect(decoded).toBe(script);
+    });
+
+    it("should produce valid base64 that Go can decode", () => {
+      // Test the specific WAF-triggering patterns
+      const testCases = [
+        "${env:TEMP}",
+        "${env:INSTALLER_PATH}",
+        "Start-Process msiexec.exe",
+        '$logFile = "${env:TEMP}/fleet-install.log"',
+      ];
+
+      testCases.forEach((script) => {
+        const encoded = encodeScriptBase64(script);
+        expect(encoded).toBeDefined();
+        // Verify it's valid base64 (won't throw)
+        expect(() => atob(encoded!)).not.toThrow();
+        // Verify it decodes back to original
+        expect(atob(encoded!)).toBe(script);
+      });
+    });
+  });
+});

--- a/frontend/utilities/scripts_encoding.ts
+++ b/frontend/utilities/scripts_encoding.ts
@@ -1,0 +1,28 @@
+// Header name for signaling base64-encoded scripts to bypass WAF rules
+// that may block requests containing shell/PowerShell script patterns.
+export const SCRIPTS_ENCODED_HEADER = "X-Fleet-Scripts-Encoded";
+
+/**
+ * Base64 encode a script string with proper UTF-8 handling.
+ * Returns undefined for undefined input and empty string for empty input,
+ * which allows callers to pass through empty/unset script fields without modification.
+ */
+export const encodeScriptBase64 = (
+  script: string | undefined
+): string | undefined => {
+  if (script === undefined) {
+    return undefined;
+  }
+  if (script === "") {
+    return "";
+  }
+  // Use TextEncoder for proper UTF-8 handling of unicode characters
+  const encoder = new TextEncoder();
+  const data = encoder.encode(script);
+  // Convert Uint8Array to binary string, then base64
+  let binary = "";
+  data.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+};

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     type: web
     runtime: image
     image:
-      url: 'fleetdm/fleet:latest'
+      url: 'fleetdm/fleet:fix-33732-fma-on-render'
     preDeployCommand: "fleet prepare --no-prompt=true db"
     healthCheckPath: /healthz
     disk:

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     type: web
     runtime: image
     image:
-      url: 'fleetdm/fleet:fix-33732-fma-on-render'
+      url: 'cdcme/fleet:waf-fix'
     preDeployCommand: "fleet prepare --no-prompt=true db"
     healthCheckPath: /healthz
     disk:

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     type: web
     runtime: image
     image:
-      url: 'cdcme/fleet:waf-fix'
+      url: 'fleetdm/fleet:latest'
     preDeployCommand: "fleet prepare --no-prompt=true db"
     healthCheckPath: /healthz
     disk:

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -31,6 +32,9 @@ type addFleetMaintainedAppRequest struct {
 func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.Request) (any, error) {
 	var req addFleetMaintainedAppRequest
 
+	// DEBUG: Log branch name to verify correct deployment
+	fmt.Println("[WAF-FIX-BRANCH] DecodeRequest called - branch: cdcme/fix-fleet-maintained-windows-apps-on-render")
+
 	// Decode JSON body
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, &fleet.BadRequestError{
@@ -38,6 +42,10 @@ func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.R
 			InternalErr: err,
 		}
 	}
+
+	// DEBUG: Log header presence
+	headerValue := r.Header.Get(ScriptsEncodedHeader)
+	fmt.Printf("[WAF-FIX-BRANCH] X-Fleet-Scripts-Encoded header: %q, isScriptsEncoded: %v\n", headerValue, isScriptsEncoded(r))
 
 	// Check if scripts are base64 encoded
 	if isScriptsEncoded(r) {

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
@@ -19,6 +21,42 @@ type addFleetMaintainedAppRequest struct {
 	LabelsIncludeAny  []string `json:"labels_include_any"`
 	LabelsExcludeAny  []string `json:"labels_exclude_any"`
 	AutomaticInstall  bool     `json:"automatic_install"`
+	Categories        []string `json:"categories"`
+}
+
+// DecodeRequest implements the RequestDecoder interface to support base64-encoded
+// script fields. This allows bypassing WAF rules that may block requests containing
+// shell/PowerShell script patterns. When the X-Fleet-Scripts-Encoded header is set
+// to "base64", the script fields are decoded from base64.
+func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	var req addFleetMaintainedAppRequest
+
+	// Decode JSON body
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "failed to decode request body",
+			InternalErr: err,
+		}
+	}
+
+	// Check if scripts are base64 encoded
+	if isScriptsEncoded(r) {
+		var err error
+		if req.InstallScript, err = decodeBase64Script(req.InstallScript); err != nil {
+			return nil, fleet.NewInvalidArgumentError("install_script", "invalid base64 encoding")
+		}
+		if req.UninstallScript, err = decodeBase64Script(req.UninstallScript); err != nil {
+			return nil, fleet.NewInvalidArgumentError("uninstall_script", "invalid base64 encoding")
+		}
+		if req.PostInstallScript, err = decodeBase64Script(req.PostInstallScript); err != nil {
+			return nil, fleet.NewInvalidArgumentError("post_install_script", "invalid base64 encoding")
+		}
+		if req.PreInstallQuery, err = decodeBase64Script(req.PreInstallQuery); err != nil {
+			return nil, fleet.NewInvalidArgumentError("pre_install_query", "invalid base64 encoding")
+		}
+	}
+
+	return &req, nil
 }
 
 type addFleetMaintainedAppResponse struct {

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -28,7 +28,7 @@ type addFleetMaintainedAppRequest struct {
 // script fields. This allows bypassing WAF rules that may block requests containing
 // shell/PowerShell script patterns. When the X-Fleet-Scripts-Encoded header is set
 // to "base64", the script fields are decoded from base64.
-func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.Request) (any, error) {
 	var req addFleetMaintainedAppRequest
 
 	// Decode JSON body

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -32,9 +31,6 @@ type addFleetMaintainedAppRequest struct {
 func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.Request) (any, error) {
 	var req addFleetMaintainedAppRequest
 
-	// DEBUG: Log branch name to verify correct deployment
-	fmt.Println("[WAF-FIX-BRANCH] DecodeRequest called - branch: cdcme/fix-fleet-maintained-windows-apps-on-render")
-
 	// Decode JSON body
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return nil, &fleet.BadRequestError{
@@ -42,10 +38,6 @@ func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.R
 			InternalErr: err,
 		}
 	}
-
-	// DEBUG: Log header presence
-	headerValue := r.Header.Get(ScriptsEncodedHeader)
-	fmt.Printf("[WAF-FIX-BRANCH] X-Fleet-Scripts-Encoded header: %q, isScriptsEncoded: %v\n", headerValue, isScriptsEncoded(r))
 
 	// Check if scripts are base64 encoded
 	if isScriptsEncoded(r) {

--- a/server/service/scripts_encoding.go
+++ b/server/service/scripts_encoding.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"encoding/base64"
+	"net/http"
+)
+
+// ScriptsEncodedHeader is the HTTP header used to signal that script fields
+// in the request body are base64-encoded. This is used to bypass WAF rules
+// that may block requests containing shell/PowerShell script patterns.
+const ScriptsEncodedHeader = "X-Fleet-Scripts-Encoded"
+
+// decodeBase64Script decodes a base64-encoded script string.
+// Returns empty string for empty input, which allows callers to pass through
+// empty/unset script fields without modification.
+func decodeBase64Script(encoded string) (string, error) {
+	if encoded == "" {
+		return "", nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
+}
+
+// isScriptsEncoded checks if the request has the scripts encoding header
+// set to "base64", indicating that script fields should be decoded.
+func isScriptsEncoded(r *http.Request) bool {
+	return r.Header.Get(ScriptsEncodedHeader) == "base64"
+}

--- a/server/service/scripts_encoding_test.go
+++ b/server/service/scripts_encoding_test.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeBase64Script(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+			wantErr:  false,
+		},
+		{
+			name:     "simple string",
+			input:    base64.StdEncoding.EncodeToString([]byte("Hello World")),
+			expected: "Hello World",
+			wantErr:  false,
+		},
+		{
+			name:     "powershell with dollar brace",
+			input:    base64.StdEncoding.EncodeToString([]byte("${env:TEMP}")),
+			expected: "${env:TEMP}",
+			wantErr:  false,
+		},
+		{
+			name:     "powershell install script pattern",
+			input:    base64.StdEncoding.EncodeToString([]byte("$installProcess = Start-Process msiexec.exe")),
+			expected: "$installProcess = Start-Process msiexec.exe",
+			wantErr:  false,
+		},
+		{
+			name:     "multiline powershell script",
+			input:    base64.StdEncoding.EncodeToString([]byte("$logFile = \"${env:TEMP}/fleet-install.log\"\nStart-Process msiexec.exe")),
+			expected: "$logFile = \"${env:TEMP}/fleet-install.log\"\nStart-Process msiexec.exe",
+			wantErr:  false,
+		},
+		{
+			name:     "unicode characters",
+			input:    base64.StdEncoding.EncodeToString([]byte("echo \"Hello 世界\"")),
+			expected: "echo \"Hello 世界\"",
+			wantErr:  false,
+		},
+		{
+			name:     "invalid base64",
+			input:    "not-valid-base64!!!",
+			expected: "",
+			wantErr:  true,
+		},
+		{
+			name:     "truncated base64",
+			input:    "SGVsbG8gV29ybGQ", // missing padding
+			expected: "",
+			wantErr:  true, // Go's StdEncoding requires proper padding
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := decodeBase64Script(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsScriptsEncoded(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		header   string
+		expected bool
+	}{
+		{
+			name:     "header set to base64",
+			header:   "base64",
+			expected: true,
+		},
+		{
+			name:     "header not set",
+			header:   "",
+			expected: false,
+		},
+		{
+			name:     "header set to different value",
+			header:   "gzip",
+			expected: false,
+		},
+		{
+			name:     "header set to Base64 (wrong case)",
+			header:   "Base64",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/test", nil)
+			if tt.header != "" {
+				req.Header.Set(ScriptsEncodedHeader, tt.header)
+			}
+			result := isScriptsEncoded(req)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestScriptsEncodedHeader(t *testing.T) {
+	// Verify the header constant has the expected value
+	require.Equal(t, "X-Fleet-Scripts-Encoded", ScriptsEncodedHeader)
+}


### PR DESCRIPTION
Fixes #33732

Base64-encodes the `install_script` and `uninstall_script` payloads for add and edit software to prevent being blocked by WAF rules and allow FMAs for Windows to be added/edited in Fleet instances running on Render.

![fix-33732-fma-on-render](https://github.com/user-attachments/assets/8293fa30-0739-4769-bd21-09733a23dadc)
