### PR TITLE
Document QA day process

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -162,6 +162,17 @@ Mitigating the outage may require writing and merging code. The current infrastr
 
 > If outside of business hours, the responding engineer should notify their manager using incident.io to bypass Do Not Disturb mode.
 
+### Participate in QA Day
+
+Once per sprint, each product group is expected to take a day to assist in QA-related activities. On that day, generally the most straightforward way to assist the QA team is to validate issues in the `Awaiting QA` stage marked with the `~assisting-qa` label. Start with issues milestoned for the lowest-version-number active release candidate, and clear your product group's queue for that release before assisting another team with QA. You may not QA issues where you made code changes, to ensure that two people run through the test plan (the implementing engineer and the person performing QA).
+
+For each issue:
+
+1. Add yourself as an assignee when you start QA. If other work comes up that prevents you from completing the QA process, remove yourself as an assignee to ensure someone else picks the issue up.
+2. Validate the changes, either via the test plan (for stories) or by reproducing the bug on an older version and the fix in the current version (for bugs).
+3. Document QA steps performed and outcome in a comment on the story (not subtask) or bug.
+4. If changes are needed to make QA pass, either create an unreleased bug (if changes required are small relative to the size of the original bug or story, e.g. a missed edge case) or move the issue (and relevant subtasks, if there are any) back to `In progress` (if changes required are significant relative to the sisze of the ticket, e.g. if an item listed in the test plan fails). Mention in the relevant product group's Slack channel when you take either of these actions to ensure QA failures are addressed quickly (e.g. the product group's tech lead may need to assign an unreleased bug fix to an engineer other than the developer(s) on the original bug or story).
+5. Once QA passes, move the issue to `Ready for release`.
 
 ### Create a release candidate
 


### PR DESCRIPTION
This PR/handbook entry intentionally errs on the side of being prescriptive on prioritization/per-ticket workflow, in case I have the wrong idea on any part of this.