### PR TITLE
Added to gitignore: third_party/vuln-check/go.sum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ fleet_tables_*.ext
 .env
 .tool-versions
 .zed/
+third_party/vuln-check/go.sum
 
 # Required to not make `fleet-desktop` macOS executable built with a `dirty` flag (see #35006).
 Fleet\ Desktop.app


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31605

Some dev tools automatically create a `go.sum` file. It is not needed for our third-party vuln usecase. We are interested in library vulns, and not vulns of the library dependencies.