### PR TITLE
Alternative browser host gitops

### DIFF
--- a/changes/38096-alternative-browser-host-gitops
+++ b/changes/38096-alternative-browser-host-gitops
@@ -1,0 +1,1 @@
+* Updated gitops related tests to validate that users can get/set the alternative browser hosts fleet desktop setting.

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/appConfig.json
@@ -147,7 +147,8 @@
     "sso_server_url": "https://sso.fleetdm.com"
   },
   "fleet_desktop": {
-    "transparency_url": "https://fleetdm.com/transparency"
+    "transparency_url": "https://fleetdm.com/transparency",
+    "alternative_browser_host": "musica.alternativa"
   },
   "vulnerability_settings": {
     "databases_path": ""

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
@@ -44,7 +44,7 @@ features:
     users:
     mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
 fleet_desktop:
-  alternative_browser_host: ""
+  alternative_browser_host: musica.alternativa
   transparency_url: https://fleetdm.com/transparency
 host_expiry_settings:
   host_expiry_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
@@ -44,7 +44,7 @@ features:
     users:
     mdm: "SELECT enrolled, server_url, installed_from_dep, payload_identifier FROM mdm;"
 fleet_desktop:
-  alternative_browser_host: ""
+  alternative_browser_host: musica.alternativa
   transparency_url: https://fleetdm.com/transparency
 host_expiry_settings:
   host_expiry_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -96,7 +96,7 @@ org_settings:
     enable_host_users: true
     enable_software_inventory: true
   fleet_desktop:
-    alternative_browser_host:
+    alternative_browser_host: musica.alternativa
     transparency_url: https://fleetdm.com/transparency
   host_expiry_settings:
     host_expiry_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -78,7 +78,7 @@ org_settings:
     enable_host_users: true
     enable_software_inventory: true
   fleet_desktop:
-    alternative_browser_host:
+    alternative_browser_host: musica.alternativa
     transparency_url: https://fleetdm.com/transparency
   host_expiry_settings:
     host_expiry_enabled: false

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -2928,3 +2928,82 @@ team_settings:
 		}
 	}
 }
+
+// TestFleetDesktopSettingsBrowserAlternativeHost tests that user can mutate the fleet_desktop.alternative_browser_host
+// setting via GitOps.
+func (s *enterpriseIntegrationGitopsTestSuite) TestFleetDesktopSettingsBrowserAlternativeHost() {
+	t := s.T()
+	ctx := context.Background()
+
+	user := s.createGitOpsUser(t)
+	fleetCfg := s.createFleetctlConfig(t, user)
+
+	type tmplParams struct {
+		AlternativeBrowserHost string
+	}
+	globalCfgTpl, err := template.New("t1").Parse(`
+agent_options:
+controls:
+queries:
+policies:
+org_settings:
+  secrets:
+    - secret: test_secret
+  fleet_desktop:
+    {{ .AlternativeBrowserHost }}
+`)
+	require.NoError(t, err)
+
+	// Set the required environment variables
+	t.Setenv("FLEET_URL", s.Server.URL)
+	t.Setenv("FLEET_GLOBAL_ENROLL_SECRET", "global_enroll_secret")
+	t.Setenv("FLEET_WORKSTATIONS_ENROLL_SECRET", "workstations_enroll_secret")
+	t.Setenv("FLEET_WORKSTATIONS_CANARY_ENROLL_SECRET", "workstations_canary_enroll_secret")
+
+	testCases := []struct {
+		Name                   string
+		AlternativeBrowserHost string
+		Expected               string
+		ShouldError            bool
+	}{
+		{
+			Name:                   "custom",
+			AlternativeBrowserHost: `alternative_browser_host: "example1.com"`,
+			Expected:               "example1.com",
+		},
+		{
+			Name:                   "empty value",
+			AlternativeBrowserHost: `alternative_browser_host: ""`,
+			Expected:               "",
+		},
+		{
+			Name:                   "invalid value",
+			AlternativeBrowserHost: `alternative_browser_host: "http://example2.com"`,
+			ShouldError:            true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+
+			globalCfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+			require.NoError(t, err)
+
+			require.NoError(t, globalCfgTpl.Execute(globalCfgFile, tmplParams{
+				AlternativeBrowserHost: testCase.AlternativeBrowserHost,
+			}))
+
+			if testCase.ShouldError {
+				fleetctl.RunAppCheckErr(t, []string{"gitops", "--config", fleetCfg.Name(), "-f", globalCfgFile.Name()}, "applying fleet config: PATCH /api/latest/fleet/config received status 422 Validation Failed: must be a valid hostname or IP address")
+			} else {
+				s.assertDryRunOutput(t, fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetCfg.Name(), "-f", globalCfgFile.Name(), "--dry-run"}))
+				s.assertRealRunOutput(t, fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetCfg.Name(), "-f", globalCfgFile.Name()}))
+			}
+
+			storedCfg, err := s.DS.AppConfig(ctx)
+			require.NoError(t, err)
+			require.NotNil(t, storedCfg)
+			require.Equal(t, testCase.Expected, storedCfg.FleetDesktop.AlternativeBrowserHost)
+		})
+	}
+}

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -109,7 +109,10 @@ const FleetDesktop = ({
       <PageDescription
         variant="right-panel"
         content={
-          <>Customize the default transparency URL and browser host to customize Fleet Desktop experience.</>
+          <>
+            Customize the default transparency URL and browser host to customize
+            Fleet Desktop experience.
+          </>
         }
       />
       <form onSubmit={onFormSubmit} autoComplete="off">

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -110,7 +110,7 @@ const FleetDesktop = ({
         variant="right-panel"
         content={
           <>
-            Customize the default transparency URL and browser host to customize
+            Override the default transparency URL or browser host to customize
             Fleet Desktop experience.
           </>
         }

--- a/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/FleetDesktop/FleetDesktop.tsx
@@ -109,7 +109,7 @@ const FleetDesktop = ({
       <PageDescription
         variant="right-panel"
         content={
-          <>Override default URLs to customize the Fleet Desktop experience.</>
+          <>Customize the default transparency URL and browser host to customize Fleet Desktop experience.</>
         }
       />
       <form onSubmit={onFormSubmit} autoComplete="off">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38096

The work required for this was done in [here](https://github.com/fleetdm/fleet/pull/38409) - this just adds/updates related tests. While QA'ing this I noticed a discrepancy between the UI and the Figma specs, instead of opening a new PR, the issue was patched here.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [X] Verified that the setting is exported via `fleetctl generate-gitops`
- [X] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [X] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)