### PR TITLE
Fleet UI: Fixed hover color of links in error flash messages

### DIFF
--- a/changes/36862-fix-flash-message-link-color
+++ b/changes/36862-fix-flash-message-link-color
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed hover color of links in error flash messages

--- a/frontend/components/CustomLink/_styles.scss
+++ b/frontend/components/CustomLink/_styles.scss
@@ -40,7 +40,8 @@
     color: inherit; // Overrides fleet blue link color with parent color
   }
 
-  &--tooltip-link {
+  &--tooltip-link,
+  &--flash-message-link {
     font-size: inherit; // Overrides link default font size with parent tooltip font size
     @include animated-bottom-border($core-fleet-white, $ui-off-white);
 
@@ -58,6 +59,14 @@
 
       .external-link-icon__arrow {
         stroke: $tooltip-bg;
+      }
+    }
+  }
+
+  &--flash-message-link {
+    &:hover {
+      .external-link-icon__arrow {
+        stroke: $core-vibrant-red;
       }
     }
   }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -502,7 +502,7 @@ func CheckProfileIsNotSigned(data []byte) error {
 	mc := mobileconfig.Mobileconfig(data)
 	if mc.IsSignedProfile() {
 		return &fleet.BadRequestError{
-			Message: "Couldn't add. Configuration profiles can't be signed. Fleet wil sign the profile for you. Learn more: https://fleetdm.com/learn-more-about/unsigning-configuration-profiles",
+			Message: "Couldn't add. Configuration profiles can't be signed. Fleet will sign the profile for you. Learn more: https://fleetdm.com/learn-more-about/unsigning-configuration-profiles",
 		}
 	}
 	return nil

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -3438,7 +3438,7 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 		"apple.mobileconfig", []byte("\x00\x01\x02"), s.token, nil)
 	res = s.DoRawWithHeaders("POST", "/api/latest/fleet/configuration_profiles", body.Bytes(), http.StatusBadRequest, headers)
 	errMsg = extractServerErrorText(res.Body)
-	require.Contains(t, errMsg, "Configuration profiles can't be signed. Fleet wil sign the profile for you.")
+	require.Contains(t, errMsg, "Configuration profiles can't be signed. Fleet will sign the profile for you.")
 
 	// Apple/Android invalid json declaration
 	body, headers = generateNewProfileMultipartRequest(t,


### PR DESCRIPTION
## Issue
Closes #36862 

## Description
- Fixed hover color of links in error flash messages (global, not local bug)
- Fix typo in an error message

## Screen recording of fix

https://github.com/user-attachments/assets/e87b4919-dc08-4287-b843-4324040a71eb




# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually
