### PR TITLE
Don't tag g-website or flakey CI bugs with ~unreleased bug tag, add `x & y` version handling

### DIFF
--- a/.github/workflows/auto-tag-unreleased-bugs.yml
+++ b/.github/workflows/auto-tag-unreleased-bugs.yml
@@ -27,11 +27,8 @@ jobs:
             const issue = context.payload.issue;
             const labels = issue.labels.map(label => label.name);
 
-            const hasNoopLabel = labels.some(label =>
-              label.includes('~released bug') || label.includes('~unreleased bug') || labels.includes('#g-website')
-            );
-
-            if (hasNoopLabel) {
+            const noopLabels = ['~released bug', '~unreleased bug', '#g-website', 'flaky-ci-tests'];
+            if (labels.some(label => noopLabels.includes(label))) {
               return;
             }
 

--- a/.github/workflows/auto-tag-unreleased-bugs.yml
+++ b/.github/workflows/auto-tag-unreleased-bugs.yml
@@ -27,11 +27,11 @@ jobs:
             const issue = context.payload.issue;
             const labels = issue.labels.map(label => label.name);
 
-            const hasReleasedLabel = labels.some(label =>
-              label.includes('~released bug') || label.includes('~unreleased bug')
+            const hasNoopLabel = labels.some(label =>
+              label.includes('~released bug') || label.includes('~unreleased bug') || labels.includes('#g-website')
             );
 
-            if (hasReleasedLabel) {
+            if (hasNoopLabel) {
               return;
             }
 

--- a/.github/workflows/auto-tag-unreleased-bugs.yml
+++ b/.github/workflows/auto-tag-unreleased-bugs.yml
@@ -111,15 +111,30 @@ jobs:
             // Normalize version for comparison
             // Remove common prefixes/suffixes and extract core version number
             const normalizeVersion = (version) => {
-              // Extract version number pattern (e.g., "4.62.0" from "v4.62.0" or "4.62.0-123-abc")
-              const match = version.match(/v?(\d+\.\d+\.\d+)/);
-              return match ? match[1] : version;
+              // First try to extract x.y.z pattern
+              let match = version.match(/v?(\d+\.\d+\.\d+)/);
+              if (match) return match[1];
+              
+              // If no patch version, try x.y pattern and add .0
+              match = version.match(/v?(\d+\.\d+)(?!\.\d)/);
+              if (match) return match[1] + '.0';
+              
+              return version;
             };
 
-            const normalizedReportedVersion = normalizeVersion(reportedVersion);
-
-            // Check if the reported version matches any released version
-            const isReleased = releasedVersions.some(releasedVer => releasedVer === normalizedReportedVersion);
+            // Split version string on "&" to handle multiple versions (e.g., "4.60 & 4.61")
+            const reportedVersions = reportedVersion.split('&').map(v => v.trim());
+            
+            // Check if ANY of the reported versions matches any released version
+            let isReleased = false;
+            for (const version of reportedVersions) {
+              const normalizedVersion = normalizeVersion(version);
+              if (releasedVersions.some(releasedVer => releasedVer === normalizedVersion)) {
+                console.log(`Found released version: ${normalizedVersion}`);
+                isReleased = true;
+                break;
+              }
+            }
 
             if (isReleased) {
               console.log(`Bug is released; leaving as-is`);


### PR DESCRIPTION
e.g. #39380, #39308, #39618.

We'll have more of these later.