### PR TITLE
Add permissions docs for downloading fleetd installers

### DIFF
--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -106,6 +106,7 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 | Lock, unlock, and wipe hosts\*                                                                                                             |          |            | ✅         | ✅    |         |
 | Turn off MDM                                                                                                                               |          |            | ✅         | ✅    |         |
 | Configure Microsoft Entra conditional access integration                                                                                   |          |            |           | ✅    |       |
+| Download fleetd installers                                                                                                                 |          |            | ✅        | ✅    |       |
 
 \* Applies only to Fleet Premium
 
@@ -180,6 +181,7 @@ Users with access to multiple teams can be assigned different roles for each tea
 | View script details by host                                                                                                      | ✅            | ✅             | ✅              | ✅         |             |
 | Lock, unlock, and wipe hosts                                                                                                     |               |                | ✅              | ✅         |             |
 | Turn off MDM                                                                                                                     |               |                | ✅              | ✅         |             |
+| Download fleetd installers                                                                                                       |               |                | ✅              | ✅         |             |
 
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)


### PR DESCRIPTION
Permissions docs changes for #29719.
- Only global admins/maintainers have access to all (`No team`'s and team's) enroll secrets and URLs (observers/observers+ get no `Add hosts` in the UI).
- Only team admins/maintainers have access to the team's enroll secrets and URLs (observers/observers+ get no `Add hosts` in the UI).