### PR TITLE
Only mark installed apps verified if version matches

### DIFF
--- a/server/datastore/mysql/in_house_apps.go
+++ b/server/datastore/mysql/in_house_apps.go
@@ -611,7 +611,8 @@ SELECT
 		hihsi.command_uuid AS command_uuid,
 		ncr.updated_at AS ack_at,
 		ncr.status AS install_command_status,
-		iha.bundle_identifier AS bundle_identifier
+		iha.bundle_identifier AS bundle_identifier,
+		iha.version AS expected_version
 FROM nano_command_results ncr
 JOIN host_in_house_software_installs hihsi ON hihsi.command_uuid = ncr.command_uuid
 JOIN in_house_apps iha ON iha.id = hihsi.in_house_app_id AND iha.platform = hihsi.platform

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -1990,7 +1990,8 @@ SELECT
 	hvsi.host_id AS host_id,
 	ncr.updated_at AS ack_at,
 	ncr.status AS install_command_status,
-	va.bundle_identifier AS bundle_identifier
+	va.bundle_identifier AS bundle_identifier,
+	va.latest_version AS expected_version
 FROM nano_command_results ncr
 JOIN host_vpp_software_installs hvsi ON hvsi.command_uuid = ncr.command_uuid
 JOIN vpp_apps va ON va.adam_id = hvsi.adam_id AND va.platform = hvsi.platform

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -155,6 +155,7 @@ type HostVPPSoftwareInstall struct {
 	InstallCommandStatus string     `db:"install_command_status"`
 	BundleIdentifier     string     `db:"bundle_identifier"`
 	RetryCount           int        `db:"retry_count"`
+	ExpectedVersion      string     `db:"expected_version"`
 }
 
 type HostVPPSoftwareInstallLite struct {

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -110,7 +110,7 @@ func (s *integrationMDMTestSuite) TestVPPAppInstallVerification() {
 		Name:             "App 3",
 		BundleIdentifier: "c-3",
 		IconURL:          "https://example.com/images/3/512x512.png",
-		LatestVersion:    "2.0.0",
+		LatestVersion:    "3.0.0",
 	}
 	var addAppResp addAppStoreAppResponse
 	s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", &addAppStoreAppRequest{TeamID: &team.ID, AppStoreID: macOSApp.AdamID, SelfService: true}, http.StatusOK, &addAppResp)


### PR DESCRIPTION
Fixes #32740

 ## Summary

Fixes iDevice VPP apps showing as "installed" even when the device has an outdated version after clicking "Update".

## Details

The VPP app verification logic in `NewInstalledApplicationListResultsHandler` only checked if an app was installed (`appFromResult.Installed == true`) but never compared the installed version against the expected version from `vpp_apps.latest_version`.

### Fix

Added version comparison to the verification logic. Apps are only marked as "verified" when _both_ conditions are met:

  - App is installed on device
  - Installed version matches expected version from database

When version mismatches, verification continues polling (within timeout) to allow the device to complete the update.

### Expected Behavior

  - App update shows "pending" until device reports correct version
  - App shows "installed" only when version matches
  - Legacy installs (empty `ExpectedVersion`) fall back to installed-only check