### PR TITLE
Fleet UI: Fix software/script policy update logic

### DIFF
--- a/changes/31160-fix-setting-automation
+++ b/changes/31160-fix-setting-automation
@@ -1,0 +1,1 @@
+- Fleet UI: Fix saving of policy automation that triggers software installs and script runs

--- a/changes/31256-fix-windows-app-custom-package-metadata copy
+++ b/changes/31256-fix-windows-app-custom-package-metadata copy
@@ -1,0 +1,1 @@
+- Fleet UI: Fix saving of policy triggered software installs and script runs

--- a/changes/31256-fix-windows-app-custom-package-metadata copy
+++ b/changes/31256-fix-windows-app-custom-package-metadata copy
@@ -1,1 +1,0 @@
-- Fleet UI: Fix saving of policy triggered software installs and script runs

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -553,28 +553,8 @@ const ManagePolicyPage = ({
     try {
       setIsUpdatingPolicies(true);
 
-      const changedPolicies = formData.filter((formPolicy) => {
-        const prevPolicyState = policiesAvailableToAutomate.find(
-          (policy) => policy.id === formPolicy.id
-        );
-
-        const turnedOff =
-          prevPolicyState?.install_software !== undefined &&
-          formPolicy.installSoftwareEnabled === false;
-
-        const turnedOn =
-          prevPolicyState?.install_software === undefined &&
-          formPolicy.installSoftwareEnabled === true;
-
-        const updatedSwId =
-          prevPolicyState?.install_software?.software_title_id !== undefined &&
-          formPolicy.swIdToInstall !==
-            prevPolicyState?.install_software?.software_title_id;
-
-        return turnedOff || turnedOn || updatedSwId;
-      });
-
-      if (!changedPolicies.length) {
+      // Truly dirty items previously detected in InstallSoftwareModal
+      if (!formData.length) {
         renderFlash("success", "No changes detected.");
         return;
       }
@@ -583,7 +563,7 @@ const ManagePolicyPage = ({
       const results: PromiseSettledResult<any>[] = [];
 
       // Use reduce to execute promises sequentially
-      await changedPolicies.reduce(async (previousPromise, changedPolicy) => {
+      await formData.reduce(async (previousPromise, changedPolicy) => {
         await previousPromise;
         try {
           const result = await teamPoliciesAPI.update(changedPolicy.id, {
@@ -647,27 +627,8 @@ const ManagePolicyPage = ({
     try {
       setIsUpdatingPolicies(true);
 
-      const changedPolicies = formData.filter((formPolicy) => {
-        const prevPolicyState = policiesAvailableToAutomate.find(
-          (policy) => policy.id === formPolicy.id
-        );
-
-        const turnedOff =
-          prevPolicyState?.run_script !== undefined &&
-          formPolicy.scriptIdToRun === null;
-
-        const turnedOn =
-          prevPolicyState?.run_script === undefined &&
-          formPolicy.scriptIdToRun !== null;
-
-        const updatedScriptId =
-          prevPolicyState?.run_script?.id !== undefined &&
-          formPolicy.scriptIdToRun !== prevPolicyState?.run_script?.id;
-
-        return turnedOff || turnedOn || updatedScriptId;
-      });
-
-      if (!changedPolicies.length) {
+      // Truly dirty items previously detected in PolicyRunScriptModal
+      if (!formData.length) {
         renderFlash("success", "No changes detected.");
         return;
       }

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tests.tsx
@@ -1,0 +1,108 @@
+// InstallSoftwareModal.test.ts (or a separate helper test file)
+
+import {
+  getOriginalSoftwareState,
+  getCurrentSoftwareState,
+  getTrulyDirtyInstallSoftwareItems,
+} from "./InstallSoftwareModal"; // adjust path
+import { IFormPolicy } from "../PoliciesPaginatedList/PoliciesPaginatedList";
+
+const MOCK_POLICY_SOFTWARE = {
+  software_title_id: 20,
+  name: "1Password",
+  display_name: "",
+};
+
+const createMockPolicyForInstallSoftware = (
+  overrides: Partial<IFormPolicy> = {}
+): IFormPolicy =>
+  ({
+    id: 1,
+    name: "Policy",
+    platform: "darwin",
+    installSoftwareEnabled: false,
+    swIdToInstall: undefined,
+    ...overrides,
+  } as IFormPolicy);
+
+describe("getOriginalSoftwareState", () => {
+  it("extracts original software id when present", () => {
+    const policy = createMockPolicyForInstallSoftware({
+      install_software: MOCK_POLICY_SOFTWARE,
+    });
+    const { originallyEnabled, originalSwId } = getOriginalSoftwareState(
+      policy
+    );
+
+    expect(originallyEnabled).toBe(true);
+    expect(originalSwId).toBe(20);
+  });
+});
+
+describe("getCurrentSoftwareState", () => {
+  it("normalizes disabled state and null-ish swIdToInstall", () => {
+    const policy = createMockPolicyForInstallSoftware({
+      installSoftwareEnabled: false,
+      swIdToInstall: undefined,
+    });
+
+    const { nowEnabled, nowSwId } = getCurrentSoftwareState(policy);
+
+    expect(nowEnabled).toBe(false);
+    expect(nowSwId).toBeNull();
+  });
+
+  it("returns enabled with selected software id", () => {
+    const policy = createMockPolicyForInstallSoftware({
+      installSoftwareEnabled: true,
+      swIdToInstall: 99,
+    });
+
+    const { nowEnabled, nowSwId } = getCurrentSoftwareState(policy);
+
+    expect(nowEnabled).toBe(true);
+    expect(nowSwId).toBe(99);
+  });
+});
+
+describe("getTrulyDirtyInstallSoftwareItems", () => {
+  it("returns only policies that changed enablement or software id", () => {
+    const dirtyItems: IFormPolicy[] = [
+      // 1. Unchanged: originally enabled, still enabled, same software -> excluded
+      createMockPolicyForInstallSoftware({
+        id: 1,
+        install_software: MOCK_POLICY_SOFTWARE,
+        installSoftwareEnabled: true,
+        swIdToInstall: MOCK_POLICY_SOFTWARE.software_title_id,
+      }),
+
+      // 2. Turned on: originally disabled, now enabled with swId -> included
+      createMockPolicyForInstallSoftware({
+        id: 2,
+        installSoftwareEnabled: true,
+        swIdToInstall: 20,
+      }),
+
+      // 3. Turned off: originally enabled, now disabled -> included
+      createMockPolicyForInstallSoftware({
+        id: 3,
+        install_software: MOCK_POLICY_SOFTWARE,
+        installSoftwareEnabled: false,
+        swIdToInstall: undefined,
+      }),
+
+      // 4. Software changed: originally enabled with A, now enabled with B -> included
+      createMockPolicyForInstallSoftware({
+        id: 4,
+        install_software: MOCK_POLICY_SOFTWARE,
+        installSoftwareEnabled: true,
+        swIdToInstall: 30,
+      }),
+    ];
+
+    const result = getTrulyDirtyInstallSoftwareItems(dirtyItems);
+    const ids = result.map((p) => p.id).sort();
+
+    expect(ids).toEqual([2, 3, 4]);
+  });
+});

--- a/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/InstallSoftwareModal/InstallSoftwareModal.tests.tsx
@@ -1,10 +1,15 @@
-// InstallSoftwareModal.test.ts (or a separate helper test file)
+// Note: We intentionally test getOriginalSoftwareState, getCurrentSoftwareState,
+// and getTrulyDirtyInstallSoftwareItems in isolation instead of writing a
+// full integration test for InstallSoftwareModal’s onSubmit. A realistic
+// integration test would need standing up PoliciesPaginatedList, pagination,
+// and react-query data loading, which adds a lot of brittle setup for minor
+// extra confidence over these focused unit tests.
 
 import {
   getOriginalSoftwareState,
   getCurrentSoftwareState,
   getTrulyDirtyInstallSoftwareItems,
-} from "./InstallSoftwareModal"; // adjust path
+} from "./InstallSoftwareModal";
 import { IFormPolicy } from "../PoliciesPaginatedList/PoliciesPaginatedList";
 
 const MOCK_POLICY_SOFTWARE = {

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tests.tsx
@@ -1,0 +1,61 @@
+import { IScript } from "interfaces/script";
+import { IFormPolicy } from "../PoliciesPaginatedList/PoliciesPaginatedList";
+import { getTrulyDirtyItems } from "./PolicyRunScriptModal";
+
+describe("getTrulyDirtyItems", () => {
+  const createMockPolicyForScriptAutomation = (
+    overrides: Partial<IFormPolicy> = {}
+  ): IFormPolicy =>
+    ({
+      id: 1,
+      name: "Policy",
+      run_script: undefined,
+      runScriptEnabled: false,
+      scriptIdToRun: undefined,
+      ...overrides,
+    } as IFormPolicy);
+
+  it("returns only policies that changed enablement or script", () => {
+    const originalScriptId = 10;
+
+    const dirtyItems: IFormPolicy[] = [
+      // 1. Unchanged: originally enabled, still enabled, same script -> should be filtered out
+      createMockPolicyForScriptAutomation({
+        id: 1,
+        run_script: { id: originalScriptId } as Pick<IScript, "id" | "name">,
+        runScriptEnabled: true,
+        scriptIdToRun: originalScriptId,
+      }),
+
+      // 2. Turned on: originally disabled (no run_script), now enabled with script -> included
+      createMockPolicyForScriptAutomation({
+        id: 2,
+        run_script: undefined,
+        runScriptEnabled: true,
+        scriptIdToRun: 20,
+      }),
+
+      // 3. Turned off: originally enabled, now disabled -> included
+      createMockPolicyForScriptAutomation({
+        id: 3,
+        run_script: { id: originalScriptId } as Pick<IScript, "id" | "name">,
+        runScriptEnabled: false,
+        scriptIdToRun: undefined,
+      }),
+
+      // 4. Script changed: originally enabled with script A, now enabled with script B -> included
+      createMockPolicyForScriptAutomation({
+        id: 4,
+        run_script: { id: originalScriptId } as Pick<IScript, "id" | "name">,
+        runScriptEnabled: true,
+        scriptIdToRun: 30,
+      }),
+    ];
+
+    const result = getTrulyDirtyItems(dirtyItems);
+
+    const ids = result.map((p) => p.id).sort();
+    expect(ids).toEqual([2, 3, 4]);
+    expect(ids).not.toContain(1);
+  });
+});

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
@@ -35,6 +35,24 @@ interface IScriptDropdownField {
 
 export type IPolicyRunScriptFormData = IFormPolicy[];
 
+export const getTrulyDirtyItems = (dirtyItems: IFormPolicy[]) =>
+  dirtyItems.filter((item) => {
+    // Original state from policy row as loaded into the list
+    const originalScriptId = item.run_script?.id ?? null;
+    const originallyEnabled = originalScriptId !== null;
+
+    // Current state from UI form
+    const nowEnabled = !!item.runScriptEnabled;
+    const nowScriptId = item.scriptIdToRun ?? null;
+
+    const turnedOn = !originallyEnabled && nowEnabled;
+    const turnedOff = originallyEnabled && !nowEnabled;
+    const scriptChanged =
+      originallyEnabled && nowEnabled && nowScriptId !== originalScriptId;
+
+    return turnedOn || turnedOff || scriptChanged;
+  });
+
 interface IPolicyRunScriptModal {
   onExit: () => void;
   onSubmit: (formData: IPolicyRunScriptFormData) => void;
@@ -70,31 +88,10 @@ const PolicyRunScriptModal = ({
   );
 
   const onUpdate = useCallback(() => {
-    if (!paginatedListRef.current) {
-      return;
-    }
+    if (!paginatedListRef.current) return;
 
     const dirtyItems = paginatedListRef.current.getDirtyItems();
-
-    const trulyDirtyItems = dirtyItems.filter((item) => {
-      console.log("item", item);
-      // Original state from policy row as loaded into the list
-      const originalScriptId = item.run_script?.id ?? null;
-      const originallyEnabled = originalScriptId !== null;
-
-      // Current state from UI form
-      const nowEnabled = !!item.runScriptEnabled;
-      const nowScriptId = item.scriptIdToRun ?? null;
-
-      const turnedOn = !originallyEnabled && nowEnabled;
-      const turnedOff = originallyEnabled && !nowEnabled;
-      const scriptChanged =
-        originallyEnabled && nowEnabled && nowScriptId !== originalScriptId;
-
-      return turnedOn || turnedOff || scriptChanged;
-    });
-
-    onSubmit(trulyDirtyItems);
+    onSubmit(getTrulyDirtyItems(dirtyItems));
   }, [onSubmit]);
 
   const onSelectPolicyScript = (

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
@@ -70,9 +70,31 @@ const PolicyRunScriptModal = ({
   );
 
   const onUpdate = useCallback(() => {
-    if (paginatedListRef.current) {
-      onSubmit(paginatedListRef.current.getDirtyItems());
+    if (!paginatedListRef.current) {
+      return;
     }
+
+    const dirtyItems = paginatedListRef.current.getDirtyItems();
+
+    const trulyDirtyItems = dirtyItems.filter((item) => {
+      console.log("item", item);
+      // Original state from policy row as loaded into the list
+      const originalScriptId = item.run_script?.id ?? null;
+      const originallyEnabled = originalScriptId !== null;
+
+      // Current state from UI form
+      const nowEnabled = !!item.runScriptEnabled;
+      const nowScriptId = item.scriptIdToRun ?? null;
+
+      const turnedOn = !originallyEnabled && nowEnabled;
+      const turnedOff = originallyEnabled && !nowEnabled;
+      const scriptChanged =
+        originallyEnabled && nowEnabled && nowScriptId !== originalScriptId;
+
+      return turnedOn || turnedOff || scriptChanged;
+    });
+
+    onSubmit(trulyDirtyItems);
   }, [onSubmit]);
 
   const onSelectPolicyScript = (


### PR DESCRIPTION
## Issue
Closes #31160 

## Description
- Fix Policy automation for software not being detected as changed when it was
- Fix Policy automation for script being detected as changed when it's not

## Screen recording of fix
https://fleetdm.zoom.us/clips/share/VzcRL8K_Qqql-G9qAIbgkg

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
