### PR TITLE
Fixing 2 errors still showing up as server errors in OTEL

### DIFF
--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2,10 +2,14 @@ package service
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -948,6 +952,22 @@ type submitDistributedQueryResultsRequestShim struct {
 
 func (shim *submitDistributedQueryResultsRequestShim) hostNodeKey() string {
 	return shim.NodeKey
+}
+
+// DecodeBody implements the bodyDecoder interface for custom request body
+// decoding. This endpoint receives large payloads (distributed query results),
+// making it susceptible to client read timeouts (poll.DeadlineExceededError).
+// By implementing DecodeBody, we can classify those network errors as client errors.
+func (shim *submitDistributedQueryResultsRequestShim) DecodeBody(_ context.Context, r io.Reader, _ url.Values, _ []*x509.Certificate) error {
+	if err := json.NewDecoder(r).Decode(shim); err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			osqueryErr := NewOsqueryError("request body read error: "+err.Error(), false)
+			osqueryErr.StatusCode = http.StatusRequestTimeout
+			return osqueryErr
+		}
+		return err
+	}
+	return nil
 }
 
 func (shim *submitDistributedQueryResultsRequestShim) toRequest(ctx context.Context) (*SubmitDistributedQueryResultsRequest, error) {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -55,6 +55,9 @@ func (svc *Service) AuthenticateHost(ctx context.Context, nodeKey string) (*flee
 		// OK
 	case fleet.IsNotFound(err):
 		return nil, false, newOsqueryErrorWithInvalidNode("authentication error: invalid node key")
+	case errors.Is(err, context.Canceled):
+		// Most likely client disconnected, so we treat this as a client error.
+		return nil, false, err
 	default:
 		return nil, false, newOsqueryError("authentication error: " + err.Error())
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38756

Unreleased bugs (not fully fixed by previous bug fix):
- Fixing context canceled fails during auth.
- Fixing timeout exceeded during distributed writes.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
  - QA'd the normal case
  - Error case fixes will be verified with next Dogfood deploy



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for cancelled authentication contexts to provide more accurate error reporting
  * Enhanced timeout handling for large distributed query submissions with proper HTTP 408 response codes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->