### PR TITLE
Website: Update Fleet Premium trial page

### DIFF
--- a/website/assets/js/pages/fleet-premium-trial.page.js
+++ b/website/assets/js/pages/fleet-premium-trial.page.js
@@ -32,7 +32,7 @@ parasails.registerPage('fleet-premium-trial', {
       await setTimeout(()=>{
         $('[purpose="command-copy-button"]').removeClass('copied');
       }, 2000);
-      navigator.clipboard.writeText(this.me.fleetPremiumTrialLicenseKey);
+      navigator.clipboard.writeText(this.trialLicenseKey);
     }
   }
 });

--- a/website/assets/styles/pages/fleet-premium-trial.less
+++ b/website/assets/styles/pages/fleet-premium-trial.less
@@ -3,6 +3,7 @@
   background: url('/images/background-fleet-ui-1400x1264@2x.png');
   background-size: cover;
   height: 100vh;
+  min-height: 800px;
   h3 {
     color: var(--text-text-brand, #192147);
 

--- a/website/views/pages/fleet-premium-trial.ejs
+++ b/website/views/pages/fleet-premium-trial.ejs
@@ -25,7 +25,7 @@
         <div purpose="license-key">
           <div purpose="trial-key-fade"></div>
           <div purpose="license-key-container">
-            <code><span>{{me.fleetPremiumTrialLicenseKey}}</span></code>
+            <code><span>{{trialLicenseKey}}</span></code>
           </div>
           <a purpose="command-copy-button" @click="clickCopyLicenseKey()"></a>
         </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/38576

Changes:
- Updated the Fleet Premium trial page to display the trial license key sent from the page's view action instead of displaying it from the `me` variable set in the custom hook.
- Added a minimum height to the Fleet Premium trial page to prevent the modal scrolling outside of the page's background