### PR TITLE
Fleet UI: Run script 400px truncation instead of 250px (QA followup)

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -106,7 +106,10 @@ export const generateTableColumnConfigs = (
             onClick={onClickScriptName}
             variant="inverse"
           >
-            <TooltipTruncatedTextCell value={cellProps.row.original.name} />
+            <TooltipTruncatedTextCell
+              value={cellProps.row.original.name}
+              classes="w400"
+            />
           </Button>
         );
       },


### PR DESCRIPTION
## Issue
Closes #34359

## Description
- During QA, noticed the text felt like it was being cut off prematurely
- Increased text cell truncation width from 250px to 400px

## Screen recording of fix
https://fleetdm.zoom.us/clips/share/u1Hiz_ipRgu9MRwNF7DIdg


## Testing

- [x] QA'd all new/changed functionality manually
