### PR TITLE
🤖 Improve build version population based on git branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,23 +11,13 @@ BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 # 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
 # 3. Otherwise fall back to git describe
 ifndef VERSION
-# Check for rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z pattern
-RC_VERSION_BASE := $(shell echo "$(BRANCH)" | sed -E -n 's/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2/p')
-ifneq ($(RC_VERSION_BASE),)
-UTC_TIMESTAMP := $(shell date -u +"%y%m%d%H%M")
-VERSION := $(RC_VERSION_BASE)-rc.$(UTC_TIMESTAMP)
-else
-# Check for X.Y.Z-anything pattern
-BRANCH_VERSION_BASE := $(shell echo "$(BRANCH)" | sed -E -n 's/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1/p')
-ifneq ($(BRANCH_VERSION_BASE),)
-UTC_TIMESTAMP := $(shell date -u +"%y%m%d%H%M")
-VERSION := $(BRANCH_VERSION_BASE)+$(UTC_TIMESTAMP)
-else
+VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2-rc.$$(date -u +'%y%m%d%H%M')/p")
+ifeq ($(VERSION),)
+VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
+endif
+ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags --always --dirty)
 endif
-endif
-else
-# VERSION was explicitly provided, use it as-is
 endif
 REVISION = $(shell git rev-parse HEAD)
 REVSHORT = $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ ifndef VERSION
 	# 1. rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z → X.Y.Z-rc.YYMMDDhhmm
 	VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2-rc.$$(date -u +'%y%m%d%H%M')/p")
 	ifeq ($(VERSION),)
-		# 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
-		VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
+		# 2. X.Y.Z-anything or vX.Y.Z-anything → X.Y.Z+YYMMDDhhmm
+		VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^v?([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
 	endif
 	# 3. Otherwise fall back to git describe
 	ifeq ($(VERSION),)

--- a/Makefile
+++ b/Makefile
@@ -7,16 +7,16 @@ BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 
 # If VERSION is not explicitly set, check for version patterns in branch name
 ifndef VERSION
-# 1. rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z → X.Y.Z-rc.YYMMDDhhmm
-VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2-rc.$$(date -u +'%y%m%d%H%M')/p")
-ifeq ($(VERSION),)
-# 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
-VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
-endif
-# 3. Otherwise fall back to git describe
-ifeq ($(VERSION),)
-VERSION := $(shell git describe --tags --always --dirty)
-endif
+	# 1. rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z → X.Y.Z-rc.YYMMDDhhmm
+	VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2-rc.$$(date -u +'%y%m%d%H%M')/p")
+	ifeq ($(VERSION),)
+		# 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
+		VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
+	endif
+	# 3. Otherwise fall back to git describe
+	ifeq ($(VERSION),)
+		VERSION := $(shell git describe --tags --always --dirty)
+	endif
 endif
 REVISION = $(shell git rev-parse HEAD)
 REVSHORT = $(shell git rev-parse --short HEAD)

--- a/Makefile
+++ b/Makefile
@@ -6,15 +6,14 @@ PATH := $(shell npm bin):$(PATH)
 BRANCH = $(shell git rev-parse --abbrev-ref HEAD)
 
 # If VERSION is not explicitly set, check for version patterns in branch name
-# Priority:
-# 1. rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z → X.Y.Z-rc.YYMMDDhhmm
-# 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
-# 3. Otherwise fall back to git describe
 ifndef VERSION
+# 1. rc-minor-fleet-vX.Y.Z or rc-patch-fleet-vX.Y.Z → X.Y.Z-rc.YYMMDDhhmm
 VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^rc-(minor|patch)-fleet-v([0-9]+\.[0-9]+\.[0-9]+).*/\2-rc.$$(date -u +'%y%m%d%H%M')/p")
 ifeq ($(VERSION),)
+# 2. X.Y.Z-anything → X.Y.Z+YYMMDDhhmm
 VERSION := $(shell echo "$(BRANCH)" | sed -E -n "s/^([0-9]+\.[0-9]+\.[0-9]+)[-+].*/\1+$$(date -u +'%y%m%d%H%M')/p")
 endif
+# 3. Otherwise fall back to git describe
 ifeq ($(VERSION),)
 VERSION := $(shell git describe --tags --always --dirty)
 endif

--- a/changes/39522-build-workflow
+++ b/changes/39522-build-workflow
@@ -1,0 +1,1 @@
+* Added automatic tagging of prerelease/post-release versions on local build based on branch name


### PR DESCRIPTION
For #39522. Guessing this doesn't resolve goreleaser issues though?

Tested with this branch (shows a snapshot), `4.77.9-plus-sparklies`, `v4.77.12-without-sparkles`, and `rc-patch-fleet-v4.77.7` locally to make sure this behaves properly.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually