### PR TITLE
Website: update sitemap and new pages

### DIFF
--- a/website/api/controllers/download-sitemap.js
+++ b/website/api/controllers/download-sitemap.js
@@ -66,7 +66,8 @@ module.exports = {
       '/orchestration',
       '/device-management',
       '/software-management',
-      '/meetups',
+      '/software-management',
+      '/fleet-gitops',
       // Other stuff:
       // > Note: /handbook overview page is already included amongst the markdown pages
       // > Note: Same for /docs
@@ -80,6 +81,9 @@ module.exports = {
       '/scripts',// « overview page (all subpages are dynamic)
       '/os-settings',
       '/fast-track',
+      '/meetups',
+      '/testimonials',
+      '/gitops-workshop',
       // FUTURE: Do something smarter to get hand-coded HTML pages from routes.js, like how rebuild-cloud-sdk works, to avoid this manual duplication.
       // See also https://github.com/sailshq/sailsjs.com/blob/b53c6e6a90c9afdf89e5cae00b9c9dd3f391b0e7/api/helpers/get-pages-for-sitemap.js#L27
     ];

--- a/website/api/controllers/download-sitemap.js
+++ b/website/api/controllers/download-sitemap.js
@@ -66,7 +66,6 @@ module.exports = {
       '/orchestration',
       '/device-management',
       '/software-management',
-      '/software-management',
       '/fleet-gitops',
       // Other stuff:
       // > Note: /handbook overview page is already included amongst the markdown pages

--- a/website/views/pages/landing-pages/basic-comparison.ejs
+++ b/website/views/pages/landing-pages/basic-comparison.ejs
@@ -30,5 +30,6 @@
       </div>
     </div>
   </div>
+  <signup-modal></signup-modal>
 </div>
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>

--- a/website/views/pages/landing-pages/gitops-workshop.ejs
+++ b/website/views/pages/landing-pages/gitops-workshop.ejs
@@ -144,5 +144,6 @@
       </div>
     </div>
   </div>
+  <signup-modal></signup-modal>
 </div>
 <%- /* Expose server-rendered data as window.SAILS_LOCALS :: */ exposeLocalsToBrowser() %>


### PR DESCRIPTION
Changes:
- Added new(/missing) pages to the website's sitemap
- Added the signup modal to comparison pages and the GitOps workshop page. 