### PR TITLE
Update fleetctl apply documentation

### DIFF
--- a/docs/Contributing/guides/cli/fleetctl-apply.md
+++ b/docs/Contributing/guides/cli/fleetctl-apply.md
@@ -1,6 +1,6 @@
 # fleetctl apply
 
-The `fleectl apply` command and YAML interface is used for one-off imports and backwards compatibility with `fleetctl gitops`. The `fleetctl apply` verb is not included in Fleet's testing coverage and is planed for deprecation in a future version of Fleet.
+The `fleectl apply` command and YAML interface is used for one-off imports and backwards compatibility with `fleetctl gitops`. The `fleetctl apply` verb is not included in Fleet's testing coverage and will be deprecated in a future version of Fleet.
 
 To use Fleet's best practice GitOps workflows, check out the [GitOps docs](https://fleetdm.com/docs/using-fleet/gitops).
 

--- a/docs/Contributing/guides/cli/fleetctl-apply.md
+++ b/docs/Contributing/guides/cli/fleetctl-apply.md
@@ -1,8 +1,8 @@
 # fleetctl apply
 
-The `fleectl apply` command and YAML interface is used for one-off imports and backwards compatibility GitOps.
+The `fleectl apply` command and YAML interface is used for one-off imports and backwards compatibility with `fleetctl gitops`. The `fleetctl apply` verb is not included in Fleet's testing coverage and is planed for deprecation in a future version of Fleet.
 
-To use Fleet's best practice GitOps, check out the [GitOps docs](https://fleetdm.com/docs/using-fleet/gitops).
+To use Fleet's best practice GitOps workflows, check out the [GitOps docs](https://fleetdm.com/docs/using-fleet/gitops).
 
 ## Queries
 


### PR DESCRIPTION
UPDATE @noahtalerman: Closed because I misspoke on Friday's "🪂 Activations and migrations" call. Currently, there are no plans to deprecate fleetctl apply.

We do test fleetctl apply when we make changes/bug fixes to it's functionality.

---

Clarify usage of fleetctl apply and note deprecation plans.

@noahtalerman added more text.