### PR TITLE
Add step-based and intra-step framework for migration progress

### DIFF
--- a/server/datastore/mysql/migrations/tables/migration.go
+++ b/server/datastore/mysql/migrations/tables/migration.go
@@ -16,7 +16,9 @@ import (
 
 var MigrationClient = goose.New("migration_status_tables", goose.MySqlDialect{})
 
-var outputTo = os.Stderr // can override in tests
+// can override in tests
+var outputTo = os.Stderr
+var progressInterval = time.Second * 5
 
 type migrationStep func(tx *sql.Tx) error
 
@@ -45,7 +47,7 @@ func incrementalMigrationStep(count incrementCounter, execute incrementalExecuto
 		// Every five seconds, echo the % progress of the executor
 		done := make(chan struct{})
 		go func() {
-			ticker := time.NewTicker(time.Second * 5)
+			ticker := time.NewTicker(progressInterval)
 			defer ticker.Stop()
 			for {
 				select {

--- a/server/datastore/mysql/migrations/tables/migration_helpers_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_helpers_test.go
@@ -164,7 +164,7 @@ func TestIncrementalMigrationStep(t *testing.T) {
 			},
 			func(tx *sql.Tx, increment func()) error {
 				// Simulate work with increments
-				for i := 0; i < 10; i++ {
+				for range 10 {
 					increment()
 					time.Sleep(5 * time.Millisecond)
 				}
@@ -203,7 +203,7 @@ func TestIncrementalMigrationStep(t *testing.T) {
 			},
 			func(tx *sql.Tx, increment func()) error {
 				// Call increment multiple times
-				for i := 0; i < 50; i++ {
+				for range 50 {
 					increment()
 					incrementCount++
 				}

--- a/server/datastore/mysql/migrations/tables/migration_helpers_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_helpers_test.go
@@ -176,8 +176,8 @@ func TestIncrementalMigrationStep(t *testing.T) {
 		err = step(tx)
 		require.NoError(t, err)
 
-		// Verify progress output was written
-		assert.Len(t, strings.Split(strings.Trim(buf.String(), "\n"), "\n"), 5)
+		// Verify progress output was written (includes 100% complete at the end)
+		assert.Len(t, strings.Split(strings.Trim(buf.String(), "\n"), "\n"), 6)
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})
@@ -217,7 +217,7 @@ func TestIncrementalMigrationStep(t *testing.T) {
 		err = step(tx)
 		require.NoError(t, err)
 		assert.Equal(t, 50, incrementCount)
-		require.Equal(t, "    Almost done...\n", buf.String())
+		require.Equal(t, "    Almost done...\n    100% complete\n", buf.String())
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})

--- a/server/datastore/mysql/migrations/tables/migration_helpers_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_helpers_test.go
@@ -1,0 +1,396 @@
+package tables
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBasicMigrationStep(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("success", func(t *testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectExec("ALTER TABLE foo ADD COLUMN bar INT").WillReturnResult(sqlmock.NewResult(0, 0))
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		step := basicMigrationStep("ALTER TABLE foo ADD COLUMN bar INT", "failed to add column")
+		err = step(tx)
+		require.NoError(t, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("error", func(t *testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectExec("ALTER TABLE foo ADD COLUMN bar INT").WillReturnError(errors.New("syntax error"))
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		step := basicMigrationStep("ALTER TABLE foo ADD COLUMN bar INT", "failed to add column")
+		err = step(tx)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to add column")
+		assert.Contains(t, err.Error(), "syntax error")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestIncrementalMigrationStep(t *testing.T) {
+	// Save original values and restore after test
+	originalOutputTo := outputTo
+	originalProgressInterval := progressInterval
+	defer func() {
+		outputTo = originalOutputTo
+		progressInterval = originalProgressInterval
+	}()
+
+	t.Run("zero count skips execution", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		executeCalled := false
+		step := incrementalMigrationStep(
+			func(tx *sql.Tx) (uint, error) {
+				return 0, nil
+			},
+			func(tx *sql.Tx, increment func()) error {
+				executeCalled = true
+				return nil
+			},
+		)
+
+		err = step(tx)
+		require.NoError(t, err)
+		assert.False(t, executeCalled, "executor should not be called when count is 0")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("count error is returned", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		expectedErr := errors.New("count query failed")
+		step := incrementalMigrationStep(
+			func(tx *sql.Tx) (uint, error) {
+				return 0, expectedErr
+			},
+			func(tx *sql.Tx, increment func()) error {
+				return nil
+			},
+		)
+
+		err = step(tx)
+		require.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("executor error is returned", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		expectedErr := errors.New("executor failed")
+		step := incrementalMigrationStep(
+			func(tx *sql.Tx) (uint, error) {
+				return 5, nil
+			},
+			func(tx *sql.Tx, increment func()) error {
+				return expectedErr
+			},
+		)
+
+		err = step(tx)
+		require.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("progress output", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		// Override output and progress interval for testing
+		var buf bytes.Buffer
+		outputTo = &buf
+		progressInterval = 10 * time.Millisecond
+
+		step := incrementalMigrationStep(
+			func(tx *sql.Tx) (uint, error) {
+				return 10, nil
+			},
+			func(tx *sql.Tx, increment func()) error {
+				// Simulate work with increments
+				for i := 0; i < 10; i++ {
+					increment()
+					time.Sleep(5 * time.Millisecond)
+				}
+				// Wait for at least one progress tick
+				time.Sleep(15 * time.Millisecond)
+				return nil
+			},
+		)
+
+		err = step(tx)
+		require.NoError(t, err)
+
+		// Verify progress output was written
+		output := buf.String()
+		assert.Contains(t, output, "% complete")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("increment updates progress", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		// Override output and progress interval for testing
+		var buf bytes.Buffer
+		outputTo = &buf
+		progressInterval = 5 * time.Millisecond
+
+		incrementCount := 0
+		step := incrementalMigrationStep(
+			func(tx *sql.Tx) (uint, error) {
+				return 100, nil
+			},
+			func(tx *sql.Tx, increment func()) error {
+				// Call increment multiple times
+				for i := 0; i < 50; i++ {
+					increment()
+					incrementCount++
+				}
+				// Allow time for progress ticker
+				time.Sleep(10 * time.Millisecond)
+				return nil
+			},
+		)
+
+		err = step(tx)
+		require.NoError(t, err)
+		assert.Equal(t, 50, incrementCount)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+func TestWithSteps(t *testing.T) {
+	// Save original values and restore after test
+	originalOutputTo := outputTo
+	defer func() {
+		outputTo = originalOutputTo
+	}()
+
+	t.Run("empty steps succeeds", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		err = withSteps([]migrationStep{}, tx)
+		require.NoError(t, err)
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("single step no step output", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		outputTo = &buf
+
+		stepCalled := false
+		steps := []migrationStep{
+			func(tx *sql.Tx) error {
+				stepCalled = true
+				return nil
+			},
+		}
+
+		err = withSteps(steps, tx)
+		require.NoError(t, err)
+		assert.True(t, stepCalled)
+
+		// Single step should not output step number
+		output := buf.String()
+		assert.NotContains(t, output, "Step")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("multiple steps with output", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		outputTo = &buf
+
+		callOrder := []int{}
+		steps := []migrationStep{
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 1)
+				return nil
+			},
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 2)
+				return nil
+			},
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 3)
+				return nil
+			},
+		}
+
+		err = withSteps(steps, tx)
+		require.NoError(t, err)
+		assert.Equal(t, []int{1, 2, 3}, callOrder)
+
+		// Multiple steps should output step numbers
+		output := buf.String()
+		assert.Contains(t, output, "Step 1 of 3")
+		assert.Contains(t, output, "Step 2 of 3")
+		assert.Contains(t, output, "Step 3 of 3")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("error stops execution", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		outputTo = &buf
+
+		expectedErr := errors.New("step 2 failed")
+		callOrder := []int{}
+		steps := []migrationStep{
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 1)
+				return nil
+			},
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 2)
+				return expectedErr
+			},
+			func(tx *sql.Tx) error {
+				callOrder = append(callOrder, 3)
+				return nil
+			},
+		}
+
+		err = withSteps(steps, tx)
+		require.Error(t, err)
+		assert.Equal(t, expectedErr, err)
+		assert.Equal(t, []int{1, 2}, callOrder, "step 3 should not be called after step 2 fails")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("integration with basicMigrationStep", func(t *testing.T) {
+		db, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer db.Close()
+
+		mock.ExpectBegin()
+		mock.ExpectExec("ALTER TABLE foo ADD COLUMN a INT").WillReturnResult(sqlmock.NewResult(0, 0))
+		mock.ExpectExec("ALTER TABLE foo ADD COLUMN b INT").WillReturnResult(sqlmock.NewResult(0, 0))
+
+		tx, err := db.Begin()
+		require.NoError(t, err)
+
+		var buf bytes.Buffer
+		outputTo = &buf
+
+		steps := []migrationStep{
+			basicMigrationStep("ALTER TABLE foo ADD COLUMN a INT", "failed to add column a"),
+			basicMigrationStep("ALTER TABLE foo ADD COLUMN b INT", "failed to add column b"),
+		}
+
+		err = withSteps(steps, tx)
+		require.NoError(t, err)
+
+		output := buf.String()
+		assert.Contains(t, output, "Step 1 of 2")
+		assert.Contains(t, output, "Step 2 of 2")
+
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+}
+
+// TestOutputToAndProgressIntervalDefaults verifies the default values of the package variables
+func TestOutputToAndProgressIntervalDefaults(t *testing.T) {
+	// Note: These tests verify the defaults are sensible
+	// The actual io.Writer interface check is sufficient
+	var _ io.Writer = outputTo
+	assert.Equal(t, 5*time.Second, progressInterval)
+}

--- a/server/datastore/mysql/migrations/tables/migration_helpers_test.go
+++ b/server/datastore/mysql/migrations/tables/migration_helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 	"time"
 
@@ -176,7 +177,7 @@ func TestIncrementalMigrationStep(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify progress output was written
-		assert.Equal(t, "20% complete\n40% complete\n60% complete\n80% complete\n100% complete\n", buf.String())
+		assert.Len(t, strings.Split(strings.Trim(buf.String(), "\n"), "\n"), 5)
 
 		require.NoError(t, mock.ExpectationsWereMet())
 	})


### PR DESCRIPTION
Resolves #35916.

For example:

```go
	return withSteps([]migrationStep{
		basicMigrationStep("SELECT NOW()", "couldn't select from hosts"),
		incrementalMigrationStep(func(tx *sql.Tx) (uint64, error) {
			return 25, nil
		}, func(tx *sql.Tx, increment incrementCountFn) error {
			for range 25 {
				time.Sleep(time.Second)
				increment()
			}
			return nil
		}),
	}, tx)
```

gets you

```
2026/01/20 17:16:30 [2026-01-20] Test Migration
  Step 1 of 2
  Step 2 of 2
    16% complete
    36% complete
    56% complete
    76% complete
    96% complete
    100% complete
Migrations completed.
```

No need to use this on short migrations, but we can throw this wherever on longer migrations, and progress display and upgdate frequency can be adjusted independent of the migrations themselves.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually