### PR TITLE
Website: Update logged warnings in get-vpp-app-metadata

### DIFF
--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -122,8 +122,8 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
-      // Ignore bad request and invalid stoken vpp token responses when loggin a warning.
-      if(![400, 403].includes(err.statusCode)) {
+      // Ignore invalid stoken vpp token responses when logging errors returned by the Apple API.
+      if(err.statusCode !== 403) {
         sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
       }
       return err;

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -122,7 +122,10 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
-      sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      // Ignore bad request and invalid stoken vpp token responses when loggin a warning.
+      if(![400, 403].includes(err.statusCode)) {
+        sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      }
       return err;
     });
 


### PR DESCRIPTION
Changes:
- Updated the get-vpp-app-metadata action to not log warnings if a Fleet server sends a request with an invalid vpp token