### PR TITLE
Limited disk encryption key escrowing when setting enabled

### DIFF
--- a/changes/33296-disk-encryption
+++ b/changes/33296-disk-encryption
@@ -1,0 +1,1 @@
+* Limited disk encryption key escrowing when global or team setting enabled

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -9383,8 +9383,10 @@ func (s *integrationMDMTestSuite) TestHostDiskEncryptionKey() {
 	// escrowing a new encryption key should create a new acitivy entry
 	activities = s.listActivities()
 	escrowKeyActivity = fleet.ActivityTypeEscrowedDiskEncryptionKey{}
+	newActivityCount := 0
 	for _, activity := range activities {
-		if activity.Type == escrowKeyActivity.ActivityName() && activity.ID != seenEscrowKeyActivityID {
+		if activity.Type == escrowKeyActivity.ActivityName() && activity.ID > seenEscrowKeyActivityID {
+			newActivityCount++
 			err := json.Unmarshal(*activity.Details, &escrowKeyActivity)
 			require.NoError(t, err)
 			require.True(t, activity.FleetInitiated)
@@ -9392,6 +9394,7 @@ func (s *integrationMDMTestSuite) TestHostDiskEncryptionKey() {
 			seenEscrowKeyActivityID = activity.ID
 		}
 	}
+	require.Equal(t, 1, newActivityCount, "Expected exactly one new escrow activity")
 	require.Equal(t, escrowKeyActivity.HostID, host.ID)
 	require.Equal(t, escrowKeyActivity.HostDisplayName, host.DisplayName())
 
@@ -9474,11 +9477,11 @@ func (s *integrationMDMTestSuite) TestHostDiskEncryptionKey() {
 
 		// New escrow activity
 		activities = s.listActivities()
-		escrowCountFinal := 0
+		newEscrowCount := 0
 		escrowKeyActivity = fleet.ActivityTypeEscrowedDiskEncryptionKey{}
 		for _, activity := range activities {
-			if activity.Type == escrowKeyActivity.ActivityName() && activity.ID != seenEscrowKeyActivityID {
-				escrowCountFinal++
+			if activity.Type == escrowKeyActivity.ActivityName() && activity.ID > seenEscrowKeyActivityID {
+				newEscrowCount++
 				err := json.Unmarshal(*activity.Details, &escrowKeyActivity)
 				require.NoError(t, err)
 				require.True(t, activity.FleetInitiated)
@@ -9486,7 +9489,7 @@ func (s *integrationMDMTestSuite) TestHostDiskEncryptionKey() {
 				seenEscrowKeyActivityID = activity.ID
 			}
 		}
-		require.Equal(t, escrowCountBefore+1, escrowCountFinal)
+		require.Equal(t, 1, newEscrowCount)
 		require.NotZero(t, seenEscrowKeyActivityID)
 		require.Equal(t, escrowKeyActivity.HostID, host.ID)
 		require.Equal(t, escrowKeyActivity.HostDisplayName, host.DisplayName())

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -21,6 +21,7 @@ import (
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
+	"github.com/fleetdm/fleet/v4/server/service/osquery_utils"
 	"github.com/fleetdm/fleet/v4/server/worker"
 	"github.com/go-kit/log/level"
 )
@@ -1171,6 +1172,15 @@ func (svc *Service) SetOrUpdateDiskEncryptionKey(ctx context.Context, encryption
 		return badRequest("host is not enrolled with fleet")
 	}
 
+	// Only archive the key if disk encryption is enabled for this host (team/globally)
+	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger, svc.ds, host) {
+		level.Debug(svc.logger).Log(
+			"msg", "skipping key archival, disk encryption not enabled for host team/globally",
+			"host_id", host.ID,
+		)
+		return nil
+	}
+
 	var (
 		encryptedEncryptionKey string
 		decryptable            *bool
@@ -1268,6 +1278,15 @@ func (svc *Service) EscrowLUKSData(ctx context.Context, passphrase string, salt 
 
 	if clientError != "" {
 		return svc.ds.ReportEscrowError(ctx, host.ID, clientError)
+	}
+
+	// Only archive the key if disk encryption is enabled for this host (team/globally)
+	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger, svc.ds, host) {
+		level.Debug(svc.logger).Log(
+			"msg", "skipping LUKS key archival, disk encryption not enabled for host team/globally",
+			"host_id", host.ID,
+		)
+		return nil
 	}
 
 	encryptedPassphrase, encryptedSalt, validatedKeySlot, err := svc.validateAndEncrypt(ctx, passphrase, salt, keySlot)

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -182,7 +182,11 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 		ctx = test.HostContext(ctx, host)
 
 		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-			return &fleet.AppConfig{}, nil
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			}, nil
 		}
 
 		ds.NewActivityFunc = func(
@@ -266,6 +270,15 @@ func TestOrbitLUKSDataSave(t *testing.T) {
 			OsqueryHostID: ptr.String("test"),
 			ID:            1,
 		}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			}, nil
+		}
+
 		expectedErrorMessage := "internal error: missing server private key"
 		ds.ReportEscrowErrorFunc = func(ctx context.Context, hostID uint, err string) error {
 			require.Equal(t, expectedErrorMessage, err)

--- a/server/service/osquery_utils/disk_encryption_helpers.go
+++ b/server/service/osquery_utils/disk_encryption_helpers.go
@@ -1,0 +1,43 @@
+package osquery_utils
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+// IsDiskEncryptionEnabledForHost checks if disk encryption is enabled for the
+// host team or globally if the host is not assigned to a team.
+func IsDiskEncryptionEnabledForHost(ctx context.Context, logger log.Logger, ds fleet.Datastore, host *fleet.Host) bool {
+	// team
+	if host.TeamID != nil {
+		teamMDM, err := ds.TeamMDMConfig(ctx, *host.TeamID)
+		if err != nil {
+			level.Debug(logger).Log(
+				"msg", "failed to get team MDM config for disk encryption check",
+				"host_id", host.ID,
+				"team_id", *host.TeamID,
+				"err", err,
+			)
+			return false
+		}
+		if teamMDM == nil {
+			return false
+		}
+		return teamMDM.EnableDiskEncryption
+	}
+
+	// global
+	appConfig, err := ds.AppConfig(ctx)
+	if err != nil {
+		level.Debug(logger).Log(
+			"msg", "failed to get app config for disk encryption check",
+			"host_id", host.ID,
+			"err", err,
+		)
+		return false
+	}
+	return appConfig.MDM.EnableDiskEncryption.Value
+}

--- a/server/service/osquery_utils/disk_encryption_helpers_test.go
+++ b/server/service/osquery_utils/disk_encryption_helpers_test.go
@@ -1,0 +1,120 @@
+package osquery_utils
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/pkg/optjson"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/go-kit/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDiskEncryptionEnabledForHost(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	t.Run("team has disk encryption enabled", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+
+		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+			require.Equal(t, uint(1), teamID)
+			return &fleet.TeamMDM{
+				EnableDiskEncryption: true,
+			}, nil
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.True(t, result)
+		require.True(t, ds.TeamMDMConfigFuncInvoked)
+	})
+
+	t.Run("team has disk encryption disabled", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+
+		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+			return &fleet.TeamMDM{
+				EnableDiskEncryption: false,
+			}, nil
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.False(t, result)
+		require.True(t, ds.TeamMDMConfigFuncInvoked)
+	})
+
+	t.Run("team has disk encryption disabled even when global is enabled", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+
+		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+			return &fleet.TeamMDM{
+				EnableDiskEncryption: false,
+			}, nil
+		}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			require.Fail(t, "AppConfig should not be called when host has a team")
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			}, nil
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.False(t, result, "Team setting should take precedence over global setting")
+		require.True(t, ds.TeamMDMConfigFuncInvoked)
+		require.False(t, ds.AppConfigFuncInvoked, "Global config should not be checked when host is on a team")
+	})
+
+	t.Run("global disk encryption enabled (no team)", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: nil}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			}, nil
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.True(t, result)
+		require.True(t, ds.AppConfigFuncInvoked)
+	})
+
+	t.Run("global disk encryption disabled (no team)", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: nil}
+
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{
+				MDM: fleet.MDM{
+					EnableDiskEncryption: optjson.SetBool(false),
+				},
+			}, nil
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.False(t, result)
+		require.True(t, ds.AppConfigFuncInvoked)
+	})
+
+	t.Run("error getting team config returns false", func(t *testing.T) {
+		ds := new(mock.Store)
+		host := &fleet.Host{ID: 1, TeamID: ptr.Uint(1)}
+
+		ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+			return nil, &fleet.Error{Message: "db error"}
+		}
+
+		result := IsDiskEncryptionEnabledForHost(ctx, logger, ds, host)
+		require.False(t, result)
+	})
+}

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2554,6 +2554,17 @@ func directIngestDiskEncryptionKeyFileDarwin(
 		decryptable = ptr.Bool(false)
 	}
 
+	// Only archive the key if disk encryption is enabled for this host (team / globally)
+	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
+		level.Debug(logger).Log(
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileDarwin",
+			"msg", "skipping key archival, disk encryption not enabled for host (team/globally)",
+			"host", host.Hostname,
+		)
+		return nil
+	}
+
 	archived, err := ds.SetOrUpdateHostDiskEncryptionKey(ctx, host, base64Key, "", decryptable)
 	if err != nil {
 		return err
@@ -2616,6 +2627,17 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 	base64Key := base64.StdEncoding.EncodeToString(b)
 	if base64Key == "" {
 		decryptable = ptr.Bool(false)
+	}
+
+	// Only archive the key if disk encryption is enabled for this host (team/globally)
+	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
+		level.Debug(logger).Log(
+			"component", "service",
+			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
+			"msg", "skipping key archival, disk encryption not enabled for host team/globally",
+			"host", host.Hostname,
+		)
+		return nil
 	}
 
 	archived, err := ds.SetOrUpdateHostDiskEncryptionKey(ctx, host, base64Key, "", decryptable)

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1838,6 +1838,14 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 	logger := log.NewNopLogger()
 	host := &fleet.Host{ID: 1}
 
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			MDM: fleet.MDM{
+				EnableDiskEncryption: optjson.SetBool(true),
+			},
+		}, nil
+	}
+
 	var wantKey string
 
 	mockFileLines := func(wantKey string, wantEncrypted string) []map[string]string {


### PR DESCRIPTION
**Related issue:** Resolves #33296

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Disk encryption key escrowing now only proceeds when disk encryption is explicitly enabled at the global or team level.

**Tests**
- Significantly expanded test coverage for Mobile Device Management, including VPP app handling, device enrollment workflows, host lock/wipe operations, SCEP proxy integrations, and DigiCert certificate handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->