### PR TITLE
Add Sourcetree as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/scripts/sourcetree_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/sourcetree_install.ps1
@@ -1,0 +1,17 @@
+$logFile = "${env:TEMP}/fleet-install-software.log"
+
+try {
+
+$installProcess = Start-Process msiexec.exe `
+  -ArgumentList "/quiet /norestart /lv ${logFile} /i `"${env:INSTALLER_PATH}`" ACCEPTEULA=1" `
+  -PassThru -Verb RunAs -Wait
+
+Get-Content $logFile -Tail 500
+
+Exit $installProcess.ExitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}
+

--- a/ee/maintained-apps/inputs/winget/sourcetree.json
+++ b/ee/maintained-apps/inputs/winget/sourcetree.json
@@ -1,0 +1,10 @@
+{
+  "name": "Sourcetree",
+  "slug": "sourcetree/windows",
+  "package_identifier": "Atlassian.Sourcetree",
+  "unique_identifier": "Sourcetree Enterprise",
+  "installer_arch": "x64",
+  "installer_type": "msi",
+  "installer_scope": "machine",
+  "default_categories": ["Developer tools"]
+}

--- a/ee/maintained-apps/inputs/winget/sourcetree.json
+++ b/ee/maintained-apps/inputs/winget/sourcetree.json
@@ -3,6 +3,7 @@
   "slug": "sourcetree/windows",
   "package_identifier": "Atlassian.Sourcetree",
   "unique_identifier": "Sourcetree Enterprise",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/sourcetree_install.ps1",
   "installer_arch": "x64",
   "installer_type": "msi",
   "installer_scope": "machine",

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1353,6 +1353,13 @@
       "description": "SourceTree is a graphical client for Git version control."
     },
     {
+      "name": "Sourcetree",
+      "slug": "sourcetree/windows",
+      "platform": "windows",
+      "unique_identifier": "Sourcetree Enterprise",
+      "description": "SourceTree is a graphical client for Git version control."
+    },
+    {
       "name": "Splashtop Business",
       "slug": "splashtop-business/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/sourcetree/windows.json
+++ b/ee/maintained-apps/outputs/sourcetree/windows.json
@@ -6,7 +6,7 @@
         "exists": "SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian';"
       },
       "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.27.msi",
-      "install_script_ref": "8959087b",
+      "install_script_ref": "17f62246",
       "uninstall_script_ref": "68f17a4a",
       "sha256": "8999c801177338dab61680b1d80c6f2e131f6a8220565425203e87f2b60da659",
       "default_categories": [
@@ -16,7 +16,7 @@
     }
   ],
   "refs": {
-    "68f17a4a": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{E18DCCFE-AFC4-42A5-A020-1FF11BF12D39}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
-    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+    "17f62246": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\" ACCEPTEULA=1\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n\n",
+    "68f17a4a": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{E18DCCFE-AFC4-42A5-A020-1FF11BF12D39}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n"
   }
 }

--- a/ee/maintained-apps/outputs/sourcetree/windows.json
+++ b/ee/maintained-apps/outputs/sourcetree/windows.json
@@ -1,0 +1,22 @@
+{
+  "versions": [
+    {
+      "version": "3.4.27",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Sourcetree Enterprise' AND publisher = 'Atlassian';"
+      },
+      "installer_url": "https://product-downloads.atlassian.com/software/sourcetree/windows/ga/SourcetreeEnterpriseSetup_3.4.27.msi",
+      "install_script_ref": "8959087b",
+      "uninstall_script_ref": "68f17a4a",
+      "sha256": "8999c801177338dab61680b1d80c6f2e131f6a8220565425203e87f2b60da659",
+      "default_categories": [
+        "Developer tools"
+      ],
+      "upgrade_code": "{E18DCCFE-AFC4-42A5-A020-1FF11BF12D39}"
+    }
+  ],
+  "refs": {
+    "68f17a4a": "# Fleet uninstalls app by finding all related product codes for the specified upgrade code\n$inst = New-Object -ComObject \"WindowsInstaller.Installer\"\n$timeoutSeconds = 300  # 5 minute timeout per product\n\nforeach ($product_code in $inst.RelatedProducts(\"{E18DCCFE-AFC4-42A5-A020-1FF11BF12D39}\")) {\n    $process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n    \n    # Wait for process with timeout\n    $completed = $process.WaitForExit($timeoutSeconds * 1000)\n    \n    if (-not $completed) {\n        Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n        Exit 1603  # ERROR_UNINSTALL_FAILURE\n    }\n    \n    # If the uninstall failed, bail\n    if ($process.ExitCode -ne 0) {\n        Write-Output \"Uninstall for $($product_code) exited $($process.ExitCode)\"\n        Exit $process.ExitCode\n    }\n}\n\n# All uninstalls succeeded; exit success\nExit 0\n",
+    "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Windows version of Sourcetree Enterprise to the maintained apps catalog. The changes introduce metadata, installation, and uninstallation details for this app, ensuring it can be managed and deployed via Fleet.

**Addition of Sourcetree Enterprise (Windows):**

* Added a new input definition for Sourcetree Enterprise in `winget/sourcetree.json`, specifying package identifiers and installer details.
* Updated `apps.json` to include Sourcetree Enterprise for the Windows platform, with appropriate metadata and description.
* Created a new output file `sourcetree/windows.json` with version info, install/uninstall PowerShell scripts, installer URL, SHA256 hash, and upgrade code for proper management.