### PR TITLE
"Sprint" => Milestone

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -2,7 +2,7 @@
   task: "🦢📊 Product design sprint review" # 2024-03-06 TODO: Link to responsibility or corresponding "how to" info e.g. https://fleetdm.com/handbook/company/product-groups#making-changes
   startedOn: "2024-03-07" 
   frequency: "Triweekly" 
-  description: "1. For all stories that are not estimated, update their target engineering sprint on the roadmap board and add their respective customer requests to the feature fest board. 2. For stories that we're no longer working on, remove them from the drafting board, remove them from the roadmap board, and notify stakeholders. 3. Prepare the '🎁 Feature fest' board." 
+  description: "1. For all stories that are not estimated, update their milestone on the release planning board and add their respective customer requests to the feature fest board. 2. For stories that we're no longer working on, remove them from the drafting board, remove them from the roadmap board, and notify stakeholders. 3. Prepare the '🎁 Feature fest' board." 
   moreInfoUrl:  
   dri: "noahtalerman" 
 -


### PR DESCRIPTION
- @noahtalerman: We decided to use the Milestone field in GitHub for the "Release planning" project instead of the custom "Sprint" field. That way, we only have one field to update when a user story is moved from one release to another.
- @noahtalerman: I removed the "Sprint" field from the "Release planning" project.
