### PR TITLE
Set failing policy webhook interval to 1 hour

### DIFF
--- a/it-and-security/teams/workstations-canary.yml
+++ b/it-and-security/teams/workstations-canary.yml
@@ -5,6 +5,7 @@ team_settings:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL
       enable_failing_policies_webhook: true
       host_batch_size: 0
+      interval: 3600000000000
       policy_ids:
         - 14937
         - 14100

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -5,6 +5,7 @@ team_settings:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL
       enable_failing_policies_webhook: true
       host_batch_size: 0
+      interval: 3600000000000
       policy_ids:
         - 14946
         - 15329


### PR DESCRIPTION
This pull request introduces a configuration update to the `team_settings` for both the `workstations` and `workstations-canary` teams. The main change is the addition of an `interval` parameter to control the timing for the failing policies webhook.

Configuration updates:

* Added the `interval` parameter with a value of `3600000000000` to the `team_settings` in `it-and-security/teams/workstations.yml`.
* Added the `interval` parameter with a value of `3600000000000` to the `team_settings` in `it-and-security/teams/workstations-canary.yml`.