### PR TITLE
Update instructions for turning off MDM on Windows hosts

### DIFF
--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -142,7 +142,7 @@ In the Google Admin console:
 
 2. If MDM is turned on, for macOS, Windows, iOS/iPadOS, and Android hosts:
   - For macOS hosts, select **Actions > Turn off MDM** on the host's details page to turn MDM off. 
-  - For Windows hosts, download the [turn off MDM script](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/windows/scripts/turn-off-mdm.ps1) and deploy via **Actions > Run script** on the host's details page. 
+  - For Windows hosts, download the [turn off MDM script](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/windows/scripts/turn-off-mdm.ps1), add it to the host's team on the **Scripts** page in Fleet, and run the script via **Actions > Run script** on the host's details page. 
   - For iOS/iPadOS and Android hosts, select **Actions > Unenroll**.
 
 3. Next, for macOS, Windows, and Linux hosts [uninstall fleetd](https://fleetdm.com/guides/how-to-uninstall-fleetd). 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -142,7 +142,7 @@ In the Google Admin console:
 
 2. If MDM is turned on, for macOS, Windows, iOS/iPadOS, and Android hosts:
   - For macOS hosts, select **Actions > Turn off MDM** to turn MDM off. 
-  - For Windows hosts, download and run the [turn off MDM script](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/windows/scripts/turn-off-mdm.ps1) on the host. 
+  - For Windows hosts, download the [turn off MDM script](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/windows/scripts/turn-off-mdm.ps1) and deploy via **Actions > Run script** on the host's details page. 
   - For iOS/iPadOS and Android hosts, select **Actions > Unenroll**.
 
 3. Next, for macOS, Windows, and Linux hosts [uninstall fleetd](https://fleetdm.com/guides/how-to-uninstall-fleetd). 

--- a/articles/enroll-hosts.md
+++ b/articles/enroll-hosts.md
@@ -141,7 +141,7 @@ In the Google Admin console:
 1. Determine if your host has MDM features turned on by looking at the **MDM status** on the host's **Host details** page. 
 
 2. If MDM is turned on, for macOS, Windows, iOS/iPadOS, and Android hosts:
-  - For macOS hosts, select **Actions > Turn off MDM** to turn MDM off. 
+  - For macOS hosts, select **Actions > Turn off MDM** on the host's details page to turn MDM off. 
   - For Windows hosts, download the [turn off MDM script](https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/windows/scripts/turn-off-mdm.ps1) and deploy via **Actions > Run script** on the host's details page. 
   - For iOS/iPadOS and Android hosts, select **Actions > Unenroll**.
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38092

This pull request updates the instructions for turning off MDM on Windows hosts in the enrollment documentation. The change clarifies the recommended method for deploying the script the script via Fleet.

Documentation improvements:

* Updated the Windows host instructions in `articles/enroll-hosts.md` to recommend deploying the "turn off MDM" script via **Actions > Run script** on the host's details page, rather than running the script manually.