### PR TITLE
Website: Reduce length of article description meta tag to fix deploy.

### DIFF
--- a/articles/what-is-application-management.md
+++ b/articles/what-is-application-management.md
@@ -194,4 +194,4 @@ Look for unified inventory and policy engines that treat macOS as seriously as W
 <meta name="authorGitHubUsername" value="nonpunctual">
 <meta name="category" value="articles">
 <meta name="publishedOn" value="2026-01-11">
-<meta name="description" value="An introduction to application management, what it includes, why it matters, and how modern tools automate software deployment, updates, and compliance at scale.">
+<meta name="description" value="An introduction to application management, what it includes, why it matters, and how tools automate software deployment, updates, and compliance.">


### PR DESCRIPTION
Changes:
- Reduced the length of the `description` meta tag value on the "What is application management?" article