### PR TITLE
Ignore `gdm-greeter` user (to support GNOME 49 sessions in Fedora)

### DIFF
--- a/orbit/changes/37447-account-for-gdm-greeter
+++ b/orbit/changes/37447-account-for-gdm-greeter
@@ -1,0 +1,1 @@
+* Updated fleetd to ignore the `gdm-greeter` user in GNOME 49 sessions when starting Fleet Desktop.

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -25,8 +25,10 @@ func UserLoggedInViaGui() (*string, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get login user: %w", err)
 	}
+
 	// Bail out if the user is gdm or root, since they aren't GUI users.
-	if user.Name == "gdm" || user.Name == "root" {
+	// User gdm-greeter is active during the GUI log-in prompt (GNOME 49).
+	if user.Name == "gdm" || user.Name == "root" || user.Name == "gdm-greeter" {
 		return nil, nil
 	}
 	// Check if the user has a GUI session.


### PR DESCRIPTION
Resolves #37447.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [X] Verified that fleetd runs on Linux
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
