### PR TITLE
Cherry-Pick: Drop attempt number from index to avoid extra write overhead

### DIFF
--- a/server/datastore/mysql/migrations/tables/20260109231821_AddAttemptNumberToScriptsAndSoftwareInstalls.go
+++ b/server/datastore/mysql/migrations/tables/20260109231821_AddAttemptNumberToScriptsAndSoftwareInstalls.go
@@ -28,14 +28,14 @@ func Up_20260109231821(tx *sql.Tx) error {
 
 	_, err = tx.Exec(`
 		ALTER TABLE host_script_results
-		ADD INDEX idx_host_script_results_host_policy_attempt (host_id, policy_id, attempt_number);
+		ADD INDEX idx_host_script_results_host_policy (host_id, policy_id);
 	`)
 	if err != nil {
 		return errors.Wrap(err, "adding index to host_script_results")
 	}
 	_, err = tx.Exec(`
 		ALTER TABLE host_software_installs
-		ADD INDEX idx_host_software_installs_host_policy_attempt (host_id, policy_id, attempt_number);
+		ADD INDEX idx_host_software_installs_host_policy (host_id, policy_id);
 	`)
 	if err != nil {
 		return errors.Wrap(err, "adding index to host_software_installs")


### PR DESCRIPTION
Merged into `main` in #38391. Landing this in the RC since this matters most on the first release where the change lands.