### PR TITLE
Add Fleet server configs for new Apple VPP metadata endpoints

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3230,7 +3230,7 @@ The best practice is to set this to 3x the number of new employees (end users) t
 
 By default, Fleet retrieves [Apple App Store (VPP) metadata](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata) from Apple using an API token from Fleet's Apple Developer account. This API token is hosted on fleetdm.com.
 
-If you have an [Apple developer account that is enabled as MDM vendor](https://developer.apple.com/help/account/service-configurations/apps-and-books-for-organizations), Fleet server can directly communicate with the [Apple Apps and Books API](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata).
+If you have an [Apple Developer account that is enabled as MDM vendor](https://developer.apple.com/help/account/service-configurations/apps-and-books-for-organizations), you can optionally configure Fleet with your own API token. This way, Fleet can directly communicate with Apple.
 
 If set to `false` then you must specify [mdm.apple_vpp_app_metadata_api_bearer_token](#mdm-apple-vpp-app-metadata-api-bearer-token).
 

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3211,7 +3211,7 @@ The content of the Windows WSTEP identity key. An RSA private key, PEM-encoded.
       -----END RSA PRIVATE KEY-----
   ```
 
-### mdm.sso_rate_limit_per_minute
+### mdm.sso​_rate​_limit​_per​_minute
 
 The number of requests per minute allowed to [Initiate SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#initiate-sso-during-dep-enrollment) and
 [Complete SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#complete-sso-during-dep-enrollment) endpoints, combined.
@@ -3224,6 +3224,44 @@ The best practice is to set this to 3x the number of new employees (end users) t
   ```yaml
   mdm:
     sso_rate_limit_per_minute: 200
+  ```
+
+### mdm.apple_vpp_app_store_region
+
+Override the default region (`us`) for the Apple App Store storefront.
+
+- Default value: us
+- Environment variable: `FLEET_MDM_APPLE_VPP_APP_STORE_REGION`
+- Config file format:
+  ```yaml
+  mdm:
+    apple_vpp_app_store_region: de
+  ```
+
+
+
+### mdm.apple_vpp_app_metadata_endpoint_url
+
+Override the default region (`us`) for the Apple App Store storefront.
+
+- Default value: ...
+- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_ENDPOINT_URL`
+- Config file format:
+  ```yaml
+  mdm:
+    apple_vpp_app_metadata_endpoint_url: https://...
+  ```
+
+### mdm.apple_vpp_app_metadata_endpoint_bearer_token
+
+Override the default region (`us`) for the Apple App Store storefront.
+
+- Default value: ...
+- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_ENDPOINT_BEARER_TOKEN`
+- Config file format:
+  ```yaml
+  mdm:
+    apple_vpp_app_metadata_endpoint_bearer_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ92eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp
   ```
 
 ## Partnerships

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3228,7 +3228,7 @@ The best practice is to set this to 3x the number of new employees (end users) t
 
 ### mdm.apple_vpp_app_store_region
 
-Override the default region (`us`) for the Apple App Store storefront.
+Specify the Apple App Store region. The region affects the availability of apps in Fleet. For example, if you [add apps to Apple Business Manager](https://fleetdm.com/guides/install-app-store-apps#apple-vpp) that aren't available in the `de` region, they won't appear in Fleet.
 
 - Default value: us
 - Environment variable: `FLEET_MDM_APPLE_VPP_APP_STORE_REGION`
@@ -3239,29 +3239,33 @@ Override the default region (`us`) for the Apple App Store storefront.
   ```
 
 
+### mdm.apple_vpp_app_metadata_api_proxy
 
-### mdm.apple_vpp_app_metadata_endpoint_url
+By default, Fleet server retrieves metadata for Apple VPP apps via Fleet proxy, using an authentication token hosted on fleetdm.com.
 
-Override the default region (`us`) for the Apple App Store storefront.
+If you have an [Apple developer account that is enabled as MDM vendor](https://developer.apple.com/help/account/service-configurations/apps-and-books-for-organizations), Fleet server can directly communicate with the [Apple Apps and Books API](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata).
 
-- Default value: ...
-- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_ENDPOINT_URL`
+If set to `false` then you must specify [mdm.apple_vpp_app_metadata_api_bearer_token](#mdm-apple-vpp-app-metadata-api-bearer-token).
+
+
+- Default value: true
+- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_API_PROXY`
 - Config file format:
   ```yaml
   mdm:
-    apple_vpp_app_metadata_endpoint_url: https://...
+    apple_vpp_app_metadata_api_url: false
   ```
 
-### mdm.apple_vpp_app_metadata_endpoint_bearer_token
+### mdm.apple_vpp_app_metadata_api_bearer_token
 
-Override the default region (`us`) for the Apple App Store storefront.
+Bearer token to authenticate requests to Apple Apps and Books API. This is required if [mdm.apple_vpp_app_metadata_api_proxy](#mdm-apple-vpp-app-metadata-api-proxy) is set to `false`.
 
-- Default value: ...
-- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_ENDPOINT_BEARER_TOKEN`
+- Default value: none
+- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_API_BEARER_TOKEN`
 - Config file format:
   ```yaml
   mdm:
-    apple_vpp_app_metadata_endpoint_bearer_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ92eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp
+    apple_vpp_app_metadata_api_bearer_token: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ92eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikp
   ```
 
 ## Partnerships

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3226,19 +3226,6 @@ The best practice is to set this to 3x the number of new employees (end users) t
     sso_rate_limit_per_minute: 200
   ```
 
-### mdm.apple_vpp_app_store_region
-
-Specify the Apple App Store region. The region affects the availability of apps in Fleet. For example, if you [add apps to Apple Business Manager](https://fleetdm.com/guides/install-app-store-apps#apple-vpp) that aren't available in the `de` region, they won't appear in Fleet.
-
-- Default value: us
-- Environment variable: `FLEET_MDM_APPLE_VPP_APP_STORE_REGION`
-- Config file format:
-  ```yaml
-  mdm:
-    apple_vpp_app_store_region: de
-  ```
-
-
 ### mdm.apple_vpp_app_metadata_api_proxy
 
 By default, Fleet server retrieves metadata for Apple VPP apps via Fleet proxy, using an authentication token hosted on fleetdm.com.

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3228,7 +3228,7 @@ The best practice is to set this to 3x the number of new employees (end users) t
 
 ### mdm.apple_vpp_app_metadata_api_proxy
 
-By default, Fleet server retrieves metadata for Apple VPP apps via Fleet proxy, using an authentication token hosted on fleetdm.com.
+By default, Fleet retrieves [Apple App Store (VPP) metadata](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata) from Apple using an API token from Fleet's Apple Developer account. This API token is hosted on fleetdm.com.
 
 If you have an [Apple developer account that is enabled as MDM vendor](https://developer.apple.com/help/account/service-configurations/apps-and-books-for-organizations), Fleet server can directly communicate with the [Apple Apps and Books API](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata).
 

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3211,7 +3211,7 @@ The content of the Windows WSTEP identity key. An RSA private key, PEM-encoded.
       -----END RSA PRIVATE KEY-----
   ```
 
-### mdm.sso​_rate​_limit​_per​_minute
+### mdm.sso_rate_limit_per_minute
 
 The number of requests per minute allowed to [Initiate SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#initiate-sso-during-dep-enrollment) and
 [Complete SSO during DEP enrollment](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/api-for-contributors.md#complete-sso-during-dep-enrollment) endpoints, combined.

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -3226,26 +3226,11 @@ The best practice is to set this to 3x the number of new employees (end users) t
     sso_rate_limit_per_minute: 200
   ```
 
-### mdm.apple_vpp_app_metadata_api_proxy
+### mdm.apple_vpp_app_metadata_api_bearer_token
 
 By default, Fleet retrieves [Apple App Store (VPP) metadata](https://developer.apple.com/documentation/devicemanagement/get-your-apps-metadata) from Apple using an API token from Fleet's Apple Developer account. This API token is hosted on fleetdm.com.
 
 If you have an [Apple Developer account that is enabled as MDM vendor](https://developer.apple.com/help/account/service-configurations/apps-and-books-for-organizations), you can optionally configure Fleet with your own API token. This way, Fleet can directly communicate with Apple.
-
-If set to `false` then you must specify [mdm.apple_vpp_app_metadata_api_bearer_token](#mdm-apple-vpp-app-metadata-api-bearer-token).
-
-
-- Default value: true
-- Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_API_PROXY`
-- Config file format:
-  ```yaml
-  mdm:
-    apple_vpp_app_metadata_api_url: false
-  ```
-
-### mdm.apple_vpp_app_metadata_api_bearer_token
-
-Bearer token to authenticate requests to Apple Apps and Books API. This is required if [mdm.apple_vpp_app_metadata_api_proxy](#mdm-apple-vpp-app-metadata-api-proxy) is set to `false`.
 
 - Default value: none
 - Environment variable: `FLEET_MDM_APPLE_VPP_APP_METADATA_API_BEARER_TOKEN`


### PR DESCRIPTION
Related to:

- #32461

We decided to ship this in 4.81. This PR removes it from `docs-v4.80.0`: #38626