### PR TITLE
Make sure we are able to detect team label conflicts due to add/update

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4748,4 +4748,13 @@ func TestComputeLabelMoves(t *testing.T) {
 		_, err := computeLabelMoves(allChanges)
 		require.ErrorContains(t, err, "already being added")
 	})
+
+	t.Run("conflict: trying to add an existing label", func(t *testing.T) {
+		allChanges := map[string][]spec.LabelChange{
+			"team1": {{Name: "conflict", Op: "=", FileName: "file1.yml"}},
+			"team2": {{Name: "conflict", Op: "+", FileName: "file2.yml"}},
+		}
+		_, err := computeLabelMoves(allChanges)
+		require.Error(t, err)
+	})
 }


### PR DESCRIPTION
Relates to #36759 

Resolves issue found during QA run that prevented conflict detection when a label was being updated and added at the same time.
