### PR TITLE
Add hash_sha256 and package_name filter documentation

### DIFF
--- a/changes/32965-hash-package-name-filters
+++ b/changes/32965-hash-package-name-filters
@@ -1,1 +1,0 @@
-- Added `hash_sha256` and `package_name` query parameters to the GET /api/v1/fleet/software/titles endpoint to allow checking if a custom software package already exists before uploading. Both parameters require `team_id` to be specified.

--- a/changes/32965-hash-package-name-filters
+++ b/changes/32965-hash-package-name-filters
@@ -1,0 +1,1 @@
+- Added `hash_sha256` and `package_name` query parameters to the GET /api/v1/fleet/software/titles endpoint to allow checking if a custom software package already exists before uploading. Both parameters require `team_id` to be specified.

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -9966,6 +9966,8 @@ Get a list of all software.
 | max_cvss_score | integer | query | _Available in Fleet Premium_. Filters to only include software with vulnerabilities that have a CVSS version 3.x base score lower than what's specified.   |
 | exploit | boolean | query | _Available in Fleet Premium_. If `true`, filters to only include software with vulnerabilities that have been actively exploited in the wild (`cisa_known_exploit: true`). Default is `false`.  |
 | platform | string | query | Filters software titles available for install by platforms. `team_id` must be specified to filter by platform. Options are: `"macos"` (alias of `"darwin"`), `"darwin"` `"windows"`, `"linux"`, `"chrome"`, `"ios"`, `"ipados"`. To show titles from multiple platforms, separate the platforms with commas (e.g. `?platform=darwin,windows`). |
+| hash_sha256 | string | query | Filters to only include custom software packages (uploaded installers) with the specified SHA-256 hash. `team_id` must be specified to filter by hash. This allows checking if a specific package already exists before uploading. |
+| package_name | string | query | Filters to only include custom software packages (uploaded installers) with the specified package filename. `team_id` must be specified to filter by package name. This allows checking if a specific package already exists before uploading. |
 | exclude_fleet_maintained_apps | boolean | query | If `true` or `1`, Fleet maintained apps will not be included in the list of `software_titles`. Default is `false` |
 
 


### PR DESCRIPTION
Documentation for new query parameters added to GET /api/v1/fleet/software/titles:

- `hash_sha256`: Filter by SHA-256 hash of uploaded installer
- `package_name`: Filter by filename of uploaded installer

Both parameters require `team_id` to be specified.

Related code PR: #38474
Fixes #32965