### PR TITLE
Fix `TestVPPAppScheduledUpdates`

### DIFF
--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -1914,12 +1914,12 @@ func (s *integrationMDMTestSuite) TestVPPAppScheduledUpdates() {
 	// Reset the VPP proxy data to what it was before this test
 	s.registerResetVPPProxyData(t)
 
-	// Set an iOS and iPadOS app on the VPP response.
-	s.appleVPPProxySrvData = map[string]string{
-		"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "1.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
-	}
-
 	vppAutoUpdateTest := func(t *testing.T, team *fleet.Team, host *fleet.Host, deviceClient *mdmtest.TestAppleMDMClient) {
+		// Set an iOS and iPadOS app on the VPP response.
+		s.appleVPPProxySrvData = map[string]string{
+			"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "1.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
+		}
+
 		if team.ID != 0 {
 			// Transfer host to team.
 			s.Do("POST", "/api/latest/fleet/hosts/transfer",


### PR DESCRIPTION
Fixing `TestVPPAppScheduledUpdates` on `main` (broken by the addition of version checking when verifying VPP installs/updates).

Fix is about setting the VPP proxy versions data inside the sub-tests vs only once in the main test (because each sub-test modifies the latest version).