### PR TITLE
Fleet UI: Fix edit software/config for no teams bug

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
@@ -46,7 +46,7 @@ const EditConfigurationModal = ({
   refetchSoftwareTitle,
   onExit,
 }: EditConfigurationModal) => {
-  const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
+  const { renderFlash } = useContext(NotificationContext);
 
   const [isUpdatingConfiguration, setIsUpdatingConfiguration] = useState(false);
   const [canSaveForm, setCanSaveForm] = useState(true);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -104,10 +104,10 @@ const SoftwareSummaryCard = ({
   } = meta;
 
   const canEditAppearance = canManageSoftware;
-
   const canEditSoftware = canManageSoftware;
-
   const canEditConfiguration = canManageSoftware && isAndroidPlayStoreApp;
+  /** Installer modals require a specific team; hidden from "All Teams" */
+  const hasValidTeamId = typeof teamId === "number" && teamId >= 0;
 
   const onClickEditAppearance = () => setShowEditIconModal(true);
   const onClickEditSoftware = () => setShowEditSoftwareModal(true);
@@ -153,32 +153,29 @@ const SoftwareSummaryCard = ({
           />
         )}
       </Card>
-      {showEditIconModal &&
-        typeof teamId === "number" &&
-        teamId >= 0 &&
-        softwareInstaller && (
-          <EditIconModal
-            softwareId={softwareId}
-            teamIdForApi={teamId}
-            software={softwareInstaller}
-            onExit={() => setShowEditIconModal(false)}
-            refetchSoftwareTitle={refetchSoftwareTitle}
-            iconUploadedAt={iconUploadedAt}
-            setIconUploadedAt={setIconUploadedAt}
-            installerType={installerType}
-            previewInfo={{
-              name: softwareTitle.display_name || softwareTitle.name,
-              titleName: softwareTitle.name,
-              type: formatSoftwareType(softwareTitle),
-              source: softwareTitle.source,
-              currentIconUrl: softwareTitle.icon_url,
-              versions: softwareTitle.versions?.length ?? 0,
-              countsUpdatedAt: softwareTitle.counts_updated_at,
-              selfServiceVersion: softwareInstaller.version,
-            }}
-          />
-        )}
-      {showEditSoftwareModal && softwareInstaller && teamId && (
+      {showEditIconModal && hasValidTeamId && softwareInstaller && (
+        <EditIconModal
+          softwareId={softwareId}
+          teamIdForApi={teamId}
+          software={softwareInstaller}
+          onExit={() => setShowEditIconModal(false)}
+          refetchSoftwareTitle={refetchSoftwareTitle}
+          iconUploadedAt={iconUploadedAt}
+          setIconUploadedAt={setIconUploadedAt}
+          installerType={installerType}
+          previewInfo={{
+            name: softwareTitle.display_name || softwareTitle.name,
+            titleName: softwareTitle.name,
+            type: formatSoftwareType(softwareTitle),
+            source: softwareTitle.source,
+            currentIconUrl: softwareTitle.icon_url,
+            versions: softwareTitle.versions?.length ?? 0,
+            countsUpdatedAt: softwareTitle.counts_updated_at,
+            selfServiceVersion: softwareInstaller.version,
+          }}
+        />
+      )}
+      {showEditSoftwareModal && hasValidTeamId && softwareInstaller && (
         <EditSoftwareModal
           router={router}
           softwareId={softwareId}
@@ -194,7 +191,7 @@ const SoftwareSummaryCard = ({
           source={softwareTitle.source}
         />
       )}
-      {showEditConfigurationModal && softwareInstaller && teamId && (
+      {showEditConfigurationModal && hasValidTeamId && softwareInstaller && (
         <EditConfigurationModal
           softwareInstaller={softwareInstaller as IAppStoreApp}
           softwareId={softwareId}


### PR DESCRIPTION
## Issue
Closes #37724 
Closes #37610 

## Description
- Edit software and edit configuration conditionals were catching no teams as not valid team number even though no teams has software installers
- Fix conditionals

## Screenshots of fixes
<img width="1137" height="491" alt="Screenshot 2025-12-29 at 10 13 49 AM" src="https://github.com/user-attachments/assets/177bf5eb-25cd-48f1-95d1-01076a2c95d5" />
<img width="1237" height="594" alt="Screenshot 2025-12-29 at 10 14 04 AM" src="https://github.com/user-attachments/assets/d4de0cf2-4463-4b9c-9d20-2dbf4d5e4cec" />


## Testing

- [x] QA'd all new/changed functionality manually
