### PR TITLE
escape custom env vars in XML files

### DIFF
--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -195,6 +195,12 @@ func TestExpandEnv(t *testing.T) {
 			"$fleet_var_test", // Should not be replaced
 			nil,
 		},
+		{
+			map[string]string{"custom_secret": "test&123"},
+			"<Add>$custom_secret</Add>",
+			"<Add>test&amp;123</Add>",
+			nil,
+		},
 	} {
 		// save the current env before clearing it.
 		testutils.SaveEnv(t)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves oversight on initial bug fix: https://github.com/fleetdm/fleet/issues/32920#issuecomment-3716712957

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced XML-aware handling for environment variable expansion in fleet secrets. Automatically escapes special characters within XML documents while preserving unescaped expansion for non-XML content.

* **Tests**
  * Added test case to verify correct escaping of special characters (such as ampersands) in environment variables when used within XML elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->