### PR TITLE
Fix: redirect to SSO > End Users tab from Controls > Setup experience > End user auth set up

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
@@ -88,7 +88,7 @@ const EndUserAuthentication = ({
             info="Connect Fleet to your identity provider (IdP) to get started."
             buttonText="Connect"
             router={router}
-            path={PATHS.ADMIN_INTEGRATIONS_IDENTITY_PROVIDER}
+            path={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
           />
         ) : (
           <EndUserAuthForm


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
Ad-hoc fix. Context: https://fleetdm.slack.com/archives/C084F4MKYSJ/p1768917147413809

The **Connect** button was redirecting to `Settings > Integrations > IdP` instead of `Settings > SSO > End users`.

<img width="1385" height="499" alt="Screenshot 2026-01-20 at 11 17 34 AM" src="https://github.com/user-attachments/assets/67b5dff3-73a9-415a-975a-5bd504248ef1" />
