### PR TITLE
Allow disabling schedule with empty start/end time

### DIFF
--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -836,6 +836,9 @@ func (ds *Datastore) UpdateSoftwareTitleAutoUpdateConfig(ctx context.Context, ti
 	invalidTimeErr := "invalid auto-update time format: must be in HH:MM 24-hour format"
 	for _, t := range []*string{config.AutoUpdateStartTime, config.AutoUpdateEndTime} {
 		if t == nil {
+			if config.AutoUpdateEnabled != nil && *config.AutoUpdateEnabled {
+				return fleet.NewInvalidArgumentError("auto_update_time", invalidTimeErr)
+			}
 			continue
 		}
 		duration, err := time.Parse("15:04", *t)

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -2716,14 +2716,15 @@ func testUpdateAutoUpdateConfig(t *testing.T, ds *Datastore) {
 	// Disable auto-update.
 	err = ds.UpdateSoftwareTitleAutoUpdateConfig(ctx, titleID, *teamID, fleet.SoftwareAutoUpdateConfig{
 		AutoUpdateEnabled:   ptr.Bool(false),
-		AutoUpdateStartTime: ptr.String(startTime),
-		AutoUpdateEndTime:   ptr.String(endTime),
+		AutoUpdateStartTime: nil,
+		AutoUpdateEndTime:   nil,
 	})
 	require.NoError(t, err)
 
 	titleResult, err = ds.SoftwareTitleByID(ctx, titleID, teamID, fleet.TeamFilter{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
 	require.NoError(t, err)
 	require.False(t, *titleResult.AutoUpdateEnabled)
+	// Note that the times should not have changed.
 	require.NotNil(t, titleResult.AutoUpdateStartTime)
 	require.Equal(t, startTime, *titleResult.AutoUpdateStartTime)
 	require.NotNil(t, titleResult.AutoUpdateEndTime)

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -140,7 +140,7 @@ func updateAppStoreAppEndpoint(ctx context.Context, request interface{}, svc fle
 		return updateAppStoreAppResponse{Err: err}, nil
 	}
 
-	if req.AutoUpdateEnabled != nil && req.AutoUpdateStartTime != nil && req.AutoUpdateEndTime != nil {
+	if req.AutoUpdateEnabled != nil {
 		// Update AutoUpdateConfig separately
 		err = svc.UpdateSoftwareTitleAutoUpdateConfig(ctx, req.TitleID, req.TeamID, fleet.SoftwareAutoUpdateConfig{
 			AutoUpdateEnabled:   req.AutoUpdateEnabled,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37599

# Details

Fixes an unreleased issue where if you clear the start/end time of a software auto-update schedule and then attempt to disable and save the schedule, the API returns an error due to the start/end time being invalid.  Now, the start/end time will be unchanged if the schedule is disabled.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
- [X] Alerted the release DRI if additional load testing is needed
