### PR TITLE
Guide tweak: "MDM turned off"

### DIFF
--- a/articles/install-app-store-apps.md
+++ b/articles/install-app-store-apps.md
@@ -48,7 +48,7 @@ Currently, Android apps can only be installed via self-service in the end user's
 
 Currently, Apple App Store (VPP) apps can't be uninstalled via Fleet.
 
-> VPP apps on iOS/iPadOS will be uninstalled when the host is unenrolled from MDM.
+> VPP apps on iOS/iPadOS will be uninstalled when the host is unenrolled from Fleet.
 
 ## API and GitOps
 

--- a/articles/install-app-store-apps.md
+++ b/articles/install-app-store-apps.md
@@ -48,7 +48,7 @@ Currently, Android apps can only be installed via self-service in the end user's
 
 Currently, Apple App Store (VPP) apps can't be uninstalled via Fleet.
 
-> VPP apps on iOS/iPadOS will be uninstalled when the host is unenrolled from Fleet.
+> VPP apps on iOS/iPadOS hosts will be uninstalled when the host has MDM features turned off.
 
 ## API and GitOps
 


### PR DESCRIPTION
https://fleetdm.com/handbook/company/why-this-way#why-does-fleet-use-mdm-on-off-instead-of-mdm-enrolled-unenrolled

For the auto uninstall managed apps story: https://github.com/fleetdm/fleet/issues/35941
