### PR TITLE
Updated NDES SCEP proxy to auto-detect response encoding

### DIFF
--- a/changes/36652-okta-ca
+++ b/changes/36652-okta-ca
@@ -1,0 +1,1 @@
+Updated NDES SCEP proxy to auto-detect response encoding, enabling compatibility with Okta CA and other UTF-8-based CAs.

--- a/ee/server/service/scep_proxy.go
+++ b/ee/server/service/scep_proxy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/go-kit/log"
 	"github.com/google/uuid"
+	"golang.org/x/net/html/charset"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -39,6 +40,85 @@ const (
 	NDESChallengeInvalidAfter      = 57 * time.Minute
 	SmallstepChallengeInvalidAfter = 4 * time.Minute
 )
+
+// decodeHTMLResponse decodes HTTP response body to a string, handling various encodings.
+// Windows NDES servers return UTF-16 LE (often without BOM), while Okta returns UTF-8.
+//
+// Detection order:
+//  1. UTF-16 LE heuristic (for Windows NDES compatibility; checked first because
+//     charset detection libraries can't parse meta tags in UTF-16 encoded content)
+//  2. Content-Type charset header and BOM detection via charset.DetermineEncoding
+//  3. Fall back to UTF-8
+func decodeHTMLResponse(body []byte, contentType string) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	// Check for UTF-16 LE first. Windows NDES servers return UTF-16 LE without BOM
+	// and without proper Content-Type charset. We must detect this before trying
+	// charset.DetermineEncoding, which would fail to parse meta tags in UTF-16 bytes.
+	if looksLikeUTF16LE(body) {
+		// Use BOMOverride to handle BOM if present (strips it from output)
+		utf16le := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
+		decoder := unicode.BOMOverride(utf16le.NewDecoder())
+		if decoded, _, err := transform.Bytes(decoder, body); err == nil {
+			return string(decoded)
+		}
+	}
+
+	// Standard HTML5 encoding detection:
+	// - Checks Content-Type charset parameter
+	// - Detects BOM (Byte Order Mark)
+	// - Prescans for meta charset tags
+	enc, _, _ := charset.DetermineEncoding(body, contentType)
+	if enc != nil {
+		if decoded, _, err := transform.Bytes(enc.NewDecoder(), body); err == nil {
+			return string(decoded)
+		}
+	}
+
+	// Default: treat as UTF-8
+	return string(body)
+}
+
+// looksLikeUTF16LE checks if the body appears to be UTF-16 LE encoded.
+// Detection is done in order of reliability:
+// 1. BOM (Byte Order Mark) - most authoritative
+// 2. HTML pattern - UTF-16 LE HTML starts with '<' 0x00
+// 3. Null byte percentage - fallback heuristic
+func looksLikeUTF16LE(body []byte) bool {
+	if len(body) < 4 {
+		return false
+	}
+
+	// 1. Check for UTF-16 LE BOM (FF FE) - most reliable indicator
+	if body[0] == 0xFF && body[1] == 0xFE {
+		return true
+	}
+
+	// 2. Check for HTML pattern: '<' followed by 0x00
+	// HTML content starts with '<' (e.g., "<HTML>", "<!DOCTYPE>")
+	// In UTF-16 LE, this becomes 0x3C 0x00 - very unlikely in valid UTF-8
+	if body[0] == '<' && body[1] == 0x00 {
+		return true
+	}
+
+	// 3. Fallback: count null bytes at odd positions
+	// UTF-16 LE ASCII has null at every odd position (char, 0x00, char, 0x00, ...)
+	// Require 90% to reduce false positives from UTF-8 with occasional nulls
+
+	// utf16DetectionSampleSize is the number of bytes to examine when detecting UTF-16 LE encoding.
+	const utf16DetectionSampleSize = 100
+	checkLen := min(len(body), utf16DetectionSampleSize)
+	nullCount := 0
+	for i := 1; i < checkLen; i += 2 {
+		if body[i] == 0x00 {
+			nullCount++
+		}
+	}
+	checked := checkLen / 2
+	return checked > 0 && float64(nullCount)/float64(checked) >= 0.9 // 90%
+}
 
 // scepCertificateRequest abstracts the common operations needed for SCEP certificate
 // requests across different platforms (Apple, Windows, Android).
@@ -447,18 +527,15 @@ func (s *SCEPConfigService) GetNDESSCEPChallenge(ctx context.Context, proxy flee
 			"unexpected status code: %d; could not retrieve the enrollment challenge password; invalid admin URL or credentials; please correct and try again",
 			resp.StatusCode)})
 	}
-	// Make a transformer that converts MS-Win default to UTF8:
-	win16le := unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM)
-	// Make a transformer that is like win16le, but abides by BOM:
-	utf16bom := unicode.BOMOverride(win16le.NewDecoder())
+	defer resp.Body.Close()
 
-	// Make a Reader that uses utf16bom:
-	unicodeReader := transform.NewReader(resp.Body, utf16bom)
-	bodyText, err := io.ReadAll(unicodeReader)
+	// Read raw bytes first to detect encoding
+	rawBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "reading response body")
 	}
-	htmlString := string(bodyText)
+
+	htmlString := decodeHTMLResponse(rawBody, resp.Header.Get("Content-Type"))
 
 	matches := challengeRegex.FindStringSubmatch(htmlString)
 	challenge := ""

--- a/ee/server/service/scep_proxy_test.go
+++ b/ee/server/service/scep_proxy_test.go
@@ -99,6 +99,83 @@ func TestValidateNDESSCEPAdminURL(t *testing.T) {
 	}
 	err = svc.ValidateNDESSCEPAdminURL(context.Background(), proxy)
 	assert.NoError(t, err)
+
+	// Test UTF-8 response (like Okta returns) - should also work with auto-detection
+	returnPage = func() []byte {
+		// Return UTF-8 directly without converting to UTF-16
+		dat, err := os.ReadFile("./testdata/mscep_admin_password.html")
+		require.NoError(t, err)
+		return dat
+	}
+	err = svc.ValidateNDESSCEPAdminURL(context.Background(), proxy)
+	assert.NoError(t, err)
+}
+
+func TestDecodeHTMLResponse(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       []byte
+		contentType string
+		expected    string
+	}{
+		{
+			name:        "empty input",
+			input:       []byte{},
+			contentType: "",
+			expected:    "",
+		},
+		{
+			name:        "UTF-8 ASCII without content type",
+			input:       []byte("<HTML><Body>The enrollment challenge password is: <B> ABC123 </B></Body></HTML>"),
+			contentType: "",
+			expected:    "<HTML><Body>The enrollment challenge password is: <B> ABC123 </B></Body></HTML>",
+		},
+		{
+			name:        "UTF-8 with explicit charset",
+			input:       []byte("<HTML><Body>Test</Body></HTML>"),
+			contentType: "text/html; charset=utf-8",
+			expected:    "<HTML><Body>Test</Body></HTML>",
+		},
+		{
+			name: "UTF-16 LE detected by HTML pattern",
+			input: func() []byte {
+				// "<HTML>" in UTF-16 LE: '<' 0x00 'H' 0x00 ... detected by '<' 0x00 pattern
+				s := "<HTML>"
+				result := make([]byte, len(s)*2)
+				for i := 0; i < len(s); i++ {
+					result[i*2] = s[i]
+					result[i*2+1] = 0x00
+				}
+				return result
+			}(),
+			contentType: "",
+			expected:    "<HTML>",
+		},
+		{
+			name: "UTF-16 LE detected by BOM",
+			input: func() []byte {
+				// BOM (FF FE) followed by "<H>" in UTF-16 LE
+				return []byte{0xFF, 0xFE, '<', 0x00, 'H', 0x00, '>', 0x00}
+			}(),
+			contentType: "",
+			expected:    "<H>",
+		},
+		{
+			name:        "short UTF-8 input",
+			input:       []byte("Hi"),
+			contentType: "",
+			expected:    "Hi",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := decodeHTMLResponse(tc.input, tc.contentType)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
 }
 
 func TestValidateSCEPURL(t *testing.T) {


### PR DESCRIPTION
Updated NDES SCEP proxy to auto-detect response encoding, enabling compatibility with Okta CA and other UTF-8-based CAs.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36652

Video demo: https://www.youtube.com/watch?v=M7yLXEofdCE

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved response encoding handling in the NDES SCEP proxy with automatic detection, enabling seamless compatibility with Okta CA and other certificate authorities using UTF-8 encoding.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->