### PR TITLE
Website: update clay webhook inputs and historical event helper

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -75,6 +75,9 @@ module.exports = {
     },
     historicalContentUrl: {
       type: 'string',
+    },
+    relatedCampaign: {
+      type: 'string',
     }
   },
 
@@ -87,7 +90,7 @@ module.exports = {
   },
 
 
-  fn: async function ({webhookSecret, firstName, lastName, linkedinUrl, contactSource, jobTitle, intentSignal, historicalContent, historicalContentUrl}) {
+  fn: async function ({webhookSecret, firstName, lastName, linkedinUrl, contactSource, jobTitle, intentSignal, historicalContent, historicalContentUrl, relatedCampaign}) {
 
 
     if (!sails.config.custom.clayWebhookSecret) {
@@ -131,6 +134,7 @@ module.exports = {
       eventContent: historicalContent,
       eventContentUrl: historicalContentUrl,
       linkedinUrl: trimmedLinkedinUrl,
+      relatedCampaign,
     })
     .intercept((err)=>{
       sails.log.warn(`When the receive-from-clay webhook received information about LinkedIn activity, a historical event record could not be created. Full error: ${require('util').inspect(err)}`);

--- a/website/api/helpers/salesforce/create-historical-event.js
+++ b/website/api/helpers/salesforce/create-historical-event.js
@@ -72,6 +72,9 @@ module.exports = {
     linkedinUrl: {
       type: 'string',
     },
+    relatedCampaign: {
+      type: 'string',
+    }
   },
 
 
@@ -86,7 +89,7 @@ module.exports = {
   },
 
 
-  fn: async function ({ salesforceAccountId, salesforceContactId, eventType, linkedinUrl, intentSignal, eventContent, eventContentUrl, fleetWebsitePageUrl, websiteVisitReason}) {
+  fn: async function ({ salesforceAccountId, salesforceContactId, eventType, linkedinUrl, intentSignal, eventContent, eventContentUrl, fleetWebsitePageUrl, websiteVisitReason, relatedCampaign}) {
     // Return undefined if we're not running in a production environment.
     if(sails.config.environment !== 'production') {
       sails.log.verbose('Skipping Salesforce integration...');
@@ -137,7 +140,8 @@ module.exports = {
         Interactor_profile_url__c: linkedinUrl,// eslint-disable-line camelcase
 
         Page_URL__c: fleetWebsitePageUrl,// eslint-disable-line camelcase
-        Website_visit_reason__c: websiteVisitReason// eslint-disable-line camelcase
+        Website_visit_reason__c: websiteVisitReason,// eslint-disable-line camelcase
+        Related_campaign__c: relatedCampaign// eslint-disable-line camelcase
       });
     }).intercept((err)=>{
       return new Error(`An error occured when creating a new Historical event record in Salesforce. full error ${require('util').inspect(err, {depth: null})}`);


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/38500

Changes:
- Added support for a `relatedCampaign` input to the receive-from-clay webhook.
- Updated the `create-historical-event` helper to set `relatedCampaign` on new historical event records (if provided)