### PR TITLE
use combined endpoint for android

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/UnenrollMdmModal/UnenrollMdmModal.tsx
@@ -40,11 +40,7 @@ const UnenrollMdmModal = ({
   const submitUnenrollMdm = async () => {
     setRequestState("unenrolling");
     try {
-      if (isAndroid(hostPlatform)) {
-        await mdmAPI.unenrollAndroidHostFromMdm(hostId, 5000);
-      } else {
-        await mdmAPI.unenrollHostFromMdm(hostId, 5000);
-      }
+      await mdmAPI.unenrollHostFromMdm(hostId, 5000);
       const successMessage =
         isIPadOrIPhone(hostPlatform) || isAndroid(hostPlatform) ? (
           <>

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -102,19 +102,14 @@ export type IGetBootstrapPackageSummaryResponse = IBootstrapPackageAggregate;
 
 const mdmService = {
   unenrollHostFromMdm: (hostId: number, timeout?: number) => {
-    const { HOST_MDM_UNENROLL } = endpoints;
+    const { HOST_MDM } = endpoints;
     return sendRequest(
-      "PATCH",
-      HOST_MDM_UNENROLL(hostId),
+      "DELETE",
+      HOST_MDM(hostId),
       undefined,
       undefined,
       timeout
     );
-  },
-  // Android-specific: admin-initiated unenroll uses POST /api/_version_/fleet/hosts/{id}/mdm/unenroll
-  unenrollAndroidHostFromMdm: (hostId: number, timeout?: number) => {
-    const path = `${endpoints.HOST_MDM(hostId)}/unenroll`;
-    return sendRequest("POST", path, undefined, undefined, timeout);
   },
   requestCSR: () => {
     const { MDM_REQUEST_CSR } = endpoints;

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -181,8 +181,6 @@ export default {
   MDM_EULA_UPLOAD: `/${API_VERSION}/fleet/mdm/setup/eula`,
   MDM_EULA_METADATA: `/${API_VERSION}/fleet/mdm/setup/eula/metadata`,
   HOST_MDM: (id: number) => `/${API_VERSION}/fleet/hosts/${id}/mdm`,
-  HOST_MDM_UNENROLL: (id: number) =>
-    `/${API_VERSION}/fleet/mdm/hosts/${id}/unenroll`,
   HOST_ENCRYPTION_KEY: (id: number) =>
     `/${API_VERSION}/fleet/hosts/${id}/encryption_key`,
 


### PR DESCRIPTION
fix a bug that the frontend wasn't changed to use the shared mdm unenroll endpoint