### PR TITLE
Fix accidental remove in `releaser.sh`

### DIFF
--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -173,6 +173,10 @@ release_fleetd_to_edge () {
     echo "Releasing fleetd to edge..."
     ORBIT_TAG="orbit-v$VERSION"
     prompt "A tag will be pushed to trigger a Github Action to build desktop and orbit."
+    pushd "$GIT_REPOSITORY_DIRECTORY"
+    git tag "$ORBIT_TAG"
+    git push origin "$ORBIT_TAG"
+    popd
     DESKTOP_ARTIFACT_DOWNLOAD_DIRECTORY="$ARTIFACTS_DOWNLOAD_DIRECTORY/desktop"
     mkdir -p "$DESKTOP_ARTIFACT_DOWNLOAD_DIRECTORY"
     "$GO_TOOLS_DIRECTORY/download-artifacts" desktop \


### PR DESCRIPTION
Fixing an accidental remove in https://github.com/fleetdm/fleet/pull/36409

I just meant to remove the `create_fleetd_release_pr` part, but ended up removing important commands :)