### PR TITLE
Allow <Atomic> windows profiles

### DIFF
--- a/changes/31922-do-not-send-windows-profiles-atomically
+++ b/changes/31922-do-not-send-windows-profiles-atomically
@@ -1,0 +1,1 @@
+- Added a feature to allow IT admins to specify non-atomic Windows MDM profiles.

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -168,7 +168,7 @@ func (v *windowsProfileValidator) handleStartElement(el xml.StartElement) error 
 		}
 
 		if elementName == "Atomic" && v.isAtomicProfile == nil {
-			// We are at top level, and we see Atomic, mark the entire profile.
+			// We are at top level, and we see Atomic element first, mark the entire profile as atomic.
 			v.isAtomicProfile = ptr.Bool(true)
 		} else if elementName == "Atomic" && v.isAtomicProfile != nil && !*v.isAtomicProfile {
 			// We are at top level, we have already seen other top level elements, and now we see Atomic

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -180,10 +180,8 @@ func (v *windowsProfileValidator) handleStartElement(el xml.StartElement) error 
 			// We are at top level, and we see a non-Atomic element first, mark the profile as non-Atomic.
 			v.isAtomicProfile = ptr.Bool(false)
 		}
-	} else {
-		if v.currentElement == "Atomic" && !v.isValidNestedAtomicElement(elementName) {
-			return errors.New("Windows configuration profiles can only include <Replace> or <Add> within the <Atomic> element.")
-		}
+	} else if v.currentElement == "Atomic" && !v.isValidNestedAtomicElement(elementName) {
+		return errors.New("Windows configuration profiles can only include <Replace> or <Add> within the <Atomic> element.")
 	}
 
 	v.currentElement = elementName

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -42,7 +42,7 @@ func TestValidateUserProvided(t *testing.T) {
 </SyncML>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "Add top level element",
@@ -160,7 +160,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Alert>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with Replace and Atomic",
@@ -178,7 +178,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Atomic>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with Replace and Delete",
@@ -196,7 +196,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Delete>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with Replace and Exec",
@@ -232,7 +232,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Get>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with Replace and Results",
@@ -250,7 +250,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Results>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with Replace and Status",
@@ -268,7 +268,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Status>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "XML with elements not defined in the protocol",
@@ -286,7 +286,7 @@ func TestValidateUserProvided(t *testing.T) {
 </Foo>
 `),
 			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements.",
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
 		},
 		{
 			name: "invalid XML with mismatched tags",
@@ -469,23 +469,6 @@ func TestValidateUserProvided(t *testing.T) {
 				`),
 			},
 			wantErr: "",
-		},
-		{
-			name: "XML with top level comment followed by invalid element",
-			profile: MDMWindowsConfigProfile{
-				SyncML: []byte(`
-				  <!-- this is a comment -->
-				  <!-- this is another comment -->
-				  <LocURI>Custom/URI</LocURI>
-				  <Replace>
-				  <!-- this is a comment inside replace -->
-				    <Target>
-				      <LocURI>Custom/URI</LocURI>
-				    </Target>
-				  </Replace>
-				`),
-			},
-			wantErr: "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements after comments",
 		},
 		{
 			name: "XML with nested root element in data",

--- a/server/fleet/windows_mdm_test.go
+++ b/server/fleet/windows_mdm_test.go
@@ -781,6 +781,90 @@ func TestValidateUserProvided(t *testing.T) {
 			},
 			wantErr: fmt.Sprintf("\"ClientCertificateInstall/SCEP/%s/Install/Enroll\" must be included within <Exec>. Please add and try again.", FleetVarSCEPWindowsCertificateID.WithPrefix()),
 		},
+		{
+			name: "Atomic profile with other top-level elements",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Atomic>
+				</Atomic>
+				<Add>
+				</Add>
+				`),
+			},
+			wantErr: "<Atomic> element must wrap all the elements in a Windows configuration profile.",
+		},
+		{
+			name: "non Atomic profile with other <Atomic> top-level elements",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Add>
+				</Add>
+				<Atomic>
+				</Atomic>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
+		},
+		{
+			name: "disallow top-level Delete element",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Delete>
+				</Delete>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
+		},
+		{
+			name: "disallow top-level Get element",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Get>
+				</Get>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only have <Replace> or <Add> top level elements.",
+		},
+		{
+			name: "disallow Delete element inside Atomic profile",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Atomic>
+					<Delete>
+					</Delete>
+				</Atomic>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only include <Replace> or <Add> within the <Atomic> element.",
+		},
+		{
+			name: "disallow top-level Get element inside Atomic profile",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Atomic>
+					<Get>
+					</Get>
+				</Atomic>
+				`),
+			},
+			wantErr: "Windows configuration profiles can only include <Replace> or <Add> within the <Atomic> element.",
+		},
+		{
+			name: "valid Atomic profile",
+			profile: MDMWindowsConfigProfile{
+				SyncML: []byte(`
+				<Atomic>
+					<Add>
+						<LocURI>Custom/URI</LocURI>
+					</Add>
+					<Replace>
+						<LocURI>Another/URI</LocURI>
+					</Replace>
+				</Atomic>
+				`),
+			},
+			wantErr: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1352,7 +1352,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"mdm not enabled", 0, `<Replace></Replace>`, false, "Windows MDM isn't turned on."},
 		{"duplicate profile name", 0, `<Replace>duplicate</Replace>`, true, "configuration profile with this name already exists"},
 		{"multiple Replace", 0, `<Replace>a</Replace><Replace>b</Replace>`, true, ""},
-		{"Replace and non-Replace", 0, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements."},
+		{"Replace and non-Replace", 0, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{
 			"BitLocker profile", 0,
 			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true,
@@ -1368,7 +1368,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 		{"team mdm not enabled", 1, `<Replace></Replace>`, false, "Windows MDM isn't turned on."},
 		{"team duplicate profile name", 1, `<Replace>duplicate</Replace>`, true, "configuration profile with this name already exists"},
 		{"team multiple Replace", 1, `<Replace>a</Replace><Replace>b</Replace>`, true, ""},
-		{"team Replace and non-Replace", 1, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace>, <Add> or <Exec> top level elements."},
+		{"team Replace and non-Replace", 1, `<Replace>a</Replace><Get>b</Get>`, true, "Windows configuration profiles can only have <Replace> or <Add> top level elements."},
 		{
 			"team BitLocker profile", 1,
 			`<Replace><Item><Target><LocURI>./Device/Vendor/MSFT/BitLocker/AllowStandardUserEncryption</LocURI></Target></Item></Replace>`, true,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37931 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
