### PR TITLE
Fixed Android certificate enrollment failures caused by SCEP challenge expiration when devices were offline.

### DIFF
--- a/changes/37651-Android-fleet-challenge
+++ b/changes/37651-Android-fleet-challenge
@@ -1,0 +1,1 @@
+Fixed Android certificate enrollment failures caused by SCEP challenge expiration when devices were offline.

--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -442,7 +442,7 @@ func (ds *Datastore) GetAndTransitionCertificateTemplatesToDelivering(
 }
 
 // TransitionCertificateTemplatesToDelivered transitions the specified templates from 'delivering' to 'delivered'.
-// Challenges are created on-demand when the device fetches the certificate template via
+// The fleet_challenge is cleared so a fresh one is generated when the device fetches the certificate template via
 // GetOrCreateFleetChallengeForCertificateTemplate.
 func (ds *Datastore) TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, templateIDs []uint) error {
 	if len(templateIDs) == 0 {
@@ -453,6 +453,7 @@ func (ds *Datastore) TransitionCertificateTemplatesToDelivered(ctx context.Conte
 		UPDATE host_certificate_templates
 		SET
 			status = '%s',
+			fleet_challenge = NULL,
 			updated_at = NOW()
 		WHERE
 			host_uuid = ? AND

--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -625,8 +625,9 @@ func (ds *Datastore) GetAndroidCertificateTemplatesForRenewal(
 }
 
 // SetAndroidCertificateTemplatesForRenewal marks the specified certificate templates for renewal
-// by setting status to 'pending', clearing validity fields, and generating a new UUID.
+// by setting status to 'pending', clearing validity fields and fleet_challenge, and generating a new UUID.
 // The new UUID signals to the Android agent that the certificate needs renewal.
+// The fleet_challenge is cleared so a fresh one is generated when the device fetches the renewed certificate.
 func (ds *Datastore) SetAndroidCertificateTemplatesForRenewal(
 	ctx context.Context,
 	templates []fleet.HostCertificateTemplateForRenewal,
@@ -653,6 +654,7 @@ func (ds *Datastore) SetAndroidCertificateTemplatesForRenewal(
 			not_valid_before = NULL,
 			not_valid_after = NULL,
 			serial = NULL,
+			fleet_challenge = NULL,
 			updated_at = NOW()
 		WHERE (host_uuid, certificate_template_id) IN (%s)
 	`, fleet.CertificateTemplatePending, placeholders.String())

--- a/server/datastore/mysql/host_certificate_templates_test.go
+++ b/server/datastore/mysql/host_certificate_templates_test.go
@@ -40,6 +40,7 @@ func TestHostCertificateTemplates(t *testing.T) {
 		{"CertificateTemplateReinstalledAfterTransferBackToOriginalTeam", testCertificateTemplateReinstalledAfterTransferBackToOriginalTeam},
 		{"GetAndroidCertificateTemplatesForRenewal", testGetAndroidCertificateTemplatesForRenewal},
 		{"SetAndroidCertificateTemplatesForRenewal", testSetAndroidCertificateTemplatesForRenewal},
+		{"GetOrCreateFleetChallengeForCertificateTemplate", testGetOrCreateFleetChallengeForCertificateTemplate},
 	}
 
 	for _, c := range cases {
@@ -865,15 +866,30 @@ func testCertificateTemplateFullStateMachine(t *testing.T, ds *Datastore) {
 		require.EqualValues(t, fleet.CertificateTemplateDelivering, *r.Status)
 	}
 
-	// Step 4: Transition to delivered with challenges
-	challenges := map[uint]string{
-		setup.template.ID: "challenge-abc",
-		templateTwo.ID:    "challenge-xyz",
-	}
-	err = ds.TransitionCertificateTemplatesToDelivered(ctx, "android-host", challenges)
+	// Step 4: Transition to delivered (challenges are created on-demand)
+	err = ds.TransitionCertificateTemplatesToDelivered(ctx, "android-host", []uint{setup.template.ID, templateTwo.ID})
 	require.NoError(t, err)
 
-	// Verify final state
+	// Verify delivered state (no challenges yet)
+	records, err = ds.ListCertificateTemplatesForHosts(ctx, []string{"android-host"})
+	require.NoError(t, err)
+	require.Len(t, records, 2)
+	for _, r := range records {
+		require.NotNil(t, r.Status)
+		require.EqualValues(t, fleet.CertificateTemplateDelivered, *r.Status)
+		require.Nil(t, r.FleetChallenge) // Challenge not created yet
+	}
+
+	// Step 5: Create challenges on-demand (simulating device fetch)
+	challenge1, err := ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, "android-host", setup.template.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, challenge1)
+
+	challenge2, err := ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, "android-host", templateTwo.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, challenge2)
+
+	// Verify challenges are now set
 	records, err = ds.ListCertificateTemplatesForHosts(ctx, []string{"android-host"})
 	require.NoError(t, err)
 	require.Len(t, records, 2)
@@ -882,9 +898,9 @@ func testCertificateTemplateFullStateMachine(t *testing.T, ds *Datastore) {
 		require.EqualValues(t, fleet.CertificateTemplateDelivered, *r.Status)
 		require.NotNil(t, r.FleetChallenge)
 		if r.CertificateTemplateID == setup.template.ID {
-			require.Equal(t, "challenge-abc", *r.FleetChallenge)
+			require.Equal(t, challenge1, *r.FleetChallenge)
 		} else {
-			require.Equal(t, "challenge-xyz", *r.FleetChallenge)
+			require.Equal(t, challenge2, *r.FleetChallenge)
 		}
 	}
 
@@ -1703,4 +1719,102 @@ func testSetAndroidCertificateTemplatesForRenewal(t *testing.T, ds *Datastore) {
 	// Test empty slice doesn't error
 	err = ds.SetAndroidCertificateTemplatesForRenewal(ctx, []fleet.HostCertificateTemplateForRenewal{})
 	require.NoError(t, err)
+}
+
+func testGetOrCreateFleetChallengeForCertificateTemplate(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Create test setup
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "test team challenge"})
+	require.NoError(t, err)
+
+	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
+		Name: ptr.String("test ca challenge"),
+		Type: string(fleet.CAConfigCustomSCEPProxy),
+		URL:  ptr.String("http://localhost:8080/scep"),
+	})
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	host := test.NewHost(t, ds, "host-challenge", "192.168.1.1", "host_key_challenge", uuid.NewString(), now, test.WithPlatform("android"), test.WithTeamID(team.ID))
+
+	t.Run("returns error for non-existent template", func(t *testing.T) {
+		_, err := ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, host.UUID, 99999)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("returns error for non-delivered status", func(t *testing.T) {
+		// Create a separate template for this test
+		pendingTemplate, err := ds.CreateCertificateTemplate(ctx, &fleet.CertificateTemplate{
+			TeamID:                 team.ID,
+			Name:                   "test template pending",
+			CertificateAuthorityID: ca.ID,
+			SubjectName:            "CN=test-pending",
+		})
+		require.NoError(t, err)
+
+		// Insert a pending certificate template
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO host_certificate_templates
+				(host_uuid, certificate_template_id, status, operation_type, name, uuid)
+			VALUES (?, ?, ?, ?, 'test', UUID_TO_BIN(UUID(), true))`,
+			host.UUID, pendingTemplate.ID, fleet.CertificateTemplatePending, fleet.MDMOperationTypeInstall)
+		require.NoError(t, err)
+
+		_, err = ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, host.UUID, pendingTemplate.ID)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("creates challenge on first call and returns same on subsequent calls", func(t *testing.T) {
+		template, err := ds.CreateCertificateTemplate(ctx, &fleet.CertificateTemplate{
+			TeamID:                 team.ID,
+			Name:                   "test template challenge",
+			CertificateAuthorityID: ca.ID,
+			SubjectName:            "CN=test",
+		})
+		require.NoError(t, err)
+
+		// Insert a delivered certificate template WITHOUT a challenge
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO host_certificate_templates
+				(host_uuid, certificate_template_id, status, operation_type, name, uuid, fleet_challenge)
+			VALUES (?, ?, ?, ?, 'test', UUID_TO_BIN(UUID(), true), NULL)`,
+			host.UUID, template.ID, fleet.CertificateTemplateDelivered, fleet.MDMOperationTypeInstall)
+		require.NoError(t, err)
+
+		// First call should create a challenge
+		challenge, err := ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, host.UUID, template.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, challenge)
+		require.Len(t, challenge, 32) // Base64 encoded 24 bytes
+
+		// Verify challenge was stored in host_certificate_templates
+		var storedChallenge string
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &storedChallenge,
+			`SELECT fleet_challenge FROM host_certificate_templates WHERE host_uuid = ? AND certificate_template_id = ?`,
+			host.UUID, template.ID)
+		require.NoError(t, err)
+		require.Equal(t, challenge, storedChallenge)
+
+		// Verify challenge was also inserted into challenges table
+		var createdAt time.Time
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &createdAt,
+			`SELECT created_at FROM challenges WHERE challenge = ?`, challenge)
+		require.NoError(t, err)
+		require.WithinDuration(t, time.Now(), createdAt, 5*time.Second)
+
+		// Subsequent call should return the same challenge
+		challenge2, err := ds.GetOrCreateFleetChallengeForCertificateTemplate(ctx, host.UUID, template.ID)
+		require.NoError(t, err)
+		require.Equal(t, challenge, challenge2)
+
+		// Verify only one challenge exists in challenges table
+		var count int
+		err = sqlx.GetContext(ctx, ds.reader(ctx), &count,
+			`SELECT COUNT(*) FROM challenges WHERE challenge = ?`, challenge)
+		require.NoError(t, err)
+		require.Equal(t, 1, count)
+	})
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2616,7 +2616,7 @@ type Datastore interface {
 
 	// GetOrCreateFleetChallengeForCertificateTemplate ensures a fleet challenge exists for the given
 	// host and certificate template. If a challenge already exists, it returns it. If not, it creates
-	// a new one atomically. Only works for templates in 'delivered' status.
+	// a new one atomically. Only works for templates in 'delivered' status and with operation_type 'install'.
 	GetOrCreateFleetChallengeForCertificateTemplate(ctx context.Context, hostUUID string, certificateTemplateID uint) (string, error)
 
 	// GetCurrentTime gets the current time from the database

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2587,9 +2587,8 @@ type Datastore interface {
 	// If there are no pending certificate templates, then nothing is returned.
 	GetAndTransitionCertificateTemplatesToDelivering(ctx context.Context, hostUUID string) (*HostCertificateTemplatesForDelivery, error)
 
-	// TransitionCertificateTemplatesToDelivered transitions templates from 'delivering' to 'delivered'
-	// and sets the fleet_challenge for each template.
-	TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, challenges map[uint]string) error
+	// TransitionCertificateTemplatesToDelivered transitions the specified templates from 'delivering' to 'delivered'.
+	TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, templateIDs []uint) error
 
 	// RevertHostCertificateTemplatesToPending reverts specific host certificate templates from 'delivering' back to 'pending'.
 	RevertHostCertificateTemplatesToPending(ctx context.Context, hostUUID string, certificateTemplateIDs []uint) error
@@ -2614,6 +2613,11 @@ type Datastore interface {
 	// by setting status to 'pending', clearing validity fields, and generating a new UUID.
 	// The new UUID signals to the Android agent that the certificate needs renewal.
 	SetAndroidCertificateTemplatesForRenewal(ctx context.Context, templates []HostCertificateTemplateForRenewal) error
+
+	// GetOrCreateFleetChallengeForCertificateTemplate ensures a fleet challenge exists for the given
+	// host and certificate template. If a challenge already exists, it returns it. If not, it creates
+	// a new one atomically. Only works for templates in 'delivered' status.
+	GetOrCreateFleetChallengeForCertificateTemplate(ctx context.Context, hostUUID string, certificateTemplateID uint) (string, error)
 
 	// GetCurrentTime gets the current time from the database
 	GetCurrentTime(ctx context.Context) (time.Time, error)

--- a/server/mdm/android/service/profiles_test.go
+++ b/server/mdm/android/service/profiles_test.go
@@ -924,12 +924,12 @@ func testCertificateTemplates(t *testing.T, ds fleet.Datastore, client *mock.Cli
 		require.EqualValues(t, fleet.MDMOperationTypeInstall, certTemplate.Operation)
 	}
 
-	// Verify that host_certificate_template records were created with pending status
+	// Verify that host_certificate_template records were created with delivered status
 	var host1CertTemplates []struct {
-		HostUUID              string `db:"host_uuid"`
-		CertificateTemplateID uint   `db:"certificate_template_id"`
-		FleetChallenge        string `db:"fleet_challenge"`
-		Status                string `db:"status"`
+		HostUUID              string  `db:"host_uuid"`
+		CertificateTemplateID uint    `db:"certificate_template_id"`
+		FleetChallenge        *string `db:"fleet_challenge"`
+		Status                string  `db:"status"`
 	}
 	mysql.ExecAdhocSQL(t, ds.(*mysql.Datastore), func(q sqlx.ExtContext) error {
 		query := `
@@ -944,7 +944,8 @@ func testCertificateTemplates(t *testing.T, ds fleet.Datastore, client *mock.Cli
 
 	for _, hct := range host1CertTemplates {
 		require.Equal(t, host1.Host.UUID, hct.HostUUID)
-		require.NotEmpty(t, hct.FleetChallenge)
+		// Challenge is created on-demand when device fetches the certificate, so it's nil here
+		require.Nil(t, hct.FleetChallenge)
 		require.EqualValues(t, fleet.CertificateTemplateDelivered, hct.Status)
 	}
 

--- a/server/mdm/android/service/service.go
+++ b/server/mdm/android/service/service.go
@@ -1315,21 +1315,8 @@ func (svc *Service) BuildAndSendFleetAgentConfig(ctx context.Context, enterprise
 			continue
 		}
 
-		// Step 3: AMAPI succeeded - generate challenges for each newly delivering template
-		// Note: Android app may try to fetch the certificate, but status is still delivering and no challenge is generated yet.
-		// The app will retry until status turns to delivered.
-		challenges := make(map[uint]string)
-		for _, templateID := range certTemplates.DeliveringTemplateIDs {
-			challenge, err := svc.fleetDS.NewChallenge(ctx)
-			if err != nil {
-				level.Error(svc.logger).Log("msg", "failed to generate challenge", "host_uuid", hostUUID, "template_id", templateID, "err", err)
-				return ctxerr.Wrapf(ctx, err, "generate challenge for %s", hostUUID)
-			}
-			challenges[templateID] = challenge
-		}
-
-		// Step 4: Transition delivering → delivered with challenges
-		if err := svc.fleetDS.TransitionCertificateTemplatesToDelivered(ctx, hostUUID, challenges); err != nil {
+		// Step 3: Transition delivering → delivered
+		if err := svc.fleetDS.TransitionCertificateTemplatesToDelivered(ctx, hostUUID, certTemplates.DeliveringTemplateIDs); err != nil {
 			level.Error(svc.logger).Log("msg", "failed to transition to delivered", "host_uuid", hostUUID, "err", err)
 			return ctxerr.Wrap(ctx, err, "transition certificate templates to delivered")
 		}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1723,7 +1723,7 @@ type ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc func(ctx context.Co
 
 type GetAndTransitionCertificateTemplatesToDeliveringFunc func(ctx context.Context, hostUUID string) (*fleet.HostCertificateTemplatesForDelivery, error)
 
-type TransitionCertificateTemplatesToDeliveredFunc func(ctx context.Context, hostUUID string, challenges map[uint]string) error
+type TransitionCertificateTemplatesToDeliveredFunc func(ctx context.Context, hostUUID string, templateIDs []uint) error
 
 type RevertHostCertificateTemplatesToPendingFunc func(ctx context.Context, hostUUID string, certificateTemplateIDs []uint) error
 
@@ -1734,6 +1734,8 @@ type SetHostCertificateTemplatesToPendingRemoveForHostFunc func(ctx context.Cont
 type GetAndroidCertificateTemplatesForRenewalFunc func(ctx context.Context, limit int) ([]fleet.HostCertificateTemplateForRenewal, error)
 
 type SetAndroidCertificateTemplatesForRenewalFunc func(ctx context.Context, templates []fleet.HostCertificateTemplateForRenewal) error
+
+type GetOrCreateFleetChallengeForCertificateTemplateFunc func(ctx context.Context, hostUUID string, certificateTemplateID uint) (string, error)
 
 type GetCurrentTimeFunc func(ctx context.Context) (time.Time, error)
 
@@ -4315,6 +4317,9 @@ type DataStore struct {
 
 	SetAndroidCertificateTemplatesForRenewalFunc        SetAndroidCertificateTemplatesForRenewalFunc
 	SetAndroidCertificateTemplatesForRenewalFuncInvoked bool
+
+	GetOrCreateFleetChallengeForCertificateTemplateFunc        GetOrCreateFleetChallengeForCertificateTemplateFunc
+	GetOrCreateFleetChallengeForCertificateTemplateFuncInvoked bool
 
 	GetCurrentTimeFunc        GetCurrentTimeFunc
 	GetCurrentTimeFuncInvoked bool
@@ -10287,11 +10292,11 @@ func (s *DataStore) GetAndTransitionCertificateTemplatesToDelivering(ctx context
 	return s.GetAndTransitionCertificateTemplatesToDeliveringFunc(ctx, hostUUID)
 }
 
-func (s *DataStore) TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, challenges map[uint]string) error {
+func (s *DataStore) TransitionCertificateTemplatesToDelivered(ctx context.Context, hostUUID string, templateIDs []uint) error {
 	s.mu.Lock()
 	s.TransitionCertificateTemplatesToDeliveredFuncInvoked = true
 	s.mu.Unlock()
-	return s.TransitionCertificateTemplatesToDeliveredFunc(ctx, hostUUID, challenges)
+	return s.TransitionCertificateTemplatesToDeliveredFunc(ctx, hostUUID, templateIDs)
 }
 
 func (s *DataStore) RevertHostCertificateTemplatesToPending(ctx context.Context, hostUUID string, certificateTemplateIDs []uint) error {
@@ -10327,6 +10332,13 @@ func (s *DataStore) SetAndroidCertificateTemplatesForRenewal(ctx context.Context
 	s.SetAndroidCertificateTemplatesForRenewalFuncInvoked = true
 	s.mu.Unlock()
 	return s.SetAndroidCertificateTemplatesForRenewalFunc(ctx, templates)
+}
+
+func (s *DataStore) GetOrCreateFleetChallengeForCertificateTemplate(ctx context.Context, hostUUID string, certificateTemplateID uint) (string, error) {
+	s.mu.Lock()
+	s.GetOrCreateFleetChallengeForCertificateTemplateFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetOrCreateFleetChallengeForCertificateTemplateFunc(ctx, hostUUID, certificateTemplateID)
 }
 
 func (s *DataStore) GetCurrentTime(ctx context.Context) (time.Time, error) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37651

Switched to issue the SCEP fleet challenge on demand instead of ahead of time.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Android certificate enrollment failures caused by SCEP challenge expiration during offline periods, improving enrollment reliability when devices lack connectivity.

* **Improvements**
  * Certificate challenges are now generated on-demand when requested by devices, rather than pre-generated, enhancing offline enrollment support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->