### PR TITLE
Fix fleetctl config help display for missing arguments

### DIFF
--- a/changes/36702-fix-fleetctl-config-help
+++ b/changes/36702-fix-fleetctl-config-help
@@ -1,0 +1,1 @@
+- Fixed fleetctl config get/set to show proper usage information when called without required arguments

--- a/cmd/fleetctl/fleetctl/config.go
+++ b/cmd/fleetctl/fleetctl/config.go
@@ -337,7 +337,7 @@ func configSetCommand() *cli.Command {
 			}
 
 			if !set {
-				return cli.ShowCommandHelp(c, "set")
+				return cli.ShowSubcommandHelp(c)
 			}
 
 			return nil
@@ -356,7 +356,7 @@ func configGetCommand() *cli.Command {
 		},
 		Action: func(c *cli.Context) error {
 			if c.Args().Len() != 1 {
-				return cli.ShowCommandHelp(c, "get")
+				return cli.ShowSubcommandHelp(c)
 			}
 
 			key := c.Args().Get(0)
@@ -365,7 +365,7 @@ func configGetCommand() *cli.Command {
 			switch key {
 			case "address", "email", "token", "tls-skip-verify", "rootca", "url-prefix", "custom-headers":
 			default:
-				return cli.ShowCommandHelp(c, "get")
+				return cli.ShowSubcommandHelp(c)
 			}
 
 			configPath, context := c.String("config"), c.String("context")

--- a/cmd/fleetctl/fleetctl/config_test.go
+++ b/cmd/fleetctl/fleetctl/config_test.go
@@ -167,3 +167,32 @@ func TestCustomHeadersConfig(t *testing.T) {
 	RunAppNoChecks([]string{"get", "packs", "--config", configFile}) //nolint:errcheck
 	require.True(t, called)
 }
+
+func TestConfigGetShowsHelp(t *testing.T) {
+	t.Run("config get without args shows help", func(t *testing.T) {
+		w, err := RunAppNoChecks([]string{"config", "get"})
+		require.NoError(t, err)
+		output := w.String()
+		require.Contains(t, output, "NAME:")
+		require.Contains(t, output, "fleetctl config get")
+		require.Contains(t, output, "Get a config option")
+	})
+
+	t.Run("config get with invalid key shows help", func(t *testing.T) {
+		w, err := RunAppNoChecks([]string{"config", "get", "invalidkey"})
+		require.NoError(t, err)
+		output := w.String()
+		require.Contains(t, output, "NAME:")
+		require.Contains(t, output, "fleetctl config get")
+		require.Contains(t, output, "Get a config option")
+	})
+
+	t.Run("config set without flags shows help", func(t *testing.T) {
+		w, err := RunAppNoChecks([]string{"config", "set"})
+		require.NoError(t, err)
+		output := w.String()
+		require.Contains(t, output, "NAME:")
+		require.Contains(t, output, "fleetctl config set")
+		require.Contains(t, output, "Set config options")
+	})
+}


### PR DESCRIPTION
Replace cli.ShowCommandHelp with cli.ShowSubcommandHelp to properly show usage information when fleetctl config get/set are called without required arguments. Previously displayed confusing "No help topic for 'get'" error, now shows helpful command help matching --help behavior. Fixes #36702

## Fix: `fleetctl config get/set` now shows helpful usage information

Fixed the issue where running `fleetctl config get` or `fleetctl config set` without proper arguments would show a confusing error message. These commands now display helpful usage information, matching the behavior of `--help`.

### Before the fix

Running `fleetctl config get` without arguments:

```bash
$ fleetctl config get
Error: No help topic for 'get'
exit status 1
```

### After the fix

Now running the same commands shows helpful usage information:

#### `fleetctl config get` (without arguments)

```bash
$ fleetctl config get
NAME:
   fleetctl config get - Get a config option

USAGE:
   fleetctl config get [options]

OPTIONS:
   --config value   Path to the fleetctl config file (default: "/home/ben/.fleet/config") [$CONFIG]
   --context value  Name of fleetctl config context to use (default: "default") [$CONTEXT]
   --help, -h       show help
```

#### `fleetctl config get invalidkey` (invalid key)

```bash
$ fleetctl config get invalidkey
NAME:
   fleetctl config get - Get a config option

USAGE:
   fleetctl config get [options]

OPTIONS:
   --config value   Path to the fleetctl config file (default: "/home/ben/.fleet/config") [$CONFIG]
   --context value  Name of fleetctl config context to use (default: "default") [$CONTEXT]
   --help, -h       show help
```

#### `fleetctl config set` (without flags)

```bash
$ fleetctl config set
NAME:
   fleetctl config set - Set config options

USAGE:
   fleetctl config set [options]

OPTIONS:
   --config value                                   Path to the fleetctl config file (default: "/home/ben/.fleet/config") [$CONFIG]
   --context value                                  Name of fleetctl config context to use (default: "default") [$CONTEXT]
   --address value                                  Address of the Fleet server [$ADDRESS]
   --email value                                    Email to use when connecting to the Fleet server [$EMAIL]
   --token value                                    Fleet API token [$TOKEN]
   --tls-skip-verify                                Skip TLS certificate validation (default: false) [$INSECURE]
   --rootca value                                   Specify RootCA chain used to communicate with Fleet [$ROOTCA]
   --url-prefix value                               Specify URL Prefix to use with Fleet server (copy from server configuration) [$URL_PREFIX]
   --custom-header value [ --custom-header value ]  Specify a custom header as 'Header:Value' to be set on every request to the Fleet server (can be specified multiple times for multiple headers, note that this replaces any existing custom headers). Note that when using the environment variable to set this option, it must be set like so: 'CUSTOM_HEADER=Header:Value,Header:Value', and the value cannot contain commas. [$CUSTOM_HEADER]
   --help, -h                                       show help
```

#### Normal operation still works as expected

```bash
$ fleetctl config get address
  default.address => http://test.local

$ fleetctl config get --help
NAME:
   fleetctl config get - Get a config option

USAGE:
   fleetctl config get [options]

OPTIONS:
   --config value   Path to the fleetctl config file (default: "/home/ben/.fleet/config") [$CONFIG]
   --context value  Name of fleetctl config context to use (default: "default") [$CONTEXT]
   --help, -h       show help
```


**Related issue:** Resolves #36702

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] Added/updated automated tests

- [X] QA'd all new/changed functionality manually
