### PR TITLE
Fixed CVE false positive on ninxsoft/Mist.

### DIFF
--- a/changes/37111-ninxsoft-mist-cve
+++ b/changes/37111-ninxsoft-mist-cve
@@ -1,0 +1,1 @@
+Fixed CVE false positive on ninxsoft/Mist.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -444,6 +444,17 @@ var (
 				s.Name = "integrative-modeling-platform"
 			},
 		},
+		{
+			// ninxsoft/Mist (macOS installer download tool) is incorrectly matched against
+			// mist.io/Mist CPEs. Rename the app to prevent incorrect CPE matching with mist:mist.
+			// See https://github.com/fleetdm/fleet/issues/37111
+			matches: func(s *fleet.Software) bool {
+				return s.BundleIdentifier == "com.ninxsoft.mist" && s.Source == "apps"
+			},
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				s.Name = "ninxsoft-mist"
+			},
+		},
 	}
 )
 

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -2428,6 +2428,21 @@ func TestMutateSoftware(t *testing.T) {
 				Source:  "homebrew_packages",
 			},
 		},
+		{
+			name: "ninxsoft Mist (macOS installer download tool)",
+			s: &fleet.Software{
+				Name:             "Mist",
+				Version:          "0.30",
+				Source:           "apps",
+				BundleIdentifier: "com.ninxsoft.mist",
+			},
+			sanitized: &fleet.Software{
+				Name:             "ninxsoft-mist",
+				Version:          "0.30",
+				Source:           "apps",
+				BundleIdentifier: "com.ninxsoft.mist",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NotPanics(t, func() { mutateSoftware(tc.s, log.NewNopLogger()) })


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37111

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive CVE detection for ninxsoft Mist, preventing incorrect matching against unrelated vulnerability records.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->