### PR TITLE
Enable gzip compression in osquery when run by Orbit

### DIFF
--- a/orbit/changes/38663-enable-osquery-gzip
+++ b/orbit/changes/38663-enable-osquery-gzip
@@ -1,0 +1,1 @@
+- Set `--tls_accept_gzip=true` when connecting osquery to Fleet. This should have no effect until gzip is also enabled on the Fleet server (a new Fleet server configuration to enable this is coming).

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -924,7 +924,7 @@ func main() {
 			}
 
 			options = append(options,
-				osquery.WithFlags(osquery.FleetFlags(parsedURL)),
+				osquery.WithFlags(osquery.FleetFlags(updateRunner.OsqueryVersion, parsedURL)),
 				osquery.WithFlags([]string{"--tls_server_certs", certPath}),
 			)
 		} else if fleetURL != "https://" {
@@ -938,7 +938,7 @@ func main() {
 			}
 
 			options = append(options,
-				osquery.WithFlags(osquery.FleetFlags(parsedURL)),
+				osquery.WithFlags(osquery.FleetFlags(updateRunner.OsqueryVersion, parsedURL)),
 			)
 
 			if certPath = c.String("fleet-certificate"); certPath != "" {
@@ -1090,7 +1090,7 @@ func main() {
 			hostIdentityCertificatePath = hostIdentityCredentials.CertificatePath
 
 			options = append(options,
-				osquery.WithFlags(osquery.FleetFlags(proxy.ParsedURL)),
+				osquery.WithFlags(osquery.FleetFlags(updateRunner.OsqueryVersion, proxy.ParsedURL)),
 
 				// This is overriding the previous set of --tls_server_certs in osquery.FleetFlags above.
 				osquery.WithFlags([]string{"--tls_server_certs", proxy.CertificatePath}),

--- a/orbit/pkg/osquery/flags_test.go
+++ b/orbit/pkg/osquery/flags_test.go
@@ -30,14 +30,11 @@ func TestFleetFlagsAcceptGzip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
 			flags := FleetFlags(tt.version, u)
-			found := false
-			for _, f := range flags {
-				if f == "--tls_accept_gzip=true" {
-					found = true
-					break
-				}
+			if tt.wantFlag {
+				assert.Contains(t, flags, "--tls_accept_gzip=true", "version %s missing flag", tt.version)
+			} else {
+				assert.NotContains(t, flags, "--tls_accept_gzip=true", "version %s unexpected flag", tt.version)
 			}
-			assert.Equal(t, tt.wantFlag, found, "version %s flag presence mismatch", tt.version)
 		})
 	}
 }

--- a/orbit/pkg/osquery/flags_test.go
+++ b/orbit/pkg/osquery/flags_test.go
@@ -1,0 +1,43 @@
+package osquery
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetFlagsAcceptGzip(t *testing.T) {
+	u, err := url.Parse("https://fleet.example.com")
+	require.NoError(t, err)
+
+	tests := []struct {
+		version  string
+		wantFlag bool
+	}{
+		{"5.20.0", false},
+		{"5.19.0-foobar", false},
+		{"5.21.0", true},
+		{"5.21.1", true},
+		{"5.21.0-24-g9e10d95ae", true},
+		{"5.22.0", true},
+		{"4.0.0", false},
+		{"invalid", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.version, func(t *testing.T) {
+			flags := FleetFlags(tt.version, u)
+			found := false
+			for _, f := range flags {
+				if f == "--tls_accept_gzip=true" {
+					found = true
+					break
+				}
+			}
+			assert.Equal(t, tt.wantFlag, found, "version %s flag presence mismatch", tt.version)
+		})
+	}
+}


### PR DESCRIPTION
If the osquery version is new enough (>= 5.21.0), Orbit will set the configuration option.

**Related issue:** #38663 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows (tested on macOS but functionality is same on each platform)
