### PR TITLE
GitOps: Android config generated in team software directory (#37767)

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1612,7 +1612,8 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 			config := softwareTitle.AppStoreApp.Configuration
 			if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
-				fileName := fmt.Sprintf("lib/%s/configs/%s", teamFilename, filenamePrefix+"-config.json")
+				// all per-team software-related artifacts are generated in lib/{team}/software
+				fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
 				path := fmt.Sprintf("../%s", fileName)
 				softwareSpec["configuration"] = map[string]any{
 					"path": path,


### PR DESCRIPTION
## Issue
For #30836 

## Description
- Already merged into `main` with #37767 
- This is the cherry-pick into the 4.79 RC

```
 1059  git pull fleetdm main
 1060  git fetch fleetdm
 1061  git checkout fleetdm/rc-minor-fleet-v4.79.0
 1062  git checkout -b 30836-generate-gitops-android-rc
 1063  git log main
 1064  git cherry-pick e171c02a0390f9fa19878c754e86a164168765b0
 1065  git push -u fleetdm 30836-generate-gitops-android-rc
```