### PR TITLE
Searching software versions by name will now return all versions that match the corresponding title name as well

### DIFF
--- a/changes/35028-software-versions-search
+++ b/changes/35028-software-versions-search
@@ -1,0 +1,1 @@
+Searching software versions by name will now return all versions that match the corresponding title name as well.

--- a/changes/35028-software-versions-search
+++ b/changes/35028-software-versions-search
@@ -1,1 +1,1 @@
-Searching software versions by name will now return all versions that match the corresponding title name as well.
+Software version search now includes results that match the software title name in addition to the version name.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -1877,7 +1877,7 @@ func selectSoftwareSQL(opts fleet.SoftwareListOptions) (string, []interface{}, e
 	// See: https://github.com/fleetdm/fleet/issues/35028
 	if opts.ListOptions.MatchQuery != "" {
 		ds = ds.
-			LeftJoin(
+			InnerJoin(
 				goqu.I("software_titles").As("st"),
 				goqu.On(goqu.I("s.title_id").Eq(goqu.I("st.id"))),
 			)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -103,6 +103,7 @@ func TestSoftware(t *testing.T) {
 		{"LongestCommonPrefix", testLongestCommonPrefix},
 		{"ListHostSoftwareInHouseApps", testListHostSoftwareInHouseApps},
 		{"ListHostSoftwareAndroidVPPAppMatching", testListHostSoftwareAndroidVPPAppMatching},
+		{"ListSoftwareVersionsSearchByTitleName", testListSoftwareVersionsSearchByTitleName},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -10340,4 +10341,76 @@ func testListHostSoftwareAndroidVPPAppMatching(t *testing.T, ds *Datastore) {
 		assert.True(t, *amazonApp.AppStoreApp.SelfService)
 		assert.NotNil(t, amazonApp.IconUrl)
 	}
+}
+
+// testListSoftwareVersionsSearchByTitleName tests that searching software versions
+// by a software title name finds all software entries under that title, even when
+// individual software entry names differ from the title name.
+// This is a regression test for https://github.com/fleetdm/fleet/issues/35028
+func testListSoftwareVersionsSearchByTitleName(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Create a host
+	host := test.NewHost(t, ds, "search-test-host", "", "searchtestkey", "searchtestuuid", time.Now())
+
+	// First, create software with a specific name to establish the title
+	initialSoftware := []fleet.Software{
+		{Name: "SharePoint", Version: "1.0.0", Source: "apps", BundleIdentifier: "com.microsoft.sharepoint"},
+	}
+	_, err := ds.UpdateHostSoftware(ctx, host.ID, initialSoftware)
+	require.NoError(t, err)
+
+	// Get the title_id that was created
+	var titleID uint
+	err = ds.writer(ctx).GetContext(ctx, &titleID,
+		`SELECT title_id FROM software WHERE bundle_identifier = ? LIMIT 1`,
+		"com.microsoft.sharepoint")
+	require.NoError(t, err)
+
+	// Now add more software entries with different names but the same bundle_identifier.
+	// These will be grouped under the same title "SharePoint" but their individual names
+	// do NOT contain "SharePoint".
+	allSoftware := []fleet.Software{
+		{Name: "SharePoint", Version: "1.0.0", Source: "apps", BundleIdentifier: "com.microsoft.sharepoint"},
+		{Name: "Office Shared MUI Components", Version: "16.0.5765", Source: "apps", BundleIdentifier: "com.microsoft.sharepoint"},
+		{Name: "Office Runtime Libraries", Version: "16.0.1234", Source: "apps", BundleIdentifier: "com.microsoft.sharepoint"},
+	}
+	_, err = ds.UpdateHostSoftware(ctx, host.ID, allSoftware)
+	require.NoError(t, err)
+
+	// Sync host software to populate software_host_counts
+	require.NoError(t, ds.SyncHostsSoftware(ctx, time.Now()))
+
+	// Test: Search by the title name "sharepoint" on the versions method.
+	// This should find all 3 software entries because they all belong to a title named "SharePoint",
+	// even though only 1 of them has "SharePoint" in its software.name.
+	opts := fleet.SoftwareListOptions{
+		ListOptions: fleet.ListOptions{
+			MatchQuery: "sharepoint",
+		},
+		WithHostCounts: true,
+	}
+
+	software, _, err := ds.ListSoftware(ctx, opts)
+	require.NoError(t, err)
+
+	// All 3 software entries should be found because they belong to a title named "SharePoint".
+	require.Len(t, software, 3, "Search by title name should find all software entries under that title")
+
+	// Verify we got the expected software entries
+	foundNames := make(map[string]bool)
+	for _, sw := range software {
+		foundNames[sw.Name] = true
+	}
+	assert.True(t, foundNames["SharePoint"], "Should find 'SharePoint'")
+	assert.True(t, foundNames["Office Shared MUI Components"], "Should find 'Office Shared MUI Components'")
+	assert.True(t, foundNames["Office Runtime Libraries"], "Should find 'Office Runtime Libraries'")
+
+	// Test: Search by a name that only matches one software entry (not the title)
+	// This should still work as before - find the entry by its software.name
+	opts.ListOptions.MatchQuery = "Runtime"
+	software, _, err = ds.ListSoftware(ctx, opts)
+	require.NoError(t, err)
+	require.Len(t, software, 1, "Search by software name should still work")
+	assert.Equal(t, "Office Runtime Libraries", software[0].Name)
 }

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -10360,13 +10360,6 @@ func testListSoftwareVersionsSearchByTitleName(t *testing.T, ds *Datastore) {
 	_, err := ds.UpdateHostSoftware(ctx, host.ID, initialSoftware)
 	require.NoError(t, err)
 
-	// Get the title_id that was created
-	var titleID uint
-	err = ds.writer(ctx).GetContext(ctx, &titleID,
-		`SELECT title_id FROM software WHERE bundle_identifier = ? LIMIT 1`,
-		"com.microsoft.sharepoint")
-	require.NoError(t, err)
-
 	// Now add more software entries with different names but the same bundle_identifier.
 	// These will be grouped under the same title "SharePoint" but their individual names
 	// do NOT contain "SharePoint".


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35028

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Software version search now includes all versions whose software title matches the search query, extending search capabilities beyond name-only matching.

* **Tests**
  * Added tests to verify the expanded search functionality, covering searches by partial and full title names.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->