### PR TITLE
Improve version matching in appExists for Windows

### DIFF
--- a/cmd/maintained-apps/validate/windows.go
+++ b/cmd/maintained-apps/validate/windows.go
@@ -108,6 +108,11 @@ func appExists(ctx context.Context, logger kitlog.Logger, appName, uniqueIdentif
 			if strings.HasPrefix(result.Version, appVersion+".") {
 				return true, nil
 			}
+			// Check if expected version starts with found version (handles cases where osquery reports shorter version)
+			// This handles cases where expected is "6.4.0" but osquery reports "6.4"
+			if strings.HasPrefix(appVersion, result.Version+".") {
+				return true, nil
+			}
 		}
 	}
 


### PR DESCRIPTION
Adds logic to handle cases where the expected app version is more specific than the version reported by osquery (e.g., expected '6.4.0' vs reported '6.4'). This ensures more robust version matching when validating installed applications.
