### PR TITLE
Update cisco_jabber_version_transformer.go

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/external_refs/cisco_jabber_version_transformer.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/cisco_jabber_version_transformer.go
@@ -7,6 +7,6 @@ import (
 // CiscoJabberVersionTransformer sets the version to "15.2.0" which matches what osquery reports.
 // Homebrew reports a build number (e.g., "20251027035315") instead of the app version (e.g., "15.2.0").
 func CiscoJabberVersionTransformer(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {
-	app.Version = "15.2.0"
+	app.Version = "15.2.1"
 	return app, nil
 }


### PR DESCRIPTION
This pull request makes a minor update to the Cisco Jabber version transformer. The version reported by the transformer is incremented from "15.2.0" to "15.2.1" to match the latest app version.

- Updated the `CiscoJabberVersionTransformer` in `cisco_jabber_version_transformer.go` to set `app.Version` to "15.2.1" instead of "15.2.0".