### PR TITLE
Handbook: Update ritual labels to fix website deploy workflow

### DIFF
--- a/handbook/finance/finance.rituals.yml
+++ b/handbook/finance/finance.rituals.yml
@@ -192,7 +192,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/sales#review-salesforce-opportunities"
   dri: "Sampfluger88"
   autoIssue:   
-    labels: [ ":gtm-ops","#g-unicorns" ]
+    labels: [ ":gtm-ops" ]
     repo: "confidential"
 - 
   task: "Measure intent signals"

--- a/handbook/finance/finance.rituals.yml
+++ b/handbook/finance/finance.rituals.yml
@@ -192,7 +192,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/sales#review-salesforce-opportunities"
   dri: "Sampfluger88"
   autoIssue:   
-    labels: [ ":gtm-ops" ]
+    labels: [ ":gtm-ops", ":help-gtm-ops" ]
     repo: "confidential"
 - 
   task: "Measure intent signals"

--- a/handbook/sales/sales.rituals.yml
+++ b/handbook/sales/sales.rituals.yml
@@ -14,5 +14,5 @@
   moreInfoUrl: "https://fleetdm.com/handbook/sales#communicate-gross-new-arr-added"
   dri: "alexmitchelliii"
   autoIssue:   # Enables automation of GitHub issues
-    labels: [ "#g-unicorns" ] # label to be applied to issue
+    labels: [ ":help-gtm-ops" ] # label to be applied to issue
     repo: "confidential"


### PR DESCRIPTION
Changes:
- Changed the labels used for the  "Confirm closed lost is happening within 30 days" and "Communicate Gross new ARR added" rituals to fix the failing website tests/deploys.