### PR TITLE
Add IdP department labels

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -123,3 +123,4 @@ labels:
   - path: ./lib/all/labels/department-people.yml
   - path: ./lib/all/labels/department-finance.yml
   - path: ./lib/all/labels/department-product-design.yml
+  - path: ./lib/all/labels/department-product-executive.yml

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -123,4 +123,4 @@ labels:
   - path: ./lib/all/labels/department-people.yml
   - path: ./lib/all/labels/department-finance.yml
   - path: ./lib/all/labels/department-product-design.yml
-  - path: ./lib/all/labels/department-product-executive.yml
+  - path: ./lib/all/labels/department-executive.yml

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -118,3 +118,8 @@ labels:
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
   - path: ./lib/all/labels/department-information-technology.yml
   - path: ./lib/all/labels/department-sales.yml
+  - path: ./lib/all/labels/department-marketing.yml
+  - path: ./lib/all/labels/department-engineering.yml
+  - path: ./lib/all/labels/department-people.yml
+  - path: ./lib/all/labels/department-finance.yml
+  - path: ./lib/all/labels/department-product-design.yml

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -116,3 +116,5 @@ labels:
   - path: ./lib/all/labels/conditional-access-test-group.yml
   - path: ./lib/all/labels/nudge-test-devices.yml
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
+  - path: ./lib/all/labels/department-information-technology.yml
+  - path: ./lib/all/labels/department-sales.yml

--- a/it-and-security/lib/all/labels/department-engineering.yml
+++ b/it-and-security/lib/all/labels/department-engineering.yml
@@ -1,0 +1,6 @@
+- name: "Department: Engineering"
+  description: Hosts belonging to members of the Engineering department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Engineering

--- a/it-and-security/lib/all/labels/department-executive.yml
+++ b/it-and-security/lib/all/labels/department-executive.yml
@@ -1,0 +1,6 @@
+- name: "Department: Executive"
+  description: Hosts belonging to members of the Executive department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Executive

--- a/it-and-security/lib/all/labels/department-finance.yml
+++ b/it-and-security/lib/all/labels/department-finance.yml
@@ -1,0 +1,6 @@
+- name: "Department: Finance"
+  description: Hosts belonging to members of the Finance department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Finance

--- a/it-and-security/lib/all/labels/department-information-technology.yml
+++ b/it-and-security/lib/all/labels/department-information-technology.yml
@@ -1,0 +1,6 @@
+- name: "Department: Information Technology"
+  description: Hosts belonging to members of the Information Technology department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Information Technology

--- a/it-and-security/lib/all/labels/department-marketing.yml
+++ b/it-and-security/lib/all/labels/department-marketing.yml
@@ -1,0 +1,6 @@
+- name: "Department: Marketing"
+  description: Hosts belonging to members of the Marketing department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Marketing

--- a/it-and-security/lib/all/labels/department-people.yml
+++ b/it-and-security/lib/all/labels/department-people.yml
@@ -1,0 +1,6 @@
+- name: "Department: People"
+  description: Hosts belonging to members of the People department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: People

--- a/it-and-security/lib/all/labels/department-product-design.yml
+++ b/it-and-security/lib/all/labels/department-product-design.yml
@@ -1,0 +1,6 @@
+- name: "Department: Product Design"
+  description: Hosts belonging to members of the Product Design department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Product Design

--- a/it-and-security/lib/all/labels/department-sales.yml
+++ b/it-and-security/lib/all/labels/department-sales.yml
@@ -1,0 +1,6 @@
+- name: "Department: Sales"
+  description: Hosts belonging to members of the Sales department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Sales


### PR DESCRIPTION
This pull request introduces new department-based host labels to the IT and Security configuration, allowing hosts to be categorized according to the department of their end user. The main change is the addition of seven new label definitions and their inclusion in the `default.yml` configuration.

**Department label additions:**

* Updated `it-and-security/default.yml` to include references to seven new department label files, enabling department-based host categorization.

**New department label definitions:**

* Added `department-information-technology.yml` to define a label for hosts belonging to the Information Technology department.
* Added `department-sales.yml`, `department-marketing.yml`, `department-engineering.yml`, `department-people.yml`, `department-finance.yml`, and `department-product-design.yml` to define labels for hosts in Sales, Marketing, Engineering, People, Finance, and Product Design departments, respectively. [[1]](diffhunk://#diff-dd6b63c2483cf179831fd7b3192a75f25d9eadfcba8309737ce3406912df74eaR1-R6) [[2]](diffhunk://#diff-aec6aaa00d0b092d0a427d819f61a4df9c00b5ba67d8438757c5f038860697f2R1-R6) [[3]](diffhunk://#diff-060b9bf1ab3202940dadc644616890ab99bcd81e37808ec099ff29ba064687adR1-R6) [[4]](diffhunk://#diff-ef0c2b34df74cf1cd1c32165d3c88f85b29a8d67a02e2b837f2f544e02ad2573R1-R6) [[5]](diffhunk://#diff-f491ad729d54f56ac51eaa4576f2a2c8a077a16c4abe623198ed6f3b14d03004R1-R6) [[6]](diffhunk://#diff-ce077a969811b6e57400a23a7d6cb3d40b8ebd6b6733ebd4f3f1fe7558f5fe2dR1-R6)