### PR TITLE
Fleet UI: Fix unreleased bug between locking/locating

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1279,13 +1279,7 @@ const HostDetailsPage = ({
               showRefetchSpinner={showRefetchSpinner}
               onRefetchHost={onRefetchHost}
               renderActionsDropdown={renderActionsDropdown}
-              // Setting this to "locking" because if a host is "locating", it is also
-              // "locking"; an iOS/iPadOS host isn't "locked" until the location is found.
-              hostMdmDeviceStatus={
-                hostMdmDeviceStatus === "locating"
-                  ? "locking"
-                  : hostMdmDeviceStatus
-              }
+              hostMdmDeviceStatus={hostMdmDeviceStatus}
               hostMdmEnrollmentStatus={host.mdm?.enrollment_status || undefined}
             />
           </div>

--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -52,7 +52,7 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
       );
     },
   },
-  /** Pending action is location but device status is locked */
+  /** When device_status is "locked" and pending_action is "location", still show "Locked" tag */
   locating: {
     title: "Locked",
     tagType: "warning",
@@ -91,7 +91,8 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
     generateTooltip: () =>
       "Host will unlock when it comes online.  If the host is online, it will unlock the next time it checks in to Fleet.",
   },
-  /** "locking" also includes pending action is location but device status is unlocked */
+  /** "locking" also includes device_status is "unlocked" and pending_action is "location" as
+   * that combination is a part of the locking process */
   locking: {
     title: "Lock pending",
     tagType: "warning",

--- a/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/HostHeader/helpers.tsx
@@ -52,8 +52,9 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
       );
     },
   },
+  /** Pending action is location but device status is locked */
   locating: {
-    title: "LOCKED",
+    title: "Locked",
     tagType: "warning",
     generateTooltip: (platform) => {
       if (isIPadOrIPhone(platform)) {
@@ -90,6 +91,7 @@ export const DEVICE_STATUS_TAGS: DeviceStatusTagConfig = {
     generateTooltip: () =>
       "Host will unlock when it comes online.  If the host is online, it will unlock the next time it checks in to Fleet.",
   },
+  /** "locking" also includes pending action is location but device status is unlocked */
   locking: {
     title: "Lock pending",
     tagType: "warning",

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -89,8 +89,9 @@ const API_TO_UI_DEVICE_STATUS_MAP: Record<
   lock: "locking",
   wiped: "wiped",
   wipe: "wiping",
-  /** Only if device is locked AND pending action is locating
-   * Unlocked AND pending action is locating is still "locking" */
+  /** When device_status is "locked" and pending_action is "location", show "locating",
+   * device_status is "unlocked" and pending_action is "location" is still "locking"
+   */
   location: "locating",
 };
 
@@ -112,9 +113,9 @@ export const getHostDeviceStatusUIState = (
     return API_TO_UI_DEVICE_STATUS_MAP[deviceStatus];
   }
 
-  // Special case: if the pending action is locating and the device is unlocked,
-  // the device is still in the process of "locking" to be able to locate it. So we
-  // return "locking" in this case.
+  // Special case: when pending_action is "location" and device_status is "unlocked",
+  // the device is in the process of locking in order to enable location tracking.
+  // Return "locking" in this case.
   if (pendingAction === "location" && deviceStatus === "unlocked") {
     return "locking";
   }

--- a/frontend/pages/hosts/details/helpers.ts
+++ b/frontend/pages/hosts/details/helpers.ts
@@ -89,6 +89,8 @@ const API_TO_UI_DEVICE_STATUS_MAP: Record<
   lock: "locking",
   wiped: "wiped",
   wipe: "wiping",
+  /** Only if device is locked AND pending action is locating
+   * Unlocked AND pending action is locating is still "locking" */
   location: "locating",
 };
 
@@ -109,6 +111,14 @@ export const getHostDeviceStatusUIState = (
   if (pendingAction === "") {
     return API_TO_UI_DEVICE_STATUS_MAP[deviceStatus];
   }
+
+  // Special case: if the pending action is locating and the device is unlocked,
+  // the device is still in the process of "locking" to be able to locate it. So we
+  // return "locking" in this case.
+  if (pendingAction === "location" && deviceStatus === "unlocked") {
+    return "locking";
+  }
+
   return API_TO_UI_DEVICE_STATUS_MAP[pendingAction];
 };
 

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -51,12 +51,12 @@ const getLocationMessage = (
 
     case "locking":
       return (
-        <div>
+        <>
           <p>{IOS_LOCK_REQUIRED_MESSAGE}</p>
           <p>
             Lock is pending. Host will lock the next time it checks in to Fleet.
           </p>
-        </div>
+        </>
       );
 
     case "locating":
@@ -116,6 +116,8 @@ const LocationModal = ({
   iosOrIpadosDetails,
   detailsUpdatedAt,
 }: ILocationModal) => {
+  console.log("hostGeolocation:", hostGeolocation);
+  console.log("iosOrIpadosDetails:", iosOrIpadosDetails);
   const googleMapsUrl = hostGeolocation
     ? buildGoogleMapsLinkFromGeo(hostGeolocation)
     : null;
@@ -139,19 +141,21 @@ const LocationModal = ({
   const renderContent = () => {
     return (
       <>
-        <div className={`${baseClass}__location`}>
-          {hostGeolocation && getCityCountryLocation(hostGeolocation)}{" "}
-          {googleMapsUrl && (
-            <div className={`${baseClass}__link`}>
-              <CustomLink
-                url={googleMapsUrl}
-                text="Open in Google Maps"
-                newTab
-                multiline
-              />
-            </div>
-          )}
-        </div>
+        {hostGeolocation && (
+          <div className={`${baseClass}__location`}>
+            {hostGeolocation && getCityCountryLocation(hostGeolocation)}{" "}
+            {googleMapsUrl && (
+              <div className={`${baseClass}__link`}>
+                <CustomLink
+                  url={googleMapsUrl}
+                  text="Open in Google Maps"
+                  newTab
+                  multiline
+                />
+              </div>
+            )}
+          </div>
+        )}
         <div className={`${baseClass}__message`}>
           {getLocationMessage(iosOrIpadosDetails, Boolean(hostGeolocation))}
           {shouldShowLastUpdatedAt && renderLastUpdatedAt()}

--- a/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
+++ b/frontend/pages/hosts/details/modals/LocationModal/LocationModal.tsx
@@ -116,8 +116,6 @@ const LocationModal = ({
   iosOrIpadosDetails,
   detailsUpdatedAt,
 }: ILocationModal) => {
-  console.log("hostGeolocation:", hostGeolocation);
-  console.log("iosOrIpadosDetails:", iosOrIpadosDetails);
   const googleMapsUrl = hostGeolocation
     ? buildGoogleMapsLinkFromGeo(hostGeolocation)
     : null;

--- a/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
+++ b/frontend/pages/hosts/details/modals/LocationModal/_styles.scss
@@ -3,10 +3,17 @@
     @include vertical-modal-layout;
   }
 
-  &__location,
-  &__message {
+  &__location {
     display: flex;
     align-items: baseline;
     gap: $pad-small;
+  }
+
+  &__message {
+    @include vertical-modal-layout;
+
+    p {
+      margin: 0;
+    }
   }
 }


### PR DESCRIPTION
## Issue
Closes #38963 

## Description
- Tease the difference between API returned pending action "locating" with the API returned status "locked" vs. "unlocked"
- Ensure "locating" is only for locked hosts, and locating while unlocked is still considered "locking"
- Other: Updated to not render empty div which causes unwanted padding, updated to rely on CSS modal styling mixin and remove p margins to match appwide spacing patterns

## Screen recording of bug fixed

https://github.com/user-attachments/assets/c012705b-2f5b-472f-8016-c9cf7d248426


## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
