### PR TITLE
Don't run setup experience on host that was previously enrolled

### DIFF
--- a/changes/35717-dont-enqueue-setup-experience-on-previously-enrolled-hosts
+++ b/changes/35717-dont-enqueue-setup-experience-on-previously-enrolled-hosts
@@ -1,0 +1,1 @@
+- Added logic to skip setup experience for hosts that were enrolled > 1 day ago.

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -47,6 +47,7 @@ func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatfo
 	}
 	// If the host was enrolled more than 24 hours ago, don't enqueue any items.
 	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) {
+		level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
 		return false, nil
 	}
 

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -46,7 +46,7 @@ func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatfo
 		}
 	}
 	// If the host was enrolled more than 24 hours ago, don't enqueue any items.
-	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) {
+	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) && lastEnrolledAt.Time.After(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)) {
 		level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
 		return false, nil
 	}

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-kit/log/level"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -22,6 +24,32 @@ func (ds *Datastore) ResetSetupExperienceItemsAfterFailure(ctx context.Context, 
 }
 
 func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatformLike string, hostUUID string, teamID uint, resetFailedSetupSteps bool) (bool, error) {
+	// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
+	// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
+	// Orbit version that didn't support setup experience to one that does.
+	// See https://github.com/fleetdm/fleet/issues/35717
+	stmtHost := `
+	SELECT
+		last_enrolled_at
+	FROM
+		hosts
+	WHERE uuid = ? AND platform LIKE ?
+	`
+	var lastEnrolledAt sql.NullTime
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// This shouldn't happen but we don't check for it elsewhere,
+			// so we'll log a warning and continue.
+			level.Warn(ds.logger).Log("msg", "Host not found while enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike)
+		} else {
+			return false, ctxerr.Wrap(ctx, err, "finding host for enqueueing setup experience items")
+		}
+	}
+	// If the host was enrolled more than 24 hours ago, don't enqueue any items.
+	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) {
+		return false, nil
+	}
+
 	// NOTE: currently, the Android platform does not use the "enqueue setup experience items" flow as it
 	// doesn't support any on-device UI (such as the screen showing setup progress) nor any
 	// ordering of installs - all software to install is provided as part of the Android policy


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35717

# Details

This PR adds a check before enqueuing setup experience items, so that if the specified host has already been enrolled for > 24 hours we skip the setup experience.  This handles the edge case where an enrolled host upgrades from an Orbit version that didn't support setup experience to one that does.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [X] Added/updated automated tests

- [X] QA'd all new/changed functionality manually
I didn't go through the process of getting a 1.48.1 fleetd installation on my VM, but I tested in this way:
1. Installed fleetd on a host to a team with no setup experience items
2. Manually adjusted the `last_enrolled_at` date of that host's db record to be > 24 hours in the past.
3. After enrollment, added setup experience items to that team.  No setup window popped up (expected).
4. Deleted the `setup_experience.json` file on that host and restarted Orbit.
5. On `main` branch, the setup experience window popped up.  When repeating these steps on this branch, no window popped up.
6. Also verified that for a new enrollment wiht `last_enrolled_at` in the last 24 hours, the setup experience window popped up as expected.