### PR TITLE
Fix schedule auto updates modal in `No team`

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -113,6 +113,7 @@ const SoftwareSummaryCard = ({
   const canEditConfiguration = canManageSoftware && isAndroidPlayStoreApp;
   /** Installer modals require a specific team; hidden from "All Teams" */
   const hasValidTeamId = typeof teamId === "number" && teamId >= 0;
+  const softwareInstallerOnTeam = hasValidTeamId && softwareInstaller;
 
   const canEditAutoUpdateConfig =
     softwareTitle.app_store_app && isIosOrIpadosApp && canManageSoftware;
@@ -166,7 +167,7 @@ const SoftwareSummaryCard = ({
           />
         )}
       </Card>
-      {showEditIconModal && hasValidTeamId && softwareInstaller && (
+      {showEditIconModal && softwareInstallerOnTeam && (
         <EditIconModal
           softwareId={softwareId}
           teamIdForApi={teamId}
@@ -188,7 +189,7 @@ const SoftwareSummaryCard = ({
           }}
         />
       )}
-      {showEditSoftwareModal && hasValidTeamId && softwareInstaller && (
+      {showEditSoftwareModal && softwareInstallerOnTeam && (
         <EditSoftwareModal
           router={router}
           softwareId={softwareId}
@@ -205,7 +206,7 @@ const SoftwareSummaryCard = ({
           iconUrl={softwareTitle.icon_url}
         />
       )}
-      {showEditConfigurationModal && hasValidTeamId && softwareInstaller && (
+      {showEditConfigurationModal && softwareInstallerOnTeam && (
         <EditConfigurationModal
           softwareInstaller={softwareInstaller as IAppStoreApp}
           softwareId={softwareId}
@@ -214,7 +215,7 @@ const SoftwareSummaryCard = ({
           onExit={() => setShowEditConfigurationModal(false)}
         />
       )}
-      {showEditAutoUpdateConfigModal && softwareInstaller && teamId && (
+      {showEditAutoUpdateConfigModal && softwareInstallerOnTeam && (
         <EditAutoUpdateConfigModal
           softwareTitle={softwareTitle}
           teamId={teamId}


### PR DESCRIPTION
Small (4.80.0) unreleased bug in Scheduled Auto Updates option for software in "No team".

In `main`, clicking on `Schedule auto updates` in a VPP App in "No team" doesn't open the dialog and renders a `0`:
<img width="1344" height="676" alt="Screenshot 2026-01-15 at 9 01 36 AM" src="https://github.com/user-attachments/assets/1da665ac-489e-4411-a785-d9926f9e9bb6" />
