### PR TITLE
Dynamic SCEP Challenges For Okta Certs

### DIFF
--- a/changes/34521-dynamic-scep-challenges-for-okta-certs
+++ b/changes/34521-dynamic-scep-challenges-for-okta-certs
@@ -1,1 +1,1 @@
-* Supported dunamic scep challenges for Okta certs in the UI
+* Supported dynamic scep challenges for Okta certs in the UI

--- a/changes/34521-dynamic-scep-challenges-for-okta-certs
+++ b/changes/34521-dynamic-scep-challenges-for-okta-certs
@@ -1,0 +1,1 @@
+* Supported dunamic scep challenges for Okta certs in the UI

--- a/frontend/interfaces/certificates.ts
+++ b/frontend/interfaces/certificates.ts
@@ -178,3 +178,38 @@ export const isCustomESTCertAuthority = (
     "password" in integration
   );
 };
+
+export const createMockCertificateAuthorities = (): ICertificateAuthorityPartial[] => {
+  return [
+    {
+      id: 1,
+      name: "Test NDES SCEP Proxy",
+      type: "ndes_scep_proxy",
+    },
+    {
+      id: 2,
+      name: "Test DigiCert",
+      type: "digicert",
+    },
+    {
+      id: 3,
+      name: "Test Custom SCEP Proxy",
+      type: "custom_scep_proxy",
+    },
+    {
+      id: 4,
+      name: "Test Hydrant",
+      type: "hydrant",
+    },
+    {
+      id: 5,
+      name: "Test Smallstep",
+      type: "smallstep",
+    },
+    {
+      id: 6,
+      name: "Test Custom EST Proxy",
+      type: "custom_est_proxy",
+    },
+  ];
+};

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
@@ -12,9 +12,7 @@ describe("AddCertAuthorityModal", () => {
   it("renders the Custom EST form by default", () => {
     render(<AddCertAuthorityModal certAuthorities={[]} onExit={noop} />);
 
-    expect(
-      screen.getByText("Custom EST (Enrollment Over Secure Transport)")
-    ).toBeVisible();
+    expect(screen.getByText(CA_LABEL_BY_TYPE.custom_est_proxy)).toBeVisible();
     expect(screen.getByLabelText("Name")).toBeVisible();
     expect(screen.getByLabelText("URL")).toBeVisible();
     expect(screen.getByLabelText("Username")).toBeVisible();
@@ -30,7 +28,7 @@ describe("AddCertAuthorityModal", () => {
     await user.click(screen.getByRole("combobox"));
     await user.click(
       screen.getByRole("option", {
-        name: "Custom SCEP (Simple Certificate Enrollment Protocol)",
+        name: CA_LABEL_BY_TYPE.custom_scep_proxy,
       })
     );
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
@@ -6,6 +6,7 @@ import { createMockCertificateAuthorityPartial } from "__mocks__/certificatesMoc
 import { renderWithSetup } from "test/test-utils";
 
 import AddCertAuthorityModal from "./AddCertAuthorityModal";
+import { CA_LABEL_BY_TYPE } from "./helpers";
 
 describe("AddCertAuthorityModal", () => {
   it("renders the Custom EST form by default", () => {
@@ -53,7 +54,7 @@ describe("AddCertAuthorityModal", () => {
     await user.click(screen.getByRole("combobox"));
     expect(
       screen.queryByRole("option", {
-        name: "Microsoft NDES (Network Device Enrollment Service)",
+        name: CA_LABEL_BY_TYPE.ndes_scep_proxy,
       })
     ).toBeNull();
   });

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/AddCertAuthorityModal.tests.tsx
@@ -6,7 +6,7 @@ import { createMockCertificateAuthorityPartial } from "__mocks__/certificatesMoc
 import { renderWithSetup } from "test/test-utils";
 
 import AddCertAuthorityModal from "./AddCertAuthorityModal";
-import { CA_LABEL_BY_TYPE } from "./helpers";
+import CA_LABEL_BY_TYPE from "../helpers";
 
 describe("AddCertAuthorityModal", () => {
   it("renders the Custom EST form by default", () => {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -15,16 +15,8 @@ import { ICustomSCEPFormData } from "../CustomSCEPForm/CustomSCEPForm";
 import { IHydrantFormData } from "../HydrantForm/HydrantForm";
 import { ISmallstepFormData } from "../SmallstepForm/SmallstepForm";
 import { ICustomESTFormData } from "../CustomESTForm/CustomESTForm";
+import CA_LABEL_BY_TYPE from "../helpers";
 
-export const CA_LABEL_BY_TYPE: Record<ICertificateAuthorityType, string> = {
-  custom_est_proxy: "Custom EST (Enrollment Over Secure Transport)",
-  custom_scep_proxy: "Custom SCEP (Simple Certificate Enrollment Protocol)",
-  digicert: "DigiCert",
-  hydrant: "Hydrant EST (Enrollment Over Secure Transport)",
-  ndes_scep_proxy:
-    "Okta CA or Microsoft NDES (Network Device Enrollment Service)",
-  smallstep: "Smallstep",
-};
 // keep these alphabetized
 const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
   {

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -16,26 +16,38 @@ import { IHydrantFormData } from "../HydrantForm/HydrantForm";
 import { ISmallstepFormData } from "../SmallstepForm/SmallstepForm";
 import { ICustomESTFormData } from "../CustomESTForm/CustomESTForm";
 
+export const CA_LABEL_BY_TYPE: Record<ICertificateAuthorityType, string> = {
+  custom_est_proxy: "Custom EST (Enrollment Over Secure Transport)",
+  custom_scep_proxy: "Custom SCEP (Simple Certificate Enrollment Protocol)",
+  digicert: "DigiCert",
+  hydrant: "Hydrant EST (Enrollment Over Secure Transport)",
+  ndes_scep_proxy:
+    "Okta CA or Microsoft NDES (Network Device Enrollment Service)",
+  smallstep: "Smallstep",
+};
 // keep these alphabetized
 const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
   {
-    label: "Custom EST (Enrollment Over Secure Transport)",
+    label: CA_LABEL_BY_TYPE.custom_est_proxy,
     value: "custom_est_proxy",
   },
   {
-    label: "Custom SCEP (Simple Certificate Enrollment Protocol)",
+    label: CA_LABEL_BY_TYPE.custom_scep_proxy,
     value: "custom_scep_proxy",
   },
-  { label: "DigiCert", value: "digicert" },
+  { label: CA_LABEL_BY_TYPE.digicert, value: "digicert" },
   {
-    label: "Hydrant EST (Enrollment Over Secure Transport)",
+    label: CA_LABEL_BY_TYPE.hydrant,
     value: "hydrant",
   },
   {
-    label: "Microsoft NDES (Network Device Enrollment Service)",
+    label: CA_LABEL_BY_TYPE.ndes_scep_proxy,
     value: "ndes_scep_proxy",
   },
-  { label: "Smallstep", value: "smallstep" },
+  {
+    label: CA_LABEL_BY_TYPE.smallstep,
+    value: "smallstep",
+  },
 ];
 
 /**

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
@@ -6,6 +6,7 @@ import UploadList from "pages/ManageControlsPage/components/UploadList";
 
 import CertAuthorityListHeader from "../CertAuthorityListHeader";
 import CertAuthorityListItem from "../CertAuthorityListItem";
+import CA_LABEL_BY_TYPE from "../helpers";
 
 const baseClass = "certificate-authority-list";
 
@@ -24,9 +25,10 @@ export const generateListData = (
     switch (cert.type) {
       case "ndes_scep_proxy":
         description = "Microsoft Network Device Enrollment Service (NDES)";
+        description = CA_LABEL_BY_TYPE.ndes_scep_proxy;
         break;
       case "digicert":
-        description = "DigiCert";
+        description = CA_LABEL_BY_TYPE.digicert;
         break;
       case "custom_scep_proxy":
         description = "Custom Simple Certificate Enrollment Protocol (SCEP)";
@@ -35,7 +37,7 @@ export const generateListData = (
         description = "Hydrant (EST - Enrollment Over Secure Transport) ";
         break;
       case "smallstep":
-        description = "Smallstep";
+        description = CA_LABEL_BY_TYPE.smallstep;
         break;
       case "custom_est_proxy":
         description = "Custom Enrollment Over Secure Transport (EST)";

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
@@ -21,34 +21,9 @@ export const generateListData = (
   certAuthorities: ICertificateAuthorityPartial[]
 ) => {
   return certAuthorities.map<ICertAuthorityListData>((cert) => {
-    let description = "";
-    switch (cert.type) {
-      case "ndes_scep_proxy":
-        description = "Microsoft Network Device Enrollment Service (NDES)";
-        description = CA_LABEL_BY_TYPE.ndes_scep_proxy;
-        break;
-      case "digicert":
-        description = CA_LABEL_BY_TYPE.digicert;
-        break;
-      case "custom_scep_proxy":
-        description = "Custom Simple Certificate Enrollment Protocol (SCEP)";
-        break;
-      case "hydrant":
-        description = "Hydrant (EST - Enrollment Over Secure Transport) ";
-        break;
-      case "smallstep":
-        description = CA_LABEL_BY_TYPE.smallstep;
-        break;
-      case "custom_est_proxy":
-        description = "Custom Enrollment Over Secure Transport (EST)";
-        break;
-      default:
-        description = "Unknown Certificate Authority Type";
-    }
-
     return {
       ...cert,
-      description,
+      description: CA_LABEL_BY_TYPE[cert.type],
     };
   });
 };
@@ -69,7 +44,6 @@ const CertificateAuthorityList = ({
   const listData = useMemo(() => generateListData(certAuthorities), [
     certAuthorities,
   ]);
-
   return (
     <UploadList<ICertAuthorityListData>
       className={baseClass}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
@@ -30,7 +30,6 @@ export const generateListData = (
       case "digicert":
         description = CA_LABEL_BY_TYPE.digicert;
         break;
-      // TODO - align with modal dropdown labels? waiting for design confirmation
       case "custom_scep_proxy":
         description = "Custom Simple Certificate Enrollment Protocol (SCEP)";
         break;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/CertificateAuthorityList/CertificateAuthorityList.tsx
@@ -30,6 +30,7 @@ export const generateListData = (
       case "digicert":
         description = CA_LABEL_BY_TYPE.digicert;
         break;
+      // TODO - align with modal dropdown labels? waiting for design confirmation
       case "custom_scep_proxy":
         description = "Custom Simple Certificate Enrollment Protocol (SCEP)";
         break;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/EditCertAuthorityModal/EditCertAuthorityModal.tsx
@@ -123,7 +123,6 @@ const EditCertAuthorityModal = ({
         formData={formData}
         submitBtnText="Save"
         isSubmitting={isUpdating}
-        isEditing
         isDirty={isDirty}
         onChange={onChangeForm}
         onSubmit={onEditCertAuthority}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -73,7 +73,13 @@ const NDESForm = ({
         onChange={onInputChange}
         parseTarget
         placeholder="https://example.com/certsrv/mscep_admin/"
-        helpText="The admin interface for managing the SCEP service and viewing configuration details."
+        helpText={
+          <>
+            The URL for the <b>Network Device Enrollment Service</b> page to
+            view configuration details. Okta calls this the <b>Challenge URL</b>
+            .
+          </>
+        }
       />
       <InputField
         label="Username"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -98,7 +98,12 @@ const NDESForm = ({
         onChange={onInputChange}
         parseTarget
         blockAutoComplete
-        helpText="The password required to log in to the SCEP admin page."
+        helpText={
+          <>
+            The password required to log in to the{" "}
+            <b>Network Device Enrollment Service</b> page.
+          </>
+        }
       />
       <div className="modal-cta-wrap">
         <TooltipWrapper

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -20,7 +20,6 @@ interface INDESFormProps {
   formData: INDESFormData;
   submitBtnText: string;
   isSubmitting: boolean;
-  isEditing?: boolean;
   isDirty?: boolean;
   onChange: (update: { name: string; value: string }) => void;
   onSubmit: () => void;

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -88,7 +88,7 @@ const NDESForm = ({
         onChange={onInputChange}
         parseTarget
         placeholder="username@example.microsoft.com"
-        helpText="The username in the down-level logon name format required to log in to the SCEP admin page."
+        helpText="For Microsoft, this is the username in the down-level logon name format required to log in to the SCEP admin page."
       />
       <InputField
         label="Password"

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
@@ -1,12 +1,12 @@
 import { ICertificateAuthorityType } from "interfaces/certificates";
 
 const CA_LABEL_BY_TYPE: Record<ICertificateAuthorityType, string> = {
-  custom_est_proxy: "Custom EST (Enrollment Over Secure Transport)",
-  custom_scep_proxy: "Custom SCEP (Simple Certificate Enrollment Protocol)",
+  custom_est_proxy: "Custom Enrollment Over Secure Transport (EST)",
+  custom_scep_proxy: "Custom Simple Certificate Enrollment Protocol (SCEP)",
   digicert: "DigiCert",
-  hydrant: "Hydrant EST (Enrollment Over Secure Transport)",
+  hydrant: "Hydrant Enrollment Over Secure Transport (EST)",
   ndes_scep_proxy:
-    "Okta CA or Microsoft NDES (Network Device Enrollment Service)",
+    "Okta CA or Microsoft Network Device Enrollment Service (NDES)",
   smallstep: "Smallstep",
 };
 

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/helpers.tsx
@@ -1,0 +1,13 @@
+import { ICertificateAuthorityType } from "interfaces/certificates";
+
+const CA_LABEL_BY_TYPE: Record<ICertificateAuthorityType, string> = {
+  custom_est_proxy: "Custom EST (Enrollment Over Secure Transport)",
+  custom_scep_proxy: "Custom SCEP (Simple Certificate Enrollment Protocol)",
+  digicert: "DigiCert",
+  hydrant: "Hydrant EST (Enrollment Over Secure Transport)",
+  ndes_scep_proxy:
+    "Okta CA or Microsoft NDES (Network Device Enrollment Service)",
+  smallstep: "Smallstep",
+};
+
+export default CA_LABEL_BY_TYPE;


### PR DESCRIPTION
**Related issue:** Resolves #34521 

Updated NDES add/edit modal:
<img width="649" height="592" alt="Screenshot 2026-01-27 at 11 29 20 PM" src="https://github.com/user-attachments/assets/88a083e5-0ba3-40b9-9668-5cd0bfa427a1" />

Also - CA descriptions made consistent between modal and list:
<img width="1424" height="934" alt="Screenshot 2026-01-28 at 10 13 43 AM" src="https://github.com/user-attachments/assets/b2266e45-30e7-40ad-b5b1-d1fa2cf97952" />
<img width="738" height="572" alt="Screenshot 2026-01-28 at 11 19 13 AM" src="https://github.com/user-attachments/assets/b7e133a8-a055-41f7-b074-2f0db74f257c" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for dynamic SCEP challenges for Okta certificates.

* **Improvements**
  * Enhanced help text for NDES form fields with clearer references to Network Device Enrollment Service configuration details.
  * Align CA descriptions between cert list and cert options dropdown in Add/Edit CA modal
  * Improve organization of relevant code 

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->