### PR TITLE
Fix: IdP host vitals not automatically populated for Android hosts

### DIFF
--- a/changes/38554-populate-idp-host-vitals-android
+++ b/changes/38554-populate-idp-host-vitals-android
@@ -1,0 +1,2 @@
+- Fixed Android enrollment to associate hosts with SCIM users, populating full name, groups, and department in host       
+  vitals.

--- a/changes/38554-populate-idp-host-vitals-android
+++ b/changes/38554-populate-idp-host-vitals-android
@@ -1,2 +1,1 @@
-- Fixed Android enrollment to associate hosts with SCIM users, populating full name, groups, and department in host       
-  vitals.
+- Fixed Android enrollment to associate hosts with SCIM users, populating full name, groups, and department in host vitals.

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -549,6 +549,9 @@ func (svc *Service) addNewHost(ctx context.Context, device *androidmanagement.De
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "associating host with idp account")
 		}
+		if err := svc.fleetDS.MaybeAssociateHostWithScimUser(ctx, fleetHost.Host.ID); err != nil {
+			return ctxerr.Wrap(ctx, err, "associating android host with scim user")
+		}
 	}
 
 	// Create pending certificate templates for this newly enrolled host.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38554

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

There's already an integration test for `MaybeAssociateHostWithScimUser` which is the function call I added as a fix. See https://github.com/fleetdm/fleet/blob/b25c9522e4eb63a44e254904cf986440a7c30a95/server/datastore/mysql/hosts_test.go#L12242

- [x] QA'd all new/changed functionality manually

Enrolled physical Android device and verified that **Full name (IdP)** and **Groups (IdP)** are populated.

<img width="1435" height="768" alt="Screenshot 2026-02-03 at 3 31 16 PM" src="https://github.com/user-attachments/assets/0f7e8fc9-34f5-404c-bd1f-baed589aba60" />

