### PR TITLE
Document missing usage stats

### DIFF
--- a/articles/fleet-usage-statistics.md
+++ b/articles/fleet-usage-statistics.md
@@ -44,9 +44,30 @@ Below is the JSON payload that is sent to Fleet Device Management Inc:
   "maintenanceWindowsConfigured": true,
   "numHostsFleetDesktopEnabled": 999,
   "hostsEnrolledByOperatingSystem": {
+    "android": [
+      {
+        "version": "Android 15",
+        "numEnrolled": 999
+      },
+      ...
+    ],
     "darwin": [
       {
         "version": "macOS 12.3.1",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "ios": [
+      {
+        "version": "iOS 26.0.1",
+        "numEnrolled": 999
+      },
+      ...
+    ],
+    "ipados": [
+      {
+        "version": "iPadOS 26.1",
         "numEnrolled": 999
       },
       ...


### PR DESCRIPTION
Jordan confirmed that we include iOS, iPadOS, and Android enrollments, but it's not documented.

<img width="509" height="1050" alt="Screenshot 2026-02-02 at 13 29 42" src="https://github.com/user-attachments/assets/b5786dd0-7438-4436-8941-7f18fff4014d" />
