### PR TITLE
Fix: Show error reason when trying to edit a label that conflicts with a built-in label name

### DIFF
--- a/changes/37146-create-builtin-label-error-msg
+++ b/changes/37146-create-builtin-label-error-msg
@@ -1,1 +1,1 @@
-- Show error reason when trying to create a label that conflicts with a built-in label name
+- Show error reason when trying to create or edit a label that conflicts with a built-in label name

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -103,7 +103,8 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't edit label. Please try again.";
       if (status === 409) {
-        errorMessage = "A label with this name already exists.";
+        errorMessage =
+          "Couldn't edit label: A label with this name already exists.";
       } else if (status === 422) {
         const reason = getErrorReason(error);
         if (reason) {

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -9,6 +9,7 @@ import labelsAPI, {
   IGetLabelResponse,
 } from "services/entities/labels";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { getErrorReason } from "interfaces/errors";
 import { ILabel } from "interfaces/label";
 import { IHost } from "interfaces/host";
 import { NotificationContext } from "context/notification";
@@ -98,8 +99,18 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     try {
       await labelsAPI.update(labelId, formData);
       renderFlash("success", "Label updated successfully.");
-    } catch {
-      renderFlash("error", "Couldn't edit label. Please try again.");
+    } catch (error) {
+      const status = (error as { status: number }).status;
+      let errorMessage = "Couldn't edit label. Please try again.";
+      if (status === 409) {
+        errorMessage = "A label with this name already exists.";
+      } else if (status === 422) {
+        const reason = getErrorReason(error);
+        if (reason) {
+          errorMessage = `Couldn't edit label: ${reason}. Please try again.`;
+        }
+      }
+      renderFlash("error", errorMessage);
     }
   };
 

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -326,7 +326,8 @@ const NewLabelPage = ({
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't add label. Please try again.";
       if (status === 409) {
-        errorMessage = "A label with this name already exists.";
+        errorMessage =
+          "Couldn't add label: A label with this name already exists.";
       } else if (status === 422) {
         const reason = getErrorReason(error);
         if (reason) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37146

Follow-up of https://github.com/fleetdm/fleet/pull/38828 which only handled label creation. This PR adds the same behavior for edits.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<img width="1070" height="647" alt="Screenshot 2026-02-03 at 4 45 45 PM" src="https://github.com/user-attachments/assets/c4762929-df86-45f4-ae3d-d529db00890e" />


<img width="1071" height="648" alt="Screenshot 2026-02-03 at 4 39 28 PM" src="https://github.com/user-attachments/assets/a5661043-3f6a-440c-abe1-7f9beec1469b" />
