### PR TITLE
Update CODEOWNERS and custom.js for handbook ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,15 +122,15 @@ go.mod @fleetdm/go
 /handbook/company/open-positions.yml                            @ireedy
 #/handbook/company/product-groups.md                            Covered in custom.js
 /handbook/company/go-to-market-groups.md                        @sampfluger88
-/handbook/finance/security.md                   			          @allenhouchins # TODO move these files to `it-and-enablement/`
-/handbook/finance/README.md                                     @rfoo2015
-/handbook/finance/finance.rituals.yml                           @sampfluger88
-/handbook/people                    			        	            @ireedy
-/handbook/it-and-enablement                             	      @allenhouchins
-/handbook/customer-success                                    	@zayhanlon
-/handbook/marketing                                            	@akuthiala
-/handbook/sales                                                	@sampfluger88
-/handbook/ceo                                                   @mikermcneil
+/handbook/finance/security.md                   			    @allenhouchins # TODO move these files to `it-and-enablement/`
+#/handbook/finance/README.md                                    Covered in custom.js
+#/handbook/finance/finance.rituals.yml                          Covered in custom.js
+#/handbook/people                    			        	    Covered in custom.js
+#/handbook/it-and-enablement                             	    Covered in custom.js
+#/handbook/customer-success                                    	Covered in custom.js
+#/handbook/marketing                                            Covered in custom.js
+#/handbook/sales                                                Covered in custom.js
+#/handbook/ceo                                                  Covered in custom.js
 #/handbook/product-design                                     	Covered in custom.js
 #/handbook/engineering                                     	    Covered in custom.js
 
@@ -159,6 +159,6 @@ go.mod @fleetdm/go
 # 🚀 GitHub workflows
 ##############################################################################################
 /.github @lukeheath
-/.github/workflows/ @georgekarrv @sharon-fdm @lukeheath @lucasmrod @getvictor 
+/.github/workflows/ @georgekarrv @sharon-fdm @lukeheath @lucasmrod @getvictor
 # ℹ️ But wait, there's more!
 # See the comments up top to learn where else DRIs and maintainers are configured.

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -171,6 +171,12 @@ module.exports.custom = {
     'handbook/company/writing.md': 'mike-j-thomas',
     'handbook/engineering': 'lukeheath',
     'handbook/product-design': 'noahtalerman',
+    'handbook/finance': 'rfoo2015',
+    'handbook/people': 'ireedy',
+    'handbook/it-and-enablement': 'allenhouchins',
+    'handbook/sales': 'sampfluger88',
+    'handbook/customer-success': 'zayhanlon',
+    'handbook/marketing': 'akuthiala',
 
     // 🫧 Other brandfronts
     'README.md': 'mikermcneil',// « GitHub brandfront
@@ -272,16 +278,16 @@ module.exports.custom = {
     '.github/workflows/dogfood-gitops.yml': 'allenhouchins',
 
     // Repo automation and change control settings
-    'CODEOWNERS': ['mikermcneil', 'sampfluger88', 'lukeheath'],// (« for changing who reviews is automatically requested from for given paths)
-    'website/config/custom.js': ['eashaw', 'mikermcneil', 'lukeheath', 'sampfluger88'],// (« for changing whose changes automatically approve and unfreeze relevant PRs changing given paths)
+    'CODEOWNERS': ['mikermcneil', 'sampfluger88', 'lukeheath', 'ireedy'],// (« for changing who reviews is automatically requested from for given paths)
+    'website/config/custom.js': ['eashaw', 'mikermcneil', 'lukeheath', 'sampfluger88', 'ireedy'],// (« for changing whose changes automatically approve and unfreeze relevant PRs changing given paths)
 
     // Handbook
     'handbook/README.md': 'mikermcneil', // See https://github.com/fleetdm/fleet/pull/13195
     'handbook/company': 'mikermcneil',
     'handbook/company/product-maturity-assessment': ['mikermcneil','noahtalerman','allenhouchins'],
     'handbook/company/open-positions.yml': ['sampfluger88', 'mikermcneil', 'ireedy'],
-    'handbook/company/communications.md': ['mikermcneil'],
-    'handbook/company/writing.md': ['mike-j-thomas', 'mikermcneil'],
+    'handbook/company/communications.md': ['mikermcneil', 'sampfluger88'],
+    'handbook/company/writing.md': ['mike-j-thomas', 'mikermcneil', 'sampfluger88'],
     'handbook/company/go-to-market-groups.md': ['sampfluger88', 'mikermcneil'],
     'handbook/company/leadership.md': ['sampfluger88', 'mikermcneil', 'ireedy'],
     'handbook/it-and-enablement': ['sampfluger88', 'mikermcneil', 'allenhouchins'],


### PR DESCRIPTION
Moved several handbook path ownerships from CODEOWNERS to custom.js and added corresponding entries in custom.js. Updated reviewer lists for CODEOWNERS and custom.js files to include 'ireedy'. Adjusted ownership for specific handbook sections to reflect current maintainers.

