### PR TITLE
Fix broken front end link

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1089,7 +1089,7 @@ module.exports.routes = {
   'GET /learn-more-about/calendar-events': '/announcements/fleet-in-your-calendar-introducing-maintenance-windows',
   'GET /learn-more-about/setup-windows-mdm': '/guides/windows-mdm-setup',
   'GET /learn-more-about/setup-abm': '/docs/using-fleet/mdm-setup#apple-business-manager-abm',
-  'GET /learn-more-about/renew-apns': '/docs/using-fleet/apple-mdm-setup#turn-on-apple-mdm',
+  'GET /learn-more-about/renew-apns': '/guides/apple-mdm-setup#turn-on-apple-mdm',
   'GET /learn-more-about/renew-abm': '/docs/using-fleet/mdm-setup#apple-business-manager-abm',
   'GET /learn-more-about/fleet-server-private-key': '/docs/configuration/fleet-server-configuration#server-private-key',
   'GET /learn-more-about/agent-options': '/docs/configuration/agent-configuration',


### PR DESCRIPTION
This pull request makes a small update to the website's route configuration, correcting the target path for the `renew-apns` guide. The route now points to the correct location in the `/guides` section rather than `/docs`.

- Updated the `'GET /learn-more-about/renew-apns'` route in `routes.js` to point to `/guides/apple-mdm-setup#turn-on-apple-mdm` instead of `/docs/using-fleet/apple-mdm-setup#turn-on-apple-mdm`.