### PR TITLE
Fleet UI: Do not allow clicking on run script if globally disabled

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -446,7 +446,7 @@ const Advanced = ({
                     </>
                   )
                 }
-                helpText="Features that run scripts under-the-hood (e.g. software install, lock/wipe) will still be available."
+                helpText="Features that run scripts under-the-hood (e.g. software install, lock/wipe, payload-free packages) will still be available."
               >
                 Disable script execution features
               </Checkbox>

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1158,6 +1158,11 @@ describe("Host Actions Dropdown", () => {
           app: {
             isGlobalAdmin: true,
             currentUser: createMockUser(),
+            config: {
+              server_settings: {
+                scripts_disabled: false, // scriptsGloballyDisabled = false
+              },
+            },
           },
         },
       });
@@ -1176,16 +1181,20 @@ describe("Host Actions Dropdown", () => {
       );
 
       await user.click(screen.getByText("Actions"));
-
       expect(screen.getByText("Run script")).toBeInTheDocument();
     });
 
-    it("renders the Run script action as enabled when `scripts_enabled` is `null`", async () => {
+    it("renders the Run script action as enabled when scripts_enabled is null", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
             isGlobalAdmin: true,
             currentUser: createMockUser(),
+            config: {
+              server_settings: {
+                scripts_disabled: false,
+              },
+            },
           },
         },
       });
@@ -1232,6 +1241,11 @@ describe("Host Actions Dropdown", () => {
           app: {
             isGlobalAdmin: true,
             currentUser: createMockUser(),
+            config: {
+              server_settings: {
+                scripts_disabled: false,
+              },
+            },
           },
         },
       });
@@ -1256,13 +1270,51 @@ describe("Host Actions Dropdown", () => {
           ?.parentElement
       ).toHaveClass("actions-dropdown-select__option--is-disabled");
 
+      await waitFor(() => user.hover(screen.getByText("Run script")));
+      expect(
+        screen.getByText(/fleetd agent with --enable-scripts/i)
+      ).toBeInTheDocument();
+    });
+
+    it("renders the Run script action as disabled when scripts are disabled globally", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            currentUser: createMockUser(),
+            config: {
+              server_settings: {
+                scripts_disabled: true, // scriptsGloballyDisabled = true
+              },
+            },
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          isConnectedToFleetMdm
+          hostPlatform="darwin"
+          hostMdmEnrollmentStatus={null}
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
       await waitFor(() => {
         waitFor(() => {
           user.hover(screen.getByText("Run script"));
         });
 
         expect(
-          screen.getByText(/fleetd agent with --enable-scripts/i)
+          screen.getByText(
+            /Running scripts is disabled in organization settings./i
+          )
         ).toBeInTheDocument();
       });
     });

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tsx
@@ -74,6 +74,7 @@ const HostActionsDropdown = ({
     doesStoreEncryptionKey: doesStoreEncryptionKey ?? false,
     hostMdmDeviceStatus,
     hostScriptsEnabled,
+    scriptsGloballyDisabled: globalConfig?.server_settings.scripts_disabled,
     isPrimoMode: globalConfig?.partnerships?.enable_primo ?? false,
     hostMdmEnrollmentStatus,
   });

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/RunScriptModal.tsx
@@ -84,6 +84,8 @@ const RunScriptModal = ({
       generateTableColumnConfigs(
         currentUser,
         hostTeamId,
+        // 4.81+ users won't reach this modal if scripts are disabled
+        // Intentionally left disabled actions in as a safeguard
         !!config?.server_settings?.scripts_disabled,
         onClickViewScript,
         onSelectAction

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -134,7 +134,7 @@ export const generateTableColumnConfigs = (
               <TooltipWrapper
                 tipContent={
                   <div>
-                    Running scripts is disabled in organization settings
+                    Running scripts is disabled in organization settings.
                   </div>
                 }
               >


### PR DESCRIPTION
## Issue
Closes #33903 

## Description
- Better UX when user cannot click on an action that they cannot perform

## Screen recording of fix


https://github.com/user-attachments/assets/cd893d8d-d29a-4650-a07e-fe3f888d251b


## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
