### PR TITLE
fleetd chrome 1.3.5 release

### DIFF
--- a/ee/fleetd-chrome/CHANGELOG.md
+++ b/ee/fleetd-chrome/CHANGELOG.md
@@ -1,3 +1,7 @@
+## fleetd-chrome 1.3.5 (Jan 27, 2026)
+
+* Updated inquirer dependency version to resolve vulnerabilities
+
 ## fleetd-chrome 1.3.3 (August 8, 2025)
 
 * Fixed a bug which caused fleetd-chrome to fail enrollment.

--- a/ee/fleetd-chrome/CHANGELOG.md
+++ b/ee/fleetd-chrome/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## fleetd-chrome 1.3.5 (Jan 27, 2026)
 
-* Updated inquirer dependency version to resolve vulnerabilities
+* Updated Lodash dependency version to resolve vulnerabilities.
+
+## fleetd-chrome 1.3.4 (Jan 23, 2026)
+
+* Updated inquirer dependency version to resolve vulnerabilities.
 
 ## fleetd-chrome 1.3.3 (August 8, 2025)
 

--- a/ee/fleetd-chrome/changes/inquirer
+++ b/ee/fleetd-chrome/changes/inquirer
@@ -1,1 +1,0 @@
-* Updated inquirer dependency version to resolve vulnerabilities

--- a/ee/fleetd-chrome/package-lock.json
+++ b/ee/fleetd-chrome/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fleetd-for-chrome",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fleetd-for-chrome",
-      "version": "1.3.3",
+      "version": "1.3.5",
       "dependencies": {
         "async-mutex": "^0.5.0",
         "dotenv": "^16.0.3",

--- a/ee/fleetd-chrome/package.json
+++ b/ee/fleetd-chrome/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fleetd-for-chrome",
   "description": "Extension for Fleetd on ChromeOS",
-  "version": "1.3.3",
+  "version": "1.3.5",
   "dependencies": {
     "async-mutex": "^0.5.0",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
# Details

v1.3.5 release of Chrome extension, including dependency fixes. v1.3.4 went to beta but will go unreleased since another dependency update came in right after it, so just skipping ahead to v1.3.5.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually
 - No functional changes, but did smoke tests on a Chromebook 👍 
