### PR TITLE
Validate certificate template names (#37765)

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/components/AddCertificateModal/helpers.ts
@@ -37,7 +37,7 @@ export const generateFormValidations = (
         {
           name: "required",
           isValid: (formData: IAddCertFormData) => {
-            return formData.name.length > 0;
+            return formData.name.trim().length > 0;
           },
         },
         {

--- a/server/datastore/mysql/certificate_templates.go
+++ b/server/datastore/mysql/certificate_templates.go
@@ -162,6 +162,9 @@ func (ds *Datastore) CreateCertificateTemplate(ctx context.Context, certificateT
 		) VALUES (?, ?, ?, ?)
 	`, certificateTemplate.Name, certificateTemplate.TeamID, certificateTemplate.CertificateAuthorityID, certificateTemplate.SubjectName)
 	if err != nil {
+		if IsDuplicate(err) {
+			return nil, ctxerr.Wrap(ctx, alreadyExists("CertificateTemplate", certificateTemplate.Name), "inserting certificate_template")
+		}
 		return nil, ctxerr.Wrap(ctx, err, "inserting certificate_template")
 	}
 

--- a/server/service/certificate_templates_test.go
+++ b/server/service/certificate_templates_test.go
@@ -85,6 +85,88 @@ func TestCreateCertificateTemplate(t *testing.T) {
 		// Check that the error is about invalid CA type
 		require.Contains(t, err.Error(), "not found")
 	})
+
+	t.Run("Empty or whitespace-only name", func(t *testing.T) {
+		whitespaceNames := []string{"", " ", "  ", "\t", "\n", "   \t\n  "}
+		for _, name := range whitespaceNames {
+			_, err := svc.CreateCertificateTemplate(ctx, name, TeamID, uint(ValidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Certificate template name is required")
+		}
+	})
+
+	t.Run("Name too long", func(t *testing.T) {
+		longName := string(make([]byte, 256))
+		for i := range longName {
+			longName = longName[:i] + "a" + longName[i+1:]
+		}
+		_, err := svc.CreateCertificateTemplate(ctx, longName, TeamID, uint(ValidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Certificate template name is too long")
+	})
+
+	t.Run("Name with invalid characters", func(t *testing.T) {
+		testCases := []struct {
+			name string
+		}{
+			{name: "template@name"},
+			{name: "template#name"},
+			{name: "template$name"},
+			{name: "template%name"},
+			{name: "template.name"},
+			{name: "template/name"},
+			{name: "template\\name"},
+			{name: "template!name"},
+			{name: "template?name"},
+			{name: "template*name"},
+			{name: "template+name"},
+			{name: "template=name"},
+			{name: "template<name>"},
+			{name: "template(name)"},
+			{name: "template[name]"},
+			{name: "template{name}"},
+			{name: "template|name"},
+			{name: "template;name"},
+			{name: "template:name"},
+			{name: "template'name"},
+			{name: "template\"name"},
+			{name: "template`name"},
+			{name: "template~name"},
+			{name: "template^name"},
+			{name: "template	name"},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := svc.CreateCertificateTemplate(ctx, tc.name, TeamID, uint(ValidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "Invalid certificate template name")
+			})
+		}
+	})
+
+	t.Run("Name with valid characters", func(t *testing.T) {
+		validNames := []string{
+			"my template",
+			" my template ",
+			"my-template",
+			"my_template",
+			"MyTemplate123",
+			"Template 1",
+			"UPPERCASE",
+			"lowercase",
+			"Mix-Ed_Case 123",
+			"a",
+			"1",
+			"a1",
+			"1a",
+		}
+		for _, name := range validNames {
+			t.Run(name, func(t *testing.T) {
+				_, err := svc.CreateCertificateTemplate(ctx, name, TeamID, uint(ValidCATypeID), "CN=$FLEET_VAR_HOST_UUID")
+				require.NoError(t, err)
+			})
+		}
+	})
 }
 
 func TestApplyCertificateTemplateSpecs(t *testing.T) {
@@ -235,5 +317,57 @@ func TestApplyCertificateTemplateSpecs(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("Empty name", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "",
+				CertificateAuthorityId: 1,
+				SubjectName:            "foo",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Certificate template name is required")
+	})
+
+	t.Run("Whitespace-only name", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "   ",
+				CertificateAuthorityId: 1,
+				SubjectName:            "foo",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Certificate template name is required")
+	})
+
+	t.Run("Name with invalid characters", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "template@name",
+				CertificateAuthorityId: 1,
+				SubjectName:            "foo",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Invalid certificate template name")
+	})
+
+	t.Run("Name too long", func(t *testing.T) {
+		longName := string(make([]byte, 256))
+		for i := range longName {
+			longName = longName[:i] + "a" + longName[i+1:]
+		}
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   longName,
+				CertificateAuthorityId: 1,
+				SubjectName:            "foo",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Certificate template name is too long")
 	})
 }

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -186,7 +186,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateLifecycle() {
 	})
 
 	// Step: Create a certificate template
-	certTemplateName := t.Name() + "-CertTemplate"
+	certTemplateName := strings.ReplaceAll(t.Name(), "/", "-") + "-CertTemplate"
 	var createResp createCertificateTemplateResponse
 	s.DoJSON("POST", "/api/latest/fleet/certificates", createCertificateTemplateRequest{
 		Name:                   certTemplateName,
@@ -307,7 +307,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateSpecEndpointAndAMAPIFai
 	caID := ca.ID
 
 	// Step: Create certificate template via spec/certificates endpoint with $FLEET_VAR_HOST_UUID
-	certTemplateName := t.Name() + "-CertTemplate"
+	certTemplateName := strings.ReplaceAll(t.Name(), "/", "-") + "-CertTemplate"
 	var applyResp applyCertificateTemplateSpecsResponse
 	s.DoJSON("POST", "/api/latest/fleet/spec/certificates", applyCertificateTemplateSpecsRequest{
 		Specs: []*fleet.CertificateRequestSpec{
@@ -429,7 +429,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateNoTeamWithIDPVariable()
 	caID := ca.ID
 
 	// Step: Create certificate template for "no team" (team_id = 0) with IDP_USERNAME variable
-	certTemplateName := t.Name() + "-CertTemplate"
+	certTemplateName := strings.ReplaceAll(t.Name(), "/", "-") + "-CertTemplate"
 	var createResp createCertificateTemplateResponse
 	subjectName := "CN=$FLEET_VAR_HOST_END_USER_IDP_USERNAME"
 	s.DoJSON("POST", "/api/latest/fleet/certificates", createCertificateTemplateRequest{
@@ -586,7 +586,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateUnenrollReenroll() {
 	require.NoError(t, s.ds.UpdateHost(ctx, host))
 
 	// Step: Create the first certificate template (while host is enrolled)
-	certTemplateName := t.Name() + "-CertTemplate1"
+	certTemplateName := strings.ReplaceAll(t.Name(), "/", "-") + "-CertTemplate1"
 	var createResp createCertificateTemplateResponse
 	s.DoJSON("POST", "/api/latest/fleet/certificates", createCertificateTemplateRequest{
 		Name:                   certTemplateName,
@@ -614,7 +614,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateUnenrollReenroll() {
 	require.Equal(t, 0, enrolledStatus, "Host should be marked as unenrolled in host_mdm")
 
 	// Step: Create a second certificate template while host is unenrolled
-	certTemplateName2 := t.Name() + "-CertTemplate2"
+	certTemplateName2 := strings.ReplaceAll(t.Name(), "/", "-") + "-CertTemplate2"
 	s.DoJSON("POST", "/api/latest/fleet/certificates", createCertificateTemplateRequest{
 		Name:                   certTemplateName2,
 		TeamID:                 teamID,


### PR DESCRIPTION
Fix for unreleased bug:
- Enforce validation rules for certificate template names (e.g., length, allowed characters).
- Implement duplicate name error handling in MySQL datastore.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37761

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
* Certificate template naming now enforced with validation rules: no empty or whitespace-only names, character restrictions, and maximum length limits.
  * Validation occurs on both client and server sides.

* **Bug Fixes**
* Improved error handling and messaging for duplicate certificate templates.
  * Corrected certificate validation error message text.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit a3cc31dac8b1698a2d3b4a7351e2a267888c4e69)
