### PR TITLE
Show error reason when trying to create a label that conflicts with a built-in label name

### DIFF
--- a/changes/37146-create-builtin-label-error-msg
+++ b/changes/37146-create-builtin-label-error-msg
@@ -1,0 +1,1 @@
+- Show error reason when trying to create a label that conflicts with a built-in label name

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -31,6 +31,7 @@ import {
 } from "interfaces/label";
 import { IHost } from "interfaces/host";
 import { IInputFieldParseTarget } from "interfaces/form_field";
+import { getErrorReason } from "interfaces/errors";
 
 import SidePanelPage from "components/SidePanelPage";
 import MainContent from "components/MainContent";
@@ -322,12 +323,17 @@ const NewLabelPage = ({
       router.push(PATHS.MANAGE_LABELS);
       renderFlash("success", "Label added successfully.");
     } catch (error) {
-      renderFlash(
-        "error",
-        (error as { status: number }).status === 409
-          ? "A label with this name already exists."
-          : "Couldn't add label. Please try again."
-      );
+      const status = (error as { status: number }).status;
+      let errorMessage = "Couldn't add label. Please try again.";
+      if (status === 409) {
+        errorMessage = "A label with this name already exists.";
+      } else if (status === 422) {
+        const reason = getErrorReason(error);
+        if (reason) {
+          errorMessage = `Couldn't add label: ${reason}. Please try again.`;
+        }
+      }
+      renderFlash("error", errorMessage);
     }
     setIsUpdating(false);
   };


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37146

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<img width="1898" height="1159" alt="Screenshot 2026-01-27 at 9 51 24 AM" src="https://github.com/user-attachments/assets/8f0f122f-5dbe-456d-bee6-fb60771260e0" />
