### PR TITLE
Fleet UI: fix unreleased disabled overlay sizing

### DIFF
--- a/frontend/pages/SoftwarePage/components/cards/SelfServicePreview/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/cards/SelfServicePreview/_styles.scss
@@ -41,7 +41,7 @@
   &__disabled-overlay {
     position: absolute;
     width: 540px;
-    height: 335px;
+    height: 265px;
     z-index: 1000;
   }
 


### PR DESCRIPTION
## Issue
Closes #39256
Unreleased bug from #38241

## Description
- Previews looking the same made self-service section shorter but the disabled overlay was not updated to be shorter as well
- Update disabled overlay to only cover the self-service preview and not the save button

## Screenrecording of fix

https://github.com/user-attachments/assets/c8520ef4-88b2-4662-8ee0-671773d6206e



# Checklist for submitter


## Testing

- [x] Caught from automated E2e tests <3 
- [x] QA'd all new/changed functionality manually
