### PR TITLE
Fix category key casing for "Developer tools"

### DIFF
--- a/cmd/maintained-apps/main.go
+++ b/cmd/maintained-apps/main.go
@@ -119,7 +119,7 @@ func processOutput(ctx context.Context, app *maintained_apps.FMAManifestApp) err
 var allowedCategories = map[string]struct{}{
 	"Browsers":        {},
 	"Communication":   {},
-	"Developer Tools": {},
+	"Developer tools": {},
 	"Productivity":    {},
 	"Security":        {},
 	"Utilities":       {},


### PR DESCRIPTION
Updated the allowedCategories map to use 'Developer tools' instead of 'Developer Tools' to ensure category matching is consistent with how this category is displayed in the UI.