### PR TITLE
Fleet UI: Remove duplication example software

### DIFF
--- a/frontend/pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal/CategoriesEndUserExperienceModal.tsx
+++ b/frontend/pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal/CategoriesEndUserExperienceModal.tsx
@@ -44,13 +44,23 @@ const columns: Column<ISoftwareRow>[] = [
   },
 ];
 
+type ExampleSoftware = {
+  title: string;
+};
+
+const EXAMPLE_SOFTWARE_ROWS: ExampleSoftware[] = [
+  { title: "1Password" },
+  { title: "Adobe Acrobat Reader" },
+  { title: "Box Drive" },
+];
+
 const getData = (
   name: string,
   displayName: string,
   iconUrl: string | null,
   source?: string
-): ISoftwareRow[] => [
-  {
+): ISoftwareRow[] => {
+  const currentSoftwareRow: ISoftwareRow = {
     name: (
       <SoftwareNameCell
         name={name}
@@ -61,38 +71,24 @@ const getData = (
         isSelfService
       />
     ),
-  },
-  {
+  };
+
+  // Filters out the current software from the example rows to avoid duplication
+  const exampleSoftwareRows: ISoftwareRow[] = EXAMPLE_SOFTWARE_ROWS.filter(
+    (item) => item.title !== name
+  ).map((item) => ({
     name: (
       <SoftwareNameCell
-        name="1Password"
+        name={item.title}
         source="apps"
         pageContext="deviceUser"
         isSelfService
       />
     ),
-  },
-  {
-    name: (
-      <SoftwareNameCell
-        name="Adobe Acrobat Reader"
-        source="apps"
-        pageContext="deviceUser"
-        isSelfService
-      />
-    ),
-  },
-  {
-    name: (
-      <SoftwareNameCell
-        name="Box Drive"
-        source="apps"
-        pageContext="deviceUser"
-        isSelfService
-      />
-    ),
-  },
-];
+  }));
+
+  return [currentSoftwareRow, ...exampleSoftwareRows];
+};
 
 const EmptyState = () => <div>No software found</div>;
 


### PR DESCRIPTION
## Issue
Follow up for #34646 

## Description
- Filters out the current software from the example rows to avoid duplication

## Screenshot of fix
e.g. Adobe Acrobat only shows once, 1Password only shows once

<img width="1316" height="559" alt="Screenshot 2026-01-12 at 10 20 00 AM" src="https://github.com/user-attachments/assets/25f1e066-5eb0-4da7-ae98-32f4a4c0b584" />
<img width="1291" height="565" alt="Screenshot 2026-01-12 at 10 19 43 AM" src="https://github.com/user-attachments/assets/d5ac44b9-487b-4b1d-91d5-a85911809baa" />



## Testing

- [x] QA'd all new/changed functionality manually
