### PR TITLE
Rename auto-update keys

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1641,10 +1641,10 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 						softwareSpec["auto_update_enabled"] = *softwareTitle.AutoUpdateEnabled
 					}
 					if softwareTitle.AutoUpdateStartTime != nil {
-						softwareSpec["auto_update_start_time"] = *softwareTitle.AutoUpdateStartTime
+						softwareSpec["auto_update_window_start"] = *softwareTitle.AutoUpdateStartTime
 					}
 					if softwareTitle.AutoUpdateEndTime != nil {
-						softwareSpec["auto_update_end_time"] = *softwareTitle.AutoUpdateEndTime
+						softwareSpec["auto_update_window_end"] = *softwareTitle.AutoUpdateEndTime
 					}
 				}
 			}

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -894,11 +894,11 @@ func TestGenerateSoftwareAutoUpdateSchedule(t *testing.T) {
 			require.True(t, ok)
 			assert.Equal(t, true, val)
 
-			start, ok := a["auto_update_start_time"]
+			start, ok := a["auto_update_window_start"]
 			require.True(t, ok)
 			assert.Equal(t, "01:00", start)
 
-			end, ok := a["auto_update_end_time"]
+			end, ok := a["auto_update_window_end"]
 			require.True(t, ok)
 			assert.Equal(t, "03:00", end)
 		}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4793,8 +4793,8 @@ software:
     - app_store_id: "1234567890"
       platform: "ios"
       auto_update_enabled: true
-      auto_update_start_time: "01:00"
-      auto_update_end_time: "05:00"
+      auto_update_window_start: "01:00"
+      auto_update_window_end: "05:00"
       self_service: false
       labels_include_any: []
       labels_exclude_any: []
@@ -5055,8 +5055,8 @@ software:
     - app_store_id: "2"
       platform: "ios"
       auto_update_enabled: true
-      auto_update_start_time: "01:00"
-      auto_update_end_time: "05:00"
+      auto_update_window_start: "01:00"
+      auto_update_window_end: "05:00"
       self_service: false
 `)
 		require.NoError(t, err)
@@ -5156,8 +5156,8 @@ software:
     - app_store_id: "2"
       platform: "ios"
       auto_update_enabled: true
-      auto_update_start_time: "25:00"
-      auto_update_end_time: "05:00"
+      auto_update_window_start: "25:00"
+      auto_update_window_end: "05:00"
       self_service: false
 `)
 		require.NoError(t, err)

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -32,6 +32,6 @@ app_store_apps:
     setup_experience: true
   - app_store_id: com.example.ios-auto-update
     auto_update_enabled: true
-    auto_update_start_time: "01:00"
-    auto_update_end_time: "03:00"
+    auto_update_window_start: "01:00"
+    auto_update_window_end: "03:00"
     platform: ios

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/teams/team-a-thumbsup.yml
@@ -89,8 +89,8 @@ software:
     setup_experience: true
   - app_store_id: com.example.ios-auto-update
     auto_update_enabled: true
-    auto_update_end_time: "03:00"
-    auto_update_start_time: "01:00"
+    auto_update_window_end: "03:00"
+    auto_update_window_start: "01:00"
     icon:
       path: "../lib/team-a-👍/icons/my-ios-auto-update-app-ios-icon.png"
     platform: ios

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -2763,14 +2763,14 @@ software:
       platform: ios
       self_service: false
       auto_update_enabled: true
-      auto_update_start_time: "02:00"
-      auto_update_end_time: "06:00"
+      auto_update_window_start: "02:00"
+      auto_update_window_end: "06:00"
     - app_store_id: "2"
       platform: ipados
       self_service: false
       auto_update_enabled: true
-      auto_update_start_time: "03:00"
-      auto_update_end_time: "07:00"
+      auto_update_window_start: "03:00"
+      auto_update_window_end: "07:00"
 queries:
 policies:
 agent_options:
@@ -2865,8 +2865,8 @@ software:
       platform: ios
       self_service: false
       auto_update_enabled: true
-      auto_update_start_time: "02:00"
-      auto_update_end_time: "06:00"
+      auto_update_window_start: "02:00"
+      auto_update_window_end: "06:00"
     - app_store_id: "2"
       platform: ipados
       self_service: false

--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -1731,8 +1731,8 @@ This activity contains the following fields:
 - "labels_exclude_any": Target hosts that don't have any label in the array.
 - "software_display_name": Display name of the software title.
 - "auto_update_enabled": Whether automatic updates are enabled for iOS/iPadOS App Store (VPP) apps.
-- "auto_update_start_time": Update window start time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
-- "auto_update_end_time": Update window end time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
+- "auto_update_window_start": Update window start time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
+- "auto_update_window_end": Update window end time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
 
 
 #### Example
@@ -1759,8 +1759,8 @@ This activity contains the following fields:
   ]
   "software_display_name": "Logic Pro DAW"
   "auto_update_enabled": true
-  "auto_update_start_time": "22:00"
-  "auto_update_end_time": "02:00"
+  "auto_update_window_start": "22:00"
+  "auto_update_window_end": "02:00"
 }
 ```
 

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -192,8 +192,8 @@ export interface ISoftwareTitleDetails {
   bundle_identifier?: string;
   versions_count?: number;
   auto_update_enabled?: boolean;
-  auto_update_start_time?: string;
-  auto_update_end_time?: string;
+  auto_update_window_start?: string;
+  auto_update_window_end?: string;
   /** @deprecated Use extension_for instead */
   browser?: string;
 }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
@@ -90,8 +90,8 @@ describe("Edit Auto Update Config Modal", () => {
         <EditAutoUpdateConfigModal
           softwareTitle={createMockSoftwareTitleDetails({
             auto_update_enabled: true,
-            auto_update_start_time: "02:00",
-            auto_update_end_time: "04:00",
+            auto_update_window_start: "02:00",
+            auto_update_window_end: "04:00",
           })}
           teamId={1}
           refetchSoftwareTitle={jest.fn()}
@@ -144,8 +144,8 @@ describe("Edit Auto Update Config Modal", () => {
         <EditAutoUpdateConfigModal
           softwareTitle={createMockSoftwareTitleDetails({
             auto_update_enabled: true,
-            auto_update_start_time: "02:00",
-            auto_update_end_time: "04:00",
+            auto_update_window_start: "02:00",
+            auto_update_window_end: "04:00",
           })}
           teamId={1}
           refetchSoftwareTitle={jest.fn()}
@@ -510,8 +510,8 @@ describe("Edit Auto Update Config Modal", () => {
       await waitFor(() => {
         expect(requestSpy).toHaveBeenCalledWith({
           auto_update_enabled: true,
-          auto_update_start_time: "02:00",
-          auto_update_end_time: "04:00",
+          auto_update_window_start: "02:00",
+          auto_update_window_end: "04:00",
           labels_include_any: [],
           labels_exclude_any: [],
           team_id: 1,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
@@ -76,8 +76,8 @@ const EditAutoUpdateConfigModal = ({
   const [isUpdatingConfiguration, setIsUpdatingConfiguration] = useState(false);
   const [formData, setFormData] = useState<ISoftwareAutoUpdateConfigFormData>({
     autoUpdateEnabled: softwareTitle.auto_update_enabled || false,
-    autoUpdateStartTime: softwareTitle.auto_update_start_time || "",
-    autoUpdateEndTime: softwareTitle.auto_update_end_time || "",
+    autoUpdateStartTime: softwareTitle.auto_update_window_start || "",
+    autoUpdateEndTime: softwareTitle.auto_update_window_end || "",
     targetType: getTargetType(softwareTitle.app_store_app as IAppStoreApp),
     customTarget: getCustomTarget(softwareTitle.app_store_app as IAppStoreApp),
     labelTargets: generateSelectedLabels(

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/helpers.ts
@@ -60,7 +60,7 @@ export const getInstallerCardInfo = (
     isScriptPackage:
       SCRIPT_PACKAGE_SOURCES.includes(softwareTitle.source) || false,
     autoUpdateEnabled: softwareTitle.auto_update_enabled,
-    autoUpdateStartTime: softwareTitle.auto_update_start_time,
-    autoUpdateEndTime: softwareTitle.auto_update_end_time,
+    autoUpdateStartTime: softwareTitle.auto_update_window_start,
+    autoUpdateEndTime: softwareTitle.auto_update_window_end,
   };
 };

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -190,8 +190,8 @@ export interface IEditAppStoreAppPostBody {
   display_name?: string;
   configuration?: string;
   auto_update_enabled?: boolean;
-  auto_update_start_time?: string;
-  auto_update_end_time?: string;
+  auto_update_window_start?: string;
+  auto_update_window_end?: string;
 }
 
 const ORDER_KEY = "name";
@@ -342,8 +342,8 @@ const handleAutoUpdateConfigAppStoreAppForm = (
 ) => {
   body.auto_update_enabled = formData.autoUpdateEnabled;
   if (formData.autoUpdateEnabled) {
-    body.auto_update_start_time = formData.autoUpdateStartTime;
-    body.auto_update_end_time = formData.autoUpdateEndTime;
+    body.auto_update_window_start = formData.autoUpdateStartTime;
+    body.auto_update_window_end = formData.autoUpdateEndTime;
   }
   if (formData.targetType === "Custom") {
     const selectedLabels = listNamesFromSelectedLabels(formData.labelTargets);

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -30,9 +30,9 @@ func (ds *Datastore) SoftwareTitleByID(ctx context.Context, id uint, teamID *uin
 	)
 
 	if teamID != nil {
-		autoUpdatesSelect = `sus.enabled as auto_update_enabled, sus.start_time as auto_update_start_time, sus.end_time as auto_update_end_time, `
+		autoUpdatesSelect = `sus.enabled as auto_update_enabled, sus.start_time as auto_update_window_start, sus.end_time as auto_update_window_end, `
 		autoUpdatesJoin = fmt.Sprintf("LEFT JOIN software_update_schedules sus ON sus.title_id = st.id AND sus.team_id = %d", *teamID)
-		autoUpdatesGroupBy = "auto_update_enabled, auto_update_start_time, auto_update_end_time, "
+		autoUpdatesGroupBy = "auto_update_enabled, auto_update_window_start, auto_update_window_end, "
 		teamFilter = fmt.Sprintf("sthc.team_id = %d AND sthc.global_stats = 0", *teamID)
 		softwareInstallerGlobalOrTeamIDFilter = fmt.Sprintf("si.global_or_team_id = %d", *teamID)
 		vppAppsTeamsGlobalOrTeamIDFilter = fmt.Sprintf("vat.global_or_team_id = %d", *teamID)
@@ -875,8 +875,8 @@ SELECT
 	sus.team_id,
 	sus.title_id,
 	sus.enabled AS auto_update_enabled,
-	sus.start_time AS auto_update_start_time,
-	sus.end_time AS auto_update_end_time
+	sus.start_time AS auto_update_window_start,
+	sus.end_time AS auto_update_window_end
 FROM software_update_schedules sus
 JOIN software_titles st ON st.id = sus.title_id
 WHERE sus.team_id = ? AND st.source = ?

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -2459,8 +2459,8 @@ type ActivityEditedAppStoreApp struct {
 	SoftwareDisplayName string                    `json:"software_display_name"`
 	Configuration       json.RawMessage           `json:"configuration,omitempty"`
 	AutoUpdateEnabled   *bool                     `json:"auto_update_enabled,omitempty"`
-	AutoUpdateStartTime *string                   `json:"auto_update_start_time,omitempty"`
-	AutoUpdateEndTime   *string                   `json:"auto_update_end_time,omitempty"`
+	AutoUpdateStartTime *string                   `json:"auto_update_window_start,omitempty"`
+	AutoUpdateEndTime   *string                   `json:"auto_update_window_end,omitempty"`
 }
 
 func (a ActivityEditedAppStoreApp) ActivityName() string {
@@ -2480,8 +2480,8 @@ func (a ActivityEditedAppStoreApp) Documentation() (activity string, details str
 - "labels_exclude_any": Target hosts that don't have any label in the array.
 - "software_display_name": Display name of the software title.
 - "auto_update_enabled": Whether automatic updates are enabled for iOS/iPadOS App Store (VPP) apps.
-- "auto_update_start_time": Update window start time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
-- "auto_update_end_time": Update window end time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
+- "auto_update_window_start": Update window start time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
+- "auto_update_window_end": Update window end time (local time of the device) when automatic updates will take place for iOS/iPadOS App Store (VPP) apps, formatted as HH:MM.
 `, `{
   "software_title": "Logic Pro",
   "software_title_id": 123,
@@ -2503,8 +2503,8 @@ func (a ActivityEditedAppStoreApp) Documentation() (activity string, details str
   ]
   "software_display_name": "Logic Pro DAW"
   "auto_update_enabled": true
-  "auto_update_start_time": "22:00"
-  "auto_update_end_time": "02:00"
+  "auto_update_window_start": "22:00"
+  "auto_update_window_end": "02:00"
 }`
 }
 

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -315,11 +315,11 @@ type SoftwareAutoUpdateConfig struct {
 	AutoUpdateEnabled *bool `json:"auto_update_enabled,omitempty" db:"auto_update_enabled"`
 	// AutoUpdateStartTime is the beginning of the maintenance window for the software title.
 	// This is only applicable when viewing a title in the context of a team.
-	AutoUpdateStartTime *string `json:"auto_update_start_time,omitempty" db:"auto_update_start_time"`
+	AutoUpdateStartTime *string `json:"auto_update_window_start,omitempty" db:"auto_update_window_start"`
 	// AutoUpdateEndTime is the end of the maintenance window for the software title.
 	// If the end time is less than the start time, the window wraps to the next day.
 	// This is only applicable when viewing a title in the context of a team.
-	AutoUpdateEndTime *string `json:"auto_update_end_time,omitempty" db:"auto_update_end_time"`
+	AutoUpdateEndTime *string `json:"auto_update_window_end,omitempty" db:"auto_update_window_end"`
 }
 
 type SoftwareAutoUpdateSchedule struct {
@@ -801,8 +801,8 @@ type VPPBatchPayload struct {
 	Platform            InstallableDevicePlatform `json:"platform"`
 	Configuration       json.RawMessage           `json:"configuration,omitempty"`
 	AutoUpdateEnabled   *bool                     `json:"auto_update_enabled,omitempty"`
-	AutoUpdateStartTime *string                   `json:"auto_update_start_time,omitempty"`
-	AutoUpdateEndTime   *string                   `json:"auto_update_end_time,omitempty"`
+	AutoUpdateStartTime *string                   `json:"auto_update_window_start,omitempty"`
+	AutoUpdateEndTime   *string                   `json:"auto_update_window_end,omitempty"`
 }
 
 func (v VPPBatchPayload) GetPlatform() string {
@@ -827,8 +827,8 @@ type VPPBatchPayloadWithPlatform struct {
 	DisplayName         string          `json:"display_name"`
 	Configuration       json.RawMessage `json:"configuration,omitempty"`
 	AutoUpdateEnabled   *bool           `json:"auto_update_enabled,omitempty"`
-	AutoUpdateStartTime *string         `json:"auto_update_start_time,omitempty"`
-	AutoUpdateEndTime   *string         `json:"auto_update_end_time,omitempty"`
+	AutoUpdateStartTime *string         `json:"auto_update_window_start,omitempty"`
+	AutoUpdateEndTime   *string         `json:"auto_update_window_end,omitempty"`
 }
 
 type SoftwareCategory struct {

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -271,8 +271,8 @@ type TeamSpecAppStoreApp struct {
 	Configuration      TeamSpecSoftwareAsset `json:"configuration"`
 	// Auto-update fields for VPP apps
 	AutoUpdateEnabled   *bool   `json:"auto_update_enabled,omitempty"`
-	AutoUpdateStartTime *string `json:"auto_update_start_time,omitempty"`
-	AutoUpdateEndTime   *string `json:"auto_update_end_time,omitempty"`
+	AutoUpdateStartTime *string `json:"auto_update_window_start,omitempty"`
+	AutoUpdateEndTime   *string `json:"auto_update_window_end,omitempty"`
 }
 
 func (spec TeamSpecAppStoreApp) ResolvePaths(baseDir string) TeamSpecAppStoreApp {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -23530,7 +23530,7 @@ func (s *integrationEnterpriseTestSuite) TestUpdateSoftwareAutoUpdateConfig() {
 		AutoUpdateEndTime:   ptr.String("04:00"),
 	}, http.StatusOK, &titlesResp)
 
-	s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":"adam_vpp_app_1", "auto_update_enabled":true, "auto_update_end_time":"04:00", "auto_update_start_time":"02:00", "platform":"ipados", "self_service":false, "software_display_name":"", "software_icon_url":null, "software_title":"vpp1", "software_title_id":%d, "team_id":%d, "team_name":"%s"}`, vppApp.TitleID, team.ID, team.Name), 0)
+	s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":"adam_vpp_app_1", "auto_update_enabled":true, "auto_update_window_end":"04:00", "auto_update_window_start":"02:00", "platform":"ipados", "self_service":false, "software_display_name":"", "software_icon_url":null, "software_title":"vpp1", "software_title_id":%d, "team_id":%d, "team_name":"%s"}`, vppApp.TitleID, team.ID, team.Name), 0)
 
 	// Get the software title again.
 	s.DoJSON("GET", fmt.Sprintf("/api/v1/fleet/software/titles/%d", vppApp.TitleID), nil, http.StatusOK, &titlesResp, "team_id", fmt.Sprintf("%d", teamID))
@@ -23547,7 +23547,7 @@ func (s *integrationEnterpriseTestSuite) TestUpdateSoftwareAutoUpdateConfig() {
 		DisplayName: ptr.String("New Display Name"),
 	}, http.StatusOK, &titlesResp)
 
-	s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":"adam_vpp_app_1",  "auto_update_enabled":true, "auto_update_end_time":"04:00", "auto_update_start_time":"02:00", "platform":"ipados", "self_service":false, "software_display_name":"New Display Name", "software_icon_url":null, "software_title":"vpp1", "software_title_id":%d, "team_id":%d, "team_name":"%s"}`, vppApp.TitleID, team.ID, team.Name), 0)
+	s.lastActivityMatches(fleet.ActivityEditedAppStoreApp{}.ActivityName(), fmt.Sprintf(`{"app_store_id":"adam_vpp_app_1",  "auto_update_enabled":true, "auto_update_window_end":"04:00", "auto_update_window_start":"02:00", "platform":"ipados", "self_service":false, "software_display_name":"New Display Name", "software_icon_url":null, "software_title":"vpp1", "software_title_id":%d, "team_id":%d, "team_name":"%s"}`, vppApp.TitleID, team.ID, team.Name), 0)
 
 	// Disable the auto-update config
 	s.DoJSON("PATCH", fmt.Sprintf("/api/v1/fleet/software/titles/%d/app_store_app", vppApp.TitleID), updateAppStoreAppRequest{

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -112,11 +112,11 @@ type updateAppStoreAppRequest struct {
 	AutoUpdateEnabled *bool           `json:"auto_update_enabled,omitempty"`
 	// AutoUpdateStartTime is the beginning of the maintenance window for the software title.
 	// This is only applicable when viewing a title in the context of a team.
-	AutoUpdateStartTime *string `json:"auto_update_start_time,omitempty"`
+	AutoUpdateStartTime *string `json:"auto_update_window_start,omitempty"`
 	// AutoUpdateStartTime is the end of the maintenance window for the software title.
 	// If the end time is less than the start time, the window wraps to the next day.
 	// This is only applicable when viewing a title in the context of a team.
-	AutoUpdateEndTime *string `json:"auto_update_end_time,omitempty"`
+	AutoUpdateEndTime *string `json:"auto_update_window_end,omitempty"`
 }
 
 type updateAppStoreAppResponse struct {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #33391

## Testing

- [X] Added/updated automated tests
there's a number of tests for this, if they still pass we're in good shape
- [X] QA'd all new/changed functionality manually
I tested the front-end successfully, and saw an auto-update go through on an ipad. Also verified that the activity metadata is correct.