### PR TITLE
Remove duplicate instructions in README.md

### DIFF
--- a/handbook/it-and-enablement/README.md
+++ b/handbook/it-and-enablement/README.md
@@ -20,8 +20,8 @@ This page details processes specific to working [with](#contact-us) and [within]
   - Please **use issue comments and GitHub mentions** to communicate follow-ups or answer questions related to your request.
 
 > To **make a request** of the GTM Ops team, [create an issue](https://github.com/fleetdm/confidential/issues/new?assignees=&labels=%3Agtm-ops&projects=&template=1-custom-request.md&title=) and a team member will get back to you within one business day (If urgent, mention [Sam Pfluger](https://fleetdm.slack.com/team/U05CS07KASK) in the [#g-unicorns](https://fleetdm.slack.com/archives/C08BTMFTUCR) Slack channel).
-  - Any Fleet team member can [view the kanban board](https://github.com/orgs/fleetdm/projects/100/views/1) for this department, including pending tasks and the status of new requests.
-  - Please **use issue comments and GitHub mentions** to communicate follow-ups or answer questions related to your request. 
+>  - Any Fleet team member can [view the kanban board](https://github.com/orgs/fleetdm/projects/100/views/1) for this department, including pending tasks and the status of new requests.
+>  - Please **use issue comments and GitHub mentions** to communicate follow-ups or answer questions related to your request. 
 
 ## Responsibilities
 


### PR DESCRIPTION
Fixed callout box regarding kanban board access and communication methods.

