### PR TITLE
Cherry-Pick: Fix showing all labels when we shouldn't in new query targets UI

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -172,19 +172,15 @@ const PolicyForm = ({
     Error
   >(
     ["custom_labels", currentTeam],
-    () => {
+    () => labelsAPI.summary(currentTeam?.id, true),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
       // Wait for the current team to load from context before pulling labels, otherwise on a page load
       // directly on the policies new/edit page this gets called with currentTeam not set, then again
       // with the correct team value. If we don't trigger on currentTeam changes we'll just start with a
       // null team ID here and never populate with the correct team unless we navigate from another page
       // where team context is already set prior to navigation.
-      return !currentTeam
-        ? ({ labels: [] } as ILabelsSummaryResponse)
-        : labelsAPI.summary(currentTeam?.id, true);
-    },
-    {
-      ...DEFAULT_USE_QUERY_OPTIONS,
-      enabled: isPremiumTier,
+      enabled: isPremiumTier && !!currentTeam,
       staleTime: 10000,
       select: (res) => ({ labels: getCustomLabels(res.labels) }),
     }

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tests.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tests.tsx
@@ -3,6 +3,7 @@ import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import createMockQuery from "__mocks__/queryMock";
 import createMockUser from "__mocks__/userMock";
+import createMockTeam from "__mocks__/teamMock";
 import createMockConfig from "__mocks__/configMock";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
@@ -221,6 +222,7 @@ describe("SaveNewQueryModal", () => {
       context: {
         app: {
           currentUser: createMockUser(),
+          currentTeam: createMockTeam(),
           isGlobalObserver: false,
           isGlobalAdmin: true,
           isGlobalMaintainer: false,

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -77,7 +77,7 @@ const SaveNewQueryModal = ({
   queryReportsDisabled,
   platformSelector,
 }: ISaveNewQueryModalProps): JSX.Element => {
-  const { config, isPremiumTier } = useContext(AppContext);
+  const { config, isPremiumTier, currentTeam } = useContext(AppContext);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -107,10 +107,15 @@ const SaveNewQueryModal = ({
     isFetching: isFetchingLabels,
   } = useQuery<ILabelsSummaryResponse, Error>(
     ["custom_labels"],
-    () => labelsAPI.summary(apiTeamIdForQuery, true),
+    () => labelsAPI.summary(currentTeam?.id, true),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      enabled: isPremiumTier,
+      // Wait for the current team to load from context before pulling labels, otherwise on a page load
+      // directly on the page this gets called with currentTeam not set, then again
+      // with the correct team value. If we don't trigger on currentTeam changes we'll just start with a
+      // null team ID here and never populate with the correct team unless we navigate from another page
+      // where team context is already set prior to navigation.
+      enabled: isPremiumTier && !!currentTeam,
       staleTime: 10000,
       select: (res) => ({ labels: getCustomLabels(res.labels) }),
     }


### PR DESCRIPTION
Merged into `main` in #38065.