### PR TITLE
Generalize `executable_hashes` table's executable path discovery logic

### DIFF
--- a/orbit/pkg/table/executable_hashes/executable_hashes_test.go
+++ b/orbit/pkg/table/executable_hashes/executable_hashes_test.go
@@ -41,7 +41,7 @@ func TestGenerateWithExactPath(t *testing.T) {
 	// Create the actual executable binary in Contents/MacOS/
 	execPath := filepath.Join(macosDir, execName)
 	content := []byte("test file content for hashing")
-	require.NoError(t, os.WriteFile(execPath, content, 0o755))
+	require.NoError(t, os.WriteFile(execPath, content, 0o644))
 
 	h := sha256.New()
 	h.Write(content)
@@ -102,7 +102,7 @@ func TestGenerateWithWildcard(t *testing.T) {
 
 		// Create the actual executable in Contents/MacOS/
 		execPath := filepath.Join(macosDir, bundleInfo.executableName)
-		require.NoError(t, os.WriteFile(execPath, bundleInfo.content, 0o755))
+		require.NoError(t, os.WriteFile(execPath, bundleInfo.content, 0o644))
 
 		h := sha256.New()
 		h.Write(bundleInfo.content)
@@ -110,7 +110,7 @@ func TestGenerateWithWildcard(t *testing.T) {
 		expectedExecPathByBundlePath[bundlePath] = execPath
 	}
 
-	appRows, err := Generate(context.Background(), table.QueryContext{
+	rows, err := Generate(context.Background(), table.QueryContext{
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
 				Constraints: []table.Constraint{{
@@ -120,6 +120,9 @@ func TestGenerateWithWildcard(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+
 	serviceRows, err := Generate(context.Background(), table.QueryContext{
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
@@ -132,7 +135,7 @@ func TestGenerateWithWildcard(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, serviceRows, 2)
-	rows := append(appRows, serviceRows...)
+	rows = append(rows, serviceRows...)
 
 	got := make(map[string]fileInfo, 4)
 	for _, row := range rows {

--- a/orbit/pkg/table/executable_hashes/executable_hashes_test.go
+++ b/orbit/pkg/table/executable_hashes/executable_hashes_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,10 +19,29 @@ func TestGenerateWithExactPath(t *testing.T) {
 	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
-	path := filepath.Join(dir, "example.bin")
-	execPath := path
+	// Create a macOS app bundle structure
+	bundlePath := filepath.Join(dir, "Test.app")
+	contentsDir := filepath.Join(bundlePath, "Contents")
+	macosDir := filepath.Join(contentsDir, "MacOS")
+	require.NoError(t, os.MkdirAll(macosDir, 0o755))
+
+	execName := "Test"
+	// Create Info.plist with CFBundleExecutable key
+	infoPlistPath := filepath.Join(contentsDir, "Info.plist")
+	infoPlistContent := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>%s</string>
+</dict>
+</plist>`, execName)
+	require.NoError(t, os.WriteFile(infoPlistPath, []byte(infoPlistContent), 0o644))
+
+	// Create the actual executable binary in Contents/MacOS/
+	execPath := filepath.Join(macosDir, execName)
 	content := []byte("test file content for hashing")
-	require.NoError(t, os.WriteFile(path, content, 0o600))
+	require.NoError(t, os.WriteFile(execPath, content, 0o755))
 
 	h := sha256.New()
 	h.Write(content)
@@ -31,7 +51,7 @@ func TestGenerateWithExactPath(t *testing.T) {
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
 				Constraints: []table.Constraint{{
-					Expression: path,
+					Expression: bundlePath,
 					Operator:   table.OperatorEquals,
 				}},
 			},
@@ -39,7 +59,7 @@ func TestGenerateWithExactPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, path, rows[0][colPath])
+	require.Equal(t, bundlePath, rows[0][colPath])
 	require.Equal(t, execPath, rows[0][colExecPath])
 	require.Equal(t, expectedHash, rows[0][colExecHash])
 }
@@ -48,37 +68,73 @@ func TestGenerateWithWildcard(t *testing.T) {
 	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
-	testFiles := map[string][]byte{
-		"foo.bin": []byte("content of foo"),
-		"bar.bin": []byte("content of bar"),
-		"baz.bin": []byte("content of baz"),
+	testBundles := map[string]struct {
+		executableName string
+		content        []byte
+	}{
+		"Foo.app":      {"Foo", []byte("content of foo")},
+		"Bar.app":      {"Bar", []byte("content of bar")},
+		"Baz.service":  {"Baz", []byte("content of baz")},
+		"Bonk.service": {"Bonk", []byte("content of bonk")},
 	}
 
 	expectedHashByBundlePath := make(map[string]string)
+	expectedExecPathByBundlePath := make(map[string]string)
 
-	for filename, content := range testFiles {
-		path := filepath.Join(dir, filename)
-		require.NoError(t, os.WriteFile(path, content, 0o600))
+	// Create macOS app bundle structures
+	for bundleName, bundleInfo := range testBundles {
+		bundlePath := filepath.Join(dir, bundleName)
+		contentsDir := filepath.Join(bundlePath, "Contents")
+		macosDir := filepath.Join(contentsDir, "MacOS")
+		require.NoError(t, os.MkdirAll(macosDir, 0o755))
+
+		// Create Info.plist with CFBundleExecutable key
+		infoPlistPath := filepath.Join(contentsDir, "Info.plist")
+		infoPlistContent := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>%s</string>
+</dict>
+</plist>`, bundleInfo.executableName)
+		require.NoError(t, os.WriteFile(infoPlistPath, []byte(infoPlistContent), 0o644))
+
+		// Create the actual executable in Contents/MacOS/
+		execPath := filepath.Join(macosDir, bundleInfo.executableName)
+		require.NoError(t, os.WriteFile(execPath, bundleInfo.content, 0o755))
 
 		h := sha256.New()
-		h.Write(content)
-		expectedHashByBundlePath[path] = hex.EncodeToString(h.Sum(nil))
+		h.Write(bundleInfo.content)
+		expectedHashByBundlePath[bundlePath] = hex.EncodeToString(h.Sum(nil))
+		expectedExecPathByBundlePath[bundlePath] = execPath
 	}
 
-	rows, err := Generate(context.Background(), table.QueryContext{
+	appRows, err := Generate(context.Background(), table.QueryContext{
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
 				Constraints: []table.Constraint{{
-					Expression: filepath.Join(dir, "%.bin"),
+					Expression: filepath.Join(dir, "%.app"),
+					Operator:   table.OperatorLike,
+				}},
+			},
+		},
+	})
+	serviceRows, err := Generate(context.Background(), table.QueryContext{
+		Constraints: map[string]table.ConstraintList{
+			colPath: {
+				Constraints: []table.Constraint{{
+					Expression: filepath.Join(dir, "%.service"),
 					Operator:   table.OperatorLike,
 				}},
 			},
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, rows, len(testFiles))
+	require.Len(t, serviceRows, 2)
+	rows := append(appRows, serviceRows...)
 
-	got := make(map[string]fileInfo, len(rows))
+	got := make(map[string]fileInfo, 4)
 	for _, row := range rows {
 		got[row[colPath]] = fileInfo{
 			Path:       row[colPath],
@@ -87,11 +143,11 @@ func TestGenerateWithWildcard(t *testing.T) {
 		}
 	}
 
-	for path, expectedHash := range expectedHashByBundlePath {
-		require.Contains(t, got, path)
-		info := got[path]
-		require.Equal(t, path, info.Path)
-		require.Equal(t, path, info.ExecPath)
+	for bundlePath, expectedHash := range expectedHashByBundlePath {
+		require.Contains(t, got, bundlePath)
+		info := got[bundlePath]
+		require.Equal(t, bundlePath, info.Path)
+		require.Equal(t, expectedExecPathByBundlePath[bundlePath], info.ExecPath)
 		require.Equal(t, expectedHash, info.ExecSha256)
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #[38885](https://github.com/fleetdm/fleet/issues/38885) 

- Also removes current "get the sha256 of a binary path directly" functionality from the table as well, so it is now strictly for getting the executable hashes for application bundles with the `/Contents/Info.plist` > `CFBundleExecutable` and `/Contents/MacOS/<executable>` structure

Hash and path ingested and served for `Spotlight.service`:
<img width="1590" height="782" alt="Screenshot 2026-01-26 at 11 11 16 PM" src="https://github.com/user-attachments/assets/788ed139-c50a-49f6-84dc-6236c21b0aa9" />
<img width="1590" height="297" alt="Screenshot 2026-01-26 at 11 10 17 PM" src="https://github.com/user-attachments/assets/a3270e6c-a0e2-4d17-ad05-98d61f2213a7" />


- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results


## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes