### PR TITLE
Fleet UI: Add a location modal to the host details page if a location exists

### DIFF
--- a/frontend/__mocks__/hostMock.ts
+++ b/frontend/__mocks__/hostMock.ts
@@ -1,4 +1,4 @@
-import { IHost, IHostEndUser } from "interfaces/host";
+import { IHost, IHostEndUser, IGeoLocation } from "interfaces/host";
 import { IHostMdmProfile } from "interfaces/mdm";
 import { pick } from "lodash";
 
@@ -119,6 +119,20 @@ const DEFAULT_HOST_MOCK: IHost = {
 
 const createMockHost = (overrides?: Partial<IHost>): IHost => {
   return { ...DEFAULT_HOST_MOCK, ...overrides };
+};
+
+export const createMockHostGeolocation = (
+  overrides: Partial<IGeoLocation> = {}
+): IGeoLocation => {
+  return {
+    country_iso: "US",
+    city_name: "Minneapolis",
+    geometry: {
+      type: "Point",
+      coordinates: [-93.2602, 44.9844], // [lng, lat]
+    },
+    ...overrides,
+  };
 };
 
 export const createMockHostResponse = { host: createMockHost() };

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -132,7 +132,7 @@ interface IMdmMacOsSetup {
 }
 
 export type HostMdmDeviceStatus = "unlocked" | "locked" | "wiped";
-export type HostMdmPendingAction = "unlock" | "lock" | "wipe" | "";
+export type HostMdmPendingAction = "unlock" | "lock" | "wipe" | "location" | "";
 
 export interface IHostMdmData {
   encryption_key_available: boolean;
@@ -197,7 +197,7 @@ export interface IPolicyHostResponse {
   status?: string;
 }
 
-interface IGeoLocation {
+export interface IGeoLocation {
   country_iso: string;
   city_name: string;
   geometry?: {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -21,9 +21,6 @@ import hostAPI, {
 import teamAPI, { ILoadTeamsResponse } from "services/entities/teams";
 import commandAPI from "services/entities/command";
 
-// TODO: Remove
-import { createMockHostGeolocation } from "__mocks__/hostMock";
-
 import {
   IHost,
   IMacadminsResponse,
@@ -687,12 +684,7 @@ const HostDetailsPage = ({
 
   const summaryData = normalizeEmptyValues(pick(host, HOST_SUMMARY_DATA));
 
-  const fakeHost = {
-    ...host,
-    geolocation: createMockHostGeolocation(),
-  };
-
-  const vitalsData = normalizeEmptyValues(pick(fakeHost, HOST_VITALS_DATA));
+  const vitalsData = normalizeEmptyValues(pick(host, HOST_VITALS_DATA));
 
   const osqueryData = normalizeEmptyValues(pick(host, HOST_OSQUERY_DATA));
 
@@ -1686,7 +1678,7 @@ Observer plus must be checked against host's team id  */
         )}
         {showLocationModal && (
           <LocationModal
-            hostGeolocation={fakeHost.geolocation}
+            hostGeolocation={host.geolocation}
             onExit={toggleLocationModal}
             iosOrIpadosDetails={{
               isIosOrIpadosHost,

--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -52,6 +52,38 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
       );
     },
   },
+  locating: {
+    title: "LOCKED",
+    tagType: "warning",
+    generateTooltip: (platform) => {
+      if (isIPadOrIPhone(platform)) {
+        return (
+          <>
+            Host is locked. The end user can&apos;t use the host until
+            <br />
+            unlocked. To unlock select <b>Actions &gt; Unlock</b>.
+          </>
+        );
+      } else if (isMacOS(platform)) {
+        return (
+          <>
+            Host is locked. The end user can&apos;t use the host until
+            <br />
+            the six-digit PIN has been entered. To view pin select
+            <br />
+            <b>Actions &gt; Unlock</b>.
+          </>
+        );
+      }
+      return (
+        <>
+          Host is locked. The end user can&apos;t use the host until
+          <br />
+          unlocked. To unlock select <b>Actions &gt; Unlock</b>.
+        </>
+      );
+    },
+  },
   unlocking: {
     title: "UNLOCK PENDING",
     tagType: "warning",
@@ -106,6 +138,12 @@ export const REFETCH_TOOLTIP_MESSAGES: Record<
     </>
   ),
   locked: (
+    <>
+      You can&apos;t fetch data from <br /> a locked host.
+    </>
+  ),
+  // Same as locked
+  locating: (
     <>
       You can&apos;t fetch data from <br /> a locked host.
     </>

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -35,6 +35,7 @@ import DataSet from "components/DataSet";
 import CardHeader from "components/CardHeader";
 import TooltipWrapperArchLinuxRolling from "components/TooltipWrapperArchLinuxRolling";
 import Icon from "components/Icon/Icon";
+import Button from "components/buttons/Button";
 
 import DiskSpaceIndicator from "pages/hosts/components/DiskSpaceIndicator";
 
@@ -44,6 +45,7 @@ interface IVitalsProps {
   mdm?: IHostMdmData;
   osVersionRequirement?: IAppleDeviceUpdates;
   className?: string;
+  toggleLocationModal?: () => void;
 }
 
 const baseClass = "vitals-card";
@@ -111,6 +113,7 @@ const Vitals = ({
   mdm,
   osVersionRequirement,
   className,
+  toggleLocationModal,
 }: IVitalsProps) => {
   const isIosOrIpadosHost = isIPadOrIPhone(vitalsData.platform);
   const isAndroidHost = isAndroid(vitalsData.platform);
@@ -243,14 +246,21 @@ const Vitals = ({
   const renderGeolocation = () => {
     const geolocation = vitalsData.geolocation;
 
-    if (!geolocation) {
+    if (!geolocation && !isIosOrIpadosHost) {
       return null;
     }
 
+    // Also used in location modal
     const location = [geolocation?.city_name, geolocation?.country_iso]
       .filter(Boolean)
       .join(", ");
-    return <DataSet title="Location" value={location} />;
+
+    const geoLocationButton = (
+      <Button variant="text-link" onClick={toggleLocationModal}>
+        {isIosOrIpadosHost ? "Show location" : location}
+      </Button>
+    );
+    return <DataSet title="Location" value={geoLocationButton} />;
   };
 
   const renderBattery = () => {

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -247,8 +247,7 @@ const Vitals = ({
   const renderGeolocation = () => {
     const geolocation = vitalsData.geolocation;
 
-    // This section is hidden only if non-ipados non-ios and no geolocation
-    if (!geolocation && !isIosOrIpadosHost) {
+    if (!isIosOrIpadosHost && !geolocation) {
       return null;
     }
 

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -38,6 +38,7 @@ import Icon from "components/Icon/Icon";
 import Button from "components/buttons/Button";
 
 import DiskSpaceIndicator from "pages/hosts/components/DiskSpaceIndicator";
+import { getCityCountryLocation } from "../../modals/LocationModal/LocationModal";
 
 interface IVitalsProps {
   vitalsData: { [key: string]: any };
@@ -246,18 +247,16 @@ const Vitals = ({
   const renderGeolocation = () => {
     const geolocation = vitalsData.geolocation;
 
+    // This section is hidden only if non-ipados non-ios and no geolocation
     if (!geolocation && !isIosOrIpadosHost) {
       return null;
     }
 
-    // Also used in location modal
-    const location = [geolocation?.city_name, geolocation?.country_iso]
-      .filter(Boolean)
-      .join(", ");
-
     const geoLocationButton = (
       <Button variant="text-link" onClick={toggleLocationModal}>
-        {isIosOrIpadosHost ? "Show location" : location}
+        {isIosOrIpadosHost
+          ? "Show location"
+          : getCityCountryLocation(geolocation)}
       </Button>
     );
     return <DataSet title="Location" value={geoLocationButton} />;

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -74,7 +74,8 @@ export type HostMdmDeviceStatusUIState =
   | "unlocking"
   | "locking"
   | "wiped"
-  | "wiping";
+  | "wiping"
+  | "locating";
 
 // Exclude the empty string from HostPendingAction as that doesn't represent a
 // valid device status.
@@ -88,6 +89,7 @@ const API_TO_UI_DEVICE_STATUS_MAP: Record<
   lock: "locking",
   wiped: "wiped",
   wipe: "wiping",
+  location: "locating",
 };
 
 const deviceUpdatingStates = ["unlocking", "locking", "wiping"] as const;

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
@@ -28,13 +28,8 @@ describe("LocationModal", () => {
     // Location name (city, country)
     expect(screen.getByText("Minneapolis, US")).toBeVisible();
 
-    // Last updated text when detailsUpdatedAt is not provided
-    expect(
-      screen.getByText(/Last reported location : unavailable/i)
-    ).toBeVisible();
-
     // Google Maps link built from coordinates (lat,lng)
-    const link = screen.getByRole("link", { name: /Google Maps/i });
+    const link = screen.getByRole("link", { name: /Open in Google Maps/i });
     expect(link).toBeVisible();
     expect(link).toHaveAttribute(
       "href",
@@ -42,18 +37,21 @@ describe("LocationModal", () => {
     );
   });
 
-  it("renders LastUpdatedText when detailsUpdatedAt is provided", () => {
+  it("renders LastUpdatedText when detailsUpdatedAt is 2 days ago", () => {
+    const currentDate = new Date();
+    currentDate.setDate(currentDate.getDate() - 2);
+    const twoDaysAgo = currentDate.toISOString();
+
     render(
       <LocationModal
         hostGeolocation={createMockHostGeolocation()}
-        detailsUpdatedAt="2025-01-01T12:00:00Z"
+        detailsUpdatedAt={twoDaysAgo}
         onExit={noop}
         onClickLock={noop}
       />
     );
 
-    // Only assert the prefix text; LastUpdatedText handles the timestamp formatting
-    expect(screen.getByText(/Last reported location/i)).toBeVisible();
+    expect(screen.getByText(/Updated 2 days ago/i)).toBeInTheDocument();
   });
 
   it("shows iOS unlocked message when iOS host is unlocked", () => {
@@ -119,11 +117,8 @@ describe("LocationModal", () => {
       />
     );
 
-    expect(
-      screen.getByText(
-        /Location not available. Please close this modal and select/i
-      )
-    ).toBeVisible();
+    expect(screen.getByText(/Location not available/i)).toBeVisible();
+    expect(screen.getByText(/Close this modal/i)).toBeVisible();
     expect(screen.getByText("Refetch")).toBeVisible();
   });
 
@@ -137,8 +132,7 @@ describe("LocationModal", () => {
       />
     );
 
-    // iOS default branch should return null when hasLocation = true,
-    // so we render the standard location content.
+    // With a location present, the standard content renders
     expect(screen.getByText("Minneapolis, US")).toBeVisible();
   });
 

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
@@ -1,15 +1,171 @@
 import React from "react";
+import { noop } from "lodash";
 import { render, screen } from "@testing-library/react";
 
 import { createMockHostGeolocation } from "__mocks__/hostMock";
+
+import { HostMdmDeviceStatusUIState } from "../../helpers";
 import LocationModal from "./LocationModal";
 
-// Mock current time for time stamp test
-beforeAll(() => {
-  jest.useFakeTimers();
-  jest.setSystemTime(new Date("2022-05-08T10:00:00Z"));
+const makeIosDetails = (
+  status: HostMdmDeviceStatusUIState,
+  isIosOrIpadosHost = true
+) => ({
+  isIosOrIpadosHost,
+  hostMdmDeviceStatus: status,
 });
 
 describe("LocationModal", () => {
-  console.log("tests todo");
+  it("renders basic location info and Google Maps link when hostGeolocation is provided", () => {
+    render(
+      <LocationModal
+        hostGeolocation={createMockHostGeolocation()}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    // Location name (city, country)
+    expect(screen.getByText("Minneapolis, US")).toBeVisible();
+
+    // Last updated text when detailsUpdatedAt is not provided
+    expect(
+      screen.getByText(/Last reported location : unavailable/i)
+    ).toBeVisible();
+
+    // Google Maps link built from coordinates (lat,lng)
+    const link = screen.getByRole("link", { name: "Open in Google Maps" });
+    expect(link).toBeVisible();
+    expect(link).toHaveAttribute(
+      "href",
+      "https://www.google.com/maps?q=44.9844,-93.2602"
+    );
+  });
+
+  it("renders LastUpdatedText when detailsUpdatedAt is provided", () => {
+    render(
+      <LocationModal
+        hostGeolocation={createMockHostGeolocation()}
+        detailsUpdatedAt="2025-01-01T12:00:00Z"
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    // Only assert the prefix text; LastUpdatedText handles the timestamp formatting
+    expect(screen.getByText(/Last reported location/i)).toBeVisible();
+  });
+
+  it("shows iOS unlocked message when iOS host is unlocked", () => {
+    render(
+      <LocationModal
+        iosOrIpadosDetails={makeIosDetails("unlocked")}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /To view location, Apple requires that iOS hosts are locked \(Lost Mode\) first./i
+      )
+    ).toBeVisible();
+  });
+
+  it("shows iOS locking message when lock is pending", () => {
+    render(
+      <LocationModal
+        iosOrIpadosDetails={makeIosDetails("locking")}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /To view location, Apple requires that iOS hosts are locked \(Lost Mode\) first./i
+      )
+    ).toBeVisible();
+    expect(
+      screen.getByText(
+        /Lock is pending. Host will lock the next time it checks in to Fleet./i
+      )
+    ).toBeVisible();
+  });
+
+  it("shows iOS locating message when location is pending", () => {
+    render(
+      <LocationModal
+        iosOrIpadosDetails={makeIosDetails("locating")}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /Location is pending. Host will share location the next time it checks in to Fleet./i
+      )
+    ).toBeVisible();
+  });
+
+  it("shows refetch message when iOS host has no location and status is unrecognized/empty", () => {
+    render(
+      <LocationModal
+        iosOrIpadosDetails={makeIosDetails("wiping")}
+        // no hostGeolocation => hasLocation = false
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        /Location not available. Please close this modal and select/i
+      )
+    ).toBeVisible();
+    expect(screen.getByText("Refetch")).toBeVisible();
+  });
+
+  it("falls back to normal location view when iOS host has a location and status is unrecognized/empty", () => {
+    render(
+      <LocationModal
+        hostGeolocation={createMockHostGeolocation()}
+        iosOrIpadosDetails={makeIosDetails("wiping")}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    // iOS default branch should return null when hasLocation = true,
+    // so we render the standard location content.
+    expect(screen.getByText("Minneapolis, US")).toBeVisible();
+  });
+
+  it("renders Lock/Cancel footer buttons when iOS host is unlocked", () => {
+    render(
+      <LocationModal
+        iosOrIpadosDetails={makeIosDetails("unlocked")}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Lock" })).toBeVisible();
+  });
+
+  it("renders Done footer button otherwise", () => {
+    render(
+      <LocationModal
+        hostGeolocation={createMockHostGeolocation()}
+        // non‑iOS host
+        iosOrIpadosDetails={makeIosDetails("unlocked", false)}
+        onExit={noop}
+        onClickLock={noop}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Done" })).toBeVisible();
+  });
 });

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { createMockHostGeolocation } from "__mocks__/hostMock";
+import LocationModal from "./LocationModal";
+
+// Mock current time for time stamp test
+beforeAll(() => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date("2022-05-08T10:00:00Z"));
+});
+
+describe("LocationModal", () => {
+  console.log("tests todo");
+});

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tests.tsx
@@ -34,7 +34,7 @@ describe("LocationModal", () => {
     ).toBeVisible();
 
     // Google Maps link built from coordinates (lat,lng)
-    const link = screen.getByRole("link", { name: "Open in Google Maps" });
+    const link = screen.getByRole("link", { name: /Google Maps/i });
     expect(link).toBeVisible();
     expect(link).toHaveAttribute(
       "href",

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -1,0 +1,46 @@
+import React, { useEffect, useRef, useState } from "react";
+
+import { IGeoLocation } from "interfaces/host";
+
+import Modal from "components/Modal";
+import ModalFooter from "components/ModalFooter";
+import Button from "components/buttons/Button";
+
+const baseClass = "location-modal";
+
+interface ILocationModal {
+  hostGeolocation?: IGeoLocation;
+  onExit: () => void;
+}
+
+const LocationModal = ({ hostGeolocation, onExit }: ILocationModal) => {
+  if (!hostGeolocation) {
+    return null;
+  }
+
+  const renderContent = () => {
+    return (
+      <div className={`${baseClass}__content`}>{hostGeolocation.city_name}</div>
+    );
+  };
+  const renderFooter = () => (
+    <ModalFooter
+      primaryButtons={
+        <Button type="submit" onClick={onExit}>
+          Done
+        </Button>
+      }
+    />
+  );
+
+  return (
+    <Modal title="Location" className={baseClass} onExit={onExit} width="large">
+      <>
+        {renderContent()}
+        {renderFooter()}
+      </>
+    </Modal>
+  );
+};
+
+export default LocationModal;

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -27,10 +27,10 @@ const getLocationMessage = (
   hasLocation: boolean
 ): JSX.Element | null => {
   const FETCH_LATEST_LOCATION_MESSAGE = (
-    <div>
+    <>
       Close this modal and select <strong>Refetch</strong> to fetch new
       location.
-    </div>
+    </>
   );
   const IOS_LOCKING_MESSAGE = (
     <>
@@ -136,7 +136,7 @@ const LocationModal = ({
   );
   const renderContent = () => {
     return (
-      <div className={`${baseClass}__content`}>
+      <>
         <div className={`${baseClass}__location`}>
           {hostGeolocation && getCityCountryLocation(hostGeolocation)}{" "}
           {googleMapsUrl && (
@@ -154,7 +154,7 @@ const LocationModal = ({
           {getLocationMessage(iosOrIpadosDetails, Boolean(hostGeolocation))}
           {shouldShowLastUpdatedAt && renderLastUpdatedAt()}
         </div>
-      </div>
+      </>
     );
   };
 

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -9,6 +9,7 @@ import CustomLink from "components/CustomLink";
 import LastUpdatedText from "components/LastUpdatedText";
 
 import { HostMdmDeviceStatusUIState } from "../../helpers";
+import DataSet from "components/DataSet";
 
 const baseClass = "location-modal";
 
@@ -139,10 +140,15 @@ const LocationModal = ({
     return (
       <div className={`${baseClass}__content`}>
         <div className={`${baseClass}__updated-at`}>
-          Last reported location {lastUpdatedAt}
+          <DataSet
+            title="Last reported location"
+            value={
+              <>
+                {location} {lastUpdatedAt}
+              </>
+            }
+          />
         </div>
-        <div className={`${baseClass}__name`}>{location}</div>
-        <div className={`${baseClass}__map`}>{"Insert map here"}</div>
         {googleMapsUrl && (
           <div className={`${baseClass}__link`}>
             <CustomLink url={googleMapsUrl} text="Open in Google Maps" newTab />
@@ -185,7 +191,7 @@ const LocationModal = ({
   };
 
   return (
-    <Modal title="Location" className={baseClass} onExit={onExit} width="large">
+    <Modal title="Location" className={baseClass} onExit={onExit}>
       <>
         {renderContent()}
         {renderFooter()}

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -1,37 +1,188 @@
-import React, { useEffect, useRef, useState } from "react";
+import React from "react";
 
 import { IGeoLocation } from "interfaces/host";
 
 import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Button from "components/buttons/Button";
+import CustomLink from "components/CustomLink";
+import LastUpdatedText from "components/LastUpdatedText";
+
+import { HostMdmDeviceStatusUIState } from "../../helpers";
 
 const baseClass = "location-modal";
+
+const getIosLocationMessage = (
+  status: HostMdmDeviceStatusUIState,
+  hasLocation: boolean
+): JSX.Element | null => {
+  const contentClass = `${baseClass}__content`;
+
+  switch (status) {
+    case "unlocked":
+      return (
+        <div className={contentClass}>
+          To view location, Apple requires that iOS hosts are locked (Lost Mode)
+          first.
+        </div>
+      );
+    case "locking":
+      return (
+        <div className={contentClass}>
+          <p>
+            To view location, Apple requires that iOS hosts are locked (Lost
+            Mode) first.
+          </p>
+          <p>
+            Lock is pending. Host will lock the next time it checks in to Fleet.
+          </p>
+        </div>
+      );
+    case "locating":
+      return (
+        <div className={contentClass}>
+          Location is pending. Host will share location the next time it checks
+          in to Fleet.
+        </div>
+      );
+    default:
+      if (!hasLocation) {
+        return (
+          <div className={contentClass}>
+            Location not available. Please close this modal and select{" "}
+            <strong>Refetch</strong> to fetch latest location.
+          </div>
+        );
+      }
+      return null;
+  }
+};
+
+const buildGoogleMapsLinkFromGeo = (loc: IGeoLocation): string | null => {
+  const { country_iso, city_name, geometry } = loc;
+
+  // Prefer coordinates if valid
+  if (
+    geometry &&
+    Array.isArray(geometry.coordinates) &&
+    geometry.coordinates.length >= 2
+  ) {
+    const [lng, lat] = geometry.coordinates; // GeoJSON is [lng, lat]
+    if (lat != null && lng != null) {
+      return `https://www.google.com/maps?q=${lat},${lng}`;
+    }
+  }
+
+  // Fallback to "City, Country"
+  if (city_name && country_iso) {
+    const query = encodeURIComponent(`${city_name}, ${country_iso}`);
+    return `https://www.google.com/maps/search/?api=1&query=${query}`;
+  }
+
+  return null;
+};
+
+interface IIosOrIpadosDetails {
+  isIosOrIpadosHost: boolean;
+  hostMdmDeviceStatus: HostMdmDeviceStatusUIState;
+}
 
 interface ILocationModal {
   hostGeolocation?: IGeoLocation;
   onExit: () => void;
+  onClickLock: () => void;
+  iosOrIpadosDetails?: IIosOrIpadosDetails;
+  detailsUpdatedAt?: string;
 }
 
-const LocationModal = ({ hostGeolocation, onExit }: ILocationModal) => {
-  if (!hostGeolocation) {
-    return null;
-  }
+const LocationModal = ({
+  hostGeolocation,
+  onExit,
+  onClickLock,
+  iosOrIpadosDetails,
+  detailsUpdatedAt,
+}: ILocationModal) => {
+  const googleMapsUrl = hostGeolocation
+    ? buildGoogleMapsLinkFromGeo(hostGeolocation)
+    : null;
+
+  const location = hostGeolocation
+    ? [hostGeolocation.city_name, hostGeolocation.country_iso]
+        .filter(Boolean)
+        .join(", ")
+    : "";
+
+  const lastUpdatedAt = detailsUpdatedAt ? (
+    <LastUpdatedText
+      lastUpdatedAt={detailsUpdatedAt}
+      customTooltipText="The last time location data was updated."
+    />
+  ) : (
+    ": unavailable"
+  );
 
   const renderContent = () => {
+    if (iosOrIpadosDetails?.isIosOrIpadosHost) {
+      const iosContent = getIosLocationMessage(
+        iosOrIpadosDetails.hostMdmDeviceStatus,
+        Boolean(hostGeolocation)
+      );
+      if (iosContent) {
+        return iosContent;
+      }
+    }
+
+    if (!hostGeolocation) {
+      return null;
+    }
+
     return (
-      <div className={`${baseClass}__content`}>{hostGeolocation.city_name}</div>
+      <div className={`${baseClass}__content`}>
+        <div className={`${baseClass}__updated-at`}>
+          Last reported location {lastUpdatedAt}
+        </div>
+        <div className={`${baseClass}__name`}>{location}</div>
+        <div className={`${baseClass}__map`}>{"Insert map here"}</div>
+        {googleMapsUrl && (
+          <div className={`${baseClass}__link`}>
+            <CustomLink url={googleMapsUrl} text="Open in Google Maps" newTab />
+          </div>
+        )}
+      </div>
     );
   };
-  const renderFooter = () => (
-    <ModalFooter
-      primaryButtons={
-        <Button type="submit" onClick={onExit}>
-          Done
-        </Button>
-      }
-    />
-  );
+
+  const renderFooter = () => {
+    const isIos = iosOrIpadosDetails?.isIosOrIpadosHost;
+    const status = iosOrIpadosDetails?.hostMdmDeviceStatus;
+
+    if (isIos && status === "unlocked") {
+      return (
+        <ModalFooter
+          primaryButtons={
+            <>
+              <Button type="button" onClick={onExit} variant="inverse">
+                Cancel
+              </Button>
+              <Button type="button" onClick={onClickLock}>
+                Lock
+              </Button>
+            </>
+          }
+        />
+      );
+    }
+
+    return (
+      <ModalFooter
+        primaryButtons={
+          <Button type="button" onClick={onExit}>
+            Done
+          </Button>
+        }
+      />
+    );
+  };
 
   return (
     <Modal title="Location" className={baseClass} onExit={onExit} width="large">

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -32,7 +32,7 @@ const getLocationMessage = (
       location.
     </>
   );
-  const IOS_LOCKING_MESSAGE = (
+  const IOS_LOCK_REQUIRED_MESSAGE = (
     <>
       To view location, Apple requires that iOS hosts are locked (Lost Mode)
       first.
@@ -47,12 +47,12 @@ const getLocationMessage = (
 
   switch (hostMdmDeviceStatus) {
     case "unlocked":
-      return <div>{IOS_LOCKING_MESSAGE}</div>;
+      return <div>{IOS_LOCK_REQUIRED_MESSAGE}</div>;
 
     case "locking":
       return (
         <div>
-          <p>{IOS_LOCKING_MESSAGE}</p>
+          <p>{IOS_LOCK_REQUIRED_MESSAGE}</p>
           <p>
             Lock is pending. Host will lock the next time it checks in to Fleet.
           </p>
@@ -120,20 +120,22 @@ const LocationModal = ({
     ? buildGoogleMapsLinkFromGeo(hostGeolocation)
     : null;
 
-  // Only show last updated at for non-iOS/iPadOS hosts and for iOS/iPadOS hosts
-  // when "locked" and location is available
+  const isIosOrIpadosHost = iosOrIpadosDetails?.isIosOrIpadosHost || false;
+  const isIosLockedWithLocationAvail =
+    iosOrIpadosDetails?.isIosOrIpadosHost &&
+    iosOrIpadosDetails?.hostMdmDeviceStatus === "locked" &&
+    hostGeolocation !== null;
+
   const shouldShowLastUpdatedAt =
-    !iosOrIpadosDetails?.isIosOrIpadosHost ||
-    (iosOrIpadosDetails?.isIosOrIpadosHost &&
-      iosOrIpadosDetails?.hostMdmDeviceStatus === "locked" &&
-      hostGeolocation !== null &&
-      detailsUpdatedAt);
+    !isIosOrIpadosHost || isIosLockedWithLocationAvail;
+
   const renderLastUpdatedAt = () => (
     <LastUpdatedText
       lastUpdatedAt={detailsUpdatedAt}
       customTooltipText="The last time location data was updated."
     />
   );
+
   const renderContent = () => {
     return (
       <>

--- a/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
@@ -3,7 +3,8 @@
     @include vertical-modal-layout;
   }
 
-  dd {
+  dd,
+  dt {
     align-items: baseline;
     gap: $pad-small;
   }

--- a/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
@@ -3,8 +3,9 @@
     @include vertical-modal-layout;
   }
 
-  dd,
-  dt {
+  &__location,
+  &__message {
+    display: flex;
     align-items: baseline;
     gap: $pad-small;
   }

--- a/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
@@ -1,0 +1,2 @@
+.location-modal {
+}

--- a/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
@@ -1,2 +1,10 @@
 .location-modal {
+  &__content {
+    @include vertical-modal-layout;
+  }
+
+  dd {
+    align-items: baseline;
+    gap: $pad-small;
+  }
 }

--- a/frontend/pages/hosts/details/modals/LocationModal/index.ts
+++ b/frontend/pages/hosts/details/modals/LocationModal/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./LocationModal";


### PR DESCRIPTION
## Issue
Closes #37269
Parent issue #33509 

This is being merged into the [feature branch](https://github.com/fleetdm/fleet/tree/33509-feature-branch)

## Description
- FE for Location modal

> Note: this branch is named 37270-lock-modal but it's actually 37269 location modal

If some of the following don't apply, delete the relevant line.

## Screenshots
(test data for minneapolis, non test data for unlocking iphone)

<img width="708" height="318" alt="Screenshot 2025-12-31 at 12 23 59 PM" src="https://github.com/user-attachments/assets/e04ac0fd-ed1b-44d0-84e8-909833e1781d" />
<img width="765" height="299" alt="Screenshot 2025-12-31 at 12 29 33 PM" src="https://github.com/user-attachments/assets/7c187bbe-8c39-4533-ad31-976c31e04378" />


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
