### PR TITLE
Website: Remove duplicate heading on contact form

### DIFF
--- a/website/views/pages/contact.ejs
+++ b/website/views/pages/contact.ejs
@@ -11,7 +11,6 @@
       </div>
       <div v-else-if="formToDisplay === 'apply'">
         <h2 purpose="application-form-heading" v-if="formToDisplay === 'apply'">Apply for an open position</h2>
-        <h2>Request a workshop</h2>
       </div>
       <div v-else-if="formToDisplay === 'gitops-workshop-request'">
         <h2 class="mb-3">Request a workshop</h2>


### PR DESCRIPTION
Changes:
- Removed a duplicated heading on the "Apply for an open position" form