### PR TITLE
API and YAML reference: Add missing `interval` field for policy automations

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,6 +982,8 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
+- `interval` is how often...
+
 #### activities_webhook
 
 - `enable_activities_webhook` (default: `false`)

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often policy and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`)
+- `interval` is how often policy and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `"24h"`)
 
 #### activities_webhook
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often policy and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `"24h"`)
+- `interval` is how often policy and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`)
 
 #### activities_webhook
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day))
+- `interval` is how often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`)
 
 #### activities_webhook
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often...
+- `interval` is how often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day))
 
 #### activities_webhook
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`)
+- `interval` is how often policy and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`)
 
 #### activities_webhook
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -982,7 +982,7 @@ Can only be configured for all teams (`org_settings`).
 
 The `webhook_settings` section lets you define webhook settings for failing policy, vulnerability, and host status [automations](https://fleetdm.com/docs/using-fleet/automations).
 
-- `interval` is how often policy and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`)
+- `interval` is how often policy webhooks/tickets and host status webhooks are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`)
 
 #### activities_webhook
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12190,7 +12190,7 @@ _Available in Fleet Premium_
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often Fleet triggers policy automations in nanoseconds (default: `3600000000000` (1 day)) |
+| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day)) |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook2). |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook2).           |
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,7 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | string | How often policy and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`) |
+| interval          |               | string | How often policy webhooks/tickets and host status webhooks are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,7 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often Fleet triggers policy automations in nanoseconds (default: `3600000000000` (1 day)) |
+| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day)) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,6 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
+| interval          |               | integer | How often Fleet triggers policy automations in nanoseconds (default: `3600000000000` (1 day)) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |
@@ -12189,6 +12190,7 @@ _Available in Fleet Premium_
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
+| interval          |               | integer | How often Fleet triggers policy automations in nanoseconds (default: `3600000000000` (1 day)) |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook2). |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook2).           |
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12190,7 +12190,7 @@ _Available in Fleet Premium_
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day)) |
+| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`) |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook2). |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook2).           |
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,7 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | string | How often policy, vulnerability, and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`) |
+| interval          |               | string | How often policy and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |
@@ -12190,7 +12190,6 @@ _Available in Fleet Premium_
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`) |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook2). |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook2).           |
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,7 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`) |
+| interval          |               | string | How often policy, vulnerability, and host status automations are triggered, formatted as number + unit of measurement (e.g. `"90m"`). Can be specified in seconds (`"s"`), minutes (`"m"`), or hours (`"h"`). (Default: `"24h"`) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -2190,7 +2190,7 @@ _Available in Fleet Premium._
 
 | Name                              | Type  | Description   |
 | ---------------------             | ----- | ---------------------------------------------------------------------------------------------- |
-| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered in nanoseconds (default: `3600000000000` (1 day)) |
+| interval          |               | integer | How often policy, vulnerability, and host status automations are triggered. Accepts values of `s` (seconds), `m` (minutes), and `h` (hours) (default: `24h`) |
 | host_status_webhook               | array | See [`webhook_settings.host_status_webhook`](#webhook-settings-host-status-webhook).           |
 | failing_policies_webhook          | array | See [`webhook_settings.failing_policies_webhook`](#webhook-settings-failing-policies-webhook). |
 | vulnerabilities_webhook           | array | See [`webhook_settings.vulnerabilities_webhook`](#webhook-settings-vulnerabilities-webhook).   |


### PR DESCRIPTION
How we learned we were missing these: https://github.com/fleetdm/fleet/pull/38325#discussion_r2691714596
