### PR TITLE
Update Docker slug for macOS FMA

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -298,7 +298,7 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
-    - slug: docker/darwin # Docker for macOS (ARM)
+    - slug: docker-desktop/darwin # Docker for macOS (ARM)
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -243,7 +243,7 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
-    - slug: docker/darwin # Docker for macOS (ARM)
+    - slug: docker-desktop/darwin # Docker for macOS (ARM)
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts


### PR DESCRIPTION
Changed the Docker software slug from 'docker/darwin' to 'docker-desktop/darwin' for Apple Silicon macOS hosts in both workstations and workstations-canary YAML files to ensure correct package referencing.
