### PR TITLE
Website: Update values to match CRM picklist values

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -59,7 +59,7 @@ module.exports = {
         'Fleet channel member in MacAdmins Slack',
         'Fleet channel member in osquery Slack',
         'Implemented a trial key',
-        'Signed up Fleet event',
+        'Signed up for Fleet event',
         'Engaged with Fleetie at event',
         'Attended a Fleet happy hour',
         'Stared the fleetdm/fleet repo on GitHub',

--- a/website/api/helpers/salesforce/create-historical-event.js
+++ b/website/api/helpers/salesforce/create-historical-event.js
@@ -50,7 +50,7 @@ module.exports = {
         'Fleet channel member in MacAdmins Slack',
         'Fleet channel member in osquery Slack',
         'Implemented a trial key',
-        'Signed up Fleet event',
+        'Signed up for Fleet event',
         'Engaged with Fleetie at event',
         'Attended a Fleet happy hour',
         'Stared the fleetdm/fleet repo on GitHub',

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -191,7 +191,7 @@ module.exports = {
 
         if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer === 'https://fleetdm.com/') {
           // If no referrer is set, or the referrer is set to the Fleet website, we'll assume this user came to the website directly
-          attributionDetails.sourceChannelDetails = 'Direct Traffic (DT)';
+          attributionDetails.sourceChannelDetails = 'Direct traffic (DT)';
           attributionDetails.campaign = 'Default-DT-Direct';
         } else {
           // Otherwise, we'll check the referer value and attempt to categorize the referer.


### PR DESCRIPTION
Changes:
- Updated the accepted `intentSingal` values in the receive-from-clay webhook and the createHistoricalEvent helper to match the picklist values in Salesforce
- updated a "most recent/source channel details" value set in the updateOrCreateContactAndAccount helper to match the picklist value in Salesforce.