### PR TITLE
Rename bookmark from 'Sprint planning' to 'Release planning'

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
@@ -561,7 +561,7 @@
                         </dict>
                         <dict>
                             <key>name</key>
-                            <string>🗺️ Sprint planning</string>
+                            <string>🗺️ Release planning</string>
                             <key>url</key>
                             <string>https://github.com/orgs/fleetdm/projects/87</string>
                         </dict>


### PR DESCRIPTION
Less confusing. We already have a meeting called "Pre-sprint planning"
