### PR TITLE
Clean up android app config data layer, fix no-team persist bug

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1758,7 +1758,10 @@ func (ds *Datastore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs
 		return nil, ctxerr.Wrap(ctx, err, "building bulk get android app configurations query")
 	}
 
-	var configs []*fleet.AndroidAppConfiguration
+	var configs []*struct {
+		ApplicationID string          `db:"application_id"`
+		Configuration json.RawMessage `db:"configuration"`
+	}
 	err = sqlx.SelectContext(ctx, ds.reader(ctx), &configs, stmt, args...)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "bulk get android app configurations")

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql/common_mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
@@ -1839,11 +1840,7 @@ func (ds *Datastore) updateAndroidAppConfigurationTx(ctx context.Context, tx sql
 			configuration = VALUES(configuration)
 	`
 
-	var teamIDPtr *uint
-	if teamID > 0 {
-		teamIDPtr = &teamID
-	}
-	_, err = tx.ExecContext(ctx, stmt, appID, teamIDPtr, teamID, config)
+	_, err = tx.ExecContext(ctx, stmt, appID, ptr.UintOrNilIfZero(teamID), teamID, config)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "updateAndroidAppConfiguration")
 	}

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -1675,7 +1675,7 @@ WHERE
 // HasAndroidAppConfigurationChanged checks if the new configuration for an Android app
 // identified by application_id and global_or_team_id is different from the existing one. This
 // is a datastore method so that we rely on mysql's canonicalisation of JSON for comparison.
-func (ds *Datastore) HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, globalOrTeamID uint, newConfig json.RawMessage) (bool, error) {
+func (ds *Datastore) HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, teamID uint, newConfig json.RawMessage) (bool, error) {
 	const stmt = `
 SELECT
 	CAST(? AS JSON) != configuration AS has_changed
@@ -1692,7 +1692,7 @@ WHERE
 	}
 
 	var hasChanged bool
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &hasChanged, stmt, newConfigStr, applicationID, globalOrTeamID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &hasChanged, stmt, newConfigStr, applicationID, teamID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			// old config does not exist, so old one is changed if not empty
@@ -1705,22 +1705,15 @@ WHERE
 
 // GetAndroidAppConfiguration retrieves the configuration for an Android app
 // identified by adam_id and global_or_team_id.
-func (ds *Datastore) GetAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) (*fleet.AndroidAppConfiguration, error) {
+func (ds *Datastore) GetAndroidAppConfiguration(ctx context.Context, adamID string, teamID uint) (*fleet.AndroidAppConfiguration, error) {
 	stmt := `
-		SELECT
-			id,
-			application_id,
-			team_id,
-			global_or_team_id,
-			configuration,
-			created_at,
-			updated_at
+		SELECT application_id, team_id, configuration
 		FROM android_app_configurations
 		WHERE application_id = ? AND global_or_team_id = ?
 	`
 
 	var config fleet.AndroidAppConfiguration
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &config, stmt, adamID, globalOrTeamID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &config, stmt, adamID, teamID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ctxerr.Wrap(ctx, notFound("AndroidAppConfiguration"))
@@ -1759,7 +1752,7 @@ func (ds *Datastore) GetAndroidAppConfigurationByAppTeamID(ctx context.Context, 
 	return &config, nil
 }
 
-func (ds *Datastore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error) {
+func (ds *Datastore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, teamID uint) (map[string]json.RawMessage, error) {
 	const bulkGetStmt = `
 	SELECT
 		application_id,
@@ -1772,7 +1765,7 @@ func (ds *Datastore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs
 		return nil, nil
 	}
 
-	stmt, args, err := sqlx.In(bulkGetStmt, appIDs, globalOrTeamID)
+	stmt, args, err := sqlx.In(bulkGetStmt, appIDs, teamID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "building bulk get android app configurations query")
 	}
@@ -1817,55 +1810,14 @@ WHERE
 	return nil
 }
 
-// InsertAndroidAppConfiguration creates a new Android app configuration entry.
-func (ds *Datastore) InsertAndroidAppConfiguration(ctx context.Context, config *fleet.AndroidAppConfiguration) error {
-	stmt := `
-		INSERT INTO android_app_configurations
-		(application_id, team_id, global_or_team_id, configuration)
-		VALUES (?, ?, ?, ?)
-	`
-
-	_, err := ds.writer(ctx).ExecContext(ctx, stmt, config.ApplicationID, config.TeamID, config.GlobalOrTeamID, config.Configuration)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "insert android app configuration")
-	}
-
-	return nil
-}
-
-// UpdateAndroidAppConfiguration updates an existing Android app configuration.
-func (ds *Datastore) UpdateAndroidAppConfiguration(ctx context.Context, config *fleet.AndroidAppConfiguration) error {
-	stmt := `
-		UPDATE android_app_configurations
-		SET configuration = ?, updated_at = CURRENT_TIMESTAMP(6)
-		WHERE application_id = ? AND global_or_team_id = ?
-	`
-
-	result, err := ds.writer(ctx).ExecContext(ctx, stmt, config.Configuration, config.ApplicationID, config.GlobalOrTeamID)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "update android app configuration")
-	}
-
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "update android app configuration rows affected")
-	}
-
-	if rows == 0 {
-		return ctxerr.Wrap(ctx, notFound("AndroidAppConfiguration"))
-	}
-
-	return nil
-}
-
 // DeleteAndroidAppConfiguration removes an Android app configuration.
-func (ds *Datastore) DeleteAndroidAppConfiguration(ctx context.Context, appID string, globalOrTeamID uint) error {
+func (ds *Datastore) DeleteAndroidAppConfiguration(ctx context.Context, appID string, teamID uint) error {
 	stmt := `
 		DELETE FROM android_app_configurations
 		WHERE application_id = ? AND global_or_team_id = ?
 	`
 
-	result, err := ds.writer(ctx).ExecContext(ctx, stmt, appID, globalOrTeamID)
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt, appID, teamID)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "delete android app configuration")
 	}

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -2356,21 +2356,19 @@ func testInsertAndGetAndroidAppConfiguration(t *testing.T, ds *Datastore) {
 	retrieved, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
 	require.NoError(t, err)
 	require.NotNil(t, retrieved)
-	require.Equal(t, appID, retrieved.ApplicationID)
-	require.Nil(t, retrieved.TeamID)
-	require.JSONEq(t, string(config.Configuration), string(retrieved.Configuration))
+	require.JSONEq(t, string(config.Configuration), string(*retrieved))
 
 	// test bulk-get configuration
 	configsByAppID, err := ds.BulkGetAndroidAppConfigurations(testCtx(), []string{appID}, 0)
 	require.NoError(t, err)
 	require.Len(t, configsByAppID, 1)
-	require.Equal(t, string(retrieved.Configuration), string(configsByAppID[appID]))
+	require.Equal(t, string(*retrieved), string(configsByAppID[appID]))
 
 	// bulk-get configuration returns any known app config, ignores others
 	configsByAppID, err = ds.BulkGetAndroidAppConfigurations(testCtx(), []string{appID, "no-such-app"}, 0)
 	require.NoError(t, err)
 	require.Len(t, configsByAppID, 1)
-	require.Equal(t, string(retrieved.Configuration), string(configsByAppID[appID]))
+	require.Equal(t, string(*retrieved), string(configsByAppID[appID]))
 }
 
 func testUpdateAndroidAppConfiguration(t *testing.T, ds *Datastore) {
@@ -2394,7 +2392,7 @@ func testUpdateAndroidAppConfiguration(t *testing.T, ds *Datastore) {
 	// Verify update
 	retrieved, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
 	require.NoError(t, err)
-	require.JSONEq(t, string(newConfig), string(retrieved.Configuration))
+	require.JSONEq(t, string(newConfig), string(*retrieved))
 }
 
 func testDeleteAndroidAppConfiguration(t *testing.T, ds *Datastore) {
@@ -2488,15 +2486,12 @@ func testAndroidAppConfigurationGlobalVsTeam(t *testing.T, ds *Datastore) {
 	// Verify global configuration
 	retrievedGlobal, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"managedConfiguration": {"env": "global"}}`, string(retrievedGlobal.Configuration))
-	require.Nil(t, retrievedGlobal.TeamID)
+	require.JSONEq(t, `{"managedConfiguration": {"env": "global"}}`, string(*retrievedGlobal))
 
 	// Verify team configuration
 	retrievedTeam, err := ds.GetAndroidAppConfiguration(testCtx(), appID, teamID)
 	require.NoError(t, err)
-	require.JSONEq(t, `{"managedConfiguration": {"env": "team"}}`, string(retrievedTeam.Configuration))
-	require.NotNil(t, retrievedTeam.TeamID)
-	require.Equal(t, teamID, *retrievedTeam.TeamID)
+	require.JSONEq(t, `{"managedConfiguration": {"env": "team"}}`, string(*retrievedTeam))
 }
 
 func testAddDeleteAndroidAppWithConfiguration(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -2346,7 +2346,7 @@ func testInsertAndGetAndroidAppConfiguration(t *testing.T, ds *Datastore) {
 	configuration := json.RawMessage(`{"managedConfiguration": {"key": "value"}}`)
 
 	// Insert configuration
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, configuration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, configuration))
 
 	// Get configuration
 	retrieved, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
@@ -2374,11 +2374,11 @@ func testUpdateAndroidAppConfiguration(t *testing.T, ds *Datastore) {
 	configuration := json.RawMessage(`{"managedConfiguration": {"key": "value1"}}`)
 
 	// Insert initial configuration
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, configuration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, configuration))
 
 	// Update configuration
 	newConfig := json.RawMessage(`{"managedConfiguration": {"key": "value2"}, "workProfileWidgets": "WORK_PROFILE_WIDGETS_ALLOWED"}`)
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, newConfig))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, newConfig))
 
 	// Verify update
 	retrieved, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
@@ -2393,7 +2393,7 @@ func testDeleteAndroidAppConfiguration(t *testing.T, ds *Datastore) {
 	configuration := json.RawMessage(`{"managedConfiguration": {}}`)
 
 	// Insert configuration
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, configuration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, configuration))
 
 	// Verify it exists
 	_, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
@@ -2429,7 +2429,7 @@ func testAndroidAppConfigurationCascadeDeleteTeam(t *testing.T, ds *Datastore) {
 	configuration := json.RawMessage(`{"managedConfiguration": {}}`)
 
 	// Insert configuration
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), ptr.Uint(teamID), appID, configuration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), teamID, appID, configuration))
 
 	// Verify it exists
 	_, err := ds.GetAndroidAppConfiguration(testCtx(), appID, teamID)
@@ -2452,11 +2452,11 @@ func testAndroidAppConfigurationGlobalVsTeam(t *testing.T, ds *Datastore) {
 
 	// Insert global configuration
 	globalConfiguration := json.RawMessage(`{"managedConfiguration": {"env": "global"}}`)
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, globalConfiguration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, globalConfiguration))
 
 	// Insert team configuration
 	teamConfiguration := json.RawMessage(`{"managedConfiguration": {"env": "team"}}`)
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), ptr.Uint(teamID), appID, teamConfiguration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), teamID, appID, teamConfiguration))
 
 	// Verify global configuration
 	retrievedGlobal, err := ds.GetAndroidAppConfiguration(testCtx(), appID, 0)
@@ -2544,7 +2544,7 @@ func testHasAndroidAppConfigurationChanged(t *testing.T, ds *Datastore) {
 	setupTestApp(t, ds, appID)
 
 	configuration := json.RawMessage(`{"managedConfiguration": {"a": 1}}`)
-	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), nil, appID, configuration))
+	require.NoError(t, ds.updateAndroidAppConfigurationTx(testCtx(), ds.writer(testCtx()), 0, appID, configuration))
 
 	cases := []struct {
 		desc         string

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -100,8 +100,8 @@ WHERE
 	if err != nil && !fleet.IsNotFound(err) {
 		return nil, ctxerr.Wrap(ctx, err, "get android configuration for app store app")
 	}
-	if config != nil && config.Configuration != nil {
-		app.Configuration = config.Configuration
+	if config != nil {
+		app.Configuration = *config
 	}
 
 	if teamID != nil {

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -522,7 +522,7 @@ func (ds *Datastore) SetTeamVPPApps(ctx context.Context, teamID *uint, incomingA
 			}
 
 			if toAdd.Configuration != nil {
-				if err := ds.updateAndroidAppConfigurationTx(ctx, tx, teamID, toAdd.AdamID, toAdd.Configuration); err != nil {
+				if err := ds.updateAndroidAppConfigurationTx(ctx, tx, ptr.ValOrZero(teamID), toAdd.AdamID, toAdd.Configuration); err != nil {
 					return ctxerr.Wrap(ctx, err, "setting configuration for android app")
 				}
 			}
@@ -662,7 +662,7 @@ func (ds *Datastore) InsertVPPAppWithTeam(ctx context.Context, app *fleet.VPPApp
 		}
 
 		if app.Configuration != nil && app.Platform == fleet.AndroidPlatform {
-			if err := ds.updateAndroidAppConfigurationTx(ctx, tx, teamID, app.AdamID, app.Configuration); err != nil {
+			if err := ds.updateAndroidAppConfigurationTx(ctx, tx, ptr.ValOrZero(teamID), app.AdamID, app.Configuration); err != nil {
 				return ctxerr.Wrap(ctx, err, "setting configuration for android app")
 			}
 		}

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -2595,7 +2595,7 @@ func testAndroidAppConfigs(t *testing.T, ds *Datastore) {
 		config, err := ds.GetAndroidAppConfiguration(ctx, a.AdamID, team.ID)
 		require.True(t, err == nil || fleet.IsNotFound(err))
 		if config != nil {
-			a.Configuration = config.Configuration
+			a.Configuration = *config
 			assigned[a.VPPAppID] = a
 		}
 	}
@@ -2620,9 +2620,17 @@ func testAndroidAppConfigs(t *testing.T, ds *Datastore) {
 	for _, a := range assigned {
 		config, err := ds.GetAndroidAppConfiguration(ctx, a.AdamID, team.ID)
 		require.True(t, err == nil || fleet.IsNotFound(err))
+		byAppTeamIdConfig, byAppTeamIdErr := ds.GetAndroidAppConfigurationByAppTeamID(ctx, a.AppTeamID)
+
 		if config != nil {
-			a.Configuration = config.Configuration
+			a.Configuration = *config
 			assigned[a.VPPAppID] = a
+
+			require.NoError(t, byAppTeamIdErr)
+			require.JSONEq(t, string(*config), string(*byAppTeamIdConfig))
+		} else {
+			require.Nil(t, byAppTeamIdConfig)
+			require.True(t, fleet.IsNotFound(byAppTeamIdErr))
 		}
 	}
 

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -141,13 +141,9 @@ type AndroidPolicyRequestPayloadMetadata struct {
 // AndroidAppConfiguration represents an Android app configuration stored in Fleet.
 // It contains the managedConfiguration and workProfileWidgets settings for an Android app.
 type AndroidAppConfiguration struct {
-	ID             uint            `db:"id" json:"id"`
-	ApplicationID  string          `db:"application_id" json:"application_id"`
-	TeamID         *uint           `db:"team_id" json:"team_id,omitempty"`
-	GlobalOrTeamID uint            `db:"global_or_team_id" json:"global_or_team_id"`
-	Configuration  json.RawMessage `db:"configuration" json:"configuration"`
-	CreatedAt      time.Time       `db:"created_at" json:"created_at"`
-	UpdatedAt      time.Time       `db:"updated_at" json:"updated_at"`
+	ApplicationID string          `db:"application_id" json:"application_id"`
+	TeamID        *uint           `db:"team_id" json:"team_id,omitempty"`
+	Configuration json.RawMessage `db:"configuration" json:"configuration"`
 }
 
 var (
@@ -209,6 +205,7 @@ func ValidateAndroidAppConfiguration(config json.RawMessage) error {
 				Message: `Couldn't update configuration. Only "managedConfiguration" and "workProfileWidgets" are supported as top-level keys.`,
 			}
 		}
+
 		return &BadRequestError{
 			Message: "Couldn't update configuration. Invalid JSON.",
 		}

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -138,14 +138,6 @@ type AndroidPolicyRequestPayloadMetadata struct {
 	SettingsOrigin map[string]string `json:"settings_origin"` // Map of policy setting name, to profile uuid.
 }
 
-// AndroidAppConfiguration represents an Android app configuration stored in Fleet.
-// It contains the managedConfiguration and workProfileWidgets settings for an Android app.
-type AndroidAppConfiguration struct {
-	ApplicationID string          `db:"application_id" json:"application_id"`
-	TeamID        *uint           `db:"team_id" json:"team_id,omitempty"`
-	Configuration json.RawMessage `db:"configuration" json:"configuration"`
-}
-
 var (
 	policyFieldsCache map[string]bool
 	policyFieldsOnce  sync.Once

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2395,10 +2395,9 @@ type Datastore interface {
 	// VPP app install record for the setup experience flow.
 	InsertAndroidSetupExperienceSoftwareInstall(ctx context.Context, payload *HostAndroidVPPSoftwareInstall) error
 
-	// GetAndroidAppConfiguration retrieves the configuration for an Android app
-	// identified by adam_id and global_or_team_id.
-	GetAndroidAppConfiguration(ctx context.Context, adamID string, teamID uint) (*AndroidAppConfiguration, error)
-	GetAndroidAppConfigurationByAppTeamID(ctx context.Context, vppAppTeamID uint) (*AndroidAppConfiguration, error)
+	// GetAndroidAppConfiguration retrieves the configuration for an Android app by application ID and team
+	GetAndroidAppConfiguration(ctx context.Context, applicationID string, teamID uint) (*json.RawMessage, error)
+	GetAndroidAppConfigurationByAppTeamID(ctx context.Context, vppAppTeamID uint) (*json.RawMessage, error)
 	HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, teamID uint, newConfig json.RawMessage) (bool, error)
 
 	SetAndroidAppInstallPendingApplyConfig(ctx context.Context, hostUUID, applicationID string, policyVersion int64) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2397,24 +2397,18 @@ type Datastore interface {
 
 	// GetAndroidAppConfiguration retrieves the configuration for an Android app
 	// identified by adam_id and global_or_team_id.
-	GetAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) (*AndroidAppConfiguration, error)
+	GetAndroidAppConfiguration(ctx context.Context, adamID string, teamID uint) (*AndroidAppConfiguration, error)
 	GetAndroidAppConfigurationByAppTeamID(ctx context.Context, vppAppTeamID uint) (*AndroidAppConfiguration, error)
-	HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, globalOrTeamID uint, newConfig json.RawMessage) (bool, error)
+	HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, teamID uint, newConfig json.RawMessage) (bool, error)
 
 	SetAndroidAppInstallPendingApplyConfig(ctx context.Context, hostUUID, applicationID string, policyVersion int64) error
 
 	// BulkGetAndroidAppConfigurations retrieves Android app configurations for
 	// all provided apps and returns them indexed by the app id.
-	BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error)
-
-	// InsertAndroidAppConfiguration creates a new Android app configuration entry.
-	InsertAndroidAppConfiguration(ctx context.Context, config *AndroidAppConfiguration) error
-
-	// UpdateAndroidAppConfiguration updates an existing Android app configuration.
-	UpdateAndroidAppConfiguration(ctx context.Context, config *AndroidAppConfiguration) error
+	BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, teamID uint) (map[string]json.RawMessage, error)
 
 	// DeleteAndroidAppConfiguration removes an Android app configuration.
-	DeleteAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) error
+	DeleteAndroidAppConfiguration(ctx context.Context, adamID string, teamID uint) error
 
 	ListMDMAndroidUUIDsToHostIDs(ctx context.Context, hostIDs []uint) (map[string]uint, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1559,17 +1559,17 @@ type ListAndroidEnrolledDevicesForReconcileFunc func(ctx context.Context) ([]*an
 
 type InsertAndroidSetupExperienceSoftwareInstallFunc func(ctx context.Context, payload *fleet.HostAndroidVPPSoftwareInstall) error
 
-type GetAndroidAppConfigurationFunc func(ctx context.Context, adamID string, globalOrTeamID uint) (*fleet.AndroidAppConfiguration, error)
+type GetAndroidAppConfigurationFunc func(ctx context.Context, applicationID string, teamID uint) (*json.RawMessage, error)
 
-type GetAndroidAppConfigurationByAppTeamIDFunc func(ctx context.Context, vppAppTeamID uint) (*fleet.AndroidAppConfiguration, error)
+type GetAndroidAppConfigurationByAppTeamIDFunc func(ctx context.Context, vppAppTeamID uint) (*json.RawMessage, error)
 
-type HasAndroidAppConfigurationChangedFunc func(ctx context.Context, applicationID string, globalOrTeamID uint, newConfig json.RawMessage) (bool, error)
+type HasAndroidAppConfigurationChangedFunc func(ctx context.Context, applicationID string, teamID uint, newConfig json.RawMessage) (bool, error)
 
 type SetAndroidAppInstallPendingApplyConfigFunc func(ctx context.Context, hostUUID string, applicationID string, policyVersion int64) error
 
-type BulkGetAndroidAppConfigurationsFunc func(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error)
+type BulkGetAndroidAppConfigurationsFunc func(ctx context.Context, appIDs []string, teamID uint) (map[string]json.RawMessage, error)
 
-type DeleteAndroidAppConfigurationFunc func(ctx context.Context, adamID string, globalOrTeamID uint) error
+type DeleteAndroidAppConfigurationFunc func(ctx context.Context, adamID string, teamID uint) error
 
 type ListMDMAndroidUUIDsToHostIDsFunc func(ctx context.Context, hostIDs []uint) (map[string]uint, error)
 
@@ -9618,25 +9618,25 @@ func (s *DataStore) InsertAndroidSetupExperienceSoftwareInstall(ctx context.Cont
 	return s.InsertAndroidSetupExperienceSoftwareInstallFunc(ctx, payload)
 }
 
-func (s *DataStore) GetAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) (*fleet.AndroidAppConfiguration, error) {
+func (s *DataStore) GetAndroidAppConfiguration(ctx context.Context, applicationID string, teamID uint) (*json.RawMessage, error) {
 	s.mu.Lock()
 	s.GetAndroidAppConfigurationFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetAndroidAppConfigurationFunc(ctx, adamID, globalOrTeamID)
+	return s.GetAndroidAppConfigurationFunc(ctx, applicationID, teamID)
 }
 
-func (s *DataStore) GetAndroidAppConfigurationByAppTeamID(ctx context.Context, vppAppTeamID uint) (*fleet.AndroidAppConfiguration, error) {
+func (s *DataStore) GetAndroidAppConfigurationByAppTeamID(ctx context.Context, vppAppTeamID uint) (*json.RawMessage, error) {
 	s.mu.Lock()
 	s.GetAndroidAppConfigurationByAppTeamIDFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetAndroidAppConfigurationByAppTeamIDFunc(ctx, vppAppTeamID)
 }
 
-func (s *DataStore) HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, globalOrTeamID uint, newConfig json.RawMessage) (bool, error) {
+func (s *DataStore) HasAndroidAppConfigurationChanged(ctx context.Context, applicationID string, teamID uint, newConfig json.RawMessage) (bool, error) {
 	s.mu.Lock()
 	s.HasAndroidAppConfigurationChangedFuncInvoked = true
 	s.mu.Unlock()
-	return s.HasAndroidAppConfigurationChangedFunc(ctx, applicationID, globalOrTeamID, newConfig)
+	return s.HasAndroidAppConfigurationChangedFunc(ctx, applicationID, teamID, newConfig)
 }
 
 func (s *DataStore) SetAndroidAppInstallPendingApplyConfig(ctx context.Context, hostUUID string, applicationID string, policyVersion int64) error {
@@ -9646,18 +9646,18 @@ func (s *DataStore) SetAndroidAppInstallPendingApplyConfig(ctx context.Context, 
 	return s.SetAndroidAppInstallPendingApplyConfigFunc(ctx, hostUUID, applicationID, policyVersion)
 }
 
-func (s *DataStore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error) {
+func (s *DataStore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs []string, teamID uint) (map[string]json.RawMessage, error) {
 	s.mu.Lock()
 	s.BulkGetAndroidAppConfigurationsFuncInvoked = true
 	s.mu.Unlock()
-	return s.BulkGetAndroidAppConfigurationsFunc(ctx, appIDs, globalOrTeamID)
+	return s.BulkGetAndroidAppConfigurationsFunc(ctx, appIDs, teamID)
 }
 
-func (s *DataStore) DeleteAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) error {
+func (s *DataStore) DeleteAndroidAppConfiguration(ctx context.Context, adamID string, teamID uint) error {
 	s.mu.Lock()
 	s.DeleteAndroidAppConfigurationFuncInvoked = true
 	s.mu.Unlock()
-	return s.DeleteAndroidAppConfigurationFunc(ctx, adamID, globalOrTeamID)
+	return s.DeleteAndroidAppConfigurationFunc(ctx, adamID, teamID)
 }
 
 func (s *DataStore) ListMDMAndroidUUIDsToHostIDs(ctx context.Context, hostIDs []uint) (map[string]uint, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1569,10 +1569,6 @@ type SetAndroidAppInstallPendingApplyConfigFunc func(ctx context.Context, hostUU
 
 type BulkGetAndroidAppConfigurationsFunc func(ctx context.Context, appIDs []string, globalOrTeamID uint) (map[string]json.RawMessage, error)
 
-type InsertAndroidAppConfigurationFunc func(ctx context.Context, config *fleet.AndroidAppConfiguration) error
-
-type UpdateAndroidAppConfigurationFunc func(ctx context.Context, config *fleet.AndroidAppConfiguration) error
-
 type DeleteAndroidAppConfigurationFunc func(ctx context.Context, adamID string, globalOrTeamID uint) error
 
 type ListMDMAndroidUUIDsToHostIDsFunc func(ctx context.Context, hostIDs []uint) (map[string]uint, error)
@@ -4032,12 +4028,6 @@ type DataStore struct {
 
 	BulkGetAndroidAppConfigurationsFunc        BulkGetAndroidAppConfigurationsFunc
 	BulkGetAndroidAppConfigurationsFuncInvoked bool
-
-	InsertAndroidAppConfigurationFunc        InsertAndroidAppConfigurationFunc
-	InsertAndroidAppConfigurationFuncInvoked bool
-
-	UpdateAndroidAppConfigurationFunc        UpdateAndroidAppConfigurationFunc
-	UpdateAndroidAppConfigurationFuncInvoked bool
 
 	DeleteAndroidAppConfigurationFunc        DeleteAndroidAppConfigurationFunc
 	DeleteAndroidAppConfigurationFuncInvoked bool
@@ -9661,20 +9651,6 @@ func (s *DataStore) BulkGetAndroidAppConfigurations(ctx context.Context, appIDs 
 	s.BulkGetAndroidAppConfigurationsFuncInvoked = true
 	s.mu.Unlock()
 	return s.BulkGetAndroidAppConfigurationsFunc(ctx, appIDs, globalOrTeamID)
-}
-
-func (s *DataStore) InsertAndroidAppConfiguration(ctx context.Context, config *fleet.AndroidAppConfiguration) error {
-	s.mu.Lock()
-	s.InsertAndroidAppConfigurationFuncInvoked = true
-	s.mu.Unlock()
-	return s.InsertAndroidAppConfigurationFunc(ctx, config)
-}
-
-func (s *DataStore) UpdateAndroidAppConfiguration(ctx context.Context, config *fleet.AndroidAppConfiguration) error {
-	s.mu.Lock()
-	s.UpdateAndroidAppConfigurationFuncInvoked = true
-	s.mu.Unlock()
-	return s.UpdateAndroidAppConfigurationFunc(ctx, config)
 }
 
 func (s *DataStore) DeleteAndroidAppConfiguration(ctx context.Context, adamID string, globalOrTeamID uint) error {

--- a/server/ptr/ptr.go
+++ b/server/ptr/ptr.go
@@ -21,6 +21,15 @@ func Uint(x uint) *uint {
 	return &x
 }
 
+// UintOrNilIfZero returns nil if the supplied value is zero, else a pointer to the provided uint.
+// This is useful for cases that expect nil to be supplied for "No team" instead of zero.
+func UintOrNilIfZero(x uint) *uint {
+	if x > 0 {
+		return &x
+	}
+	return nil
+}
+
 // Bool returns a pointer to the provided bool.
 func Bool(x bool) *bool {
 	return &x

--- a/server/ptr/ptr.go
+++ b/server/ptr/ptr.go
@@ -22,7 +22,8 @@ func Uint(x uint) *uint {
 }
 
 // UintOrNilIfZero returns nil if the supplied value is zero, else a pointer to the provided uint.
-// This is useful for cases that expect nil to be supplied for "No team" instead of zero.
+// This is useful for cases that expect nil to be supplied for "No team" instead of zero, and allows for
+// a quick way to sidestep e.g. https://github.com/fleetdm/fleet/issues/37729 (which ptr.Uint() would cause).
 func UintOrNilIfZero(x uint) *uint {
 	if x > 0 {
 		return &x

--- a/server/worker/software_worker.go
+++ b/server/worker/software_worker.go
@@ -134,9 +134,9 @@ func (v *SoftwareWorker) makeAndroidAppAvailable(ctx context.Context, applicatio
 		return ctxerr.Wrap(ctx, err, "get android app configuration")
 	}
 	var configByAppID map[string]json.RawMessage
-	if config != nil && config.Configuration != nil {
+	if config != nil {
 		configByAppID = map[string]json.RawMessage{
-			applicationID: config.Configuration,
+			applicationID: *config,
 		}
 	}
 


### PR DESCRIPTION
Resolves #37729. Unreleased, so no changes file.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored Android app configuration storage and retrieval to use JSON-based format instead of structured objects.
  * Updated configuration lookups to use team-based identification consistently.
  * Added new method for retrieving Android app configurations by app team ID.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->