### PR TITLE
Website: prefix header in proxied apple request

### DIFF
--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -118,7 +118,7 @@ module.exports = {
       },
       headers: {
         'Authorization': `Bearer ${tokenForThisRequest}`,
-        'Cookie': `${vppToken}`,
+        'Cookie': `itvt=${vppToken}`,
       }
     })
     .tolerate((err)=>{


### PR DESCRIPTION
Changes:
- Updated the get-vpp-app-metadata action to prefix the provided vpp token before it sends it to an Apple API