### PR TITLE
Put Android profiles in pending immediately on upload

### DIFF
--- a/changes/35613-android-profiles-pending
+++ b/changes/35613-android-profiles-pending
@@ -1,0 +1,1 @@
+Updated Android MDM profiles to show up as pending on upload, the same as Apple MDM profiles.

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -137,13 +137,9 @@ func (s *integrationMDMTestSuite) createEnrolledAndroidHost(t *testing.T, ctx co
 			AppliedPolicyID:      ptr.String("1"),
 		},
 	}
-	// TODO(JK): test that this doesn't mess other things
 	androidHostInput.SetNodeKey("android/" + hostUUID)
 	createdAndroidHost, err := s.ds.NewAndroidHost(ctx, androidHostInput)
 	require.NoError(t, err)
-
-	fmt.Println(createdAndroidHost.Hostname)
-	fmt.Println(createdAndroidHost.Host.ID)
 
 	host := createdAndroidHost.Host
 	orbitNodeKey := *host.NodeKey

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -137,9 +137,13 @@ func (s *integrationMDMTestSuite) createEnrolledAndroidHost(t *testing.T, ctx co
 			AppliedPolicyID:      ptr.String("1"),
 		},
 	}
-	androidHostInput.SetNodeKey(enterpriseID)
+	// TODO(JK): test that this doesn't mess other things
+	androidHostInput.SetNodeKey("android/" + hostUUID)
 	createdAndroidHost, err := s.ds.NewAndroidHost(ctx, androidHostInput)
 	require.NoError(t, err)
+
+	fmt.Println(createdAndroidHost.Hostname)
+	fmt.Println(createdAndroidHost.Host.ID)
 
 	host := createdAndroidHost.Host
 	orbitNodeKey := *host.NodeKey

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -8725,18 +8725,15 @@ func (s *integrationMDMTestSuite) TestHostMDMAndroidProfilesStatus() {
 	res := s.DoRawWithHeaders("POST", "/api/latest/fleet/configuration_profiles", body.Bytes(), http.StatusOK, headers)
 	require.NotNil(t, res)
 
-	// profiles should get to pending even before the cron job s.awaitTriggerAndroidProfileSchedule(t)
-
+	// profiles should be added with NULL status even before the cron job (s.awaitTriggerAndroidProfileSchedule(t))
 	var profiles []fleet.HostMDMAndroidProfile
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 		err := sqlx.SelectContext(ctx, q, &profiles, "SELECT host_uuid, status, operation_type FROM host_mdm_android_profiles")
 		require.NoError(t, err)
-		mysql.DumpTable(t, q, "mdm_android_configuration_profiles")
-		mysql.DumpTable(t, q, "host_mdm_android_profiles")
 		return nil
 	})
 
 	require.Len(t, profiles, 2)
-	require.Equal(t, profiles[0].Status, nil)
-	require.Equal(t, profiles[1].Status, nil)
+	require.Nil(t, profiles[0].Status)
+	require.Nil(t, profiles[1].Status)
 }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -8727,10 +8727,16 @@ func (s *integrationMDMTestSuite) TestHostMDMAndroidProfilesStatus() {
 
 	// profiles should get to pending even before the cron job s.awaitTriggerAndroidProfileSchedule(t)
 
+	var profiles []fleet.HostMDMAndroidProfile
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		err := sqlx.SelectContext(ctx, q, &profiles, "SELECT host_uuid, status, operation_type FROM host_mdm_android_profiles")
+		require.NoError(t, err)
 		mysql.DumpTable(t, q, "mdm_android_configuration_profiles")
 		mysql.DumpTable(t, q, "host_mdm_android_profiles")
 		return nil
 	})
 
+	require.Len(t, profiles, 2)
+	require.Equal(t, profiles[0].Status, nil)
+	require.Equal(t, profiles[1].Status, nil)
 }

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1801,12 +1801,6 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 		}
 		return nil, ctxerr.Wrap(ctx, err)
 	}
-	// TODO(JK): this will set all profiles to null, only the reconcile profiles job will actually
-	// set these to pending. In apple profiles there is no need to wait for the job to set the
-	// status to pending and additional fields.
-	// --- It might not even do the same to macOS as for iOS/iPadOS. <- nevermind, it exlcudes macOS ONLY profiles
-	// It looks like for apple (macos only?) the logic that would happen in ReconcileProfiles for android
-	// happens in bulkSetPendingMDMAppleHostProfilesDB
 	if _, err := svc.ds.BulkSetPendingMDMHostProfiles(ctx, nil, nil, []string{newCP.ProfileUUID}, nil); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "bulk set pending host profiles")
 	}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1801,6 +1801,15 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 		}
 		return nil, ctxerr.Wrap(ctx, err)
 	}
+	// TODO(JK): this will set all profiles to null, only the reconcile profiles job will actually
+	// set these to pending. In apple profiles there is no need to wait for the job to set the
+	// status to pending and additional fields.
+	// --- It might not even do the same to macOS as for iOS/iPadOS. <- nevermind, it exlcudes macOS ONLY profiles
+	// It looks like for apple (macos only?) the logic that would happen in ReconcileProfiles for android
+	// happens in bulkSetPendingMDMAppleHostProfilesDB
+	if _, err := svc.ds.BulkSetPendingMDMHostProfiles(ctx, nil, nil, []string{newCP.ProfileUUID}, nil); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "bulk set pending host profiles")
+	}
 
 	var (
 		actTeamID   *uint

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2669,6 +2669,9 @@ func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
 	ds.NewMDMAndroidConfigProfileFunc = func(ctx context.Context, cp fleet.MDMAndroidConfigProfile) (*fleet.MDMAndroidConfigProfile, error) {
 		return &fleet.MDMAndroidConfigProfile{}, nil
 	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(ctx context.Context, hostIDs, teamIDs []uint, profileUUIDs, hostUUIDs []string) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
 
 	testCases := []struct {
 		name    string


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35613
Android profiles will now show up in the UI as "pending" immediately on a profile upload, to match Apple profiles behavior. Previously, you would have to wait until the `mdm_android_profile_manager` cron job for them to show up and actually install them.
This could cost a little bit of performance, but is the existing behavior for Apple profiles.
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually:
- Adding an Android profile adds it to null in host_mdm_android_profiles, which makes it show up as “pending” immediately  in the UI. When `mdm_android_profile_manager` runs it sets them to pending in the database instead of null.
- Deleting a profile will also cause all profiles to become pending immediately. 