### PR TITLE
Website: move attribution details to session

### DIFF
--- a/website/api/controllers/create-or-update-one-newsletter-subscription.js
+++ b/website/api/controllers/create-or-update-one-newsletter-subscription.js
@@ -50,7 +50,7 @@ module.exports = {
         psychologicalStageChangeReason = this.req.session.adAttributionString;
       }
     }
-    let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
+    let attributionDetailsOrUndefined = this.req.session.marketingAttribution;// Will be undefined if this is not set.
 
     sails.helpers.flow.build(async()=>{
       let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
@@ -59,7 +59,7 @@ module.exports = {
         description: `Subscribed to the Fleet newsletter`,
         psychologicalStage: '3 - Intrigued',
         psychologicalStageChangeReason,
-        marketingAttributionCookie: attributionCookieOrUndefined,
+        marketingAttributionInformation: attributionDetailsOrUndefined,
       });
 
       await sails.helpers.salesforce.createHistoricalEvent.with({

--- a/website/api/controllers/customers/save-billing-info-and-subscribe.js
+++ b/website/api/controllers/customers/save-billing-info-and-subscribe.js
@@ -164,14 +164,14 @@ module.exports = {
 
     let todayOn = new Date();
     let isoTimestampForDescription = todayOn.toISOString();
-    let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
+    let attributionDetailsOrUndefined = this.req.session.marketingAttribution;
 
     sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
       emailAddress: this.req.me.emailAddress,
       firstName: this.req.me.firstName,
       lastName: this.req.me.lastName,
       organization: this.req.me.organization,
-      marketingAttributionCookie: attributionCookieOrUndefined,
+      marketingAttributionInformation: attributionDetailsOrUndefined,
       contactSource: 'Website - Sign up',// Note: this is only set on new contacts.
       description: `Purchased a self-service Fleet Premium license on ${isoTimestampForDescription.split('T')[0]} for ${quoteRecord.numberOfHosts} host${quoteRecord.numberOfHosts > 1 ? 's' : ''}.`
     }).exec((err)=>{

--- a/website/api/controllers/deliver-contact-form-message.js
+++ b/website/api/controllers/deliver-contact-form-message.js
@@ -84,8 +84,8 @@ Fleet Premium subscription details:
       subject = 'New Fleet Premium customer message';
     }
 
-    // If the submitter has a marketing attribution cookie, send the details when creating/updating a contact/account/historical record.
-    let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
+    // If the submitter has a marketing attribution information set in their cookie, send the details when creating/updating a contact/account/historical record.
+    let attributionDetailsOrUndefined = this.req.session.marketingAttribution;// Will be undefined if this is not set.
     // Note: We're using sails.helpers.flow.build INSIDE of a build helper here so that errors from the Salesforce helpers do not prevent the support email from being sent.
     // This is so we can be sure the website has had time to create/update CRM records before unthread attempts creates them with no parent account record.
     sails.helpers.flow.build(async ()=>{
@@ -97,7 +97,7 @@ Fleet Premium subscription details:
           lastName: lastName,
           contactSource: 'Website - Contact forms',
           description: `Sent a contact form message: ${message}`,
-          marketingAttributionCookie: attributionCookieOrUndefined
+          marketingAttributionInformation: attributionDetailsOrUndefined
         }).intercept((err)=>{
           return new Error(`Could not create/update a contact or account. Full error: ${require('util').inspect(err)}`);
         });

--- a/website/api/controllers/deliver-talk-to-us-form-submission.js
+++ b/website/api/controllers/deliver-talk-to-us-form-submission.js
@@ -81,7 +81,7 @@ module.exports = {
     if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
       throw 'invalidEmailDomain';
     }
-    let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;
+    let attributionDetailsOrUndefined = this.req.session.marketingAttribution;// Will be undefined if this is not set.
 
     let contactInformation = {
       emailAddress: emailAddress,
@@ -91,7 +91,7 @@ module.exports = {
       primaryBuyingSituation: primaryBuyingSituation === 'security-misc' ? 'Endpoint operations - Security' : primaryBuyingSituation === 'it-misc' ? 'Endpoint operations - IT' : primaryBuyingSituation === 'it-major-mdm' ? 'Device management (MDM)' : primaryBuyingSituation === 'it-gap-filler-mdm' ? 'IT - Gap-filler MDM' : primaryBuyingSituation === 'security-vm' ? 'Vulnerability management' : undefined,
       psychologicalStage: '4 - Has use case',
       psychologicalStageChangeReason: 'Website - Contact forms',
-      marketingAttributionCookie: attributionCookieOrUndefined
+      marketingAttributionInformation: attributionDetailsOrUndefined
     };
 
     // If the user said they have 700+ hosts, Update/create a contact and account, and send them to the "Talk to us" Calendly event.

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -235,7 +235,7 @@ the account verification message.)`,
         psychologicalStageChangeReason = this.req.session.adAttributionString;
       }
     }
-    let attributionCookieOrUndefined = this.req.cookies.marketingAttribution;// Will be undefined if this is not set.
+    let attributionDetailsOrUndefined = this.req.session.marketingAttribution;// Will be undefined if this is not set.
 
     sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
       emailAddress: newEmailAddress,
@@ -244,7 +244,7 @@ the account verification message.)`,
       // organization: emailDomain,// Note: organization is not provided because we're relying on the enrichment helper to find the correct account for this person.
       contactSource: 'Website - Sign up',
       psychologicalStageChangeReason,
-      marketingAttributionCookie: attributionCookieOrUndefined
+      marketingAttributionInformation: attributionDetailsOrUndefined
     }).exec((err)=>{
       if(err){
         sails.log.warn(`Background task failed: When a user (email: ${newEmailAddress} signed up for a fleetdm.com account, a Contact and Account record could not be created/updated in the CRM.`, err);

--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -66,7 +66,7 @@ module.exports = {
       ],
     },
 
-    marketingAttributionCookie: {
+    marketingAttributionInformation: {
       type: {},
       description: 'The contents of the marketingAttribution cookie set in the requesting user\'s browser',
     }
@@ -89,7 +89,7 @@ module.exports = {
 
   },
 
-  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, jobTitle, primaryBuyingSituation, psychologicalStage, psychologicalStageChangeReason, contactSource, description, getStartedResponses, intentSignal, marketingAttributionCookie}) {
+  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, jobTitle, primaryBuyingSituation, psychologicalStage, psychologicalStageChangeReason, contactSource, description, getStartedResponses, intentSignal, marketingAttributionInformation}) {
 
     // Return undefined if we're not running in a production environment.
     if(sails.config.environment !== 'production') {
@@ -155,14 +155,11 @@ module.exports = {
     //  ╔═╗╦═╗╔═╗╔═╗╔═╗╔═╗╔═╗╔═╗  ╔╦╗╔═╗╦═╗╦╔═╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔╦╗╔╦╗╦═╗╦╔╗ ╦ ╦╔╦╗╦╔═╗╔╗╔
     //  ╠═╝╠╦╝║ ║║  ║╣ ║╣ ╚═╗╚═╗  ║║║╠═╣╠╦╝╠╩╗║╣  ║ ║║║║║ ╦  ╠═╣ ║  ║ ╠╦╝║╠╩╗║ ║ ║ ║║ ║║║║
     //  ╩  ╩╚═╚═╝╚═╝╚═╝╚═╝╚═╝╚═╝  ╩ ╩╩ ╩╩╚═╩ ╩╚═╝ ╩ ╩╝╚╝╚═╝  ╩ ╩ ╩  ╩ ╩╚═╩╚═╝╚═╝ ╩ ╩╚═╝╝╚╝
-    //  ╔═╗╔═╗╔═╗╦╔═╦╔═╗
-    //  ║  ║ ║║ ║╠╩╗║║╣
-    //  ╚═╝╚═╝╚═╝╩ ╩╩╚═╝
     let attributionDetails = undefined;// We'll do a simple falsy check of this value when we determine what variables we'll need to set (e.g., Source channel or Most recent channel)
-    if(marketingAttributionCookie) {
+    if(marketingAttributionInformation) {
       attributionDetails = {};
       // Determine if this user is "Digital" or "Organic"
-      let lowerCaseMediumValue = marketingAttributionCookie.medium ? marketingAttributionCookie.medium.toLowerCase() : '';
+      let lowerCaseMediumValue = marketingAttributionInformation.medium ? marketingAttributionInformation.medium.toLowerCase() : '';
       let sourceFriendlyNameByCodeName = {
         // "Organic" sources:
         // os: 'Organic search',
@@ -179,17 +176,17 @@ module.exports = {
 
       attributionDetails.sourceChannelDetails = sourceFriendlyNameByCodeName[lowerCaseMediumValue] ? sourceFriendlyNameByCodeName[lowerCaseMediumValue] : undefined;
 
-      attributionDetails.initialUrl = marketingAttributionCookie.initialUrl;
+      attributionDetails.initialUrl = marketingAttributionInformation.initialUrl;
 
       if(['ps', 'so', 'pm', 'cs', 'em'].includes(lowerCaseMediumValue)) {
         // If the medium is set to a "Digital" source, we'll set the (most recent/source) campaign to the utm_campaign value the user visited the website with.
-        attributionDetails.campaign = marketingAttributionCookie.campaign;
+        attributionDetails.campaign = marketingAttributionInformation.campaign;
         attributionDetails.sourceChannel = 'Digital';
       } else {
         // If no medium was provided via utm parameter, set the source channel to "Organic".
         attributionDetails.sourceChannel = 'Organic';
 
-        if(!marketingAttributionCookie.referrer || marketingAttributionCookie.referrer === 'https://fleetdm.com/') {
+        if(!marketingAttributionInformation.referrer || marketingAttributionInformation.referrer === 'https://fleetdm.com/') {
           // If no referrer is set, or the referrer is set to the Fleet website, we'll assume this user came to the website directly
           attributionDetails.sourceChannelDetails = 'Direct traffic (DT)';
           attributionDetails.campaign = 'Default-DT-Direct';
@@ -220,11 +217,11 @@ module.exports = {
             'https://www.quora.com/',
           ];
 
-          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.includes(marketingAttributionCookie.referrer)) {
+          if(REFERRER_DOMAINS_FOR_ORGANIC_SEARCH.includes(marketingAttributionInformation.referrer)) {
             // If search engine » Organic search
             attributionDetails.sourceChannelDetails = 'Organic search (OS)';
             attributionDetails.campaign = 'Default-OS-Organic';
-          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.includes(marketingAttributionCookie.referrer)) {
+          } else if(REFERRER_DOMAINS_FOR_ORGANIC_SOCIAL.includes(marketingAttributionInformation.referrer)) {
             // If social media » Organic social
             attributionDetails.sourceChannelDetails = 'Organic social (SOC)';
             attributionDetails.campaign = 'Default-SOC-Social';

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -369,7 +369,7 @@ will be disabled and/or hidden in the UI.
                       sails.log.verbose('Skipping Salesforce integration...');
                       return;
                     }
-                    let attributionCookieOrUndefined = req.cookies.marketingAttribution;// Will be undefined if this is not set.
+                    let attributionDetailsOrUndefined = req.session.marketingAttribution;// Will be undefined if this is not set.
 
                     let recordIds = await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
                       emailAddress: sanitizedUser.emailAddress,

--- a/website/api/hooks/custom/index.js
+++ b/website/api/hooks/custom/index.js
@@ -211,26 +211,19 @@ will be disabled and/or hidden in the UI.
 
             // If a user does not have a marketingAttribution dictionary set in their session , check for UTM parameters
             if(!req.session.marketingAttribution) {
-
               if(req.cookies.marketingAttribution){
-                sails.log('retrieving existing information from cookie before clearing it.');
                 // If a user previously had a marketingAttribution cookie set, we'll set it in the users session, and create a new expiresAt timestamp
                 marketingAttributionInformation = req.cookies.marketingAttribution;
                 marketingAttributionInformation.expiresAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
                 // Clear the cookie that is no longer in use (if it is set).
                 res.clearCookie('marketingAttribution');
               }
-              sails.log('setting new marketing attribution!');
               req.session.marketingAttribution = marketingAttributionInformation;
-              sails.log(req.session.marketingAttribution);
             } else {
-              sails.log('req.session.marketingAttribution exists.');
               // If the user has marketingAttribution details set in their session, we'll check the timestamp to see if the attribution details have expired.
               if(req.session.marketingAttribution.expiresAt < Date.now()) {
-                sails.log('Marketing attribution is no longer valid :)');
                 req.session.marketingAttribution = marketingAttributionInformation;
               }
-              sails.log(req.session.marketingAttribution);
             }
 
             // Check for website personalization parameter, and if valid, absorb it in the session.


### PR DESCRIPTION
Changes:
- Updated the custom hook to set attribution details in website visitors' sessions instead of a cookie
- Updated the variable name in the updateOrCreateContactAndAccount helper, and updated places where it is being used.
- 