### PR TITLE
Add debugging section for host enrollment

### DIFF
--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -150,6 +150,27 @@ You can unenroll a macOS, Windows, or Linux host from Fleet (iOS, iPadOS, and An
 
 > If an end user wants to switch their workstation's operating system (e.g. Windows to Linux), before they switch, delete the host from Fleet. Then, re-enroll the host.
 
+## Debugging
+
+If you're running into issues when enrolling hosts, the best practice is to look for errors in the fleetd logs. Fleetd will send stdout/stderr logs to the following directories:
+
+  - macOS: `/private/var/log/orbit/orbit.std{out|err}.log`.
+  - Windows: `C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log` (the log file is rotated).
+  - Linux: Orbit and osqueryd stdout/stderr output is sent to syslog (`/var/log/syslog` on Debian systems, `/var/log/messages` on CentOS, and `journalctl -u orbit` on Fedora).
+
+If the `logger_path` agent configuration is set to `filesystem`, fleetd will send osquery's "result" and "status" logs to the following directories:
+  - Windows: `C:\Program Files\Orbit\osquery_log`
+  - macOS: `/opt/orbit/osquery_log`
+  - Linux: `/opt/orbit/osquery_log`
+
+The Fleet Desktop log files can be found in the following directories depending on the platform:
+
+  - Linux: `$XDG_STATE_HOME/Fleet or $HOME/.local/state/Fleet`
+  - macOS: `$HOME/Library/Logs/Fleet`
+  - Windows: `%LocalAppData%/Fleet`
+
+The log file name is `fleet-desktop.log`.
+
 ## Advanced
 
 - [Supported osquery versions](#supported-osquery-versions)
@@ -161,7 +182,6 @@ You can unenroll a macOS, Windows, or Linux host from Fleet (iOS, iPadOS, and An
 - [Using host identity certificates](#using-host-identity-certificates)
 - [Specifying update channels](#specifying-update-channels)
 - [Testing osquery queries locally](#testing-osquery-queries-locally)
-- [Finding fleetd logs](#finding-fleetd-logs)
 - [Using system keystore for enroll secret](#using-system-keystore-for-enroll-secret)
 - [Generating fleetd for Windows using local WiX toolset](#generating-fleetd-for-windows-using-local-wix-toolset)
 - [Config-less fleetd agent deployment](#config-less-fleetd-agent-deployment)
@@ -418,27 +438,6 @@ When a new version of osquery is released, it's added to the `edge` channel for 
 Fleet comes packaged with `osqueryi` which is a tool for testing osquery queries locally.
 
 With fleetd installed on your host, run `orbit osqueryi` or `orbit shell` to open the `osqueryi`.
-
-### Finding fleetd logs
-
-Fleetd will send stdout/stderr logs to the following directories:
-
-  - macOS: `/private/var/log/orbit/orbit.std{out|err}.log`.
-  - Windows: `C:\Windows\system32\config\systemprofile\AppData\Local\FleetDM\Orbit\Logs\orbit-osquery.log` (the log file is rotated).
-  - Linux: Orbit and osqueryd stdout/stderr output is sent to syslog (`/var/log/syslog` on Debian systems, `/var/log/messages` on CentOS, and `journalctl -u orbit` on Fedora).
-
-If the `logger_path` agent configuration is set to `filesystem`, fleetd will send osquery's "result" and "status" logs to the following directories:
-  - Windows: `C:\Program Files\Orbit\osquery_log`
-  - macOS: `/opt/orbit/osquery_log`
-  - Linux: `/opt/orbit/osquery_log`
-
-The Fleet Desktop log files can be found in the following directories depending on the platform:
-
-  - Linux: `$XDG_STATE_HOME/Fleet or $HOME/.local/state/Fleet`
-  - macOS: `$HOME/Library/Logs/Fleet`
-  - Windows: `%LocalAppData%/Fleet`
-
-The log file name is `fleet-desktop.log`.
 
 ### Using system keystore for enroll secret
 


### PR DESCRIPTION
- @noahtalerman: Best practice for debugging enrollment is to look for errors in the logs. Right now, this section is hiding under "Advanced"
