### PR TITLE
Remove obsolete assertions to fix failing tests

### DIFF
--- a/cmd/fleetctl/integrationtest/preview/preview_test.go
+++ b/cmd/fleetctl/integrationtest/preview/preview_test.go
@@ -41,11 +41,6 @@ func TestIntegrationsPreview(t *testing.T) {
 
 	// run some sanity checks on the preview environment
 
-	// starter library queries must have been loaded
-	queries := fleetctl.RunAppForTest(t, []string{"get", "queries", "--config", configPath, "--json"})
-	n := strings.Count(queries, `"kind":"query"`)
-	require.Greater(t, n, 0)
-
 	// app configuration must disable analytics
 	appConf := fleetctl.RunAppForTest(t, []string{"get", "config", "--include-server-config", "--config", configPath, "--yaml"})
 	ok := strings.Contains(appConf, `enable_analytics: false`)

--- a/server/service/endpoint_setup_test.go
+++ b/server/service/endpoint_setup_test.go
@@ -502,18 +502,6 @@ func TestApplyStarterLibraryWithMockClient(t *testing.T) {
 	teamName := team1["name"].(string)
 	require.NotEmpty(t, teamName, "Team name should not be empty")
 
-	// Verify the scripts
-	scripts, ok := team1["scripts"].([]interface{})
-	require.True(t, ok, "Team should have scripts")
-	require.Len(t, scripts, 3, "Team should have 3 scripts")
-
-	// Verify that script references were rewritten to point to the temporary directory
-	for _, v := range scripts {
-		path := v.(string)
-		assert.Contains(t, path, os.TempDir(), "Script path should contain the temporary directory")
-		assert.True(t, filepath.IsAbs(path), "Script path should be absolute")
-	}
-
 	// Verify that the starter library URL was requested
 	assert.Contains(t, mockRT.calls, starterLibraryURL, "The starter library URL should have been requested")
 }


### PR DESCRIPTION
Since https://github.com/fleetdm/fleet/pull/39181 got merged, a couple tests were constantly failing as they expected scripts and queries after loading the starter library, but that library doesn't have any of those anymore.