### PR TITLE
Auto-bump deps on wix-docker

### DIFF
--- a/tools/wix-docker/Dockerfile
+++ b/tools/wix-docker/Dockerfile
@@ -10,6 +10,7 @@ RUN true \
     wget \
     unzip \
     osslsigncode \
+    && apt upgrade -y \
     && mkdir /wix \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
We already do this for bomutils, and this will get us out from under a few vuln alerts in the published Docker iamges.