### PR TITLE
Android software can't be removed from setup experience

### DIFF
--- a/articles/setup-experience.md
+++ b/articles/setup-experience.md
@@ -134,7 +134,9 @@ Add setup experience software:
 2. Click **Add software**, then select or search for the software you want installed during the setup experience.
 3. Press **Save** to save your selection.
 
-To see the end user experience on iOS/iPadOS, check out the [iOS video](https://www.youtube.com/shorts/_XXNGrQPqys) and [iPadOS video](https://www.youtube.com/shorts/IIzo4NyUolM).
+To see the end user experience on iOS/iPadOS, check out the [iOS video](https://www.youtube.com/shorts/_XXNGrQPqys) and [iPadOS video](https://www.youtube.com/shorts/IIzo4NyUolM)
+
+> Currently, if Android software is deleted from **Setup experience > Install software**, it still gets installed when Android hosts enroll. We'll improve this in [#36859](https://github.com/fleetdm/fleet/issues/36859).
 
 ### Retries
 


### PR DESCRIPTION
Currently, Android software can't be removed from the setup experience. We have a story that we aim to ship in 4.82. Until we ship, I added a  callout in the setup experience guide.
