### PR TITLE
Add MaintainedApp identifier to not found error

### DIFF
--- a/changes/37896-maintainedapp-notfound-error
+++ b/changes/37896-maintainedapp-notfound-error
@@ -1,0 +1,2 @@
+- Improved error message when a Fleet-maintained app is not found to include the app slug or ID.
+

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -82,7 +82,7 @@ func (ds *Datastore) GetMaintainedAppByID(ctx context.Context, appID uint, teamI
 	var app fleet.MaintainedApp
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &app, stmt, args...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.Wrap(ctx, notFound("MaintainedApp"), "no matching maintained app found")
+			return nil, ctxerr.Wrap(ctx, notFound("MaintainedApp").WithID(appID), "no matching maintained app found")
 		}
 
 		return nil, ctxerr.Wrap(ctx, err, "getting maintained app by id")
@@ -108,7 +108,7 @@ func (ds *Datastore) GetMaintainedAppBySlug(ctx context.Context, slug string, te
 	var app fleet.MaintainedApp
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &app, stmt, args...); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.Wrap(ctx, notFound("MaintainedApp"), "no matching maintained app found")
+			return nil, ctxerr.Wrap(ctx, notFound("MaintainedApp").WithName(slug), "no matching maintained app found")
 		}
 
 		return nil, ctxerr.Wrap(ctx, err, "getting maintained app by slug")

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -24,6 +24,8 @@ func TestMaintainedApps(t *testing.T) {
 		{"ListAndGetAvailableApps", testListAndGetAvailableApps},
 		{"SyncAndRemoveApps", testSyncAndRemoveApps},
 		{"GetMaintainedAppBySlug", testGetMaintainedAppBySlug},
+		{"GetMaintainedAppByIDNotFound", testGetMaintainedAppByIDNotFound},
+		{"GetMaintainedAppBySlugNotFound", testGetMaintainedAppBySlugNotFound},
 	}
 
 	for _, c := range cases {
@@ -541,4 +543,24 @@ func testGetMaintainedAppBySlug(t *testing.T, ds *Datastore) {
 		UniqueIdentifier: "fleet.maintained1",
 		TitleID:          nil,
 	}, gotApp)
+}
+
+func testGetMaintainedAppByIDNotFound(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	_, err := ds.GetMaintainedAppByID(ctx, 9999, nil)
+	require.Error(t, err)
+
+	var nfe fleet.NotFoundError
+	require.ErrorAs(t, err, &nfe)
+	require.Contains(t, err.Error(), "9999")
+}
+
+func testGetMaintainedAppBySlugNotFound(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	_, err := ds.GetMaintainedAppBySlug(ctx, "nonexistent/darwin", nil)
+	require.Error(t, err)
+
+	var nfe fleet.NotFoundError
+	require.ErrorAs(t, err, &nfe)
+	require.Contains(t, err.Error(), "nonexistent/darwin")
 }


### PR DESCRIPTION
## Changes

When a Fleet-maintained app is not found, the error message now includes the app identifier (ID or slug) to help with debugging.

**Before:** `MaintainedApp was not found`
**After:** `MaintainedApp 123 was not found` or `MaintainedApp zoom/darwin was not found`

## Related issue

Fixes #37896

## Checklist

- [x] Changes file added (see `changes/37896-maintainedapp-notfound-error`)
- [x] Code follows existing patterns (`notFound().WithID()` and `notFound().WithName()`)
- [x] Tests added for not-found error cases