### PR TITLE
Add `brew_list` table for Homebrew package info on macOS

### DIFF
--- a/orbit/pkg/table/brew_list/brew_list.go
+++ b/orbit/pkg/table/brew_list/brew_list.go
@@ -1,0 +1,349 @@
+//go:build darwin
+
+// Package brew_list implements the table for getting Homebrew package information
+// on macOS systems.
+//
+// Based on https://github.com/allenhouchins/fleet-extensions/tree/main/brew_list
+package brew_list
+
+import (
+	"bufio"
+	"context"
+	"database/sql"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/osquery/osquery-go/plugin/table"
+	"github.com/rs/zerolog/log"
+)
+
+func Columns() []table.ColumnDefinition {
+	return []table.ColumnDefinition{
+		table.TextColumn("package_name"),
+		table.TextColumn("version"),
+		table.TextColumn("install_path"),
+		table.TextColumn("type"),
+	}
+}
+
+func Generate(ctx context.Context, queryContext table.QueryContext) ([]map[string]string, error) {
+	// Find Homebrew installation path
+	brewPath, err := findHomebrewPath()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to find Homebrew installation")
+		return []map[string]string{}, nil
+	}
+
+	// Read from Homebrew database directly
+	results, err := readHomebrewDatabase(ctx, brewPath)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to read Homebrew database")
+		return []map[string]string{}, nil
+	}
+
+	return results, nil
+}
+
+func findHomebrewPath() (string, error) {
+	// First, try to find brew using 'which' command
+	whichCmd := exec.Command("which", "brew")
+	output, err := whichCmd.Output()
+	if err == nil {
+		brewPath := strings.TrimSpace(string(output))
+		if brewPath != "" {
+			// Extract the Homebrew root directory from the brew binary path
+			// e.g., /opt/homebrew/bin/brew -> /opt/homebrew
+			homebrewRoot := filepath.Dir(filepath.Dir(brewPath))
+			if _, err := os.Stat(homebrewRoot); err == nil {
+				return homebrewRoot, nil
+			}
+		}
+	}
+
+	// Fallback: check common Homebrew installation paths
+	homebrewPaths := []string{
+		"/opt/homebrew", // Apple Silicon Mac
+		"/usr/local",    // Intel Mac
+	}
+
+	for _, path := range homebrewPaths {
+		// Check if the path exists and contains Homebrew
+		if _, err := os.Stat(path); err == nil {
+			// Check for Homebrew-specific files
+			if _, err := os.Stat(filepath.Join(path, "bin", "brew")); err == nil {
+				return path, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("Homebrew installation not found")
+}
+
+func readHomebrewDatabase(ctx context.Context, brewPath string) ([]map[string]string, error) {
+	// Try multiple possible database locations
+	possibleDBPaths := []string{
+		filepath.Join(brewPath, "var", "db", "formula_versions.db"),
+		filepath.Join(brewPath, "var", "db", "formula_versions.sqlite"),
+		filepath.Join(brewPath, "var", "db", "formula_versions"),
+		filepath.Join(brewPath, "var", "db", "homebrew.db"),
+		filepath.Join(brewPath, "var", "db", "homebrew.sqlite"),
+		filepath.Join(brewPath, "var", "db", "homebrew"),
+	}
+
+	var dbPath string
+	for _, path := range possibleDBPaths {
+		if _, err := os.Stat(path); err == nil {
+			dbPath = path
+			break
+		}
+	}
+
+	if dbPath == "" {
+		return readBrewCommands(ctx, brewPath)
+	}
+
+	// Copy database to temporary location to avoid locking issues
+	tempDB, err := copyDatabase(dbPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to copy database: %v", err)
+	}
+	defer os.Remove(tempDB)
+
+	// Open the temporary database
+	db, err := sql.Open("sqlite3", tempDB)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open database: %v", err)
+	}
+	defer db.Close()
+
+	// Query the database for installed packages
+	rows, err := db.QueryContext(ctx, `
+		SELECT name, version, path 
+		FROM formula_versions 
+		WHERE installed = 1
+		ORDER BY name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query database: %v", err)
+	}
+	defer rows.Close()
+
+	var results []map[string]string
+	for rows.Next() {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		var name, version, path sql.NullString
+		err := rows.Scan(&name, &version, &path)
+		if err != nil {
+			log.Debug().Err(err).Msg("failed to scan row")
+			continue
+		}
+
+		packageName := ""
+		if name.Valid {
+			packageName = name.String
+		}
+
+		packageVersion := ""
+		if version.Valid {
+			packageVersion = version.String
+		}
+
+		installPath := ""
+		if path.Valid {
+			installPath = path.String
+		} else {
+			// Fallback: construct path from Homebrew prefix
+			installPath = filepath.Join(brewPath, "opt", packageName)
+		}
+
+		if packageName != "" {
+			// Determine if it's a cask or formula
+			packageType := determinePackageType(brewPath, packageName)
+
+			results = append(results, map[string]string{
+				"package_name": packageName,
+				"version":      packageVersion,
+				"install_path": installPath,
+				"type":         packageType,
+			})
+		}
+	}
+
+	return results, nil
+}
+
+func copyDatabase(srcPath string) (string, error) {
+	// Create temporary file
+	tempFile, err := os.CreateTemp("", "homebrew_db_*.db")
+	if err != nil {
+		return "", err
+	}
+	tempPath := tempFile.Name()
+	tempFile.Close()
+
+	// Copy the database file
+	srcFile, err := os.Open(srcPath)
+	if err != nil {
+		os.Remove(tempPath)
+		return "", err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(tempPath)
+	if err != nil {
+		os.Remove(tempPath)
+		return "", err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		os.Remove(tempPath)
+		return "", err
+	}
+
+	return tempPath, nil
+}
+
+func readBrewCommands(ctx context.Context, brewPath string) ([]map[string]string, error) {
+	// Use brew commands with proper environment setup to avoid root issues
+	brewBinary := filepath.Join(brewPath, "bin", "brew")
+
+	// Get list of installed packages
+	cmd := exec.CommandContext(ctx, brewBinary, "list")
+	cmd.Env = append(os.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1", "HOMEBREW_NO_ANALYTICS=1")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("brew list command failed: %v", err)
+	}
+
+	// Try to get versions using brew list --versions first
+	versionMap := make(map[string]string)
+	versionCmd := exec.CommandContext(ctx, brewBinary, "list", "--versions")
+	versionCmd.Env = append(os.Environ(), "HOMEBREW_NO_AUTO_UPDATE=1", "HOMEBREW_NO_ANALYTICS=1")
+	versionOutput, err := versionCmd.CombinedOutput()
+	if err != nil {
+		// Fallback: try to get versions from package directories
+		versionMap = getVersionsFromDirectories(brewPath, strings.Fields(string(output)))
+	} else {
+		// Parse versions from command output
+		scanner := bufio.NewScanner(strings.NewReader(string(versionOutput)))
+		for scanner.Scan() {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			default:
+			}
+
+			line := strings.TrimSpace(scanner.Text())
+			parts := strings.Fields(line)
+			if len(parts) >= 2 {
+				versionMap[parts[0]] = parts[1]
+			}
+		}
+	}
+
+	// Parse package list and build results
+	results := []map[string]string{}
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+
+	for scanner.Scan() {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		packageName := strings.TrimSpace(scanner.Text())
+		if packageName == "" {
+			continue
+		}
+
+		// Get version from the map and construct install path
+		version := versionMap[packageName]
+		installPath := filepath.Join(brewPath, "opt", packageName)
+
+		// Determine if it's a cask or formula
+		packageType := determinePackageType(brewPath, packageName)
+
+		results = append(results, map[string]string{
+			"package_name": packageName,
+			"version":      version,
+			"install_path": installPath,
+			"type":         packageType,
+		})
+	}
+
+	return results, nil
+}
+
+func getVersionsFromDirectories(brewPath string, packageNames []string) map[string]string {
+	versionMap := make(map[string]string)
+
+	for _, packageName := range packageNames {
+		// Try to read version from package directory
+		packagePath := filepath.Join(brewPath, "opt", packageName)
+
+		// Check if there's a version file
+		versionFile := filepath.Join(packagePath, "VERSION")
+		if content, err := os.ReadFile(versionFile); err == nil {
+			version := strings.TrimSpace(string(content))
+			if version != "" {
+				versionMap[packageName] = version
+				continue
+			}
+		}
+
+		// Check if there's a .version file
+		versionFile = filepath.Join(packagePath, ".version")
+		if content, err := os.ReadFile(versionFile); err == nil {
+			version := strings.TrimSpace(string(content))
+			if version != "" {
+				versionMap[packageName] = version
+				continue
+			}
+		}
+
+		// Try to extract version from symlink target
+		if linkTarget, err := os.Readlink(packagePath); err == nil {
+			// Extract version from path like /opt/homebrew/Cellar/package/1.2.3
+			parts := strings.Split(linkTarget, "/")
+			for i, part := range parts {
+				if part == "Cellar" && i+2 < len(parts) {
+					// The version should be the part after the package name
+					versionMap[packageName] = parts[i+2]
+					break
+				}
+			}
+		}
+	}
+
+	return versionMap
+}
+
+func determinePackageType(brewPath, packageName string) string {
+	// Check if it's a cask by looking in the Caskroom directory
+	caskPath := filepath.Join(brewPath, "Caskroom", packageName)
+	if _, err := os.Stat(caskPath); err == nil {
+		return "cask"
+	}
+
+	// Check if it's a formula by looking in the Cellar directory
+	cellarPath := filepath.Join(brewPath, "Cellar", packageName)
+	if _, err := os.Stat(cellarPath); err == nil {
+		return "formula"
+	}
+
+	// Default to formula if we can't determine
+	return "formula"
+}

--- a/orbit/pkg/table/extension_darwin.go
+++ b/orbit/pkg/table/extension_darwin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/app_sso_platform"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/authdb"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/table/brew_list"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/codesign"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/csrutil_info"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/table/dataflattentable"
@@ -111,6 +112,8 @@ func PlatformTables(opts PluginOpts) ([]osquery.OsqueryPlugin, error) {
 		table.NewPlugin("santa_status", santa.StatusColumns(), santa.GenerateStatus),
 		table.NewPlugin("santa_allowed", santa.LogColumns(), santa.GenerateAllowed),
 		table.NewPlugin("santa_denied", santa.LogColumns(), santa.GenerateDenied),
+
+		table.NewPlugin("brew_list", brew_list.Columns(), brew_list.Generate),
 	}
 
 	// append platform specific tables

--- a/schema/tables/brew_list.yml
+++ b/schema/tables/brew_list.yml
@@ -1,0 +1,70 @@
+name: brew_list
+description: List all Homebrew packages (formulas and casks) installed on macOS systems. This table provides package names, versions, installation paths, and package types.
+platforms:
+  - darwin
+evented: false
+examples: |-
+  List all installed Homebrew packages:
+
+  ```
+  SELECT * FROM brew_list;
+  ```
+
+  Find a specific package:
+
+  ```
+  SELECT * FROM brew_list WHERE package_name = 'git';
+  ```
+
+  Count total packages:
+
+  ```
+  SELECT COUNT(*) as total_packages FROM brew_list;
+  ```
+
+  List only casks (macOS only):
+
+  ```
+  SELECT * FROM brew_list WHERE type = 'cask';
+  ```
+
+  List only formulae:
+
+  ```
+  SELECT * FROM brew_list WHERE type = 'formula';
+  ```
+
+  Count packages by type:
+
+  ```
+  SELECT type, COUNT(*) as count FROM brew_list GROUP BY type;
+  ```
+
+  Find packages with specific version patterns:
+
+  ```
+  SELECT package_name, version FROM brew_list WHERE version LIKE '2.%';
+  ```
+notes: |-
+  - This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+  - The table automatically detects Homebrew installation locations on macOS systems (supports both Apple Silicon and Intel Macs).
+  - The table uses multiple data collection methods: it first attempts to read from Homebrew's SQLite database, then falls back to `brew list` commands if the database is not available.
+  - If Homebrew is not installed or not accessible, the table will return empty results without errors.
+columns:
+  - name: package_name
+    description: Name of the Homebrew package
+    required: false
+    type: text
+  - name: version
+    description: Installed version of the package
+    required: false
+    type: text
+  - name: install_path
+    description: Full path where the package is installed (typically under the Homebrew prefix, e.g., /opt/homebrew/opt/<package_name> or /usr/local/opt/<package_name>)
+    required: false
+    type: text
+  - name: type
+    description: Package type - either "cask" (macOS GUI applications) or "formula" (command-line tools and libraries).
+    required: false
+    type: text
+


### PR DESCRIPTION
This pull request introduces a new `brew_list` table for macOS systems, enabling Fleet to list all Homebrew-installed packages (both formulas and casks) along with their versions, installation paths, and types. The implementation includes robust detection of Homebrew installations, reads directly from Homebrew's database when available, and falls back to command-line parsing as needed. Documentation and schema for the new table are also provided.

**New Homebrew package listing table:**

* Added a new `brew_list` table implementation in `brew_list.go` that detects Homebrew installation, reads package data from the Homebrew SQLite database when possible, and falls back to parsing `brew list` command output if necessary. The table returns package name, version, install path, and type (formula or cask).
* Registered the `brew_list` table in the platform-specific table registration for macOS in `extension_darwin.go`, making it available to osquery on macOS systems. [[1]](diffhunk://#diff-4c9ade3d475001a482c681538183cd1c6a45cabec826b8b0c138a04035434441R10) [[2]](diffhunk://#diff-4c9ade3d475001a482c681538183cd1c6a45cabec826b8b0c138a04035434441R115-R116)

**Documentation and schema:**

* Added a schema file `brew_list.yml` describing the new table, its columns, usage examples, and notes about its behavior and platform support.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
