### PR TITLE
Fleet UI: Updates to lock modal only

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tests.tsx
@@ -1,0 +1,80 @@
+import React from "react";
+import { screen } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import LockModal from "./LockModal";
+
+const MOCK_PROPS = {
+  id: 7,
+  platform: "darwin",
+  hostName: "macos-host-1",
+  onSuccess: jest.fn(),
+  onClose: jest.fn(),
+};
+
+describe("LockModal", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders macOS description and confirm text for non‑iOS", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<LockModal {...MOCK_PROPS} />);
+
+    expect(
+      screen.getByText(
+        /Lock a host when it needs to be returned to your organization./i
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Fleet will generate a six-digit unlock PIN./i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/I wish to lock/i)).toBeInTheDocument();
+    expect(screen.getByText(/macos-host-1/i)).toBeInTheDocument();
+  });
+
+  it("renders iOS Lost Mode description and preview card when platform is iOS/iPadOS", () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    render(<LockModal {...MOCK_PROPS} platform="ios" hostName="iphone-1" />);
+
+    expect(
+      screen.getByText(/This enables what Apple calls/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Lost Mode/i)).toBeInTheDocument();
+    expect(screen.getByText(/End user experience/i)).toBeInTheDocument();
+    expect(
+      screen.getByAltText(/iPhone with a lock screen message/i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/I wish to lock/i)).toBeInTheDocument();
+    expect(screen.getByText(/iphone-1/i)).toBeInTheDocument();
+  });
+
+  it("disables Lock button until confirm checkbox is checked", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user } = render(<LockModal {...MOCK_PROPS} />);
+
+    const lockButton = screen.getByRole("button", { name: "Lock" });
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+
+    expect(lockButton).toBeDisabled();
+    expect(cancelButton).toBeEnabled();
+
+    const checkbox = screen.getByRole("checkbox", {
+      name: /macos-host-1/i,
+    });
+
+    await user.click(checkbox);
+
+    expect(lockButton).toBeEnabled();
+  });
+
+  it("calls onClose when Cancel is clicked", async () => {
+    const render = createCustomRenderer({ withBackendMock: true });
+    const { user } = render(<LockModal {...MOCK_PROPS} />);
+
+    const cancelButton = screen.getByRole("button", { name: "Cancel" });
+    await user.click(cancelButton);
+
+    expect(MOCK_PROPS.onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/LockModal/LockModal.tsx
@@ -27,7 +27,7 @@ const IosOrIpadLockPreview = () => {
       <h3>End user experience</h3>
       <p>
         Instead of &quot;Fleet&quot;, the message will show the{" "}
-        <b>Organization Name</b> that you configured in{" "}
+        <b>Organization name</b> that you configured in{" "}
         <Link to={PATHS.ADMIN_ORGANIZATION_INFO}>Organization settings</Link>.
       </p>
       <img src={IphoneLockPreview} alt="iPhone with a lock screen message" />
@@ -69,17 +69,19 @@ const LockModal = ({
 
   const renderDescription = () => {
     if (isIPadOrIPhone(platform)) {
-      // if (true) {
       return (
-        <p>
-          This will enable{" "}
-          <CustomLink
-            url="https://fleetdm.com/learn-more-about/managed-lost-mode"
-            newTab
-            text="Lost Mode"
-          />
-          . It can only be unlocked through Fleet.
-        </p>
+        <>
+          <p>
+            This enables what Apple calls{" "}
+            <CustomLink
+              url="https://fleetdm.com/learn-more-about/managed-lost-mode"
+              newTab
+              text="Lost Mode"
+            />
+            .
+          </p>
+          <p> It can only be unlocked through Fleet.</p>
+        </>
       );
     }
 
@@ -94,7 +96,7 @@ const LockModal = ({
   };
 
   return (
-    <Modal className={baseClass} title="Lock host" onExit={onClose}>
+    <Modal className={baseClass} title="Lock" onExit={onClose}>
       <>
         <div className={`${baseClass}__modal-content`}>
           <div className={`${baseClass}__description`}>
@@ -102,7 +104,7 @@ const LockModal = ({
           </div>
           <div className={`${baseClass}__confirm-message`}>
             <span>
-              <b>Please check to confirm:</b>
+              <b>Confirm:</b>
             </span>
             <Checkbox
               wrapperClassName={`${baseClass}__lock-checkbox`}


### PR DESCRIPTION
## Issue
Closes #37270
Parent issue #33509 

This is being merged into the [feature branch](https://github.com/fleetdm/fleet/tree/33509-feature-branch)

## Description
- Minor tweaks to existing lock modal only
- Update titles for similar modals per figma
- Add tests to existing lock modal

## Testing

- [x] QA'd all new/changed functionality manually
