### PR TITLE
Remove host's VPP install rows when removing host

### DIFF
--- a/changes/30691-remove-vpp-install-data-host-delete
+++ b/changes/30691-remove-vpp-install-data-host-delete
@@ -1,0 +1,1 @@
+- When a host is deleted, any associated VPP software installation records are also deleted.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -569,9 +569,10 @@ var hostRefs = []string{
 	"conditional_access_scep_certificates",
 	// unlike for host_software_installs, where we use soft-delete so that
 	// existing activities can still access the installation details, this is not
-	// needed for in-house apps as the activity contains the MDM command UUID and
-	// can access the request/response without this table's entry.
+	// needed for in-house apps or vpp apps as the activity contains the MDM
+	// command UUID and can access the request/response without this table's entry.
 	"host_in_house_software_installs",
+	"host_vpp_software_installs",
 	"host_last_known_locations",
 }
 


### PR DESCRIPTION
## Issue
Closes #30697 

## Description
- When a host is deleted, it's related `host_vpp_software_installs` are deleted as well, clearing the statuses from the host software library. If a host is re-enrolled, previous vpp software install information does not return
- As intended, activities can still see these software install information because command uuids are still linked there

## Screenshot of fix
These rows would persist after wipe and deleting the host from Fleet
<img width="1512" height="499" alt="Screenshot 2026-01-21 at 10 00 10 AM" src="https://github.com/user-attachments/assets/ba19aa8c-3bd0-4b01-8f94-0a532264e5e7" />
With the fix, these rows are removed
<img width="1092" height="316" alt="Screenshot 2026-01-21 at 10 51 34 AM" src="https://github.com/user-attachments/assets/ebb59140-94a2-476d-8908-04d1032b5bff" />
When re-enrolled to Fleet, the device does not show installed statuses that do not apply
<img width="1125" height="579" alt="Screenshot 2026-01-21 at 10 51 55 AM" src="https://github.com/user-attachments/assets/3f714393-ad19-4a56-8bef-3ec4220f3e2a" />



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
