### PR TITLE
Safely split incoming request headers, remove support for token presence in request body

### DIFF
--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -49,16 +49,16 @@ func FromContext(ctx context.Context) (Token, bool) {
 func parseHeaderLimited(authHeader string) ([]string, bool) {
 	parts := make([]string, 2)
 
-	pre, remain, foundDelimeter := strings.Cut(authHeader, tokenDelimiter)
-	if !foundDelimeter {
+	pre, remain, foundDelimiter := strings.Cut(authHeader, tokenDelimiter)
+	if !foundDelimiter {
 		return nil, false
 	}
 	parts[0] = pre
 	// Ensure the token value is the last part of the string and there are no more
 	// delimiters. This avoids an issue where malicious input could contain additional delimiters
-	// causing unecessary overhead parsing tokens.
-	post, _, unexpectedDelimeterFound := strings.Cut(remain, tokenDelimiter)
-	if unexpectedDelimeterFound {
+	// causing unnecessary overhead parsing tokens.
+	post, _, unexpectedDelimiterFound := strings.Cut(remain, tokenDelimiter)
+	if unexpectedDelimiterFound {
 		// more than 2 parts
 		return nil, false
 	}

--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -25,7 +25,7 @@ func FromHTTPRequest(r *http.Request) Token {
 	headerCouple, ok := parseHeaderLimited(authHeader)
 	if ok && strings.ToUpper(headerCouple[0]) == "BEARER" {
 		// If the Authorization header is present and properly formatted, return the token.
-		// Preserve case-insensitivity of "Bearer " prefix while case-sensitivity of the token value
+		// Preserve case-insensitivity for "Bearer" prefix while case-sensitivity for the token value
 		return Token(headerCouple[1])
 	}
 	return ""

--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -25,7 +25,7 @@ func FromHTTPRequest(r *http.Request) Token {
 	headerCouple, ok := parseHeaderLimited(authHeader)
 	if ok && strings.ToUpper(headerCouple[0]) == "BEARER" {
 		// If the Authorization header is present and properly formatted, return the token.
-		// Preserve case-insensitivity of "Bearer:" while case-sensitivity of token value
+		// Preserve case-insensitivity of "Bearer " prefix while case-sensitivity of the token value
 		return Token(headerCouple[1])
 	}
 	return ""

--- a/server/contexts/token/token.go
+++ b/server/contexts/token/token.go
@@ -23,9 +23,11 @@ type Token string
 func FromHTTPRequest(r *http.Request) Token {
 	headers := r.Header.Get("Authorization")
 	headerParts, ok := splitToken(headers)
-
+	if !ok {
+		return ""
+	}
 	// If the Authorization header is present and properly formatted, return the token.
-	if ok && strings.ToUpper(headerParts[0]) == "BEARER" {
+	if strings.ToUpper(headerParts[0]) == "BEARER" {
 		if headerParts[1] == "" {
 			// Empty "BEARER" value in header, return empty token
 			return ""

--- a/server/contexts/token/token_test.go
+++ b/server/contexts/token/token_test.go
@@ -58,6 +58,39 @@ func TestFromHTTPRequest(t *testing.T) {
 				Body:   io.NopCloser(strings.NewReader("token=bar")),
 			},
 			want: "bar",
+		}, {
+			name: "BEARER with 3 parts",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"BEARER foobar extra"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "",
+		}, {
+			name: "BEARER with multiple extra parts",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"BEARER foobar extra parts here"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "",
+		}, {
+			name: "bearer lowercase with extra parts",
+			r: &http.Request{
+				Header: map[string][]string{
+					"Authorization": {"bearer foobar extra"},
+					"Content-Type":  {"application/x-www-form-urlencoded"},
+				},
+				Method: http.MethodPost,
+				Body:   io.NopCloser(strings.NewReader("token=bar")),
+			},
+			want: "",
 		},
 	}
 	for _, tt := range tests {

--- a/server/contexts/token/token_test.go
+++ b/server/contexts/token/token_test.go
@@ -57,7 +57,7 @@ func TestFromHTTPRequest(t *testing.T) {
 				Method: http.MethodPost,
 				Body:   io.NopCloser(strings.NewReader("token=bar")),
 			},
-			want: "bar",
+			want: "", // no longe support parsing token from request body
 		}, {
 			name: "BEARER with 3 parts",
 			r: &http.Request{

--- a/server/contexts/token/token_test.go
+++ b/server/contexts/token/token_test.go
@@ -57,7 +57,7 @@ func TestFromHTTPRequest(t *testing.T) {
 				Method: http.MethodPost,
 				Body:   io.NopCloser(strings.NewReader("token=bar")),
 			},
-			want: "", // no longe support parsing token from request body
+			want: "", // no longer support parsing token from request body
 		}, {
 			name: "BEARER with 3 parts",
 			r: &http.Request{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issues:**
- Prevents unbounded split length exploits similar to https://nvd.nist.gov/vuln/detail/CVE-2025-30204
- Also removes parsing of request body for token, see https://github.com/fleetdm/fleet/issues/39659
   - @iansltx I figured since this PR updates the code blocks in question, makes sense to [remove the body parsing here](https://github.com/fleetdm/fleet/pull/39427/changes#diff-83b0d73af21e81cf2c5ed4448718d0760543699fe6e36e401372467befea29edL30-L33), and clean up the [related dead code](https://github.com/fleetdm/fleet/blob/c1e3e89b5fd1986f87b5ac227ae85dbdea18f074/frontend/services/entities/installers.ts#L13) in a follow-up 

See https://fleetdm.slack.com/archives/C019WG4GH0A/p1770322925865209

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually