### PR TITLE
randomize APNS query

### DIFF
--- a/changes/36644-randomize-apns-query
+++ b/changes/36644-randomize-apns-query
@@ -1,0 +1,1 @@
+- Randomized APNS query to ensure all pending Apple hosts gets a push notification

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -7162,7 +7162,7 @@ func testGetEnrollmentIDsWithPendingMDMAppleCommands(t *testing.T, ds *Datastore
 	// Get a list of pending ID's 3 times and match against the first list, to avoid test flakiness.
 	// In a real world scenario it's okay for it to be the same as we will fetch it again later.
 	allAttemptsWereEqual := true
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		secondIds, err := ds.GetEnrollmentIDsWithPendingMDMAppleCommands(ctx)
 		require.NoError(t, err)
 		isIdsEqual := assert.ObjectsAreEqualValues(firstIds, secondIds)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36644 

Randomizes the query so we get a new set of 500 every time, and also improves the index by adding a priority where clause.

It should fine handle up towards 10.000 filtered entries before becoming slow, and at most we have seen 2k with a customer.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually