### PR TITLE
Obfuscate calendar key

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -276,6 +276,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json) // For JSON parsing in unit tests
+    testImplementation(libs.okhttp.mockwebserver)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -276,7 +276,6 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.json) // For JSON parsing in unit tests
-    testImplementation(libs.okhttp.mockwebserver)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ datastorePreferences = "1.2.0"
 navigationCompose = "2.9.6"
 json = "20231013"
 mockk = "1.13.13"
-okhttp = "5.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -56,7 +55,6 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
-okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ datastorePreferences = "1.2.0"
 navigationCompose = "2.9.6"
 json = "20231013"
 mockk = "1.13.13"
+okhttp = "5.3.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -55,6 +56,7 @@ androidx-compose-material-icons-extended = { group = "androidx.compose.material"
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx" }
 json = { group = "org.json", name = "json", version.ref = "json" }
 mockk-android = { group = "io.mockk", name = "mockk-android", version.ref = "mockk" }
+okhttp-mockwebserver = { group = "com.squareup.okhttp3", name = "mockwebserver", version.ref = "okhttp" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/changes/13800-obfuscate-calendar-key
+++ b/changes/13800-obfuscate-calendar-key
@@ -1,0 +1,1 @@
+* the google calendar intergration api key json is now obfuscated in GET requests 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1116,7 +1116,7 @@ func TestGitOpsFullGlobal(t *testing.T) {
 	assert.Len(t, appliedMacProfiles, 1)
 	assert.Len(t, appliedWinProfiles, 1)
 	require.Len(t, savedAppConfig.Integrations.GoogleCalendar, 1)
-	assert.Equal(t, "service@example.com", savedAppConfig.Integrations.GoogleCalendar[0].ApiKey["client_email"])
+	assert.Equal(t, "service@example.com", savedAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["client_email"])
 	assert.True(t, savedAppConfig.ActivityExpirySettings.ActivityExpiryEnabled)
 	assert.Equal(t, 60, savedAppConfig.ActivityExpirySettings.ActivityExpiryWindow)
 	assert.True(t, savedAppConfig.ServerSettings.AIFeaturesDisabled)

--- a/ee/server/calendar/google_calendar.go
+++ b/ee/server/calendar/google_calendar.go
@@ -72,9 +72,9 @@ func NewGoogleCalendar(config *GoogleCalendarConfig) *GoogleCalendar {
 	switch {
 	case config.API != nil:
 		// Use the provided API.
-	case config.IntegrationConfig.ApiKey[fleet.GoogleCalendarEmail] == loadEmail:
+	case config.IntegrationConfig.ApiKey.Values[fleet.GoogleCalendarEmail] == loadEmail:
 		config.API = &GoogleCalendarLoadAPI{Logger: config.Logger}
-	case config.IntegrationConfig.ApiKey[fleet.GoogleCalendarEmail] == MockEmail:
+	case config.IntegrationConfig.ApiKey.Values[fleet.GoogleCalendarEmail] == MockEmail:
 		config.API = &GoogleCalendarMockAPI{config.Logger}
 	default:
 		config.API = &GoogleCalendarLowLevelAPI{logger: config.Logger}
@@ -283,8 +283,8 @@ func (lowLevelAPI *GoogleCalendarLowLevelAPI) withRetry(fn func() (any, error)) 
 func (c *GoogleCalendar) Configure(userEmail string) error {
 	adjustedUserEmail := adjustEmail(userEmail)
 	err := c.config.API.Configure(
-		c.config.Context, c.config.IntegrationConfig.ApiKey[fleet.GoogleCalendarEmail],
-		c.config.IntegrationConfig.ApiKey[fleet.GoogleCalendarPrivateKey], adjustedUserEmail,
+		c.config.Context, c.config.IntegrationConfig.ApiKey.Values[fleet.GoogleCalendarEmail],
+		c.config.IntegrationConfig.ApiKey.Values[fleet.GoogleCalendarPrivateKey], adjustedUserEmail,
 		c.config.ServerURL,
 	)
 	if err != nil {

--- a/ee/server/calendar/google_calendar_integration_test.go
+++ b/ee/server/calendar/google_calendar_integration_test.go
@@ -57,10 +57,10 @@ func (s *googleCalendarIntegrationTestSuite) TestCreateGetDeleteEvent() {
 		Context: context.Background(),
 		IntegrationConfig: &fleet.GoogleCalendarIntegration{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				"client_email": loadEmail,
 				"private_key":  s.server.URL,
-			},
+			}},
 		},
 		Logger: kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stdout)),
 	}
@@ -124,10 +124,10 @@ func (s *googleCalendarIntegrationTestSuite) TestFillUpCalendar() {
 		Context: context.Background(),
 		IntegrationConfig: &fleet.GoogleCalendarIntegration{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				"client_email": loadEmail,
 				"private_key":  s.server.URL,
-			},
+			}},
 		},
 		Logger: kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stdout)),
 	}

--- a/ee/server/calendar/google_calendar_test.go
+++ b/ee/server/calendar/google_calendar_test.go
@@ -137,10 +137,10 @@ func makeConfig(mockAPI *MockGoogleCalendarLowLevelAPI) *GoogleCalendarConfig {
 	config := &GoogleCalendarConfig{
 		Context: context.Background(),
 		IntegrationConfig: &fleet.GoogleCalendarIntegration{
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				fleet.GoogleCalendarEmail:      baseServiceEmail,
 				fleet.GoogleCalendarPrivateKey: basePrivateKey,
-			},
+			}},
 		},
 		Logger:    logger,
 		API:       mockAPI,

--- a/frontend/interfaces/integration.ts
+++ b/frontend/interfaces/integration.ts
@@ -63,7 +63,7 @@ export interface IIntegrationFormErrors {
 
 export interface IGlobalCalendarIntegration {
   domain: string;
-  api_key_json: string;
+  api_key_json: Record<string, string>;
 }
 
 interface ITeamCalendarSettings {

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -7,6 +7,7 @@ import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
 import configAPI from "services/entities/config";
 import paths from "router/paths";
+import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
@@ -46,15 +47,13 @@ const API_KEY_JSON_PLACEHOLDER = `{
   "universe_domain": "googleapis.com"
 }`;
 
-const MASKED_VALUE = "********";
-
 // Check if the API key JSON object contains obfuscated values
 const isObfuscatedApiKey = (apiKeyJson: Record<string, string>): boolean => {
   if (!apiKeyJson || Object.keys(apiKeyJson).length === 0) {
     return false;
   }
   // If all values are "********", the API key is obfuscated
-  return Object.values(apiKeyJson).every((value) => value === MASKED_VALUE);
+  return Object.values(apiKeyJson).every((value) => value === UNCHANGED_PASSWORD_API_RESPONSE);
 };
 
 interface ICalendarsFormErrors {
@@ -109,7 +108,7 @@ const Calendars = (): JSX.Element => {
           // Show masked value in UI
           setFormData({
             domain: data.integrations.google_calendar[0].domain,
-            apiKeyJson: MASKED_VALUE,
+            apiKeyJson: UNCHANGED_PASSWORD_API_RESPONSE,
           });
         } else {
           // Show the actual API key JSON
@@ -138,7 +137,7 @@ const Calendars = (): JSX.Element => {
       errors.domain = "Domain must be completed";
     }
     // Skip JSON validation if the value is the masked placeholder
-    if (curFormData.apiKeyJson && curFormData.apiKeyJson !== MASKED_VALUE) {
+    if (curFormData.apiKeyJson && curFormData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE) {
       try {
         JSON.parse(curFormData.apiKeyJson);
       } catch (e: unknown) {
@@ -175,10 +174,10 @@ const Calendars = (): JSX.Element => {
 
     // Determine the API key to submit
     let apiKeyToSubmit;
-    if (formData.apiKeyJson === MASKED_VALUE) {
+    if (formData.apiKeyJson === UNCHANGED_PASSWORD_API_RESPONSE) {
       // User didn't change the masked value, don't send it (backend will preserve existing)
       apiKeyToSubmit = undefined;
-    } else if (formData.apiKeyJson && formData.apiKeyJson !== MASKED_VALUE) {
+    } else if (formData.apiKeyJson && formData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE) {
       // User provided a new API key
       apiKeyToSubmit = JSON.parse(formData.apiKeyJson);
     } else {
@@ -320,7 +319,7 @@ const Calendars = (): JSX.Element => {
                       error={formErrors.apiKeyJson}
                       disabled={gomEnabled}
                       helpText={
-                        apiKeyJson === MASKED_VALUE
+                        apiKeyJson === UNCHANGED_PASSWORD_API_RESPONSE
                           ? "API key is configured. Replace with a new key to update."
                           : undefined
                       }

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -53,7 +53,9 @@ const isObfuscatedApiKey = (apiKeyJson: Record<string, string>): boolean => {
     return false;
   }
   // If all values are "********", the API key is obfuscated
-  return Object.values(apiKeyJson).every((value) => value === UNCHANGED_PASSWORD_API_RESPONSE);
+  return Object.values(apiKeyJson).every(
+    (value) => value === UNCHANGED_PASSWORD_API_RESPONSE
+  );
 };
 
 interface ICalendarsFormErrors {
@@ -137,7 +139,10 @@ const Calendars = (): JSX.Element => {
       errors.domain = "Domain must be completed";
     }
     // Skip JSON validation if the value is the masked placeholder
-    if (curFormData.apiKeyJson && curFormData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE) {
+    if (
+      curFormData.apiKeyJson &&
+      curFormData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE
+    ) {
       try {
         JSON.parse(curFormData.apiKeyJson);
       } catch (e: unknown) {
@@ -177,7 +182,10 @@ const Calendars = (): JSX.Element => {
     if (formData.apiKeyJson === UNCHANGED_PASSWORD_API_RESPONSE) {
       // User didn't change the masked value, don't send it (backend will preserve existing)
       apiKeyToSubmit = undefined;
-    } else if (formData.apiKeyJson && formData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE) {
+    } else if (
+      formData.apiKeyJson &&
+      formData.apiKeyJson !== UNCHANGED_PASSWORD_API_RESPONSE
+    ) {
       // User provided a new API key
       apiKeyToSubmit = JSON.parse(formData.apiKeyJson);
     } else {

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -98,7 +98,10 @@ const Calendars = (): JSX.Element => {
   } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
     select: (data: IConfig) => data,
     onSuccess: (data) => {
-      if (data.integrations.google_calendar) {
+      if (
+        Array.isArray(data.integrations.google_calendar) &&
+        data.integrations.google_calendar.length > 0
+      ) {
         const apiKeyJsonObj = data.integrations.google_calendar[0].api_key_json;
 
         // Check if the API key is obfuscated

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/helpers.tsx
@@ -6,6 +6,7 @@ import {
   ICertificatesCustomSCEP,
 } from "interfaces/certificates";
 import deepDifference from "utilities/deep_difference";
+import { UNCHANGED_PASSWORD_API_RESPONSE } from "utilities/constants";
 
 import { ICertFormData } from "../AddCertAuthorityModal/AddCertAuthorityModal";
 import { getDisplayErrMessage } from "../AddCertAuthorityModal/helpers";
@@ -15,8 +16,6 @@ import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
 import { IHydrantFormData } from "../HydrantForm/HydrantForm";
 import { ISmallstepFormData } from "../SmallstepForm/SmallstepForm";
 import { ICustomESTFormData } from "../CustomESTForm/CustomESTForm";
-
-const UNCHANGED_PASSWORD_API_RESPONSE = "********";
 
 export const generateDefaultFormData = (
   certAuthority: ICertificateAuthority

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -10,6 +10,8 @@ import { IHost } from "interfaces/host";
 const { origin } = global.window.location;
 export const BASE_URL = `${origin}${URL_PREFIX}/api`;
 
+export const UNCHANGED_PASSWORD_API_RESPONSE = "********";
+
 export enum PolicyResponse {
   PASSING = "passing",
   FAILING = "failing",

--- a/server/cron/calendar_cron_test.go
+++ b/server/cron/calendar_cron_test.go
@@ -234,9 +234,9 @@ func TestCalendarEventsMultipleHosts(t *testing.T) {
 				GoogleCalendar: []*fleet.GoogleCalendarIntegration{
 					{
 						Domain: "example.com",
-						ApiKey: map[string]string{
+						ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 							fleet.GoogleCalendarEmail: "calendar-mock@example.com",
-						},
+						}},
 					},
 				},
 			},
@@ -420,9 +420,9 @@ func TestCalendarEvents1KHosts(t *testing.T) {
 				GoogleCalendar: []*fleet.GoogleCalendarIntegration{
 					{
 						Domain: "example.com",
-						ApiKey: map[string]string{
+						ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 							fleet.GoogleCalendarEmail: "calendar-mock@example.com",
-						},
+						}},
 					},
 				},
 			},
@@ -753,9 +753,9 @@ func TestEventBody(t *testing.T) {
 				GoogleCalendar: []*fleet.GoogleCalendarIntegration{
 					{
 						Domain: "example.com",
-						ApiKey: map[string]string{
+						ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 							fleet.GoogleCalendarEmail: "calendar-mock@example.com",
-						},
+						}},
 					},
 				},
 			},

--- a/server/datastore/mysql/migrations/tables/20250904091745_AddCertificateAuthoritiesTable_test.go
+++ b/server/datastore/mysql/migrations/tables/20250904091745_AddCertificateAuthoritiesTable_test.go
@@ -83,9 +83,9 @@ func TestUp_20250904091745(t *testing.T) {
 	integrations.GoogleCalendar = []*fleet.GoogleCalendarIntegration{
 		{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				"fleet": "test",
-			},
+			}},
 		},
 	}
 

--- a/server/datastore/mysql/statistics.go
+++ b/server/datastore/mysql/statistics.go
@@ -147,7 +147,7 @@ func (ds *Datastore) ShouldSendStatistics(ctx context.Context, frequency time.Du
 			stats.Organization = lic.GetOrganization()
 		}
 		stats.AIFeaturesDisabled = appConfig.ServerSettings.AIFeaturesDisabled
-		stats.MaintenanceWindowsConfigured = len(appConfig.Integrations.GoogleCalendar) > 0 && appConfig.Integrations.GoogleCalendar[0].Domain != "" && len(appConfig.Integrations.GoogleCalendar[0].ApiKey) > 0
+		stats.MaintenanceWindowsConfigured = len(appConfig.Integrations.GoogleCalendar) > 0 && appConfig.Integrations.GoogleCalendar[0].Domain != "" && !appConfig.Integrations.GoogleCalendar[0].ApiKey.IsEmpty()
 
 		stats.MaintenanceWindowsEnabled = false
 		teams, err := ds.ListTeams(ctx, fleet.TeamFilter{User: &fleet.User{

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -686,6 +686,14 @@ func (c *AppConfig) Obfuscate() {
 	for _, zdIntegration := range c.Integrations.Zendesk {
 		zdIntegration.APIToken = MaskedPassword
 	}
+	for _, gcIntegration := range c.Integrations.GoogleCalendar {
+		if len(gcIntegration.ApiKey) > 0 {
+			// Obfuscate the entire Google Calendar API key
+			for key := range gcIntegration.ApiKey {
+				gcIntegration.ApiKey[key] = MaskedPassword
+			}
+		}
+	}
 	// // TODO(hca): confirm that we're properly masking credentials in the new endpoints
 	// if c.Integrations.NDESSCEPProxy.Valid {
 	// 	c.Integrations.NDESSCEPProxy.Value.Password = MaskedPassword

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -687,12 +687,7 @@ func (c *AppConfig) Obfuscate() {
 		zdIntegration.APIToken = MaskedPassword
 	}
 	for _, gcIntegration := range c.Integrations.GoogleCalendar {
-		if len(gcIntegration.ApiKey) > 0 {
-			// Obfuscate the entire Google Calendar API key
-			for key := range gcIntegration.ApiKey {
-				gcIntegration.ApiKey[key] = MaskedPassword
-			}
-		}
+		gcIntegration.ApiKey.SetMasked()
 	}
 	// // TODO(hca): confirm that we're properly masking credentials in the new endpoints
 	// if c.Integrations.NDESSCEPProxy.Valid {
@@ -780,8 +775,10 @@ func (c *AppConfig) Copy() *AppConfig {
 		for i, g := range c.Integrations.GoogleCalendar {
 			gCal := *g
 			clone.Integrations.GoogleCalendar[i] = &gCal
-			clone.Integrations.GoogleCalendar[i].ApiKey = make(map[string]string, len(g.ApiKey))
-			maps.Copy(clone.Integrations.GoogleCalendar[i].ApiKey, g.ApiKey)
+			if len(g.ApiKey.Values) > 0 {
+				clone.Integrations.GoogleCalendar[i].ApiKey.Values = make(map[string]string, len(g.ApiKey.Values))
+				maps.Copy(clone.Integrations.GoogleCalendar[i].ApiKey.Values, g.ApiKey.Values)
+			}
 		}
 	}
 	// // TODO(hca): do we want to cache the new grouped CAs datastore method?

--- a/server/fleet/app_test.go
+++ b/server/fleet/app_test.go
@@ -509,6 +509,15 @@ func TestGoogleCalendarApiKeyMarshalUnmarshal(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("unmarshal null", func(t *testing.T) {
+		data := []byte(`null`)
+		var key GoogleCalendarApiKey
+		err := json.Unmarshal(data, &key)
+		require.NoError(t, err)
+		require.False(t, key.IsMasked())
+		require.True(t, key.IsEmpty())
+	})
+
 	t.Run("full integration roundtrip", func(t *testing.T) {
 		// Test the full struct with the API key
 		intg := GoogleCalendarIntegration{

--- a/server/fleet/integrations.go
+++ b/server/fleet/integrations.go
@@ -412,6 +412,13 @@ func (k GoogleCalendarApiKey) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements json.Unmarshaler. Accepts either "********" string
 // (sets masked=true) or a JSON object (populates Values).
 func (k *GoogleCalendarApiKey) UnmarshalJSON(data []byte) error {
+	// Handle null - treat as empty (will fail validation if required)
+	if string(data) == "null" {
+		k.Values = nil
+		k.masked = false
+		return nil
+	}
+
 	// Try to unmarshal as a string first (for masked value)
 	var str string
 	if err := json.Unmarshal(data, &str); err == nil {

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -533,7 +533,7 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 					{APIToken: "zendesktoken"},
 				},
 				GoogleCalendar: []*fleet.GoogleCalendarIntegration{
-					{ApiKey: map[string]string{
+					{ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 						"type":                         "service_account",
 						"project_id":                   "test-project-123",
 						"private_key_id":               "key-id-456",
@@ -545,7 +545,7 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 						"auth_provider_x509_cert_url":  "https://www.googleapis.com/oauth2/v1/certs",
 						"client_x509_cert_url":         "https://www.googleapis.com/robot/v1/metadata/x509/test",
 						"universe_domain":              "googleapis.com",
-					}},
+					}}},
 				},
 			},
 		}, nil
@@ -624,19 +624,8 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 				require.Equal(t, ac.SMTPSettings.SMTPPassword, fleet.MaskedPassword)
 				require.Equal(t, ac.Integrations.Jira[0].APIToken, fleet.MaskedPassword)
 				require.Equal(t, ac.Integrations.Zendesk[0].APIToken, fleet.MaskedPassword)
-				// Verify all fields in Google Calendar API key are obfuscated
-				gcApiKey := ac.Integrations.GoogleCalendar[0].ApiKey
-				require.Equal(t, gcApiKey["type"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["project_id"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["private_key_id"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey[fleet.GoogleCalendarPrivateKey], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey[fleet.GoogleCalendarEmail], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["client_id"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["auth_uri"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["token_uri"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["auth_provider_x509_cert_url"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["client_x509_cert_url"], fleet.MaskedPassword)
-				require.Equal(t, gcApiKey["universe_domain"], fleet.MaskedPassword)
+				// Verify Google Calendar API key is masked (will serialize to "********")
+				require.True(t, ac.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 			}
 		})
 	}
@@ -1764,11 +1753,11 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 			GoogleCalendar: []*fleet.GoogleCalendarIntegration{
 				{
 					Domain: "example.com",
-					ApiKey: map[string]string{
+					ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 						fleet.GoogleCalendarEmail:      "test@example.com",
 						fleet.GoogleCalendarPrivateKey: "original-private-key",
 						"project_id":                   "original-project",
-					},
+					}},
 				},
 			},
 		},
@@ -1797,11 +1786,11 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 	t.Run("preserve API key when omitted (no changes)", func(t *testing.T) {
 		// Reset to original state
 		dsAppConfig.Integrations.GoogleCalendar[0].Domain = "example.com"
-		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = map[string]string{
+		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = fleet.GoogleCalendarApiKey{Values: map[string]string{
 			fleet.GoogleCalendarEmail:      "test@example.com",
 			fleet.GoogleCalendarPrivateKey: "original-private-key",
 			"project_id":                   "original-project",
-		}
+		}}
 
 		// Update without including api_key_json (simulates frontend sending masked value)
 		updateJSON := `{
@@ -1818,23 +1807,22 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 		// API key should be preserved (check datastore, not returned config which is obfuscated)
 		require.Len(t, dsAppConfig.Integrations.GoogleCalendar, 1)
 		require.Equal(t, "example.com", dsAppConfig.Integrations.GoogleCalendar[0].Domain)
-		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
-		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey["project_id"])
+		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarEmail])
+		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarPrivateKey])
+		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["project_id"])
 
-		// Returned config should be obfuscated
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+		// Returned config should be obfuscated (masked)
+		require.True(t, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	})
 
 	t.Run("preserve API key when updating only domain", func(t *testing.T) {
 		// Reset to original state
 		dsAppConfig.Integrations.GoogleCalendar[0].Domain = "example.com"
-		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = map[string]string{
+		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = fleet.GoogleCalendarApiKey{Values: map[string]string{
 			fleet.GoogleCalendarEmail:      "test@example.com",
 			fleet.GoogleCalendarPrivateKey: "original-private-key",
 			"project_id":                   "original-project",
-		}
+		}}
 
 		// Update only domain, omit api_key_json
 		updateJSON := `{
@@ -1851,22 +1839,22 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 		// Domain should be updated, API key preserved (check datastore)
 		require.Len(t, dsAppConfig.Integrations.GoogleCalendar, 1)
 		require.Equal(t, "newdomain.com", dsAppConfig.Integrations.GoogleCalendar[0].Domain)
-		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
-		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey["project_id"])
+		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarEmail])
+		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarPrivateKey])
+		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["project_id"])
 
-		// Returned config should be obfuscated
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
+		// Returned config should be obfuscated (masked)
+		require.True(t, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	})
 
 	t.Run("replace API key when new one provided (not merge)", func(t *testing.T) {
 		// Reset to original state
 		dsAppConfig.Integrations.GoogleCalendar[0].Domain = "example.com"
-		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = map[string]string{
+		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = fleet.GoogleCalendarApiKey{Values: map[string]string{
 			fleet.GoogleCalendarEmail:      "test@example.com",
 			fleet.GoogleCalendarPrivateKey: "original-private-key",
 			"project_id":                   "original-project",
-		}
+		}}
 
 		// Provide new API key with different fields
 		updateJSON := `{
@@ -1888,25 +1876,24 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 		// API key should be completely replaced (not merged) - check datastore
 		require.Len(t, dsAppConfig.Integrations.GoogleCalendar, 1)
 		require.Equal(t, "example.com", dsAppConfig.Integrations.GoogleCalendar[0].Domain)
-		require.Equal(t, "new@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, "new-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
-		require.Equal(t, "new-value", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey["new_field"])
+		require.Equal(t, "new@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarEmail])
+		require.Equal(t, "new-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarPrivateKey])
+		require.Equal(t, "new-value", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["new_field"])
 		// Old fields should NOT be present (confirms replacement, not merge)
-		_, hasOldProject := dsAppConfig.Integrations.GoogleCalendar[0].ApiKey["project_id"]
+		_, hasOldProject := dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["project_id"]
 		require.False(t, hasOldProject, "old project_id should not be present after replacement")
 
-		// Returned config should be obfuscated
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey["new_field"])
+		// Returned config should be obfuscated (masked)
+		require.True(t, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	})
 
 	t.Run("validation passes with preserved API key", func(t *testing.T) {
 		// Reset to valid state
 		dsAppConfig.Integrations.GoogleCalendar[0].Domain = "example.com"
-		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = map[string]string{
+		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = fleet.GoogleCalendarApiKey{Values: map[string]string{
 			fleet.GoogleCalendarEmail:      "valid@example.com",
 			fleet.GoogleCalendarPrivateKey: "-----BEGIN PRIVATE KEY-----\nvalid-key\n-----END PRIVATE KEY-----",
-		}
+		}}
 
 		// Update without api_key_json (should preserve valid key and pass validation)
 		updateJSON := `{
@@ -1922,32 +1909,28 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 
 		// Should succeed with preserved API key (check datastore)
 		require.Len(t, dsAppConfig.Integrations.GoogleCalendar, 1)
-		require.Equal(t, "valid@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, "-----BEGIN PRIVATE KEY-----\nvalid-key\n-----END PRIVATE KEY-----", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+		require.Equal(t, "valid@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarEmail])
+		require.Equal(t, "-----BEGIN PRIVATE KEY-----\nvalid-key\n-----END PRIVATE KEY-----", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarPrivateKey])
 
-		// Returned config should be obfuscated
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
+		// Returned config should be obfuscated (masked)
+		require.True(t, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	})
 
-	t.Run("preserve API key when fully masked values sent", func(t *testing.T) {
+	t.Run("preserve API key when masked value sent", func(t *testing.T) {
 		// Reset to original state
 		dsAppConfig.Integrations.GoogleCalendar[0].Domain = "example.com"
-		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = map[string]string{
+		dsAppConfig.Integrations.GoogleCalendar[0].ApiKey = fleet.GoogleCalendarApiKey{Values: map[string]string{
 			fleet.GoogleCalendarEmail:      "test@example.com",
 			fleet.GoogleCalendarPrivateKey: "original-private-key",
 			"project_id":                   "original-project",
-		}
+		}}
 
-		// Send fully masked api_key_json (simulates frontend accidentally sending obfuscated values)
+		// Send masked api_key_json (simulates frontend sending back obfuscated value)
 		updateJSON := `{
 			"integrations": {
 				"google_calendar": [{
 					"domain": "example.com",
-					"api_key_json": {
-						"client_email": "********",
-						"private_key": "********",
-						"project_id": "********"
-					}
+					"api_key_json": "********"
 				}]
 			}
 		}`
@@ -1958,12 +1941,11 @@ func TestModifyAppConfigGoogleCalendarAPIKey(t *testing.T) {
 		// API key should be preserved, not overwritten with masked values (check datastore)
 		require.Len(t, dsAppConfig.Integrations.GoogleCalendar, 1)
 		require.Equal(t, "example.com", dsAppConfig.Integrations.GoogleCalendar[0].Domain)
-		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
-		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey["project_id"])
+		require.Equal(t, "test@example.com", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarEmail])
+		require.Equal(t, "original-private-key", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values[fleet.GoogleCalendarPrivateKey])
+		require.Equal(t, "original-project", dsAppConfig.Integrations.GoogleCalendar[0].ApiKey.Values["project_id"])
 
-		// Returned config should be obfuscated
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-		require.Equal(t, fleet.MaskedPassword, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+		// Returned config should be obfuscated (masked)
+		require.True(t, updatedAppConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	})
 }

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -533,7 +533,19 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 					{APIToken: "zendesktoken"},
 				},
 				GoogleCalendar: []*fleet.GoogleCalendarIntegration{
-					{ApiKey: map[string]string{fleet.GoogleCalendarPrivateKey: "google-calendar-private-key"}},
+					{ApiKey: map[string]string{
+						"type":                         "service_account",
+						"project_id":                   "test-project-123",
+						"private_key_id":               "key-id-456",
+						fleet.GoogleCalendarPrivateKey: "-----BEGIN PRIVATE KEY-----\nMIIE...\n-----END PRIVATE KEY-----",
+						fleet.GoogleCalendarEmail:      "test@test-project.iam.gserviceaccount.com",
+						"client_id":                    "123456789",
+						"auth_uri":                     "https://accounts.google.com/o/oauth2/auth",
+						"token_uri":                    "https://oauth2.googleapis.com/token",
+						"auth_provider_x509_cert_url":  "https://www.googleapis.com/oauth2/v1/certs",
+						"client_x509_cert_url":         "https://www.googleapis.com/robot/v1/metadata/x509/test",
+						"universe_domain":              "googleapis.com",
+					}},
 				},
 			},
 		}, nil
@@ -612,8 +624,19 @@ func TestAppConfigSecretsObfuscated(t *testing.T) {
 				require.Equal(t, ac.SMTPSettings.SMTPPassword, fleet.MaskedPassword)
 				require.Equal(t, ac.Integrations.Jira[0].APIToken, fleet.MaskedPassword)
 				require.Equal(t, ac.Integrations.Zendesk[0].APIToken, fleet.MaskedPassword)
-				// Google Calendar private key is not obfuscated
-				require.Equal(t, ac.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey], "google-calendar-private-key")
+				// Verify all fields in Google Calendar API key are obfuscated
+				gcApiKey := ac.Integrations.GoogleCalendar[0].ApiKey
+				require.Equal(t, gcApiKey["type"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["project_id"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["private_key_id"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey[fleet.GoogleCalendarPrivateKey], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey[fleet.GoogleCalendarEmail], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["client_id"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["auth_uri"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["token_uri"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["auth_provider_x509_cert_url"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["client_x509_cert_url"], fleet.MaskedPassword)
+				require.Equal(t, gcApiKey["universe_domain"], fleet.MaskedPassword)
 			}
 		})
 	}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6938,8 +6938,7 @@ func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {
 
 	appConfig := s.getConfig()
 	require.Len(t, appConfig.Integrations.GoogleCalendar, 1)
-	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+	assert.True(t, appConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	assert.Equal(t, domain, appConfig.Integrations.GoogleCalendar[0].Domain)
 
 	// Add 2nd config -- not allowed at this time
@@ -6999,8 +6998,7 @@ func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {
 	)
 	appConfig = s.getConfig()
 	require.Len(t, appConfig.Integrations.GoogleCalendar, 1)
-	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+	assert.True(t, appConfig.Integrations.GoogleCalendar[0].ApiKey.IsMasked())
 	assert.Equal(t, domain, appConfig.Integrations.GoogleCalendar[0].Domain)
 
 	// Clearing other integrations does not clear Google Calendar integration

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -6938,8 +6938,8 @@ func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {
 
 	appConfig := s.getConfig()
 	require.Len(t, appConfig.Integrations.GoogleCalendar, 1)
-	assert.Equal(t, email, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-	assert.Equal(t, privateKey, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
+	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
 	assert.Equal(t, domain, appConfig.Integrations.GoogleCalendar[0].Domain)
 
 	// Add 2nd config -- not allowed at this time
@@ -6999,8 +6999,8 @@ func (s *integrationTestSuite) TestGoogleCalendarIntegrations() {
 	)
 	appConfig = s.getConfig()
 	require.Len(t, appConfig.Integrations.GoogleCalendar, 1)
-	assert.Equal(t, email, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
-	assert.Equal(t, privateKey, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
+	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarEmail])
+	assert.Equal(t, fleet.MaskedPassword, appConfig.Integrations.GoogleCalendar[0].ApiKey[fleet.GoogleCalendarPrivateKey])
 	assert.Equal(t, domain, appConfig.Integrations.GoogleCalendar[0].Domain)
 
 	// Clearing other integrations does not clear Google Calendar integration

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -10873,9 +10873,9 @@ func (s *integrationEnterpriseTestSuite) TestCalendarEvents() {
 	appCfg.Integrations.GoogleCalendar = []*fleet.GoogleCalendarIntegration{
 		{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				fleet.GoogleCalendarEmail: "calendar-mock@example.com",
-			},
+			}},
 		},
 	}
 	err = s.ds.SaveAppConfig(ctx, appCfg)
@@ -11159,9 +11159,9 @@ func (s *integrationEnterpriseTestSuite) TestCalendarEventsTransferringHosts() {
 	appCfg.Integrations.GoogleCalendar = []*fleet.GoogleCalendarIntegration{
 		{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				fleet.GoogleCalendarEmail: "calendar-mock@example.com",
-			},
+			}},
 		},
 	}
 	err = s.ds.SaveAppConfig(ctx, appCfg)
@@ -15775,9 +15775,9 @@ func (s *integrationEnterpriseTestSuite) TestCalendarCallback() {
 	appCfg.Integrations.GoogleCalendar = []*fleet.GoogleCalendarIntegration{
 		{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				fleet.GoogleCalendarEmail: calendar.MockEmail,
-			},
+			}},
 		},
 	}
 	err = s.ds.SaveAppConfig(ctx, appCfg)
@@ -16275,9 +16275,9 @@ func (s *integrationEnterpriseTestSuite) TestCalendarEventBodyUpdate() {
 	appCfg.Integrations.GoogleCalendar = []*fleet.GoogleCalendarIntegration{
 		{
 			Domain: "example.com",
-			ApiKey: map[string]string{
+			ApiKey: fleet.GoogleCalendarApiKey{Values: map[string]string{
 				fleet.GoogleCalendarEmail: calendar.MockEmail,
-			},
+			}},
 		},
 	}
 	err = s.ds.SaveAppConfig(ctx, appCfg)

--- a/tools/cloner-check/generated_files/appconfig.txt
+++ b/tools/cloner-check/generated_files/appconfig.txt
@@ -96,7 +96,9 @@ github.com/fleetdm/fleet/v4/server/fleet/ZendeskIntegration	EnableFailingPolicie
 github.com/fleetdm/fleet/v4/server/fleet/ZendeskIntegration	EnableSoftwareVulnerabilities	bool
 github.com/fleetdm/fleet/v4/server/fleet/Integrations	GoogleCalendar	[]*fleet.GoogleCalendarIntegration
 github.com/fleetdm/fleet/v4/server/fleet/GoogleCalendarIntegration	Domain	string
-github.com/fleetdm/fleet/v4/server/fleet/GoogleCalendarIntegration	ApiKey	map[string]string
+github.com/fleetdm/fleet/v4/server/fleet/GoogleCalendarIntegration	ApiKey	fleet.GoogleCalendarApiKey
+github.com/fleetdm/fleet/v4/server/fleet/GoogleCalendarApiKey	Values	map[string]string
+github.com/fleetdm/fleet/v4/server/fleet/GoogleCalendarApiKey	masked	bool
 github.com/fleetdm/fleet/v4/server/fleet/Integrations	ConditionalAccessEnabled	optjson.Bool
 github.com/fleetdm/fleet/v4/pkg/optjson/Bool	Set	bool
 github.com/fleetdm/fleet/v4/pkg/optjson/Bool	Valid	bool


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves confidential #13800

This is a "quick and dirty" change to resolve https://github.com/fleetdm/confidential/issues/13800.  There is a follow up story to redesign the UI to better match other integration modals and how to handle obfuscated values. 

  Backend

  - Obfuscation: Extended AppConfig.Obfuscate() to mask all fields in Google Calendar api_key_json with "********"
  - Preservation logic: When api_key_json is omitted from PATCH requests, the existing value is preserved (allows updating domain without re-entering credentials)
  - Replacement logic: When api_key_json is provided, it completely replaces the old value (prevents Go's JSON map merging behavior)


  Frontend

  - Detection: Automatically detects when API returns obfuscated values (all fields = "********")
  - Display: Shows "********" in the API key JSON text area with help text: "API key is configured. Replace with a new key to update."
  - Smart submission: Omits api_key_json field when unchanged (triggers backend preservation)
  - Validation: Skips JSON parsing validation for masked values

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [X] Added/updated automated tests


- [X] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Google Calendar API keys are now obfuscated in the admin interface, displayed as masked values in API responses and the UI
  * Users can update the calendar domain independently without affecting the stored API key
  * API keys can be optionally updated or preserved during app configuration changes, improving flexibility and security

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->