### PR TITLE
Fleet UI: installed sw in inventory do not show failures

### DIFF
--- a/changes/31663-installed-sw-failure
+++ b/changes/31663-installed-sw-failure
@@ -1,0 +1,1 @@
+- Fleet UI: If the software is detected as installed on software library page, hide any Fleet install/uninstall failures from page. Admin can view these failures from host details > activities.

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -95,6 +95,23 @@ describe("SoftwareInstallDetailsModal", () => {
       ).not.toBeInTheDocument();
     });
 
+    it("treats failed_install as installed when host still reports installed versions", () => {
+      render(
+        <StatusMessage
+          softwareName="CoolApp"
+          installResult={createMockSoftwareInstallResult({
+            status: "failed_install",
+          })}
+          isMyDevicePage={false}
+          hasInstalledVersions
+        />
+      );
+
+      expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
+      expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
+      expect(screen.queryByText(/failed to install/i)).not.toBeInTheDocument();
+    });
+
     it("on host details page, renders failed install without retry", () => {
       render(
         <StatusMessage

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -38,6 +38,7 @@ import {
   INSTALL_DETAILS_STATUS_ICONS,
   getInstallDetailsStatusPredicate,
 } from "../constants";
+import { hasIn } from "lodash";
 
 const baseClass = "software-install-details-modal";
 
@@ -99,11 +100,11 @@ export const StatusMessage = ({
     created_at,
   } = installResult;
 
-  // Treat failed_install / failed_uninstall as installed
-  // when the host still reports installed versions (4.82 #31663)
+  // Treat failed_install/ failed_uninstall with installed versions as installed
+  // as the host still reports installed versions (4.82 #31663)
   const isActuallyInstalled =
-    ["failed_install", "failed_uninstall"].includes(status || "") &&
-    hasInstalledVersions;
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(status || "");
 
   if (isActuallyInstalled) {
     return (

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -38,7 +38,6 @@ import {
   INSTALL_DETAILS_STATUS_ICONS,
   getInstallDetailsStatusPredicate,
 } from "../constants";
-import { hasIn } from "lodash";
 
 const baseClass = "software-install-details-modal";
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
@@ -133,6 +133,65 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     });
   });
 
+  it("treats failed_install as installed when app is already installed", async () => {
+    renderModal({
+      details: {
+        commandUuid: "uuid-failed-installed",
+        fleetInstallStatus: "failed_install",
+        hostDisplayName: "Marko's MacBook Pro",
+        appName: "Logic Pro",
+      },
+      hostSoftware: createMockHostSoftware({
+        id: 42,
+        name: "Logic Pro",
+        installed_versions: [
+          {
+            version: "1.0.0",
+            bundle_identifier: "com.example.logicpro",
+            installed_paths: ["/Applications/Logic Pro.app"],
+            vulnerabilities: [],
+          },
+        ],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
+      expect(screen.getByText(/Current version/i)).toBeInTheDocument();
+    });
+
+    // No failure wording when treated as installed
+    expect(screen.queryByText(/failed to install/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Please re-attempt this installation/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders install failed message when app is not installed", async () => {
+    renderModal({
+      details: {
+        commandUuid: "uuid-failed",
+        fleetInstallStatus: "failed_install",
+        hostDisplayName: "Marko's MacBook Pro",
+        appName: "Logic Pro",
+      },
+      hostSoftware: createMockHostSoftware({
+        id: 99,
+        name: "Logic Pro",
+        installed_versions: [],
+      }),
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/The MDM command \(request\) to install/i)
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Please re-attempt this installation/i)
+    ).toBeInTheDocument();
+  });
+
   it("renders Done button by default", async () => {
     const onCancel = jest.fn();
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -71,6 +71,21 @@ export const getStatusMessage = ({
 
   const isPendingInstall = displayStatus === "pending_install";
 
+  // Treat failed_install / failed_uninstall with installed versions as installed
+  // as the host still reports installed versions (4.82 #31663)
+  // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
+  const isActuallyInstalled =
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus || "");
+
+  if (isActuallyInstalled) {
+    return (
+      <>
+        <b>{appName}</b> is installed.
+      </>
+    );
+  }
+
   // Handles the case where software is installed manually by the user and not through Fleet
   // This IPA software_packages modal matches app_store_app modal and software_packages modal
   // for software installed manually shown with VppInstallDetailsModal and SoftwareInstallDetailsModal
@@ -118,21 +133,6 @@ export const getStatusMessage = ({
         The MDM command (request) to install <b>{appName}</b>
         {!isMyDevicePage && <> on {formattedHost}</>} was acknowledged but the
         installation has not been verified. Please re-attempt this installation.
-      </>
-    );
-  }
-
-  // Treat failed_install / failed_uninstall as installed
-  // when the host still reports installed versions (4.82 #31663)
-  // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
-  const isActuallyInstalled =
-    ["failed_install", "failed_uninstall"].includes(displayStatus || "") &&
-    hasInstalledVersions;
-
-  if (isActuallyInstalled) {
-    return (
-      <>
-        <b>{appName}</b> is installed.
       </>
     );
   }

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
@@ -223,7 +223,7 @@ describe("getStatusMessage helper function", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("shows macOS update tip when app is already installed", () => {
+  it("treats failed_install as installed when app is already installed on macOS", () => {
     render(
       getStatusMessage({
         displayStatus: "failed_install",
@@ -236,21 +236,15 @@ describe("getStatusMessage helper function", () => {
         hasInstalledVersions: true,
       })
     );
+
+    expect(screen.getByText(/Logic Pro/i)).toBeInTheDocument();
+    expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
     expect(
-      screen.getByText(/The host acknowledged the MDM command to install/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/but the app failed to install/i)
-    ).toBeInTheDocument();
-    // Text is split by TooltipWrapper, so check for the parts separately
-    expect(
-      screen.getByText(/If you're updating the app and the app is open,/i)
-    ).toBeInTheDocument();
-    expect(screen.getByText(/close it/i)).toBeInTheDocument();
-    expect(screen.getByText(/and try again\./i)).toBeInTheDocument();
+      screen.queryByText(/If you're updating the app and the app is open/i)
+    ).not.toBeInTheDocument();
   });
 
-  it("doesn't show update tip when app is already installed on iOS", () => {
+  it("treats failed_install as installed when app is already installed on iOS", () => {
     render(
       getStatusMessage({
         displayStatus: "failed_install",
@@ -263,18 +257,15 @@ describe("getStatusMessage helper function", () => {
         hasInstalledVersions: true,
       })
     );
+
+    expect(screen.getByText(/Slack/i)).toBeInTheDocument();
+    expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
     expect(
-      screen.getByText(/The host acknowledged the MDM command to install/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/but the app failed to install/i)
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByText(/If you're updating the app and the app is open/i)
+      screen.queryByText(/The host acknowledged the MDM command to install/i)
     ).not.toBeInTheDocument();
   });
 
-  it("doesn't show update tip when app is already installed on iPadOS", () => {
+  it("treats failed_install as installed when app is already installed on iPadOS", () => {
     render(
       getStatusMessage({
         displayStatus: "failed_install",
@@ -287,12 +278,34 @@ describe("getStatusMessage helper function", () => {
         hasInstalledVersions: true,
       })
     );
+
+    expect(screen.getByText(/Slack/i)).toBeInTheDocument();
+    expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
     expect(
-      screen.getByText(/The host acknowledged the MDM command to install/i)
-    ).toBeInTheDocument();
+      screen.queryByText(/The host acknowledged the MDM command to install/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides macOS update tip when failed_install and app is already installed", () => {
+    render(
+      getStatusMessage({
+        displayStatus: "failed_install",
+        isMDMStatusNotNow: false,
+        isMDMStatusAcknowledged: true,
+        appName: "Logic Pro",
+        hostDisplayName: "Marko's MacBook Pro",
+        commandUpdatedAt: "2025-07-29T22:49:52Z",
+        platform: "darwin",
+        hasInstalledVersions: true,
+      })
+    );
+
     expect(
-      screen.getByText(/but the app failed to install/i)
-    ).toBeInTheDocument();
+      screen.queryByText(/The host acknowledged the MDM command to install/i)
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/but the app failed to install/i)
+    ).not.toBeInTheDocument();
     expect(
       screen.queryByText(/If you're updating the app and the app is open/i)
     ).not.toBeInTheDocument();

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -80,11 +80,11 @@ export const getStatusMessage = ({
     displayStatus
   );
 
-  // Treat failed_install / failed_uninstall as installed when Fleet
-  // says failed but the host reports the app as installed (4.82 #31663)
+  // Treat failed_install / failed_uninstall with installed versions as installed
+  // as the host still reports installed versions (4.82 #31663)
   const isActuallyInstalled =
-    ["failed_install", "failed_uninstall"].includes(displayStatus || "") &&
-    hasInstalledVersions;
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus || "");
 
   if (isActuallyInstalled) {
     return (
@@ -425,7 +425,12 @@ export const VppInstallDetailsModal = ({
   // NOTE: Currently no uninstall VPP but added for symmetry with SoftwareInstallDetailsModal
   const excludeInstallDetails =
     hasInstalledVersions &&
-    ["failed_install", "failed_uninstall"].includes(displayStatus);
+    [
+      "failed_install_installed",
+      "failed_uninstall_installed",
+      "failed_install",
+      "failed_uninstall",
+    ].includes(displayStatus || "");
 
   const renderContent = () => {
     if (isLoadingVPPCommandResult) {

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -571,7 +571,9 @@ export interface IHostSoftware {
 // Error UI statuses
 export const HOST_SOFTWARE_UI_ERROR_STATUSES = [
   "failed_install", // Install attempt failed
+  "failed_install_installed", // Install attempt failed but version still present
   "failed_install_update_available", // Install/update failed; newer installer version available
+  "failed_uninstall_installed", // Uninstall attempt failed but version still present
   "failed_uninstall", // Uninstall attempt failed
   "failed_uninstall_update_available", // Uninstall/update failed; newer installer version available
   "failed_script", // Script package failed to run

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -440,7 +440,7 @@ describe("InstallStatusCell - component", () => {
     });
   });
 
-  it("renders 'Failed' for failed_install_update_available", async () => {
+  it("renders 'Update available' with failure tooltip for failed_install_update_available", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -458,16 +458,19 @@ describe("InstallStatusCell - component", () => {
         onShowVPPInstallDetails={noop}
       />
     );
-    expect(screen.getByRole("button", { name: /Failed/i })).toBeInTheDocument();
-    expect(screen.getByTestId("error-icon")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Update available/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("error-outline-icon")).toBeInTheDocument();
 
-    await user.hover(screen.getByText("Failed"));
+    // Still see failure message in tooltip
+    await user.hover(screen.getByText("Update available"));
     await waitFor(() => {
       expect(screen.getByText(/failed to install/i)).toBeInTheDocument();
     });
   });
 
-  it("renders 'Failed (uninstall)' for failed_uninstall_update_available", async () => {
+  it("renders 'Update available' with failed uninstall tooltip for failed_uninstall_update_available", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -491,11 +494,11 @@ describe("InstallStatusCell - component", () => {
       />
     );
     expect(
-      screen.getByRole("button", { name: /Failed \(uninstall\)/i })
+      screen.getByRole("button", { name: /Update available/i })
     ).toBeInTheDocument();
-    expect(screen.getByTestId("error-icon")).toBeInTheDocument();
+    expect(screen.getByTestId("error-outline-icon")).toBeInTheDocument();
 
-    await user.hover(screen.getByText("Failed (uninstall)"));
+    await user.hover(screen.getByText("Update available"));
     await waitFor(() => {
       expect(screen.getByText(/to uninstall again/i)).toBeInTheDocument();
     });

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -250,13 +250,13 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
       ),
   },
   failed_install_update_available: {
-    iconName: "error",
+    iconName: "error-outline", // Match update available icon and not failed install icon
     displayText: "Update available", // Shows "Update available" modal instead of "Failed" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedInstallTooltip,
   },
   failed_uninstall_update_available: {
-    iconName: "error",
+    iconName: "error-outline", // Match update available icon and not failed uninstall icon
     displayText: "Update available", // Shows "Update available" modal instead of "Failed (uninstall)" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedUninstallTooltip,

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -49,8 +49,6 @@ interface TooltipArgs {
   lastInstalledAt?: string;
   isAppleAppStoreApp?: boolean;
   isHostOnline?: boolean;
-  /** API statuses */
-  apiStatus?: SoftwareInstallUninstallStatus | null;
 }
 
 export type IStatusDisplayConfig = {
@@ -114,16 +112,24 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   installed: {
     iconName: "success",
     displayText: "Installed", // Opens "Install details" modal
-    tooltip: ({ apiStatus, lastInstalledAt, isSelfService }) => {
-      // Software detected as installed will always show "Installed" along with install details modal but when API status is failed install/uninstall, a tooltip will appear addressing failure 4.82 #31663
-      if (apiStatus === "failed_install") {
-        return failedInstallTooltip({ lastInstalledAt, isSelfService });
-      }
-      if (apiStatus === "failed_uninstall") {
-        return failedUninstallTooltip({ lastInstalledAt, isSelfService });
-      }
-      return undefined;
-    }, // No tooltip for installed state
+    tooltip: () => {
+      return undefined; // No tooltip for installed state
+    },
+  },
+  failed_install_installed: {
+    iconName: "success",
+    displayText: "Installed", // Opens "Install details" modal
+    tooltip: ({ lastInstalledAt, isSelfService }) => {
+      return failedInstallTooltip({ lastInstalledAt, isSelfService });
+    },
+  },
+  // Different from failed_uninstall as currently installed detailsUI overrides failed uninstall details UI
+  failed_uninstall_installed: {
+    iconName: "success",
+    displayText: "Installed", // Opens "Install details" modal
+    tooltip: ({ lastInstalledAt, isSelfService }) => {
+      return failedUninstallTooltip({ lastInstalledAt, isSelfService });
+    },
   },
   recently_updated: {
     iconName: "success",
@@ -549,7 +555,6 @@ const InstallStatusCell = ({
     isAppleAppStoreApp,
     isSelfService,
     isHostOnline,
-    apiStatus: software.status,
   });
 
   return (

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -50,7 +50,7 @@ interface TooltipArgs {
   isAppleAppStoreApp?: boolean;
   isHostOnline?: boolean;
   /** API statuses */
-  apiStatus?: SoftwareInstallUninstallStatus;
+  apiStatus?: SoftwareInstallUninstallStatus | null;
 }
 
 export type IStatusDisplayConfig = {

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -252,13 +252,13 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   failed_install_update_available: {
     iconName: "error",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed" modal as of 4.82 #31663
-    // Users can find failure information in host activity logs
+    // Tooltip indicates failure info in host activity logs
     tooltip: failedInstallTooltip,
   },
   failed_uninstall_update_available: {
     iconName: "error",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed (uninstall)" modal as of 4.82 #31663
-    // Users can find failure information in host activity logs
+    // Tooltip indicates failure info in host activity logs
     tooltip: failedUninstallTooltip,
   },
   // Script package statuses

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -230,7 +230,8 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
   failed_install_update_available: {
     iconName: "error",
-    displayText: "Failed",
+    displayText: "Update available", // Show "Update available" modal instead of "Failed" modal as of 4.82 #31663
+    // Users can find failure information in host activity logs
     tooltip: ({ isSelfService, isHostOnline, lastInstalledAt }) =>
       isSelfService || isHostOnline ? (
         <>
@@ -266,7 +267,8 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
   failed_uninstall_update_available: {
     iconName: "error",
-    displayText: "Failed (uninstall)",
+    displayText: "Update available", // Show "Update available" modal instead of "Failed (uninstall)" modal as of 4.82 #31663
+    // Users can find failure information in host activity logs
     tooltip: ({ isSelfService, isHostOnline, lastInstalledAt }) =>
       isSelfService || isHostOnline ? (
         <>

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -159,7 +159,7 @@ describe("SelfService", () => {
     expect(moreText).not.toBeInTheDocument();
   });
 
-  it("renders failed status and 'Install' action button and 'Retry uninstall' dropdown with 'failed_uninstall' status and installed_versions detected", async () => {
+  it("renders installed status and 'Install' action button and 'Retry uninstall' dropdown with 'installed' status and installed_versions detected", async () => {
     mockServer.use(
       customDeviceSoftwareHandler({
         software: [
@@ -180,7 +180,7 @@ describe("SelfService", () => {
 
     expect(
       screen.getByTestId("install-status-cell__status--test")
-    ).toHaveTextContent("Failed");
+    ).toHaveTextContent("Installed");
 
     expect(screen.getByRole("button", { name: "Reinstall" })).toBeEnabled();
     const moreDropdown = getMoreDropdown();

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -159,7 +159,7 @@ describe("SelfService", () => {
     expect(moreText).not.toBeInTheDocument();
   });
 
-  it("renders installed status and 'Install' action button and 'Retry uninstall' dropdown with 'installed' status and installed_versions detected", async () => {
+  it("renders installed status and 'Install' action button and 'Retry uninstall' dropdown with 'failed_installed' status and installed_versions detected", async () => {
     mockServer.use(
       customDeviceSoftwareHandler({
         software: [

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -182,7 +182,6 @@ describe("SelfService", () => {
       screen.getByTestId("install-status-cell__status--test")
     ).toHaveTextContent("Installed");
 
-    expect(screen.getByRole("button", { name: "Reinstall" })).toBeEnabled();
     const moreDropdown = getMoreDropdown();
     await user.click(moreDropdown);
     const dropdown = document.getElementById("react-select-9-listbox");

--- a/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tests.ts
@@ -120,13 +120,14 @@ describe("getUiStatus", () => {
     });
     expect(getUiStatus(sw, true)).toBe("failed_install_update_available");
   });
-
-  it("returns 'failed_install' when failed_install and no update available", () => {
+  // As of 4.81 shows install details modal with installed status if versions still present #31663
+  // Users can hover over installed in InstallStatusCell for more info to see failure logs in host activity
+  it("returns 'failed_install_installed' when failed_install and no update available but there's installed versions", () => {
     const sw = createMockHostSoftware({
       status: "failed_install",
       // version equal to installed version
     });
-    expect(getUiStatus(sw, true)).toBe("failed_install");
+    expect(getUiStatus(sw, true)).toBe("failed_install_installed");
   });
 
   it("returns 'failed_uninstall_update_available' when failed_uninstall and update available", () => {
@@ -136,13 +137,14 @@ describe("getUiStatus", () => {
     });
     expect(getUiStatus(sw, true)).toBe("failed_uninstall_update_available");
   });
-
-  it("returns 'failed_uninstall' when failed_uninstall and no update available", () => {
+  // As of 4.81 shows install details modal with installed status if versions still present #31663
+  // Users can hover over installed in InstallStatusCell for more info to see failure logs in host activity
+  it("returns 'failed_uninstall_installed' when failed_uninstall and no update available but there's installed versions", () => {
     const sw = createMockHostSoftware({
       status: "failed_uninstall",
       // version equal to installed version
     });
-    expect(getUiStatus(sw, true)).toBe("failed_uninstall");
+    expect(getUiStatus(sw, true)).toBe("failed_uninstall_installed");
   });
 
   it("returns 'updating' if pending_install and update is available, host online", () => {

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -213,6 +213,7 @@ export const getUiStatus = (
   }
 
   // 0.5 Treat failed install/uninstall as installed if versions still present as of 4.82 #31663
+  // UI tooltip indicates failure info in host activity logs, but shows the "Installed" status along with the install details modal
   if (
     (status === "failed_install" || status === "failed_uninstall") &&
     installed_versions &&

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -212,6 +212,15 @@ export const getUiStatus = (
     return "never_ran_script";
   }
 
+  // 0.5 Treat failed install/uninstall as installed if versions still present as of 4.82 #31663
+  if (
+    (status === "failed_install" || status === "failed_uninstall") &&
+    installed_versions &&
+    installed_versions.length > 0
+  ) {
+    return "installed";
+  }
+
   // 1. Failed install states
   if (status === "failed_install") {
     if (
@@ -262,7 +271,7 @@ export const getUiStatus = (
     return isHostOnline ? "uninstalling" : "pending_uninstall";
   }
 
-  // **Recently_uninstalled check comes BEFORE update_available**
+  // Recently_uninstalled check comes BEFORE update_available
   if (status === null && lastUninstallDate && hostSoftwareUpdatedAt) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastUninstallDate);
     if (newerDate === lastUninstallDate || recentUserActionDetected) {


### PR DESCRIPTION
## Issue
Closes #31663 

## Description
- Status is no longer just Fleet status, but shows installed if installed
- Users must see failures in activity feed

## Screenrecording
- [BE Blocker](https://fleetdm.zoom.us/clips/share/U_aFoZ7NSpmqREOu-LBcZQ)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
