### PR TITLE
Website: add learn-more-about redirect for changed link

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -1188,6 +1188,7 @@ module.exports.routes = {
   'GET /learn-more-about/available-fma-versions': 'https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps/outputs',
   'GET /learn-more-about/connect-microsoft-entra': '/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id',
   'GET /learn-more-about/macos-configuration-profiles-same-scope': '/guides/custom-os-settings#upgrading-to-4-71-0',
+  'GET /learn-more-about/configuration-profiles-user-channel': '/guides/custom-os-settings#upgrading-to-4-71-0',
   'GET /learn-more-about/disable-okta-conditional-access': '/guides/okta-conditional-access-integration#disabling-okta-conditional-access',
   'GET /learn-more-about/deploy-self-service-to-ios': '/guides/software-self-service#deploy-self-service-on-ios-and-ipados',
 


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/37463

Changes:
- Added a redirect for a link that was used in an older version of Fleet