### PR TITLE
Fix VPP versions to be valid semantic versions

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3964,14 +3964,11 @@ var versionPattern = regexp.MustCompile(
 
 // trimLeadingZeros converts "00123" → "123", "000" → "0", "0" → "0"
 func trimLeadingZeros(s string) string {
+	s = strings.TrimLeft(s, "0")
 	if s == "" {
 		return "0"
 	}
-	n, err := strconv.ParseInt(s, 10, 64)
-	if err != nil {
-		return s // fallback - should not happen with our regex
-	}
-	return strconv.FormatInt(n, 10)
+	return s
 }
 
 // toValidSemVer is a best effort transformation to make `version` a valid semantic version.

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3972,6 +3972,8 @@ func trimLeadingZeros(s string) string {
 }
 
 // toValidSemVer is a best effort transformation to make `version` a valid semantic version.
+// Currently doesn't support fixing versions that have non-numerical pre-release strings (because
+// we haven't seen those in the wild for the apps where this method is used, currently VPP apps).
 func toValidSemVer(version string) string {
 	// Cleanup spaces.
 	version = strings.TrimSpace(version)
@@ -3980,7 +3982,8 @@ func toValidSemVer(version string) string {
 		return version
 	}
 
-	matches := versionPattern.FindStringSubmatch(version)
+	versionModified := strings.ReplaceAll(version, "-", ".")
+	matches := versionPattern.FindStringSubmatch(versionModified)
 	if matches == nil {
 		// May not be a valid version string, nothing we can do.
 		return version

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -6430,3 +6430,61 @@ func TestIsTimezoneInWindow(t *testing.T) {
 		})
 	}
 }
+
+func TestToValidSemVer(t *testing.T) {
+	testVersions := []struct {
+		rawVersion      string
+		expectedVersion string
+	}{
+		{
+			"25.48.0",
+			"25.48.0",
+		},
+		{
+			" 353.0 ", // Meta Horizon like version.
+			"353.0",
+		},
+		{
+			"18.14.0",
+			"18.14.0",
+		},
+		{
+			"412.0.0",
+			"412.0.0",
+		},
+		{
+			"00.00.01",
+			"0.0.1",
+		},
+		{
+			"6.0.251229",
+			"6.0.251229",
+		},
+		{
+			"4.2602.11600",
+			"4.2602.11600",
+		},
+		{
+			"144.0.7559.53", // Google Chrome like version.
+			"144.0.7559-53",
+		},
+		{
+			"21.02.3", // YouTube like version.
+			"21.2.3",
+		},
+		{
+			"21", // Just major version.
+			"21",
+		},
+		{
+			"v2.3.4", // Remove leading v.
+			"2.3.4",
+		},
+	}
+	for _, tc := range testVersions {
+		cleanedVersion := toValidSemVer(tc.rawVersion)
+		require.Equal(t, tc.expectedVersion, cleanedVersion)
+		_, err := fleet.VersionToSemverVersion(cleanedVersion)
+		assert.NoError(t, err, tc.rawVersion)
+	}
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -6507,6 +6507,11 @@ func TestToValidSemVer(t *testing.T) {
 			"2.3.4",
 			false,
 		},
+		{
+			"02.03.04-01",
+			"2.3.4-1",
+			false,
+		},
 	}
 	for _, tc := range testVersions {
 		cleanedVersion := toValidSemVer(tc.rawVersion)


### PR DESCRIPTION
Resolves #38218.

Test shows the versions that were having issues (Youtube, Chrome, Meta Horizon).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced version normalization for Apple MDM software update detection, improving accuracy when comparing various version formats to determine necessary updates.

* **Tests**
  * Added comprehensive test coverage for version normalization with diverse input formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->