### PR TITLE
Update it-and-enablement.rituals.yml

### DIFF
--- a/handbook/it-and-enablement/it-and-enablement.rituals.yml
+++ b/handbook/it-and-enablement/it-and-enablement.rituals.yml
@@ -7,17 +7,17 @@
   moreInfoUrl: "https://fleetdm.com/handbook/company/why-this-way#why-make-work-visible" #URL used to highlight "description:" test in table
   dri: "allenhouchins" # DRI for ritual (assignee if autoIssue) (TODO display GitHub proflie pic instead of name or title)
   autoIssue:   
-    labels: [ ":help-it-and-enablement" ]
+    labels: [ ":help-solutions-consulting" ]
     repo: "confidential"
 - 
-  task: "Complete IT & Enablement KPIs"
+  task: "Complete GTM KPIs"
   startedOn: "2024-08-30" 
   frequency: "Weekly"
-  description: "Complete IT & Enablement KPIs for this week"
+  description: "Complete GTM KPIs for this week"
   moreInfoUrl: 
   dri: "sampfluger88"
   autoIssue:   
-    labels: [ ":help-it-and-enablement" ]
+    labels: [ ":gtm-ops" ]
     repo: "fleet"
 -
   task: "Confirm closed lost is happening within 30 days"
@@ -27,7 +27,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/sales#review-salesforce-opportunities"
   dri: "Sampfluger88"
   autoIssue:   
-    labels: [ ":help-it-and-enablement","#g-unicorns" ]
+    labels: [ ":gtm-ops","#g-unicorns" ]
     repo: "confidential"
 - 
   task: "Measure intent signals"
@@ -63,5 +63,5 @@
   description: "Review [list of active instances](https://github.com/fleetdm/confidential/tree/main/infrastructure/cloud) to see what can be shutdown and deleted."
   dri: "allenhouchins"
   autoIssue:   
-    labels: [ ":help-it-and-enablement",":solutions" ]
+    labels: [ ":help-solutions-consulting" ]
     repo: "confidential"


### PR DESCRIPTION
This pull request updates several rituals in the `handbook/it-and-enablement/it-and-enablement.rituals.yml` file to better reflect current team responsibilities and terminology. The main changes involve updating labels, task names, and descriptions to align with the GTM (Go-To-Market) and Solutions Consulting teams instead of IT & Enablement.

**Label and terminology updates:**

* Changed auto-issue labels from `:help-it-and-enablement` to `:help-solutions-consulting` or `:gtm-ops` for relevant tasks, reflecting new team ownership. [[1]](diffhunk://#diff-483df03958997b79be68a86398698de7a100112403982bedbd85d63803015abaL10-R20) [[2]](diffhunk://#diff-483df03958997b79be68a86398698de7a100112403982bedbd85d63803015abaL30-R30) [[3]](diffhunk://#diff-483df03958997b79be68a86398698de7a100112403982bedbd85d63803015abaL66-R66)
* Updated task names and descriptions from "IT & Enablement KPIs" to "GTM KPIs" for weekly reporting, clarifying the focus of the ritual.

**Repository assignment adjustments:**

* Changed the repository assignment for auto-issues, ensuring tasks are routed to the appropriate team repositories.

These changes help ensure rituals are accurately assigned and described according to current team structures and responsibilities.