### PR TITLE
allow activation declarations

### DIFF
--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -733,8 +733,8 @@ func (r *MDMAppleRawDeclaration) ValidateUserProvided(allowCustomOSUpdatesAndFil
 		return NewInvalidArgumentError(r.Type, "Declaration profile can’t include status subscription type. To get host’s vitals, please use queries and policies.")
 	}
 
-	if !strings.HasPrefix(r.Type, "com.apple.configuration.") {
-		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) are supported.")
+	if !strings.HasPrefix(r.Type, "com.apple.configuration.") && !strings.HasPrefix(r.Type, "com.apple.activation.") {
+		return NewInvalidArgumentError(r.Type, "Only configuration declarations (com.apple.configuration.) and activation declarations (com.apple.activation.) are supported.")
 	}
 
 	return err

--- a/server/service/integration_mdm_ddm_test.go
+++ b/server/service/integration_mdm_ddm_test.go
@@ -49,13 +49,13 @@ func (s *integrationMDMTestSuite) TestAppleDDMBatchUpload() {
 		decls = append(decls, newDeclBytes(i))
 	}
 
-	// Non-configuration type should fail
+	// Non-configuration and non-activation type should fail
 	res := s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
-		{Name: "bad", Contents: []byte(`{"Type": "com.apple.activation", "Payload": "test"}`)},
+		{Name: "bad", Contents: []byte(`{"Type": "com.apple.management.foo", "Payload": "test"}`)},
 	}}, http.StatusUnprocessableEntity)
 
 	errMsg := extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration.) are supported")
+	require.Contains(t, errMsg, "Only configuration declarations (com.apple.configuration.) and activation declarations (com.apple.activation.) are supported")
 
 	// "com.apple.configuration.softwareupdate.enforcement.specific" type should fail
 	res = s.Do("POST", "/api/latest/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #
In the PR we add support for using `com.apple.activation` [declarations](https://developer.apple.com/documentation/devicemanagement/activationsimple).

Currently Fleet prevents you from using activation declarations. I'm unsure why. Activations can be used by the system to apply other declarations when particular predicates are met.

We would like to be able to apply a Legacy Profile Configurations using a local status. We are currently unable to do this with Fleet. 

Let me know if you need anything from me to help get this across the finish line.
## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)