### PR TITLE
Only default update_new_hosts key if not explicitly set

### DIFF
--- a/changes/39048-only-default-if-update-new-hosts-not-explictly-set
+++ b/changes/39048-only-default-if-update-new-hosts-not-explictly-set
@@ -1,0 +1,1 @@
+- Fixed an issue where GitOps would not respect the value set on `update_new_hosts` for macOS updates.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -780,6 +780,7 @@ controls:
   macos_updates:
     deadline: "2025-10-10"
     minimum_version: "18.0"
+    update_new_hosts: false
   ios_updates:
     deadline: "2024-10-10"
     minimum_version: "18.0"
@@ -838,8 +839,9 @@ software:
 
 	assert.Equal(t, "2025-10-10", savedTeam.Config.MDM.MacOSUpdates.Deadline.Value)
 	assert.Equal(t, "18.0", savedTeam.Config.MDM.MacOSUpdates.MinimumVersion.Value)
-	// To keep things backwards compatible if MinimumVersion & Deadline are set, then UpdateNewHosts should be set to true
-	assert.Equal(t, optjson.SetBool(true), savedTeam.Config.MDM.MacOSUpdates.UpdateNewHosts)
+
+	// Ensure the default value (if deadline and minimum_version are set) can be overriden with explicit setting
+	assert.Equal(t, optjson.SetBool(false), savedTeam.Config.MDM.MacOSUpdates.UpdateNewHosts)
 
 	// The previous run created the team, so let's rerun with an existing team
 	_ = RunAppForTest(t, []string{"gitops", "-f", tmpFile.Name()})

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2196,9 +2196,9 @@ func (c *Client) DoGitOps(
 			macOSUpdates["deadline"] = ""
 		}
 
-		// To keep things backward compatible, if a minimum_version and deadline are both set,
-		// then we also set update_new_hosts
-		if macOSUpdates["minimum_version"] != "" && macOSUpdates["deadline"] != "" {
+		// To keep things backward compatible, if a minimum_version and deadline are both set but the user hasn't set update_new_hosts,
+		// then we default update_new_hosts to true
+		if macOSUpdates["minimum_version"] != "" && macOSUpdates["deadline"] != "" && macOSUpdates["update_new_hosts"] == nil {
 			macOSUpdates["update_new_hosts"] = true
 		}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39048 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
