### PR TITLE
to `fleetd` RC: Generalize `executable_hashes` table's executable path discovery logi…

### DIFF
--- a/orbit/pkg/table/executable_hashes/executable_hashes_test.go
+++ b/orbit/pkg/table/executable_hashes/executable_hashes_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,10 +19,29 @@ func TestGenerateWithExactPath(t *testing.T) {
 	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
-	path := filepath.Join(dir, "example.bin")
-	execPath := path
+	// Create a macOS app bundle structure
+	bundlePath := filepath.Join(dir, "Test.app")
+	contentsDir := filepath.Join(bundlePath, "Contents")
+	macosDir := filepath.Join(contentsDir, "MacOS")
+	require.NoError(t, os.MkdirAll(macosDir, 0o755))
+
+	execName := "Test"
+	// Create Info.plist with CFBundleExecutable key
+	infoPlistPath := filepath.Join(contentsDir, "Info.plist")
+	infoPlistContent := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>%s</string>
+</dict>
+</plist>`, execName)
+	require.NoError(t, os.WriteFile(infoPlistPath, []byte(infoPlistContent), 0o644))
+
+	// Create the actual executable binary in Contents/MacOS/
+	execPath := filepath.Join(macosDir, execName)
 	content := []byte("test file content for hashing")
-	require.NoError(t, os.WriteFile(path, content, 0o600))
+	require.NoError(t, os.WriteFile(execPath, content, 0o644))
 
 	h := sha256.New()
 	h.Write(content)
@@ -31,7 +51,7 @@ func TestGenerateWithExactPath(t *testing.T) {
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
 				Constraints: []table.Constraint{{
-					Expression: path,
+					Expression: bundlePath,
 					Operator:   table.OperatorEquals,
 				}},
 			},
@@ -39,7 +59,7 @@ func TestGenerateWithExactPath(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Len(t, rows, 1)
-	require.Equal(t, path, rows[0][colPath])
+	require.Equal(t, bundlePath, rows[0][colPath])
 	require.Equal(t, execPath, rows[0][colExecPath])
 	require.Equal(t, expectedHash, rows[0][colExecHash])
 }
@@ -48,37 +68,76 @@ func TestGenerateWithWildcard(t *testing.T) {
 	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
-	testFiles := map[string][]byte{
-		"foo.bin": []byte("content of foo"),
-		"bar.bin": []byte("content of bar"),
-		"baz.bin": []byte("content of baz"),
+	testBundles := map[string]struct {
+		executableName string
+		content        []byte
+	}{
+		"Foo.app":      {"Foo", []byte("content of foo")},
+		"Bar.app":      {"Bar", []byte("content of bar")},
+		"Baz.service":  {"Baz", []byte("content of baz")},
+		"Bonk.service": {"Bonk", []byte("content of bonk")},
 	}
 
 	expectedHashByBundlePath := make(map[string]string)
+	expectedExecPathByBundlePath := make(map[string]string)
 
-	for filename, content := range testFiles {
-		path := filepath.Join(dir, filename)
-		require.NoError(t, os.WriteFile(path, content, 0o600))
+	// Create macOS app bundle structures
+	for bundleName, bundleInfo := range testBundles {
+		bundlePath := filepath.Join(dir, bundleName)
+		contentsDir := filepath.Join(bundlePath, "Contents")
+		macosDir := filepath.Join(contentsDir, "MacOS")
+		require.NoError(t, os.MkdirAll(macosDir, 0o755))
+
+		// Create Info.plist with CFBundleExecutable key
+		infoPlistPath := filepath.Join(contentsDir, "Info.plist")
+		infoPlistContent := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleExecutable</key>
+	<string>%s</string>
+</dict>
+</plist>`, bundleInfo.executableName)
+		require.NoError(t, os.WriteFile(infoPlistPath, []byte(infoPlistContent), 0o644))
+
+		// Create the actual executable in Contents/MacOS/
+		execPath := filepath.Join(macosDir, bundleInfo.executableName)
+		require.NoError(t, os.WriteFile(execPath, bundleInfo.content, 0o644))
 
 		h := sha256.New()
-		h.Write(content)
-		expectedHashByBundlePath[path] = hex.EncodeToString(h.Sum(nil))
+		h.Write(bundleInfo.content)
+		expectedHashByBundlePath[bundlePath] = hex.EncodeToString(h.Sum(nil))
+		expectedExecPathByBundlePath[bundlePath] = execPath
 	}
 
 	rows, err := Generate(context.Background(), table.QueryContext{
 		Constraints: map[string]table.ConstraintList{
 			colPath: {
 				Constraints: []table.Constraint{{
-					Expression: filepath.Join(dir, "%.bin"),
+					Expression: filepath.Join(dir, "%.app"),
 					Operator:   table.OperatorLike,
 				}},
 			},
 		},
 	})
 	require.NoError(t, err)
-	require.Len(t, rows, len(testFiles))
+	require.Len(t, rows, 2)
 
-	got := make(map[string]fileInfo, len(rows))
+	serviceRows, err := Generate(context.Background(), table.QueryContext{
+		Constraints: map[string]table.ConstraintList{
+			colPath: {
+				Constraints: []table.Constraint{{
+					Expression: filepath.Join(dir, "%.service"),
+					Operator:   table.OperatorLike,
+				}},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, serviceRows, 2)
+	rows = append(rows, serviceRows...)
+
+	got := make(map[string]fileInfo, 4)
 	for _, row := range rows {
 		got[row[colPath]] = fileInfo{
 			Path:       row[colPath],
@@ -87,11 +146,11 @@ func TestGenerateWithWildcard(t *testing.T) {
 		}
 	}
 
-	for path, expectedHash := range expectedHashByBundlePath {
-		require.Contains(t, got, path)
-		info := got[path]
-		require.Equal(t, path, info.Path)
-		require.Equal(t, path, info.ExecPath)
+	for bundlePath, expectedHash := range expectedHashByBundlePath {
+		require.Contains(t, got, bundlePath)
+		info := got[bundlePath]
+		require.Equal(t, bundlePath, info.Path)
+		require.Equal(t, expectedExecPathByBundlePath[bundlePath], info.ExecPath)
 		require.Equal(t, expectedHash, info.ExecSha256)
 	}
 }


### PR DESCRIPTION
See #38827 