### PR TITLE
update alignment and styles of host status tag

### DIFF
--- a/changes/issue-37832-alignment-host-status-tag
+++ b/changes/issue-37832-alignment-host-status-tag
@@ -1,0 +1,1 @@
+- tweak host status tag styles on host details page

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tests.tsx
@@ -134,7 +134,7 @@ describe("HostHeader", () => {
       />
     );
 
-    await user.hover(screen.getByText("LOCKED"));
+    await user.hover(screen.getByText("Locked"));
 
     expect(await screen.findByText(/Host is locked/i)).toBeInTheDocument();
   });

--- a/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/HostHeader.tsx
@@ -165,6 +165,7 @@ const HostHeader = ({
           position="top"
           underline={false}
           showArrow
+          className={`${baseClass}__device-status-tag-wrapper`}
         >
           <span className={classNames}>{tag.title}</span>
         </TooltipWrapper>

--- a/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostHeader/_styles.scss
@@ -1,9 +1,18 @@
 .host-header {
+  &__device-status-tag-wrapper {
+    // We are aligning self on the tag wrapper to center it vertically with the Host title.
+    // This tag will not always display and the default of the parent container is
+    // align: baseline, so we need to overrride this explicitly for the tag when we display it.
+    align-self: center;
+  }
+
   &__device-status-tag {
+    display: block;
     margin-left: $pad-small;
     background-color: $ui-warning;
     padding: $pad-xsmall;
-    font-size: 10px;
+    font-size: $xx-small;
+    color: $core-fleet-black;
     font-weight: $bold;
     border-radius: $border-radius;
 
@@ -19,7 +28,7 @@
 
   &__last-fetched {
     font-size: $xx-small;
-    color: $core-fleet-black;
+    color: $ui-fleet-black-75;
     margin: 0;
     margin-left: $pad-medium;
   }

--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -21,7 +21,7 @@ type DeviceStatusTagConfig = Record<
 
 export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
   locked: {
-    title: "LOCKED",
+    title: "Locked",
     tagType: "warning",
     generateTooltip: (platform) => {
       if (isIPadOrIPhone(platform)) {
@@ -53,13 +53,13 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
     },
   },
   unlocking: {
-    title: "UNLOCK PENDING",
+    title: "Unlock pending",
     tagType: "warning",
     generateTooltip: () =>
       "Host will unlock when it comes online.  If the host is online, it will unlock the next time it checks in to Fleet.",
   },
   locking: {
-    title: "LOCK PENDING",
+    title: "Lock pending",
     tagType: "warning",
     generateTooltip: () => (
       <>
@@ -70,7 +70,7 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
     ),
   },
   wiped: {
-    title: "WIPED",
+    title: "Wiped",
     tagType: "error",
     generateTooltip: (platform) =>
       isMacOS(platform)
@@ -78,7 +78,7 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
         : "Host is wiped.",
   },
   wiping: {
-    title: "WIPE PENDING",
+    title: "Wipe pending",
     tagType: "error",
     generateTooltip: () =>
       "Host will wipe when it comes online. If the host is online, it will wipe the next time it checks in to Fleet.",


### PR DESCRIPTION
**Related issue:** Resolves #34774

This updates the alignment of the host status tag to be vertically aligned with the host name on the host details page

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] QA'd all new/changed functionality manually
