### PR TITLE
Added bug prioritization section to handbook

### DIFF
--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -991,7 +991,7 @@ At sprint kickoff, the EM or TL may assign planned issues to specific contributo
 When selecting which bug to work on next, prioritize in the following order:
 
 1. **P0, P1, P2 bugs**: High-priority bugs take precedence over all other bugs.
-2. **Customer bugs**: Bugs with a `customer-` label are prioritized because they directly impact paying customers.
+2. **Customer bugs**: Bugs with a `customer-` label are prioritized because they directly impact customers.
 3. **Flaky tests**: Flaky tests impact engineering velocity and should be addressed promptly.
 4. **Dogfood issues**: Bugs with the `~dogfood` label are prioritized because we have the best context for reproducing and fixing them.
 5. **Oldest bugs**: Among remaining bugs, work on the oldest first.

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -986,6 +986,15 @@ At sprint kickoff, the EM or TL may assign planned issues to specific contributo
    - Help complete sub-issues for active user stories.
 4. **Look ahead when sprint work is done.** If all sprint work is complete or blocked, check the team's drafting board for issues in the "Estimated" column. Prioritize unreleased bugs over released bugs.
 
+#### Bug prioritization
+
+When selecting which bug to work on next, prioritize in the following order:
+
+1. **P0, P1, P2 bugs**: High-priority bugs take precedence over all other bugs.
+2. **Customer bugs**: Bugs with a `customer-` label are prioritized because they directly impact paying customers.
+3. **Flaky tests**: Flaky tests impact engineering velocity and should be addressed promptly.
+4. **Dogfood issues**: Bugs with the `~dogfood` label are prioritized because we have the best context for reproducing and fixing them.
+5. **Oldest bugs**: Among remaining bugs, work on the oldest first.
 
 ## Outside contributions
 


### PR DESCRIPTION
Flaky tests were discussed at 1/13 Backend sync, and engineers agreed they needed to be prioritized.
Better to fix them quickly than blindly disable them.