### PR TITLE
Fleet UI: Show VPP version for software setup

### DIFF
--- a/changes/36541-missing-vpp-version-add-software
+++ b/changes/36541-missing-vpp-version-add-software
@@ -1,0 +1,1 @@
+- Fleet UI: Show VPP version for adding software during setup

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/SelectSoftwareTable/SelectSoftwareTableConfig.tsx
@@ -96,18 +96,20 @@ const generateTableConfig = (
         }
 
         const title = cellProps.row.original;
-        let versionFoRender = title.software_package?.version;
+        let displayedVersion =
+          title.software_package?.version || title.app_store_app?.version;
+
         if (platform === "linux") {
           const packageTypeCopy = getSetupExperienceLinuxPackageCopy(
             title.source
           );
           if (packageTypeCopy) {
-            versionFoRender = (
-              versionFoRender ?? DEFAULT_EMPTY_CELL_VALUE
+            displayedVersion = (
+              displayedVersion ?? DEFAULT_EMPTY_CELL_VALUE
             ).concat(` (.${packageTypeCopy})`);
           }
         }
-        return <TextCell value={versionFoRender} />;
+        return <TextCell value={displayedVersion} />;
       },
       sortType: "caseInsensitive",
     },


### PR DESCRIPTION
## Issue
Closes #36541 

## Description
- This table was ignoring `.app_store_app.version` and only pulling android latest, and package versions 

## Screenshot of fix
<img width="974" height="403" alt="Screenshot 2026-01-15 at 4 39 02 PM" src="https://github.com/user-attachments/assets/349a3f11-ea6a-4f45-8f6d-40bb2d77ceab" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
