### PR TITLE
Fleet UI (GitOps Mode): Disable edit software modal fields for FMAs, add GitOps tooltips on Save buttons

### DIFF
--- a/changes/39419-disable-gitops-edit-fma
+++ b/changes/39419-disable-gitops-edit-fma
@@ -1,0 +1,1 @@
+- Fleet UI: Do not allow editing Fleet-maintained app in the UI while GitOps mode is enabled

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tsx
@@ -16,6 +16,7 @@ import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Checkbox from "components/forms/fields/Checkbox";
 import TargetLabelSelector from "components/TargetLabelSelector";
+import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 import {
   CUSTOM_TARGET_OPTIONS,
@@ -200,87 +201,91 @@ const EditAutoUpdateConfigModal = ({
 
   return (
     <Modal className={baseClass} title="Schedule auto updates" onExit={onExit}>
-      <div className={formClassNames}>
-        <div className={`${formClass}__form-frame`}>
-          <Card paddingSize="medium" borderRadiusSize="medium">
-            <div className={`${formClass}__auto-update-config`}>
-              <div className={`form-field`}>
-                <div className="form-field__label">Auto updates</div>
-                <div className="form-field__subtitle">
-                  Automatically update <strong>{softwareTitle.name}</strong> on
-                  all targeted hosts when a new version is available.
+      <>
+        <div className={formClassNames}>
+          <div className={`${formClass}__form-frame`}>
+            <Card paddingSize="medium" borderRadiusSize="medium">
+              <div className={`${formClass}__auto-update-config`}>
+                <div className={`form-field`}>
+                  <div className="form-field__label">Auto updates</div>
+                  <div className="form-field__subtitle">
+                    Automatically update <strong>{softwareTitle.name}</strong>{" "}
+                    on all targeted hosts when a new version is available.
+                  </div>
+                  <div>
+                    <Checkbox
+                      value={formData.autoUpdateEnabled}
+                      onChange={(newVal: boolean) => onToggleEnabled(newVal)}
+                    >
+                      Enable auto updates
+                    </Checkbox>
+                  </div>
                 </div>
-                <div>
-                  <Checkbox
-                    value={formData.autoUpdateEnabled}
-                    onChange={(newVal: boolean) => onToggleEnabled(newVal)}
-                  >
-                    Enable auto updates
-                  </Checkbox>
-                </div>
+                {formData.autoUpdateEnabled && (
+                  <>
+                    <div>
+                      <div className="form-field">
+                        <div className={updateWindowLabelClass}>
+                          {updateWindowLabel}
+                        </div>
+                        <div className="form-field__subtitle">
+                          Times are formatted as HH:MM in 24 hour time (e.g.,
+                          &quot;13:37&quot;).
+                        </div>
+                      </div>
+                    </div>
+                    <div>
+                      <div
+                        className={`${formClass}__auto-update-schedule-form`}
+                      >
+                        <span className="date-time-inputs">
+                          <InputField
+                            value={formData.autoUpdateStartTime}
+                            onChange={onChangeTimeField}
+                            onBlur={() =>
+                              setFormValidation(validateFormData(formData))
+                            }
+                            label="Earliest start time"
+                            name="autoUpdateStartTime"
+                            parseTarget
+                            error={earliestStartTimeError}
+                          />
+                          <InputField
+                            value={formData.autoUpdateEndTime}
+                            onChange={onChangeTimeField}
+                            onBlur={() =>
+                              setFormValidation(validateFormData(formData))
+                            }
+                            label="Latest start time"
+                            name="autoUpdateEndTime"
+                            parseTarget
+                            error={latestStartTimeError}
+                          />
+                        </span>
+                      </div>
+                    </div>
+                  </>
+                )}
               </div>
-              {formData.autoUpdateEnabled && (
-                <>
-                  <div>
-                    <div className="form-field">
-                      <div className={updateWindowLabelClass}>
-                        {updateWindowLabel}
-                      </div>
-                      <div className="form-field__subtitle">
-                        Times are formatted as HH:MM in 24 hour time (e.g.,
-                        &quot;13:37&quot;).
-                      </div>
-                    </div>
-                  </div>
-                  <div>
-                    <div className={`${formClass}__auto-update-schedule-form`}>
-                      <span className="date-time-inputs">
-                        <InputField
-                          value={formData.autoUpdateStartTime}
-                          onChange={onChangeTimeField}
-                          onBlur={() =>
-                            setFormValidation(validateFormData(formData))
-                          }
-                          label="Earliest start time"
-                          name="autoUpdateStartTime"
-                          parseTarget
-                          error={earliestStartTimeError}
-                        />
-                        <InputField
-                          value={formData.autoUpdateEndTime}
-                          onChange={onChangeTimeField}
-                          onBlur={() =>
-                            setFormValidation(validateFormData(formData))
-                          }
-                          label="Latest start time"
-                          name="autoUpdateEndTime"
-                          parseTarget
-                          error={latestStartTimeError}
-                        />
-                      </span>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-          </Card>
-          <Card paddingSize="medium" borderRadiusSize="medium">
-            <TargetLabelSelector
-              selectedTargetType={formData.targetType}
-              selectedCustomTarget={formData.customTarget}
-              selectedLabels={formData.labelTargets}
-              customTargetOptions={CUSTOM_TARGET_OPTIONS}
-              className={`${formClass}__target`}
-              onSelectTargetType={onSelectTargetType}
-              onSelectCustomTarget={onSelectCustomTargetOption}
-              onSelectLabel={onSelectLabel}
-              labels={labels || []}
-              dropdownHelpText={
-                generateHelpText(false, formData.customTarget) // maps to !automaticInstall help text
-              }
-              subTitle="Changes to targets will also apply to self-service."
-            />
-          </Card>
+            </Card>
+            <Card paddingSize="medium" borderRadiusSize="medium">
+              <TargetLabelSelector
+                selectedTargetType={formData.targetType}
+                selectedCustomTarget={formData.customTarget}
+                selectedLabels={formData.labelTargets}
+                customTargetOptions={CUSTOM_TARGET_OPTIONS}
+                className={`${formClass}__target`}
+                onSelectTargetType={onSelectTargetType}
+                onSelectCustomTarget={onSelectCustomTargetOption}
+                onSelectLabel={onSelectLabel}
+                labels={labels || []}
+                dropdownHelpText={
+                  generateHelpText(false, formData.customTarget) // maps to !automaticInstall help text
+                }
+                subTitle="Changes to targets will also apply to self-service."
+              />
+            </Card>
+          </div>
         </div>
         <ModalFooter
           primaryButtons={
@@ -288,18 +293,28 @@ const EditAutoUpdateConfigModal = ({
               <Button onClick={onExit} variant="inverse">
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                onClick={onSubmitForm}
-                isLoading={isUpdatingConfiguration}
-                disabled={!formValidation.isValid || isUpdatingConfiguration}
-              >
-                Save
-              </Button>
+              <GitOpsModeTooltipWrapper
+                position="right"
+                tipOffset={8}
+                renderChildren={(disableChildren) => (
+                  <Button
+                    type="submit"
+                    onClick={onSubmitForm}
+                    isLoading={isUpdatingConfiguration}
+                    disabled={
+                      !formValidation.isValid ||
+                      isUpdatingConfiguration ||
+                      disableChildren
+                    }
+                  >
+                    Save
+                  </Button>
+                )}
+              />
             </>
           }
         />
-      </div>
+      </>
     </Modal>
   );
 };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -51,7 +51,9 @@ interface IEditSoftwareModalProps {
   installerType: InstallerType;
   router: InjectedRouter;
   openViewYamlModal: () => void;
+  isFleetMaintainedApp?: boolean;
   isIosOrIpadosApp?: boolean;
+  gitOpsModeEnabled?: boolean;
   name: string;
   displayName: string;
   source?: string;
@@ -67,6 +69,7 @@ const EditSoftwareModal = ({
   installerType,
   router,
   openViewYamlModal,
+  isFleetMaintainedApp = false,
   isIosOrIpadosApp = false,
   name,
   displayName,
@@ -77,6 +80,12 @@ const EditSoftwareModal = ({
   const { config } = useContext(AppContext);
 
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled || false;
+  // Viewing an FMA in GitOps mode only allows viewing options, not editing
+  const isGitOpsCompatible = gitOpsModeEnabled && isFleetMaintainedApp;
+
+  const formClassNames = classnames(`${baseClass}__package-form`, {
+    [`${baseClass}__package-form--disabled`]: isGitOpsCompatible,
+  });
 
   const [editSoftwareModalClasses, setEditSoftwareModalClasses] = useState(
     baseClass
@@ -342,7 +351,7 @@ const EditSoftwareModal = ({
       return (
         <PackageForm
           labels={labels || []}
-          className={`${baseClass}__package-form`}
+          className={formClassNames}
           isEditingSoftware
           onCancel={onExit}
           onSubmit={onClickSavePackage}
@@ -354,6 +363,7 @@ const EditSoftwareModal = ({
           defaultUninstallScript={softwarePackage.uninstall_script}
           defaultSelfService={softwarePackage.self_service}
           defaultCategories={softwarePackage.categories}
+          gitopsCompatible={isGitOpsCompatible}
         />
       );
     }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/_styles.scss
@@ -11,6 +11,17 @@
     gap: $pad-medium;
   }
 
+  &__package-form {
+    &--disabled {
+      // We don't want to disable entire form or we can't get into the advanced options dropdown
+      .advanced-options-fields {
+        @include disabled(
+          true
+        ); // True allows pointer events to copy/scroll fields
+      }
+    }
+  }
+
   &--hidden {
     display: none;
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -327,7 +327,7 @@ const SoftwareInstallerCard = ({
             />
           )}
         </div>
-        {gitOpsModeEnabled && (isCustomPackage || isFleetMaintainedApp) && (
+        {gitOpsModeEnabled && isCustomPackage && (
           <div className={`${baseClass}__row-2`}>
             <div className={`${baseClass}__yaml-button-wrapper`}>
               <Button onClick={onToggleViewYaml}>View YAML</Button>
@@ -367,7 +367,7 @@ const SoftwareInstallerCard = ({
           isAndroidApp={isAndroidPlayStoreApp}
         />
       )}
-      {showViewYamlModal && (isCustomPackage || isFleetMaintainedApp) && (
+      {showViewYamlModal && isCustomPackage && (
         <ViewYamlModal
           softwareTitleName={softwareTitleName}
           softwareTitleId={softwareId}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/SoftwareInstallerCard.tsx
@@ -327,7 +327,7 @@ const SoftwareInstallerCard = ({
             />
           )}
         </div>
-        {gitOpsModeEnabled && isCustomPackage && (
+        {gitOpsModeEnabled && (isCustomPackage || isFleetMaintainedApp) && (
           <div className={`${baseClass}__row-2`}>
             <div className={`${baseClass}__yaml-button-wrapper`}>
               <Button onClick={onToggleViewYaml}>View YAML</Button>
@@ -367,7 +367,7 @@ const SoftwareInstallerCard = ({
           isAndroidApp={isAndroidPlayStoreApp}
         />
       )}
-      {showViewYamlModal && isCustomPackage && (
+      {showViewYamlModal && (isCustomPackage || isFleetMaintainedApp) && (
         <ViewYamlModal
           softwareTitleName={softwareTitleName}
           softwareTitleId={softwareId}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/SoftwareSummaryCard.tsx
@@ -110,6 +110,7 @@ const SoftwareSummaryCard = ({
     softwareInstaller,
     installerType,
     isIosOrIpadosApp,
+    isFleetMaintainedApp,
     isAndroidPlayStoreApp,
     canManageSoftware,
   } = meta;
@@ -205,6 +206,7 @@ const SoftwareSummaryCard = ({
           refetchSoftwareTitle={refetchSoftwareTitle}
           installerType={installerType}
           openViewYamlModal={onToggleViewYaml}
+          isFleetMaintainedApp={isFleetMaintainedApp}
           isIosOrIpadosApp={isIosOrIpadosApp}
           name={softwareTitle.name}
           displayName={softwareDisplayName}

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/ViewYamlModal/ViewYamlModal.tsx
@@ -6,7 +6,7 @@ import { NotificationContext } from "context/notification";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
 import FileSaver from "file-saver";
-import { ISoftwarePackage, SCRIPT_PACKAGE_SOURCES } from "interfaces/software";
+import { ISoftwarePackage } from "interfaces/software";
 import softwareAPI from "services/entities/software";
 
 import Modal from "components/Modal";

--- a/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/AdvancedOptionsFields/AdvancedOptionsFields.tsx
@@ -26,6 +26,8 @@ interface IAdvancedOptionsFieldsProps {
   onChangeInstallScript: (value: string) => void;
   onChangePostInstallScript: (value?: string) => void;
   onChangeUninstallScript: (value?: string) => void;
+  gitopsCompatible?: boolean;
+  gitOpsModeEnabled?: boolean;
 }
 
 const AdvancedOptionsFields = ({
@@ -46,8 +48,12 @@ const AdvancedOptionsFields = ({
   onChangeInstallScript,
   onChangePostInstallScript,
   onChangeUninstallScript,
+  gitopsCompatible = false,
+  gitOpsModeEnabled = false,
 }: IAdvancedOptionsFieldsProps) => {
   const classNames = classnames(baseClass, className);
+
+  const disableFields = gitopsCompatible && gitOpsModeEnabled;
 
   const renderLabelComponent = (): JSX.Element | null => {
     if (!showSchemaButton) {
@@ -76,6 +82,7 @@ const AdvancedOptionsFields = ({
         onChange={onChangePreInstallQuery}
         labelActionComponent={renderLabelComponent()}
         helpText="Software will be installed only if the query returns results."
+        readOnly={disableFields}
       />
       <Editor
         wrapEnabled
@@ -86,6 +93,7 @@ const AdvancedOptionsFields = ({
         helpText={installScriptHelpText}
         label="Install script"
         labelTooltip={installScriptTooltip}
+        readOnly={disableFields}
       />
       <Editor
         label="Post-install script"
@@ -97,6 +105,7 @@ const AdvancedOptionsFields = ({
         onChange={onChangePostInstallScript}
         value={postInstallScript}
         helpText={postInstallScriptHelpText}
+        readOnly={disableFields}
       />
       <Editor
         label="Uninstall script"
@@ -108,6 +117,7 @@ const AdvancedOptionsFields = ({
         onChange={onChangeUninstallScript}
         value={uninstallScript}
         helpText={uninstallScriptHelpText}
+        readOnly={disableFields}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageAdvancedOptions/PackageAdvancedOptions.tsx
@@ -202,6 +202,9 @@ interface IPackageAdvancedOptionsProps {
   onChangeInstallScript: (value: string) => void;
   onChangePostInstallScript: (value?: string) => void;
   onChangeUninstallScript: (value?: string) => void;
+  /** Currently for editing FMA only, users cannot edit */
+  gitopsCompatible?: boolean;
+  gitOpsModeEnabled?: boolean;
 }
 
 const PackageAdvancedOptions = ({
@@ -217,6 +220,8 @@ const PackageAdvancedOptions = ({
   onChangeInstallScript,
   onChangePostInstallScript,
   onChangeUninstallScript,
+  gitopsCompatible = false,
+  gitOpsModeEnabled = false,
 }: IPackageAdvancedOptionsProps) => {
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const name = selectedPackage?.name || "";
@@ -247,6 +252,8 @@ const PackageAdvancedOptions = ({
         onChangeInstallScript={onChangeInstallScript}
         onChangePostInstallScript={onChangePostInstallScript}
         onChangeUninstallScript={onChangeUninstallScript}
+        gitopsCompatible={gitopsCompatible}
+        gitOpsModeEnabled={gitOpsModeEnabled}
       />
     );
   };

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -112,8 +112,8 @@ const PackageForm = ({
   gitopsCompatible = false,
 }: IPackageFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const gitOpsModeEnabled = useContext(AppContext).config?.gitops
-    .gitops_mode_enabled;
+  const { gitops_mode_enabled: gitOpsModeEnabled, repository_url: repoURL } =
+    useContext(AppContext).config?.gitops || {};
 
   const initialFormData: IPackageFormData = {
     software: defaultSoftware || null,
@@ -266,8 +266,13 @@ const PackageForm = ({
     setFormValidation(generateFormValidation(newData));
   };
 
-  const isSubmitDisabled = !formValidation.isValid;
-  const submitTooltipContent = createTooltipContent(formValidation);
+  const disableFieldsForGitOps = gitopsCompatible && gitOpsModeEnabled;
+  const isSubmitDisabled = !formValidation.isValid || disableFieldsForGitOps;
+  const submitTooltipContent = createTooltipContent(
+    formValidation,
+    repoURL,
+    disableFieldsForGitOps
+  );
 
   const classNames = classnames(baseClass, className);
 
@@ -322,7 +327,7 @@ const PackageForm = ({
               ? getFileDetails(formData.software, true)
               : undefined
           }
-          gitopsCompatible={false}
+          gitopsCompatible={gitopsCompatible}
           gitOpsModeEnabled={gitOpsModeEnabled}
         />
         <div
@@ -398,6 +403,8 @@ const PackageForm = ({
             onChangeInstallScript={onChangeInstallScript}
             onChangePostInstallScript={onChangePostInstallScript}
             onChangeUninstallScript={onChangeUninstallScript}
+            gitopsCompatible={gitopsCompatible}
+            gitOpsModeEnabled={gitOpsModeEnabled}
           />
         )}
         <div className={`${baseClass}__action-buttons`}>

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -25,7 +25,6 @@ import {
   getTargetType,
 } from "pages/SoftwarePage/helpers";
 import TargetLabelSelector from "components/TargetLabelSelector";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import Card from "components/Card";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { validateQuery } from "components/forms/validators/validate_query";
 
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
+import { getGitOpsModeTipContent } from "utilities/helpers";
 import { IPackageFormData, IPackageFormValidation } from "./PackageForm";
 
 type IMessageFunc = (formData: IPackageFormData) => string;
@@ -209,8 +210,13 @@ export const generateFormValidation = (formData: IPackageFormData) => {
 };
 
 export const createTooltipContent = (
-  formValidation: IPackageFormValidation
+  formValidation: IPackageFormValidation,
+  repoURL?: string,
+  disabledFieldsForGitOps?: boolean
 ) => {
+  if (disabledFieldsForGitOps) {
+    return getGitOpsModeTipContent(repoURL);
+  }
   const messages = Object.values(formValidation)
     .filter((field) => field.isValid === false && field.message)
     .map((field) => field.message);

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -214,7 +214,7 @@ export const createTooltipContent = (
   repoURL?: string,
   disabledFieldsForGitOps?: boolean
 ) => {
-  if (disabledFieldsForGitOps) {
+  if (disabledFieldsForGitOps && repoURL) {
     return getGitOpsModeTipContent(repoURL);
   }
   const messages = Object.values(formValidation)


### PR DESCRIPTION
## Issue
Closes #39419 (originally flagged as #39275, but confirmed that was expected behavior and uncovered other bugs when triaging)

## Screenrecordings of fixes

https://github.com/user-attachments/assets/43f86f36-4456-4cf1-8a89-b30cf8ab53fa


https://github.com/user-attachments/assets/b378ba45-c422-483d-8301-478a597a139e



# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-

## Testing

- [x] QA'd all new/changed functionality manually
