### PR TITLE
Add missing `teamId` for getting labels in auto update modal

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
@@ -88,7 +88,7 @@ const EditAutoUpdateConfigModal = ({
   // Fetch labels for TargetLabelSelector
   const { data: labels } = useQuery<ILabelSummary[], Error>(
     ["custom_labels"],
-    () => labelsAPI.summary().then((res) => getCustomLabels(res.labels)),
+    () => labelsAPI.summary(teamId).then((res) => getCustomLabels(res.labels)),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
     }


### PR DESCRIPTION
Unreleased bug in 4.80.0.
I found this because I saw a label from another team listed.

Easy thing to miss because this modal was added after [the team labels PR](https://github.com/fleetdm/fleet/commit/8e4e89f4e943d9a8685f4362a1b68755dfd03ddd) from @iansltx for 4.79.0.