### PR TITLE
Standardize macOS app update queries and related automation

### DIFF
--- a/.github/scripts/dogfood-policy-updater-latest-1password-macos.sh
+++ b/.github/scripts/dogfood-policy-updater-latest-1password-macos.sh
@@ -54,7 +54,7 @@ if [ "$policy_version_number" != "$latest_1password_macos_version" ]; then
     echo "Updating query line with the new version..."
 
     # Prepare the new query line
-    new_query_line="query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app') OR EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '$latest_1password_macos_version') >= 0);"
+    new_query_line="query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '$latest_1password_macos_version') < 0);"
 
     # Update the response
     updated_response=$(echo "$response" | sed "s/query: .*/$new_query_line/")

--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -1,5 +1,5 @@
 - name: macOS - 1Password up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app') OR EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.0') >= 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.0') < 0);
   critical: false
   description: The host may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
   resolution: Check for updates using 1Password's built-in update functionality or download the latest version from self-service. 

--- a/it-and-security/lib/macos/policies/update-firefox.yml
+++ b/it-and-security/lib/macos/policies/update-firefox.yml
@@ -1,5 +1,5 @@
 - name: macOS - Firefox up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app') OR EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '140.0.2') >= 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '140.0.2') < 0);
   critical: false
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: Download the latest version from self-service or check for updates using Firefox's built-in update functionality. You can also delete Firefox if you are no longer using it. 

--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -1,5 +1,5 @@
 - name: macOS - Slack up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app') OR EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.43.52') >= 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.43.52') < 0);
   critical: false
   description: The host may be running an outdated version of Slack, which could pose security vulnerabilities or compatibility issues.
   resolution: Slack can be updated by downloading the latest version from the App Store or by using Slack's built-in update functionality.


### PR DESCRIPTION
This pull request updates the logic used to check whether macOS applications (1Password, Firefox, and Slack) are up to date. The new queries simplify and improve accuracy by directly identifying outdated app versions, rather than relying on a combination of existence and version checks.

**Policy query logic updates:**

* Updated the query in `update-1password.yml` to directly select hosts with outdated 1Password versions, making the check more precise.
* Updated the query in `update-firefox.yml` to directly select hosts with outdated Firefox versions, improving accuracy.
* Updated the query in `update-slack.yml` to directly select hosts with outdated Slack versions, ensuring more reliable detection.

**Script logic update:**

* Changed the query line construction in `.github/scripts/dogfood-policy-updater-latest-1password-macos.sh` to match the new logic for identifying outdated 1Password installations.