### PR TITLE
Website: Reduce noise from vpp proxy endpoint

### DIFF
--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -122,6 +122,9 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
+      if(err.statusCode === 401) {// Only log a warning for authentication errors related to the generated token for this request.
+        sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      }
       return err;
     });
 

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -122,10 +122,6 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
-      // Ignore invalid stoken vpp token responses when logging errors returned by the Apple API.
-      if(err.statusCode !== 403) {
-        sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
-      }
       return err;
     });
 


### PR DESCRIPTION
Changes:
- Updated the get-vpp-app-metadata endpoint to only log errors returned from the Apple API related to authentication