### PR TITLE
Use tablewriter package in DumpTable util

### DIFF
--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"bytes"
 	"context"
 	"crypto/md5"
 	"crypto/rand"
@@ -552,23 +553,20 @@ func DumpTable(t *testing.T, q sqlx.QueryerContext, tableName string, cols ...st
 }
 
 func printDumpTable(t *testing.T, cols []string, rows [][]string) {
-	var w io.Writer = os.Stdout
-	table := tablewriter.NewWriter(w)
-	table.SetRowLine(false)
-	table.SetAutoWrapText(false)
+	writer := bytes.NewBufferString("")
+	table := tablewriter.NewWriter(writer)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
-	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoFormatHeaders(false)
+	table.SetAutoWrapText(false)
+	table.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(true)
-	// table.SetCenterSeparator(" ")
-	// table.SetColumnSeparator("")
-	// table.SetBorder(true)
-	// table.SetTablePadding("\t")
-	// table.SetNoWhiteSpace(true)
+	table.SetRowLine(false)
 
 	table.SetHeader(cols)
 	table.AppendBulk(rows)
 	table.Render()
+
+	t.Log("\n" + writer.String())
 }
 
 func generateDummyWindowsProfileContents(uuid string) fleet.MDMWindowsProfileContents {

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -553,7 +553,7 @@ func DumpTable(t *testing.T, q sqlx.QueryerContext, tableName string, cols ...st
 }
 
 func printDumpTable(t *testing.T, cols []string, rows [][]string) {
-	writer := bytes.NewBufferString("")
+	writer := bytes.NewBufferString("\n")
 	table := tablewriter.NewWriter(writer)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoFormatHeaders(false)
@@ -566,7 +566,7 @@ func printDumpTable(t *testing.T, cols []string, rows [][]string) {
 	table.AppendBulk(rows)
 	table.Render()
 
-	t.Log("\n" + writer.String())
+	t.Log(writer.String())
 }
 
 func generateDummyWindowsProfileContents(uuid string) fleet.MDMWindowsProfileContents {

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -553,7 +553,7 @@ func DumpTable(t *testing.T, q sqlx.QueryerContext, tableName string, cols ...st
 }
 
 func printDumpTable(t *testing.T, cols []string, rows [][]string) {
-	writer := bytes.NewBufferString("\n")
+	writer := bytes.NewBufferString("")
 	table := tablewriter.NewWriter(writer)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetAutoFormatHeaders(false)
@@ -566,7 +566,7 @@ func printDumpTable(t *testing.T, cols []string, rows [][]string) {
 	table.AppendBulk(rows)
 	table.Render()
 
-	t.Log(writer.String())
+	t.Logf("\n%s", writer.String())
 }
 
 func generateDummyWindowsProfileContents(uuid string) fleet.MDMWindowsProfileContents {

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -520,20 +520,18 @@ func DumpTable(t *testing.T, q sqlx.QueryerContext, tableName string, cols ...st
 	t.Logf(">> dumping table %s:", tableName)
 
 	data := [][]string{}
-	var columnNames []string
+	columns, err := rows.Columns()
+	require.NoError(t, err)
 
 	var anyDst []any
 	var strDst []sql.NullString
 	for rows.Next() {
 		if anyDst == nil {
-			cols, err := rows.Columns()
-			require.NoError(t, err)
-			anyDst = make([]any, len(cols))
-			strDst = make([]sql.NullString, len(cols))
-			for i := range cols {
+			anyDst = make([]any, len(columns))
+			strDst = make([]sql.NullString, len(columns))
+			for i := range columns {
 				anyDst[i] = &strDst[i]
 			}
-			columnNames = cols
 		}
 		require.NoError(t, rows.Scan(anyDst...))
 
@@ -549,7 +547,7 @@ func DumpTable(t *testing.T, q sqlx.QueryerContext, tableName string, cols ...st
 	}
 	require.NoError(t, rows.Err())
 
-	printDumpTable(t, columnNames, data)
+	printDumpTable(t, columns, data)
 	t.Logf("<< dumping table %s completed", tableName)
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #
Adds `olekukonko/tablewriter` to the the mysql.DumpTable testing util, for easier reading of tables with many columns.
Could potentially look worse in some situations, but in my opinion adds more clarity overall.

### Example
```
    testing_utils.go:519: >> dumping table in_house_apps:
    testing_utils.go:533: [id title_id team_id global_or_team_id filename version storage_id created_at updated_at platform bundle_identifier self_service url]
    testing_utils.go:546: 1	1	1	1	foo.ipa	1.2.3	testingtesting123	2026-01-26T19:21:19Z	2026-01-26T19:21:19Z	ipados	com.foo	0
    testing_utils.go:546: 2	2	1	1	foo.ipa	1.2.3	testingtesting123	2026-01-26T19:21:19Z	2026-01-26T19:21:19Z	ios	com.foo	0
    testing_utils.go:549: << dumping table in_house_apps completed
    testing_utils.go:519: >> dumping table software_titles:
    testing_utils.go:533: [id name source extension_for bundle_identifier additional_identifier is_kernel application_id unique_identifier upgrade_code]
    testing_utils.go:546: 1	foo	ipados_apps		com.foo	2	0	NULL	com.foo	NULL
    testing_utils.go:546: 2	foo	ios_apps		com.foo	1	0	NULL	com.foo	NULL
    testing_utils.go:549: << dumping table software_titles completed
```

```
    testing_utils.go:521: >> dumping table in_house_apps:
    testing_utils.go:569:
        +----+----------+---------+-------------------+----------+---------+-------------------+----------------------+----------------------+----------+-------------------+--------------+-----+
        | id | title_id | team_id | global_or_team_id | filename | version | storage_id        | created_at           | updated_at           | platform | bundle_identifier | self_service | url |
        +----+----------+---------+-------------------+----------+---------+-------------------+----------------------+----------------------+----------+-------------------+--------------+-----+
        | 1  | 1        | 1       | 1                 | foo.ipa  | 1.2.3   | testingtesting123 | 2026-01-26T20:36:52Z | 2026-01-26T20:36:52Z | ipados   | com.foo           | 0            |     |
        | 2  | 2        | 1       | 1                 | foo.ipa  | 1.2.3   | testingtesting123 | 2026-01-26T20:36:52Z | 2026-01-26T20:36:52Z | ios      | com.foo           | 0            |     |
        +----+----------+---------+-------------------+----------+---------+-------------------+----------------------+----------------------+----------+-------------------+--------------+-----+
    testing_utils.go:552: << dumping table in_house_apps completed
    testing_utils.go:521: >> dumping table software_titles:
    testing_utils.go:569:
        +----+------+-------------+---------------+-------------------+-----------------------+-----------+----------------+-------------------+--------------+
        | id | name | source      | extension_for | bundle_identifier | additional_identifier | is_kernel | application_id | unique_identifier | upgrade_code |
        +----+------+-------------+---------------+-------------------+-----------------------+-----------+----------------+-------------------+--------------+
        | 1  | foo  | ipados_apps |               | com.foo           | 2                     | 0         | NULL           | com.foo           | NULL         |
        | 2  | foo  | ios_apps    |               | com.foo           | 1                     | 0         | NULL           | com.foo           | NULL         |
        +----+------+-------------+---------------+-------------------+-----------------------+-----------+----------------+-------------------+--------------+
    testing_utils.go:552: << dumping table software_titles completed
```