### PR TITLE
Add `Fleet Desktop.app` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ fleet_tables_*.ext
 .env
 .tool-versions
 .zed/
+
+# Required to not make `fleet-desktop` macOS executable built with a `dirty` flag (see #35006).
+Fleet\ Desktop.app

--- a/orbit/changes/35006-add-tmp-folder-to-.gitignore
+++ b/orbit/changes/35006-add-tmp-folder-to-.gitignore
@@ -1,0 +1,1 @@
+* Fixed macOS `fleet-desktop` that was being displayed as dirty by `go version -m`.


### PR DESCRIPTION
Resolves #35006.
See https://github.com/fleetdm/fleet/issues/35006#issuecomment-3693239452.

Output when running the dirty check on `main`:
```
make desktop-app-tar-gz
go run ./tools/desktop macos
{"level":"info","command":"/Users/lucas/go/bin/go build -o Fleet Desktop.app/Contents/MacOS/fleet-desktop_amd64 -ldflags -X=main.version= ./orbit/cmd/desktop","time":"2025-12-30T08:38:20-03:00","message":"Build fleet-desktop executable amd64"}
{"level":"info","command":"/Users/lucas/go/bin/go build -o Fleet Desktop.app/Contents/MacOS/fleet-desktop_arm64 -ldflags -X=main.version= ./orbit/cmd/desktop","time":"2025-12-30T08:38:23-03:00","message":"Build fleet-desktop executable arm64"}
{"level":"info","output":"On branch test-branch-dirty\nUntracked files:\n  (use \"git add <file>...\" to include in what will be committed)\n\tFleet Desktop.app/\n\nnothing added to commit but untracked files present (use \"git add\" to track)\n","time":"2025-12-30T08:38:26-03:00","message":"git status"}
Error: detected dirty executable: {Path:github.com/fleetdm/fleet/v4 Version:v4.43.5-0.20251230113816-9bae7b475999+dirty Sum: Replace:<nil>}
exit status 1
make: *** [desktop-app-tar-gz] Error 1
```

Output on this branch:
```
make desktop-app-tar-gz
go run ./tools/desktop macos
{"level":"info","command":"/Users/lucas/go/bin/go build -o Fleet Desktop.app/Contents/MacOS/fleet-desktop_amd64 -ldflags -X=main.version= ./orbit/cmd/desktop","time":"2025-12-30T08:39:43-03:00","message":"Build fleet-desktop executable amd64"}
{"level":"info","command":"/Users/lucas/go/bin/go build -o Fleet Desktop.app/Contents/MacOS/fleet-desktop_arm64 -ldflags -X=main.version= ./orbit/cmd/desktop","time":"2025-12-30T08:39:47-03:00","message":"Build fleet-desktop executable arm64"}
Generated desktop.app.tar.gz successfully.
```

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## fleetd/orbit/Fleet Desktop

- [X] Verified that fleetd runs on macOS
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
