### PR TITLE
handle NotNow status from device so that it does not block the DEP setup experience flow

### DIFF
--- a/changes/issue-37371-not-now-status
+++ b/changes/issue-37371-not-now-status
@@ -1,0 +1,1 @@
+- handle the NotNow status from the device during DEP setup experience so it does not delay the release of the device

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -372,8 +372,10 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 
 		var completed bool
 		for _, r := range res {
-			// succeeded or failed, it is done (final state)
-			if r.Status == fleet.MDMAppleStatusAcknowledged || r.Status == fleet.MDMAppleStatusError ||
+			// succeeded or failed, it is done (final state). We also consider "NotNow"
+			// as completed, as it means the device is not going to process that command
+			// now, and we don't want to block the DEP device release because of that.
+			if r.Status == fleet.MDMAppleStatusAcknowledged || r.Status == fleet.MDMAppleStatusError || r.Status == fleet.MDMAppleStatusNotNow ||
 				r.Status == fleet.MDMAppleStatusCommandFormatError {
 				completed = true
 				break

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -360,7 +360,7 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 		return err
 	}
 
-	// used to cross reference against the setup experience statuse below
+	// used to cross reference against the setup experience statuses below
 	notNowCmdUUIDs := make(map[string]any)
 
 	for _, cmdUUID := range args.EnrollmentCommands {
@@ -375,7 +375,6 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 
 		var completed bool
 		for _, r := range res {
-
 			if r.Status == fleet.MDMAppleStatusNotNow {
 				notNowCmdUUIDs[cmdUUID] = ""
 			}

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -360,6 +360,9 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 		return err
 	}
 
+	// used to cross reference against the setup experience statuse below
+	notNowCmdUUIDs := make(map[string]any)
+
 	for _, cmdUUID := range args.EnrollmentCommands {
 		if cmdUUID == "" {
 			continue
@@ -372,11 +375,15 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 
 		var completed bool
 		for _, r := range res {
+
+			if r.Status == fleet.MDMAppleStatusNotNow {
+				notNowCmdUUIDs[cmdUUID] = ""
+			}
+
 			// succeeded or failed, it is done (final state). We also consider "NotNow"
 			// as completed, as it means the device is not going to process that command
 			// now, and we don't want to block the DEP device release because of that.
-			if r.Status == fleet.MDMAppleStatusAcknowledged || r.Status == fleet.MDMAppleStatusError || r.Status == fleet.MDMAppleStatusNotNow ||
-				r.Status == fleet.MDMAppleStatusCommandFormatError {
+			if r.Status == fleet.MDMAppleStatusAcknowledged || r.Status == fleet.MDMAppleStatusError || r.Status == fleet.MDMAppleStatusNotNow || r.Status == fleet.MDMAppleStatusCommandFormatError {
 				completed = true
 				break
 			}
@@ -455,6 +462,14 @@ func (a *AppleMDM) runPostDEPReleaseDevice(ctx context.Context, args appleMDMArg
 			return ctxerr.Wrap(ctx, err, "retrieving setup experience status results for host pending DEP release")
 		}
 		for _, status := range setupExperienceStatuses {
+			// skip items that had the command response of "NotNow" as those setup exp statuses will be pending/running
+			// and we have decided to not block the device release for NotNow status so we dont want to reenqueue these.
+			if status.NanoCommandUUID != nil {
+				if _, ok := notNowCmdUUIDs[*status.NanoCommandUUID]; ok {
+					continue
+				}
+			}
+
 			if status.Status == fleet.SetupExperienceStatusPending || status.Status == fleet.SetupExperienceStatusRunning {
 				level.Info(a.Log).Log("msg", "re-enqueuing due to setup experience items still pending or running", "host_uuid", args.HostUUID, "status_id", status.ID)
 				if err := reenqueueTask(); err != nil {

--- a/server/worker/apple_mdm_test.go
+++ b/server/worker/apple_mdm_test.go
@@ -887,7 +887,7 @@ func TestAppleMDM(t *testing.T) {
 			if i == 4 {
 				// after 4 attempts, record a result for the command so it gets released
 				mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-					_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result) 
+					_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result)
 						SELECT ?, command_uuid, ?, ? FROM nano_commands`,
 						h.UUID, "Acknowledged", `<?xml`)
 					return err
@@ -1012,7 +1012,7 @@ INSERT INTO setup_experience_status_results (
 
 		// Acknowledge the commands - the release job should still re-enqueue itself and await the installs
 		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result) 
+			_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result)
 						SELECT ?, command_uuid, ?, ? FROM nano_commands`,
 				h.UUID, "Acknowledged", `<?xml`)
 			return err
@@ -1189,7 +1189,7 @@ INSERT INTO setup_experience_status_results (
 
 		// Acknowledge the commands - the release job should still re-enqueue itself and await the remaining installs
 		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result) 
+			_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result)
 						SELECT ?, command_uuid, ?, ? FROM nano_commands`,
 				h.UUID, "Acknowledged", `<?xml`)
 			return err
@@ -1244,6 +1244,69 @@ INSERT INTO setup_experience_status_results (
 		}
 
 		require.Contains(t, getEnqueuedCommandTypes(t), "DeviceConfigured")
+	})
+
+	t.Run("treats NotNow status as a finished command status that does not block device release", func(t *testing.T) {
+		mysql.SetTestABMAssets(t, ds, testOrgName)
+		defer mysql.TruncateTables(t, ds)
+
+		h := createEnrolledHost(t, 1, nil, true, "darwin")
+
+		mdmWorker := &AppleMDM{
+			Datastore: ds,
+			Log:       nopLog,
+			Commander: apple_mdm.NewMDMAppleCommander(mdmStorage, mockPusher{}),
+		}
+		w := NewWorker(ds, nopLog)
+		w.Register(mdmWorker)
+
+		err := QueueAppleMDMJob(ctx, ds, nopLog, AppleMDMPostDEPEnrollmentTask, h.UUID, "darwin", nil, "", true, false)
+		require.NoError(t, err)
+
+		// run the worker, should succeed and enqueue the release job
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		// ensure the job's not_before allows it to be returned if it were to run again
+		time.Sleep(time.Second)
+
+		require.ElementsMatch(t, []string{"InstallEnterpriseApplication"}, getEnqueuedCommandTypes(t))
+
+		// get the release job
+		jobs, err := ds.GetQueuedJobs(ctx, 1, time.Now().UTC().Add(time.Minute))
+		require.NoError(t, err)
+		require.Len(t, jobs, 1)
+
+		releaseJob := jobs[0]
+		require.Equal(t, fleet.JobStateQueued, releaseJob.State)
+		require.Equal(t, appleMDMJobName, releaseJob.Name)
+		require.Contains(t, string(*releaseJob.Args), AppleMDMPostDEPReleaseDeviceTask)
+
+		// record a "NotNow" result for the command - this should be treated as completed
+		// and should not block device release
+		mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, `INSERT INTO nano_command_results (id, command_uuid, status, result)
+				SELECT ?, command_uuid, ?, ? FROM nano_commands`,
+				h.UUID, "NotNow", `<?xml`)
+			return err
+		})
+
+		// update the job to make it available to run immediately
+		releaseJob.NotBefore = time.Now().UTC().Add(-time.Minute)
+		_, err = ds.UpdateJob(ctx, releaseJob.ID, releaseJob)
+		require.NoError(t, err)
+
+		// run the worker - should release the device immediately since NotNow is treated as completed
+		err = w.ProcessJobs(ctx)
+		require.NoError(t, err)
+
+		// the device should be released (DeviceConfigured command enqueued)
+		require.ElementsMatch(t, []string{"InstallEnterpriseApplication", "DeviceConfigured"}, getEnqueuedCommandTypes(t))
+
+		// job queue should be empty - no re-enqueue because NotNow is a final state
+		jobs, err = ds.GetQueuedJobs(ctx, 1, time.Now().UTC().Add(time.Minute))
+		require.NoError(t, err)
+		require.Len(t, jobs, 0)
 	})
 }
 


### PR DESCRIPTION
**Related issue:** Resolves #37371

This is a quick change to handle the NotNow status from a mdm command response from the device. We consider the task complete so that it will not block the device releasing during the DEP setup experience.


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
