### PR TITLE
Fix `command_line_flags` placement in agent configuration docs

### DIFF
--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -17,11 +17,6 @@ config:
     distributed_tls_max_attempts: 3
     logger_tls_endpoint: /api/osquery/log
     logger_tls_period: 10
-  command_line_flags: # requires Fleet's agent (fleetd)
-    verbose: true
-    disable_watchdog: false
-    disable_tables: chrome_extensions
-    logger_path: /path/to/logger
   decorators:
     load:
       - "SELECT version FROM osquery_info"
@@ -43,6 +38,11 @@ config:
       - /Users/wxs/sigs/bar.sig
       sig_group_2:
       - /Users/wxs/sigs/baz.sig
+command_line_flags: # requires Fleet's agent (fleetd)
+  verbose: true
+  disable_watchdog: false
+  disable_tables: chrome_extensions
+  logger_path: /path/to/logger
 ```
 
 ### options and command_line_flags

--- a/docs/Configuration/agent-configuration.md
+++ b/docs/Configuration/agent-configuration.md
@@ -38,7 +38,7 @@ config:
       - /Users/wxs/sigs/bar.sig
       sig_group_2:
       - /Users/wxs/sigs/baz.sig
-command_line_flags: # requires Fleet's agent (fleetd)
+command_line_flags:
   verbose: true
   disable_watchdog: false
   disable_tables: chrome_extensions


### PR DESCRIPTION
## Changes

Fixes incorrect YAML example in `docs/Configuration/agent-configuration.md` where `command_line_flags` was shown nested under `config:` instead of at the top level.

**File changed:** `docs/Configuration/agent-configuration.md`

## What was wrong

The example in the `## config` section showed `command_line_flags` indented under `config:`:

```yaml
config:
  options:
    distributed_interval: 3
    ...
  command_line_flags: # ❌ WRONG - nested under config
    verbose: true
    ...
  decorators:
    ...
```

This is incorrect and causes the following error when applied via `fleetctl apply` for team YAML files:

```
Error: applying teams: POST /api/latest/fleet/spec/teams received status 400 Bad Request: 
"command_line_flags" should be part of the top level object
```

## Correct placement

Per the original implementation in [#7377](https://github.com/fleetdm/fleet/issues/7377), `command_line_flags` must be a **top-level key** under `agent_options`, at the same level as `config:`:

```yaml
config:
  options:
    distributed_interval: 3
    ...
  decorators:
    ...
  yara:
    ...
command_line_flags: # ✅ CORRECT - top level, sibling of config
  verbose: true
  ...
```

This is consistent with:
- The [Configuration files docs](https://fleetdm.com/docs/configuration/configuration-files) which correctly show `command_line_flags: {}` at the top level
- Issue #7377 which states: *"The overrides setting does not accommodate command_line_flags, which is why it is only allowed at the top-level (and not inside config or every override)"*
- The overrides section of the same page which notes: *"the command_line_flags key is not supported in the overrides"*

## Related issues
- Closes: https://github.com/fleetdm/confidential/issues/14206
- Closes: https://github.com/fleetdm/confidential/issues/14207
