### PR TITLE
Fix debug log lines

### DIFF
--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -2796,7 +2796,11 @@ func (ds *Datastore) RenewMDMManagedCertificates(ctx context.Context) error {
 		limit := 1000
 		for hostPlatform, table := range hostProfileTables {
 			if limit == 0 {
-				level.Debug(ds.logger).Log("msg", "Skipping check of %s certificates on %s hosts to renew - limit exceeded by prior platform", hostCertType, hostPlatform)
+				level.Debug(ds.logger).Log(
+					"msg", "skipping check of certificates hosts to renew, limit exceeded by prior platform",
+					"host_cert_type", hostCertType,
+					"host_platform", hostPlatform,
+				)
 				continue
 			}
 			// This will trigger a resend next time profiles are checked
@@ -2837,7 +2841,11 @@ func (ds *Datastore) RenewMDMManagedCertificates(ctx context.Context) error {
 				return ctxerr.Wrap(ctx, err, "retrieving mdm managed certificates to renew")
 			}
 			if len(hostCertsToRenew) == 0 {
-				level.Debug(ds.logger).Log("msg", "No %s certificates on %s hosts to renew", hostCertType, hostPlatform)
+				level.Debug(ds.logger).Log(
+					"msg", "No certificates on hosts to renew",
+					"host_cert_type", hostCertType,
+					"host_platform", hostPlatform,
+				)
 				continue
 			}
 			limit -= len(hostCertsToRenew)

--- a/server/service/endpoint_middleware.go
+++ b/server/service/endpoint_middleware.go
@@ -225,7 +225,7 @@ func authenticatedOrbitHost(
 }
 
 func getOrbitNodeKey(ctx context.Context, r interface{}) (string, error) {
-	if onk, err := r.(interface{ orbitHostNodeKey() string }); err {
+	if onk, ok := r.(interface{ orbitHostNodeKey() string }); ok {
 		return onk.orbitHostNodeKey(), nil
 	}
 	return "", errors.New("error getting orbit node key")


### PR DESCRIPTION
Log lines were of the form:
```
73:level=debug ts=2025-12-31T16:07:22.404852Z msg="No %s certificates on %s hosts to renew" digicert=apple
```

(Found while investigating some oncall issues.)