### PR TITLE
Add ellipsis to cut-off placeholder text in search fields

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -169,6 +169,10 @@
       min-width: 250px;
     }
 
+    .input-with-icon:placeholder-shown {
+      text-overflow: ellipsis;
+    }
+
     &.stack-table-controls {
       padding-bottom: $pad-large;
       margin-left: 0;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves https://github.com/fleetdm/fleet/issues/39171

#### Before
<img width="324" height="174" alt="Screenshot 2026-01-30 at 5 35 46 PM" src="https://github.com/user-attachments/assets/5969b815-ce94-4835-936e-f8ce27427caa" />

#### After
<img width="331" height="179" alt="Screenshot 2026-01-30 at 5 34 58 PM" src="https://github.com/user-attachments/assets/18fcb458-acb9-4041-b347-1b1f5d18b2a2" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually