### PR TITLE
False negative vulnerability for Adobe Acrobat Reader DC

### DIFF
--- a/changes/35366-false-negative-adobe-acrobat-reader-dc
+++ b/changes/35366-false-negative-adobe-acrobat-reader-dc
@@ -1,0 +1,1 @@
+* Fixed false negative for Adobe Reader DC CVE-2025-54257 & CVE-2025-54255

--- a/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
+++ b/docs/Contributing/product-groups/orchestration/understanding-host-vitals.md
@@ -1144,6 +1144,17 @@ SELECT
 FROM chocolatey_packages
 ```
 
+## software_windows_acrobat_dc
+
+- Description: Software override query used to determine whether the Adobe Acrobat Reader program name needs to include the DC postfix
+
+- Platforms: windows
+
+- Query:
+```sql
+SELECT 1 FROM registry WHERE key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Adobe\Adobe Acrobat\DC'
+```
+
 ## software_windows_last_opened_at
 
 - Description: A software override query[^1] to append last_opened_at information to Windows software entries.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1359,7 +1359,7 @@ var SoftwareOverrideQueries = map[string]DetailQuery{
 				orig := row["name"]
 				lower := strings.ToLower(orig)
 
-				if !strings.HasPrefix(lower, "adobe acrobat") {
+				if !strings.HasPrefix(lower, "adobe acrobat") && !strings.HasPrefix(lower, "acrobat reader") {
 					continue
 				}
 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1343,7 +1343,7 @@ FROM chrome_extensions`,
 // software_{macos|windows|linux} queries for the expected columns.
 var SoftwareOverrideQueries = map[string]DetailQuery{
 	// windows_acrobat_dc checks the Windows registry to determine if "DC" should be appended to the Adobe Acrobat
-	// Reader display name. While Adobe recently rebranded the free version to "Adobe Acrobat (64-bit)" — matching
+	// product name. While Adobe recently rebranded the free version to "Adobe Acrobat (64-bit)" — matching
 	// the naming convention of the paid product — our vulnerability detection engine requires the "DC" postfix for accurate
 	// signature matching.
 	"windows_acrobat_dc": {
@@ -1363,10 +1363,15 @@ var SoftwareOverrideQueries = map[string]DetailQuery{
 					continue
 				}
 
-				// Replace the 'acrobat' part for 'acrobat DC'
-				if idx := strings.Index(lower, "acrobat"); idx != -1 {
-					splitPoint := idx + len("acrobat")
-					softwareResults[i]["name"] = orig[:splitPoint] + " DC" + orig[splitPoint:]
+				// We need to correctly identify whether the name is in the
+				// form of `... Acrobat Reader ...` or just `... Acrobat ...`
+				options := []string{"reader", "acrobat"}
+				for _, variant := range options {
+					if idx := strings.Index(lower, variant); idx != -1 {
+						splitPoint := idx + len(variant)
+						softwareResults[i]["name"] = orig[:splitPoint] + " DC" + orig[splitPoint:]
+						break
+					}
 				}
 			}
 

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1347,7 +1347,7 @@ var SoftwareOverrideQueries = map[string]DetailQuery{
 	// the naming convention of the paid product — our vulnerability detection engine requires the "DC" postfix for accurate
 	// signature matching.
 	"windows_acrobat_dc": {
-		Description: "Software override query used to determine whether the Adobe Acrobat Reader program name needs to include the DC postfix or not",
+		Description: "Software override query used to determine whether the Adobe Acrobat Reader program name needs to include the DC postfix",
 		Platforms:   []string{"windows"},
 		Query:       `SELECT 1 FROM registry WHERE key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Adobe\Adobe Acrobat\DC'`,
 		SoftwareProcessResults: func(softwareResults, registryResults []map[string]string) []map[string]string {

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -3078,35 +3078,41 @@ func TestWindowsLastOpenedAt(t *testing.T) {
 
 func TestWindowsAcrobatDC(t *testing.T) {
 	processFunc := SoftwareOverrideQueries["windows_acrobat_dc"].SoftwareProcessResults
+	softwareResults := []map[string]string{
+		{"name": "Adobe Acrobat Reader 64-bit"},
+		{"name": "Adobe Acrobat 2017"},
+		{"name": "Acrobat Reader"},
+	}
 
-	t.Run("no registry results", func(t *testing.T) {
-		softwareResults := []map[string]string{
-			{"name": "Adobe Acrobat Reader 64-bit"},
-			{"name": "Adobe Acrobat 2017"},
-			{"name": "Acrobat Reader"},
-		}
+	testCases := []struct {
+		name            string
+		registryResults []map[string]string
+		expected        []map[string]string
+	}{
+		{
+			name:            "no registry results",
+			registryResults: nil,
+			expected:        softwareResults,
+		},
+		{
+			name: "registry results",
+			registryResults: []map[string]string{
+				{"present": ""},
+			},
+			expected: []map[string]string{
+				{"name": "Adobe Acrobat Reader DC 64-bit"},
+				{"name": "Adobe Acrobat DC 2017"},
+				{"name": "Acrobat Reader DC"},
+			},
+		},
+	}
 
-		got := processFunc(softwareResults, nil)
-		require.Equal(t, softwareResults, got)
-	})
-
-	t.Run("registry results present", func(t *testing.T) {
-		softwareResults := []map[string]string{
-			{"name": "Adobe Acrobat Reader 64-bit"},
-			{"name": "Adobe Acrobat 2017"},
-			{"name": "Acrobat Reader"},
-		}
-
-		registryResults := []map[string]string{{"present": "1"}}
-
-		got := processFunc(softwareResults, registryResults)
-		want := []map[string]string{
-			{"name": "Adobe Acrobat Reader DC 64-bit"},
-			{"name": "Adobe Acrobat DC 2017"},
-			{"name": "Acrobat Reader"},
-		}
-		require.Equal(t, want, got)
-	})
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := processFunc(softwareResults, testCase.registryResults)
+			require.Equal(t, testCase.expected, result)
+		})
+	}
 }
 
 func TestTPMPinSetVerifyIngest(t *testing.T) {

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -729,5 +729,15 @@
       "vendor": ["pgadmin"],
       "target_sw": ["postgresql"]
     }
+  },
+  {
+    "software": {
+      "name": ["Acrobat Reader"],
+      "source": ["apps"],
+      "bundle_identifier": ["com.adobe.Reader"]
+    },
+    "filter": {
+      "product": ["acrobat_reader_dc"]
+    }
   }
 ]


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
Resolves #35366 

The false negative was caused by a mismatch in product name translation for `acrobat_reader_dc`. The resolution required platform-specific logic to accurately identify the "Document Cloud" (DC) variants.

#### Windows
On Windows systems, the software was inconsistently reported as `Adobe Acrobat (x64)`. To resolve this, a registry inspection query was used to distinguish between DC and Classic variants.

#### macOS
Since 2020, all Adobe Reader versions for macOS inherently include DC capabilities, meaning granular version checks were unnecessary for this case, thus a new cpe translation rule was used for solving the problem.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually