### PR TITLE
GitOps: Allow team yml to apply display_name to software package

### DIFF
--- a/changes/37508-gitops-team-software-display_name
+++ b/changes/37508-gitops-team-software-display_name
@@ -1,0 +1,1 @@
+* GitOps Mode: Now allows team yml to apply display_name to software package

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -230,6 +230,12 @@ func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePac
 	packageLevel.InstallDuringSetup = spec.InstallDuringSetup
 	packageLevel.SelfService = spec.SelfService
 
+	// This will only override display name set at path: path/to/software.yml level
+	// if display_name is specified at the team level yml
+	if spec.DisplayName != "" {
+		packageLevel.DisplayName = spec.DisplayName
+	}
+
 	return packageLevel, nil
 }
 


### PR DESCRIPTION
## Issue
Closes #37508 

## Description
- `display_name` for software in team.yml (if present) will override `display_name` for software in software.yml

## Screen recording of current behavior + fix
> Note: Only viewable to people at Fleet as I have some environment variables containing tokens on my screen

https://fleetdm.zoom.us/clips/share/JZEiieyxTpixxVPebGv4jg

## Screenshot of display_name correctly applying from team yml
<img width="668" height="453" alt="Screenshot 2026-01-14 at 11 00 10 PM" src="https://github.com/user-attachments/assets/6730afb4-3482-4f1a-8382-a9529198c32c" />
<img width="1262" height="485" alt="Screenshot 2026-01-14 at 11 00 26 PM" src="https://github.com/user-attachments/assets/1a696ec8-25fd-4395-9825-d5b75ff10e72" />


# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually
