### PR TITLE
Drop performance issue comment about debug archive

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -36,5 +36,3 @@ These steps:
 ### 🕯️ More info _(optional)_
 <!-- Add any additional details you think could be relevant to solving or reproducing the bug (e.g., "this does not reproduce when...") -->
 N/A
-
-<!-- If this is a performance issue, follow these steps to generate and attach a debug archive: https://fleetdm.com/docs/using-fleet/monitoring-fleet#debugging-performance-issues -->


### PR DESCRIPTION
We basically never see a debug archive come in, even for performance related issues, and we usually have better ways of pulling requisite performance related data than the debug archive.