### PR TITLE
Fleet UI: Tarballs and script packages skip recent updates UI statuses

### DIFF
--- a/changes/39437-tarballs-ui-status
+++ b/changes/39437-tarballs-ui-status
@@ -1,0 +1,1 @@
+- Fleet UI: Fix install/uninstall tarballs package to skip recently updated status that is waiting for a change in software inventory

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -623,6 +623,7 @@ export const isSoftwareInProgressStatus = (
 export const HOST_SOFTWARE_UI_SUCCESS_STATUSES = [
   "installed", // Present in inventory; no newer fleet installer version (tarballs: successful install only)
   "uninstalled", // Not present in inventory (tarballs: successful uninstall or never installed)
+  // NOTE: Recently statuses cannot apply to tarballs as we cannot detect inventory
   "recently_updated", // Update applied (installer newer than inventory), but inventory not yet refreshed
   "recently_installed", // Install applied (installer NOT newer than inventory), but inventory not yet refreshed
   "recently_uninstalled", // Uninstall applied, but inventory not yet refreshed

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -299,7 +299,7 @@ export const SCRIPT_PACKAGE_SOURCES = ["sh_packages", "ps1_packages"];
 /** Sources that don't map cleanly to versions or hosts in software inventory.
  * UI behavior for these sources:
  * - Never shows “Update available” (no version to compare against the package version).
- * - Skips refetching host details after install/uninstall (no inventory entry to detect).
+ * - Skips showing recently updated and waiting for inventory  UI status/tooltip after successful install/uninstall (no inventory entry to await)
  * - Skips showing a host count (hosts cannot be mapped to the package).
  * - Skips showing a versions table (versions cannot be mapped to the package).
  * - Skips linking to “View all hosts” (hosts cannot be mapped to the package). */

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -296,6 +296,13 @@ export const INSTALLABLE_SOURCE_PLATFORM_CONVERSION = {
 
 export const SCRIPT_PACKAGE_SOURCES = ["sh_packages", "ps1_packages"];
 
+/** Sources that don't map cleanly to versions or hosts in software inventory.
+ * UI behavior for these sources:
+ * - Never shows “Update available” (no version to compare against the package version).
+ * - Skips refetching host details after install/uninstall (no inventory entry to detect).
+ * - Skips showing a host count (hosts cannot be mapped to the package).
+ * - Skips showing a versions table (versions cannot be mapped to the package).
+ * - Skips linking to “View all hosts” (hosts cannot be mapped to the package). */
 export const NO_VERSION_OR_HOST_DATA_SOURCES = [
   "tgz_packages",
   ...SCRIPT_PACKAGE_SOURCES,

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -179,6 +179,7 @@ const HostSoftwareLibrary = ({
     }));
   }, [hostSoftwareLibraryRes, isHostOnline, softwareUpdatedAt]);
 
+  console.log("enhancedSoftware in HostSoftwareLibrary:", enhancedSoftware);
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
   const isAwaitingHostDetailsPolling = useRef(isHostDetailsPolling);

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibrary.tsx
@@ -180,7 +180,6 @@ const HostSoftwareLibrary = ({
     }));
   }, [hostSoftwareLibraryRes, isHostOnline, softwareUpdatedAt]);
 
-  console.log("enhancedSoftware in HostSoftwareLibrary:", enhancedSoftware);
   const pendingSoftwareSetRef = useRef<Set<string>>(new Set()); // Track for polling
   const pollingTimeoutIdRef = useRef<NodeJS.Timeout | null>(null);
   const isAwaitingHostDetailsPolling = useRef(isHostDetailsPolling);
@@ -253,25 +252,10 @@ const HostSoftwareLibrary = ({
         );
 
         if (completedIds.length > 0) {
-          // Only refetch host details for inventory‑detectable sources
-          const shouldRefetchHostDetails = response.software.some(
-            (software) => {
-              const isCompleted = completedIds.includes(String(software.id));
-              if (!isCompleted) return false;
-
-              const isInventoryDetectableSource = !NO_VERSION_OR_HOST_DATA_SOURCES.includes(
-                software.source
-              );
-
-              return isInventoryDetectableSource;
-            }
-          );
-
-          if (shouldRefetchHostDetails) {
-            // To update the software library information of newly installed/uninstalled
-            // software that appears in software inventory
-            refetchHostDetails();
-          }
+          // Refetch host details to:
+          // - Update the software library version information of newly installed/uninstalled software of inventory‑detectable sources only
+          // - Update the software inventory of any changes to software detected by software inventory
+          refetchHostDetails();
         }
 
         // Compare new set with the previous set

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tsx
@@ -350,23 +350,10 @@ const SoftwareSelfService = ({
           // Trigger an additional refetch to ensure UI status is up-to-date
           // If already refetching, queue another refetch
 
-          // Only trigger refetch for pending installs/uninstalls whose sources appear in software inventory
-          const shouldRefetchHostDetails = response.software.some(
-            (software) => {
-              const isCompleted = completedAppIds.includes(String(software.id));
-              if (!isCompleted) return false;
-
-              const isInventoryDetectableSource = !NO_VERSION_OR_HOST_DATA_SOURCES.includes(
-                software.source
-              );
-
-              return isInventoryDetectableSource;
-            }
-          );
-
-          if (shouldRefetchHostDetails) {
-            refetchHostDetails();
-          }
+          // Refetch host details to:
+          // - Update the software library version information of newly installed/uninstalled software of inventory‑detectable sources only
+          // - Update the software inventory of any changes to software detected by software inventory
+          refetchHostDetails();
         }
 
         // Compare new set with the previous set

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
@@ -45,8 +45,6 @@ const SelfServiceTable = ({
   const initialSortDirection = queryParams.order_direction || "asc";
   const initialSortPage = queryParams.page || 0;
 
-  console.log("enhancedSoftware in SelfServiceTable:", enhancedSoftware);
-
   return (
     <div className={`${baseClass}__table`}>
       <CategoriesMenu

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/SelfServiceTable/SelfServiceTable.tsx
@@ -45,6 +45,8 @@ const SelfServiceTable = ({
   const initialSortDirection = queryParams.order_direction || "asc";
   const initialSortPage = queryParams.page || 0;
 
+  console.log("enhancedSoftware in SelfServiceTable:", enhancedSoftware);
+
   return (
     <div className={`${baseClass}__table`}>
       <CategoriesMenu

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -195,8 +195,9 @@ export const getUiStatus = (
   const lastUninstallDate = getLastUninstall(software)?.uninstalled_at;
   const installerVersion = getInstallerVersion(software);
   const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(source);
-  // Scripts and tarballs do not map to software inventory, so we will skip inventory-based checks such as recently_installed/recently_uninstalled
-  // This guard allows the switch to 'installed' or 'uninstalled' immediately after a script/tarball action succeeds.
+  // Some sources (e.g. tarballs, scripts) do not map to software inventory, so we will always skip
+  // inventory-based checks (e.g. recently_installed/recently_uninstalled) for these software sources
+  // This guard allows the switch to 'installed' or 'uninstalled' immediately after a tarball action succeeds.
   const isInventoryDetectableSource = !NO_VERSION_OR_HOST_DATA_SOURCES.includes(
     source
   );
@@ -212,6 +213,9 @@ export const getUiStatus = (
     if (status === "pending_install") {
       return isHostOnline ? "running_script" : "pending_script";
     }
+    // We never show recently installed/updated or waiting for inventory for script packages
+    // Since version won't be retreived from inventory, we are not waiting on a refetch
+    // UI status immediately changes to "Ran" status after a successful install
     if (status === "installed") {
       return "ran_script";
     }

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -197,7 +197,7 @@ export const getUiStatus = (
   const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(source);
   // Scripts and tarballs do not report inventory, so skip inventory-based checks such as recently_installed/recently_uninstalled
   // This will turn the ui_status to 'installed' or 'uninstalled' directly after install/uninstall of script/tarball packages succeeds
-  const willNotRetrieveInventory = NO_VERSION_OR_HOST_DATA_SOURCES.includes(
+  const incompatibleWithInventory = NO_VERSION_OR_HOST_DATA_SOURCES.includes(
     source
   );
   /** True if a recent user-initiated action (install/uninstall) was detected for this software */
@@ -279,7 +279,7 @@ export const getUiStatus = (
     status === null &&
     lastUninstallDate &&
     hostSoftwareUpdatedAt &&
-    willNotRetrieveInventory
+    !incompatibleWithInventory // Skip recently installed UI status as we are not waiting for inventory updates
   ) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastUninstallDate);
     if (newerDate === lastUninstallDate || recentUserActionDetected) {
@@ -308,7 +308,11 @@ export const getUiStatus = (
 
   // 6. Recently installed (not an update)
   if (status === "installed") {
-    if (lastInstallDate && hostSoftwareUpdatedAt && !willNotRetrieveInventory) {
+    if (
+      lastInstallDate &&
+      hostSoftwareUpdatedAt &&
+      !incompatibleWithInventory // Skip recently installed UI status as we are not waiting for inventory updates
+    ) {
       const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastInstallDate);
       if (newerDate === lastInstallDate || recentUserActionDetected) {
         return "recently_installed";

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -195,9 +195,9 @@ export const getUiStatus = (
   const lastUninstallDate = getLastUninstall(software)?.uninstalled_at;
   const installerVersion = getInstallerVersion(software);
   const isScriptPackage = SCRIPT_PACKAGE_SOURCES.includes(source);
-  // Scripts and tarballs do not report inventory, so skip inventory-based checks such as recently_installed/recently_uninstalled
-  // This will turn the ui_status to 'installed' or 'uninstalled' directly after install/uninstall of script/tarball packages succeeds
-  const incompatibleWithInventory = NO_VERSION_OR_HOST_DATA_SOURCES.includes(
+  // Scripts and tarballs do not map to software inventory, so we will skip inventory-based checks such as recently_installed/recently_uninstalled
+  // This guard allows the switch to 'installed' or 'uninstalled' immediately after a script/tarball action succeeds.
+  const isInventoryDetectableSource = !NO_VERSION_OR_HOST_DATA_SOURCES.includes(
     source
   );
   /** True if a recent user-initiated action (install/uninstall) was detected for this software */
@@ -279,7 +279,7 @@ export const getUiStatus = (
     status === null &&
     lastUninstallDate &&
     hostSoftwareUpdatedAt &&
-    !incompatibleWithInventory // Skip recently installed UI status as we are not waiting for inventory updates
+    isInventoryDetectableSource // Only wait for inventory updates for sources that appear in software inventory
   ) {
     const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastUninstallDate);
     if (newerDate === lastUninstallDate || recentUserActionDetected) {
@@ -311,7 +311,7 @@ export const getUiStatus = (
     if (
       lastInstallDate &&
       hostSoftwareUpdatedAt &&
-      !incompatibleWithInventory // Skip recently installed UI status as we are not waiting for inventory updates
+      isInventoryDetectableSource // Only wait for inventory updates for sources that appear in software inventory
     ) {
       const newerDate = getNewerDate(hostSoftwareUpdatedAt, lastInstallDate);
       if (newerDate === lastInstallDate || recentUserActionDetected) {


### PR DESCRIPTION
## Issue
Closes #31721

## Description
For Tarballs packages and scripts  (payload free) packages:
- Skip recently installed/uninstalled status since they don't check for software inventory
- Tests for recently installed / recently uninstalled status is skipped for tarballs packages

> Note: We will NOT remove calling for a host details refetch. Even though tarballs packages don't map/update based on software inventory, if the script successfully installed/uninstalled a package, the software inventory page should be checked for new or removed software checked with the host details refetch 

## Screen recordings
https://fleetdm.zoom.us/clips/share/_b8LzSZVTUSEjksECJz4Ew
https://fleetdm.zoom.us/clips/share/-lV_gYJkTs2168Wcm5jcoA

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
