### PR TITLE
Website: Fix value in product design rituals YAML

### DIFF
--- a/handbook/product-design/product-design.rituals.yml
+++ b/handbook/product-design/product-design.rituals.yml
@@ -104,8 +104,8 @@
   task: "✅ 🎉 Confirm and celebrate"
   startedOn: "2026-01-20" 
   frequency: "Weekly" 
-  description: "Head of Product Design (HPD) and relevant Product Designer(s) run through the confirm and celebrate responsibility: https://fleetdm.com/handbook/product-design#confirm-and-celebrate 
-  moreInfoUrl:  
+  description: "Head of Product Design (HPD) and relevant Product Designer(s) run through the confirm and celebrate responsibility: https://fleetdm.com/handbook/product-design#confirm-and-celebrate"
+  moreInfoUrl:  https://fleetdm.com/handbook/product-design#confirm-and-celebrate
   dri: "noahtalerman"
 -
   task: "Review reference docs for upcoming release"


### PR DESCRIPTION
Changes:
- Added a closing quotation mark to the description of the "Confirm and celebrate" ritual to fix an error that is preventing the website from deploying.