### PR TITLE
GitOps: Android config generated in team software directory

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1613,7 +1613,8 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 			config := softwareTitle.AppStoreApp.Configuration
 			if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
-				fileName := fmt.Sprintf("lib/%s/configs/%s", teamFilename, filenamePrefix+"-config.json")
+				// all per-team software-related artifacts are generated in lib/{team}/software
+				fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
 				path := fmt.Sprintf("../%s", fileName)
 				softwareSpec["configuration"] = map[string]any{
 					"path": path,


### PR DESCRIPTION
## Issue
For #30836 

## Description
- [x] Android config goes into `../<team>/software/` directory when generating
- [x] Confirmed for no teams
- [x] Confirmed that nothing is generated when android is empty json

## Screenshot of update

<img width="1443" height="741" alt="Screenshot 2025-12-30 at 4 53 52 PM" src="https://github.com/user-attachments/assets/1465279c-2ae6-4de0-916c-8439312d7eca" />




## Testing

- [x] QA'd all new/changed functionality manually
