### PR TITLE
Fix flaky test: Use setSkipWorkerJobs

### DIFF
--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -147,7 +147,7 @@ func WithOTAIdpUUID(idpUUID string) TestMDMAppleClientOption {
 	}
 }
 
-// Will added the specified reference as a query parameter to the MDMURL after the
+// Will add the specified reference as a query parameter to the MDMURL after the
 // client fetches the enrollment profile but prior to attempting SCEP enrollment. Note that this
 // is not a full simulation of legacy enrollments (especially, as it relates to IdP). Rather it
 // is enough to test certain SCEP renewal scenarios for iOS/IPadOS devices

--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -997,6 +997,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowUpdateScript() {
 	t := s.T()
 	ctx := context.Background()
 
+	s.setSkipWorkerJobs(t)
+
 	device, host, tm := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
 
 	// enroll the host


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38898 


Looking at the logs from the issue, we see that the command to install fleetd is being sent twice, which indicates the worker job ran twice. Speculative fix to setSkipWorkerJobs was validated with RandoKiller™.

```
2026-01-27T16:57:48.2528634Z {"host_uuid":"09A54077-7060-43FB-9E97-7EC4F8EFD248","info":"sent command to install fleetd"}
2026-01-27T16:57:48.2574915Z {"host_uuid":"09A54077-7060-43FB-9E97-7EC4F8EFD248","info":"unable to find a bootstrap package for DEP enrolled device, skipping installation"}
2026-01-27T16:57:48.2735754Z     integration_mdm_test.go:944: [awaitTriggerProfileSchedule] Starting profile schedule trigger at 2026-01-27T16:57:48Z
2026-01-27T16:57:48.2742390Z     integration_mdm_test.go:948: [awaitTriggerProfileSchedule] Triggering profile schedule...
2026-01-27T16:57:48.2784612Z     integration_mdm_test.go:964: [awaitTriggerProfileSchedule] Waiting for 3 jobs to complete...
2026-01-27T16:57:48.2792241Z {"instanceID":"TestIntegrationsMDM","level":"debug","msg":"done, trigger received","schedule":"mdm_apple_profile_manager"}
2026-01-27T16:57:48.2809898Z {"host_uuid":"09A54077-7060-43FB-9E97-7EC4F8EFD248","info":"sent command to install fleetd"}
```