### PR TITLE
Improved error message when trying to apply CAs via gitops without a premium license

### DIFF
--- a/changes/issue-32110-new-err-message-license-ca-gitops
+++ b/changes/issue-32110-new-err-message-license-ca-gitops
@@ -1,0 +1,1 @@
+- add better errro message when trying to apply certificate authorities via gitops without the correct license

--- a/cmd/fleetctl/fleetctl/apply.go
+++ b/cmd/fleetctl/fleetctl/apply.go
@@ -95,7 +95,7 @@ func applyCommand() *cli.Command {
 			teamsVPPApps := make(map[string][]fleet.VPPAppResponse)
 			teamsScripts := make(map[string][]fleet.ScriptResponse)
 
-			_, _, _, _, err = fleetClient.ApplyGroup(c.Context, false, specs, baseDir, logf, nil, opts, teamsSoftwareInstallers, teamsVPPApps, teamsScripts)
+			_, _, _, _, err = fleetClient.ApplyGroup(c.Context, false, specs, baseDir, logf, nil, opts, teamsSoftwareInstallers, teamsVPPApps, teamsScripts, nil)
 			if err != nil {
 				return err
 			}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -579,7 +579,7 @@ func (c *Client) ApplyGroup(
 
 	if specs.CertificateAuthorities != nil {
 		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions); err != nil {
-			// only do this custom message for gitops as we reference the applying filename which is only makes sense in gitops
+			// only do this custom message for gitops as we reference the applying filename which only makes sense in gitops
 			if err.Error() == "missing or invalid license" && viaGitOps && filename != nil {
 				return nil, nil, nil, nil, fmt.Errorf("Couldn't edit \"%s\" at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.", *filename)
 			}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -530,6 +530,7 @@ func (c *Client) ApplyGroup(
 	teamsSoftwareInstallers map[string][]fleet.SoftwarePackageResponse,
 	teamsVPPApps map[string][]fleet.VPPAppResponse,
 	teamsScripts map[string][]fleet.ScriptResponse,
+	filename *string,
 ) (map[string]uint, map[string][]fleet.SoftwarePackageResponse, map[string][]fleet.VPPAppResponse, map[string][]fleet.ScriptResponse, error) {
 	logfn := func(format string, args ...interface{}) {
 		if logf != nil {
@@ -578,6 +579,10 @@ func (c *Client) ApplyGroup(
 
 	if specs.CertificateAuthorities != nil {
 		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions); err != nil {
+			// only do this custom message for gitops as we reference the applying filename which is only makes sense in gitops
+			if err.Error() == "missing or invalid license" && viaGitOps && filename != nil {
+				return nil, nil, nil, nil, fmt.Errorf("Couldn't edit \"%s\" at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.", *filename)
+			}
 			return nil, nil, nil, nil, fmt.Errorf("applying certificate authorities: %w", err)
 		}
 		// TODO(hca): is more detailed logging a hard requirement or can it be a follow up improvement?
@@ -2300,7 +2305,7 @@ func (c *Client) DoGitOps(
 			Overwrite: true,
 		},
 		ExpandEnvConfigProfiles: true,
-	}, teamsSoftwareInstallers, teamsVPPApps, teamsScripts)
+	}, teamsSoftwareInstallers, teamsVPPApps, teamsScripts, &filename)
 	if err != nil {
 		return nil, err
 	}

--- a/server/service/endpoint_setup.go
+++ b/server/service/endpoint_setup.go
@@ -248,6 +248,7 @@ func ApplyStarterLibrary(
 			teamsSoftwareInstallers,
 			teamsVPPApps,
 			teamsScripts,
+			nil,
 		)
 		return err
 	}


### PR DESCRIPTION
**Related issue:** Resolves #35645

This changes the error message for an invalid license when trying to apply certificate authorities via GitOps

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
