### PR TITLE
Fleet UI: Update the read-only SQL editor to appear non-interactive

### DIFF
--- a/changes/33509-see-host-location
+++ b/changes/33509-see-host-location
@@ -1,0 +1,1 @@
+- Fleet UI: Surface host location as google map, including iOS/iPadOS while in lost mode

--- a/changes/33509-see-host-location
+++ b/changes/33509-see-host-location
@@ -1,1 +1,0 @@
-- Fleet UI: Surface host location as google map, including iOS/iPadOS while in lost mode

--- a/changes/34124-sql-editor-disabled
+++ b/changes/34124-sql-editor-disabled
@@ -1,0 +1,1 @@
+- Fleet UI: Adjust the read-only SQL editor to appear non-interactive

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -7,10 +7,33 @@
     &--error {
       color: $core-vibrant-red;
     }
+
     &--with-action {
       display: flex;
       justify-content: space-between;
       align-items: center;
+
+      .sql-editor__label-text {
+        flex: 1 1 auto;
+        margin-right: $pad-small;
+      }
+
+      .sql-editor__label-actions {
+        display: flex;
+        align-items: center;
+        gap: $pad-xsmall;
+        flex: 0 0 auto;
+      }
+
+      .sql-editor__copy-wrapper {
+        display: flex;
+        align-items: center;
+        gap: $pad-xxsmall;
+      }
+
+      .sql-editor__copied-confirmation {
+        @include copy-message;
+      }
 
       button {
         height: initial; // aligning space between label and textarea
@@ -32,6 +55,29 @@
     }
     &--disabled {
       @include disabled;
+    }
+
+    &--readonly-copy {
+      cursor: default;
+
+      .ace-fleet:hover {
+        border: 1px solid $ui-blue-gray;
+      }
+
+      // remove interaction on both code + gutter
+      .ace_scroller,
+      .ace_gutter {
+        pointer-events: auto;
+        cursor: not-allowed;
+        user-select: none;
+      }
+
+      // keep label actions (copy, etc.) usable
+      .sql-editor__label-actions,
+      .sql-editor__label-actions * {
+        pointer-events: auto;
+        cursor: pointer;
+      }
     }
   }
 

--- a/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
+++ b/frontend/pages/labels/components/DynamicLabelForm/DynamicLabelForm.tsx
@@ -140,6 +140,7 @@ const DynamicLabelForm = ({
               onLoad={onLoad}
               wrapperClassName={`${baseClass}__text-editor-wrapper form-field`}
               wrapEnabled
+              enableCopy={isEditing}
             />
             <PlatformField
               platform={platform}

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -207,6 +207,7 @@ $max-width: 2560px;
   border: solid 1px #e2e4ea;
   border-radius: 10px;
   padding: 2px 6px;
+  margin: -4px 0;
 }
 
 @mixin color-contrasted-sections {


### PR DESCRIPTION
## Issue
Closes #34124 

## Description
- Makes the SQL editor that's readonly and copyable not look editable
- Ensured cannot reach it via mouse or keyboard, ensured copy button works, ensured styling doesn't change on hover anywhere

## Screenrecording of update


https://github.com/user-attachments/assets/00e73111-d674-488f-8c07-8a3813e547fc


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
