### PR TITLE
Added `conditional_access.cert_serial_format` server option to allow specifying the Okta conditional access certificate serial format.

### DIFF
--- a/changes/38549-okta-cond-access-cert-format
+++ b/changes/38549-okta-cond-access-cert-format
@@ -1,0 +1,1 @@
+Added `conditional_access.cert_serial_format` server option to allow specifying the Okta conditional access certificate serial format.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -204,6 +204,8 @@ the way that the Fleet server works.
 				initFatal(fmt.Errorf("%s is not a valid value for osquery_host_identifier", config.Osquery.HostIdentifier), "set host identifier")
 			}
 
+			config.ConditionalAccess.Validate(initFatal)
+
 			if len(config.Server.URLPrefix) > 0 {
 				// Massage provided prefix to match expected format
 				config.Server.URLPrefix = strings.TrimSuffix(config.Server.URLPrefix, "/")

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -58,8 +58,9 @@ func (e *notFoundError) IsNotFound() bool {
 
 // idpService implements the Okta conditional access IdP functionality.
 type idpService struct {
-	ds     fleet.Datastore
-	logger kitlog.Logger
+	ds               fleet.Datastore
+	logger           kitlog.Logger
+	certSerialFormat string
 }
 
 // RegisterIdP registers the HTTP handlers for Okta conditional access IdP endpoints.
@@ -74,8 +75,9 @@ func RegisterIdP(
 	}
 
 	svc := &idpService{
-		ds:     ds,
-		logger: kitlog.With(logger, "component", "conditional-access-idp"),
+		ds:               ds,
+		logger:           kitlog.With(logger, "component", "conditional-access-idp"),
+		certSerialFormat: fleetConfig.ConditionalAccess.CertSerialFormat,
 	}
 
 	// Create logging middleware
@@ -164,10 +166,10 @@ func (s *idpService) serveSSO(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Parse serial number (hex string to uint64)
-	serial, err := parseSerialNumber(serialStr)
+	// Parse serial number (hex or decimal string to uint64, based on config)
+	serial, err := parseSerialNumber(serialStr, s.certSerialFormat)
 	if err != nil {
-		level.Error(s.logger).Log("msg", "invalid certificate serial format", "serial", serialStr, "err", err)
+		level.Error(s.logger).Log("msg", "invalid certificate serial format", "serial", serialStr, "format", s.certSerialFormat, "err", err)
 		http.Redirect(w, r, certificateErrorURL, http.StatusSeeOther)
 		return
 	}
@@ -257,22 +259,27 @@ func (w *statusInterceptingWriter) WriteHeader(statusCode int) {
 	w.ResponseWriter.WriteHeader(statusCode)
 }
 
-// parseSerialNumber parses a certificate serial number from hex string to uint64.
+// parseSerialNumber parses a certificate serial number from hex or decimal string to uint64.
 // The serial number is provided by the load balancer in the X-Client-Cert-Serial header.
 //
 // SECURITY NOTE: This function only supports certificate serial numbers up to uint64 max
 // (18,446,744,073,709,551,615). While X.509 allows serial numbers up to 160 bits, this
 // limitation is acceptable because Fleet controls the Certificate Authority and generates
 // all certificates via SCEP
-func parseSerialNumber(serialStr string) (uint64, error) {
-	// Remove any colons or spaces that might be in the serial number
+func parseSerialNumber(serialStr string, format string) (uint64, error) {
+	// Remove any colons or spaces that might be in the serial number (common in hex format)
 	serialStr = strings.ReplaceAll(serialStr, ":", "")
 	serialStr = strings.ReplaceAll(serialStr, " ", "")
 
-	// Parse as hex (base 16) to uint64
-	serial, err := strconv.ParseUint(serialStr, 16, 64)
+	// Determine the base for parsing
+	base := 16 // default to hex
+	if format == config.CertSerialFormatDecimal {
+		base = 10
+	}
+
+	serial, err := strconv.ParseUint(serialStr, base, 64)
 	if err != nil {
-		return 0, fmt.Errorf("parse serial number: %w", err)
+		return 0, fmt.Errorf("parse serial number (format=%s): %w", format, err)
 	}
 
 	return serial, nil

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -271,7 +271,6 @@ func parseSerialNumber(serialStr string, format string) (uint64, error) {
 	serialStr = strings.ReplaceAll(serialStr, ":", "")
 	serialStr = strings.ReplaceAll(serialStr, " ", "")
 
-	// Determine the base for parsing
 	base := 16 // default to hex
 	if format == config.CertSerialFormatDecimal {
 		base = 10

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -74,7 +74,13 @@ b1ctZeF7HaWwFdTC8GqWI6zzRFn+YA3f/yYibhowuEypPQeSjlI=
 func newTestService() (*idpService, *mock.Store) {
 	ds := new(mock.Store)
 	logger := kitlog.NewNopLogger()
-	return &idpService{ds: ds, logger: logger}, ds
+	return &idpService{ds: ds, logger: logger, certSerialFormat: config.CertSerialFormatHex}, ds
+}
+
+func newTestServiceWithCertFormat(certFormat string) (*idpService, *mock.Store) {
+	ds := new(mock.Store)
+	logger := kitlog.NewNopLogger()
+	return &idpService{ds: ds, logger: logger, certSerialFormat: certFormat}, ds
 }
 
 func mockAppConfigFunc(serverURL string) func(context.Context) (*fleet.AppConfig, error) {
@@ -210,70 +216,142 @@ func TestServeMetadata(t *testing.T) {
 }
 
 func TestParseSerialNumber(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     string
-		expected  uint64
-		expectErr bool
-	}{
-		{
-			name:     "simple hex number",
-			input:    "1A2B3C",
-			expected: 0x1A2B3C,
-		},
-		{
-			name:     "hex with colons",
-			input:    "1A:2B:3C",
-			expected: 0x1A2B3C,
-		},
-		{
-			name:     "hex with spaces",
-			input:    "1A 2B 3C",
-			expected: 0x1A2B3C,
-		},
-		{
-			name:     "mixed colons and spaces",
-			input:    "1A:2B 3C",
-			expected: 0x1A2B3C,
-		},
-		{
-			name:     "large serial number",
-			input:    "DEADBEEF12345678",
-			expected: 0xDEADBEEF12345678,
-		},
-		{
-			name:     "lowercase hex",
-			input:    "abcdef123456",
-			expected: 0xABCDEF123456,
-		},
-		{
-			name:      "invalid hex characters",
-			input:     "GHIJKL",
-			expectErr: true,
-		},
-		{
-			name:      "empty string",
-			input:     "",
-			expectErr: true,
-		},
-		{
-			name:      "overflow uint64",
-			input:     "FFFFFFFFFFFFFFFF1",
-			expectErr: true,
-		},
-	}
+	t.Run("hex format", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			input     string
+			expected  uint64
+			expectErr bool
+		}{
+			{
+				name:     "simple hex number",
+				input:    "1A2B3C",
+				expected: 0x1A2B3C,
+			},
+			{
+				name:     "hex with colons",
+				input:    "1A:2B:3C",
+				expected: 0x1A2B3C,
+			},
+			{
+				name:     "hex with spaces",
+				input:    "1A 2B 3C",
+				expected: 0x1A2B3C,
+			},
+			{
+				name:     "mixed colons and spaces",
+				input:    "1A:2B 3C",
+				expected: 0x1A2B3C,
+			},
+			{
+				name:     "large serial number",
+				input:    "DEADBEEF12345678",
+				expected: 0xDEADBEEF12345678,
+			},
+			{
+				name:     "lowercase hex",
+				input:    "abcdef123456",
+				expected: 0xABCDEF123456,
+			},
+			{
+				name:      "invalid hex characters",
+				input:     "GHIJKL",
+				expectErr: true,
+			},
+			{
+				name:      "empty string",
+				input:     "",
+				expectErr: true,
+			},
+			{
+				name:      "overflow uint64",
+				input:     "FFFFFFFFFFFFFFFF1",
+				expectErr: true,
+			},
+		}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := parseSerialNumber(tt.input)
-			if tt.expectErr {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, result)
-			}
-		})
-	}
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := parseSerialNumber(tt.input, config.CertSerialFormatHex)
+				if tt.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("decimal format", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			input     string
+			expected  uint64
+			expectErr bool
+		}{
+			{
+				name:     "simple decimal number",
+				input:    "1234567890",
+				expected: 1234567890,
+			},
+			{
+				name:     "serial number 10 (bug case)",
+				input:    "10",
+				expected: 10,
+			},
+			{
+				name:     "serial number 15 (bug case)",
+				input:    "15",
+				expected: 15,
+			},
+			{
+				name:      "large serial number",
+				input:     "542242443644849078027064623851697342324729218861",
+				expected:  0, // Too large for uint64
+				expectErr: true,
+			},
+			{
+				name:     "max uint64",
+				input:    "18446744073709551615",
+				expected: 18446744073709551615,
+			},
+			{
+				name:      "invalid decimal characters",
+				input:     "12ABC34",
+				expectErr: true,
+			},
+			{
+				name:      "empty string",
+				input:     "",
+				expectErr: true,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				result, err := parseSerialNumber(tt.input, config.CertSerialFormatDecimal)
+				if tt.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, tt.expected, result)
+				}
+			})
+		}
+	})
+
+	t.Run("default format is hex", func(t *testing.T) {
+		// When format is empty or unknown, should default to hex
+		result, err := parseSerialNumber("A", "")
+		require.NoError(t, err)
+		require.Equal(t, uint64(10), result)
+
+		result, err = parseSerialNumber("A", "unknown")
+		require.NoError(t, err)
+		require.Equal(t, uint64(10), result)
+	})
+
 }
 
 func TestServeSSO(t *testing.T) {
@@ -351,6 +429,31 @@ func TestServeSSO(t *testing.T) {
 				require.True(t, ds.AppConfigFuncInvoked)
 			})
 		}
+	})
+
+	t.Run("decimal format parses serial correctly (bug fix)", func(t *testing.T) {
+		// This test verifies the bug fix: when using Caddy as reverse proxy,
+		// serial numbers are sent in decimal format. For example, serial "10"
+		// in decimal should be looked up as 10, not 16 (which is what hex parsing would give).
+		svc, ds := newTestServiceWithCertFormat(config.CertSerialFormatDecimal)
+
+		ds.GetConditionalAccessCertHostIDBySerialNumberFunc = func(ctx context.Context, serial uint64) (uint, error) {
+			// When using decimal format, "10" should be parsed as 10, not 16
+			require.Equal(t, uint64(10), serial)
+			return 123, nil
+		}
+		ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(false)
+
+		req := httptest.NewRequest("POST", idpSSOPath, nil)
+		req.Header.Set("X-Client-Cert-Serial", "10") // Caddy sends decimal format
+		w := httptest.NewRecorder()
+
+		svc.serveSSO(w, req)
+
+		require.Equal(t, http.StatusSeeOther, w.Code)
+		require.True(t, ds.GetConditionalAccessCertHostIDBySerialNumberFuncInvoked)
+		require.True(t, ds.AppConfigFuncInvoked)
 	})
 
 	t.Run("infrastructure errors return 500", func(t *testing.T) {

--- a/server/config/config_test.go
+++ b/server/config/config_test.go
@@ -828,3 +828,43 @@ func TestServerConfigWithH2C(t *testing.T) {
 
 	t.Logf("Response from ServerConfig: %s", string(body))
 }
+
+func TestConditionalAccessConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		format    string
+		expectErr bool
+	}{
+		{
+			name:      "valid hex format",
+			format:    CertSerialFormatHex,
+			expectErr: false,
+		},
+		{
+			name:      "valid decimal format",
+			format:    CertSerialFormatDecimal,
+			expectErr: false,
+		},
+		{
+			name:      "invalid format",
+			format:    "invalid",
+			expectErr: true,
+		},
+		{
+			name:      "empty format",
+			format:    "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ConditionalAccessConfig{CertSerialFormat: tt.format}
+			called := false
+			cfg.Validate(func(err error, msg string) { called = true })
+			require.Equal(t, tt.expectErr, called)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38549

Associated documentation update PR: https://github.com/fleetdm/fleet/pull/38702

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced conditional_access.cert_serial_format to choose certificate serial number format (hex or decimal); hex is default.
  * SSO certificate serial parsing now respects the configured format.

* **Bug Fixes**
  * Improved parsing and error handling for certificate serial numbers across formats.

* **Tests**
  * Added unit tests for configuration validation and serial-number parsing for both hex and decimal.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->