### PR TITLE
Document FLEET_DEV_* configuration for bypassing Fleet VPP metadata poxy, using a different storefront region

### DIFF
--- a/articles/install-app-store-apps.md
+++ b/articles/install-app-store-apps.md
@@ -18,7 +18,11 @@ You can also manage which Google Play Store apps are available for self-service 
 
 3. Select **Add software > App store**, then select the app you just purchased.
 
-> Currently, Fleet only supports Apple App Store apps from the United States (US) region. If the app is listed on the [Apple App Store](https://apps.apple.com/) and it has `/us` in the URL (e.g. https://apps.apple.com/us/app/slack/id618783545) then it's supported.
+#### Advanced configuration
+
+By default, Fleet retrieves apps from the `us` Apple storefront. To specify a different region, start Fleet with the `FLEET_DEV_VPP_REGION` environment variable set to another storefront (e.g. `fr`).
+
+By default, Fleet proxies app metadata requests to remove the need to configure extra credentials beyond a VPP token; if you want to communicate directly with Apple's app catalog API, start Fleet with the `FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL` environment variable set to `apple`, and set the `FLEET_DEV_VPP_METADATA_BEARER_TOKEN` environment variable to a valid Apple Developer JWT.
 
 ### Google Play (Android)
 

--- a/articles/install-app-store-apps.md
+++ b/articles/install-app-store-apps.md
@@ -18,11 +18,7 @@ You can also manage which Google Play Store apps are available for self-service 
 
 3. Select **Add software > App store**, then select the app you just purchased.
 
-#### Advanced configuration
-
-By default, Fleet retrieves apps from the `us` Apple storefront. To specify a different region, start Fleet with the `FLEET_DEV_VPP_REGION` environment variable set to another storefront (e.g. `fr`).
-
-By default, Fleet proxies app metadata requests to remove the need to configure extra credentials beyond a VPP token; if you want to communicate directly with Apple's app catalog API, start Fleet with the `FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL` environment variable set to `apple`, and set the `FLEET_DEV_VPP_METADATA_BEARER_TOKEN` environment variable to a valid Apple Developer JWT.
+> Currently, Fleet only supports Apple App Store apps from the United States (US) region. If the app is listed on the [Apple App Store](https://apps.apple.com/) and it has `/us` in the URL (e.g. https://apps.apple.com/us/app/slack/id618783545) then it's supported.
 
 ### Google Play (Android)
 

--- a/articles/install-app-store-apps.md
+++ b/articles/install-app-store-apps.md
@@ -2,23 +2,39 @@
 
 _Available in Fleet Premium_
 
-In Fleet, you can install Apple App Store apps on your macOS, iOS, and iPadOS hosts. To do this, you must first [turn on Apple MDM](https://fleetdm.com/guides/apple-mdm-setup#turn-on-apple-mdm) and Apple's [Volume Purchasing Program (VPP)](https://fleetdm.com/guides/apple-mdm-setup#volume-purchasing-program-vpp).
+In Fleet, you can install Apple App Store apps on your macOS, iOS, and iPadOS hosts, including custom apps.
 
-You can also manage which Google Play Store apps are available for self-serivce in your end user's Android work profiles. Google only allows free Google Play Store apps. [Paid apps aren't supported](https://www.androidenterprise.community/discussions/conversations/distributing-paid-apps/653).
+You can also manage which Google Play Store apps are available for self-service in your end user's Android work profiles. Google only allows free Google Play Store apps. [Paid apps aren't supported](https://www.androidenterprise.community/discussions/conversations/distributing-paid-apps/653).
 
-Currently, Fleet only supports Apple App Store apps from the United States (US) region. If the app is listed on the [Apple App Store](https://apps.apple.com/) and it has `/us` in the URL (e.g. https://apps.apple.com/us/app/slack/id618783545) then it's supported.
+## Add an app
 
-## Add app
+### Apple (VPP)
 
-1. In Fleet, head to the **Software** page and select a team in the teams dropdown.
+> Before using Fleet to manage VPP apps, you must first [turn on Apple MDM](https://fleetdm.com/guides/apple-mdm-setup#turn-on-apple-mdm) and Apple's [Volume Purchasing Program (VPP)](https://fleetdm.com/guides/apple-mdm-setup#volume-purchasing-program-vpp). Once you've completed that setup, you can follow the directions below for each app.
 
-2. Select **Add software > App store** and choose a platform.
+1. Purchase the relevant app through Apple Business Manager (ABM). You must perform this step even if the app is free, or if it is a custom app you own. Learn how in [Apple's documentation](https://support.apple.com/guide/apple-business-manager/select-and-buy-content-axmc21817890/web).
 
-3. To add Apple App Store (VPP) apps to Fleet, you must first purchase them through Apple Business Manager (ABM), even if they are free. Learn how in [Apple's documentation](https://support.apple.com/guide/apple-business-manager/select-and-buy-content-axmc21817890/web).
+2. In Fleet, head to the **Software** page and select a team in the teams dropdown.
 
-4. To add Google Play Store (Android) apps, head to the [Google Play Store](https://play.google.com/store/apps), find the app, and copy the ID at the end of the URL (e.g. "com.android.chrome")
+3. Select **Add software > App store**, then select the app you just purchased.
 
-## Edit or remove app
+#### Advanced configuration
+
+By default, Fleet retrieves apps from the `us` Apple storefront. To specify a different region, start Fleet with the `FLEET_DEV_VPP_REGION` environment variable set to another storefront (e.g. `fr`).
+
+By default, Fleet proxies app metadata requests to remove the need to configure extra credentials beyond a VPP token; if you want to communicate directly with Apple's app catalog API, start Fleet with the `FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL` environment variable set to `apple`, and set the `FLEET_DEV_VPP_METADATA_BEARER_TOKEN` environment variable to a valid Apple Developer JWT.
+
+### Google Play (Android)
+
+> Before using Fleet to manage Google Play Store apps, you must first [turn on Android MDM](https://fleetdm.com/guides/android-mdm-setup). Once you've completed that setup, you can follow the directions below for each app.
+
+1. Head to the [Google Play Store](https://play.google.com/store/apps), find the app, and copy the ID at the end of the URL (e.g. "com.android.chrome")
+
+2. In Fleet, head to the **Software** page and select a team in the teams dropdown.
+
+3. Select **Add software > App store**, choose the Android platform, then enter the application ID.
+
+## Edit or remove an app
 
 1. In Fleet, head to the **Software** page and select a team in the teams dropdown.
 
@@ -28,13 +44,17 @@ Currently, Fleet only supports Apple App Store apps from the United States (US) 
 
 4. To remove the app, on the **Software details** page, select the trash can (delete) icon.
 
-## Install app
+## Install an app
 
-Apple App Store (VPP) apps can be installed manually on each host's Host details page. For macOS apps, apps can also be installed via self-service on the end user's **Fleet Desktop > My device** page or [automatically via policy automation](https://fleetdm.com/guides/automatic-software-install-in-fleet).
+### Apple (VPP)
 
-Currently, Android apps can only be installed via self-service in the end user's managed Google Play Store (work profile).
+Apps can be installed manually on each host's Host details page. For macOS apps, apps can also be installed via self-service on the end user's **Fleet Desktop > My device** page or [automatically via policy automation](https://fleetdm.com/guides/automatic-software-install-in-fleet).
 
 Currently, Apple App Stpre (VPP) apps can't be uninstalled via Fleet.
+
+### Google Play (Android)
+
+Android apps can be installed via self-service in the end user's managed Google Play Store (work profile).
 
 ## API and GitOps
 
@@ -46,5 +66,5 @@ To manage App Store apps using Fleet's best practice GitOps, check out the `app_
 <meta name="authorFullName" value="Jahziel Villasana-Espinoza">
 <meta name="authorGitHubUsername" value="jahzielv">
 <meta name="category" value="guides">
-<meta name="publishedOn" value="2025-02-28">
+<meta name="publishedOn" value="2026-01-08">
 <meta name="description" value="This guide will walk you through installing Apple App Store and Google Play Store apps on macOS, iOS, iPadOS, and Android hosts.">

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -222,25 +222,6 @@ license:
   enforce_host_limit: false
 ```
 
-### FLEET_DEV_VPP_REGION
-
-Override the default region (`us`) for the Apple App Store storefront.
-
-This is only available as an environment variable (not as YAML).
-
-### FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL
-
-Override the default URL (a Fleet-managed proxy) for retrieving VPP app metadata. Specify `apple` to interact with Apple's API directly
-(in which case you'll also need to set `FLEET_DEV_VPP_METADATA_BEARER_TOKEN`).
-
-This is only available as an environment variable (not as YAML).
-
-### FLEET_DEV_VPP_METADATA_BEARER_TOKEN
-
-Override the bearer token provided alongside VPP metadata requests. By default, Fleet will request a bearer token from
-the Fleet-run proxy when a token doesn't exist, or if auth fails. Auto-generated tokens are only good for interacting
-with the Fleet proxy, not Apple directly.
-
 ## YAML files
 
 ### features.detail_query_overrides

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -1,6 +1,6 @@
 # Configuration for contributors
 
-Don't use these Fleet server configuration options. For Fleet server configuraiton, please use the public [Fleet server configuration documentation](https://fleetdm.com/docs/configuration/fleet-server-configuration) instead. For YAML, please use the [public GitOps documentation](https://fleetdm.com/docs/configuration/yaml-files) instead.
+Don't use these Fleet server configuration options. For Fleet server configuration, please use the public [Fleet server configuration documentation](https://fleetdm.com/docs/configuration/fleet-server-configuration) instead. For YAML, please use the [public GitOps documentation](https://fleetdm.com/docs/configuration/yaml-files) instead.
 
 These options in this document are only used when contributing to Fleet. They frequently change to reflect current functionality.
 
@@ -221,6 +221,25 @@ license:
   key: foobar
   enforce_host_limit: false
 ```
+
+### FLEET_DEV_VPP_REGION
+
+Override the default region (`us`) for the Apple App Store storefront.
+
+This is only available as an environment variable (not as YAML).
+
+### FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL
+
+Override the default URL (a Fleet-managed proxy) for retrieving VPP app metadata. Specify `apple` to interact with Apple's API directly
+(in which case you'll also need to set `FLEET_DEV_VPP_METADATA_BEARER_TOKEN`).
+
+This is only available as an environment variable (not as YAML).
+
+### FLEET_DEV_VPP_METADATA_BEARER_TOKEN
+
+Override the bearer token provided alongside VPP metadata requests. By default, Fleet will request a bearer token from
+the Fleet-run proxy when a token doesn't exist, or if auth fails. Auto-generated tokens are only good for interacting
+with the Fleet proxy, not Apple directly.
 
 ## YAML files
 

--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -222,6 +222,25 @@ license:
   enforce_host_limit: false
 ```
 
+### FLEET_DEV_VPP_REGION
+
+Override the default region (`us`) for the Apple App Store storefront.
+
+This is only available as an environment variable (not as YAML).
+
+### FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL
+
+Override the default URL (a Fleet-managed proxy) for retrieving VPP app metadata. Specify `apple` to interact with Apple's API directly
+(in which case you'll also need to set `FLEET_DEV_VPP_METADATA_BEARER_TOKEN`).
+
+This is only available as an environment variable (not as YAML).
+
+### FLEET_DEV_VPP_METADATA_BEARER_TOKEN
+
+Override the bearer token provided alongside VPP metadata requests. By default, Fleet will request a bearer token from
+the Fleet-run proxy when a token doesn't exist, or if auth fails. Auto-generated tokens are only good for interacting
+with the Fleet proxy, not Apple directly.
+
 ## YAML files
 
 ### features.detail_query_overrides


### PR DESCRIPTION
This reverts commit 5780568b93f136938927c34f314920bf4335dffd. Code backing this documentation is included in #37969 as it makes QA easier.