### PR TITLE
Website: Update GitHub webhook reviews

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -526,7 +526,7 @@ module.exports = {
         // if(!isMainBranchFrozen && pocketOfPrNumbersUnfrozen.length > 0) {
         //   await Platform.updateOne({id: platformRecord.id}).set({currentUnfrozenGitHubPrNumbers: []});
         // }
-        if (isAutoApprovalExpected) {
+        if (isAutoApprovalExpected && issueOrPr.user.login !== 'fleet-release') {
           // [?] https://docs.github.com/en/rest/reference/pulls#create-a-review-for-a-pull-request
           await sails.helpers.http.post(`https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/reviews`, {
             event: 'APPROVE'


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/38750

Changes:
- Updated the website's GitHub webhook to not attempt to approve pull requests opened by fleet-release