### PR TITLE
Fixed Safari cve false positives

### DIFF
--- a/changes/35194-safari-cve-false-positives
+++ b/changes/35194-safari-cve-false-positives
@@ -1,0 +1,1 @@
+* Fixed false positives for Safari CVE-2023-28205

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -374,6 +374,24 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:apple:safari:16.4.1:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:apple:safari:16.5:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:apple:safari:16.6:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
 		"cpe:2.3:a:apple:safari:15.6.1:*:*:*:*:macos:*:*": {
 			excludedCVEs: []string{
 				"CVE-2023-28205",
@@ -724,43 +742,64 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		},
 		{
 			platform: "darwin",
-			version:  "13.3.1",
+			version:  "13.3",
 			osID:     5,
+			// macOS Ventura 13.3.0 is vulnerable (< 13.3.1)
+			includedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "13.3.1",
+			osID:     6,
 			// macOS Ventura 13.3.1 includes system-level WebKit patch for CVE-2023-28205
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 		{
 			platform: "darwin",
+			version:  "13.4",
+			osID:     7,
+			// macOS Ventura 13.4 is patched (>= 13.3.1)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "13.5",
+			osID:     8,
+			// macOS Ventura 13.5 is patched (>= 13.3.1)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
 			version:  "12.7.6",
-			osID:     6,
+			osID:     9,
 			// macOS Monterey 12.7.6 did NOT receive system-level fix (rely on Safari matching)
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 		{
 			platform: "darwin",
 			version:  "12.6.5",
-			osID:     7,
+			osID:     10,
 			// macOS Monterey 12.6.5 did NOT fix CVE-2023-28205 (only fixed CVE-2023-28206)
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 		{
 			platform: "darwin",
 			version:  "11.7.10",
-			osID:     8,
+			osID:     11,
 			// macOS Big Sur 11.7.10 did NOT receive system-level fix (rely on Safari matching)
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 		{
 			platform: "darwin",
 			version:  "11.7.6",
-			osID:     9,
+			osID:     12,
 			// macOS Big Sur 11.7.6 did NOT fix CVE-2023-28205 (only fixed CVE-2023-28206)
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 		{
 			platform: "darwin",
 			version:  "10.15.7",
-			osID:     10,
+			osID:     13,
 			// macOS Catalina (10.x) should NOT match CVE-2023-28205 (pre-Big Sur)
 			excludedCVEs: []string{"CVE-2023-28205"},
 		},

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -368,6 +368,30 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			},
 			continuesToUpdate: true,
 		},
+		"cpe:2.3:a:apple:safari:16.2:*:*:*:*:macos:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2023-28205", resolvedInVersion: "16.4.1"},
+			},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:apple:safari:15.6.1:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:apple:safari:14.1.2:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
+		"cpe:2.3:a:apple:safari:13.1.3:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{
+				"CVE-2023-28205",
+			},
+			continuesToUpdate: true,
+		},
 		"cpe:2.3:a:microsoft:365_apps:16.0.17628.20144:*:*:*:*:windows:*:*": {
 			includedCVEs: []cve{
 				{ID: "CVE-2024-21402"},
@@ -690,6 +714,55 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			osID:     3,
 			// This was resolved in 15.3, so it should be excluded. See https://github.com/fleetdm/fleet/issues/26561.
 			excludedCVEs: []string{"CVE-2025-24176"},
+		},
+		{
+			platform: "darwin",
+			version:  "13.2",
+			osID:     4,
+			// macOS Ventura 13.2 < 13.3.1 is vulnerable to CVE-2023-28205
+			includedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "13.3.1",
+			osID:     5,
+			// macOS Ventura 13.3.1 includes system-level WebKit patch for CVE-2023-28205
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "12.7.6",
+			osID:     6,
+			// macOS Monterey 12.7.6 did NOT receive system-level fix (rely on Safari matching)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "12.6.5",
+			osID:     7,
+			// macOS Monterey 12.6.5 did NOT fix CVE-2023-28205 (only fixed CVE-2023-28206)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "11.7.10",
+			osID:     8,
+			// macOS Big Sur 11.7.10 did NOT receive system-level fix (rely on Safari matching)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "11.7.6",
+			osID:     9,
+			// macOS Big Sur 11.7.6 did NOT fix CVE-2023-28205 (only fixed CVE-2023-28206)
+			excludedCVEs: []string{"CVE-2023-28205"},
+		},
+		{
+			platform: "darwin",
+			version:  "10.15.7",
+			osID:     10,
+			// macOS Catalina (10.x) should NOT match CVE-2023-28205 (pre-Big Sur)
+			excludedCVEs: []string{"CVE-2023-28205"},
 		},
 	}
 


### PR DESCRIPTION
**Related issue:** Resolves #35194

The NVD database for CVE-2023-28205 contains two broad CPE match rules:
Safari: Any version < 16.4.1 is vulnerable
macOS: Any version < 13.3.1 is vulnerable

The problem is Safari versions 13.x, 14.x, and 15.x were never actually vulnerable to this CVE and macOS versions 10.x, 11.x, and 12.x never received a system-level fix for this CVE. 

Apple fixed the cve in two ways
1. Safari 16.4.1 standalone update
2. macOS Ventura 13.3.1 system update fix at the OS level

This is why there is such a complicated `IgnoreIf` for the `CPEMatchingRule`.

If some of the following don't apply, delete the relevant line.
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved accuracy of Safari CVE-2023-28205 vulnerability detection with version-specific filtering for Safari 16.0-16.4.0 and macOS Ventura.

* **Tests**
  * Added comprehensive test coverage for CVE-2023-28205 across multiple Safari versions and macOS releases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->