### PR TITLE
Fleet UI: Fix os_version not wired (#38400)

### DIFF
--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -414,6 +414,7 @@ export const HOST_SUMMARY_DATA: (keyof IHost)[] = [
   "team_name",
   "display_name", // Not rendered on my device page
   "maintenance_window", // Not rendered on my device page
+  "os_version",
 ];
 
 export const HOST_VITALS_DATA = [


### PR DESCRIPTION
## Issue
Closes #38397 

## Description
- This was merged into `main` with #38400 
- This is a cherry-pick into 4.80 RC