### PR TITLE
Fleet UI: Fix os_version not wired

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -414,6 +414,7 @@ export const HOST_SUMMARY_DATA: (keyof IHost)[] = [
   "team_name",
   "display_name", // Not rendered on my device page
   "maintenance_window", // Not rendered on my device page
+  "os_version",
 ];
 
 export const HOST_VITALS_DATA = [


### PR DESCRIPTION
## Issue
Closes #38397

## Description
- See issue

## Screenshot of fix
- This is the page now loading

<img width="1225" height="447" alt="Screenshot 2026-01-15 at 2 16 13 PM" src="https://github.com/user-attachments/assets/4a3837d3-6f38-487b-9bd0-dafa1d696fab" />


- [x] QA'd all new/changed functionality manually
