### PR TITLE
Update fleet-keynote-theme.yml

### DIFF
--- a/it-and-security/lib/macos/software/fleet-keynote-theme.yml
+++ b/it-and-security/lib/macos/software/fleet-keynote-theme.yml
@@ -1,3 +1,3 @@
-hash_sha256: 010b8dedc6c5688a75923f5fa0641ddd96c6bc2ba0d5b0d95dc87b5a622906cd
+hash_sha256: acc7b267b868b57a8d5e8ebcc9abc0460ba4163664900877553f8c1c42b570f1
 icon:
   path: ../../all/icons/keynote-theme-swan.png


### PR DESCRIPTION
Updated installer pkg to remove the retired dark theme. One thing to note, this pkg installer only works on the older version of Keynote.