### PR TITLE
Website: (Microsoft compliance proxy) Add support for multiple compliance partner shared secret config variables.

### DIFF
--- a/website/api/policies/is-cloud-customer.js
+++ b/website/api/policies/is-cloud-customer.js
@@ -12,7 +12,7 @@ module.exports = async function (req, res, proceed) {
 
   // If an MS API KEY header was provided, check to see if it matches the entraSharedSecret.
   if (req.get('MS-API-KEY')) {
-    if(req.get('MS-API-KEY') === sails.config.custom.cloudCustomerCompliancePartnerSharedSecret){
+    if([sails.config.custom.cloudCustomerCompliancePartnerSharedSecret, sails.config.custom.alternateCompliancePartnerSharedSecret].includes(req.get('MS-API-KEY'))){
       return proceed();
     }
   }

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -477,6 +477,7 @@ module.exports.custom = {
   // compliancePartnerClientId: '…',
   // compliancePartnerClientSecret: '…',
   // cloudCustomerCompliancePartnerSharedSecret: '…',
+  // alternateCompliancePartnerSharedSecret: '…',
 
 
   // Android proxy


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/13468

Changes:
- Updated the `is-cloud-customer` policy to support a second compliance partner shared secret config variable.