### PR TITLE
Expose VPP metadata bearer token as public config, interact directly with Apple when set

### DIFF
--- a/changes/38622-vpp-metadata-api-server-config
+++ b/changes/38622-vpp-metadata-api-server-config
@@ -1,0 +1,1 @@
+* Allowed specifying an Apple Connect JWT for interacting directly with Apple APIs when retrieving VPP app metadata.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -1800,7 +1800,7 @@ func newRefreshVPPAppVersionsSchedule(
 	instanceID string,
 	ds fleet.Datastore,
 	logger kitlog.Logger,
-	vppAuth apple_apps.Authenticator,
+	vppAppsConfig apple_apps.Config,
 ) (*schedule.Schedule, error) {
 	const (
 		name            = string(fleet.CronRefreshVPPAppVersions)
@@ -1812,7 +1812,7 @@ func newRefreshVPPAppVersionsSchedule(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
 		schedule.WithJob("refresh_vpp_app_version", func(ctx context.Context) error {
-			return vpp.RefreshVersions(ctx, ds, vppAuth)
+			return vpp.RefreshVersions(ctx, ds, vppAppsConfig)
 		}),
 	)
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1217,7 +1217,7 @@ the way that the Fleet server works.
 				}
 
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-					return newRefreshVPPAppVersionsSchedule(ctx, instanceID, ds, logger, apple_apps.GetAuthenticator(ctx, ds, config.License.Key, config.MDM.AppleConnectJWT))
+					return newRefreshVPPAppVersionsSchedule(ctx, instanceID, ds, logger, apple_apps.Configure(ctx, ds, config.License.Key, config.MDM.AppleConnectJWT))
 				}); err != nil {
 					initFatal(err, "failed to register refresh vpp app versions schedule")
 				}

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1217,7 +1217,7 @@ the way that the Fleet server works.
 				}
 
 				if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
-					return newRefreshVPPAppVersionsSchedule(ctx, instanceID, ds, logger, apple_apps.GetAuthenticator(ctx, ds, config.License.Key))
+					return newRefreshVPPAppVersionsSchedule(ctx, instanceID, ds, logger, apple_apps.GetAuthenticator(ctx, ds, config.License.Key, config.MDM.AppleConnectJWT))
 				}); err != nil {
 					initFatal(err, "failed to register refresh vpp app versions schedule")
 				}

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -252,7 +252,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 	var appStoreApps []*fleet.VPPApp
 
 	if len(incomingAppleApps) > 0 {
-		apps, err := getVPPAppsMetadata(ctx, incomingAppleApps, vppToken, svc.getVPPAuthenticator(ctx))
+		apps, err := getVPPAppsMetadata(ctx, incomingAppleApps, vppToken, svc.getVPPConfig(ctx))
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "refreshing VPP app metadata")
 		}
@@ -462,7 +462,7 @@ func (svc *Service) GetAppStoreApps(ctx context.Context, teamID *uint) ([]*fleet
 		adamIDs = append(adamIDs, a.AdamID)
 	}
 
-	metadata, err := apple_apps.GetMetadata(adamIDs, vppToken, svc.getVPPAuthenticator(ctx))
+	metadata, err := apple_apps.GetMetadata(adamIDs, vppToken, svc.getVPPConfig(ctx))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "fetching VPP asset metadata")
 	}
@@ -628,7 +628,7 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 
 		asset := assets[0]
 
-		assetMetadata, err := apple_apps.GetMetadata([]string{asset.AdamID}, vppToken, svc.getVPPAuthenticator(ctx))
+		assetMetadata, err := apple_apps.GetMetadata([]string{asset.AdamID}, vppToken, svc.getVPPConfig(ctx))
 		if err != nil {
 			return 0, ctxerr.Wrap(ctx, err, "fetching VPP asset metadata")
 		}
@@ -746,11 +746,11 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 	return addedApp.TitleID, nil
 }
 
-func (svc *Service) getVPPAuthenticator(ctx context.Context) apple_apps.Authenticator {
-	return apple_apps.GetAuthenticator(ctx, svc.ds, svc.config.License.Key, svc.config.MDM.AppleConnectJWT)
+func (svc *Service) getVPPConfig(ctx context.Context) apple_apps.Config {
+	return apple_apps.Configure(ctx, svc.ds, svc.config.License.Key, svc.config.MDM.AppleConnectJWT)
 }
 
-func getVPPAppsMetadata(ctx context.Context, ids []fleet.VPPAppTeam, vppToken string, vppAuthenticator apple_apps.Authenticator) ([]*fleet.VPPApp, error) {
+func getVPPAppsMetadata(ctx context.Context, ids []fleet.VPPAppTeam, vppToken string, vppConfig apple_apps.Config) ([]*fleet.VPPApp, error) {
 	var apps []*fleet.VPPApp
 
 	// Map of adamID to platform, then to whether it's available as self-service
@@ -791,7 +791,7 @@ func getVPPAppsMetadata(ctx context.Context, ids []fleet.VPPAppTeam, vppToken st
 	for adamID := range adamIDMap {
 		adamIDs = append(adamIDs, adamID)
 	}
-	assetMetadata, err := apple_apps.GetMetadata(adamIDs, vppToken, vppAuthenticator)
+	assetMetadata, err := apple_apps.GetMetadata(adamIDs, vppToken, vppConfig)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "fetching VPP asset metadata")
 	}

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -747,7 +747,7 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, teamID *uint, appID flee
 }
 
 func (svc *Service) getVPPAuthenticator(ctx context.Context) apple_apps.Authenticator {
-	return apple_apps.GetAuthenticator(ctx, svc.ds, svc.config.License.Key)
+	return apple_apps.GetAuthenticator(ctx, svc.ds, svc.config.License.Key, svc.config.MDM.AppleConnectJWT)
 }
 
 func getVPPAppsMetadata(ctx context.Context, ids []fleet.VPPAppTeam, vppToken string, vppAuthenticator apple_apps.Authenticator) ([]*fleet.VPPApp, error) {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -765,6 +765,9 @@ type MDMConfig struct {
 	// AppleSCEPSignerAllowRenewalDays are the allowable renewal days for
 	// certificates.
 	AppleSCEPSignerAllowRenewalDays int `yaml:"apple_scep_signer_allow_renewal_days"`
+	// AppleConnectJWT is the Apple Connect JWT used to access VPP app metadata.
+	// If supplied, Fleet will contact the Apple API directly rather than checking the Fleet proxy
+	AppleConnectJWT string `yaml:"apple_vpp_app_metadata_api_bearer_token"`
 
 	// WindowsWSTEPIdentityCert is the path to the certificate used to sign
 	// WSTEP responses.
@@ -1557,6 +1560,7 @@ func (man Manager) addConfigs() {
 	man.addConfigBool("mdm.apple_enable", false, "Enable MDM Apple functionality")
 	man.addConfigInt("mdm.apple_scep_signer_validity_days", 365, "Days signed client certificates will be valid")
 	man.addConfigInt("mdm.apple_scep_signer_allow_renewal_days", 14, "Allowable renewal days for client certificates")
+	man.addConfigString("mdm.apple_vpp_app_metadata_api_bearer_token", "", "Apple Connect JWT, used for accessing VPP app metadata directly from Apple")
 	man.addConfigString("mdm.apple_scep_challenge", "", "SCEP static challenge for enrollment")
 	man.addConfigDuration("mdm.apple_dep_sync_periodicity", 1*time.Minute, "How much time to wait for DEP profile assignment")
 	man.addConfigString("mdm.windows_wstep_identity_cert", "", "Microsoft WSTEP PEM-encoded certificate path")

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1877,6 +1877,7 @@ func (man Manager) LoadConfig() FleetConfig {
 			AppleBMKeyBytes:                   man.getConfigString("mdm.apple_bm_key_bytes"),
 			AppleEnable:                       man.getConfigBool("mdm.apple_enable"),
 			AppleSCEPSignerValidityDays:       man.getConfigInt("mdm.apple_scep_signer_validity_days"),
+			AppleConnectJWT:                   man.getConfigString("mdm.apple_vpp_app_metadata_api_bearer_token"),
 			AppleSCEPSignerAllowRenewalDays:   man.getConfigInt("mdm.apple_scep_signer_allow_renewal_days"),
 			AppleSCEPChallenge:                man.getConfigString("mdm.apple_scep_challenge"),
 			AppleDEPSyncPeriodicity:           man.getConfigDuration("mdm.apple_dep_sync_periodicity"),

--- a/server/mdm/apple/apple_apps/api.go
+++ b/server/mdm/apple/apple_apps/api.go
@@ -75,6 +75,13 @@ type Config struct {
 	authenticator authenticator
 }
 
+func StubbedConfig() Config {
+	return Config{
+		baseURL:       getBaseURL(false),
+		authenticator: func(forceRenew bool) (string, error) { return "", nil },
+	}
+}
+
 // client is a package-level client (similar to http.DefaultClient) so it can
 // be reused instead of created as needed, as the internal Transport typically
 // has internal state (cached connections, etc) and it's safe for concurrent

--- a/server/mdm/apple/apple_apps/api.go
+++ b/server/mdm/apple/apple_apps/api.go
@@ -75,9 +75,9 @@ type Config struct {
 	authenticator authenticator
 }
 
-func StubbedConfig(baseURL string) Config {
+func StubbedConfig() Config {
 	return Config{
-		baseURL:       baseURL,
+		baseURL:       getBaseURL(false),
 		authenticator: func(forceRenew bool) (string, error) { return "", nil },
 	}
 }
@@ -285,14 +285,6 @@ func Configure(ctx context.Context, ds DataStore, licenseKey string, token strin
 		return Config{
 			authenticator: func(forceRenew bool) (string, error) { return token, nil },
 			baseURL:       getBaseURL(true),
-		}
-	}
-
-	// Check for dev mode override token (used in tests)
-	if devToken := dev_mode.Env("FLEET_DEV_VPP_METADATA_BEARER_TOKEN"); devToken != "" {
-		return Config{
-			authenticator: func(forceRenew bool) (string, error) { return devToken, nil },
-			baseURL:       getBaseURL(false),
 		}
 	}
 

--- a/server/mdm/apple/apple_apps/api.go
+++ b/server/mdm/apple/apple_apps/api.go
@@ -265,8 +265,7 @@ type DataStore interface {
 	fleet.AccessesMDMConfigAssets
 }
 
-func GetAuthenticator(ctx context.Context, ds DataStore, licenseKey string) Authenticator {
-	token := dev_mode.Env("FLEET_DEV_VPP_METADATA_BEARER_TOKEN")
+func GetAuthenticator(ctx context.Context, ds DataStore, licenseKey string, token string) Authenticator {
 	if token != "" {
 		return func(bool) (string, error) { return token, nil }
 	}

--- a/server/mdm/apple/apple_apps/api.go
+++ b/server/mdm/apple/apple_apps/api.go
@@ -75,9 +75,9 @@ type Config struct {
 	authenticator authenticator
 }
 
-func StubbedConfig() Config {
+func StubbedConfig(baseURL string) Config {
 	return Config{
-		baseURL:       getBaseURL(false),
+		baseURL:       baseURL,
 		authenticator: func(forceRenew bool) (string, error) { return "", nil },
 	}
 }
@@ -285,6 +285,14 @@ func Configure(ctx context.Context, ds DataStore, licenseKey string, token strin
 		return Config{
 			authenticator: func(forceRenew bool) (string, error) { return token, nil },
 			baseURL:       getBaseURL(true),
+		}
+	}
+
+	// Check for dev mode override token (used in tests)
+	if devToken := dev_mode.Env("FLEET_DEV_VPP_METADATA_BEARER_TOKEN"); devToken != "" {
+		return Config{
+			authenticator: func(forceRenew bool) (string, error) { return devToken, nil },
+			baseURL:       getBaseURL(false),
 		}
 	}
 

--- a/server/mdm/apple/vpp/refresh.go
+++ b/server/mdm/apple/vpp/refresh.go
@@ -11,7 +11,7 @@ import (
 )
 
 // RefreshVersions updatest the LatestVersion fields for the VPP apps stored in Fleet.
-func RefreshVersions(ctx context.Context, ds fleet.Datastore, vppAuthenticator apple_apps.Authenticator) error {
+func RefreshVersions(ctx context.Context, ds fleet.Datastore, vppAppsConfig apple_apps.Config) error {
 	apps, err := ds.GetAllVPPApps(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting all VPP apps")
@@ -29,7 +29,6 @@ func RefreshVersions(ctx context.Context, ds fleet.Datastore, vppAuthenticator a
 	for _, app := range apps {
 		adamIDs[app.AdamID] = struct{}{}
 		appsByAdamID[app.AdamID] = append(appsByAdamID[app.AdamID], app)
-
 	}
 	adamIDsToQuery := slices.Collect(maps.Keys(adamIDs))
 
@@ -46,7 +45,7 @@ func RefreshVersions(ctx context.Context, ds fleet.Datastore, vppAuthenticator a
 	var appsToUpdate []*fleet.VPPApp
 
 	for _, vppToken := range vppTokens {
-		meta, err := apple_apps.GetMetadata(adamIDsToQuery, vppToken.Token, vppAuthenticator)
+		meta, err := apple_apps.GetMetadata(adamIDsToQuery, vppToken.Token, vppAppsConfig)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "getting VPP app metadata from Apple API")
 		}

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -17803,7 +17803,7 @@ func (s *integrationMDMTestSuite) TestRefreshVPPAppVersions() {
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1" + t.Name())}}, http.StatusOK, &newTeamResp)
 	team := newTeamResp.Team
 
-	stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
+	stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
 
 	// Set up VPP token
 	orgName := "Fleet Device Management Inc."
@@ -17917,7 +17917,7 @@ func (s *integrationMDMTestSuite) TestRefreshVPPAppVersionsForAllPlatforms() {
 		"3": `{"id": "3", "attributes": {"name": "App 3", "platformAttributes": {"ios": {"bundleId": "b-3", "artwork": {"url": "https://example.com/images/3/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "3.0.0"}}}, "deviceFamilies": ["iphone"]}}`,
 	}
 
-	stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
+	stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
 
 	var newTeamResp teamResponse
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1" + t.Name())}}, http.StatusOK, &newTeamResp)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -180,6 +180,7 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 
 	fleetCfg := config.TestConfig()
+	fleetCfg.MDM.AppleConnectJWT = "fake-token" // skip as we test VPP auth elsewhere
 	testCert, testKey, err := apple_mdm.NewSCEPCACertKey()
 	require.NoError(s.T(), err)
 	testCertPEM := tokenpki.PEMCertificate(testCert.Raw)
@@ -706,8 +707,6 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 	s.T().Setenv("FLEET_DEV_GDMF_URL", s.appleGDMFSrv.URL)
 	s.T().Setenv("TEST_FLEETDM_API_URL", fleetdmSrv.URL)
 	s.T().Setenv("FLEET_DEV_STOKEN_AUTHENTICATED_APPS_URL", s.appleVPPProxySrv.URL)
-	// Set a static bearer token so the authenticator doesn't try to call an auth endpoint (tested elsewhere)
-	s.T().Setenv("FLEET_DEV_VPP_METADATA_BEARER_TOKEN", "test-bearer-token")
 
 	s.mockedDownloadFleetdmMeta = fleetdbase.Metadata{
 		MSIURL:           fmt.Sprintf("https://download-testing.fleetdm.com/archive/stable/%s/fleetd-base.msi", uuid.NewString()),
@@ -17803,7 +17802,7 @@ func (s *integrationMDMTestSuite) TestRefreshVPPAppVersions() {
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1" + t.Name())}}, http.StatusOK, &newTeamResp)
 	team := newTeamResp.Team
 
-	stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
+	stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
 
 	// Set up VPP token
 	orgName := "Fleet Device Management Inc."
@@ -17917,7 +17916,7 @@ func (s *integrationMDMTestSuite) TestRefreshVPPAppVersionsForAllPlatforms() {
 		"3": `{"id": "3", "attributes": {"name": "App 3", "platformAttributes": {"ios": {"bundleId": "b-3", "artwork": {"url": "https://example.com/images/3/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "3.0.0"}}}, "deviceFamilies": ["iphone"]}}`,
 	}
 
-	stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
+	stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
 
 	var newTeamResp teamResponse
 	s.DoJSON("POST", "/api/latest/fleet/teams", &createTeamRequest{TeamPayload: fleet.TeamPayload{Name: ptr.String("Team 1" + t.Name())}}, http.StatusOK, &newTeamResp)

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -2190,7 +2190,7 @@ func (s *integrationMDMTestSuite) TestVPPAppScheduledUpdates() {
 			"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "2.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
 		}
 
-		stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
+		stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
 		err = vpp.RefreshVersions(ctx, s.ds, stubbedConfig)
 		require.NoError(t, err)
 

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -2189,8 +2190,8 @@ func (s *integrationMDMTestSuite) TestVPPAppScheduledUpdates() {
 			"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "2.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
 		}
 
-		noopAuthenticator := func(bool) (string, error) { return "", nil } // authentication is tested elsewhere
-		err = vpp.RefreshVersions(ctx, s.ds, noopAuthenticator)
+		stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
+		err = vpp.RefreshVersions(ctx, s.ds, stubbedConfig)
 		require.NoError(t, err)
 
 		// Spoof the previous installation time to skip the installed-1-hour-ago filtering.
@@ -2333,7 +2334,7 @@ func (s *integrationMDMTestSuite) TestVPPAppScheduledUpdates() {
 		s.appleVPPProxySrvData = map[string]string{
 			"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "3.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
 		}
-		err = vpp.RefreshVersions(ctx, s.ds, noopAuthenticator)
+		err = vpp.RefreshVersions(ctx, s.ds, stubbedConfig)
 		require.NoError(t, err)
 
 		// Refetch, should not trigger auto-update because the app was recently updated (in the last hour).

--- a/server/service/integration_vpp_install_test.go
+++ b/server/service/integration_vpp_install_test.go
@@ -2190,7 +2190,7 @@ func (s *integrationMDMTestSuite) TestVPPAppScheduledUpdates() {
 			"1": `{"id": "1", "attributes": {"name": "App 1", "platformAttributes": {"ios": {"bundleId": "app-1", "artwork": {"url": "https://example.com/images/1/{w}x{h}.{f}"}, "latestVersionInfo": {"versionDisplay": "2.0.0"}}}, "deviceFamilies": ["iphone", "ipad"]}}`,
 		}
 
-		stubbedConfig := apple_apps.StubbedConfig() // authentication is tested elsewhere
+		stubbedConfig := apple_apps.StubbedConfig(s.appleVPPProxySrv.URL) // authentication is tested elsewhere
 		err = vpp.RefreshVersions(ctx, s.ds, stubbedConfig)
 		require.NoError(t, err)
 


### PR DESCRIPTION
Resolves #38622.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually

## New Fleet configuration settings

- [x] Setting(s) is/are explicitly excluded from GitOps