### PR TITLE
Dogfood: Fix AWS Backup Role permissions to unblock cross-region replication

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/aws-backup.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/aws-backup.tf
@@ -20,6 +20,19 @@ data "aws_iam_policy_document" "aws_backup_policy" {
   statement {
     effect = "Allow"
     actions = [
+      "backup:StartCopyJob",
+      "backup:ListCopyJobs",
+      "backup:ListCopyJobSummaries",
+      "backup:DescribeCopyJob",
+      "backup:CopyIntoBackupVault",
+      "backup:CopyFromBackupVault"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    effect = "Allow"
+    actions = [
       "dynamodb:DescribeTable",
       "dynamodb:CreateBackup"
     ]


### PR DESCRIPTION
- Adds permissions to fix/allow cross-region replication os Aurora and S3 backups.