### PR TITLE
Wrong indentation for the title

### DIFF
--- a/articles/software-self-service.md
+++ b/articles/software-self-service.md
@@ -48,6 +48,7 @@ On your Mac, open [iMazing Profile Editor](https://imazing.com/profile-editor). 
 - **Icon:** Upload a square icon that will be displayed as the app icon on the home screen.
 - **Full Screen:** Check this field.
 - **Target Application Bundle Identifier:** Select **Choose...**, type "safari" in the search box, and select **Safari - com.apple.mobilesafari**.
+
 #### Download configuration profile
 
 You can also download the configuration profile (`.mobileconfig`) and change values in code editor. If you want to change the icon, use iMazing Profile Editor and follow the steps above.


### PR DESCRIPTION
The title has weird padding:

<img width="967" height="561" alt="Screenshot 2025-12-26 at 13 11 08" src="https://github.com/user-attachments/assets/b78c2a13-60d1-4168-9cc0-3dc8f4e55e63" />
