### PR TITLE
Update chrome extension README

### DIFF
--- a/ee/fleetd-chrome/README.md
+++ b/ee/fleetd-chrome/README.md
@@ -77,16 +77,24 @@ npm run test
    2. Go to Devices > Chrome > Apps & Extensions > Users & browsers
    3. Under Organizational Units, select the group that your ChromeOS device is in, or the top-level Fleet Device Management OU to test the beta on all ChromeOS devices (yours may not be in a specific OU).
    4. Select the production extension (fleeedmmihkfkeemmipgmhhjemlljidg), change its installation policy to "Block", and save your changes. This will remove the production extension from the selected devices so that you can test the beta.
+       > Note: some Fleet employees may see a "This extension is not allowed" warning pop up in their browsers after this step. This is normal.
    5. Select the beta extension (bfleegjcoffelppfmadimianphbcdjkb), change its installation policy to "Force install" and save your change. This will push the beta extension out to the selected devices.
    6. Verify that the beta extension has installed on a device using the Chrome extension manager, and test your changes!
 7. Once the beta release is tested, make a PR with the updates to the version and changelog and tag the commit with `fleetd-chrome-vX.X.X`. This will trigger the release workflow. 
 8. In the Google admin console, set the beta extension installation policy to "Block" and the production extension to "Force install".
-9. Announce the release in the #help-engineering channel in Slack.
+    > Note: some Fleet employees may see a "This extension is not allowed" warning pop up in their browsers after this step. This is normal.
+9. Announce the release in the #help-releases and #help-engineering channels in Slack.
 
 Using GitHub Actions, the build is automatically uploaded to R2 and properly configured clients should be able to update immediately when the job completes. Note that automatic updates seem to only happen about once a day in Chrome -- Hit the "Update" button in `chrome://extensions` to trigger the update manually.
 
-### Beta releases
+## Troubleshooting
 
-Beta releases are pushed to `https://chrome-beta.fleetdm.com/updates.xml` with the extension ID `bfleegjcoffelppfmadimianphbcdjkb`.
+The first step in troubleshooting a released extension (beta or production) is to go to [chrome://extensions](chrome://extensions) in your browser (or click the "Manage Extensions" link under the extensions menu), turn on Developer Mode using the toggle at the top-right corner of the page, then click the "Inspect views service worker" link in the Fleetd for Chrome extension. From there you can view the Console to see any error messages that the extension is logging.
 
-Kick off a beta release by updating the [package.json](./package.json), then tag a commit with `fleetd-chrome-vX.X.X-beta` to kick off the build and deploy.
+### Chrome device not appearing in Dogfood
+
+If the extension is logging errors like `enroll failed: no matching secret found`, check the enroll secret set in the "Policy for extensions" for the extension in the Google admin console (Apps & Extensions -> Users & Browsers -> select the fleet extension -> scroll all the way down to the bottom of the right-hand drawer). Ensure that the `enroll_secret` value represents a valid secret for a team on the Fleet dogfood instance.  
+
+### Device not receiving updated extension version
+
+First, try hitting the "Update" button on the [chrome://extensions](chrome://extensions) page in your browser. If that doesn't work, you can toggle the policy for the extension to "Block", wait a moment for it to be removed from the device, and then change it back to "Force install". 


### PR DESCRIPTION
Updated the README for the Fleetd Chrome extension:

* Added note re: the warning you get when blocking the extension during testing
* Removed redundant beta release info
* Added instruction to post in #help-releases about new extension releases
* Added troubleshooting steps