### PR TITLE
Drop attempt number from index to avoid extra write overhead

### DIFF
--- a/server/datastore/mysql/migrations/tables/20260109231821_AddAttemptNumberToScriptsAndSoftwareInstalls.go
+++ b/server/datastore/mysql/migrations/tables/20260109231821_AddAttemptNumberToScriptsAndSoftwareInstalls.go
@@ -28,14 +28,14 @@ func Up_20260109231821(tx *sql.Tx) error {
 
 	_, err = tx.Exec(`
 		ALTER TABLE host_script_results
-		ADD INDEX idx_host_script_results_host_policy_attempt (host_id, policy_id, attempt_number);
+		ADD INDEX idx_host_script_results_host_policy (host_id, policy_id);
 	`)
 	if err != nil {
 		return errors.Wrap(err, "adding index to host_script_results")
 	}
 	_, err = tx.Exec(`
 		ALTER TABLE host_software_installs
-		ADD INDEX idx_host_software_installs_host_policy_attempt (host_id, policy_id, attempt_number);
+		ADD INDEX idx_host_software_installs_host_policy (host_id, policy_id);
 	`)
 	if err != nil {
 		return errors.Wrap(err, "adding index to host_software_installs")


### PR DESCRIPTION
Found in connection with #35916. No changes file as this is effectively an unreleased bugfix (will cherry-pick this). No updates to tests because tests don't test index existence.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)