### PR TITLE
API docs: Typo fix

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -11201,7 +11201,7 @@ _Available in Fleet Premium._
 
 #### Example
 
-`GET /api/v1/fleet/software/titles/123/package?alt=media?team_id=2`
+`GET /api/v1/fleet/software/titles/123/package?alt=media&team_id=2`
 
 ##### Default response
 


### PR DESCRIPTION
Additional query parameters use `&` instead of `?`