### PR TITLE
Add auto update fields to Batch-apply App Store apps request parameters

### DIFF
--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -4756,6 +4756,9 @@ _Available in Fleet Premium._
 | app_store_apps.install_during_setup | boolean  | body  | Specifies whether the VPP app is included in Setup experience.                                                                                                                                                                |
 | app_store_apps.labels_include_any | array   | body  | App will only be available for install on hosts that **have any** of these labels. Only one of either `labels_include_any` or `labels_exclude_any` can be included in the request. |
 | app_store_apps.labels_exclude_any | array   | body  | App will only be available for install on hosts that **don't have any** of these labels. Only one of either `labels_include_any` or `labels_exclude_any` can be included in the request. |
+| app_store_apps.auto_update_enabled | boolean | body | **Optional**. Whether automatic updates are enabled for this iOS/iPadOS VPP app. |
+| app_store_apps.auto_update_start_time | string | body | **Optional**. The start time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
+| app_store_apps.auto_update_end_time | string | body | **Optional**. The end time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
 
 #### Example
 
@@ -4777,7 +4780,10 @@ _Available in Fleet Premium._
     },
     {
       "app_store_id": "497799835",
-      "self_service": true
+      "self_service": true,
+      "auto_update_enabled": true,
+      "auto_update_start_time": "01:00",
+      "auto_update_end_time": "05:00"
     }
   ]
 }

--- a/docs/Contributing/reference/api-for-contributors.md
+++ b/docs/Contributing/reference/api-for-contributors.md
@@ -4757,8 +4757,8 @@ _Available in Fleet Premium._
 | app_store_apps.labels_include_any | array   | body  | App will only be available for install on hosts that **have any** of these labels. Only one of either `labels_include_any` or `labels_exclude_any` can be included in the request. |
 | app_store_apps.labels_exclude_any | array   | body  | App will only be available for install on hosts that **don't have any** of these labels. Only one of either `labels_include_any` or `labels_exclude_any` can be included in the request. |
 | app_store_apps.auto_update_enabled | boolean | body | **Optional**. Whether automatic updates are enabled for this iOS/iPadOS VPP app. |
-| app_store_apps.auto_update_start_time | string | body | **Optional**. The start time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
-| app_store_apps.auto_update_end_time | string | body | **Optional**. The end time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
+| app_store_apps.auto_update_window_start | string | body | **Optional**. The start time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
+| app_store_apps.auto_update_window_end | string | body | **Optional**. The end time (in HH:MM format, local time) of the window during which automatic updates can occur. Required if `auto_update_enabled` is `true`. |
 
 #### Example
 
@@ -4782,8 +4782,8 @@ _Available in Fleet Premium._
       "app_store_id": "497799835",
       "self_service": true,
       "auto_update_enabled": true,
-      "auto_update_start_time": "01:00",
-      "auto_update_end_time": "05:00"
+      "auto_update_window_start": "01:00",
+      "auto_update_window_end": "05:00"
     }
   ]
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
This is related to [iOS/iPad VPP auto-updates: GitOps](https://github.com/fleetdm/fleet/issues/35457), and is required for this PR [GitOps support for scheduled auto updates settings](https://github.com/fleetdm/fleet/pull/37851) after reviewing it with @lucasmrod 

Follow-up will be to update the [VPPBatchPayload struct](https://github.com/fleetdm/fleet/blob/main/server/fleet/software.go#L681-L694) with these 3 fields in the mentioned PR.