### PR TITLE
Fix missing upgrade codes when Windows FMAs are uploaded via GitOps

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2363,6 +2363,10 @@ func (svc *Service) softwareBatchUpload(
 
 				installer.Platform = p.MaintainedApp.Platform
 				installer.Source = p.MaintainedApp.Source()
+				if installer.Source == "programs" && p.MaintainedApp.UpgradeCode != "" {
+					installer.UpgradeCode = p.MaintainedApp.UpgradeCode
+				}
+
 				installer.Extension = extension
 				installer.BundleIdentifier = p.MaintainedApp.BundleIdentifier()
 				installer.StorageID = p.MaintainedApp.SHA256

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -18784,83 +18784,20 @@ func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedApps() {
 	require.Equal(t, len(hSWRes.Software), 1)
 	sw0 := hSWRes.Software[0]
 	require.Equal(t, warpUpgradeCode, *sw0.UpgradeCode)
-}
 
-func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedAppsViaGitOps() {
-	// Test that `upgrade_code` is correctly associated with Windows FMAs when added via the
-	// GitOps batch upload endpoint (POST /api/latest/fleet/software/batch).
-	// This is a regression test for a bug where the upgrade code was not being pulled from
-	// the FMA manifest when adding Windows FMAs via GitOps.
-
-	t := s.T()
-	ctx := context.Background()
-
-	warpUpgradeCode := "{1BF42825-7B65-4CA9-AFFF-B7B5E1CE27B4}"
-
-	installerBytes := []byte("abc")
-	installerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = w.Write(installerBytes)
-	}))
-	defer installerServer.Close()
-
-	// Mock server to serve manifest with upgrade code
-	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var versions []*ma.FMAManifestApp
-		versions = append(versions, &ma.FMAManifestApp{
-			Version: "25.9.558.0",
-			Queries: ma.FMAQueries{
-				Exists: "SELECT 1 FROM osquery_info;",
-			},
-			InstallerURL:       installerServer.URL + "/installer.msi",
-			InstallScriptRef:   "foobaz",
-			UninstallScriptRef: "foobaz",
-			SHA256:             "no_check",
-			UpgradeCode:        warpUpgradeCode,
-		})
-
-		manifest := ma.FMAManifestFile{
-			Versions: versions,
-			Refs: map[string]string{
-				"foobaz": "Hello World!",
-			},
-		}
-
-		err := json.NewEncoder(w).Encode(manifest)
-		require.NoError(t, err)
-	}))
-	t.Cleanup(manifestServer.Close)
-
-	mockTransport := &mockRoundTripper{
-		mockServer:  manifestServer.URL,
-		origBaseURL: "https://raw.githubusercontent.com",
-		next:        http.DefaultTransport,
-	}
-	http.DefaultTransport = mockTransport
-
-	// Insert the list of maintained apps
-	maintained_apps.SyncApps(t, s.ds)
-
-	// Get the WARP app slug for Windows
-	var warpSlug string
+	// nuke the title so we can try this with a batch upload
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &warpSlug, "SELECT slug FROM fleet_maintained_apps WHERE name = 'Cloudflare WARP' AND platform = 'windows'")
+		_, err := q.ExecContext(ctx, "DELETE FROM software_titles WHERE upgrade_code = ?", warpUpgradeCode)
+		return err
 	})
-	require.NotEmpty(t, warpSlug)
-
-	// Create a team for the test
-	tm, err := s.ds.NewTeam(ctx, &fleet.Team{
-		Name:        t.Name(),
-		Description: "test team for gitops upgrade code",
-	})
-	require.NoError(t, err)
 
 	// Use the batch endpoint (GitOps) to add the Windows FMA
 	softwareToInstall := []*fleet.SoftwareInstallerPayload{
-		{Slug: &warpSlug, SelfService: true},
+		{Slug: ptr.String("cloudflare-warp/windows"), SelfService: true},
 	}
 	var batchResponse batchSetSoftwareInstallersResponse
-	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: softwareToInstall}, http.StatusAccepted, &batchResponse, "team_name", tm.Name)
-	packages := waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, tm.Name, batchResponse.RequestUUID)
+	s.DoJSON("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: softwareToInstall}, http.StatusAccepted, &batchResponse)
+	packages := waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, "", batchResponse.RequestUUID)
 	require.Len(t, packages, 1)
 	require.NotNil(t, packages[0].TitleID)
 
@@ -18873,19 +18810,17 @@ func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedAppsViaGi
 	require.Equal(t, warpUpgradeCode, *installerUpgradeCode)
 
 	// Also verify the software title has the upgrade code
-	var lSTResp listSoftwareTitlesResponse
+	var afterBatch listSoftwareTitlesResponse
 	s.DoJSON(
 		"GET", "/api/latest/fleet/software/titles",
 		listSoftwareTitlesRequest{},
-		http.StatusOK, &lSTResp,
+		http.StatusOK, &afterBatch,
 		"per_page", "1",
 		"available_for_install", "true",
-		"team_id", fmt.Sprintf("%d", tm.ID),
+		"team_id", "0",
 	)
-	require.Len(t, lSTResp.SoftwareTitles, 1)
-	title := lSTResp.SoftwareTitles[0]
-	require.NotNil(t, title.UpgradeCode)
-	require.Equal(t, warpUpgradeCode, *title.UpgradeCode)
+	require.Len(t, afterBatch.SoftwareTitles, 1)
+	require.Equal(t, warpUpgradeCode, *afterBatch.SoftwareTitles[0].UpgradeCode)
 }
 
 func (s *integrationEnterpriseTestSuite) TestWindowsMigrateMDMNotEnabled() {


### PR DESCRIPTION
Relates to #37771.

No changes file as the #37772 changes file covers this.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually