### PR TITLE
Fix: Long text strings not appearing correctly in new host vitals (#39154)

### DIFF
--- a/changes/39125-fix-host-vitals-long-strings
+++ b/changes/39125-fix-host-vitals-long-strings
@@ -1,0 +1,2 @@
+- Truncated long strings (Operating system and Hardware model) in Host details > Vitals.
+- Renamed "Disk space" to "Disk space available" in Host details > Vitals.

--- a/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostTableConfig.tsx
@@ -299,7 +299,6 @@ const allHostTableHeaders: IHostTableColumnConfig[] = [
       }
       return (
         <DiskSpaceIndicator
-          inTableCell
           gigsDiskSpaceAvailable={gigs_disk_space_available}
           percentDiskSpaceAvailable={percent_disk_space_available}
           gigsTotalDiskSpace={gigs_total_disk_space}

--- a/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
+++ b/frontend/pages/hosts/components/DiskSpaceIndicator/DiskSpaceIndicator.tsx
@@ -16,7 +16,6 @@ interface IDiskSpaceIndicatorProps {
   gigsTotalDiskSpace?: number;
   gigsAllDiskSpace?: number;
   platform: string;
-  inTableCell?: boolean;
   tooltipPosition?: PlacesType;
 }
 
@@ -26,7 +25,6 @@ const DiskSpaceIndicator = ({
   gigsTotalDiskSpace,
   gigsAllDiskSpace,
   platform,
-  inTableCell = false,
   tooltipPosition = "top",
 }: IDiskSpaceIndicatorProps): JSX.Element => {
   // Check if storage measurement is not supported (sentinel value -1)
@@ -96,11 +94,7 @@ const DiskSpaceIndicator = ({
       </>
     ) : null;
 
-  const renderCopy = () => (
-    <>
-      {gigsDiskSpaceAvailable} GB{!inTableCell && " available"}
-    </>
-  );
+  const copyText = `${gigsDiskSpaceAvailable} GB`;
 
   return (
     <span className={baseClass}>
@@ -122,10 +116,10 @@ const DiskSpaceIndicator = ({
           tooltipClass="copy-tooltip-content"
           tipContent={copyTootltipContent}
         >
-          {renderCopy()}
+          {copyText}
         </TooltipWrapper>
       ) : (
-        renderCopy()
+        copyText
       )}
     </span>
   );

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -373,7 +373,7 @@ describe("Disk space field visibility", () => {
 
     render(<Vitals vitalsData={mockHost} />);
 
-    expect(screen.queryByText("Disk space")).not.toBeInTheDocument();
+    expect(screen.queryByText("Disk space available")).not.toBeInTheDocument();
   });
 
   it("shows disk space field for zero storage (disk full)", () => {
@@ -385,7 +385,7 @@ describe("Disk space field visibility", () => {
 
     render(<Vitals vitalsData={mockHost} />);
 
-    expect(screen.getByText("Disk space")).toBeInTheDocument();
+    expect(screen.getByText("Disk space available")).toBeInTheDocument();
   });
 
   it("renders disk space normally for positive values", () => {
@@ -397,7 +397,7 @@ describe("Disk space field visibility", () => {
 
     render(<Vitals vitalsData={mockHost} />);
 
-    expect(screen.getByText("Disk space")).toBeInTheDocument();
+    expect(screen.getByText("Disk space available")).toBeInTheDocument();
   });
 
   it("handles other negative values as not supported", () => {
@@ -409,6 +409,6 @@ describe("Disk space field visibility", () => {
 
     render(<Vitals vitalsData={mockHost} />);
 
-    expect(screen.queryByText("Disk space")).not.toBeInTheDocument();
+    expect(screen.queryByText("Disk space available")).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -166,7 +166,10 @@ const Vitals = ({
       return (
         <>
           {DeviceIdDataSet}
-          <DataSet title="Hardware model" value={vitalsData.hardware_model} />
+          <DataSet
+            title="Hardware model"
+            value={<TooltipTruncatedText value={vitalsData.hardware_model} />}
+          />
         </>
       );
     }
@@ -177,7 +180,10 @@ const Vitals = ({
       return (
         <>
           {DeviceIdDataSet}
-          <DataSet title="Hardware model" value={vitalsData.hardware_model} />
+          <DataSet
+            title="Hardware model"
+            value={<TooltipTruncatedText value={vitalsData.hardware_model} />}
+          />
         </>
       );
     }
@@ -186,7 +192,10 @@ const Vitals = ({
     // (either Serial number or Enrollment ID).
     return (
       <>
-        <DataSet title="Hardware model" value={vitalsData.hardware_model} />
+        <DataSet
+          title="Hardware model"
+          value={<TooltipTruncatedText value={vitalsData.hardware_model} />}
+        />
         {DeviceIdDataSet}
         <DataSet
           title="Private IP address"
@@ -319,10 +328,10 @@ const Vitals = ({
 
     const title = isAndroidHost ? (
       <TooltipWrapper tipContent="Includes internal and removable storage (e.g. microSD card).">
-        Disk space
+        Disk space available
       </TooltipWrapper>
     ) : (
-      "Disk space"
+      "Disk space available"
     );
 
     return (
@@ -440,7 +449,7 @@ const Vitals = ({
           <TooltipWrapperArchLinuxRolling />
         </>
       ) : (
-        version
+        <TooltipTruncatedText value={version} />
       );
       return (
         <DataSet
@@ -462,16 +471,23 @@ const Vitals = ({
       <DataSet
         title="Operating system"
         value={
-          <>
+          <span className={`${baseClass}__os-version`}>
             {!osVersionRequirementMet && (
               <Icon name="error-outline" color="ui-fleet-black-75" />
             )}
             <TooltipWrapper
+              className={`${baseClass}__os-version-tooltip`}
               tipContent={
                 osVersionRequirementMet ? (
-                  "Meets minimum version requirement."
+                  <>
+                    {vitalsData.os_version}
+                    <br />
+                    Meets minimum version requirement.
+                  </>
                 ) : (
                   <>
+                    {vitalsData.os_version}
+                    <br />
                     Does not meet minimum version requirement.
                     <br />
                     Deadline to update: {osVersionRequirement.deadline}
@@ -479,10 +495,13 @@ const Vitals = ({
                 )
               }
             >
-              {vitalsData.os_version}
+              <span className={`${baseClass}__os-version-text`}>
+                {vitalsData.os_version}
+              </span>
             </TooltipWrapper>
-          </>
+          </span>
         }
+        className={`${baseClass}__os-data-set`}
       />
     );
   };

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -53,6 +53,34 @@
     }
   }
 
+  // OS version with requirement icon + tooltip truncation
+  &__os-version {
+    display: flex;
+    align-items: center;
+    gap: $pad-xsmall;
+    min-width: 0;
+
+    // Prevent the error icon from shrinking
+    .icon {
+      flex-shrink: 0;
+    }
+  }
+
+  &__os-version-tooltip {
+    min-width: 0;
+
+    > .component__tooltip-wrapper__element {
+      overflow: hidden;
+    }
+  }
+
+  &__os-version-text {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   .text-muted {
     color: $ui-fleet-black-50;
   }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39125

PR to main was: https://github.com/fleetdm/fleet/pull/39154

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually

### Disk space

Renamed to `Disk space available` following [Scott's suggestion](https://github.com/fleetdm/fleet/issues/39125#issuecomment-3836462342) (we don't have to truncate at all since content will fit).

For linux hosts specifically, we already have a tooltip and show extra information (see https://github.com/fleetdm/fleet/issues/31671) <img width="208" height="95" alt="Screenshot 2026-02-02 at 2 10 52 PM" src="https://github.com/user-attachments/assets/c9aa3391-1c6d-4591-a838-1b48bb37a269" />

Non-linux hosts:
<img width="169" height="63" alt="Screenshot 2026-02-02 at 2 11 05 PM" src="https://github.com/user-attachments/assets/41addcbb-5a26-44c3-a16b-d13b3db2a642" />


### OS version

There was an existing tooltip when min version requirement is not met. Decided to also show the version within it.

<img width="282" height="117" alt="Screenshot 2026-02-02 at 1 50 01 PM" src="https://github.com/user-attachments/assets/c136ff2d-56a3-46b5-80d5-090f85fed734" />

Similar as above, when the min version requirement is met.

<img width="282" height="103" alt="Screenshot 2026-02-02 at 1 50 25 PM" src="https://github.com/user-attachments/assets/9afc75a9-334a-4ab8-b4ee-3a79130bfd39" />

When there's no version requirement, just show the version only when it's cut off.

<img width="276" height="70" alt="Screenshot 2026-02-02 at 1 51 03 PM" src="https://github.com/user-attachments/assets/1ef9c924-5a49-43d9-9c76-16fed9aaea0d" />

### Hardware model

<img width="183" height="50" alt="Screenshot 2026-02-02 at 1 59 01 PM" src="https://github.com/user-attachments/assets/03a43d17-76ea-413f-bde0-ae0b82fd379b" />

<img width="229" height="60" alt="Screenshot 2026-02-02 at 1 59 04 PM" src="https://github.com/user-attachments/assets/4745202c-114e-4264-a74f-51da1894fc5a" />



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed
