### PR TITLE
Fleet UI: Clarify delete VPP app pending install nuance

### DIFF
--- a/changes/33272-delete-software-pending-installs-nuance
+++ b/changes/33272-delete-software-pending-installs-nuance
@@ -1,0 +1,1 @@
+- Fleet UI: Clarify what happens to pending software installs when deleting VPP apps

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tests.tsx
@@ -1,0 +1,66 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+
+import { noop } from "lodash";
+
+import DeleteSoftwareModal from "./DeleteSoftwareModal";
+
+const renderModal = (
+  props: Partial<React.ComponentProps<typeof DeleteSoftwareModal>> = {}
+) => {
+  return render(
+    <DeleteSoftwareModal
+      softwareId={1}
+      teamId={1}
+      onExit={noop}
+      onSuccess={noop}
+      {...props}
+    />
+  );
+};
+
+describe("DeleteSoftwareModal", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("renders GitOps banner when gitOpsModeEnabled is true", () => {
+    renderModal({ gitOpsModeEnabled: true });
+
+    expect(
+      screen.getByText(
+        "You are currently in GitOps mode. If the package is defined in GitOps, it will reappear when GitOps runs."
+      )
+    ).toBeVisible();
+  });
+
+  it("renders default platform message when not VPP app or Android app", () => {
+    renderModal();
+
+    expect(screen.getByText(/won't be uninstalled/i)).toBeVisible();
+    expect(
+      screen.getByText(/Pending installs and uninstalls will be canceled\./i)
+    ).toBeVisible();
+  });
+
+  it("renders App Store message when isAppStoreApp is true", () => {
+    renderModal({ isAppStoreApp: true });
+
+    expect(screen.getByText(/won't be uninstalled/i)).toBeVisible();
+    expect(
+      screen.getByText(
+        /Pending or already started installs and uninstalls won't be canceled/i
+      )
+    ).toBeVisible();
+  });
+
+  it("renders Android message when isAndroidApp is true", () => {
+    renderModal({ isAndroidApp: true });
+
+    expect(
+      screen.getByText(
+        /Currently, software won't be deleted from self-service \(managed Google Play\) and won't be uninstalled from the hosts\./i
+      )
+    ).toBeVisible();
+  });
+});

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -16,36 +16,49 @@ const DELETE_SW_USED_BY_POLICY_ERROR_MSG =
 const DELETE_SW_INSTALLED_DURING_SETUP_ERROR_MSG =
   "Couldn't delete. This software is installed during new host setup. Please remove software in Controls > Setup experience and try again.";
 
-const getPendingInstallMessage = (
-  isAppStoreApp: boolean,
-  isAndroidApp: boolean,
-  name?: string
-) => {
-  console.log("isAndroidApp:", isAndroidApp);
+const getPlatformMessage = (isAppStoreApp: boolean, isAndroidApp: boolean) => {
   // Android apps do not have pending installs/uninstalls as they are initiated through setup experience or by user
   if (isAndroidApp) {
-    return ".";
+    return (
+      <p>
+        Currently, software won&apos;t be deleted from self-service (managed
+        Google Play) and won&apos;t be uninstalled from the hosts.
+      </p>
+    );
   }
 
   // VPP apps pending installs/uninstalls commands are not cancelled (future story #25912) but results only show in activity feed, as software is removed from host's software library
   if (isAppStoreApp) {
     return (
       <>
-        {" "}
-        and any pending installs or uninstalls for <strong>{name}</strong> will
-        still complete, but results will no longer appear in Fleet.
+        <p>
+          Software <strong>won&apos;t be uninstalled</strong> from hosts.
+        </p>
+        <p>
+          Pending or already started installs and uninstalls won&apos;t be
+          canceled, and the results won&apos;t appear in Fleet.
+        </p>
       </>
     );
   }
 
-  return ", but any pending installs or uninstalls will be canceled.";
+  return (
+    <>
+      <p>
+        Software <strong>won&apos;t be uninstalled</strong> from hosts.
+      </p>
+      <p>
+        Pending installs and uninstalls will be canceled. If they have already
+        started, they won&apos; be canceled, and the results won&apos;t appear
+        in Fleet.
+      </p>
+    </>
+  );
 };
 
 interface IDeleteSoftwareModalProps {
   softwareId: number;
   teamId: number;
-  softwareTitleName?: string;
-  softwareDisplayName?: string;
   onExit: () => void;
   onSuccess: () => void;
   gitOpsModeEnabled?: boolean;
@@ -56,8 +69,6 @@ interface IDeleteSoftwareModalProps {
 const DeleteSoftwareModal = ({
   softwareId,
   teamId,
-  softwareTitleName,
-  softwareDisplayName,
   onExit,
   onSuccess,
   gitOpsModeEnabled,
@@ -87,8 +98,6 @@ const DeleteSoftwareModal = ({
     onExit();
   }, [softwareId, teamId, renderFlash, onSuccess, onExit]);
 
-  const name = softwareDisplayName || softwareTitleName;
-
   return (
     <Modal
       className={baseClass}
@@ -103,25 +112,8 @@ const DeleteSoftwareModal = ({
             GitOps, it will reappear when GitOps runs.
           </InfoBanner>
         )}
-        <p>
-          Are you sure you want to delete <strong>{name}</strong>?
-        </p>
-        <ul>
-          <li>
-            Software won&apos;t be uninstalled from existing hosts
-            {getPendingInstallMessage(isAppStoreApp, isAndroidApp, name)}
-          </li>
-          <li>
-            Installs or uninstalls currently running on a host will still
-            complete, but results won&apos;t appear in Fleet.
-          </li>
-          <li>
-            Installed software will appear as{" "}
-            <strong>{softwareTitleName}</strong> in software inventories and
-            will use the default icon.
-          </li>
-        </ul>
-        <p>You cannot undo this action.</p>
+        {getPlatformMessage(isAppStoreApp, isAndroidApp)}
+        <p>Custom icon and display name will be deleted.</p>
         <div className="modal-cta-wrap">
           <Button
             variant="alert"

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -21,10 +21,12 @@ const getPendingInstallMessage = (
   isAndroidApp: boolean,
   name?: string
 ) => {
+  // Android apps do not have pending installs/uninstalls as they are initiated through setup experience or by user
   if (isAndroidApp) {
     (".");
   }
 
+  // VPP apps pending installs/uninstalls commands are not cancelled (future story #25912) but results only show in activity feed, as software is removed from host's software library
   if (isAppStoreApp) {
     return (
       <>
@@ -106,7 +108,7 @@ const DeleteSoftwareModal = ({
         <ul>
           <li>
             Software won&apos;t be uninstalled from existing hosts
-            {getPendingInstallMessage(isAppStoreApp, name)}
+            {getPendingInstallMessage(isAppStoreApp, isAndroidApp, name)}
           </li>
           <li>
             Installs or uninstalls currently running on a host will still

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -16,6 +16,28 @@ const DELETE_SW_USED_BY_POLICY_ERROR_MSG =
 const DELETE_SW_INSTALLED_DURING_SETUP_ERROR_MSG =
   "Couldn't delete. This software is installed during new host setup. Please remove software in Controls > Setup experience and try again.";
 
+const getPendingInstallMessage = (
+  isAppStoreApp: boolean,
+  isAndroidApp: boolean,
+  name?: string
+) => {
+  if (isAndroidApp) {
+    (".");
+  }
+
+  if (isAppStoreApp) {
+    return (
+      <>
+        {" "}
+        and any pending installs or uninstalls for <strong>{name}</strong> will
+        still complete, but results will no longer appear in Fleet.
+      </>
+    );
+  }
+
+  return ", but any pending installs or uninstalls will be canceled.";
+};
+
 interface IDeleteSoftwareModalProps {
   softwareId: number;
   teamId: number;
@@ -24,6 +46,8 @@ interface IDeleteSoftwareModalProps {
   onExit: () => void;
   onSuccess: () => void;
   gitOpsModeEnabled?: boolean;
+  isAppStoreApp?: boolean;
+  isAndroidApp?: boolean;
 }
 
 const DeleteSoftwareModal = ({
@@ -34,6 +58,8 @@ const DeleteSoftwareModal = ({
   onExit,
   onSuccess,
   gitOpsModeEnabled,
+  isAppStoreApp = false,
+  isAndroidApp = false,
 }: IDeleteSoftwareModalProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -58,6 +84,8 @@ const DeleteSoftwareModal = ({
     onExit();
   }, [softwareId, teamId, renderFlash, onSuccess, onExit]);
 
+  const name = softwareDisplayName || softwareTitleName;
+
   return (
     <Modal
       className={baseClass}
@@ -73,14 +101,13 @@ const DeleteSoftwareModal = ({
           </InfoBanner>
         )}
         <p>
-          Are you sure you want to delete{" "}
-          <strong>{softwareDisplayName || softwareTitleName}</strong>?
+          Are you sure you want to delete <strong>{name}</strong>?
         </p>
         <ul>
           <li>
-            Software won&apos;t be uninstalled from existing hosts, but any
-            pending installs and uninstalls will be canceled.
-          </li>{" "}
+            Software won&apos;t be uninstalled from existing hosts
+            {getPendingInstallMessage(isAppStoreApp, name)}
+          </li>
           <li>
             Installs or uninstalls currently running on a host will still
             complete, but results won&apos;t appear in Fleet.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/DeleteSoftwareModal/DeleteSoftwareModal.tsx
@@ -21,9 +21,10 @@ const getPendingInstallMessage = (
   isAndroidApp: boolean,
   name?: string
 ) => {
+  console.log("isAndroidApp:", isAndroidApp);
   // Android apps do not have pending installs/uninstalls as they are initiated through setup experience or by user
   if (isAndroidApp) {
-    (".");
+    return ".";
   }
 
   // VPP apps pending installs/uninstalls commands are not cancelled (future story #25912) but results only show in activity feed, as software is removed from host's software library

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -358,8 +358,6 @@ const SoftwareInstallerCard = ({
         <DeleteSoftwareModal
           gitOpsModeEnabled={gitOpsModeEnabled}
           softwareId={softwareId}
-          softwareDisplayName={softwareDisplayName}
-          softwareTitleName={softwareTitleName}
           teamId={teamId}
           onExit={() => setShowDeleteModal(false)}
           onSuccess={onDeleteSuccess}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -363,6 +363,10 @@ const SoftwareInstallerCard = ({
           teamId={teamId}
           onExit={() => setShowDeleteModal(false)}
           onSuccess={onDeleteSuccess}
+          isAppStoreApp={
+            installerType === "app-store" && !isAndroidPlayStoreApp
+          }
+          isAndroidApp={isAndroidPlayStoreApp}
         />
       )}
       {showViewYamlModal && isCustomPackage && (


### PR DESCRIPTION
## Issue
Closes #33272


## Description
- Confirmed behavior for VPP apps that they still install on an offline host when it comes online, even after the software has been removed from fleet
- Updated the text
- Removed all text regarding pending installs for Android apps

## Screenshot of fix

New design copies as of 1/20/26

<img width="859" height="411" alt="Screenshot 2026-01-20 at 10 46 40 AM" src="https://github.com/user-attachments/assets/efb56cc3-85e8-442b-833a-7df36dd9b30a" />
<img width="1015" height="552" alt="Screenshot 2026-01-20 at 10 46 54 AM" src="https://github.com/user-attachments/assets/0b636745-7460-4aa8-933c-6e7a5f6b2890" />
<img width="966" height="450" alt="Screenshot 2026-01-20 at 10 47 09 AM" src="https://github.com/user-attachments/assets/f61b44f8-0870-4864-9c88-6558cdbde3b4" />




## Testing

- [x] QA'd all new/changed functionality manually
- [x] Added automated tests