### PR TITLE
Update Android version requirement to 14

### DIFF
--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -80,7 +80,7 @@ Fleet supports the following operating system versions on hosts.
 | Windows    | Pro and Enterprise 10+, Server 2012+    |
 | Linux      | CentOS 7.1+, Ubuntu 20.04+, Fedora 38+, Amazon Linux 2+, Debian 11+, Red Hat Enterprise Linux (RHEL) 7+, openSUSE 15.6+, Arch Linux, Omarchy |
 | ChromeOS   | 112.0.5615.134+                         |
-| Android    | 13+                                     |
+| Android    | 14+                                     |
 
 While Fleet may still function partially or fully with OS versions older than those above, Fleet does not actively test against unsupported versions and does not pursue bugs on them.
 


### PR DESCRIPTION
We officially support the last two major versions. The latest version is Android 16, and the most recent stable version was released six months ago.