### PR TITLE
Added OTEL context to logs.

### DIFF
--- a/server/contexts/logging/logging.go
+++ b/server/contexts/logging/logging.go
@@ -171,6 +171,10 @@ func (l *LoggingContext) Log(ctx context.Context, logger kitlog.Logger) {
 	}
 	keyvals = append(keyvals, "method", requestMethod, "uri", requestURI, "took", time.Since(l.StartTime))
 
+	if tc := getOTELTraceContext(ctx); tc != nil {
+		keyvals = append(keyvals, "trace_id", tc.TraceID, "span_id", tc.SpanID)
+	}
+
 	if len(l.Extras) > 0 {
 		keyvals = append(keyvals, l.Extras...)
 	}

--- a/server/contexts/logging/trace.go
+++ b/server/contexts/logging/trace.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+// traceContext holds trace_id and span_id extracted from OTEL trace context.
+type traceContext struct {
+	TraceID string
+	SpanID  string
+}
+
+// getOTELTraceContext extracts trace_id and span_id from the OTEL trace context
+// in the given context. Returns nil if no valid trace context is present.
+func getOTELTraceContext(ctx context.Context) *traceContext {
+	span := trace.SpanFromContext(ctx)
+	if span == nil {
+		return nil
+	}
+
+	spanCtx := span.SpanContext()
+	if !spanCtx.IsValid() {
+		return nil
+	}
+
+	return &traceContext{
+		TraceID: spanCtx.TraceID().String(),
+		SpanID:  spanCtx.SpanID().String(),
+	}
+}

--- a/server/contexts/logging/trace.go
+++ b/server/contexts/logging/trace.go
@@ -3,6 +3,7 @@ package logging
 import (
 	"context"
 
+	kitlog "github.com/go-kit/log"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -29,4 +30,28 @@ func getOTELTraceContext(ctx context.Context) *traceContext {
 		TraceID: spanCtx.TraceID().String(),
 		SpanID:  spanCtx.SpanID().String(),
 	}
+}
+
+// TraceLogger wraps a go-kit logger to automatically inject OTEL trace context
+// (trace_id and span_id) into every log call. It reads from the context pointer
+// on each Log() call, so it picks up child spans when the context is updated.
+type TraceLogger struct {
+	ctx    *context.Context
+	logger kitlog.Logger
+}
+
+// NewTraceLogger creates a logger that automatically injects trace_id and span_id
+// from the OTEL trace context. Pass a pointer to your context variable so the
+// logger sees updates when child spans are created.
+func NewTraceLogger(ctx *context.Context, logger kitlog.Logger) *TraceLogger {
+	return &TraceLogger{ctx: ctx, logger: logger}
+}
+
+// Log implements kitlog.Logger. It appends trace_id and span_id (if available)
+// to the keyvals before delegating to the underlying logger.
+func (t *TraceLogger) Log(keyvals ...any) error {
+	if tc := getOTELTraceContext(*t.ctx); tc != nil {
+		keyvals = append(keyvals, "trace_id", tc.TraceID, "span_id", tc.SpanID)
+	}
+	return t.logger.Log(keyvals...)
 }

--- a/server/contexts/logging/trace_test.go
+++ b/server/contexts/logging/trace_test.go
@@ -1,0 +1,39 @@
+package logging
+
+import (
+	"bytes"
+	"testing"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/stretchr/testify/assert"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+func TestLogWithTraceContext(t *testing.T) {
+	t.Run("without span", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		lc := &LoggingContext{}
+		ctx := NewContext(t.Context(), lc)
+
+		lc.Log(ctx, kitlog.NewLogfmtLogger(buf))
+
+		assert.NotContains(t, buf.String(), "trace_id=")
+		assert.NotContains(t, buf.String(), "span_id=")
+	})
+
+	t.Run("with span", func(t *testing.T) {
+		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()))
+		ctx, span := tp.Tracer("test").Start(t.Context(), "test-span")
+		defer span.End()
+
+		buf := new(bytes.Buffer)
+		lc := &LoggingContext{}
+		ctx = NewContext(ctx, lc)
+
+		lc.Log(ctx, kitlog.NewLogfmtLogger(buf))
+
+		assert.Contains(t, buf.String(), "trace_id="+span.SpanContext().TraceID().String())
+		assert.Contains(t, buf.String(), "span_id="+span.SpanContext().SpanID().String())
+	})
+}

--- a/server/contexts/logging/trace_test.go
+++ b/server/contexts/logging/trace_test.go
@@ -6,34 +6,77 @@ import (
 
 	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 )
+
+func newTestTracer() trace.Tracer {
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()))
+	return tp.Tracer("test")
+}
 
 func TestLogWithTraceContext(t *testing.T) {
 	t.Run("without span", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 		lc := &LoggingContext{}
 		ctx := NewContext(t.Context(), lc)
-
 		lc.Log(ctx, kitlog.NewLogfmtLogger(buf))
 
 		assert.NotContains(t, buf.String(), "trace_id=")
-		assert.NotContains(t, buf.String(), "span_id=")
 	})
 
 	t.Run("with span", func(t *testing.T) {
-		tp := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(tracetest.NewSpanRecorder()))
-		ctx, span := tp.Tracer("test").Start(t.Context(), "test-span")
+		ctx, span := newTestTracer().Start(t.Context(), "test")
 		defer span.End()
 
 		buf := new(bytes.Buffer)
 		lc := &LoggingContext{}
 		ctx = NewContext(ctx, lc)
-
 		lc.Log(ctx, kitlog.NewLogfmtLogger(buf))
 
 		assert.Contains(t, buf.String(), "trace_id="+span.SpanContext().TraceID().String())
 		assert.Contains(t, buf.String(), "span_id="+span.SpanContext().SpanID().String())
+	})
+}
+
+func TestTraceLogger(t *testing.T) {
+	t.Run("without span", func(t *testing.T) {
+		ctx := t.Context()
+		buf := new(bytes.Buffer)
+		logger := NewTraceLogger(&ctx, kitlog.NewLogfmtLogger(buf))
+		require.NoError(t, logger.Log("msg", "test"))
+
+		assert.NotContains(t, buf.String(), "trace_id=")
+		assert.Contains(t, buf.String(), "msg=test")
+	})
+
+	t.Run("with span", func(t *testing.T) {
+		ctx, span := newTestTracer().Start(t.Context(), "test")
+		defer span.End()
+
+		buf := new(bytes.Buffer)
+		logger := NewTraceLogger(&ctx, kitlog.NewLogfmtLogger(buf))
+		require.NoError(t, logger.Log("msg", "test"))
+
+		assert.Contains(t, buf.String(), "trace_id="+span.SpanContext().TraceID().String())
+		assert.Contains(t, buf.String(), "span_id="+span.SpanContext().SpanID().String())
+	})
+
+	t.Run("picks up child span", func(t *testing.T) {
+		tracer := newTestTracer()
+		ctx, parent := tracer.Start(t.Context(), "parent")
+		defer parent.End()
+
+		buf := new(bytes.Buffer)
+		logger := NewTraceLogger(&ctx, kitlog.NewLogfmtLogger(buf))
+
+		ctx, child := tracer.Start(ctx, "child")
+		defer child.End()
+
+		require.NoError(t, logger.Log("msg", "test"))
+		assert.Contains(t, buf.String(), "span_id="+child.SpanContext().SpanID().String())
+		assert.NotContains(t, buf.String(), "span_id="+parent.SpanContext().SpanID().String())
 	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38607 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
