### PR TITLE
Cherry-Pick: Add osquery 5.21 to version picker

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -88,6 +88,7 @@ export const MAX_OSQUERY_SCHEDULED_QUERY_INTERVAL = 604800;
 
 export const MIN_OSQUERY_VERSION_OPTIONS = [
   { label: "All", value: "" },
+  { label: "5.21.0 +", value: "5.21.0" },
   { label: "5.20.0 +", value: "5.20.0" },
   { label: "5.19.0 +", value: "5.19.0" },
   { label: "5.18.1 +", value: "5.18.1" },


### PR DESCRIPTION
Merged into `main` in #37519.