### PR TITLE
Added validation for empty certificate subject name.

### DIFF
--- a/server/service/certificate_templates_test.go
+++ b/server/service/certificate_templates_test.go
@@ -165,6 +165,15 @@ func TestCreateCertificateTemplate(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Empty or whitespace-only subject name", func(t *testing.T) {
+		whitespaceSubjectNames := []string{"", " ", "   \t\n  "}
+		for _, subjectName := range whitespaceSubjectNames {
+			_, err := svc.CreateCertificateTemplate(ctx, "my template", TeamID, uint(ValidCATypeID), subjectName)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Certificate template subject name is required")
+		}
+	})
 }
 
 func TestApplyCertificateTemplateSpecs(t *testing.T) {
@@ -364,5 +373,18 @@ func TestApplyCertificateTemplateSpecs(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "Certificate template name is too long")
+	})
+
+	t.Run("Whitespace-only subject name", func(t *testing.T) {
+		err := svc.ApplyCertificateTemplateSpecs(ctx, []*fleet.CertificateRequestSpec{
+			{
+				Name:                   "Template 2",
+				CertificateAuthorityId: 1,
+				SubjectName:            "   ",
+			},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Certificate template subject name is required")
+		require.Contains(t, err.Error(), "Template 2")
 	})
 }

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -23,8 +23,6 @@ const (
 // certificateTemplateNameRegex allows only letters, numbers, spaces, dashes, and underscores
 var certificateTemplateNameRegex = regexp.MustCompile(`^[a-zA-Z0-9 \-_]+$`)
 
-// validateCertificateTemplateSubjectName validates the certificate template subject name.
-// Returns a BadRequestError if validation fails.
 func validateCertificateTemplateSubjectName(subjectName string) error {
 	if strings.TrimSpace(subjectName) == "" {
 		return &fleet.BadRequestError{Message: "Certificate template subject name is required."}
@@ -90,7 +88,6 @@ func (svc *Service) CreateCertificateTemplate(ctx context.Context, name string, 
 		return nil, err
 	}
 
-	// Validate certificate template subject name
 	if err := validateCertificateTemplateSubjectName(subjectName); err != nil {
 		return nil, err
 	}
@@ -439,7 +436,6 @@ func (svc *Service) ApplyCertificateTemplateSpecs(ctx context.Context, specs []*
 			return err
 		}
 
-		// Validate certificate template subject name
 		if err := validateCertificateTemplateSubjectName(spec.SubjectName); err != nil {
 			return &fleet.BadRequestError{Message: fmt.Sprintf("%s (certificate %s)", err.Error(), spec.Name)}
 		}

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -23,6 +23,15 @@ const (
 // certificateTemplateNameRegex allows only letters, numbers, spaces, dashes, and underscores
 var certificateTemplateNameRegex = regexp.MustCompile(`^[a-zA-Z0-9 \-_]+$`)
 
+// validateCertificateTemplateSubjectName validates the certificate template subject name.
+// Returns a BadRequestError if validation fails.
+func validateCertificateTemplateSubjectName(subjectName string) error {
+	if strings.TrimSpace(subjectName) == "" {
+		return &fleet.BadRequestError{Message: "Certificate template subject name is required."}
+	}
+	return nil
+}
+
 // validateCertificateTemplateName validates the certificate template name.
 // Returns a BadRequestError if validation fails.
 func validateCertificateTemplateName(name string) error {
@@ -78,6 +87,11 @@ func (svc *Service) CreateCertificateTemplate(ctx context.Context, name string, 
 
 	// Validate certificate template name
 	if err := validateCertificateTemplateName(name); err != nil {
+		return nil, err
+	}
+
+	// Validate certificate template subject name
+	if err := validateCertificateTemplateSubjectName(subjectName); err != nil {
 		return nil, err
 	}
 
@@ -423,6 +437,11 @@ func (svc *Service) ApplyCertificateTemplateSpecs(ctx context.Context, specs []*
 		// Validate certificate template name
 		if err := validateCertificateTemplateName(spec.Name); err != nil {
 			return err
+		}
+
+		// Validate certificate template subject name
+		if err := validateCertificateTemplateSubjectName(spec.SubjectName); err != nil {
+			return &fleet.BadRequestError{Message: fmt.Sprintf("%s (certificate %s)", err.Error(), spec.Name)}
 		}
 
 		// Get the CA to validate its existence and type.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38109 

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation to reject certificate templates with empty or whitespace-only subject names and provide clearer error messaging when the certificate template subject name is required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->