### PR TITLE
improve err message when getting android enrollment token during ota enrollment

### DIFF
--- a/changes/issue-36935-better-message-error-token
+++ b/changes/issue-36935-better-message-error-token
@@ -1,0 +1,1 @@
+- improve error message where there is issue getting the enrollment token during ota enrollment

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -464,8 +464,8 @@
             setEnrollTokenUrl(data.android_enrollment_url);
           } catch (error) {
             renderError(
-              "Problem getting the enroll token.",
-              "There was an issue getting the enrollment token. Please contact your IT admin."
+              "Couldn't get Android enrollment token.",
+              "Please refresh the page. If the issue continues, contact your IT admin."
             );
             return;
           }

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -464,8 +464,8 @@
             setEnrollTokenUrl(data.android_enrollment_url);
           } catch (error) {
             renderError(
-              "This URL is invalid.",
-              "Enroll secret is invalid. Please contact your IT admin."
+              "Problem getting the enroll token.",
+              "There was an issue getting the enrollment token. Please contact your IT admin."
             );
             return;
           }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36935

This makes a small change to improve the error message when there is an issue getting the android enrollment token when going through the ota enrollment flow

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
