### PR TITLE
Update query for Fleet osquery policy

### DIFF
--- a/docs/solutions/windows/policies/windows-fleet-hardening.policies.yml
+++ b/docs/solutions/windows/policies/windows-fleet-hardening.policies.yml
@@ -2,4 +2,4 @@
   platform: windows
   description: "This policy checks if the uninstall and modify options are hidden for Fleet osquery by ensuring both the NoRemove and NoModify registry values are set to 1."
   resolution: "As an IT admin, set the NoRemove and NoModify registry values to 1 under the Fleet osquery uninstall key to prevent users from uninstalling or modifying the agent."
-  query: SELECT CASE WHEN COUNT(*) = 1 THEN 1 ELSE 0 END AS compliant FROM registry nr JOIN registry d ON d.path = REPLACE(nr.path, '\NoRemove', '\DisplayName') JOIN registry nm ON nm.path = REPLACE(nr.path, '\NoRemove', '\NoModify') WHERE nr.path LIKE 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\%\NoRemove' AND d.data = 'Fleet osquery' AND nr.data = '1' AND nm.data = '1';
+  query: SELECT 1 FROM registry nr JOIN registry d ON d.path = REPLACE(nr.path, '\NoRemove', '\DisplayName') JOIN registry nm ON nm.path = REPLACE(nr.path, '\NoRemove', '\NoModify') WHERE nr.path LIKE 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\%\NoRemove' AND d.data = 'Fleet osquery' AND nr.data = '1' AND nm.data = '1';


### PR DESCRIPTION
The policy currently returns a value in both a good and bad state. Updated to use `SELECT 1`


