### PR TITLE
Added cdhash, executable_path and executable_sha256 values to osquery-perf

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -2794,7 +2794,7 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 					executablePath := installedPath + "/Contents/MacOS/" + strings.TrimSuffix(s["name"], ".app")
 					// Generate a mock sha256 hash based on the executable path for consistency
 					executableSHA256 := fmt.Sprintf("%x", sha1.Sum([]byte(executablePath)))
-					executableSHA256 = executableSHA256 + executableSHA256[:24]
+					executableSHA256 += executableSHA256[:24]
 					results = append(results, map[string]string{
 						"path":              installedPath,
 						"executable_path":   executablePath,

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -2768,7 +2768,7 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 					if len(teamIdentifier) > 10 {
 						teamIdentifier = teamIdentifier[:10]
 					}
-					cdhashSHA256 := fmt.Sprintf("%x", sha1.Sum([]byte(installedPath)))
+					cdhashSHA256 := fmt.Sprintf("%x", sha1.Sum([]byte(installedPath))) // cdhash returns 40 characters, matching the length of the sha1 here
 					results = append(results, map[string]string{
 						"path":            installedPath,
 						"team_identifier": teamIdentifier,

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -5,6 +5,7 @@ import (
 	"compress/bzip2"
 	cryptorand "crypto/rand"
 	"crypto/sha1" // nolint:gosec
+	"crypto/sha256"
 	"crypto/tls"
 	"embed"
 	"encoding/base64"
@@ -2793,8 +2794,7 @@ func (a *agent) processQuery(name, query string, cachedResults *cachedResults) (
 					// Generate mock executable path
 					executablePath := installedPath + "/Contents/MacOS/" + strings.TrimSuffix(s["name"], ".app")
 					// Generate a mock sha256 hash based on the executable path for consistency
-					executableSHA256 := fmt.Sprintf("%x", sha1.Sum([]byte(executablePath)))
-					executableSHA256 += executableSHA256[:24]
+					executableSHA256 := fmt.Sprintf("%x", sha256.Sum256([]byte(executablePath)))
 					results = append(results, map[string]string{
 						"path":              installedPath,
 						"executable_path":   executablePath,


### PR DESCRIPTION
**Related issue:** #33522, #25545

https://github.com/fleetdm/fleet/pull/38118 added `executable_path` and `executable_sha256` columns to `host_software_installed_paths`. 
https://github.com/fleetdm/fleet/pull/29280 added `cdhash_sha256` column to `host_software_installed_paths`

In order to keep osquery perf realistic, we need to mock this data.