### PR TITLE
Website: Fix syncing state on "Talk to us" form

### DIFF
--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -71,7 +71,7 @@
         </ajax-form>
       </div>
       <div v-else-if="formToDisplay === 'talk-to-us'">
-        <ajax-form :handle-submitting="handleSubmittingTalkToUsForm" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules"  :cloud-error.sync="cloudError">
+        <ajax-form :handle-submitting="handleSubmittingTalkToUsForm" class="contact" :form-errors.sync="formErrors" :form-data="formData" :form-rules="talkToUsFormRules"  :cloud-error.sync="cloudError" :syncing.sync="syncing">
           <div class="form-group">
             <label for="email-address">Work email *</label>
             <input class="form-control" id="email-address" name="email-address" type="email" :class="[formErrors.emailAddress ? 'is-invalid' : '']" v-model.trim="formData.emailAddress" autocomplete="email" focus-first>


### PR DESCRIPTION
Changes:
- Updated the "Talk to us" form to end the syncing state on the submit button when the `deliver-talk-to-us-submission` action returns an error response.