### PR TITLE
Website: Update lists of responsibilities on handbook pages

### DIFF
--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -127,7 +127,7 @@ parasails.registerPage('basic-handbook', {
     // Add links to the responsibilities under the responsibilities heading.
     if($('h2#responsibilities')){
       let responsibilitiesLinksHtml = '<ul>\n';
-      $('h3').each((unused, el)=>{ responsibilitiesLinksHtml += '<li><a href="#'+_.escape($(el).attr('id'))+'">'+_.escape($(el).text())+'</a></li>\n';  });
+      $('#body-content').find('h3').each((unused, el)=>{ responsibilitiesLinksHtml += '<li><a href="#'+_.escape($(el).attr('id'))+'">'+_.escape($(el).text())+'</a></li>\n';  });
       responsibilitiesLinksHtml+= '</ul>';
       $('h2#responsibilities + p').after(responsibilitiesLinksHtml);
     }


### PR DESCRIPTION
Changes:
- Updated the list of responsibilities on department handbook pages to only include links to headings inside of handbook contents (A heading from the signup modal is currently included on each list)