### PR TITLE
Use install_uuid or command_uuid for install activity details

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -43,7 +43,8 @@ const baseClass = "software-install-details-modal";
 
 export type IPackageInstallDetails = {
   host_display_name?: string;
-  install_uuid?: string; // not actually optional
+  install_uuid?: string; // Apple app store installs
+  command_uuid?: string; // Android play store installs
 };
 
 export const renderContactOption = (url?: string) => (
@@ -224,7 +225,8 @@ export const SoftwareInstallDetailsModal = ({
   contactUrl,
 }: ISoftwareInstallDetailsProps) => {
   // will always be present
-  const installUUID = detailsFromProps.install_uuid ?? "";
+  const installUUID =
+    (detailsFromProps.install_uuid || detailsFromProps.command_uuid) ?? "";
 
   const [showInstallDetails, setShowInstallDetails] = useState(false);
   const toggleInstallDetails = () => {


### PR DESCRIPTION
For #37916

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the software install details modal to correctly identify and display installation information for both iOS App Store and Android Play Store applications, ensuring consistent tracking across all app sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->