### PR TITLE
Add hash_sha256 and package_name filters

### DIFF
--- a/changes/32965-hash-package-name-filters
+++ b/changes/32965-hash-package-name-filters
@@ -1,1 +1,0 @@
-- Added `hash_sha256` and `package_name` query parameters to the GET /api/v1/fleet/software/titles endpoint to allow checking if a custom software package already exists before uploading. Both parameters require `team_id` to be specified.

--- a/changes/32965-hash-package-name-filters
+++ b/changes/32965-hash-package-name-filters
@@ -1,0 +1,1 @@
+- Added `hash_sha256` and `package_name` query parameters to the GET /api/v1/fleet/software/titles endpoint to allow checking if a custom software package already exists before uploading. Both parameters require `team_id` to be specified.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9937,8 +9937,6 @@ Get a list of all software.
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
 | platform | string | query | Filters software titles available for install by platforms. `team_id` must be specified to filter by platform. Options are: `"macos"` (alias of `"darwin"`), `"darwin"` `"windows"`, `"linux"`, `"chrome"`, `"ios"`, `"ipados"`. To show titles from multiple platforms, separate the platforms with commas (e.g. `?platform=darwin,windows`). |
-| hash_sha256 | string | query | Filters to only include custom software packages (uploaded installers) with the specified SHA-256 hash. `team_id` must be specified to filter by hash. This allows checking if a specific package already exists before uploading. |
-| package_name | string | query | Filters to only include custom software packages (uploaded installers) with the specified package filename. `team_id` must be specified to filter by package name. This allows checking if a specific package already exists before uploading. |
 | exclude_fleet_maintained_apps | boolean | query | If `true` or `1`, Fleet maintained apps will not be included in the list of `software_titles`. Default is `false` |
 
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9937,6 +9937,8 @@ Get a list of all software.
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
 | platform | string | query | Filters software titles available for install by platforms. `team_id` must be specified to filter by platform. Options are: `"macos"` (alias of `"darwin"`), `"darwin"` `"windows"`, `"linux"`, `"chrome"`, `"ios"`, `"ipados"`. To show titles from multiple platforms, separate the platforms with commas (e.g. `?platform=darwin,windows`). |
+| hash_sha256 | string | query | Filters to only include custom software packages (uploaded installers) with the specified SHA-256 hash. `team_id` must be specified to filter by hash. This allows checking if a specific package already exists before uploading. |
+| package_name | string | query | Filters to only include custom software packages (uploaded installers) with the specified package filename. `team_id` must be specified to filter by package name. This allows checking if a specific package already exists before uploading. |
 | exclude_fleet_maintained_apps | boolean | query | If `true` or `1`, Fleet maintained apps will not be included in the list of `software_titles`. Default is `false` |
 
 

--- a/server/datastore/mysql/software_titles.go
+++ b/server/datastore/mysql/software_titles.go
@@ -159,7 +159,12 @@ func (ds *Datastore) ListSoftwareTitles(
 			// software is supported on a per team basis, so we require both
 			return nil, 0, nil, fleet.NewInvalidArgumentError("query", fleet.FilterTitlesByPlatformNeedsTeamIdErrMsg)
 		}
-
+		if opt.HashSHA256 != "" {
+			return nil, 0, nil, fleet.NewInvalidArgumentError("query", "hash_sha256 can only be provided with team_id")
+		}
+		if opt.PackageName != "" {
+			return nil, 0, nil, fleet.NewInvalidArgumentError("query", "package_name can only be provided with team_id")
+		}
 	}
 
 	dbReader := ds.reader(ctx)
@@ -506,6 +511,12 @@ WHERE
 		  {{$postfix := printf " AND (si.platform IN (%s) OR vap.platform IN (%[1]s) OR iha.platform IN (%[1]s))" (placeholders $.Platform)}}
 		  {{$additionalWhere = printf "%s %s" $additionalWhere $postfix}}
 		{{end}}
+		{{if and (hasTeamID $) $.HashSHA256}}
+		  {{$additionalWhere = printf "%s AND si.storage_id = ?" $additionalWhere}}
+		{{end}}
+		{{if and (hasTeamID $) $.PackageName}}
+		  {{$additionalWhere = printf "%s AND si.filename = ?" $additionalWhere}}
+		{{end}}
 		{{$additionalWhere}}
 	{{end}}
 	-- If teamID is set, defaults to "a software installer, in-house app or VPP app exists", and see next condition.
@@ -579,6 +590,14 @@ GROUP BY
 		for _, platform := range platforms {
 			args = append(args, platform)
 		}
+	}
+
+	if opt.HashSHA256 != "" {
+		args = append(args, opt.HashSHA256)
+	}
+
+	if opt.PackageName != "" {
+		args = append(args, opt.PackageName)
 	}
 
 	t, err := template.New("stm").Funcs(map[string]any{

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -511,6 +511,8 @@ type SoftwareTitleListOptions struct {
 	MaximumCVSS         float64 `query:"max_cvss_score,optional"`
 	PackagesOnly        bool    `query:"packages_only,optional"`
 	Platform            string  `query:"platform,optional"`
+	HashSHA256          string  `query:"hash_sha256,optional"`
+	PackageName         string  `query:"package_name,optional"`
 
 	// ForSetupExperience is an internal flag set when listing software via the
 	// setup experience endpoint, so that it filters out any software available

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -392,7 +392,8 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
 		TitleID:     titleID,
 		TeamID:      &team.ID,
-		DisplayName: ptr.String(strings.Repeat(" ", 5))}, http.StatusUnprocessableEntity, "Cannot have a display name that is all whitespace.")
+		DisplayName: ptr.String(strings.Repeat(" ", 5)),
+	}, http.StatusUnprocessableEntity, "Cannot have a display name that is all whitespace.")
 
 	s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
 		TitleID:     titleID,
@@ -490,7 +491,6 @@ func (s *integrationMDMTestSuite) TestSoftwareTitleDisplayNames() {
 			s.Assert().Empty(t.DisplayName)
 		}
 	}
-
 }
 
 func (s *integrationMDMTestSuite) TestSoftwareTitleCustomIconsPermissions() {

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -620,10 +620,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 		Source:        "apps",
 	}
 	s.uploadSoftwareInstaller(t, payload2, http.StatusOK, "")
-	installer2ID, _ := checkSoftwareInstaller(t, s.ds, payload2)
-	installer2, err := s.ds.GetSoftwareInstallerMetadataByID(context.Background(), installer2ID)
-	require.NoError(t, err)
-	hash2 := installer2.StorageID
+	_, _ = checkSoftwareInstaller(t, s.ds, payload2)
 
 	// Upload a software installer to team2 with same hash as payload1 (should be allowed)
 	payload3 := &fleet.UploadSoftwareInstallerPayload{

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -696,11 +696,13 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	require.Len(t, resp6.SoftwareTitles, 0)
 
 	// Test 7: Filter by hash_sha256 without team_id - should return error
-	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp1,
+	var resp7 listSoftwareTitlesResponse
+	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp7,
 		"hash_sha256", hash1)
 
 	// Test 8: Filter by package_name without team_id - should return error
-	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp1,
+	var resp8 listSoftwareTitlesResponse
+	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp8,
 		"package_name", "dummy_installer.pkg")
 
 	// Test 9: Filter by hash_sha256 with available_for_install=true

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -754,7 +754,6 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	require.Len(t, resp12.SoftwareTitles, 0)
 
 	// Test 13: Verify that filtering by hash doesn't return VPP or in-house apps
-	// First, list all software on team1 without filters to see total count
 	var respAll listSoftwareTitlesResponse
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &respAll,
 		"team_id", fmt.Sprint(team1.ID),

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -697,12 +697,12 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 
 	// Test 7: Filter by hash_sha256 without team_id - should return error
 	var resp7 listSoftwareTitlesResponse
-	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp7,
+	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusUnprocessableEntity, &resp7,
 		"hash_sha256", hash1)
 
 	// Test 8: Filter by package_name without team_id - should return error
 	var resp8 listSoftwareTitlesResponse
-	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp8,
+	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusUnprocessableEntity, &resp8,
 		"package_name", "dummy_installer.pkg")
 
 	// Test 9: Filter by hash_sha256 with available_for_install=true

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -594,7 +594,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	// Upload a software installer to team1
 	payload1 := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript: "install firefox",
-		Filename:      "firefox-120.0.pkg",
+		Filename:      "dummy_installer.pkg",
 		SelfService:   true,
 		TeamID:        &team1.ID,
 		Platform:      "darwin",
@@ -608,7 +608,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	// Upload a different software installer to team1 with different hash
 	payload2 := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript: "install chrome",
-		Filename:      "chrome-120.0.pkg",
+		Filename:      "EchoApp.pkg",
 		SelfService:   false,
 		TeamID:        &team1.ID,
 		Platform:      "darwin",
@@ -622,7 +622,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	// Upload a software installer to team2 with same hash as payload1 (should be allowed)
 	payload3 := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript: "install firefox",
-		Filename:      "firefox-120.0.pkg",
+		Filename:      "dummy_installer.pkg",
 		SelfService:   true,
 		TeamID:        &team2.ID,
 		Platform:      "darwin",
@@ -641,7 +641,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	require.Len(t, resp1.SoftwareTitles, 1)
 	require.Equal(t, "Firefox", resp1.SoftwareTitles[0].Name)
 	require.NotNil(t, resp1.SoftwareTitles[0].SoftwarePackage)
-	require.Equal(t, "firefox-120.0.pkg", resp1.SoftwareTitles[0].SoftwarePackage.Name)
+	require.Equal(t, "dummy_installer.pkg", resp1.SoftwareTitles[0].SoftwarePackage.Name)
 
 	// Test 2: Filter by hash_sha256 on team2 - should find Firefox
 	var resp2 listSoftwareTitlesResponse
@@ -662,17 +662,17 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	var resp4 listSoftwareTitlesResponse
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp4,
 		"team_id", fmt.Sprint(team1.ID),
-		"package_name", "firefox-120.0.pkg")
+		"package_name", "dummy_installer.pkg")
 	require.Len(t, resp4.SoftwareTitles, 1)
 	require.Equal(t, "Firefox", resp4.SoftwareTitles[0].Name)
 	require.NotNil(t, resp4.SoftwareTitles[0].SoftwarePackage)
-	require.Equal(t, "firefox-120.0.pkg", resp4.SoftwareTitles[0].SoftwarePackage.Name)
+	require.Equal(t, "dummy_installer.pkg", resp4.SoftwareTitles[0].SoftwarePackage.Name)
 
 	// Test 5: Filter by package_name on team1 - should find Chrome
 	var resp5 listSoftwareTitlesResponse
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp5,
 		"team_id", fmt.Sprint(team1.ID),
-		"package_name", "chrome-120.0.pkg")
+		"package_name", "EchoApp.pkg")
 	require.Len(t, resp5.SoftwareTitles, 1)
 	require.Equal(t, "Chrome", resp5.SoftwareTitles[0].Name)
 
@@ -689,7 +689,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 
 	// Test 8: Filter by package_name without team_id - should return error
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusBadRequest, &resp1,
-		"package_name", "firefox-120.0.pkg")
+		"package_name", "dummy_installer.pkg")
 
 	// Test 9: Filter by hash_sha256 with available_for_install=true
 	var resp9 listSoftwareTitlesResponse
@@ -704,7 +704,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	var resp10 listSoftwareTitlesResponse
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp10,
 		"team_id", fmt.Sprint(team1.ID),
-		"package_name", "chrome-120.0.pkg",
+		"package_name", "EchoApp.pkg",
 		"available_for_install", "true")
 	require.Len(t, resp10.SoftwareTitles, 1)
 	require.Equal(t, "Chrome", resp10.SoftwareTitles[0].Name)
@@ -714,7 +714,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp11,
 		"team_id", fmt.Sprint(team1.ID),
 		"hash_sha256", "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
-		"package_name", "firefox-120.0.pkg")
+		"package_name", "dummy_installer.pkg")
 	require.Len(t, resp11.SoftwareTitles, 1)
 	require.Equal(t, "Firefox", resp11.SoftwareTitles[0].Name)
 
@@ -723,7 +723,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", listSoftwareTitlesRequest{}, http.StatusOK, &resp12,
 		"team_id", fmt.Sprint(team1.ID),
 		"hash_sha256", "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
-		"package_name", "chrome-120.0.pkg")
+		"package_name", "EchoApp.pkg")
 	require.Len(t, resp12.SoftwareTitles, 0)
 
 	// Test 13: Verify that filtering by hash doesn't return VPP or in-house apps

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -615,7 +615,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 	require.NoError(t, err)
 	hash1 := installer1.StorageID
 	// Get the actual title that was extracted from the package
-	title1, err := s.ds.SoftwareTitleByID(context.Background(), *installer1.TitleID, nil)
+	title1, err := s.ds.SoftwareTitleByID(context.Background(), *installer1.TitleID, nil, fleet.TeamFilter{})
 	require.NoError(t, err)
 	titleName := title1.Name
 

--- a/server/service/integration_software_titles_test.go
+++ b/server/service/integration_software_titles_test.go
@@ -603,7 +603,7 @@ func (s *integrationMDMTestSuite) TestListSoftwareTitlesByHashAndName() {
 		Source:        "apps",
 	}
 	s.uploadSoftwareInstaller(t, payload1, http.StatusOK, "")
-	installer1ID, titleID1 := checkSoftwareInstaller(t, s.ds, payload1)
+	installer1ID, _ := checkSoftwareInstaller(t, s.ds, payload1)
 	installer1, err := s.ds.GetSoftwareInstallerMetadataByID(context.Background(), installer1ID)
 	require.NoError(t, err)
 	hash1 := installer1.StorageID


### PR DESCRIPTION
**Related issue:** Resolves #32965

## Description

This PR adds two new query parameters to the \`GET /api/v1/fleet/software/titles\` endpoint to support filtering by SHA-256 hash and package filename. This enables CI/CD automation tools to check if a custom software package already exists in Fleet before uploading.

## Changes

### API Changes
- Added \`hash_sha256\` query parameter to filter by package SHA-256 hash
- Added \`package_name\` query parameter to filter by package filename
- Both parameters require \`team_id\` to be specified (software packages are team-scoped)

### Implementation
- Updated \`SoftwareTitleListOptions\` struct with new filter fields
- Modified SQL query builder in \`selectSoftwareTitlesSQL\` to filter on \`software_installers.storage_id\` and \`software_installers.filename\`
- Added validation to enforce team_id requirement for these filters

### Testing
- Added \`TestListSoftwareTitlesByHashAndName\` integration test with 13 test scenarios
- Tests cover filtering by hash, filtering by name, error handling, team isolation, and combination with other filters

# Checklist for submitter

- [x] Changes file added for user-visible changes in \`changes/\`, \`orbit/changes/\` or \`ee/fleetd-chrome/changes\`.
- [x] Input data is properly validated, \`SELECT *\` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation (updates to one hosts's records do not affect another)
- [x] QA'd all new/changed functionality manually