### PR TITLE
Filter bogus nilaway internal error

### DIFF
--- a/.golangci-incremental.yml
+++ b/.golangci-incremental.yml
@@ -23,3 +23,10 @@ linters:
           include-pkgs: "github.com/fleetdm/fleet/v4"
   exclusions:
     generated: strict
+    rules:
+      # nilaway has a hardcoded 500 CFG block limit (_maxFuncSizeInCFGBlocks). Functions exceeding
+      # it produce an INTERNAL ERROR with a bogus $GOROOT path that crashes golangci-lint's
+      # generated_file_filter processor. These are informational skip messages, not real findings.
+      - linters:
+          - nilaway
+        text: "INTERNAL ERROR"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32999

Intended to get rid of these crash messages seen in CI:
```
Error: level=warning msg="[runner] Can't process results by generated_file_filter processor: can't filter issue &result.Issue{FromLinter:\"nilaway\", Text:\"\\x1b[31merror: \\x1b[0mINTERNAL ERROR(s):\\nnilaway_assertion_analyzer: nilaway_function_analyzer: skipping function \\x1b[95m`ListHostSoftware()`\\x1b[0m at /home/runner/work/fleet/fleet/server/datastore/mysql/software.go:4217:1: function too large (623 CFG blocks, exceeds limit of 500 blocks)\", Severity:\"\", SourceLines:[]string(nil), Pkg:(*packages.Package)(0xc002fe64e0), Pos:token.Position{Filename:\"/home/runner/work/fleet/fleet/$GOROOT/src/unicode/utf16/utf16.go\", Offset:0, Line:1, Column:1}, LineRange:(*result.Range)(nil), HunkPos:0, SuggestedFixes:[]analysis.SuggestedFix(nil), ExpectNoLint:false, ExpectedNoLintLinter:\"\", WorkingDirectoryRelativePath:\"$GOROOT/src/unicode/utf16/utf16.go\", RelativePath:\"$GOROOT/src/unicode/utf16/utf16.go\"}: failed to get doc (strict) of file /home/runner/work/fleet/fleet/$GOROOT/src/unicode/utf16/utf16.go: failed to parse file: open /home/runner/work/fleet/fleet/$GOROOT/src/unicode/utf16/utf16.go: no such file or directory"
```