### PR TITLE
Fix security vulnerabilities: SQL/command injection and path traversal

### DIFF
--- a/.github/actions/r2-upload/action.yml
+++ b/.github/actions/r2-upload/action.yml
@@ -23,8 +23,11 @@ runs:
     - name: Upload file to R2
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        GITHUB_WORKSPACE_PATH: ${{ github.workspace }}
+        INPUT_FILENAMES: ${{ inputs.filenames }}
       run: |
-        sudo ${{ github.workspace }}/.github/scripts/rclone-install.sh
+        sudo "$GITHUB_WORKSPACE_PATH/.github/scripts/rclone-install.sh"
         mkdir -p ~/.config/rclone
         echo "[r2]
         type = s3
@@ -37,7 +40,7 @@ runs:
         " > ~/.config/rclone/rclone.conf
         : # Loop over each filename in the array of filenames and upload each one.
         IFS=$'\n'
-        for filename in $(echo "${{ inputs.filenames }}" | tr "," "\n"); do
+        for filename in $(echo "$INPUT_FILENAMES" | tr "," "\n"); do
           upload_dir=${{ env.R2_BUCKET }}
           dirname=$(dirname "$filename")
           if [ "$dirname" != "" ] && [ "$dirname" != "." ]; then

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -3212,7 +3212,9 @@ func buildConfigProfilesWindowsQuery(
 		return "", false
 	}
 	sb.WriteString("</SyncBody>")
-	return fmt.Sprintf("SELECT raw_mdm_command_output FROM mdm_bridge WHERE mdm_command_input = '%s';", sb.String()), true
+	// Escape single quotes for SQLite by doubling them to prevent SQL injection
+	escapedXML := strings.ReplaceAll(sb.String(), "'", "''")
+	return fmt.Sprintf("SELECT raw_mdm_command_output FROM mdm_bridge WHERE mdm_command_input = '%s';", escapedXML), true
 }
 
 func directIngestWindowsProfiles(


### PR DESCRIPTION
## Summary

This PR addresses several security vulnerabilities identified through static analysis using Semgrep and manual code review:

### 1. SQL Injection in osquery queries
- **File**: `server/service/osquery_utils/queries.go:3215`
- **Issue**: XML content from MDM profiles was directly interpolated into SQLite queries
- **Fix**: Escape single quotes by doubling them before query construction

### 2. SQL Injection in maintained apps validation
- **Files**: `cmd/maintained-apps/validate/windows.go`, `darwin.go`
- **Issue**: App names and paths used in LIKE clauses without escaping
- **Fix**: Escape single quotes in all user-derived values before SQL construction

### 3. PowerShell Command Injection
- **File**: `cmd/maintained-apps/validate/windows.go:127`
- **Issue**: `uniqueIdentifier` embedded directly in PowerShell command without escaping
- **Fix**: Escape single quotes for PowerShell single-quoted strings

### 4. Path Traversal
- **File**: `server/mdm/maintainedapps/testing_utils.go:29`
- **Issue**: URL path directly joined with base directory without validation
- **Fix**: Clean path, check for `..` sequences, and verify resolved path stays within intended directory

### 5. GitHub Actions Shell Injection
- **File**: `.github/actions/r2-upload/action.yml`
- **Issue**: Direct `${{ }}` interpolation in `run:` scripts allows injection
- **Fix**: Use intermediate environment variables (`env:`) and quote shell variables

## Test plan

- [ ] Verify osquery queries still function correctly with special characters in MDM profiles
- [ ] Verify maintained apps validation works on Windows and macOS
- [ ] Verify R2 upload GitHub Action functions correctly
- [ ] Run existing test suites to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)