### PR TITLE
send categories from gitops

### DIFF
--- a/changes/32997-categories
+++ b/changes/32997-categories
@@ -1,1 +1,1 @@
-- Fixed bug where `fleetctl` was not sending software categories correctly in all cases.
+- Fixed bug where `fleetctl gitops` was not sending software categories correctly in all cases.

--- a/changes/32997-categories
+++ b/changes/32997-categories
@@ -1,0 +1,1 @@
+- Fixed bug where `fleetctl` was not sending software categories correctly in all cases.

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -844,6 +844,7 @@ func (spec MaintainedAppSpec) ToSoftwarePackageSpec() SoftwarePackageSpec {
 		LabelsExcludeAny:   spec.LabelsExcludeAny,
 		InstallDuringSetup: spec.InstallDuringSetup,
 		Icon:               spec.Icon,
+		Categories:         spec.Categories,
 	}
 }
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2524,43 +2524,44 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 
 	var appsPayload []fleet.VPPBatchPayload
 	appsByAppID := make(map[string]fleet.TeamSpecAppStoreApp, len(config.Software.AppStoreApps))
-	for _, vppApp := range config.Software.AppStoreApps {
-		if vppApp != nil {
+	for _, appStoreApp := range config.Software.AppStoreApps {
+		if appStoreApp != nil {
 			// can be referenced by macos_setup.software
-			appsByAppID[vppApp.AppStoreID] = *vppApp
+			appsByAppID[appStoreApp.AppStoreID] = *appStoreApp
 
-			_, installDuringSetup := noTeamSoftwareMacOSSetup[fleet.MacOSSetupSoftware{AppStoreID: vppApp.AppStoreID}]
-			if vppApp.InstallDuringSetup.Valid {
+			_, installDuringSetup := noTeamSoftwareMacOSSetup[fleet.MacOSSetupSoftware{AppStoreID: appStoreApp.AppStoreID}]
+			if appStoreApp.InstallDuringSetup.Valid {
 				if len(noTeamSoftwareMacOSSetup) > 0 {
 					return nil, nil, errConflictingVPPSetupExperienceDeclarations
 				}
-				installDuringSetup = vppApp.InstallDuringSetup.Value
+				installDuringSetup = appStoreApp.InstallDuringSetup.Value
 			}
 
-			iconHash, err := getIconHashIfValid(vppApp.Icon.Path)
+			iconHash, err := getIconHashIfValid(appStoreApp.Icon.Path)
 			if err != nil {
-				return nil, nil, fmt.Errorf("Couldn't edit app store app (%s). Invalid custom icon file %s: %w", vppApp.AppStoreID, vppApp.Icon.Path, err)
+				return nil, nil, fmt.Errorf("Couldn't edit app store app (%s). Invalid custom icon file %s: %w", appStoreApp.AppStoreID, appStoreApp.Icon.Path, err)
 			}
 
 			var androidConfig json.RawMessage
-			if vppApp.Platform == string(fleet.AndroidPlatform) {
-				androidConfig, err = getAndroidAppConfig(vppApp.Configuration.Path)
+			if appStoreApp.Platform == string(fleet.AndroidPlatform) {
+				androidConfig, err = getAndroidAppConfig(appStoreApp.Configuration.Path)
 				if err != nil {
-					return nil, nil, fmt.Errorf("Couldn't edit app store app (%s). Reading configuration %s: %w", vppApp.AppStoreID, vppApp.Configuration.Path, err)
+					return nil, nil, fmt.Errorf("Couldn't edit app store app (%s). Reading configuration %s: %w", appStoreApp.AppStoreID, appStoreApp.Configuration.Path, err)
 				}
 			}
 
 			payload := fleet.VPPBatchPayload{
-				AppStoreID:          vppApp.AppStoreID,
-				SelfService:         vppApp.SelfService,
+				AppStoreID:          appStoreApp.AppStoreID,
+				SelfService:         appStoreApp.SelfService,
 				InstallDuringSetup:  &installDuringSetup,
-				DisplayName:         vppApp.DisplayName,
-				IconPath:            vppApp.Icon.Path,
+				DisplayName:         appStoreApp.DisplayName,
+				IconPath:            appStoreApp.Icon.Path,
 				IconHash:            iconHash,
-				Platform:            fleet.InstallableDevicePlatform(vppApp.Platform),
-				AutoUpdateEnabled:   vppApp.AutoUpdateEnabled,
-				AutoUpdateStartTime: vppApp.AutoUpdateStartTime,
-				AutoUpdateEndTime:   vppApp.AutoUpdateEndTime,
+				Platform:            fleet.InstallableDevicePlatform(appStoreApp.Platform),
+				AutoUpdateEnabled:   appStoreApp.AutoUpdateEnabled,
+				AutoUpdateStartTime: appStoreApp.AutoUpdateStartTime,
+				AutoUpdateEndTime:   appStoreApp.AutoUpdateEndTime,
+				Categories:          appStoreApp.Categories,
 			}
 			if androidConfig != nil {
 				payload.Configuration = androidConfig


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32997

Categories were missing from a couple of places when assembling the requests sent by `fleetctl gitops`.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually