### PR TITLE
gate orbit enrollment to windows/linux only

### DIFF
--- a/changes/38205-remove-incorrect-eua-warning-for-macos
+++ b/changes/38205-remove-incorrect-eua-warning-for-macos
@@ -1,0 +1,1 @@
+- Removed a debug-level warning asserting that macOS devices were unauthenticated when enrolling to Fleet.

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -211,7 +211,7 @@ func (svc *Service) EnrollOrbit(ctx context.Context, hostInfo fleet.OrbitHostInf
 				if !ok {
 					level.Error(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but fleet could not determine whether orbit supports end-user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
 				} else if !mp.Has(fleet.CapabilityEndUserAuth) {
-					level.Error(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but connected with an orbit version that does not support end user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
+					level.Warn(svc.logger).Log("msg", "!!! ERR_ALLOWING_UNAUTHENTICATED: host is not authenticated, but connected with an orbit version that does not support end user authentication. proceeding with enrollment. !!! ", "host_uuid", hostInfo.HardwareUUID)
 				} else {
 					// Otherwise report the unauthenticated host and let Orbit handle it (e.g. by prompting the user to authenticate).
 					return "", fleet.NewOrbitIDPAuthRequiredError()


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38205 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
Tested with linux, windows and macos devices.  Linux and Windows still required end-user auth to happen before enrolling, macOS still did not (but not longer showed the warning).
