### PR TITLE
Website: update clay webhook

### DIFF
--- a/website/api/controllers/webhooks/receive-from-clay.js
+++ b/website/api/controllers/webhooks/receive-from-clay.js
@@ -126,7 +126,10 @@ module.exports = {
       throw 'couldNotCreateActivity';
     }
 
-    let trimmedLinkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
+    let trimmedLinkedinUrl;
+    if(linkedinUrl) {
+      trimmedLinkedinUrl = linkedinUrl.replace(sails.config.custom.RX_PROTOCOL_AND_COMMON_SUBDOMAINS, '');
+    }
 
     // Create the new Fleet website page view record.
     let newHistoricalRecordId = await sails.helpers.salesforce.createHistoricalEvent.with({


### PR DESCRIPTION
Changes:
- Updated the clay webhook to only trim LinkedIn URLs if one is provided.