### PR TITLE
Specify local admin account management for macOS

### DIFF
--- a/articles/roadmap-preview-january-2026.md
+++ b/articles/roadmap-preview-january-2026.md
@@ -20,7 +20,7 @@ In the next 3 months, Fleet will ship...
 
 Big opportunities that Fleet is building towards in the near future (next 180 days):
 
-- 🦾 Create and manage local admin accounts
+- 🦾 Create and manage local admin accounts on macOS
 - 🔄 Escrow and rotate macOS Recovery Lock passwords
 - ✨ Auto-install apps on iOS
 - 📱 Managed mobile app configuration


### PR DESCRIPTION
Slack thread: https://fleetdm.slack.com/archives/C02A8BRABB5/p1769463177334939?thread_ts=1769462565.832019&cid=C02A8BRABB5

Updates public roadmap to specify create and manage local admin accounts for macOS. 