### PR TITLE
FMA: Fix aircall category typo and add string check for category in generator

### DIFF
--- a/ee/maintained-apps/inputs/winget/aircall.json
+++ b/ee/maintained-apps/inputs/winget/aircall.json
@@ -6,5 +6,5 @@
   "installer_arch": "x64",
   "installer_type": "msi",
   "installer_scope": "machine",
-  "default_categories": ["Communicatio"]
+  "default_categories": ["Communication"]
 }

--- a/ee/maintained-apps/outputs/aircall/windows.json
+++ b/ee/maintained-apps/outputs/aircall/windows.json
@@ -10,7 +10,7 @@
       "uninstall_script_ref": "08c272d5",
       "sha256": "42e747bbeefb791ab6dca212c5b8f823bf90d6e6e6d3b0ab5db1bcd6d83bb268",
       "default_categories": [
-        "Communicatio"
+        "Communication"
       ]
     }
   ],

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -70,6 +70,7 @@ export interface ISoftwareInstallPolicy {
   name: string;
 }
 
+// Match allowedCategories in cmd/maintained-apps/main.go
 export type SoftwareCategory =
   | "Browsers"
   | "Communication"


### PR DESCRIPTION
## Issue
Closes #37803 

## Description
- Self explanatory

## Screenshot of error if typo
<img width="752" height="181" alt="Screenshot 2026-01-02 at 4 43 38 PM" src="https://github.com/user-attachments/assets/758e291c-b626-4bf0-93b8-fa53ece57a04" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
