### PR TITLE
Fleet UI: Fix decoding mdm output

### DIFF
--- a/changes/34205-fix-base64-encoding
+++ b/changes/34205-fix-base64-encoding
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed MDM install command output to correctly display UTF-8 characters

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -36,6 +36,7 @@ import {
   getInstallDetailsStatusPredicate,
   INSTALL_DETAILS_STATUS_ICONS,
 } from "../constants";
+import decodeBase64Utf8 from "../helpers";
 
 interface IGetStatusMessageProps {
   isMyDevicePage?: boolean;
@@ -248,8 +249,8 @@ export const SoftwareIpaInstallDetailsModal = ({
     }
     return {
       ...results,
-      payload: atob(results.payload),
-      result: atob(results.result),
+      payload: results.payload ? decodeBase64Utf8(results.payload) : "",
+      result: results.result ? decodeBase64Utf8(results.result) : "",
     };
   };
 

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -38,6 +38,7 @@ import {
   getInstallDetailsStatusPredicate,
   INSTALL_DETAILS_STATUS_ICONS,
 } from "../constants";
+import decodeBase64Utf8 from "../helpers";
 
 interface IGetStatusMessageProps {
   isMyDevicePage?: boolean;
@@ -295,8 +296,8 @@ export const VppInstallDetailsModal = ({
     }
     return {
       ...results,
-      payload: atob(results.payload),
-      result: atob(results.result),
+      payload: results.payload ? decodeBase64Utf8(results.payload) : "",
+      result: results.result ? decodeBase64Utf8(results.result) : "",
     };
   };
 

--- a/frontend/components/ActivityDetails/InstallDetails/helpers.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/helpers.tests.tsx
@@ -1,0 +1,39 @@
+import decodeBase64Utf8 from "./helpers";
+
+describe("Install details helpers", () => {
+  describe("decodeBase64Utf8 function", () => {
+    it("properly decodes UTF-8 base64 strings (including non-ASCII)", () => {
+      const utf8 = "Günter Møller Sánchez Peña 🎉";
+      const utf8B64 = Buffer.from(utf8, "utf-8").toString("base64");
+
+      const decoded = decodeBase64Utf8(utf8B64);
+
+      expect(decoded).toEqual(utf8);
+    });
+
+    it("properly decodes plist XML payloads", () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+<key>CommandUUID</key>
+<string>REFETCH-CERTS-1a2bc345-678e-90fg</string>
+<key>Command</key>
+<dict>
+<key>ManagedOnly</key>
+<false/>
+<key>RequestType</key>
+<string>CertificateList</string>
+</dict>
+</dict>
+</plist>`;
+
+      const xmlB64 = Buffer.from(xml, "utf-8").toString("base64");
+
+      const decoded = decodeBase64Utf8(xmlB64);
+
+      expect(decoded).toEqual(xml);
+      expect(decoded).toContain("CertificateList");
+    });
+  });
+});

--- a/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
@@ -1,0 +1,6 @@
+const decodeBase64Utf8 = (b64: string) => {
+  const bin = atob(b64); // binary string (bytes 0–255)
+  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+  return new TextDecoder("utf-8").decode(bytes);
+};
+export default decodeBase64Utf8;

--- a/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
@@ -2,8 +2,17 @@
  * atob returns a binary string (bytes 0–255), so wrap it in Uint8Array and
  * use TextDecoder to handle multi-byte UTF-8 characters. */
 const decodeBase64Utf8 = (b64: string) => {
-  const bin = atob(b64); // binary string (bytes 0–255)
-  const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
-  return new TextDecoder("utf-8").decode(bytes);
+  if (typeof b64 !== "string" || b64.trim() === "") {
+    return "";
+  }
+
+  try {
+    const bin = atob(b64); // binary string (bytes 0–255)
+    const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));
+    return new TextDecoder("utf-8").decode(bytes);
+  } catch (error) {
+    console.error("Failed to decode base64 UTF-8 payload:", error);
+    return "";
+  }
 };
 export default decodeBase64Utf8;

--- a/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/helpers.tsx
@@ -1,3 +1,6 @@
+/** Safely decode a base64-encoded UTF-8 string into a JavaScript string.
+ * atob returns a binary string (bytes 0–255), so wrap it in Uint8Array and
+ * use TextDecoder to handle multi-byte UTF-8 characters. */
 const decodeBase64Utf8 = (b64: string) => {
   const bin = atob(b64); // binary string (bytes 0–255)
   const bytes = Uint8Array.from(bin, (c) => c.charCodeAt(0));


### PR DESCRIPTION
## Issue
Closes #34205 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected UTF-8 encoding issues in MDM install commands, ensuring special and non-ASCII characters now display correctly in the command output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->