### PR TITLE
Add new sync fields to `santa_status` table and schema

### DIFF
--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -95,7 +95,7 @@ func extractValues(line string) map[string]string {
 	rest := line[pos+len(kLogEntryPreface):]
 
 	// Parse key=value pairs separated by |
-	for _, seg := range strings.Split(rest, "|") {
+	for seg := range strings.SplitSeq(rest, "|") {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
 			continue

--- a/orbit/pkg/table/santa/santa_log.go
+++ b/orbit/pkg/table/santa/santa_log.go
@@ -94,7 +94,8 @@ func extractValues(line string) map[string]string {
 	}
 	rest := line[pos+len(kLogEntryPreface):]
 
-	for seg := range strings.SplitSeq(rest, "|") {
+	// Parse key=value pairs separated by |
+	for _, seg := range strings.Split(rest, "|") {
 		seg = strings.TrimSpace(seg)
 		if seg == "" {
 			continue

--- a/orbit/pkg/table/santa/santa_status.go
+++ b/orbit/pkg/table/santa/santa_status.go
@@ -52,16 +52,19 @@ type santaStatus struct {
 		TransitiveRules int  `json:"transitive_rules"`
 	} `json:"transitive_allowlisting"`
 	Sync struct {
-		Enabled             bool   `json:"enabled"`
-		Server              string `json:"server"`
-		CleanRequired       bool   `json:"clean_required"`
-		LastSuccessfulFull  string `json:"last_successful_full"`
-		LastSuccessfulRule  string `json:"last_successful_rule"`
-		PushNotifications   string `json:"push_notifications"`
-		BundleScanning      bool   `json:"bundle_scanning"`
-		EventsPendingUpload int    `json:"events_pending_upload"`
-		ExecutionRulesHash  string `json:"execution_rules_hash"`
-		FileAccessRulesHash string `json:"file_access_rules_hash"`
+		Enabled                               bool   `json:"enabled"`
+		Server                                string `json:"server"`
+		CleanRequired                         bool   `json:"clean_required"`
+		LastSuccessfulFull                    string `json:"last_successful_full"`
+		LastSuccessfulRule                    string `json:"last_successful_rule"`
+		PushNotifications                     string `json:"push_notifications"`
+		PushServer                            string `json:"push_server"`
+		BundleScanning                        bool   `json:"bundle_scanning"`
+		EventsPendingUpload                   int    `json:"events_pending_upload"`
+		ExecutionRulesHash                    string `json:"execution_rules_hash"`
+		FullSyncIntervalSeconds               int    `json:"full_sync_interval_seconds"`
+		PushNotificationsFullSyncIntervalSecs int    `json:"push_notifications_full_sync_interval_seconds"`
+		FileAccessRulesHash                   string `json:"file_access_rules_hash"`
 	} `json:"sync"`
 	WatchItems struct {
 		Enabled          bool   `json:"enabled"`
@@ -111,7 +114,10 @@ func StatusColumns() []table.ColumnDefinition {
 		table.TextColumn("sync_push_notifications"),
 		table.IntegerColumn("sync_bundle_scanning"),
 		table.TextColumn("sync_execution_rules_hash"),
+		table.IntegerColumn("sync_full_sync_interval_seconds"),
+		table.IntegerColumn("sync_push_notifications_full_sync_interval_seconds"),
 		table.TextColumn("sync_file_access_rules_hash"),
+		table.TextColumn("sync_push_server"),
 		table.TextColumn("watch_items_data_source"),
 		table.IntegerColumn("watch_items_rule_count"),
 		table.TextColumn("watch_items_last_policy_update"),
@@ -169,15 +175,18 @@ func GenerateStatus(ctx context.Context, _ table.QueryContext) ([]map[string]str
 		"sync_push_notifications":         status.Sync.PushNotifications,
 		"sync_bundle_scanning":            boolToIntString(status.Sync.BundleScanning),
 		"sync_execution_rules_hash":       status.Sync.ExecutionRulesHash,
-		"sync_file_access_rules_hash":     status.Sync.FileAccessRulesHash,
-		"watch_items_data_source":         status.WatchItems.DataSource,
-		"watch_items_rule_count":          strconv.Itoa(status.WatchItems.RuleCount),
-		"watch_items_last_policy_update":  status.WatchItems.LastPolicyUpdate,
-		"watch_items_policy_version":      status.WatchItems.PolicyVersion,
-		"watch_items_config_path":         status.WatchItems.ConfigPath,
-		"metrics_enabled":                 boolToIntString(status.Metrics.Enabled),
-		"metrics_server":                  status.Metrics.Server,
-		"metrics_export_interval_seconds": strconv.Itoa(status.Metrics.ExportIntervalSeconds),
+		"sync_full_sync_interval_seconds": strconv.Itoa(status.Sync.FullSyncIntervalSeconds),
+		"sync_push_notifications_full_sync_interval_seconds": strconv.Itoa(status.Sync.PushNotificationsFullSyncIntervalSecs),
+		"sync_file_access_rules_hash":                        status.Sync.FileAccessRulesHash,
+		"sync_push_server":                                   status.Sync.PushServer,
+		"watch_items_data_source":                            status.WatchItems.DataSource,
+		"watch_items_rule_count":                             strconv.Itoa(status.WatchItems.RuleCount),
+		"watch_items_last_policy_update":                     status.WatchItems.LastPolicyUpdate,
+		"watch_items_policy_version":                         status.WatchItems.PolicyVersion,
+		"watch_items_config_path":                            status.WatchItems.ConfigPath,
+		"metrics_enabled":                                    boolToIntString(status.Metrics.Enabled),
+		"metrics_server":                                     status.Metrics.Server,
+		"metrics_export_interval_seconds":                    strconv.Itoa(status.Metrics.ExportIntervalSeconds),
 	}
 
 	return []map[string]string{row}, nil

--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -24563,8 +24563,26 @@
         "type": "text"
       },
       {
+        "name": "sync_full_sync_interval_seconds",
+        "description": "The full sync interval in seconds",
+        "required": false,
+        "type": "integer"
+      },
+      {
+        "name": "sync_push_notifications_full_sync_interval_seconds",
+        "description": "The push notifications full sync interval in seconds",
+        "required": false,
+        "type": "integer"
+      },
+      {
         "name": "sync_file_access_rules_hash",
         "description": "Hash of the currently applied execution ruleset",
+        "required": false,
+        "type": "text"
+      },
+      {
+        "name": "sync_push_server",
+        "description": "The push server address",
         "required": false,
         "type": "text"
       },
@@ -24740,7 +24758,7 @@
         "name": "metrics_server",
         "description": "The address of the server Santa sends metrics to.",
         "required": false,
-        "type": "integer"
+        "type": "text"
       },
       {
         "name": "watch_items_config_path",

--- a/schema/tables/santa_status.yml
+++ b/schema/tables/santa_status.yml
@@ -29,8 +29,20 @@ columns:
     description: Hash of the currently applied file access ruleset
     required: false
     type: text
+  - name: sync_full_sync_interval_seconds
+    description: The full sync interval in seconds
+    required: false
+    type: integer
+  - name: sync_push_notifications_full_sync_interval_seconds
+    description: The push notifications full sync interval in seconds
+    required: false
+    type: integer
   - name: sync_file_access_rules_hash
     description: Hash of the currently applied execution ruleset
+    required: false
+    type: text
+  - name: sync_push_server
+    description: The push server address
     required: false
     type: text
   - name: sync_bundle_scanning
@@ -148,7 +160,7 @@ columns:
   - name: metrics_server
     description: The address of the server Santa sends metrics to.
     required: false
-    type: integer
+    type: text
   - name: watch_items_config_path
     description: Path to the configuration file that defines watch items
     required: false


### PR DESCRIPTION
This pull request updates the Santa status table to include additional sync-related fields and corrects a schema type error. The main changes add new columns to track sync intervals and the push server, ensuring the schema, Go struct, and table generation logic are consistent. Additionally, a documentation comment and a type fix for an existing column are included.

**Santa sync status enhancements:**

* Added new fields to the `santaStatus` struct: `PushServer`, `FullSyncIntervalSeconds`, and `PushNotificationsFullSyncIntervalSecs` to capture additional sync details.
* Updated the `StatusColumns` function and `GenerateStatus` logic to include the new sync fields in the table output: `sync_full_sync_interval_seconds`, `sync_push_notifications_full_sync_interval_seconds`, and `sync_push_server`. [[1]](diffhunk://#diff-1e21295af3b6002891553d75334d896b280b8d28419fbe0c868830e605d1b129R117-R120) [[2]](diffhunk://#diff-1e21295af3b6002891553d75334d896b280b8d28419fbe0c868830e605d1b129R178-R181)
* Extended the `santa_status.yml` schema to define the new columns, including descriptions and types for the sync interval and push server fields.

**Schema and documentation improvements:**

* Fixed the type of the `metrics_server` column in `santa_status.yml` from `integer` to `text` to match its actual usage.
* Added a clarifying comment in `santa_log.go` to explain parsing of key-value pairs separated by `|` in log lines.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
