### PR TITLE
Skip likely-to-keep-breaking test

### DIFF
--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -120,6 +120,10 @@ jobs:
         elif [[ "${{ matrix.suite }}" == "scripts" ]]; then
           echo "CI_TEST_PKG=${{ matrix.suite }}" >> $GITHUB_ENV
           echo "NEED_ZSH=1" >> $GITHUB_ENV
+        elif [[ "${{ matrix.suite }}" == "fleetctl" && ${{ github.event_name != 'schedule' }}  ]]; then
+          echo "CI_TEST_PKG=${{ matrix.suite }}" >> $GITHUB_ENV
+          echo "NEED_DOCKER=1" >> $GITHUB_ENV
+          echo "RUN_TESTS_ARG=-skip '^(TestIntegrationsEnterpriseGitops/TestFleetGitops)'" >> $GITHUB_ENV
         else
           echo "CI_TEST_PKG=${{ matrix.suite }}" >> $GITHUB_ENV
           echo "NEED_DOCKER=1" >> $GITHUB_ENV

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -123,7 +123,7 @@ jobs:
         elif [[ "${{ matrix.suite }}" == "fleetctl" && ${{ github.event_name != 'schedule' }}  ]]; then
           echo "CI_TEST_PKG=${{ matrix.suite }}" >> $GITHUB_ENV
           echo "NEED_DOCKER=1" >> $GITHUB_ENV
-          echo "RUN_TESTS_ARG=-skip '^(TestIntegrationsEnterpriseGitops/TestFleetGitops)'" >> $GITHUB_ENV
+          echo "RUN_TESTS_ARG=-skip 'TestIntegrationsEnterpriseGitops/TestFleetGitops'" >> $GITHUB_ENV
         else
           echo "CI_TEST_PKG=${{ matrix.suite }}" >> $GITHUB_ENV
           echo "NEED_DOCKER=1" >> $GITHUB_ENV


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** None. Temporarily disables fleetctl test that depends on the gitops repo which is currently undergoing rapid improvement and is likely to break regularly. This will still run and fail during nightly runs

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [x] Added/updated automated tests


