### PR TITLE
Add instructions for sending weekly KPI update

### DIFF
--- a/handbook/people/README.md
+++ b/handbook/people/README.md
@@ -333,6 +333,22 @@ When procuring SaaS tools and services, analyze the purchase of these subscripti
 - The Head of People will upgrade or add the license seat as needed and let the requesting team member know they did it.
 
 
+### Send the weekly update
+
+Every Friday, e-group members [report their KPIs for the week](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit) by 5:00pm U.S. CT. Every Friday at 6PM, the Apprentice will post a short update in [#general](https://fleetdm.slack.com/archives/C019FNQPA23).
+  
+  To send the weekly update follow these steps:  
+  
+1. Navigate to the current weeks row in the [KPIs Google Sheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0).
+2. Check the KPI sheet at 5pm US central time to ensure all departments have updated their KPIs on time.  If any departments are delinquent, notify the department head and the Head of People.
+3. Copy the entire formula in this weeks "Weekly update" update cell and paste without formating (CMD+⇧+V) back into the same cell. The formula will now look like this:
+
+
+
+4. Paste the newly formatted message in the [#general Slack channel](https://fleetdm.slack.com/archives/C019FNQPA23) and delete the double quotes around the message and any links that unfurl from links in the weekly update message.
+5. Use the drop-down next to the send button and select "Custom time" and schedule the message to send "Today" at 18:00 or 6pm CT.
+
+
 ### Cancel a vendor or subscription
 
 Once the decision has been made not to renew a tool or subscription on Fleet's behalf, use the following steps to churn/cancel a vendor or subscription:

--- a/handbook/people/README.md
+++ b/handbook/people/README.md
@@ -335,16 +335,11 @@ When procuring SaaS tools and services, analyze the purchase of these subscripti
 
 ### Send the weekly update
 
-Every Friday, e-group members [report their KPIs for the week](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit) by 5:00pm U.S. CT. Every Friday at 6PM, the Apprentice will post a short update in [#general](https://fleetdm.slack.com/archives/C019FNQPA23).
-  
-  To send the weekly update follow these steps:  
+Every Friday, e-group members [report their KPIs for the week](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit) by 5:00pm U.S. CT. Every Friday at 6PM, the Apprentice will post a short update in [#general](https://fleetdm.slack.com/archives/C019FNQPA23). To send the weekly update follow these steps:  
   
 1. Navigate to the current weeks row in the [KPIs Google Sheet](https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit#gid=0).
 2. Check the KPI sheet at 5pm US central time to ensure all departments have updated their KPIs on time.  If any departments are delinquent, notify the department head and the Head of People.
 3. Copy the entire formula in this weeks "Weekly update" update cell and paste without formating (CMD+⇧+V) back into the same cell. The formula will now look like this:
-
-
-
 4. Paste the newly formatted message in the [#general Slack channel](https://fleetdm.slack.com/archives/C019FNQPA23) and delete the double quotes around the message and any links that unfurl from links in the weekly update message.
 5. Use the drop-down next to the send button and select "Custom time" and schedule the message to send "Today" at 18:00 or 6pm CT.
 

--- a/handbook/people/people.rituals.yml
+++ b/handbook/people/people.rituals.yml
@@ -7,6 +7,15 @@
   autoIssue:
     labels: [":help-people"]
     repo: "confidential"
+- task: "Schedule weekly update"
+  startedOn: "2026-01-23"
+  frequency: "Weekly"
+  description: "Every Friday at 6PM, the Apprentice will post a short update in #general."
+  moreInfoUrl: "https://fleetdm.com/handbook/people#schedule-the-weekly-update"
+  dri: "SFriendLee"
+  autoIssue:
+    labels: [":help-people"]
+    repo: "confidential"
 - task: "Prepare all hands deck"
   startedOn: "2023-07-01"
   frequency: "Monthly"


### PR DESCRIPTION
Added a new section detailing the process for the Apprentice to send the weekly KPI update in Slack, including steps for checking the KPI sheet, copying the update, and scheduling the message.