### PR TITLE
Unfinished Entra integration setup breaks UI

### DIFF
--- a/changes/38582-settings-integration-unfinish-setup-breaks-ui
+++ b/changes/38582-settings-integration-unfinish-setup-breaks-ui
@@ -1,0 +1,1 @@
+* Fixed bug where unfinished Entra Integration setup breaks the UI.

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -261,6 +261,11 @@ const ConditionalAccess = () => {
       return;
     }
 
+    // Don't override the error state if configuration is not done yet
+    if (entraPhase === EntraPhase.ConfirmationError && !entraConfigured) {
+      return;
+    }
+
     // Don't override if we just successfully confirmed (phase is Configured but config not yet updated)
     // However, if the tenant ID is removed (deleted), we should still update to NotConfigured
     if (

--- a/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ConditionalAccess/ConditionalAccess.tsx
@@ -158,7 +158,7 @@ enum EntraPhase {
   ConfirmationError = "confirmation-error",
   AwaitingOAuth = "awaiting-oauth",
   Configured = "configured",
-  ConsentFailed = "consent-failed",
+  ConsentMissing = "consent-missing",
 }
 
 const ConditionalAccess = () => {
@@ -198,7 +198,7 @@ const ConditionalAccess = () => {
           "Successfully verified Microsoft Entra conditional access integration"
         );
       } else {
-        setEntraPhase(EntraPhase.ConsentFailed);
+        setEntraPhase(EntraPhase.ConsentMissing);
         if (
           // IT admin did not complete the consent.
           !setup_error ||
@@ -259,7 +259,7 @@ const ConditionalAccess = () => {
     const finalStates = [
       EntraPhase.AwaitingOAuth, // Don't check config if we're in AwaitingOAuth phase
       EntraPhase.ConfirmationError, // Don't do confirm call if we are in a final error state
-      EntraPhase.ConsentFailed, // Don't do confirm call if after tenant ID provided, something went wrong
+      EntraPhase.ConsentMissing, // Don't do confirm call if after tenant ID provided, something went wrong
     ];
 
     if (finalStates.includes(entraPhase)) {
@@ -356,18 +356,25 @@ const ConditionalAccess = () => {
   };
 
   const renderEntraContent = () => {
-    if (entraPhase === EntraPhase.ConfirmingConfigured) {
-      return (
-        <SectionCard header="Microsoft Entra">
-          <Spinner />
-        </SectionCard>
-      );
-    }
-
     if (entraPhase === EntraPhase.ConfirmationError) {
       return (
         <SectionCard header="Microsoft Entra">
           <DataError />
+        </SectionCard>
+      );
+    }
+
+    if (entraPhase === EntraPhase.ConfirmingConfigured) {
+      return (
+        <SectionCard
+          header="Microsoft Entra"
+          cta={
+            <Button isLoading disabled>
+              Connect
+            </Button>
+          }
+        >
+          Please wait until Microsoft Entra configuration is confirmed.
         </SectionCard>
       );
     }

--- a/server/service/conditional_access_microsoft.go
+++ b/server/service/conditional_access_microsoft.go
@@ -134,7 +134,7 @@ func (svc *Service) ConditionalAccessMicrosoftConfirm(ctx context.Context) (conf
 	getResponse, err := svc.conditionalAccessMicrosoftProxy.Get(ctx, integration.TenantID, integration.ProxyServerSecret)
 	if err != nil {
 		level.Error(svc.logger).Log("msg", "failed to get integration settings from proxy", "err", err)
-		return false, "", &fleet.BadRequestError{Message: "failed to get integration settings from proxy"}
+		return false, "", nil
 	}
 
 	if !getResponse.SetupDone {

--- a/server/service/conditional_access_microsoft.go
+++ b/server/service/conditional_access_microsoft.go
@@ -3,13 +3,10 @@ package service
 import (
 	"context"
 	"errors"
-	"time"
 
-	"github.com/fleetdm/fleet/v4/pkg/retry"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
 	"github.com/go-kit/log/level"
 )
 
@@ -17,11 +14,6 @@ type conditionalAccessMicrosoftCreateRequest struct {
 	// MicrosoftTenantID holds the Entra tenant ID.
 	MicrosoftTenantID string `json:"microsoft_tenant_id"`
 }
-
-const (
-	microsoftProxyGetMaxAttempts = 3
-	microsoftProxyGetRetryDelay  = 200 * time.Millisecond
-)
 
 type conditionalAccessMicrosoftCreateResponse struct {
 	// MicrosoftAuthenticationURL holds the URL to redirect the admin to consent access
@@ -62,7 +54,7 @@ func (svc *Service) ConditionalAccessMicrosoftCreateIntegration(ctx context.Cont
 	case existingIntegration != nil && existingIntegration.TenantID == tenantID:
 		// Nothing to do, integration with same tenant ID has already been created.
 		// Retrieve settings of the integration to get the admin consent URL.
-		getResponse, err := svc.conditionalAccessMicrosoftProxyGetWithRetry(ctx, existingIntegration.TenantID, existingIntegration.ProxyServerSecret)
+		getResponse, err := svc.conditionalAccessMicrosoftProxy.Get(ctx, existingIntegration.TenantID, existingIntegration.ProxyServerSecret)
 		if err != nil {
 			return "", ctxerr.Wrap(ctx, err, "failed to get the integration settings")
 		}
@@ -89,7 +81,8 @@ func (svc *Service) ConditionalAccessMicrosoftCreateIntegration(ctx context.Cont
 	}
 
 	// Retrieve settings of the integration to get the admin consent URL.
-	getResponse, err := svc.conditionalAccessMicrosoftProxyGetWithRetry(ctx, proxyCreateResponse.TenantID, proxyCreateResponse.Secret)
+	getResponse, err := svc.conditionalAccessMicrosoftProxy.Get(ctx, proxyCreateResponse.TenantID, proxyCreateResponse.Secret)
+
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "failed to get the integration settings")
 	}
@@ -138,7 +131,7 @@ func (svc *Service) ConditionalAccessMicrosoftConfirm(ctx context.Context) (conf
 		return true, "", nil
 	}
 
-	getResponse, err := svc.conditionalAccessMicrosoftProxyGetWithRetry(ctx, integration.TenantID, integration.ProxyServerSecret)
+	getResponse, err := svc.conditionalAccessMicrosoftProxy.Get(ctx, integration.TenantID, integration.ProxyServerSecret)
 	if err != nil {
 		level.Error(svc.logger).Log("msg", "failed to get integration settings from proxy", "err", err)
 		return false, "", &fleet.BadRequestError{Message: "failed to get integration settings from proxy"}
@@ -253,33 +246,4 @@ func (svc *Service) ConditionalAccessMicrosoftGet(ctx context.Context) (*fleet.C
 	}
 
 	return integration, nil
-}
-
-func (svc *Service) conditionalAccessMicrosoftProxyGetWithRetry(
-	ctx context.Context,
-	tenantID string,
-	secret string,
-) (*conditional_access_microsoft_proxy.GetResponse, error) {
-	var response *conditional_access_microsoft_proxy.GetResponse
-	err := retry.Do(func() error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		var err error
-		response, err = svc.conditionalAccessMicrosoftProxy.Get(ctx, tenantID, secret)
-		return err
-	},
-		retry.WithMaxAttempts(microsoftProxyGetMaxAttempts),
-		retry.WithInterval(microsoftProxyGetRetryDelay),
-		retry.WithErrorFilter(func(err error) retry.ErrorOutcome {
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return retry.ErrorOutcomeDoNotRetry
-			}
-			return retry.ErrorOutcomeNormalRetry
-		}),
-	)
-	if err != nil {
-		return nil, err
-	}
-	return response, nil
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38582 

* Added retry logic when trying to get settings from MS Proxy on Entra settings confirm end-point. If retries fail, return error to front end.
* Updated front end to prevent `entraPhase` state to be overwritten over and over again by useQuery + useEffect.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually