### PR TITLE
Add trusted proxies config docs

### DIFF
--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -708,8 +708,8 @@ Then depending on how `fleet_server_trusted_proxies` is set, Fleet would determi
 | --- | --- | --- |
 |`none` | `5.5.5.5` | The address Fleet received the request from |
 |`192.168.0.0/24, 4.4.4.4`| `2.2.2.2` | Using `X-Forwarded-For` and skipping the trusted addresses of `192.168.0.120` and `4.4.4.4` |
-|`1`| `192.168.0.120` | The first address from the right 
-|`2`| `4.4.4.4` | The second address from the right|
+|`1`| `192.168.0.120` | The first address from the right in `x-forwarded-for`
+|`2`| `4.4.4.4` | The second address from the right in `x-forwarded-for` |
 |`header:x-real-ip`| `2.2.2.2` | The value of the specified header|
 |`header:x-peekaboo`| `5.5.5.5` |  The address Fleet received the request from, since the specified header doesn't exist in the request |
 |empty| `2.2.2.2` | The value of the `x-real-ip` header

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -706,7 +706,7 @@ Then depending on how `fleet_server_trusted_proxies` is set, Fleet would determi
 
 | Trusted proxies setting | Client IP | Explanation |
 | --- | --- | --- |
-|`none` | `5.5.5.5` | The address Fleet received the request from |
+|`"none"` | `5.5.5.5` | The address Fleet received the request from |
 |`192.168.0.0/24, 4.4.4.4`| `2.2.2.2` | Using `X-Forwarded-For` and skipping the trusted addresses of `192.168.0.120` and `4.4.4.4` |
 |`1`| `192.168.0.120` | The first address from the right 
 |`2`| `4.4.4.4` | The second address from the right|

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -696,7 +696,7 @@ Sets the strategy that Fleet uses to determine the IP address of the client maki
 
 > If no value can be determined via the configured setting (for example, if a number is supplied but no `x-forwarded-for` or `forwarded` headers exist on the request) then the remote address of the request will be used.
 
-For example, if a request with remote address `5.5.5.5` has these headers:
+For example, if a request from remote address `5.5.5.5` has these headers:
 ```
 X-Forwarded-For: 1.1.1.1, 2.2.2.2, 4.4.4.4, 192.168.0.120
 X-Real-IP: 2.2.2.2

--- a/docs/Configuration/fleet-server-configuration.md
+++ b/docs/Configuration/fleet-server-configuration.md
@@ -706,7 +706,7 @@ Then depending on how `fleet_server_trusted_proxies` is set, Fleet would determi
 
 | Trusted proxies setting | Client IP | Explanation |
 | --- | --- | --- |
-|`"none"` | `5.5.5.5` | The address Fleet received the request from |
+|`none` | `5.5.5.5` | The address Fleet received the request from |
 |`192.168.0.0/24, 4.4.4.4`| `2.2.2.2` | Using `X-Forwarded-For` and skipping the trusted addresses of `192.168.0.120` and `4.4.4.4` |
 |`1`| `192.168.0.120` | The first address from the right 
 |`2`| `4.4.4.4` | The second address from the right|


### PR DESCRIPTION
Adds documentation for the new config setting added in https://github.com/fleetdm/fleet/pull/38471.

Adding to 4.8.0 (with callout that this works in 4.80.1) on guidance from @rachaelshaw.

cc: @iansltx if you want to double-check my math on the examples 😆 