### PR TITLE
Clarify event proposal process and scope

### DIFF
--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -375,7 +375,9 @@ To process intake team members will:
 
 ### Propose an event
 
-Fleet's Marketing team is responsible for deciding/signing off on the events Fleet will participate in. To propose an event, complete the steps in the [Propose event issue](https://github.com/fleetdm/confidential/issues/new?template=prepare-event.md). Once the request has been submitted with all necessary information, the marketing team will process your request within 72 business hours.
+Fleet's Marketing team is responsible for deciding/signing off on the events Fleet will participate in. This includes any event that Fleet pays to attend or sponsor, and even events where Fleet's only involvement is that a Fleetie will give a talk or otherwise represent the brand.
+
+To propose an event, complete the steps in the [Propose event issue](https://github.com/fleetdm/confidential/issues/new?template=prepare-event.md). Once the request has been submitted with all necessary information, the marketing team will process your request within 72 business hours.
 
 
 


### PR DESCRIPTION
Expanded the description of events requiring Marketing team approval to include any event where Fleet is represented, not just those with financial involvement. This provides clearer guidance on when to submit a proposal.

