### PR TITLE
Fixed false positive CVE for Nextcloud Desktop

### DIFF
--- a/changes/38911-nextcloud-cve
+++ b/changes/38911-nextcloud-cve
@@ -1,0 +1,2 @@
+* Fixed false positive CVE for Nextcloud Desktop.
+* Fixed rare CPE error when software name sanitizes to empty (e.g. only special characters)

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -51,6 +51,11 @@ func TestCPEFromSoftware(t *testing.T) {
 	// Does not error on Unicode Names
 	_, err = CPEFromSoftware(log.NewNopLogger(), db, &fleet.Software{Name: "Девушка Фонарём", Version: "1.2.3", BundleIdentifier: "vendor", Source: "apps"}, nil, reCache)
 	require.NoError(t, err)
+
+	// Does not error on names that sanitize to empty (e.g. only special characters)
+	_, err = CPEFromSoftware(log.NewNopLogger(), db, &fleet.Software{Name: "[", Version: "1.2.3", BundleIdentifier: "vendor", Source: "apps"}, nil,
+		reCache)
+	require.NoError(t, err)
 }
 
 func TestCPETranslations(t *testing.T) {

--- a/server/vulnerabilities/nvd/cpe_translations.json
+++ b/server/vulnerabilities/nvd/cpe_translations.json
@@ -125,6 +125,15 @@
   },
   {
     "software": {
+      "bundle_identifier": ["com.nextcloud.desktopclient"]
+    },
+    "filter": {
+      "product": ["desktop"],
+      "vendor": ["nextcloud"]
+    }
+  },
+  {
+    "software": {
       "name": ["jira"],
       "source": ["python_packages"]
     },


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38911

* Fixed false positive CVE for Nextcloud Desktop.
* Fixed rare CPE error when software name sanitizes to empty (e.g. only special characters)

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive vulnerability detection for Nextcloud Desktop
  * Resolved error occurring when software names contain only special characters and sanitize to empty

<!-- end of auto-generated comment: release notes by coderabbit.ai -->