### PR TITLE
Cherry-pick to 4.80.0: Bump tar dep on fleetctl-npm to resolve CVE (#38578)

### DIFF
--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "axios": "1.13.2",
     "rimraf": "6.1.2",
-    "tar": "7.5.2"
+    "tar": "7.5.4"
   },
   "keywords": [
     "osquery",

--- a/tools/fleetctl-npm/yarn.lock
+++ b/tools/fleetctl-npm/yarn.lock
@@ -241,10 +241,10 @@ rimraf@6.1.2:
     glob "^13.0.0"
     package-json-from-dist "^1.0.1"
 
-tar@7.5.2:
-  version "7.5.2"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.2.tgz#115c061495ec51ff3c6745ff8f6d0871c5b1dedc"
-  integrity sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==
+tar@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.4.tgz#18b53b44f939a7e03ed874f1fafe17d29e306c81"
+  integrity sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
This had merge conflicts b/c 4.80.0 was on tar 7.5.2 and main was on 7.5.3, but the changes are the same (bumping to 7.5.4).

(cherry picked from commit 67414fd8a79ca9074ab23131313bced4dd328ed7)
