### PR TITLE
Fix nats_test.go flaky tests

### DIFF
--- a/server/logging/nats_test.go
+++ b/server/logging/nats_test.go
@@ -20,12 +20,11 @@ import (
 )
 
 const (
-	natsTestLogCount            = 10
-	natsTestCompressionLogCount = 2
-	natsTestDirectSubject       = "test.logs.direct"
-	natsTestStreamSubject       = "test.logs.stream"
-	natsTestStreamName          = "test-logs-stream"
-	natsTestTimeout             = 5 * time.Second
+	natsTestLogCount      = 2
+	natsTestDirectSubject = "test.logs.direct"
+	natsTestStreamSubject = "test.logs.stream"
+	natsTestStreamName    = "test-logs-stream"
+	natsTestTimeout       = 5 * time.Second
 )
 
 // makeNatsClient creates a new NATS client.
@@ -69,19 +68,13 @@ func makeNatsServer(t *testing.T) *server.Server {
 	return ns
 }
 
-// makeNatsLogs creates a number of test logs.
+// makeNatsLogs creates test logs.
 func makeNatsLogs(t *testing.T) []json.RawMessage {
-	t.Helper()
-	return makeNatsLogsN(t, natsTestLogCount)
-}
-
-// makeNatsLogsN creates n test logs.
-func makeNatsLogsN(t *testing.T, n int) []json.RawMessage {
 	t.Helper()
 
 	var logs []json.RawMessage
 
-	for i := range n {
+	for i := range natsTestLogCount {
 		logs = append(logs,
 			json.RawMessage(fmt.Sprintf(`{"foo":"bar %d"}`, i)),
 		)
@@ -360,7 +353,7 @@ func TestNatsLogWriter(t *testing.T) {
 		// Create a wait group to track outstanding logs.
 		var wg sync.WaitGroup
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Add the number of expected logs to the wait group.
@@ -451,7 +444,7 @@ func TestNatsLogWriter(t *testing.T) {
 
 		require.NoError(t, err)
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Write the expected logs to the NATS log writer, and ensure it
@@ -488,7 +481,7 @@ func TestNatsLogWriter(t *testing.T) {
 		// Create a wait group to track outstanding logs.
 		var wg sync.WaitGroup
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Add the number of expected logs to the wait group.
@@ -544,7 +537,7 @@ func TestNatsLogWriter(t *testing.T) {
 		// Create a wait group to track outstanding logs.
 		var wg sync.WaitGroup
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Add the number of expected logs to the wait group.
@@ -636,7 +629,7 @@ func TestNatsLogWriter(t *testing.T) {
 
 		require.NoError(t, err)
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Write the expected logs to the NATS log writer, and ensure it
@@ -698,7 +691,7 @@ func TestNatsLogWriter(t *testing.T) {
 
 		require.NoError(t, err)
 
-		exp := makeNatsLogsN(t, natsTestCompressionLogCount)
+		exp := makeNatsLogs(t)
 		act := []json.RawMessage{}
 
 		// Write the expected logs to the NATS log writer, and ensure it


### PR DESCRIPTION
Context: https://fleetdm.slack.com/archives/C019WG4GH0A/p1767759920870649

Looks like some of the tests in `nats_test.go` are failing due to timeouts. The timeout used for the context in these tests is 5 seconds. Instead of increasing it, I decided to reduce the number of logs that are written in tests as well as some sleep statements that I don't think are needed.
Note that in `nats.go` we use `context.WithTimeout` so that's why the context deadline exceeded error is raised.

<img width="747" height="373" alt="Screenshot 2026-01-07 at 9 38 04 AM" src="https://github.com/user-attachments/assets/1a817e8b-6a4a-4d43-9891-07f2791b82ea" />

## Testing

Did 5 test runs and measured the test completion time

### Before

<img width="1211" height="230" alt="Screenshot 2026-01-07 at 9 39 59 AM" src="https://github.com/user-attachments/assets/cf22397b-1962-439c-831f-ef9cde6bf590" />

Completion time (avg): 1.23s

### After

<img width="922" height="227" alt="Screenshot 2026-01-07 at 9 38 53 AM" src="https://github.com/user-attachments/assets/12e1bddd-a257-4313-ab89-e1339374796c" />

Completion time (avg): 0.31s
