### PR TITLE
Hide Add Query button on Host Details for unsupported host platforms

### DIFF
--- a/frontend/__mocks__/queryMock.ts
+++ b/frontend/__mocks__/queryMock.ts
@@ -1,4 +1,5 @@
 import { ISchedulableQuery } from "interfaces/schedulable_query";
+import { IQueryStats } from "interfaces/query_stats";
 
 const DEFAULT_QUERY_MOCK: ISchedulableQuery = {
   created_at: "2022-11-03T17:22:14Z",
@@ -34,6 +35,33 @@ const createMockQuery = (
   overrides?: Partial<ISchedulableQuery>
 ): ISchedulableQuery => {
   return { ...DEFAULT_QUERY_MOCK, ...overrides };
+};
+
+const DEFAULT_QUERY_STATS_MOCK: IQueryStats = {
+  scheduled_query_name: "test-query",
+  scheduled_query_id: 1,
+  query_name: "Test Query",
+  discard_data: false,
+  last_fetched: "2025-01-01T00:00:00Z",
+  automations_enabled: false,
+  description: "A test query",
+  pack_name: "test-pack",
+  pack_id: 1,
+  average_memory: 100,
+  denylisted: false,
+  executions: 10,
+  interval: 3600,
+  last_executed: "2025-01-01T00:00:00Z",
+  output_size: 1024,
+  system_time: 50,
+  user_time: 100,
+  wall_time: 150,
+};
+
+export const createMockQueryStats = (
+  overrides?: Partial<IQueryStats>
+): IQueryStats => {
+  return { ...DEFAULT_QUERY_STATS_MOCK, ...overrides };
 };
 
 export default createMockQuery;

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -65,6 +65,7 @@ import {
   isIPadOrIPhone,
   isLinuxLike,
   isWindows,
+  isChrome,
 } from "interfaces/platform";
 
 import Spinner from "components/Spinner";
@@ -1099,6 +1100,10 @@ const HostDetailsPage = ({
   const isIosOrIpadosHost = isIPadOrIPhone(host.platform);
   const isAndroidHost = isAndroid(host.platform);
   const isWindowsHost = isWindows(host.platform);
+  const isChromeHost = isChrome(host.platform);
+
+  const isSupportedHostQueriesPlatform =
+    !isIosOrIpadosHost && !isAndroidHost && !isChromeHost;
 
   const canResendProfiles =
     (isMacOSHost || isWindowsHost) &&
@@ -1311,7 +1316,10 @@ const HostDetailsPage = ({
                   queryReportsDisabled={
                     config?.server_settings?.query_reports_disabled
                   }
-                  canAddQuery={isAnyMaintainerAdminObserverPlus}
+                  canAddQuery={
+                    isAnyMaintainerAdminObserverPlus &&
+                    isSupportedHostQueriesPlatform
+                  }
                   onClickAddQuery={onClickAddQuery}
                 />
                 <UserCard

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tests.tsx
@@ -1,0 +1,100 @@
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import { noop } from "lodash";
+
+import { createMockRouter } from "test/test-utils";
+import { IQueryStats } from "interfaces/query_stats";
+
+import HostQueries from ".";
+
+const createMockQueryStats = (
+  overrides?: Partial<IQueryStats>
+): IQueryStats => ({
+  scheduled_query_name: "test-query",
+  scheduled_query_id: 1,
+  query_name: "Test Query",
+  discard_data: false,
+  last_fetched: "2025-01-01T00:00:00Z",
+  automations_enabled: false,
+  description: "A test query",
+  pack_name: "test-pack",
+  pack_id: 1,
+  average_memory: 100,
+  denylisted: false,
+  executions: 10,
+  interval: 3600,
+  last_executed: "2025-01-01T00:00:00Z",
+  output_size: 1024,
+  system_time: 50,
+  user_time: 100,
+  wall_time: 150,
+  ...overrides,
+});
+
+describe("HostQueries card", () => {
+  it("renders the queries table and add query button for supported platform with queries", () => {
+    const schedule = [
+      createMockQueryStats({ query_name: "Query 1", scheduled_query_id: 1 }),
+      createMockQueryStats({ query_name: "Query 2", scheduled_query_id: 2 }),
+    ];
+
+    render(
+      <HostQueries
+        hostId={1}
+        schedule={schedule}
+        hostPlatform="darwin"
+        router={createMockRouter()}
+        canAddQuery
+        onClickAddQuery={noop}
+      />
+    );
+
+    expect(screen.getByText("Queries")).toBeInTheDocument();
+    expect(screen.getByText("Add query")).toBeInTheDocument();
+    // Use getAllByText due to tooltip duplicates
+    expect(screen.getAllByText("Query 1").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Query 2").length).toBeGreaterThan(0);
+  });
+
+  it("renders 'Queries not supported for this host' message and hides add query button for unsupported host platform", () => {
+    render(
+      <HostQueries
+        hostId={1}
+        schedule={[]}
+        hostPlatform="chrome"
+        router={createMockRouter()}
+        canAddQuery={false}
+        onClickAddQuery={noop}
+      />
+    );
+
+    expect(screen.getByText("Queries")).toBeInTheDocument();
+    expect(
+      screen.getByText("Queries not supported for this host")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Interested in collecting data from your Chromebooks/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Add query")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state and add query button for supported platform with no queries", () => {
+    render(
+      <HostQueries
+        hostId={1}
+        schedule={[]}
+        hostPlatform="darwin"
+        router={createMockRouter()}
+        canAddQuery
+        onClickAddQuery={noop}
+      />
+    );
+
+    expect(screen.getByText("Queries")).toBeInTheDocument();
+    expect(screen.getByText("Add query")).toBeInTheDocument();
+    expect(screen.getByText("No queries")).toBeInTheDocument();
+    expect(
+      screen.getByText("Add a query to view custom vitals.")
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tests.tsx
@@ -3,33 +3,9 @@ import { screen, render } from "@testing-library/react";
 import { noop } from "lodash";
 
 import { createMockRouter } from "test/test-utils";
-import { IQueryStats } from "interfaces/query_stats";
+import { createMockQueryStats } from "__mocks__/queryMock";
 
 import HostQueries from ".";
-
-const createMockQueryStats = (
-  overrides?: Partial<IQueryStats>
-): IQueryStats => ({
-  scheduled_query_name: "test-query",
-  scheduled_query_id: 1,
-  query_name: "Test Query",
-  discard_data: false,
-  last_fetched: "2025-01-01T00:00:00Z",
-  automations_enabled: false,
-  description: "A test query",
-  pack_name: "test-pack",
-  pack_id: 1,
-  average_memory: 100,
-  denylisted: false,
-  executions: 10,
-  interval: 3600,
-  last_executed: "2025-01-01T00:00:00Z",
-  output_size: 1024,
-  system_time: 50,
-  user_time: 100,
-  wall_time: 150,
-  ...overrides,
-});
 
 describe("HostQueries card", () => {
   it("renders the queries table and add query button for supported platform with queries", () => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37847 

# Checklist for submitter

Issue is resolved by the `&& isSupportedHostQueriesPlatform` condition.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

Manually tested by passing a mocked host platform (`"ios"`) and verified the **Add Query** button is not shown.

### Before

<img width="719" height="399" alt="Screenshot 2026-01-06 at 1 55 33 PM" src="https://github.com/user-attachments/assets/12cf1bc7-62bb-4e8b-a005-b38debd5f564" />

### After

<img width="711" height="389" alt="Screenshot 2026-01-06 at 1 52 03 PM" src="https://github.com/user-attachments/assets/c077b030-451e-4333-b4e9-bcd8d9734c96" />

