### PR TITLE
Added desktop alternative browser host to Fleet Desktop paylaod

### DIFF
--- a/changes/33762-fleet-desktop-alternative-browser-host
+++ b/changes/33762-fleet-desktop-alternative-browser-host
@@ -1,0 +1,1 @@
+* Added 'AlternativeBrowserHost' to Desktop Summary payload and updated Fleet Desktop to use it over the alternative browser host set via the env.

--- a/server/fleet/device.go
+++ b/server/fleet/device.go
@@ -8,7 +8,7 @@ type DesktopSummary struct {
 	AlternativeBrowserHost string               `json:"alternative_browser_host,omitempty"`
 	FailingPolicies        *uint                `json:"failing_policies_count,omitempty"`
 	SelfService            *bool                `json:"self_service"`
-	Notifications          DesktopNotifications `json:"notifications,omitempty"`
+	Notifications          DesktopNotifications `json:"notifications"`
 	Config                 DesktopConfig        `json:"config"`
 }
 

--- a/server/fleet/device.go
+++ b/server/fleet/device.go
@@ -5,10 +5,11 @@ import "time"
 // DesktopSummary is a summary of the status of a host that's used by Fleet
 // Desktop to operate (show/hide menu items, etc)
 type DesktopSummary struct {
-	FailingPolicies *uint                `json:"failing_policies_count,omitempty"`
-	SelfService     *bool                `json:"self_service"`
-	Notifications   DesktopNotifications `json:"notifications,omitempty"`
-	Config          DesktopConfig        `json:"config"`
+	AlternativeBrowserHost string               `json:"alternative_browser_host,omitempty"`
+	FailingPolicies        *uint                `json:"failing_policies_count,omitempty"`
+	SelfService            *bool                `json:"self_service"`
+	Notifications          DesktopNotifications `json:"notifications,omitempty"`
+	Config                 DesktopConfig        `json:"config"`
 }
 
 // DesktopNotifications are notifications that the fleet server sends to

--- a/server/service/device_client.go
+++ b/server/service/device_client.go
@@ -20,7 +20,7 @@ type DeviceClient struct {
 	*baseClient
 
 	// fleetAlternativeBrowserHostFromServer serves the same purpose as fleetAlternativeBrowserHost, but this value is set
-	// on the Fleet server and takes precedence over it
+	// on the Fleet server and takes precedence over it.
 	fleetAlternativeBrowserHostFromServer string
 
 	// fleetAlternativeBrowserHost is an alternative host to use for the Fleet Desktop URLs generated for the browser.

--- a/server/service/device_client_test.go
+++ b/server/service/device_client_test.go
@@ -72,6 +72,50 @@ func TestDeviceClientGetDesktopPayload(t *testing.T) {
 		require.EqualValues(t, 15, *result.FailingPolicies)
 		require.True(t, result.Notifications.NeedsMDMMigration)
 	})
+
+	t.Run("alternative browser URL gets set from server response", func(t *testing.T) {
+		mockRequestDoer.statusCode = http.StatusOK
+		mockRequestDoer.resBody = `{"alternative_browser_host": "gogetit.com:6969"}`
+		_, err := client.DesktopSummary(token)
+		require.NoError(t, err)
+		require.EqualValues(t, "gogetit.com:6969", client.fleetAlternativeBrowserHostFromServer)
+	})
+}
+
+func TestDeviceClientGetFleetHost(t *testing.T) {
+	testCases := []struct {
+		alternativeBrowserHostFromEnv    string
+		alternativeBrowserHostFromServer string
+		expected                         string
+	}{
+		{
+			alternativeBrowserHostFromEnv:    "",
+			alternativeBrowserHostFromServer: "",
+			expected:                         "",
+		},
+		{
+			alternativeBrowserHostFromEnv:    "https://example.com",
+			alternativeBrowserHostFromServer: "",
+			expected:                         "https://example.com",
+		},
+		{
+			alternativeBrowserHostFromEnv:    "https://example.com",
+			alternativeBrowserHostFromServer: "https://two.example.com",
+			expected:                         "https://two.example.com",
+		},
+		{
+			alternativeBrowserHostFromEnv:    "",
+			alternativeBrowserHostFromServer: "https://two.example.com",
+			expected:                         "https://two.example.com",
+		},
+	}
+
+	for _, tc := range testCases {
+		client, err := NewDeviceClient("", true, "", nil, tc.alternativeBrowserHostFromEnv)
+		require.NoError(t, err)
+		client.fleetAlternativeBrowserHostFromServer = tc.alternativeBrowserHostFromServer
+		require.Equal(t, tc.expected, client.getFleetHost(""))
+	}
 }
 
 func TestDeviceClientRetryInvalidToken(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33762 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually (no regressions introduced)

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] Verified that fleetd runs on macOS, Linux and Windows