### PR TITLE
Clarify event proposal submission process

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -375,7 +375,7 @@ To process intake team members will:
 
 ### Propose an event
 
-Fleet's Marketing team is responsible for deciding/signing off on the events Fleet will participate in. To propose an event, complete the steps in the [Propose event issue](https://github.com/fleetdm/confidential/issues/new?template=prepare-event.md). Once the requester has completed all steps, the marketing team will process your request within 72 business hours.
+Fleet's Marketing team is responsible for deciding/signing off on the events Fleet will participate in. To propose an event, complete the steps in the [Propose event issue](https://github.com/fleetdm/confidential/issues/new?template=prepare-event.md). Once the request has been submitted with all necessary information, the marketing team will process your request within 72 business hours.
 
 
 


### PR DESCRIPTION
Updated instructions to specify that the marketing team will process event requests within 72 business hours after all necessary information has been submitted, improving clarity for requesters.

