### PR TITLE
Use NewGCMWithRandomNonce for AES-GCM encryption

### DIFF
--- a/server/config/config.go
+++ b/server/config/config.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/docker/go-units"
 	"github.com/fleetdm/fleet/v4/server/contexts/installersize"
+	"github.com/fleetdm/fleet/v4/server/mdm/cryptoutil"
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
 	"github.com/spf13/cast"
@@ -1093,6 +1094,15 @@ func (t *TLS) ToTLSConfig() (*tls.Config, error) {
 	cfg := &tls.Config{
 		RootCAs: rootCertPool,
 	}
+
+	if cryptoutil.IsFIPSMode() {
+		cfg.CurvePreferences = []tls.CurveID{
+			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
+		}
+	}
+
 	if t.TLSCert != "" {
 		clientCert := make([]tls.Certificate, 0, 1)
 		certs, err := tls.LoadX509KeyPair(t.TLSCert, t.TLSKey)

--- a/server/mdm/cryptoutil/fips.go
+++ b/server/mdm/cryptoutil/fips.go
@@ -1,0 +1,23 @@
+package cryptoutil
+
+import (
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	fipsMode bool
+	fipsOnce sync.Once
+)
+
+// IsFIPSMode returns true if FIPS 140-3 mode is enabled via GODEBUG.
+// It checks for GODEBUG=fips140=only or GODEBUG=fips140=on.
+func IsFIPSMode() bool {
+	fipsOnce.Do(func() {
+		godebug := os.Getenv("GODEBUG")
+		fipsMode = strings.Contains(godebug, "fips140=only") ||
+			strings.Contains(godebug, "fips140=on")
+	})
+	return fipsMode
+}

--- a/server/mdm/cryptoutil/fips_test.go
+++ b/server/mdm/cryptoutil/fips_test.go
@@ -1,0 +1,34 @@
+package cryptoutil
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestIsFIPSModeEnabled(t *testing.T) {
+	// This test runs as a subprocess with GODEBUG set to test the enabled path.
+	// We need a subprocess because sync.Once caches the result.
+	if os.Getenv("TEST_FIPS_SUBPROCESS") == "1" {
+		if !IsFIPSMode() {
+			os.Exit(1)
+		}
+		os.Exit(0)
+	}
+
+	t.Run("disabled", func(t *testing.T) {
+		// In normal test run, GODEBUG is not set, so FIPS mode is disabled.
+		if IsFIPSMode() {
+			t.Error("expected FIPS mode to be disabled")
+		}
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		// Run subprocess with GODEBUG=fips140=only
+		cmd := exec.Command(os.Args[0], "-test.run=TestIsFIPSModeEnabled")
+		cmd.Env = append(os.Environ(), "GODEBUG=fips140=only", "TEST_FIPS_SUBPROCESS=1")
+		if err := cmd.Run(); err != nil {
+			t.Error("expected FIPS mode to be enabled with GODEBUG=fips140=only")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

This PR adopts Go's `cipher.NewGCMWithRandomNonce` for AES-GCM encryption, which is both a security best practice and enables FIPS 140-3 compliance.

### Description
When building Fleet from source using Go 1.24+ with `GOFIPS140=v1.0.0` and attempting to run with `GODEBUG=fips140=only`, I ran into a couple hangups that seemed relatively to resolve so this is a crack at it.

The biggest issue was `panic: crypto/cipher: use of GCM with arbitrary IVs is not allowed in FIPS 140-only mode, use NewGCMWithRandomNonce`

A simple swap to the recommended function is able to resolve this non-compliance without affecting any existing functionality.

By switching from `cipher.NewGCM` to `cipher.NewGCMWithRandomNonce`, we can shift the responsibility of nonce generation and use to the crypto module

Both methods produce identical output: `[12-byte nonce][ciphertext][16-byte tag]`. Existing encrypted data decrypts correctly.

### FIPS 140-3 compliance

For users running Fleet in FIPS environments (`GODEBUG=fips140=only`):
- `NewGCMWithRandomNonce` is approved; `NewGCM` is not (due to arbitrary nonce risk)
- TLS config conditionally restricts to NIST curves (P-256, P-384, P-521) only when FIPS mode is detected
- Non-FIPS users retain full algorithm support including X25519

## Test plan

- [x] `go build ./...` succeeds
- [x] Existing encrypt/decrypt tests pass
- [ ] Manual verification with `GODEBUG=fips140=only go run ./cmd/fleet serve --dev`