### PR TITLE
Fixed issue where different variations of the same software weren't linked to the same software title.

### DIFF
--- a/changes/victor/36494-software-without-title
+++ b/changes/victor/36494-software-without-title
@@ -1,1 +1,1 @@
-Fixed issue where different variations of the same software weren't linked to the same software title.
+Fixed issues where different variations of the same software weren't linked to the same software title.

--- a/changes/victor/36494-software-without-title
+++ b/changes/victor/36494-software-without-title
@@ -1,1 +1,1 @@
-Fixed issue where different versions of the same Windows software weren't linked to the same software title.
+Fixed issue where different variations of the same software weren't linked to the same software title.

--- a/changes/victor/36494-software-without-title
+++ b/changes/victor/36494-software-without-title
@@ -1,0 +1,1 @@
+Fixed issue where different versions of the same Windows software weren't linked to the same software title.

--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -978,7 +978,8 @@ func (ds *Datastore) preInsertSoftwareInventory(
 						bundleID = *title.BundleIdentifier
 					}
 					key := titleKey{
-						name:         strings.ToLower(title.Name), // lowercase for case-insensitive dedup matching MySQL collation
+						// adjust for matching MySQL collation
+						name:         strings.ToLower(normalizeForCollation(title.Name)),
 						source:       title.Source,
 						extensionFor: title.ExtensionFor,
 						bundleID:     bundleID,

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -11121,3 +11121,17 @@ func testListSoftwareInventoryDeletedHost(t *testing.T, ds *Datastore) {
 	require.Equal(t, "Software", software[0].Name)
 	require.Equal(t, titleID, software[0].ID)
 }
+
+// TestUniqueSoftwareTitleStrNormalization tests that UniqueSoftwareTitleStr
+// produces consistent keys regardless of Unicode format characters (like RTL mark)
+// which MySQL's utf8mb4_unicode_ci collation ignores.
+func TestUniqueSoftwareTitleStrNormalization(t *testing.T) {
+	// With RTL mark (U+200F) - the actual bug case from production
+	keyWithRTL := UniqueSoftwareTitleStr("\u200fSmart Connect", "programs", "")
+	keyWithoutRTL := UniqueSoftwareTitleStr("Smart Connect", "programs", "")
+	assert.Equal(t, keyWithoutRTL, keyWithRTL, "RTL mark should be stripped")
+
+	// Verify regular unicode is preserved
+	keyJapanese := UniqueSoftwareTitleStr("日本語ソフト", "apps", "")
+	assert.Contains(t, keyJapanese, "日本語ソフト")
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36494 

Fixes:
- Allow matching software to title solely by non-empty upgrade code
- Match names case-insentive and trimmed whitespace and special unicode characters (in our osquery-perf dataset)
- Match bundle ID case-insensitive

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Different variations/versions of the same software that share the same upgrade code are now unified under a single software title, preventing duplicate titles and improving linkage across releases.

* **Tests**
  * Added a test verifying that entries with the same upgrade code but different names link to an existing shared title.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->