### PR TITLE
Fleet UI: Fixed broken disk space sort header on hosts table

### DIFF
--- a/changes/37006-fix-broken-disk-space-sort
+++ b/changes/37006-fix-broken-disk-space-sort
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed broken disk space sort header on hosts table

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -285,6 +285,7 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
         isSortedDesc={cellProps.column.isSortedDesc}
       />
     ),
+    accessor: "gigs_disk_space_available",
     id: "gigs_disk_space_available",
     Cell: (cellProps: IHostTableNumberCellProps) => {
       const {


### PR DESCRIPTION
## Issue
Closes #37006

## Description
- Was missing `accessor` key

## Screen recording of fix

https://github.com/user-attachments/assets/c06db5c4-a76b-4e7f-8cdf-214a4bde5f64



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
