### PR TITLE
manual agent install should only block macOS SE software

### DIFF
--- a/changes/37008-manual-agent-install-only-blocks-macos-se-software
+++ b/changes/37008-manual-agent-install-only-blocks-macos-se-software
@@ -1,0 +1,1 @@
+- Fixed an issue where enabling manual agent installation for macOS devices would incorrectly block the addition of setup experience software titles for all platforms.

--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -296,4 +296,15 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 
 	err = svc.SetSetupExperienceSoftware(ctx, "darwin", 1, []uint{})
 	require.NoError(t, err)
+
+	t.Run("should not block for non darwin hosts", func(t *testing.T) {
+		for _, platform := range fleet.SetupExperienceSupportedPlatforms {
+			if platform == "darwin" {
+				continue
+			}
+
+			err := svc.SetSetupExperienceSoftware(ctx, platform, 0, []uint{1, 2})
+			require.NoError(t, err)
+		}
+	})
 }

--- a/frontend/interfaces/platform.ts
+++ b/frontend/interfaces/platform.ts
@@ -150,7 +150,7 @@ export const isWindows = (platform: string | HostPlatform) =>
   platform === "windows";
 
 export const isMacOS = (platform: string | HostPlatform) =>
-  platform === "darwin";
+  ["darwin", "macos"].includes(platform);
 
 export const isIPadOrIPhone = (platform: string | HostPlatform) =>
   ["ios", "ipados"].includes(platform);

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tests.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 import { noop } from "lodash";
+import { SETUP_EXPERIENCE_PLATFORMS } from "interfaces/platform";
 
 import {
   createMockSoftwarePackage,
@@ -173,4 +174,48 @@ describe("AddInstallSoftware", () => {
       expect(checkbox).toBeChecked();
     });
   });
+
+  it("should disable adding software for macos with manual agent install", async () => {
+    render(
+      <AddInstallSoftware
+        savedRequireAllSoftwareMacOS={false}
+        currentTeamId={1}
+        softwareTitles={[createMockSoftwareTitle(), createMockSoftwareTitle()]}
+        onAddSoftware={noop}
+        hasManualAgentInstall
+        platform="macos"
+      />
+    );
+
+    const addSoftwareButton = screen.getByRole("button", {
+      name: "Select software",
+    });
+    expect(addSoftwareButton).toBeVisible();
+    expect(addSoftwareButton).toBeDisabled();
+  });
+
+  it.each(SETUP_EXPERIENCE_PLATFORMS.filter((val) => val !== "macos"))(
+    "should allow adding software for %s platform with manual agent install",
+    async (platform) => {
+      render(
+        <AddInstallSoftware
+          savedRequireAllSoftwareMacOS={false}
+          currentTeamId={1}
+          softwareTitles={[
+            createMockSoftwareTitle(),
+            createMockSoftwareTitle(),
+          ]}
+          onAddSoftware={noop}
+          hasManualAgentInstall
+          platform={platform}
+        />
+      );
+
+      const addSoftwareButton = screen.getByRole("button", {
+        name: "Select software",
+      });
+      expect(addSoftwareButton).toBeVisible();
+      expect(addSoftwareButton).not.toBeDisabled();
+    }
+  );
 });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -3,7 +3,7 @@ import { capitalize } from "lodash";
 
 import PATHS from "router/paths";
 import { buildQueryStringFromParams } from "utilities/url";
-import { SetupExperiencePlatform } from "interfaces/platform";
+import { isMacOS, SetupExperiencePlatform } from "interfaces/platform";
 import { ISoftwareTitle } from "interfaces/software";
 
 import { AppContext } from "context/app";
@@ -151,6 +151,9 @@ const AddInstallSoftware = ({
     </>
   );
 
+  const manualAgentInstallBlockingSoftware =
+    hasManualAgentInstall && isMacOS(platform);
+
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__description-container`}>
@@ -166,7 +169,9 @@ const AddInstallSoftware = ({
               <TooltipWrapper
                 className={`${baseClass}__manual-install-tooltip`}
                 tipContent={manuallyInstallTooltipText}
-                disableTooltip={disableChildren || !hasManualAgentInstall}
+                disableTooltip={
+                  disableChildren || !manualAgentInstallBlockingSoftware
+                }
                 position="top"
                 showArrow
                 underline={false}
@@ -176,7 +181,7 @@ const AddInstallSoftware = ({
                   onClick={onAddSoftware}
                   disabled={
                     disableChildren ||
-                    hasManualAgentInstall ||
+                    manualAgentInstallBlockingSoftware ||
                     noSoftwareUploaded
                   }
                 >

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -1063,6 +1063,10 @@ func IsApplePlatform(hostPlatform string) bool {
 	return hostPlatform == "darwin" || hostPlatform == "ios" || hostPlatform == "ipados"
 }
 
+func IsMacOSPlatform(hostPlatform string) bool {
+	return hostPlatform == "darwin"
+}
+
 // Return true if the platform is either iOS or iPadOS
 func IsAppleMobilePlatform(hostPlatform string) bool {
 	return hostPlatform == "ios" || hostPlatform == "ipados"

--- a/server/fleet/setup_experience.go
+++ b/server/fleet/setup_experience.go
@@ -238,3 +238,12 @@ type SetupExperienceCount struct {
 	Scripts    uint `db:"scripts"`
 	VPP        uint `db:"vpp"`
 }
+
+var SetupExperienceSupportedPlatforms = []string{
+	"macos",
+	"ios",
+	"ipados",
+	"windows",
+	"linux",
+	"android",
+}

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -376,19 +376,10 @@ func maybeUpdateSetupExperienceStatus(ctx context.Context, ds fleet.Datastore, r
 	return updated, err
 }
 
-var setupExperienceSupportedPlatforms = []string{
-	"macos",
-	"ios",
-	"ipados",
-	"windows",
-	"linux",
-	"android",
-}
-
 func validateSetupExperiencePlatform(platforms string) error {
 	for platform := range strings.SplitSeq(platforms, ",") {
-		if platform != "" && !slices.Contains(setupExperienceSupportedPlatforms, platform) {
-			quotedPlatforms := strings.Join(setupExperienceSupportedPlatforms, "\", \"")
+		if platform != "" && !slices.Contains(fleet.SetupExperienceSupportedPlatforms, platform) {
+			quotedPlatforms := strings.Join(fleet.SetupExperienceSupportedPlatforms, "\", \"")
 			quotedPlatforms = fmt.Sprintf("\"%s\"", quotedPlatforms)
 			return badRequestf("platform %q unsupported, platform must be one of %s", platform, quotedPlatforms)
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37008 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

