### PR TITLE
Add Spotify as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/scripts/spotify_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/spotify_install.ps1
@@ -1,0 +1,31 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+# Add arguments to install silently
+# Spotify uses /silent /skip-app-launch for silent installation
+# Note: elevationProhibited - do not use -Verb RunAs
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/silent", "/skip-app-launch"
+  PassThru = $true
+  Wait = $true
+}
+    
+# Start process and track exit code
+# Exit code 26 indicates packageInUse, which is expected in some scenarios
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+# Prints the exit code
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}
+

--- a/ee/maintained-apps/inputs/winget/scripts/spotify_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/spotify_uninstall.ps1
@@ -1,0 +1,83 @@
+# Attempts to locate Spotify's uninstaller from registry and execute it silently
+
+$displayName = "Spotify"
+$publisher = "Spotify AB"
+
+# Spotify is user-scope, so check HKCU first, then HKLM as fallback
+$paths = @(
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like "$displayName*") -and ($publisher -eq "" -or $_.Publisher -eq $publisher)
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+# Kill any running Spotify processes before uninstalling
+Stop-Process -Name "Spotify" -Force -ErrorAction SilentlyContinue
+Stop-Process -Name "SpotifyWebHelper" -Force -ErrorAction SilentlyContinue
+
+$uninstallString = $uninstall.UninstallString
+$exePath = ""
+$arguments = ""
+
+# Parse the uninstall string to extract executable path and existing arguments
+# Handles both quoted and unquoted paths
+if ($uninstallString -match '^"([^"]+)"(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} elseif ($uninstallString -match '^([^\s]+)(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} else {
+    Write-Host "Error: Could not parse uninstall string: $uninstallString"
+    Exit 1
+}
+
+# Build argument list array, preserving existing arguments and adding /silent for silent
+$argumentList = @()
+if ($arguments -ne '') {
+    # Split existing arguments and add them
+    $argumentList += $arguments -split '\s+'
+}
+# Append /silent if not already present
+if ($argumentList -notcontains "/silent" -and $arguments -notmatch '\b/silent\b') {
+    $argumentList += "/silent"
+}
+
+Write-Host "Uninstall executable: $exePath"
+Write-Host "Uninstall arguments: $($argumentList -join ' ')"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+    
+    if ($argumentList.Count -gt 0) {
+        $processOptions.ArgumentList = $argumentList
+    }
+    
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}
+

--- a/ee/maintained-apps/inputs/winget/spotify.json
+++ b/ee/maintained-apps/inputs/winget/spotify.json
@@ -1,0 +1,12 @@
+{
+  "name": "Spotify",
+  "slug": "spotify/windows",
+  "package_identifier": "Spotify.Spotify",
+  "unique_identifier": "Spotify",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/spotify_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/spotify_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "user",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -1395,6 +1395,13 @@
       "description": "Spotify is a music streaming app."
     },
     {
+      "name": "Spotify",
+      "slug": "spotify/windows",
+      "platform": "windows",
+      "unique_identifier": "Spotify",
+      "description": "Spotify is a music streaming app."
+    },
+    {
       "name": "Stats",
       "slug": "stats/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/spotify/windows.json
+++ b/ee/maintained-apps/outputs/spotify/windows.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "1.2.80.232.gcd5eb6df",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Spotify' AND publisher = 'Spotify AB';"
+      },
+      "installer_url": "https://upgrade.scdn.co/upgrade/client/win32-x86_64/spotify_installer-1.2.80.232.gcd5eb6df-705.exe",
+      "install_script_ref": "7e4727ac",
+      "uninstall_script_ref": "48d55e3d",
+      "sha256": "40f1845ceb5d1f144b38cce652c9dd34e3d4133d0c2431edfc6838a46589dd89",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "48d55e3d": "# Attempts to locate Spotify's uninstaller from registry and execute it silently\n\n$displayName = \"Spotify\"\n$publisher = \"Spotify AB\"\n\n# Spotify is user-scope, so check HKCU first, then HKLM as fallback\n$paths = @(\n  'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like \"$displayName*\") -and ($publisher -eq \"\" -or $_.Publisher -eq $publisher)\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\n# Kill any running Spotify processes before uninstalling\nStop-Process -Name \"Spotify\" -Force -ErrorAction SilentlyContinue\nStop-Process -Name \"SpotifyWebHelper\" -Force -ErrorAction SilentlyContinue\n\n$uninstallString = $uninstall.UninstallString\n$exePath = \"\"\n$arguments = \"\"\n\n# Parse the uninstall string to extract executable path and existing arguments\n# Handles both quoted and unquoted paths\nif ($uninstallString -match '^\"([^\"]+)\"(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} elseif ($uninstallString -match '^([^\\s]+)(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} else {\n    Write-Host \"Error: Could not parse uninstall string: $uninstallString\"\n    Exit 1\n}\n\n# Build argument list array, preserving existing arguments and adding /silent for silent\n$argumentList = @()\nif ($arguments -ne '') {\n    # Split existing arguments and add them\n    $argumentList += $arguments -split '\\s+'\n}\n# Append /silent if not already present\nif ($argumentList -notcontains \"/silent\" -and $arguments -notmatch '\\b/silent\\b') {\n    $argumentList += \"/silent\"\n}\n\nWrite-Host \"Uninstall executable: $exePath\"\nWrite-Host \"Uninstall arguments: $($argumentList -join ' ')\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n    \n    if ($argumentList.Count -gt 0) {\n        $processOptions.ArgumentList = $argumentList\n    }\n    \n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    \n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n\n",
+    "7e4727ac": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n# Add arguments to install silently\n# Spotify uses /silent /skip-app-launch for silent installation\n# Note: elevationProhibited - do not use -Verb RunAs\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/silent\", \"/skip-app-launch\"\n  PassThru = $true\n  Wait = $true\n}\n    \n# Start process and track exit code\n# Exit code 26 indicates packageInUse, which is expected in some scenarios\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\n# Prints the exit code\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n\n"
+  }
+}


### PR DESCRIPTION
This pull request adds full support for managing the installation and uninstallation of Spotify on Windows via winget in the maintained apps system. It introduces new configuration and script files, updates output manifests, and ensures that both install and uninstall processes are handled silently and robustly.

**Spotify Windows app integration:**

* Added a new manifest `spotify.json` in `ee/maintained-apps/inputs/winget` to define Spotify's winget package details, including references to custom install and uninstall scripts.
* Updated `ee/maintained-apps/outputs/apps.json` to register the Spotify Windows app, enabling it to be discovered and managed by the platform.
* Added a new output manifest `ee/maintained-apps/outputs/spotify/windows.json` specifying the installer URL, version, install/uninstall script references, and detection query for Spotify.

**Installation and uninstallation scripting:**

* Introduced a PowerShell install script `spotify_install.ps1` that performs a silent installation of Spotify, handling exit codes and errors gracefully.
* Added a PowerShell uninstall script `spotify_uninstall.ps1` that locates Spotify's uninstaller via the registry, kills running processes, and executes the uninstall silently, preserving existing arguments and handling errors.