### PR TITLE
Cherry-pick: Clear reset tokens and user sessions after password change

### DIFF
--- a/changes/clear-sessions-and-tokens-on-password-change
+++ b/changes/clear-sessions-and-tokens-on-password-change
@@ -1,0 +1,1 @@
+- User sessions and password reset tokens are now cleared whenever a user's password is changed.

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -9420,18 +9420,30 @@ func (s *integrationTestSuite) TestChangePassword() {
 		{"password123$", "password123$", http.StatusUnprocessableEntity},
 		// wrong old pw
 		{"passgord123$", "Password$321", http.StatusUnprocessableEntity},
+
+		// change back to original password for cleanup
+		{"Password$321", startPwd, http.StatusOK},
 	}
 
-	runTestCases := func(name string) {
+	runTestCases := func(name, userEmail string) {
+		currentPwd := startPwd
 		for _, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				var changePwResp changePasswordResponse
 				s.DoJSON("POST", endpoint, changePasswordRequest{OldPassword: tc.oldPw, NewPassword: tc.newPw}, tc.expectedStatus, &changePwResp)
+				// After a successful password change, the session is invalidated, so we need to re-authenticate
+				if tc.expectedStatus == http.StatusOK {
+					currentPwd = tc.newPw
+					s.token = s.getTestToken(userEmail, currentPwd)
+				}
 			})
 		}
 	}
 
-	runTestCases("test change passwords as admin")
+	adminEmail := "admin1@example.com"
+	// Clear the cached admin token so it will be refreshed after password changes
+	s.cachedAdminToken = ""
+	runTestCases("test change passwords as admin", adminEmail)
 
 	// create a new user
 	testUserEmail := "changepwd@example.com"
@@ -9446,13 +9458,13 @@ func (s *integrationTestSuite) TestChangePassword() {
 	s.DoJSON("POST", "/api/latest/fleet/users/admin", params, http.StatusOK, &createResp)
 	require.NotZero(t, createResp.User.ID)
 
-	// schedule cleanup with admin user's token before changing it
-	oldToken := s.token
-	t.Cleanup(func() { s.token = oldToken })
+	// Clear the cached admin token again and schedule cleanup to restore it
+	s.cachedAdminToken = ""
+	t.Cleanup(func() { s.token = s.getTestAdminToken() })
 
 	// login and run the change password tests as the user
 	s.token = s.getTestToken(testUserEmail, startPwd)
-	runTestCases("test change passwords as user")
+	runTestCases("test change passwords as user", testUserEmail)
 }
 
 func (s *integrationTestSuite) TestPasswordReset() {


### PR DESCRIPTION
(cherry picked from commit 92135b691d65ea267035dd47672da00b82b186ed)

See https://github.com/fleetdm/fleet/pull/38999, https://github.com/fleetdm/confidential/issues/13987