### PR TITLE
Bump to latest release of RustFS docker-compose dependency

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,7 +155,7 @@ services:
 
   # s3 compatible object storage (file carving/software installers)
   s3:
-    image: rustfs/rustfs:1.0.0-alpha.73
+    image: rustfs/rustfs:1.0.0-alpha.80
     ports:
       - "9000:9000"
       - "9001:9001"

--- a/tools/osquery/in-a-box/docker-compose.yml
+++ b/tools/osquery/in-a-box/docker-compose.yml
@@ -136,7 +136,7 @@ services:
       - fleet-preview
 
   s3:
-    image: rustfs/rustfs:1.0.0-alpha.73
+    image: rustfs/rustfs:1.0.0-alpha.80
     entrypoint: sh
     command: -c 'mkdir -p /data/software-installers-preview && /usr/bin/rustfs /data'
     environment:


### PR DESCRIPTION
Validated reads/writes locally on standard docker-compose.