### PR TITLE
update add host modal to handle fully managed android enrollment

### DIFF
--- a/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
+++ b/frontend/components/AddHostsModal/AddHostsModal.tests.tsx
@@ -142,9 +142,7 @@ describe("AddHostsModal", () => {
     );
 
     await user.click(screen.getByRole("tab", { name: "Android" }));
-    expect(
-      screen.queryByText(/Send this to your end users:/i)
-    ).toBeInTheDocument();
+    expect(screen.queryByText(/Enrollment instructions:/i)).toBeInTheDocument();
   });
 
   it("renders installer with secret", async () => {

--- a/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/AndroidPanel/AndroidPanel.tsx
@@ -1,16 +1,30 @@
 import React, { useContext } from "react";
 
-import CustomLink from "components/CustomLink";
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
+
+import CustomLink from "components/CustomLink";
+import Radio from "components/forms/fields/Radio";
 
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
 
-const generateUrl = (serverUrl: string, enrollSecret: string) => {
-  return `${serverUrl}/enroll?enroll_secret=${encodeURIComponent(
+type EnrollmentType = "workProfile" | "fullyManaged";
+
+const generateUrl = (
+  serverUrl: string,
+  enrollSecret: string,
+  enrollType: EnrollmentType
+) => {
+  const url = `${serverUrl}/enroll?enroll_secret=${encodeURIComponent(
     enrollSecret
   )}`;
+
+  if (enrollType === "fullyManaged") {
+    return `${url}&fully_managed=true`;
+  }
+
+  return url;
 };
 
 const baseClass = "android-panel";
@@ -21,6 +35,10 @@ interface IAndroidPanelProps {
 
 const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
   const { config, isAndroidMdmEnabledAndConfigured } = useContext(AppContext);
+
+  const [enrollmentType, setEnrollmentType] = React.useState<EnrollmentType>(
+    "workProfile"
+  );
 
   if (!config) return null;
 
@@ -36,18 +54,42 @@ const AndroidPanel = ({ enrollSecret }: IAndroidPanelProps) => {
     );
   }
 
-  const url = generateUrl(config.server_settings.server_url, enrollSecret);
+  const url = generateUrl(
+    config.server_settings.server_url,
+    enrollSecret,
+    enrollmentType
+  );
 
   return (
     <div className={baseClass}>
-      <InputField
-        label="Send this to your end users:"
-        enableCopy
-        readOnly
-        inputWrapperClass={`${baseClass}__enroll-link`}
-        name="enroll-link"
-        value={url}
-      />
+      <form>
+        <fieldset className="form-field">
+          <Radio
+            name="enrollmentType"
+            id="workProfile"
+            label="Work profile"
+            value="workProfile"
+            checked={enrollmentType === "workProfile"}
+            onChange={() => setEnrollmentType("workProfile")}
+          />
+          <Radio
+            name="enrollmentType"
+            id="fullyManaged"
+            label="Fully-managed (no work profile)"
+            value="fullyManaged"
+            checked={enrollmentType === "fullyManaged"}
+            onChange={() => setEnrollmentType("fullyManaged")}
+          />
+        </fieldset>
+        <InputField
+          label="Enrollment instructions:"
+          enableCopy
+          readOnly
+          inputWrapperClass={`${baseClass}__enroll-link`}
+          name="enroll-link"
+          value={url}
+        />
+      </form>
     </div>
   );
 };

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/WindowsMdmPage.tsx
@@ -142,10 +142,7 @@ const WindowsMdmPage = ({ router }: IWindowsMdmPageProps) => {
           {isPremiumTier && (
             // NOTE: first time using fieldset and legend. if we use this more we should make
             // a reusable component
-            <fieldset
-              disabled={!mdmOn}
-              className={`${baseClass}__enrollment-type-fieldset form-field`}
-            >
+            <fieldset disabled={!mdmOn} className="form-field">
               {/* NOTE: we use this wrapper div to style the legend since legend
                does not work well with flexbox. the wrapper div helps the gap styling apply. */}
               <div>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/__styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/WindowsMdmPage/__styles.scss
@@ -4,10 +4,4 @@
   form {
     @include vertical-form-layout;
   }
-
-  &__enrollment-type-fieldset {
-    padding: 0;
-    margin: 0;
-    border: none;
-  }
 }

--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -41,9 +41,8 @@ const DeleteHostModal = ({
 
   const hostText = () => {
     if (selectedHostIds) {
-      return `${selectedHostIds.length}${
-        isAllMatchingHostsSelected ? "+" : ""
-      } ${pluralizeHost()}`;
+      return `${selectedHostIds.length}${isAllMatchingHostsSelected ? "+" : ""
+        } ${pluralizeHost()}`;
     }
     return hostName;
   };
@@ -78,10 +77,9 @@ const DeleteHostModal = ({
             />
           </li>
           <li>
-            {/* TODO(android): iOS, iPadOS, and Android hosts will re-appear unless MDM is turned
-            off. */}
-            iOS and iPadOS hosts will re-appear unless MDM is turned off. It may
-            take up to an hour to re-appear.
+            iOS, iPadOS, and Android hosts will re-appear unless MDM is turned
+            off. For iOS and iPadOS it may take up to an hour and for Android it
+            may take up to 24 hours to re-appear.
           </li>
         </ul>
         <div className="modal-cta-wrap">

--- a/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
+++ b/frontend/pages/hosts/components/DeleteHostModal/DeleteHostModal.tsx
@@ -41,8 +41,9 @@ const DeleteHostModal = ({
 
   const hostText = () => {
     if (selectedHostIds) {
-      return `${selectedHostIds.length}${isAllMatchingHostsSelected ? "+" : ""
-        } ${pluralizeHost()}`;
+      return `${selectedHostIds.length}${
+        isAllMatchingHostsSelected ? "+" : ""
+      } ${pluralizeHost()}`;
     }
     return hostName;
   };

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -186,6 +186,12 @@ form,
   }
 }
 
+fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
 input,
 textarea,
 button {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38881

This adds the UI to the add host modal that allows for android fully managed devices.

<img width="800" height="405" alt="image" src="https://github.com/user-attachments/assets/2f86d417-ee14-456b-a06f-32c292c5e7a3" />

It also includes a small copy change for delete host modal

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
