### PR TITLE
Cherry-Pick: Update to Go 1.25.7

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.25.6-bookworm@sha256:2f768d462dbffbb0f0b3a5171009f162945b086f326e0b2a8fd5d29c3219ff14
+FROM --platform=linux/amd64 golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*

--- a/changes/go-1.25.7
+++ b/changes/go-1.25.7
@@ -1,0 +1,1 @@
+* Updated to Go 1.25.7.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.25.6
+go 1.25.7
 
 require (
 	cloud.google.com/go/pubsub v1.49.0

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine3.23@sha256:660f0b83cf50091e3777e4730ccc0e63e83fea2c420c872af5c60cb357dcafb2
+FROM golang:1.25.7-alpine3.23@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/third_party/vuln-check/go.mod
+++ b/third_party/vuln-check/go.mod
@@ -9,7 +9,7 @@
 
 module github.com/fleetdm/fleet/v4/third_party/vuln-check
 
-go 1.25.6
+go 1.25.7
 
 require (
 	// NanoMDM - Apple MDM server (server/mdm/nanomdm/)

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-alpine3.23@sha256:660f0b83cf50091e3777e4730ccc0e63e83fea2c420c872af5c60cb357dcafb2
+FROM golang:1.25.7-alpine3.23@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.25.6
+go 1.25.7
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.25.6
+go 1.25.7
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Merged into `main` in #39584. Also backports test changes based on `fleet-gitops` repo changes.