### PR TITLE
Website: update article category page

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -97,7 +97,7 @@ module.exports = {
         pageDescriptionForMeta = 'Listen to the Future of Device Management podcast.';
         break;
       case 'articles':
-        pageTitleForMeta = 'Blog';
+        pageTitleForMeta = 'Blogs';
         pageDescriptionForMeta = 'Read the latest articles from the Fleet team and community.';
         break;
     }

--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -36,7 +36,7 @@ module.exports = {
     if (category === 'articles') {
       // If the category is `/articles` we'll show all articles
       articles = sails.config.builtStaticContent.markdownPages.filter((page)=>{
-        if(_.startsWith(page.htmlId, 'articles')) {
+        if(_.startsWith(page.htmlId, 'articles') && !_.startsWith(page.url, '/guides')) {
           return page;
         }
       });
@@ -97,7 +97,7 @@ module.exports = {
         pageDescriptionForMeta = 'Listen to the Future of Device Management podcast.';
         break;
       case 'articles':
-        pageTitleForMeta = 'Articles';
+        pageTitleForMeta = 'Blog';
         pageDescriptionForMeta = 'Read the latest articles from the Fleet team and community.';
         break;
     }

--- a/website/api/controllers/articles/view-basic-article.js
+++ b/website/api/controllers/articles/view-basic-article.js
@@ -69,7 +69,7 @@ module.exports = {
       'announcements': 'Announcements',
       'podcasts': 'Podcasts',
       'report': 'Reports',
-      'articles': 'Articles',
+      'articles': 'Blogs',
     };
     let categoryFriendlyName = categoryFriendlyNamesByCategorySlug[articleCategorySlug];
     // Set the currentSection variable for the website header to "customers" if the article is shown on the testimonials page.

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -51,7 +51,7 @@ parasails.registerPage('articles', {
         this.categoryDescription = '';
         break;
       case 'articles':
-        this.articleCategory = 'Blog';
+        this.articleCategory = 'Blogs';
         this.categoryDescription = 'Read the latest articles from the Fleet team and community.';
         break;
     }

--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -51,7 +51,7 @@ parasails.registerPage('articles', {
         this.categoryDescription = '';
         break;
       case 'articles':
-        this.articleCategory = 'Articles';
+        this.articleCategory = 'Blog';
         this.categoryDescription = 'Read the latest articles from the Fleet team and community.';
         break;
     }

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -36,7 +36,7 @@
           <a href="/announcements">News</a>
           <a href="/testimonials">Case studies</a>
           <a href="/guides">Guides</a>
-          <a href="/articles">Blog</a>
+          <a href="/articles">Blogs</a>
           <a href="/releases">Releases</a>
         </div>
         <!-- <div purpose="sidebar-cta">

--- a/website/views/pages/articles/articles.ejs
+++ b/website/views/pages/articles/articles.ejs
@@ -35,7 +35,8 @@
         <div purpose="nav-links">
           <a href="/announcements">News</a>
           <a href="/testimonials">Case studies</a>
-          <a href="/articles">Articles</a>
+          <a href="/guides">Guides</a>
+          <a href="/articles">Blog</a>
           <a href="/releases">Releases</a>
         </div>
         <!-- <div purpose="sidebar-cta">


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/13527

Changes:
- Changed the name of the /articles page to "Blogs"
- Updated the blogs category to exclude guides
- Added a link to /guides to the sidebar on article category pages