### PR TITLE
Website: Add VPP metadata proxy

### DIFF
--- a/website/.eslintrc
+++ b/website/.eslintrc
@@ -54,7 +54,7 @@
     "MicrosoftComplianceTenant": true,
     "AndroidEnterprise": true,
     "RenderProofOfValue": true,
-    "InstanceUsingVpp": true
+    "FleetInstanceUsingVpp": true
     // …and any others.
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   },

--- a/website/.eslintrc
+++ b/website/.eslintrc
@@ -54,6 +54,7 @@
     "MicrosoftComplianceTenant": true,
     "AndroidEnterprise": true,
     "RenderProofOfValue": true,
+    "InstanceUsingVpp": true
     // …and any others.
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   },

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -14,7 +14,7 @@ module.exports = {
       description: 'The App store region that a proxied request will be sent to.',
     },
 
-    platforms: {
+    platform: {
       type: 'string',
       description: 'A comma separated list of the platforms that are included in this proxied request.',
     },
@@ -56,7 +56,7 @@ module.exports = {
   },
 
 
-  fn: async function ({storeRegion}) {
+  fn: async function ({storeRegion, ids, platform, additionalPlatforms, extend}) {
 
     // Validate the provided fleetServerSecret
     let authHeader = this.req.get('authorization');
@@ -99,11 +99,14 @@ module.exports = {
       }
     );
 
-    let queryParametersToSendToApple = this.req.query;
-
     let responseFromAppleApi = await sails.helpers.http.get.with({
       url: `https://api.ent.apple.com/v1/catalog/${storeRegion}/stoken-authenticated-apps`,
-      data: queryParametersToSendToApple,
+      data: {
+        ids,
+        platform,
+        additionalPlatforms,
+        extend,
+      },
       headers: {
         'Authorization': `Bearer ${tokenForThisRequest}`,
         'Cookie': `${cookieHeader}`,

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -1,0 +1,123 @@
+module.exports = {
+
+
+  friendlyName: 'Get vpp app metadata',
+
+
+  description: 'Proxies authenticated requests from Fleet instances to the Apple App store API.',
+
+
+  inputs: {
+    storeRegion: {
+      type: 'string',
+      required: true,
+      description: 'The App store region that a proxied request will be sent to.',
+    },
+
+    platforms: {
+      type: 'string',
+      description: 'A comma separated list of the platforms that are included in this proxied request.',
+    },
+
+    additionalPlatforms: {
+      type: 'string',
+      description: 'A comma separated list of platforms that are included in the proxied request.'
+    },
+
+    ids: {
+      type: 'string',
+      description: 'A comma separated list of IDs of app store apps to include in the response.'
+    },
+
+    extend: {
+      type: {},
+      description: 'An object containing the name of additional attributes to include in the API response.'
+    }
+  },
+
+
+  exits: {
+    success: {
+      description: 'The response was sent to the Fleet server',
+      outputType: {},
+    },
+    missingAuthHeader: {
+      description: 'This request is missing an authorization header.',
+      responseType: 'unauthorized'
+    },
+    invalidFleetServerSecret: {
+      description: 'Invalid authentication token.',
+      responseType: 'unauthorized',
+    },
+    missingVppToken: {
+      description: 'This request is missing a VPP app token',
+      responseType: 'badRequest',
+    },
+  },
+
+
+  fn: async function ({storeRegion}) {
+
+    // Validate the provided fleetServerSecret
+    let authHeader = this.req.get('authorization');
+    let fleetServerSecret;
+
+    if (authHeader && authHeader.startsWith('Bearer')) {
+      fleetServerSecret = authHeader.replace('Bearer', '').trim();
+    } else {
+      throw 'missingAuthHeader';
+    }
+
+    let thisFleetInstance = await FleetInstanceUsingVpp.findOne({
+      fleetServerSecret: fleetServerSecret
+    });
+
+    if(!thisFleetInstance) {
+      throw 'invalidFleetServerSecret';
+    }
+
+    let cookieHeader = this.req.get('cookie');
+    if(!cookieHeader) {
+      // If no cookie header was included return a missingVppToken (badRequest) response to the Fleet instance.
+      throw 'missingVppToken';
+    }
+    let nowAt = Date.now();
+    let nowAtInSeconds = Math.floor(nowAt / 1000);
+
+    let expiresAtInSeconds = nowAtInSeconds + 60;
+
+    let tokenForThisRequest = require('jsonwebtoken').sign(
+      {
+        iss: sails.config.custom.vppProxyTokenTeamId,
+        exp: expiresAtInSeconds,
+        iat: nowAtInSeconds,
+      },
+      sails.config.custom.vppProxyTokenPrivateKey,
+      {
+        algorithm: 'ES256',
+        keyid: sails.config.custom.vppProxyTokenKeyId,
+      }
+    );
+
+    let queryParametersToSendToApple = this.req.query;
+
+    let responseFromAppleApi = await sails.helpers.http.get.with({
+      url: `https://api.ent.apple.com/v1/catalog/${storeRegion}/stoken-authenticated-apps`,
+      data: queryParametersToSendToApple,
+      headers: {
+        'Authorization': `Bearer ${tokenForThisRequest}`,
+        'Cookie': `${cookieHeader}`,
+        'Content-Type': 'application/json'
+      }
+    })
+    .tolerate((err)=>{
+      sails.log.warn(`p1: When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      return err;
+    });
+
+    return responseFromAppleApi;
+
+  }
+
+
+};

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -16,7 +16,7 @@ module.exports = {
 
     platform: {
       type: 'string',
-      description: 'A comma separated list of the platforms that are included in this proxied request.',
+      description: 'The platform the specified app(s) runs on',
     },
 
     additionalPlatforms: {
@@ -110,7 +110,6 @@ module.exports = {
       headers: {
         'Authorization': `Bearer ${tokenForThisRequest}`,
         'Cookie': `${cookieHeader}`,
-        'Content-Type': 'application/json'
       }
     })
     .tolerate((err)=>{

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -38,7 +38,7 @@ module.exports = {
 
   exits: {
     success: {
-      description: 'The response was sent to the Fleet server',
+      description: 'App metadata was sent to the Fleet server',
       outputType: {},
     },
     missingAuthHeader: {
@@ -114,7 +114,7 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
-      sails.log.warn(`p1: When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
       return err;
     });
 

--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -1,7 +1,7 @@
 module.exports = {
 
 
-  friendlyName: 'Register or update one fleet instance using vpp',
+  friendlyName: 'Register one Fleet instance using VPP',
 
 
   description: 'Creates a registration for a Fleet instance in the website\'s database and returns a generated secret to authenticate future requests.',

--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -1,7 +1,7 @@
 module.exports = {
 
 
-  friendlyName: 'Register one Fleet instance using VPP',
+  friendlyName: 'Register one Fleet instance for using VPP',
 
 
   description: 'Creates a registration for a Fleet instance in the website\'s database and returns a generated secret to authenticate future requests.',

--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -13,11 +13,6 @@ module.exports = {
       type: 'string',
       required: true,
     },
-
-    fleetLicenseKey: {
-      type: 'string',
-      required: true,
-    }
   },
 
 
@@ -29,13 +24,23 @@ module.exports = {
       },
     },
     couldNotVerifyLicense: {
-      description: 'The provided Fleet license key could not be verified.',
+      description: 'The Fleet license key could not be verified.',
       responseType: 'unauthorized',
     },
   },
 
 
-  fn: async function ({fleetServerUrl, fleetLicenseKey}) {
+  fn: async function ({fleetServerUrl}) {
+
+    // Get the Fleet license key that was sent in the Authorization header as a bearer token.
+    let authHeader = this.req.get('authorization');
+    let fleetLicenseKey;
+
+    if (authHeader && authHeader.startsWith('Bearer')) {
+      fleetLicenseKey = authHeader.replace('Bearer', '').trim();
+    } else {
+      throw 'couldNotVerifyLicense';
+    }
 
     // Validate provided fleetLicenseKey
     try {

--- a/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-one-fleet-instance-using-vpp.js
@@ -27,6 +27,10 @@ module.exports = {
       description: 'The Fleet license key could not be verified.',
       responseType: 'unauthorized',
     },
+    invalidFleetServerUrl: {
+      description: 'The provided Fleet server URL does not appear to be a URL.',
+      responseType: 'badRequest',
+    },
   },
 
 
@@ -53,6 +57,14 @@ module.exports = {
       // If there is an error parsing the provided fleetLicenseKey, return a couldNotVerifyLicense response.
       throw 'couldNotVerifyLicense';
     }
+
+    // validate Fleet server URL
+    try {
+      new URL(fleetServerUrl);
+    } catch(unusedErr) {
+      throw 'invalidFleetServerUrl';
+    }
+
 
     // Generate a new FleetServerSecret for this Fleet instance.
     let fleetServerSecret = sails.helpers.strings.random.with({len: 30});

--- a/website/api/controllers/vpp-proxy/register-or-update-one-fleet-instance-using-vpp.js
+++ b/website/api/controllers/vpp-proxy/register-or-update-one-fleet-instance-using-vpp.js
@@ -1,0 +1,66 @@
+module.exports = {
+
+
+  friendlyName: 'Register or update one fleet instance using vpp',
+
+
+  description: 'Creates a registration for a Fleet instance in the website\'s database and returns a generated secret to authenticate future requests.',
+
+
+
+  inputs: {
+    fleetServerUrl: {
+      type: 'string',
+      required: true,
+    },
+
+    fleetLicenseKey: {
+      type: 'string',
+      required: true,
+    }
+  },
+
+
+  exits: {
+    success: {
+      description: 'A Fleet instance\'s VPP proxy registration was successfully submitted.',
+      outputType: {
+        fleetServerSecret: 'string',
+      },
+    },
+    couldNotVerifyLicense: {
+      description: 'The provided Fleet license key could not be verified.',
+      responseType: 'unauthorized',
+    },
+  },
+
+
+  fn: async function ({fleetServerUrl, fleetLicenseKey}) {
+
+    // Validate provided fleetLicenseKey
+    try {
+      require('jsonwebtoken').verify(
+        fleetLicenseKey,
+        sails.config.custom.licenseKeyGeneratorPublicKey,
+        { algorithm: 'ES256' }
+      );
+    } catch(unusedErr) {
+      // If there is an error parsing the provided fleetLicenseKey, return a couldNotVerifyLicense response.
+      throw 'couldNotVerifyLicense';
+    }
+
+    // Generate a new FleetServerSecret for this Fleet instance.
+    let fleetServerSecret = sails.helpers.strings.random.with({len: 30});
+
+    // Create a new database record for this Fleet instance.
+    await FleetInstanceUsingVpp.create({fleetInstanceUrl: fleetServerUrl, fleetServerSecret});
+
+    // Return the generated fleetServerSecret
+    return {
+      fleetServerSecret,
+    };
+
+  }
+
+
+};

--- a/website/api/models/FleetInstanceUsingVpp.js
+++ b/website/api/models/FleetInstanceUsingVpp.js
@@ -15,22 +15,14 @@ module.exports = {
     fleetInstanceUrl: {
       type: 'string',
       required: true,
-      unique: true,
       description: 'The URL of a Fleet instance that is using the fleet website VPP proxy.'
     },
 
     fleetServerSecret: {
       type: 'string',
       required: true,
-      unique: true,
       description: 'A generated secret used to autheticate & identify requests from a particular Fleet instance.'
     },
-
-    vppToken: {
-      type: 'string',
-      required: true,
-      description: 'A VPP token used to autheticate requests to an organization\'s VPP apps.'// TODO: is that acurate?
-    }
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗

--- a/website/api/models/FleetInstanceUsingVpp.js
+++ b/website/api/models/FleetInstanceUsingVpp.js
@@ -1,0 +1,47 @@
+/**
+ * InstanceUsingVpp.js// TODO: better name.
+ *
+ * @description :: A model definition represents a database table/collection.
+ * @docs        :: https://sailsjs.com/docs/concepts/models-and-orm/models
+ */
+
+module.exports = {
+
+  attributes: {
+
+    //  ╔═╗╦═╗╦╔╦╗╦╔╦╗╦╦  ╦╔═╗╔═╗
+    //  ╠═╝╠╦╝║║║║║ ║ ║╚╗╔╝║╣ ╚═╗
+    //  ╩  ╩╚═╩╩ ╩╩ ╩ ╩ ╚╝ ╚═╝╚═╝
+    fleetInstanceUrl: {
+      type: 'string',
+      required: true,
+      unique: true,
+      description: 'The URL of a Fleet instance that is using the fleet website VPP proxy.'
+    },
+
+    fleetServerSecret: {
+      type: 'string',
+      required: true,
+      unique: true,
+      description: 'A generated secret used to autheticate & identify requests from a particular Fleet instance.'
+    },
+
+    vppToken: {
+      type: 'string',
+      required: true,
+      description: 'A VPP token used to autheticate requests to an organization\'s VPP apps.'// TODO: is that acurate?
+    }
+
+    //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
+    //  ║╣ ║║║╠╩╗║╣  ║║╚═╗
+    //  ╚═╝╩ ╩╚═╝╚═╝═╩╝╚═╝
+
+
+    //  ╔═╗╔═╗╔═╗╔═╗╔═╗╦╔═╗╔╦╗╦╔═╗╔╗╔╔═╗
+    //  ╠═╣╚═╗╚═╗║ ║║  ║╠═╣ ║ ║║ ║║║║╚═╗
+    //  ╩ ╩╚═╝╚═╝╚═╝╚═╝╩╩ ╩ ╩ ╩╚═╝╝╚╝╚═╝
+
+  },
+
+};
+

--- a/website/assets/.eslintrc
+++ b/website/assets/.eslintrc
@@ -67,7 +67,8 @@
     "Platform": false,
     "AdCampaign": false,
     "MicrosoftComplianceTenant": false,
-    "AndroidEnterprise": false
+    "AndroidEnterprise": false,
+    "InstanceUsingVpp": false
     // ...and any other backend globals (e.g. `"Organization": false`)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   }

--- a/website/assets/.eslintrc
+++ b/website/assets/.eslintrc
@@ -68,7 +68,7 @@
     "AdCampaign": false,
     "MicrosoftComplianceTenant": false,
     "AndroidEnterprise": false,
-    "InstanceUsingVpp": false
+    "FleetInstanceUsingVpp": false
     // ...and any other backend globals (e.g. `"Organization": false`)
     // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   }

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -488,5 +488,9 @@ module.exports.custom = {
   // androidEnterpriseServiceAccountEmailAddress: '…',
   // androidEnterpriseServiceAccountPrivateKey: '…',
 
+  // VPP proxy
+  // vppProxyTokenTeamId: '',
+  // vppProxyTokenKeyId: '',
+  // vppProxyTokenPrivateKey: '',
 
 };

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -82,4 +82,5 @@ module.exports.policies = {
   'microsoft-proxy/view-turn-on-mdm': true,
   'view-okta-conditional-access-error': true,
   'view-fast-track': true,
+  'vpp-proxy/*': true,
 };

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1275,8 +1275,8 @@ module.exports.routes = {
   //  ╦  ╦╔═╗╔═╗  ╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗  ╔═╗╦═╗╔═╗═╗ ╦╦ ╦  ╔═╗╔╗╔╔╦╗╔═╗╔═╗╦╔╗╔╔╦╗╔═╗
   //  ╚╗╔╝╠═╝╠═╝  ║║║║╣  ║ ╠═╣ ║║╠═╣ ║ ╠═╣  ╠═╝╠╦╝║ ║╔╩╦╝╚╦╝  ║╣ ║║║ ║║╠═╝║ ║║║║║ ║ ╚═╗
   //   ╚╝ ╩  ╩    ╩ ╩╚═╝ ╩ ╩ ╩═╩╝╩ ╩ ╩ ╩ ╩  ╩  ╩╚═╚═╝╩ ╚═ ╩   ╚═╝╝╚╝═╩╝╩  ╚═╝╩╝╚╝ ╩ ╚═╝
-  'POST /api/v1/vpp/register': { action: 'vpp/register-or-update-one-fleet-instance-using-vpp', csrf: false },
-  'GET /api/v1/vpp/metadata': { action: 'vpp/get-vpp-app-metadata' },
+  'POST /api/vpp/v1/register': { action: 'vpp/register-or-update-one-fleet-instance-using-vpp', csrf: false },
+  'GET /api/vpp/v1/metadata': { action: 'vpp/get-vpp-app-metadata' },
 
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1275,7 +1275,7 @@ module.exports.routes = {
   //  ╦  ╦╔═╗╔═╗  ╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗  ╔═╗╦═╗╔═╗═╗ ╦╦ ╦  ╔═╗╔╗╔╔╦╗╔═╗╔═╗╦╔╗╔╔╦╗╔═╗
   //  ╚╗╔╝╠═╝╠═╝  ║║║║╣  ║ ╠═╣ ║║╠═╣ ║ ╠═╣  ╠═╝╠╦╝║ ║╔╩╦╝╚╦╝  ║╣ ║║║ ║║╠═╝║ ║║║║║ ║ ╚═╗
   //   ╚╝ ╩  ╩    ╩ ╩╚═╝ ╩ ╩ ╩═╩╝╩ ╩ ╩ ╩ ╩  ╩  ╩╚═╚═╝╩ ╚═ ╩   ╚═╝╝╚╝═╩╝╩  ╚═╝╩╝╚╝ ╩ ╚═╝
-  'POST /api/vpp/v1/register': { action: 'vpp-proxy/register-or-update-one-fleet-instance-using-vpp', csrf: false },
+  'POST /api/vpp/v1/register': { action: 'vpp-proxy/register-one-fleet-instance-using-vpp', csrf: false },
   'GET /api/vpp/v1/metadata/:storeRegion': { action: 'vpp-proxy/get-vpp-app-metadata' },
 
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1275,8 +1275,8 @@ module.exports.routes = {
   //  ╦  ╦╔═╗╔═╗  ╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗  ╔═╗╦═╗╔═╗═╗ ╦╦ ╦  ╔═╗╔╗╔╔╦╗╔═╗╔═╗╦╔╗╔╔╦╗╔═╗
   //  ╚╗╔╝╠═╝╠═╝  ║║║║╣  ║ ╠═╣ ║║╠═╣ ║ ╠═╣  ╠═╝╠╦╝║ ║╔╩╦╝╚╦╝  ║╣ ║║║ ║║╠═╝║ ║║║║║ ║ ╚═╗
   //   ╚╝ ╩  ╩    ╩ ╩╚═╝ ╩ ╩ ╩═╩╝╩ ╩ ╩ ╩ ╩  ╩  ╩╚═╚═╝╩ ╚═ ╩   ╚═╝╝╚╝═╩╝╩  ╚═╝╩╝╚╝ ╩ ╚═╝
-  'POST /api/vpp/v1/register': { action: 'vpp/register-or-update-one-fleet-instance-using-vpp', csrf: false },
-  'GET /api/vpp/v1/metadata': { action: 'vpp/get-vpp-app-metadata' },
+  'POST /api/vpp/v1/register': { action: 'vpp-proxy/register-or-update-one-fleet-instance-using-vpp', csrf: false },
+  'GET /api/vpp/v1/metadata/:storeRegion': { action: 'vpp-proxy/get-vpp-app-metadata' },
 
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1271,6 +1271,13 @@ module.exports.routes = {
   'GET /api/v1/microsoft-compliance-partner/device/message': { action: 'microsoft-proxy/get-one-compliance-status-result', },
   'GET /api/v1/microsoft-compliance-partner/adminconsent': { action: 'microsoft-proxy/receive-redirect-from-microsoft', },
 
+  //
+  //  ╦  ╦╔═╗╔═╗  ╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗╔╦╗╔═╗  ╔═╗╦═╗╔═╗═╗ ╦╦ ╦  ╔═╗╔╗╔╔╦╗╔═╗╔═╗╦╔╗╔╔╦╗╔═╗
+  //  ╚╗╔╝╠═╝╠═╝  ║║║║╣  ║ ╠═╣ ║║╠═╣ ║ ╠═╣  ╠═╝╠╦╝║ ║╔╩╦╝╚╦╝  ║╣ ║║║ ║║╠═╝║ ║║║║║ ║ ╚═╗
+  //   ╚╝ ╩  ╩    ╩ ╩╚═╝ ╩ ╩ ╩═╩╝╩ ╩ ╩ ╩ ╩  ╩  ╩╚═╚═╝╩ ╚═ ╩   ╚═╝╝╚╝═╩╝╩  ╚═╝╩╝╚╝ ╩ ╚═╝
+  'POST /api/v1/vpp/register': { action: 'vpp/register-or-update-one-fleet-instance-using-vpp', csrf: false },
+  'GET /api/v1/vpp/metadata': { action: 'vpp/get-vpp-app-metadata' },
+
   // Well known resources https://datatracker.ietf.org/doc/html/rfc8615
   // =============================================================================================================
   //


### PR DESCRIPTION
For https://github.com/fleetdm/fleet/issues/37261

Changes:
- Added a new database model: `FleetInstanceUsingVpp`
- Added `/api/vpp/v1/register`: An API endpoint that validates provided Fleet license keys, creates a database record for the proxy registration, and returns a generated secret used to authenticate requests to the other VPP proxy endpoint
- Added `/api/vpp/v1/metadata/:storeRegion`: An API endpoint that forwards requests to the `https://api.ent.apple.com/v1/catalog/${storeRegion}/stoken-authenticated-apps` Apple API with a token generated using Fleet's Apple developer credentials.