### PR TITLE
Website: Update exits and logged errors in create-vanta-authorization-request

### DIFF
--- a/website/api/controllers/create-vanta-authorization-request.js
+++ b/website/api/controllers/create-vanta-authorization-request.js
@@ -47,6 +47,10 @@ module.exports = {
     },
     invalidToken: {
       description: 'The provided token for the api-only user could not be used to authorize requests from fleetdm.com',
+      statusCode: 401,
+    },
+    requestToFleetInstanceForbidden: {
+      description: 'The user\'s Fleet instance returned a "403 Forbidden" response',
       statusCode: 403,
     },
     invalidLicense: {
@@ -107,8 +111,9 @@ module.exports = {
     let responseFromFleetInstance = await sails.helpers.http.get(inputs.fleetInstanceUrl+'/api/v1/fleet/me',{},{'Authorization': 'Bearer ' +inputs.fleetApiKey})
     .intercept('requestFailed', 'fleetInstanceNotResponding')
     .intercept({raw: {statusCode: 401}}, 'invalidToken')
+    .intercept({raw: {statusCode: 403}}, 'requestToFleetInstanceForbidden')
     .intercept((error)=>{
-      return new Error(`When sending a request to a Fleet instance's /me endpoint to verify that a token meets the requirements for a Vanta connection, an error occurred: ${error}`);
+      return new Error(`When sending a request to a user's (${inputs.emailAddress}) Fleet instance's (${inputs.fleetInstanceUrl}) /me endpoint to verify that a token meets the requirements for a Vanta connection, an error occurred: ${error}`);
     });
 
     // Throw an error if the response from the Fleet instance's /me API endpoint does not contain a user.
@@ -131,8 +136,9 @@ module.exports = {
     let configResponse = await sails.helpers.http.get(inputs.fleetInstanceUrl+'/api/v1/fleet/config', {}, {'Authorization': 'Bearer ' +inputs.fleetApiKey})
     .intercept('requestFailed','fleetInstanceNotResponding')
     .intercept({raw: {statusCode: 401}}, 'invalidToken')
+    .intercept({raw: {statusCode: 403}}, 'requestToFleetInstanceForbidden')
     .intercept((error)=>{
-      return new Error(`When sending a request to a Fleet instance's /config API endpoint for a Vanta connection, an error occurred: ${error}`);
+      return new Error(`When sending a request to a user's (email: ${inputs.emailAddress}) Fleet instance's (${inputs.fleetInstanceUrl}) /config API endpoint for a Vanta connection, an error occurred: ${error}`);
     });
 
 

--- a/website/views/pages/connect-vanta.ejs
+++ b/website/views/pages/connect-vanta.ejs
@@ -50,7 +50,7 @@
         This integration is only available for Fleet Premium customers.
       </cloud-error>
       <cloud-error purpose="cloud-error" v-else-if="['requestToFleetInstanceForbidden', 'invalidResponseFromFleetInstance'].includes(cloudError)">
-        An error occured when verifying the configuration of the Fleet instance. Please check to make sure that the provided URL is correct and try resubmitting.
+        An error occured when verifying the configuration of the Fleet instance. Please check to make sure that the provided URL is correct and try resubmitting, or <a href="/contact">contact support</a> if the error persists.
       </cloud-error>
       <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>
       <ajax-button style="height: 44px;" purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-info" v-if="!cloudError">Connect</ajax-button>

--- a/website/views/pages/connect-vanta.ejs
+++ b/website/views/pages/connect-vanta.ejs
@@ -49,7 +49,7 @@
       <cloud-error purpose="cloud-error" v-else-if="cloudError === 'invalidLicense'">
         This integration is only available for Fleet Premium customers.
       </cloud-error>
-      <cloud-error purpose="cloud-error" v-else-if="cloudError === 'invalidResponseFromFleetInstance'">
+      <cloud-error purpose="cloud-error" v-else-if="['requestToFleetInstanceForbidden', 'invalidResponseFromFleetInstance'].includes(cloudError)">
         An error occured when verifying the configuration of the Fleet instance. Please check to make sure that the provided URL is correct and try resubmitting.
       </cloud-error>
       <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/39401

Changes:
- Added a new exit to the create-vanta-authorization-request action that is used when a request to a Fleet instance fails with a `403 Forbidden` response.
- Updated logged errors in create-vanta-authroization-request to include more information about the request.