### PR TITLE
Add OBS Studio as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/obs.json
+++ b/ee/maintained-apps/inputs/winget/obs.json
@@ -1,0 +1,12 @@
+{
+  "name": "OBS",
+  "slug": "obs/windows",
+  "package_identifier": "OBSProject.OBSStudio",
+  "unique_identifier": "OBS Studio",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/obs_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/obs_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/scripts/obs_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/obs_install.ps1
@@ -1,0 +1,29 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+# Add argument to install silently
+# NSIS installers require /S flag for silent installation
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/S"
+  PassThru = $true
+  Wait = $true
+}
+    
+# Start process and track exit code
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+# Prints the exit code
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}
+

--- a/ee/maintained-apps/inputs/winget/scripts/obs_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/obs_uninstall.ps1
@@ -1,0 +1,81 @@
+# Attempts to locate OBS Studio's uninstaller from registry and execute it silently
+
+$displayName = "OBS Studio"
+$publisher = "OBS Project"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like "$displayName*") -and ($publisher -eq "" -or $_.Publisher -eq $publisher)
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+# Kill any running OBS processes before uninstalling
+Stop-Process -Name "obs64" -Force -ErrorAction SilentlyContinue
+Stop-Process -Name "obs32" -Force -ErrorAction SilentlyContinue
+
+$uninstallString = $uninstall.UninstallString
+$exePath = ""
+$arguments = ""
+
+# Parse the uninstall string to extract executable path and existing arguments
+# Handles both quoted and unquoted paths
+if ($uninstallString -match '^"([^"]+)"(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} elseif ($uninstallString -match '^([^\s]+)(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} else {
+    Write-Host "Error: Could not parse uninstall string: $uninstallString"
+    Exit 1
+}
+
+# Build argument list array, preserving existing arguments and adding /S for silent
+# NSIS installers require /S flag for silent uninstall
+$argumentList = @()
+if ($arguments -ne '') {
+    # Split existing arguments and add them
+    $argumentList += $arguments -split '\s+'
+}
+# Append /S if not already present
+if ($argumentList -notcontains "/S" -and $arguments -notmatch '\b/S\b') {
+    $argumentList += "/S"
+}
+
+Write-Host "Uninstall executable: $exePath"
+Write-Host "Uninstall arguments: $($argumentList -join ' ')"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+    
+    if ($argumentList.Count -gt 0) {
+        $processOptions.ArgumentList = $argumentList
+    }
+    
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}
+

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1101,6 +1101,13 @@
       "description": "OBS is open-source software for live streaming and screen recording."
     },
     {
+      "name": "OBS",
+      "slug": "obs/windows",
+      "platform": "windows",
+      "unique_identifier": "OBS Studio",
+      "description": "OBS is open-source software for live streaming and screen recording."
+    },
+    {
       "name": "Obsidian",
       "slug": "obsidian/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/obs/windows.json
+++ b/ee/maintained-apps/outputs/obs/windows.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "32.0.4",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project';"
+      },
+      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.0.4/OBS-Studio-32.0.4-Windows-x64-Installer.exe",
+      "install_script_ref": "8a919fae",
+      "uninstall_script_ref": "145a6b76",
+      "sha256": "46a18bce8e2ff662b700c91d340a519376e712fe0af0d335536e4f9fd253f10a",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "145a6b76": "# Attempts to locate OBS Studio's uninstaller from registry and execute it silently\n\n$displayName = \"OBS Studio\"\n$publisher = \"OBS Project\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like \"$displayName*\") -and ($publisher -eq \"\" -or $_.Publisher -eq $publisher)\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\n# Kill any running OBS processes before uninstalling\nStop-Process -Name \"obs64\" -Force -ErrorAction SilentlyContinue\nStop-Process -Name \"obs32\" -Force -ErrorAction SilentlyContinue\n\n$uninstallString = $uninstall.UninstallString\n$exePath = \"\"\n$arguments = \"\"\n\n# Parse the uninstall string to extract executable path and existing arguments\n# Handles both quoted and unquoted paths\nif ($uninstallString -match '^\"([^\"]+)\"(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} elseif ($uninstallString -match '^([^\\s]+)(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} else {\n    Write-Host \"Error: Could not parse uninstall string: $uninstallString\"\n    Exit 1\n}\n\n# Build argument list array, preserving existing arguments and adding /S for silent\n# NSIS installers require /S flag for silent uninstall\n$argumentList = @()\nif ($arguments -ne '') {\n    # Split existing arguments and add them\n    $argumentList += $arguments -split '\\s+'\n}\n# Append /S if not already present\nif ($argumentList -notcontains \"/S\" -and $arguments -notmatch '\\b/S\\b') {\n    $argumentList += \"/S\"\n}\n\nWrite-Host \"Uninstall executable: $exePath\"\nWrite-Host \"Uninstall arguments: $($argumentList -join ' ')\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n    \n    if ($argumentList.Count -gt 0) {\n        $processOptions.ArgumentList = $argumentList\n    }\n    \n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    \n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n\n",
+    "8a919fae": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n# Add argument to install silently\n# NSIS installers require /S flag for silent installation\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/S\"\n  PassThru = $true\n  Wait = $true\n}\n    \n# Start process and track exit code\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\n# Prints the exit code\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for managing OBS Studio on Windows using Winget, including new install and uninstall scripts for automated deployment and removal. The main changes are the introduction of a metadata file for OBS Studio and robust PowerShell scripts to handle silent installation and uninstallation.

**OBS Studio Winget Integration:**

* Added a new metadata file `obs.json` describing OBS Studio for Winget management, including identifiers, script paths, and default categories.

**Installation Script:**

* Introduced `obs_install.ps1`, a PowerShell script that installs OBS Studio silently using the `/S` flag, captures the installer exit code, and handles errors gracefully.

**Uninstallation Script:**

* Added `obs_uninstall.ps1`, a PowerShell script that locates the OBS Studio uninstaller via the Windows registry, ensures all running OBS processes are stopped, parses the uninstall command, and performs a silent uninstall (also with `/S`), including error handling and exit code reporting.