### PR TITLE
Fix Apple's spelling errors

### DIFF
--- a/docs/mdm-commands.yml
+++ b/docs/mdm-commands.yml
@@ -38,15 +38,15 @@
             cGxlLmFwcGxpY2F0aW9uYWNjZXNzLkVENzE2QUU5LUFFODktNENFQy1BNzE3LUYyMTU2
             N0UwRjUxMjwvc3RyaW5nPgoJCQk8a2V5PlBheWxvYWRUeXBlPC9rZXk+CgkJCTxzdHJp
             bmc+Y29tLmFwcGxlLmFwcGxpY2F0aW9uYWNjZXNzPC9zdHJpbmc+CgkJCTxrZXk+UGF5
-            bG9hZFVVSUQ8L2tleT4KCQkJPHN0dmluZz5FRDcxNkFFOS1BRTg5LTRDRUMtQTcxNy1G
-            MjE1NjdFMEY1MTI8L3N0cmluZz4KCQkJPGtleT5QYXlsb2FtVmVyc2lvbjwva2V5PgoJ
+            bG9hZFVVSUQ8L2tleT4KCQkJPHN0cmluZz5FRDcxNkFFOS1BRTg5LTRDRUMtQTcxNy1G
+            MjE1NjdFMEY1MTI8L3N0cmluZz4KCQkJPGtleT5QYXlsb2FkVmVyc2lvbjwva2V5PgoJ
             CQk8aW50ZWdlcj4xPC9pbnRlZ2VyPgoJCQk8a2V5PmFsbG93TG9ja1NjcmVlblRvZGF5
             Vmlldzwva2V5PgoJCQk8ZmFsc2UvPgoJCQk8a2V5PnJhdGluZ1JlZ2lvbjwva2V5PgoJ
             CQk8c3RyaW5nPnVzPC9zdHJpbmc+CgkJPC9kaWN0PgoJPC9hcnJheT4KCTxrZXk+UGF5
             bG9hZERpc3BsYXlOYW1lPC9rZXk+Cgk8c3RyaW5nPihVKSBhbGxvd0xvY2tTY3JlZW5U
             b2RheVZpZXc8L3N0cmluZz4KCTxrZXk+UGF5bG9hZElkZW50aWZpZXI8L2tleT4KCTxz
             dHJpbmc+Y29tLmFwcGxlLmRtcy5yZXN0cmljdGlvbnMuYWxsb3dMb2NrU2NyZWVuVG9k
-            YXlWaWV3PC9zdHJpbmc+Cgk8a2V5PlBheWxwYWRSZW1vdmFsRGlzYWxsb3dlZDwva2V5
+            YXlWaWV3PC9zdHJpbmc+Cgk8a2V5PlBheWxvYWRSZW1vdmFsRGlzYWxsb3dlZDwva2V5
             PgoJPGZhbHNlLz4KCTxrZXk+UGF5bG9hZFR5cGU8L2tleT4KCTxzdHJpbmc+Q29uZmln
             dXJhdGlvbjwvc3RyaW5nPgoJPGtleT5QYXlsb2FkVVVJRDwva2V5PgoJPHN0cmluZz42
             OUE0RTVGRS03NUQxLTQyOTctQkQzMi01NDA3MTBFRDYzNjA8L3N0cmluZz4KCTxrZXk+


### PR DESCRIPTION
stving -> string
PayloamVersion -> PayloadVersion
PaylpadRemovalDisallowed -> PayloadRemovalDisallowed

Originally reported at https://macadmins.slack.com/archives/C0214NELAE7/p1770365345839839

Looks like we just copied from [Apple's example](https://developer.apple.com/documentation/devicemanagement/install-profile-command), which has the errors.