### PR TITLE
Libtiff false positive vuln

### DIFF
--- a/changes/35193-libtiff
+++ b/changes/35193-libtiff
@@ -1,0 +1,1 @@
+* fixed libtiff false positive vulnerability

--- a/server/vulnerabilities/nvd/cpe_matching_rule_test.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule_test.go
@@ -261,4 +261,23 @@ func TestGetKnownNVDBugRules(t *testing.T) {
 	require.True(t, ok)
 	ok = rule.CPEMatches(cpeMeta)
 	require.False(t, ok)
+
+	// Test that CVE-2024-7006 (libtiff) only matches on Linux.
+	rule, ok = cpeMatchingRules.FindMatch("CVE-2024-7006")
+	require.True(t, ok)
+
+	// Should not match on Windows
+	cpeMetaWindows, err := wfn.Parse("cpe:2.3:a:libtiff:libtiff:4.0.0:*:*:*:*:windows:*:*")
+	require.NoError(t, err)
+	require.False(t, rule.CPEMatches(cpeMetaWindows))
+
+	// Should not match on macOS
+	cpeMetaMacOS, err := wfn.Parse("cpe:2.3:a:libtiff:libtiff:4.0.0:*:*:*:*:macos:*:*")
+	require.NoError(t, err)
+	require.False(t, rule.CPEMatches(cpeMetaMacOS))
+
+	// Should match on Linux
+	cpeMetaLinux, err := wfn.Parse("cpe:2.3:a:libtiff:libtiff:4.0.0:*:*:*:*:linux:*:*")
+	require.NoError(t, err)
+	require.True(t, rule.CPEMatches(cpeMetaLinux))
 }

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -284,6 +284,15 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.TargetSW == "windows"
 			},
 		},
+		// CVE-2024-7006 only targets Linux operating systems (libtiff vulnerability)
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2024-7006": {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.TargetSW != "linux"
+			},
+		},
 		// these CVEs only target iOS, and we don't yet support iOS vuln scanning (and can't tell iOS/Mac CPEs apart yet)
 		CPEMatchingRule{
 			CVEs: map[string]struct{}{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35193

libtiff should only be scoped to linux platforms

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

