### PR TITLE
Fixed false negative CVE for 7-Zip installed with MSI installer

### DIFF
--- a/changes/36335-7-zip-false-negative-cve
+++ b/changes/36335-7-zip-false-negative-cve
@@ -1,0 +1,1 @@
+Fixed false negative CVE for 7-Zip installed with MSI installer.

--- a/server/vulnerabilities/nvd/cpe.go
+++ b/server/vulnerabilities/nvd/cpe.go
@@ -455,6 +455,26 @@ var (
 				s.Name = "ninxsoft-mist"
 			},
 		},
+		{
+			// 7-Zip on Windows installed with MSI reports versions like "24.09.00.0" but NVD uses "24.09".
+			// Strip trailing ".00.0" components to match NVD version format.
+			// See https://github.com/fleetdm/fleet/issues/36335
+			matches: func(s *fleet.Software) bool {
+				return strings.HasPrefix(s.Name, "7-Zip") && s.Source == "programs"
+			},
+			mutate: func(s *fleet.Software, logger log.Logger) {
+				parts := strings.Split(s.Version, ".")
+				switch len(parts) {
+				case 0, 1:
+					level.Debug(logger).Log("msg", "unexpected 7-Zip version format", "source", "programs", "name", s.Name, "version", s.Version)
+					return
+				case 2:
+					return // Already in the correct format
+				default:
+					s.Version = parts[0] + "." + parts[1]
+				}
+			},
+		},
 	}
 )
 

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -2443,6 +2443,19 @@ func TestMutateSoftware(t *testing.T) {
 				BundleIdentifier: "com.ninxsoft.mist",
 			},
 		},
+		{
+			name: "7-Zip on Windows with four-part MSI version",
+			s: &fleet.Software{
+				Name:    "7-Zip 24.09 (x64)",
+				Version: "24.09.00.0",
+				Source:  "programs",
+			},
+			sanitized: &fleet.Software{
+				Name:    "7-Zip 24.09 (x64)",
+				Version: "24.09",
+				Source:  "programs",
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			require.NotPanics(t, func() { mutateSoftware(tc.s, log.NewNopLogger()) })


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36335

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false negative CVE vulnerability detection for 7-Zip installations on Windows (MSI). Version numbers are now correctly normalized to industry standards, enabling accurate identification of applicable security vulnerabilities for this software.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->