### PR TITLE
Disable Google Calendar integration

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -9,7 +9,7 @@ org_settings:
   host_expiry_settings:
     host_expiry_enabled: false
   integrations:
-    google_calendar:
+    google_calendar: []
       # - api_key_json: $DOGFOOD_CALENDAR_API_KEY
       #  domain: fleetdm.com
     jira: []

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -10,8 +10,6 @@ org_settings:
     host_expiry_enabled: false
   integrations:
     google_calendar: []
-      # - api_key_json: $DOGFOOD_CALENDAR_API_KEY
-      #  domain: fleetdm.com
     jira: []
     zendesk: []
   mdm:

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -9,7 +9,7 @@ org_settings:
   host_expiry_settings:
     host_expiry_enabled: false
   integrations:
-    google_calendar:
+    # google_calendar:
       # - api_key_json: $DOGFOOD_CALENDAR_API_KEY
       #  domain: fleetdm.com
     jira: []

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -9,7 +9,7 @@ org_settings:
   host_expiry_settings:
     host_expiry_enabled: false
   integrations:
-    # google_calendar:
+    google_calendar:
       # - api_key_json: $DOGFOOD_CALENDAR_API_KEY
       #  domain: fleetdm.com
     jira: []

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -10,8 +10,8 @@ org_settings:
     host_expiry_enabled: false
   integrations:
     google_calendar:
-      - api_key_json: $DOGFOOD_CALENDAR_API_KEY
-        domain: fleetdm.com
+      # - api_key_json: $DOGFOOD_CALENDAR_API_KEY
+      #  domain: fleetdm.com
     jira: []
     zendesk: []
   mdm:


### PR DESCRIPTION
This pull request makes a minor configuration change to the `it-and-security/default.yml` file, specifically in the `org_settings` section. The Google Calendar integration configuration has been commented out, which means it will no longer be active but is preserved for reference.

* Google Calendar integration in `org_settings.integrations.google_calendar` has been commented out, disabling it while keeping the configuration for potential future use.