### PR TITLE
Populate LastInstall for failed installs

### DIFF
--- a/changes/30392-surface-failed-install-details
+++ b/changes/30392-surface-failed-install-details
@@ -1,0 +1,1 @@
+- Fixed an issue where `last_install` details were not returned in the Host Software API for failed software installs, preventing users from viewing failure information.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -5824,6 +5824,18 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 					hydrateHostSoftwareRecordFromDb(softwareTitleRecord, softwareTitle)
 				}
 			}
+			// Here and below: populate LastInstall for software packages, VPP apps, and in-house apps
+			//even if installer is out of scope so failed install attempts show the execution ID for viewing details.
+			if softwareTitleRecord.SoftwarePackage != nil && softwareTitleRecord.SoftwarePackage.LastInstall == nil {
+				if softwareTitle != nil && softwareTitle.LastInstallInstallUUID != nil && *softwareTitle.LastInstallInstallUUID != "" {
+					softwareTitleRecord.SoftwarePackage.LastInstall = &fleet.HostSoftwareInstall{
+						InstallUUID: *softwareTitle.LastInstallInstallUUID,
+					}
+					if softwareTitle.LastInstallInstalledAt != nil {
+						softwareTitleRecord.SoftwarePackage.LastInstall.InstalledAt = *softwareTitle.LastInstallInstalledAt
+					}
+				}
+			}
 
 			// This happens when there is a software installed on the host but it is also a vpp record, so we want
 			// to grab the vpp data from the installed vpp record and merge it onto the software record
@@ -5838,6 +5850,16 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 			if softwareTitleRecord.VPPAppAdamID != nil {
 				if _, ok := filteredByVPPAdamID[*softwareTitleRecord.VPPAppAdamID]; ok {
 					promoteSoftwareTitleVPPApp(softwareTitleRecord)
+				}
+			}
+			if softwareTitleRecord.AppStoreApp != nil && softwareTitleRecord.AppStoreApp.LastInstall == nil {
+				if softwareTitle != nil && softwareTitle.LastInstallInstallUUID != nil && *softwareTitle.LastInstallInstallUUID != "" {
+					softwareTitleRecord.AppStoreApp.LastInstall = &fleet.HostSoftwareInstall{
+						CommandUUID: *softwareTitle.LastInstallInstallUUID,
+					}
+					if softwareTitle.LastInstallInstalledAt != nil {
+						softwareTitleRecord.AppStoreApp.LastInstall.InstalledAt = *softwareTitle.LastInstallInstalledAt
+					}
 				}
 			}
 
@@ -5855,6 +5877,17 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 			if softwareTitleRecord.InHouseAppID != nil {
 				if _, ok := filteredByInHouseID[*softwareTitleRecord.InHouseAppID]; ok {
 					promoteSoftwareTitleInHouseApp(softwareTitleRecord)
+				}
+			}
+			// N.b., in-house apps use SoftwarePackage struct with CommandUUID.
+			if softwareTitleRecord.SoftwarePackage != nil && softwareTitleRecord.InHouseAppID != nil && softwareTitleRecord.SoftwarePackage.LastInstall == nil {
+				if softwareTitle != nil && softwareTitle.LastInstallInstallUUID != nil && *softwareTitle.LastInstallInstallUUID != "" {
+					softwareTitleRecord.SoftwarePackage.LastInstall = &fleet.HostSoftwareInstall{
+						CommandUUID: *softwareTitle.LastInstallInstallUUID,
+					}
+					if softwareTitle.LastInstallInstalledAt != nil {
+						softwareTitleRecord.SoftwarePackage.LastInstall.InstalledAt = *softwareTitle.LastInstallInstalledAt
+					}
 				}
 			}
 

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -5836,6 +5836,17 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 					}
 				}
 			}
+			// Populate LastUninstall for software packages even if installer is out of scope.
+			if softwareTitleRecord.SoftwarePackage != nil && softwareTitleRecord.SoftwarePackage.LastUninstall == nil {
+				if softwareTitle != nil && softwareTitle.LastUninstallScriptExecutionID != nil && *softwareTitle.LastUninstallScriptExecutionID != "" {
+					softwareTitleRecord.SoftwarePackage.LastUninstall = &fleet.HostSoftwareUninstall{
+						ExecutionID: *softwareTitle.LastUninstallScriptExecutionID,
+					}
+					if softwareTitle.LastUninstallUninstalledAt != nil {
+						softwareTitleRecord.SoftwarePackage.LastUninstall.UninstalledAt = *softwareTitle.LastUninstallUninstalledAt
+					}
+				}
+			}
 
 			// This happens when there is a software installed on the host but it is also a vpp record, so we want
 			// to grab the vpp data from the installed vpp record and merge it onto the software record

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -5825,7 +5825,7 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 				}
 			}
 			// Here and below: populate LastInstall for software packages, VPP apps, and in-house apps
-			//even if installer is out of scope so failed install attempts show the execution ID for viewing details.
+			// even if installer is out of scope so failed install attempts show the execution ID for viewing details.
 			if softwareTitleRecord.SoftwarePackage != nil && softwareTitleRecord.SoftwarePackage.LastInstall == nil {
 				if softwareTitle != nil && softwareTitle.LastInstallInstallUUID != nil && *softwareTitle.LastInstallInstallUUID != "" {
 					softwareTitleRecord.SoftwarePackage.LastInstall = &fleet.HostSoftwareInstall{

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -6516,6 +6516,7 @@ func testListHostSoftwareFailInstallThenLabelExclude(t *testing.T, ds *Datastore
 // the software no longer appears (consistent with failed install behavior).
 func testListHostSoftwareFailUninstallThenLabelExclude(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
+	t.Cleanup(func() { ds.testActivateSpecificNextActivities = nil })
 	user := test.NewUser(t, ds, "user1", "user1@example.com", false)
 	host := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now(), test.WithPlatform("darwin"))
 	nanoEnroll(t, ds, host, false)

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -6394,6 +6394,9 @@ func testListHostSoftwareFailInstallThenTransferTeam(t *testing.T, ds *Datastore
 	require.Len(t, sw, 3)
 	require.Equal(t, sw[0].Name, "bar")
 	require.NotNil(t, sw[0].SoftwarePackage)
+	// Verify that LastInstall is populated for failed installs
+	require.NotNil(t, sw[0].SoftwarePackage.LastInstall, "LastInstall should be populated for failed installs")
+	require.Equal(t, hostInstall1, sw[0].SoftwarePackage.LastInstall.InstallUUID, "LastInstall.InstallUUID should match the install request UUID")
 	require.Equal(t, sw[1].Name, "foo")
 	require.NotNil(t, sw[1].SoftwarePackage)
 	require.Equal(t, sw[2].Name, "vpp1")
@@ -6479,6 +6482,9 @@ func testListHostSoftwareFailInstallThenLabelExclude(t *testing.T, ds *Datastore
 	require.Len(t, sw, 1)
 	require.Equal(t, "bar", sw[0].Name)
 	require.NotNil(t, sw[0].SoftwarePackage)
+	// Verify that LastInstall is populated for failed installs
+	require.NotNil(t, sw[0].SoftwarePackage.LastInstall, "LastInstall should be populated for failed installs")
+	require.Equal(t, hostInstall, sw[0].SoftwarePackage.LastInstall.InstallUUID, "LastInstall.InstallUUID should match the install request UUID")
 
 	// Now add the host to the exclude label
 	require.NoError(t, ds.AddLabelsToHost(ctx, host.ID, []uint{excludeLabel.ID}))
@@ -6542,6 +6548,10 @@ func testListHostSoftwareFailVPPInstallThenLabelExclude(t *testing.T, ds *Datast
 	require.NoError(t, err)
 	require.Len(t, sw, 1)
 	require.Equal(t, "vpp_app_fail_test", sw[0].Name)
+	require.NotNil(t, sw[0].AppStoreApp)
+	// Verify that LastInstall is populated for failed VPP installs
+	require.NotNil(t, sw[0].AppStoreApp.LastInstall, "LastInstall should be populated for failed VPP installs")
+	require.Equal(t, vppCmdUUID, sw[0].AppStoreApp.LastInstall.CommandUUID, "LastInstall.CommandUUID should match the install command UUID")
 
 	// Add host to exclude label
 	require.NoError(t, ds.AddLabelsToHost(ctx, host.ID, []uint{excludeLabel.ID}))


### PR DESCRIPTION
Fixes #30392

## Summary

Fixes Host Software API not returning execution IDs for failed install/uninstall attempts, preventing users from viewing failure details in the software library page.

## Details

The `ListHostSoftware` function only populated `LastInstall` and `LastUninstall` fields when software was successfully installed via `hydrateHostSoftwareRecordFromDb`. Failed install/uninstall attempts didn't surface the execution IDs needed to view failure details, even though the Activity API returned them correctly.

### Fix

Added fallback population of `LastInstall`/`LastUninstall` in `ListHostSoftware` when fields aren't already set:

  - Software packages: `InstallUUID` for failed installs, `ExecutionID` for failed uninstalls
  - VPP apps: `CommandUUID` for failed installs
  - In-house apps: `CommandUUID` for failed installs

### Expected Behavior

  - Failed installs show `last_install` with execution ID for viewing failure details
  - Failed uninstalls show `last_uninstall` with execution ID
  - Software library page displays failure details matching Activity feed behavior