### PR TITLE
cherry pick 39215 refetch

### DIFF
--- a/changes/37146-create-builtin-label-error-msg
+++ b/changes/37146-create-builtin-label-error-msg
@@ -1,1 +1,1 @@
-- Show error reason when trying to create a label that conflicts with a built-in label name
+- Show error reason when trying to create or edit a label that conflicts with a built-in label name

--- a/changes/39215-refetch
+++ b/changes/39215-refetch
@@ -1,0 +1,1 @@
+- Updated refetch logic for iPhone and iPad to only fetch location data if the host is locked.

--- a/changes/clear-sessions-and-tokens-on-password-change
+++ b/changes/clear-sessions-and-tokens-on-password-change
@@ -1,0 +1,1 @@
+- User sessions and password reset tokens are now cleared whenever a user's password is changed.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -106,7 +106,10 @@ export const generateTableColumnConfigs = (
             onClick={onClickScriptName}
             variant="inverse"
           >
-            <TooltipTruncatedTextCell value={cellProps.row.original.name} />
+            <TooltipTruncatedTextCell
+              value={cellProps.row.original.name}
+              classes="w400"
+            />
           </Button>
         );
       },

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -9,6 +9,7 @@ import labelsAPI, {
   IGetLabelResponse,
 } from "services/entities/labels";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
+import { getErrorReason } from "interfaces/errors";
 import { ILabel } from "interfaces/label";
 import { IHost } from "interfaces/host";
 import { NotificationContext } from "context/notification";
@@ -98,8 +99,19 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     try {
       await labelsAPI.update(labelId, formData);
       renderFlash("success", "Label updated successfully.");
-    } catch {
-      renderFlash("error", "Couldn't edit label. Please try again.");
+    } catch (error) {
+      const status = (error as { status: number }).status;
+      let errorMessage = "Couldn't edit label. Please try again.";
+      if (status === 409) {
+        errorMessage =
+          "Couldn't edit label: A label with this name already exists.";
+      } else if (status === 422) {
+        const reason = getErrorReason(error);
+        if (reason) {
+          errorMessage = `Couldn't edit label: ${reason}. Please try again.`;
+        }
+      }
+      renderFlash("error", errorMessage);
     }
   };
 

--- a/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
+++ b/frontend/pages/labels/NewLabelPage/NewLabelPage.tsx
@@ -326,7 +326,8 @@ const NewLabelPage = ({
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't add label. Please try again.";
       if (status === 409) {
-        errorMessage = "A label with this name already exists.";
+        errorMessage =
+          "Couldn't add label: A label with this name already exists.";
       } else if (status === 422) {
         const reason = getErrorReason(error);
         if (reason) {

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1480,7 +1480,12 @@ func (svc *Service) RefetchHost(ctx context.Context, id uint) error {
 			return ctxerr.Wrap(ctx, err, "refetch host: get host DEP assignment")
 		}
 
-		if adeData.IsDEPAssignedToFleet() {
+		lwStatus, err := svc.ds.GetHostLockWipeStatus(ctx, host)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "refetch host: get host location data")
+		}
+
+		if adeData.IsDEPAssignedToFleet() && lwStatus.IsLocked() {
 			err = svc.mdmAppleCommander.DeviceLocation(ctx, []string{host.UUID}, cmdUUID)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "refetch host: get location with MDM")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -9420,18 +9420,30 @@ func (s *integrationTestSuite) TestChangePassword() {
 		{"password123$", "password123$", http.StatusUnprocessableEntity},
 		// wrong old pw
 		{"passgord123$", "Password$321", http.StatusUnprocessableEntity},
+
+		// change back to original password for cleanup
+		{"Password$321", startPwd, http.StatusOK},
 	}
 
-	runTestCases := func(name string) {
+	runTestCases := func(name, userEmail string) {
+		currentPwd := startPwd
 		for _, tc := range testCases {
 			t.Run(name, func(t *testing.T) {
 				var changePwResp changePasswordResponse
 				s.DoJSON("POST", endpoint, changePasswordRequest{OldPassword: tc.oldPw, NewPassword: tc.newPw}, tc.expectedStatus, &changePwResp)
+				// After a successful password change, the session is invalidated, so we need to re-authenticate
+				if tc.expectedStatus == http.StatusOK {
+					currentPwd = tc.newPw
+					s.token = s.getTestToken(userEmail, currentPwd)
+				}
 			})
 		}
 	}
 
-	runTestCases("test change passwords as admin")
+	adminEmail := "admin1@example.com"
+	// Clear the cached admin token so it will be refreshed after password changes
+	s.cachedAdminToken = ""
+	runTestCases("test change passwords as admin", adminEmail)
 
 	// create a new user
 	testUserEmail := "changepwd@example.com"
@@ -9446,13 +9458,13 @@ func (s *integrationTestSuite) TestChangePassword() {
 	s.DoJSON("POST", "/api/latest/fleet/users/admin", params, http.StatusOK, &createResp)
 	require.NotZero(t, createResp.User.ID)
 
-	// schedule cleanup with admin user's token before changing it
-	oldToken := s.token
-	t.Cleanup(func() { s.token = oldToken })
+	// Clear the cached admin token again and schedule cleanup to restore it
+	s.cachedAdminToken = ""
+	t.Cleanup(func() { s.token = s.getTestAdminToken() })
 
 	// login and run the change password tests as the user
 	s.token = s.getTestToken(testUserEmail, startPwd)
-	runTestCases("test change passwords as user")
+	runTestCases("test change passwords as user", testUserEmail)
 }
 
 func (s *integrationTestSuite) TestPasswordReset() {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12499,6 +12499,11 @@ func (s *integrationMDMTestSuite) TestRefetchIOSIPadOS() {
 	host, mdmClient := s.createAppleMobileHostThenEnrollMDM("ios")
 	require.NoError(t, s.ds.SetOrUpdateMDMData(context.Background(), host.ID, false, true, "https://foo.com", true, "", "", false))
 
+	s.enableABM(t.Name())
+	abmTok, err := s.ds.GetABMTokenByOrgName(t.Context(), t.Name())
+	require.NoError(t, err)
+	s.Require().NoError(s.ds.UpsertMDMAppleHostDEPAssignments(t.Context(), []fleet.Host{*host}, abmTok.ID, nil))
+
 	// Refetch host
 	_ = s.Do("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/refetch", host.ID), nil, http.StatusOK)
 	const commandsSentPerRefetch = 3


### PR DESCRIPTION
- **Cherry-pick: Clear reset tokens and user sessions after password change (#39248)**
- **Fix: Show error reason when trying to edit a label that conflicts with a built-in label name (#39271)**
- **For R.C. - Fleet UI: Run script 400px truncation instead of 250px (QA followup) (#39243) (#39255)**
- **only refetch location data if iDevice is locked (#39241)**

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
