### PR TITLE
Add GTM Ops request process to IT handbook

### DIFF
--- a/handbook/it-and-enablement/README.md
+++ b/handbook/it-and-enablement/README.md
@@ -19,6 +19,9 @@ This page details processes specific to working [with](#contact-us) and [within]
   - Any Fleet team member can [view the kanban board](https://github.com/orgs/fleetdm/projects/69) for this department, including pending tasks and the status of new requests.
   - Please **use issue comments and GitHub mentions** to communicate follow-ups or answer questions related to your request.
 
+> To **make a request** of the GTM Ops team, [create an issue](https://github.com/fleetdm/confidential/issues/new?assignees=&labels=%3Agtm-ops&projects=&template=1-custom-request.md&title=) and a team member will get back to you within one business day (If urgent, mention [Sam Pfluger](https://fleetdm.slack.com/team/U05CS07KASK) in the [#g-unicorns](https://fleetdm.slack.com/archives/C08BTMFTUCR) Slack channel).
+  - Any Fleet team member can [view the kanban board](https://github.com/orgs/fleetdm/projects/100/views/1) for this department, including pending tasks and the status of new requests.
+  - Please **use issue comments and GitHub mentions** to communicate follow-ups or answer questions related to your request. 
 
 ## Responsibilities
 


### PR DESCRIPTION
Added instructions for making requests to the GTM Ops team, including issue creation, kanban board access, and communication guidelines in the IT and Enablement handbook.

