### PR TITLE
Fleet UI: fix unreleased disabled overlay sizing (#39305)

### DIFF
--- a/frontend/pages/SoftwarePage/components/cards/SelfServicePreview/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/cards/SelfServicePreview/_styles.scss
@@ -41,7 +41,7 @@
   &__disabled-overlay {
     position: absolute;
     width: 540px;
-    height: 335px;
+    height: 265px;
     z-index: 1000;
   }
 


### PR DESCRIPTION
## Issue
Closes #39256

## Description
- Merged into `main` already with #39305 
- This is for the 4.81 RC branch

```
 1011  git fetch fleetdm
 1012  git checkout main
 1013  git pull fleetdm main
 1014  git checkout fleetdm/rc-minor-fleet-v4.81.0
 1015  git checkout -b 39256-rc
 1016  git log main
 1017  git cherry-pick ebacf3d2ba50e0a682c2c7a310438c93ed1830bd
 1018  git push -u fleetdm 39256-rc
```