### PR TITLE
Cherry pick missing `executable_hashes` schema changes for 4.80.0

### DIFF
--- a/schema/osquery_fleet_schema.json
+++ b/schema/osquery_fleet_schema.json
@@ -10634,6 +10634,37 @@
     "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/event_taps.yml"
   },
   {
+    "name": "executable_hashes",
+    "platforms": [
+      "darwin"
+    ],
+    "description": "Calculates the sha256 hash of a macOS application executable.",
+    "columns": [
+      {
+        "name": "path",
+        "type": "text",
+        "required": true,
+        "description": "Path is the absolute path to the app folder."
+      },
+      {
+        "name": "executable_path",
+        "type": "text",
+        "required": false,
+        "description": "Path of the executable for this app."
+      },
+      {
+        "name": "executable_sha256",
+        "type": "text",
+        "required": false,
+        "description": "Calculated hex-encoded SHA256 of the executable of this app."
+      }
+    ],
+    "notes": "This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).",
+    "evented": false,
+    "url": "https://fleetdm.com/tables/executable_hashes",
+    "fleetRepoUrl": "https://github.com/fleetdm/fleet/blob/main/schema/tables/executable_hashes.yml"
+  },
+  {
     "name": "extended_attributes",
     "description": "Returns the extended attributes for files (similar to Windows ADS).",
     "url": "https://fleetdm.com/tables/extended_attributes",

--- a/schema/tables/executable_hashes.yml
+++ b/schema/tables/executable_hashes.yml
@@ -1,0 +1,19 @@
+name: executable_hashes
+platforms:
+  - darwin
+description: Calculates the sha256 hash of a macOS application executable.
+columns:
+  - name: path
+    type: text
+    required: true
+    description: Path is the absolute path to the app folder.
+  - name: executable_path
+    type: text
+    required: false
+    description: Path of the executable for this app.
+  - name: executable_sha256
+    type: text
+    required: false
+    description: Calculated hex-encoded SHA256 of the executable of this app.
+notes: This table is not a core osquery table. It is included as part of Fleet's agent ([fleetd](https://fleetdm.com/docs/get-started/anatomy#fleetd)).
+evented: false


### PR DESCRIPTION
Cherry-pick for https://github.com/fleetdm/fleet/pull/38492