### PR TITLE
Fix issue linking SCIM data to newly-enrolled hosts

### DIFF
--- a/changes/37271-use-writer-when-linking-scim-data
+++ b/changes/37271-use-writer-when-linking-scim-data
@@ -1,0 +1,1 @@
+- Fixed an issue where newly-enrolled hosts would sometimes not be linked to SCIM user data.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4452,7 +4452,7 @@ WHERE
 	hosts.id = ?`
 
 	var idpAccount fleet.MDMIdPAccount
-	err = sqlx.GetContext(ctx, ds.reader(ctx), &idpAccount, getMDMIDPSQL, hostID)
+	err = sqlx.GetContext(ctx, ds.writer(ctx), &idpAccount, getMDMIDPSQL, hostID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			// No MDM IdP account for this host, nothing to do.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -4452,6 +4452,7 @@ WHERE
 	hosts.id = ?`
 
 	var idpAccount fleet.MDMIdPAccount
+	// Use writer since the host may have just been created.
 	err = sqlx.GetContext(ctx, ds.writer(ctx), &idpAccount, getMDMIDPSQL, hostID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37271 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [ ] Added/updated automated tests
There's [an existing test suite in mysql/host_tests.go](https://github.com/fleetdm/fleet/blob/c6746e5967a1153ea4ef68888a77f342bab15598/server/datastore/mysql/hosts_test.go#L12102-L12202), but that file uses the "one main test with a bunch of cases" pattern to do a single setup call, and the setup doesn't use the read replica. I'm guessing that simply flipping that switch would probably break a bunch of tests that don't expect to have to deal with replica lag in their test data.   

- [X] QA'd all new/changed functionality manually
Set up my local dev with replication enabled and a 1 second lag time, and verified that an authenticated user had SCIM data linked.

<img width="485" height="395" alt="image" src="https://github.com/user-attachments/assets/c07369b8-a518-4bcc-ab54-08dd268a65ac" />

The ultimate test will be a remote server like Dogfood that has replication.
