### PR TITLE
Cherry-Pick: Bump tar from 7.5.4 to 7.5.7 in /tools/fleetctl-npm

### DIFF
--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "axios": "1.13.2",
     "rimraf": "6.1.2",
-    "tar": "7.5.4"
+    "tar": "7.5.7"
   },
   "keywords": [
     "osquery",

--- a/tools/fleetctl-npm/yarn.lock
+++ b/tools/fleetctl-npm/yarn.lock
@@ -241,10 +241,10 @@ rimraf@6.1.2:
     glob "^13.0.0"
     package-json-from-dist "^1.0.1"
 
-tar@7.5.4:
-  version "7.5.4"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.4.tgz#18b53b44f939a7e03ed874f1fafe17d29e306c81"
-  integrity sha512-AN04xbWGrSTDmVwlI4/GTlIIwMFk/XEv7uL8aa57zuvRy6s4hdBed+lVq2fAZ89XDa7Us3ANXcE3Tvqvja1kTA==
+tar@7.5.7:
+  version "7.5.7"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.7.tgz#adf99774008ba1c89819f15dbd6019c630539405"
+  integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
Merged into `main` in #38956