### PR TITLE
Fixed unnecessary error logging when no CPE match is found

### DIFF
--- a/changes/35447-fix-cpe-translation-error-logging
+++ b/changes/35447-fix-cpe-translation-error-logging
@@ -1,0 +1,1 @@
+* Fixed unnecessary error logging when no CPE match is found for software items like VSCode extensions and JetBrains plugins.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -526,6 +526,9 @@ func CPEFromSoftware(logger log.Logger, db *sqlx.DB, software *fleet.Software, t
 
 		var result IndexedCPEItem
 		err = db.Get(&result, stm, args...)
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", nil
+		}
 		if err != nil {
 			return "", fmt.Errorf("getting CPE for: %s: %w", software.Name, err)
 		}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35447

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed unnecessary error logging when no CPE match is found for software items such as VSCode extensions and JetBrains plugins, resulting in cleaner application logs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->