### PR TITLE
Evernote: update darwin to latest and freeze

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/evernote.json
+++ b/ee/maintained-apps/inputs/homebrew/evernote.json
@@ -5,5 +5,6 @@
   "installer_format": "dmg",
   "slug": "evernote/darwin",
   "default_categories": ["Productivity"],
-  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/evernote-install.sh"
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/evernote-install.sh",
+  "frozen": true
 }

--- a/ee/maintained-apps/inputs/homebrew/evernote.json
+++ b/ee/maintained-apps/inputs/homebrew/evernote.json
@@ -5,6 +5,5 @@
   "installer_format": "dmg",
   "slug": "evernote/darwin",
   "default_categories": ["Productivity"],
-  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/evernote-install.sh",
-  "frozen": true
+  "install_script_path": "ee/maintained-apps/inputs/homebrew/scripts/evernote-install.sh"
 }

--- a/ee/maintained-apps/outputs/evernote/darwin.json
+++ b/ee/maintained-apps/outputs/evernote/darwin.json
@@ -1,7 +1,7 @@
 {
   "versions": [
     {
-      "version": "11.1.2",
+      "version": "latest",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote';"
       },

--- a/ee/maintained-apps/outputs/evernote/darwin.json
+++ b/ee/maintained-apps/outputs/evernote/darwin.json
@@ -5,7 +5,7 @@
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote';"
       },
-      "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-11.1.2-mac-ddl-stage.dmg",
+      "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-latest.dmg",
       "install_script_ref": "c4c66da7",
       "uninstall_script_ref": "7be36873",
       "sha256": "2cca5bacb3f587032f757c10ece93d284ee1a42a3a71ad80e61f3eeea3fe40f9",

--- a/ee/maintained-apps/outputs/evernote/darwin.json
+++ b/ee/maintained-apps/outputs/evernote/darwin.json
@@ -1,14 +1,14 @@
 {
   "versions": [
     {
-      "version": "10.105.4",
+      "version": "11.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.evernote.Evernote';"
       },
-      "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-10.105.4-mac-ddl-stage-20240910164757-a2e60a8d876a07eded5d212fa56ba45214114ad0.dmg",
+      "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-11.1.2-mac-ddl-stage.dmg",
       "install_script_ref": "c4c66da7",
       "uninstall_script_ref": "7be36873",
-      "sha256": "98d1f6d52718a0b05222b7cdce14a3755ece619edf0a1b8557af75afbfe2cd73",
+      "sha256": "2cca5bacb3f587032f757c10ece93d284ee1a42a3a71ad80e61f3eeea3fe40f9",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/evernote/darwin.json
+++ b/ee/maintained-apps/outputs/evernote/darwin.json
@@ -8,7 +8,7 @@
       "installer_url": "https://mac.desktop.evernote.com/builds/Evernote-latest.dmg",
       "install_script_ref": "c4c66da7",
       "uninstall_script_ref": "7be36873",
-      "sha256": "2cca5bacb3f587032f757c10ece93d284ee1a42a3a71ad80e61f3eeea3fe40f9",
+      "sha256": "no_check",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
This pull request updates the configuration and output files for the Evernote maintained app to simplify version management and improve maintainability. The main changes involve switching to a "latest" version tracking approach and marking the app as frozen.

**Version management updates:**

* Changed the tracked version in `ee/maintained-apps/outputs/evernote/darwin.json` from a specific version (`10.105.4`) to `"latest"`, and updated the `installer_url` to always point to the latest Evernote DMG file. The `sha256` hash is now set to `"no_check"` to accommodate the dynamic installer.

**Configuration changes:**

* Added `"frozen": true` to the Evernote app input configuration in `ee/maintained-apps/inputs/homebrew/evernote.json` to indicate the app is no longer actively updated in this system.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39032
