### PR TITLE
Fixing upgrade code issues (#37785)

### DIFF
--- a/changes/37494-upgrade-code
+++ b/changes/37494-upgrade-code
@@ -1,0 +1,2 @@
+Fixed duplicate entry error when updating upgrade_code during software ingestion
+Fixed case sensitivity mismatches causing duplicate titles during software ingestion

--- a/cmd/osquery-perf/software-library/README.md
+++ b/cmd/osquery-perf/software-library/README.md
@@ -137,10 +137,10 @@ SELECT
     IFNULL(application_id, ''),
     IFNULL(upgrade_code, '')
 FROM software
-" 2>&1 | sed 's/\t/","/g' | sed 's/^/"/' | sed 's/$/"/' | tail -n +3 > source-data/server_export.csv
+" 2>&1 | sed 's/\t/","/g' | sed 's/^/"/' | sed 's/$/"/' | tail -n +2 > source-data/server_export.csv
 ```
 
-**Note:** This command properly quotes CSV fields to handle commas in values (e.g., "Red Hat, Inc."). The `tail -n +3` removes the MySQL password warning message from the output.
+**Note:** This command properly quotes CSV fields to handle commas in values (e.g., "Red Hat, Inc."). The `tail -n +2` removes the MySQL password warning message while preserving the header row.
 
 This creates a CSV with the following columns:
 - `name`, `version`, `source` - Required fields

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -426,7 +426,7 @@ func (ds *Datastore) applyChangesForNewSoftwareDB(
 	// These operations are idempotent due to INSERT IGNORE.
 	if len(incomingSoftwareByChecksum) > 0 {
 
-		err = ds.reconcileExistingTitleEmptyUpgradeCodes(ctx, incomingSoftwareByChecksum, incomingChecksumsToExistingTitles)
+		err = ds.reconcileExistingTitleEmptyWindowsUpgradeCodes(ctx, incomingSoftwareByChecksum, incomingChecksumsToExistingTitles)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "update software titles upgrade code")
 		}
@@ -695,7 +695,6 @@ func (ds *Datastore) getIncomingSoftwareChecksumsToExistingTitles(
 			return nil, nil, ctxerr.Wrap(ctx, err, "get existing titles without bundle identifier")
 		}
 		for _, titleSummary := range existingTitleSummariesForNewSoftwareWithoutBundleIdentifier {
-			// TODO - need to factor upgrade_code in here?
 			checksums, ok := uniqueTitleStrToChecksums[UniqueSoftwareTitleStr(titleSummary.Name, titleSummary.Source, titleSummary.ExtensionFor)]
 			if ok {
 				// Map all checksums that correspond to this title
@@ -747,9 +746,15 @@ func BundleIdentifierOrName(bundleIdentifier, name string) string {
 	return name
 }
 
-// UniqueSoftwareTitleStr creates a unique string representation of the software title
+// UniqueSoftwareTitleStr creates a unique string representation of the software title.
+// Returns lowercase to ensure case-insensitive matching, since MySQL uses case-insensitive
+// collation (utf8mb4_unicode_ci) but Go map lookups are case-sensitive.
 func UniqueSoftwareTitleStr(values ...string) string {
-	return strings.Join(values, fleet.SoftwareFieldSeparator)
+	lowered := make([]string, len(values))
+	for i, v := range values {
+		lowered[i] = strings.ToLower(v)
+	}
+	return strings.Join(lowered, fleet.SoftwareFieldSeparator)
 }
 
 // delete host_software that is in current map, but not in incoming map.
@@ -944,7 +949,7 @@ func (ds *Datastore) preInsertSoftwareInventory(
 						bundleID = *title.BundleIdentifier
 					}
 					key := titleKey{
-						name:         title.Name,
+						name:         strings.ToLower(title.Name), // lowercase for case-insensitive dedup matching MySQL collation
 						source:       title.Source,
 						extensionFor: title.ExtensionFor,
 						bundleID:     bundleID,
@@ -1009,8 +1014,8 @@ func (ds *Datastore) preInsertSoftwareInventory(
 							titleBundleID = *title.BundleIdentifier
 						}
 						// For apps with bundle_identifier, match by bundle_identifier (since we may have picked a different name)
-						// For others, match by name
-						nameMatches := titleSummary.Name == title.Name
+						// For others, match by name (case-insensitive to match MySQL collation)
+						nameMatches := strings.EqualFold(titleSummary.Name, title.Name)
 						// TODO - similarly match if UpgradeCodes match?
 						if bundleID != "" && titleBundleID != "" {
 							// Both have bundle_identifier - match by bundle_identifier instead of name
@@ -1202,11 +1207,59 @@ func (ds *Datastore) linkSoftwareToHost(
 	return insertedSoftware, nil
 }
 
-func (ds *Datastore) reconcileExistingTitleEmptyUpgradeCodes(
+func (ds *Datastore) reconcileExistingTitleEmptyWindowsUpgradeCodes(
 	ctx context.Context,
 	incomingSoftwareByChecksum map[string]fleet.Software,
 	incomingChecksumsToExistingTitleSummaries map[string]fleet.SoftwareTitleSummary,
 ) error {
+	// Step 1: Collect all non-empty upgrade_codes from incoming software that might need updating
+	// (i.e., where the matched title has empty or NULL upgrade_code)
+	upgradeCodesToCheck := make(map[string]struct{})
+	for swChecksum, sw := range incomingSoftwareByChecksum {
+		if sw.UpgradeCode == nil || *sw.UpgradeCode == "" {
+			continue
+		}
+		existingTitleSummary, ok := incomingChecksumsToExistingTitleSummaries[swChecksum]
+		if !ok {
+			continue
+		}
+		if existingTitleSummary.UpgradeCode == nil || *existingTitleSummary.UpgradeCode == "" {
+			upgradeCodesToCheck[*sw.UpgradeCode] = struct{}{}
+		}
+	}
+
+	if len(upgradeCodesToCheck) == 0 {
+		return nil
+	}
+
+	// Step 2: Query for existing titles that already have these upgrade_codes
+	// This allows us to detect conflicts and redirect mappings instead of failing with duplicate entry error
+	titlesWithUpgradeCodes := make(map[string]fleet.SoftwareTitleSummary)
+	upgradeCodes := make([]string, 0, len(upgradeCodesToCheck))
+	for uc := range upgradeCodesToCheck {
+		upgradeCodes = append(upgradeCodes, uc)
+	}
+
+	stmt, args, err := sqlx.In(`
+		SELECT id, name, source, upgrade_code
+		FROM software_titles
+		WHERE upgrade_code IN (?) AND source = 'programs'
+	`, upgradeCodes)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build select titles with upgrade_codes query")
+	}
+
+	var existingTitles []fleet.SoftwareTitleSummary
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &existingTitles, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "get existing titles with upgrade_codes")
+	}
+
+	for _, t := range existingTitles {
+		if t.UpgradeCode != nil {
+			titlesWithUpgradeCodes[*t.UpgradeCode] = t
+		}
+	}
+
 	existingTitlesToUpgradeCodePtrsToWrite := make(map[uint]oldAndNewUpgradeCodePtrs)
 
 	for swChecksum, sw := range incomingSoftwareByChecksum {
@@ -1221,18 +1274,34 @@ func (ds *Datastore) reconcileExistingTitleEmptyUpgradeCodes(
 		}
 
 		switch {
-		case existingTitleSummary.UpgradeCode == nil:
-			level.Warn(ds.logger).Log(
-				"msg", "Encountered Windows software title with a NULL upgrade_code, which shouldn't be possible. Writing the incoming non-empty upgrade code to the title.",
-				"title_id", existingTitleSummary.ID,
-				"title_name", existingTitleSummary.Name,
-				"source", existingTitleSummary.Source,
-				"incoming_upgrade_code", *sw.UpgradeCode,
-			)
+		case existingTitleSummary.UpgradeCode == nil || *existingTitleSummary.UpgradeCode == "":
+			// Check for conflict: does another title already have this upgrade_code?
+			if conflictingTitle, hasConflict := titlesWithUpgradeCodes[*sw.UpgradeCode]; hasConflict && conflictingTitle.ID != existingTitleSummary.ID {
+				// Redirect mapping to the title that already has this upgrade_code
+				level.Info(ds.logger).Log(
+					"msg", "redirecting software to existing title with matching upgrade_code",
+					"software_name", sw.Name,
+					"matched_title_id", existingTitleSummary.ID,
+					"matched_title_name", existingTitleSummary.Name,
+					"redirect_to_title_id", conflictingTitle.ID,
+					"redirect_to_title_name", conflictingTitle.Name,
+					"upgrade_code", *sw.UpgradeCode,
+				)
+				incomingChecksumsToExistingTitleSummaries[swChecksum] = conflictingTitle
+				continue
+			}
+			// Log warning only for NULL upgrade_code case (shouldn't happen for programs source)
+			if existingTitleSummary.UpgradeCode == nil {
+				level.Warn(ds.logger).Log(
+					"msg", "Encountered Windows software title with a NULL upgrade_code, which shouldn't be possible. Writing the incoming non-empty upgrade code to the title.",
+					"title_id", existingTitleSummary.ID,
+					"title_name", existingTitleSummary.Name,
+					"source", existingTitleSummary.Source,
+					"incoming_upgrade_code", *sw.UpgradeCode,
+				)
+			}
 			existingTitlesToUpgradeCodePtrsToWrite[existingTitleSummary.ID] = oldAndNewUpgradeCodePtrs{old: existingTitleSummary.UpgradeCode, new: sw.UpgradeCode}
-		case *existingTitleSummary.UpgradeCode == "":
-			existingTitlesToUpgradeCodePtrsToWrite[existingTitleSummary.ID] = oldAndNewUpgradeCodePtrs{old: existingTitleSummary.UpgradeCode, new: sw.UpgradeCode}
-		case existingTitleSummary.UpgradeCode != nil && *existingTitleSummary.UpgradeCode != "" && *sw.UpgradeCode != *existingTitleSummary.UpgradeCode:
+		case *sw.UpgradeCode != *existingTitleSummary.UpgradeCode:
 			// don't update this title
 			level.Warn(ds.logger).Log(
 				"msg", "Incoming software's upgrade code has changed from the existing title's. The developers of this software may have changed the upgrade code, and this may be worth investigating. Keeping the previous title's upgrade code. This will likely result is some inconsistencies, such as the title's upgrade_code possibly not being returned from the list host software endpoint.",

--- a/server/datastore/mysql/software_upgrade_code_test.go
+++ b/server/datastore/mysql/software_upgrade_code_test.go
@@ -1,19 +1,42 @@
 package mysql
 
 import (
-	"context"
 	"testing"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestUpdateSoftwareTitlesUpgradeCode(t *testing.T) {
+func TestSoftwareUpgradeCode(t *testing.T) {
 	ds := CreateMySQLDS(t)
-	ctx := context.Background()
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, ds *Datastore)
+	}{
+		{"ReconcileEmptyUpgradeCodes", testReconcileEmptyUpgradeCodes},
+		{"DuplicateEntryError", testUpgradeCodeDuplicateEntryError},
+		{"CaseSensitivityWithExistingUpgradeCode", testUpgradeCodeCaseSensitivityWithExistingUpgradeCode},
+		{"CaseSensitivityTitleDuplication", testUpdateHostSoftwareCaseSensitivityTitleDuplication},
+		{"Reconciliation", testUpdateHostSoftwareUpgradeCodeReconciliation},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			c.fn(t, ds)
+		})
+	}
+}
+
+// testReconcileEmptyUpgradeCodes tests that when a host reports software with an upgrade_code,
+// the existing title's empty upgrade_code is updated.
+func testReconcileEmptyUpgradeCodes(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
 
 	nonEmptyUc := "{A681CB20-907E-428A-9B14-2D3C1AFED244}"
 	emptyUc := ""
@@ -127,7 +150,7 @@ func TestUpdateSoftwareTitlesUpgradeCode(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			err := ds.reconcileExistingTitleEmptyUpgradeCodes(ctx, tc.incomingSwChecksumToSw, tc.incomingSwChecksumToMatchingTitle)
+			err := ds.reconcileExistingTitleEmptyWindowsUpgradeCodes(ctx, tc.incomingSwChecksumToSw, tc.incomingSwChecksumToMatchingTitle)
 			require.NoError(t, err)
 
 			for titleID, expectedUpgradeCode := range tc.expectedUpdates {
@@ -161,4 +184,279 @@ func TestUpdateSoftwareTitlesUpgradeCode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// testUpgradeCodeDuplicateEntryError tests the scenario from GitHub issue #37494:
+// Two titles with different names but the same upgrade_code. When reconciliation
+// tries to update one title's upgrade_code, it conflicts with the other title's
+// unique_identifier (which is based on upgrade_code when set).
+//
+// Scenario:
+//  1. Title A: "Visual Studio 2022" exists with upgrade_code="{guid}"
+//  2. Title B: "Visual Studio Community 2022" exists with upgrade_code=""
+//  3. Host reports "Visual Studio Community 2022" with upgrade_code="{guid}"
+//  4. Name matching finds Title B, but upgrade_code conflicts with Title A
+//  5. Fix: Redirect mapping to Title A, software gets linked to Title A
+func testUpgradeCodeDuplicateEntryError(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host := test.NewHost(t, ds, "test-host-duplicate-uc", "", "test-host-duplicate-uc-key", "test-host-duplicate-uc-uuid", time.Now())
+
+	upgradeCode := "{EB6B8302-C06E-4BEC-ADAC-932C68A3A001}"
+	emptyUc := ""
+
+	// Create Title A with upgrade_code set (simulates Host A already checked in)
+	resultA, err := ds.writer(ctx).ExecContext(ctx, `
+		INSERT INTO software_titles (name, source, upgrade_code)
+		VALUES (?, ?, ?)`,
+		"Visual Studio 2022", "programs", upgradeCode,
+	)
+	require.NoError(t, err)
+	titleAID, _ := resultA.LastInsertId()
+
+	// Create Title B with empty upgrade_code (simulates pre-existing title)
+	_, err = ds.writer(ctx).ExecContext(ctx, `
+		INSERT INTO software_titles (name, source, upgrade_code)
+		VALUES (?, ?, ?)`,
+		"Visual Studio Community 2022", "programs", emptyUc,
+	)
+	require.NoError(t, err)
+
+	// Host reports software with Title B's name but same upgrade_code as Title A
+	incomingSoftware := []fleet.Software{
+		{
+			Name:        "Visual Studio Community 2022",
+			Version:     "17.0.0",
+			Source:      "programs",
+			UpgradeCode: &upgradeCode,
+		},
+	}
+
+	// This should NOT error - the fix redirects the software to Title A
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, incomingSoftware)
+	require.NoError(t, err)
+
+	// Verify the software was linked to Title A (the one with matching upgrade_code)
+	var softwareEntries []struct {
+		ID      uint   `db:"id"`
+		Name    string `db:"name"`
+		TitleID *uint  `db:"title_id"`
+	}
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &softwareEntries, `
+		SELECT s.id, s.name, s.title_id
+		FROM software s
+		WHERE s.name = 'Visual Studio Community 2022' AND s.source = 'programs'
+	`)
+	require.NoError(t, err)
+	require.Len(t, softwareEntries, 1)
+	require.NotNil(t, softwareEntries[0].TitleID)
+	assert.Equal(t, uint(titleAID), *softwareEntries[0].TitleID,
+		"Software should be linked to Title A (the one with matching upgrade_code)")
+}
+
+// testUpgradeCodeCaseSensitivityWithExistingUpgradeCode tests that case differences
+// in software names are handled correctly when matching with existing titles.
+//
+// Scenario:
+//  1. Title "QEMU Guest Agent" exists with upgrade_code="{guid}" (from earlier ingestion)
+//  2. Host reports "QEMU guest agent" (different case) with same upgrade_code
+//  3. Case-insensitive matching finds the existing title
+//  4. Software is linked to the existing title
+func testUpgradeCodeCaseSensitivityWithExistingUpgradeCode(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host := test.NewHost(t, ds, "test-host-case-with-uc", "", "test-host-case-with-uc-key", "test-host-case-with-uc-uuid", time.Now())
+
+	upgradeCode := "{EB6B8302-C06E-4BEC-ADAC-932C68A3A002}"
+
+	// Create title with upgrade_code already set and different casing
+	result, err := ds.writer(ctx).ExecContext(ctx, `
+		INSERT INTO software_titles (name, source, upgrade_code)
+		VALUES (?, ?, ?)`,
+		"QEMU Guest Agent", "programs", upgradeCode,
+	)
+	require.NoError(t, err)
+	titleID, _ := result.LastInsertId()
+
+	// Host reports software with different casing but same upgrade_code
+	incomingSoftware := []fleet.Software{
+		{
+			Name:        "QEMU guest agent", // lowercase
+			Version:     "107.0.1",
+			Source:      "programs",
+			UpgradeCode: &upgradeCode,
+		},
+	}
+
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, incomingSoftware)
+	require.NoError(t, err)
+
+	// Verify the software was linked to the existing title (not orphaned)
+	var softwareEntries []struct {
+		ID      uint   `db:"id"`
+		Name    string `db:"name"`
+		TitleID *uint  `db:"title_id"`
+	}
+	err = sqlx.SelectContext(ctx, ds.reader(ctx), &softwareEntries, `
+		SELECT s.id, s.name, s.title_id
+		FROM software s
+		WHERE s.name LIKE '%QEMU%' AND s.source = 'programs'
+	`)
+	require.NoError(t, err)
+	require.Len(t, softwareEntries, 1)
+
+	// Software should be linked to the existing title despite case difference
+	require.NotNil(t, softwareEntries[0].TitleID, "Software should have title_id set")
+	assert.Equal(t, uint(titleID), *softwareEntries[0].TitleID,
+		"Software should be linked to existing title")
+}
+
+// testUpdateHostSoftwareCaseSensitivityTitleDuplication tests that software with different
+// casing does not create duplicate titles.
+//
+// Scenario:
+//  1. Host A reports "FooApp" with empty upgrade_code → Title created
+//  2. Host B reports "fooapp" (different case) with upgrade_code
+//  3. Expected: No duplicate title, original title's upgrade_code updated
+func testUpdateHostSoftwareCaseSensitivityTitleDuplication(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	hostA := test.NewHost(t, ds, "case-host-a", "", "casekeya", "caseuuida", time.Now())
+	hostB := test.NewHost(t, ds, "case-host-b", "", "casekeyb", "caseuuidb", time.Now())
+
+	upgradeCode := "{12345678-1234-1234-1234-123456789ABC}"
+
+	// Host A reports software with original casing and empty upgrade_code
+	swHostA := []fleet.Software{
+		{Name: "FooApp", Version: "1.0", Source: "programs", UpgradeCode: ptr.String("")},
+	}
+	_, err := ds.UpdateHostSoftware(ctx, hostA.ID, swHostA)
+	require.NoError(t, err)
+
+	// Verify title was created with original casing
+	var titlesBefore []fleet.SoftwareTitleSummary
+	err = ds.writer(ctx).SelectContext(ctx, &titlesBefore,
+		`SELECT id, name, source, upgrade_code FROM software_titles WHERE name = 'FooApp' AND source = 'programs'`)
+	require.NoError(t, err)
+	require.Len(t, titlesBefore, 1, "Should have exactly one title for FooApp")
+	originalTitleID := titlesBefore[0].ID
+
+	// Host B reports the SAME software but with different casing and a non-empty upgrade_code
+	// This simulates osquery returning the name with different casing on different hosts
+	swHostB := []fleet.Software{
+		{Name: "fooapp", Version: "1.0", Source: "programs", UpgradeCode: ptr.String(upgradeCode)},
+	}
+	_, err = ds.UpdateHostSoftware(ctx, hostB.ID, swHostB)
+	require.NoError(t, err)
+
+	// Check how many titles exist for this software (case-insensitive search)
+	var titlesAfter []struct {
+		ID          uint    `db:"id"`
+		Name        string  `db:"name"`
+		Source      string  `db:"source"`
+		UpgradeCode *string `db:"upgrade_code"`
+	}
+	err = ds.writer(ctx).SelectContext(ctx, &titlesAfter,
+		`SELECT id, name, source, upgrade_code FROM software_titles WHERE LOWER(name) = 'fooapp' AND source = 'programs'`)
+	require.NoError(t, err)
+
+	// Should have exactly 1 title (no duplicate created due to case-insensitive matching)
+	require.Len(t, titlesAfter, 1, "Should have exactly one title (case-insensitive matching)")
+
+	// Verify the title kept the original name and had its upgrade_code updated
+	require.Equal(t, originalTitleID, titlesAfter[0].ID, "Should be the same title ID")
+	require.Equal(t, "FooApp", titlesAfter[0].Name, "Title should keep original casing")
+	require.NotNil(t, titlesAfter[0].UpgradeCode)
+	require.Equal(t, upgradeCode, *titlesAfter[0].UpgradeCode, "Title's upgrade_code should be updated")
+}
+
+// testUpdateHostSoftwareUpgradeCodeReconciliation tests that when a host reports
+// software with an upgrade_code, the existing title's upgrade_code is updated.
+//
+// Scenario:
+//  1. Host A reports "Chef Cookbooks - Windows" v1.0 with empty upgrade_code
+//     → Title created with upgrade_code=""
+//  2. Host B reports "Chef Cookbooks - Windows" v2.0 with upgrade_code="{guid}"
+//     → Expected: Title's upgrade_code updated to "{guid}"
+//  3. Host A reports "Chef Cookbooks - Windows" v2.0 with empty upgrade_code
+//     → Expected: Title's upgrade_code remains "{guid}" (not cleared)
+func testUpdateHostSoftwareUpgradeCodeReconciliation(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	hostA := test.NewHost(t, ds, "reconcile-host-a", "", "reconcilekeya", "reconcileuuida", time.Now())
+	hostB := test.NewHost(t, ds, "reconcile-host-b", "", "reconcilekeyb", "reconcileuuidb", time.Now())
+
+	upgradeCode := "{FB9C576D-97C3-49E8-8119-93AC9758CD4C}"
+
+	// Host A reports software v1.0 with empty upgrade_code
+	swHostA := []fleet.Software{
+		{Name: "Chef Cookbooks - Windows", Version: "1.0", Source: "programs", UpgradeCode: ptr.String("")},
+	}
+	_, err := ds.UpdateHostSoftware(ctx, hostA.ID, swHostA)
+	require.NoError(t, err)
+
+	// Verify title was created with empty upgrade_code
+	var titlesBefore []struct {
+		ID          uint    `db:"id"`
+		Name        string  `db:"name"`
+		Source      string  `db:"source"`
+		UpgradeCode *string `db:"upgrade_code"`
+	}
+	err = ds.writer(ctx).SelectContext(ctx, &titlesBefore,
+		`SELECT id, name, source, upgrade_code FROM software_titles WHERE name = 'Chef Cookbooks - Windows' AND source = 'programs'`)
+	require.NoError(t, err)
+	require.Len(t, titlesBefore, 1, "Should have exactly one title")
+	require.NotNil(t, titlesBefore[0].UpgradeCode)
+	require.Empty(t, *titlesBefore[0].UpgradeCode, "Title should have empty upgrade_code initially")
+	originalTitleID := titlesBefore[0].ID
+
+	// Host B reports same software but v2.0 with non-empty upgrade_code
+	// This creates a NEW checksum (different version + upgrade_code affects checksum)
+	swHostB := []fleet.Software{
+		{Name: "Chef Cookbooks - Windows", Version: "2.0", Source: "programs", UpgradeCode: ptr.String(upgradeCode)},
+	}
+	_, err = ds.UpdateHostSoftware(ctx, hostB.ID, swHostB)
+	require.NoError(t, err)
+
+	// Check how many titles exist now
+	var titlesAfter []struct {
+		ID          uint    `db:"id"`
+		Name        string  `db:"name"`
+		Source      string  `db:"source"`
+		UpgradeCode *string `db:"upgrade_code"`
+	}
+	err = ds.writer(ctx).SelectContext(ctx, &titlesAfter,
+		`SELECT id, name, source, upgrade_code FROM software_titles WHERE name = 'Chef Cookbooks - Windows' AND source = 'programs'`)
+	require.NoError(t, err)
+
+	// EXPECTED: Should have exactly 1 title, with upgrade_code updated
+	require.Len(t, titlesAfter, 1, "Should have exactly one title (no duplicate created)")
+	require.Equal(t, originalTitleID, titlesAfter[0].ID, "Should be the same title")
+	require.NotNil(t, titlesAfter[0].UpgradeCode)
+	require.Equal(t, upgradeCode, *titlesAfter[0].UpgradeCode, "Title's upgrade_code should have been updated")
+
+	// Step 3: Host A reports v2.0 with empty upgrade_code
+	// The title's upgrade_code should NOT be cleared
+	swHostAv2 := []fleet.Software{
+		{Name: "Chef Cookbooks - Windows", Version: "2.0", Source: "programs", UpgradeCode: ptr.String("")},
+	}
+	_, err = ds.UpdateHostSoftware(ctx, hostA.ID, swHostAv2)
+	require.NoError(t, err)
+
+	// Verify title's upgrade_code was NOT cleared
+	var titlesAfterStep3 []struct {
+		ID          uint    `db:"id"`
+		Name        string  `db:"name"`
+		Source      string  `db:"source"`
+		UpgradeCode *string `db:"upgrade_code"`
+	}
+	err = ds.writer(ctx).SelectContext(ctx, &titlesAfterStep3,
+		`SELECT id, name, source, upgrade_code FROM software_titles WHERE name = 'Chef Cookbooks - Windows' AND source = 'programs'`)
+	require.NoError(t, err)
+
+	// EXPECTED: Still one title, upgrade_code should remain "{guid}"
+	require.Len(t, titlesAfterStep3, 1, "Should still have exactly one title")
+	require.Equal(t, originalTitleID, titlesAfterStep3[0].ID, "Should be the same title")
+	require.NotNil(t, titlesAfterStep3[0].UpgradeCode)
+	require.Equal(t, upgradeCode, *titlesAfterStep3[0].UpgradeCode, "Title's upgrade_code should NOT have been cleared")
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37494

Manually verified fixes with osquery-perf.

Fixes:
Issue 1: Duplicate entry error when updating upgrade_code Issue 2: Case sensitivity mismatch causes duplicate titles

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
* Improved software title matching to be case-insensitive, preventing duplicate entries for the same software reported with different capitalization.
* Enhanced upgrade code reconciliation logic to properly detect and handle conflicts when multiple software entries share upgrade codes.

* **Tests**
* Added test coverage for case-insensitive software title matching and upgrade code reconciliation scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit f402ae783f82a65453323c79c59145a61343f823)


