### PR TITLE
Fleet UI: Script-only package support for macOS

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -1,4 +1,4 @@
-/** For payload-free packages (e.g. software source is sh_packages or ps1_packages)
+/** For script-only packages (e.g. software source is sh_packages or ps1_packages)
  * we use SoftwareScriptDetailsModal
  * For iOS/iPadOS packages (e.g. .ipa packages software source is ios_apps or ipados_apps)
  * we use SoftwareIpaInstallDetailsModal with the command_uuid

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tests.tsx
@@ -149,7 +149,7 @@ describe("SoftwareScriptDetailsModal - ModalButtons component", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("on device user page, shows Done button for ran payload-free software script", () => {
+  it("on device user page, shows Done button for ran script-only software script", () => {
     const onCancel = jest.fn();
     render(
       <ModalButtons

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareScriptDetailsModal/SoftwareScriptDetailsModal.tsx
@@ -1,5 +1,5 @@
 /** This component is intentionally separate from SoftwareInstallDetailsModal
- * because it handles payload-free/script-based package installs (e.g. sh_packages or ps1_packages)
+ * because it handles script-only package installs (e.g. sh_packages or ps1_packages)
  *
  * Key differences from SoftwareInstallDetailsModal:
  * - Uses Script/Run/Rerun language in UI instead of Install/Retry.

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -257,8 +257,8 @@ export const SOURCE_TYPE_CONVERSION = {
   chocolatey_packages: "Package (Chocolatey)",
   pkg_packages: "Package (pkg)",
   vscode_extensions: "IDE extension", // vscode_extensions can include any vscode-based editor (e.g., Cursor, Trae, Windsurf), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
-  sh_packages: "Script-only (macOS & Linux)",
-  ps1_packages: "Script-only (Windows)",
+  sh_packages: "Script-only package (macOS & Linux)",
+  ps1_packages: "Script-only package (Windows)",
   jetbrains_plugins: "IDE extension", // jetbrains_plugins can include any JetBrains IDE (e.g., IntelliJ, PyCharm, WebStorm), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
 } as const;
 

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -257,8 +257,8 @@ export const SOURCE_TYPE_CONVERSION = {
   chocolatey_packages: "Package (Chocolatey)",
   pkg_packages: "Package (pkg)",
   vscode_extensions: "IDE extension", // vscode_extensions can include any vscode-based editor (e.g., Cursor, Trae, Windsurf), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
-  sh_packages: "Payload-free (Linux)",
-  ps1_packages: "Payload-free (Windows)",
+  sh_packages: "Script-only (macOS & Linux)",
+  ps1_packages: "Script-only (Windows)",
   jetbrains_plugins: "IDE extension", // jetbrains_plugins can include any JetBrains IDE (e.g., IntelliJ, PyCharm, WebStorm), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
 } as const;
 
@@ -375,7 +375,7 @@ export const SOFTWARE_INSTALL_STATUSES = [
   "failed_install",
 ] as const;
 
-// Payload-free (script) software statuses
+// Script-only software statuses
 export const SOFTWARE_SCRIPT_STATUSES = [
   "ran_script",
   "pending_script",
@@ -387,7 +387,7 @@ export type SoftwareInstallStatus = typeof SOFTWARE_INSTALL_STATUSES[number];
 export const SOFTWARE_INSTALL_UNINSTALL_STATUSES = [
   ...SOFTWARE_INSTALL_STATUSES,
   ...SOFTWARE_UNINSTALL_STATUSES,
-  // Payload-free (script) software statuses use API's SOFTWARE_INSTALL_STATUSES
+  // Script-only software statuses use API's SOFTWARE_INSTALL_STATUSES
 ] as const;
 
 /*
@@ -395,15 +395,15 @@ export const SOFTWARE_INSTALL_UNINSTALL_STATUSES = [
  */
 export type SoftwareInstallUninstallStatus = typeof SOFTWARE_INSTALL_UNINSTALL_STATUSES[number];
 
-/** Include payload-free statuses */
+/** Include script-only software statuses */
 export const ENAHNCED_SOFTWARE_INSTALL_UNINSTALL_STATUSES = [
   ...SOFTWARE_INSTALL_STATUSES,
   ...SOFTWARE_UNINSTALL_STATUSES,
-  ...SOFTWARE_SCRIPT_STATUSES, // Payload-free (script) software
+  ...SOFTWARE_SCRIPT_STATUSES, // Script-only software
 ] as const;
 
 /*
- * EnhancedSoftwareInstallUninstallStatus represents the possible states of software install operations including payload-free used in the UI.
+ * EnhancedSoftwareInstallUninstallStatus represents the possible states of software install operations including script-only software used in the UI.
  */
 export type EnhancedSoftwareInstallUninstallStatus = typeof ENAHNCED_SOFTWARE_INSTALL_UNINSTALL_STATUSES[number];
 
@@ -695,9 +695,9 @@ const INSTALL_STATUS_PREDICATES: Record<
   failed_install: "failed to install",
   pending_uninstall: "told Fleet to uninstall",
   failed_uninstall: "failed to uninstall",
-  ran_script: "ran", // Payload-free (script) software
-  failed_script: "failed to run", // Payload-free (script) software
-  pending_script: "told Fleet to run", // Payload-free (script) software
+  ran_script: "ran", // Script-only software
+  failed_script: "failed to run", // Script-only software
+  pending_script: "told Fleet to run", // Script-only software
 } as const;
 
 export const getInstallUninstallStatusPredicate = (
@@ -750,9 +750,9 @@ export const INSTALL_STATUS_ICONS: Record<
   failed_install: "error-outline",
   pending_uninstall: "pending-outline",
   failed_uninstall: "error-outline",
-  ran_script: "success-outline", // Payload-free (script) software
-  failed_script: "error-outline", // Payload-free (script) software
-  pending_script: "pending-outline", // Payload-free (script) software
+  ran_script: "success-outline", // Script-only software
+  failed_script: "error-outline", // Script-only software
+  pending_script: "pending-outline", // Script-only software
 } as const;
 
 type IHostSoftwarePackageWithLastInstall = IHostSoftwarePackage & {

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tests.tsx
@@ -1454,7 +1454,7 @@ describe("Activity Feed", () => {
       type: ActivityType.InstalledSoftware,
       actor_full_name: "Script Admin",
       details: {
-        software_title: "Payload-free Script",
+        software_title: "Script-only Software",
         source: "sh_packages",
         status: "installed",
         software_package: "myscript.sh",
@@ -1464,7 +1464,7 @@ describe("Activity Feed", () => {
 
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
     expect(screen.getByText(/ran/i)).toBeInTheDocument(); // For status: "installed"
-    expect(screen.getByText("Payload-free Script")).toBeInTheDocument();
+    expect(screen.getByText("Script-only Software")).toBeInTheDocument();
   });
 
   it("renders script package pending run status in InstalledSoftware activity", () => {
@@ -1472,7 +1472,7 @@ describe("Activity Feed", () => {
       type: ActivityType.InstalledSoftware,
       actor_full_name: "Script Admin",
       details: {
-        software_title: "Payload-free Script",
+        software_title: "Script-only Software",
         source: "sh_packages",
         status: "pending_install",
         software_package: "myscript.sh",
@@ -1482,7 +1482,7 @@ describe("Activity Feed", () => {
 
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
     expect(screen.getByText(/told Fleet to run/i)).toBeInTheDocument(); // For status: "pending_install"
-    expect(screen.getByText("Payload-free Script")).toBeInTheDocument();
+    expect(screen.getByText("Script-only Software")).toBeInTheDocument();
   });
 
   it("renders script package failed run status in InstalledSoftware activity", () => {
@@ -1490,7 +1490,7 @@ describe("Activity Feed", () => {
       type: ActivityType.InstalledSoftware,
       actor_full_name: "Script Admin",
       details: {
-        software_title: "Payload-free Script",
+        software_title: "Script-only Software",
         source: "ps1_packages", // Other script package source
         status: "failed_install",
         software_package: "myscript.ps1",
@@ -1500,7 +1500,7 @@ describe("Activity Feed", () => {
 
     render(<GlobalActivityItem activity={activity} isPremiumTier />);
     expect(screen.getByText(/failed to run/i)).toBeInTheDocument(); // For status: "failed_install"
-    expect(screen.getByText("Payload-free Script")).toBeInTheDocument();
+    expect(screen.getByText("Script-only Software")).toBeInTheDocument();
   });
 
   it("renders addedNdesScepProxy activity correctly", () => {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -113,7 +113,7 @@ const SoftwareCustomPackage = ({
       return;
     }
 
-    setUploadDetails(getFileDetails(formData.software, true));
+    setUploadDetails(getFileDetails(formData.software));
 
     // Note: This TODO is copied to onSaveSoftwareChanges in EditSoftwareModal
     // TODO: confirm we are deleting the second sentence (not modifying it) for non-self-service installers

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -416,7 +416,7 @@ const EditSoftwareModal = ({
       )}
       {!!pendingPackageUpdates.software && showFileProgressModal && (
         <FileProgressModal
-          fileDetails={getFileDetails(pendingPackageUpdates.software, true)}
+          fileDetails={getFileDetails(pendingPackageUpdates.software)}
           fileProgress={uploadProgress}
         />
       )}

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -56,15 +56,24 @@ export interface IPackageFormValidation {
   customTarget?: { isValid: boolean };
 }
 
+const getGraphicName = (ext: string) => {
+  if (ext === "sh") {
+    return "file-sh";
+  } else if (ext === "ps1") {
+    return "file-ps1";
+  }
+  return "file-pkg";
+};
+
 const renderFileTypeMessage = () => {
   return (
     <>
       macOS (.pkg), iOS/iPadOS (.ipa),
       <br />
       Windows (.msi, .exe.,{" "}
-      <TooltipWrapper tipContent="Payload-free package">.ps1</TooltipWrapper>),
+      <TooltipWrapper tipContent="Script-only package">.ps1</TooltipWrapper>),
       or Linux (.deb, .rpm,{" "}
-      <TooltipWrapper tipContent="Payload-free package">.sh</TooltipWrapper>)
+      <TooltipWrapper tipContent="Script-only package">.sh</TooltipWrapper>)
     </>
   );
 };
@@ -314,7 +323,7 @@ const PackageForm = ({
       <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <FileUploader
           canEdit={canEditFile}
-          graphicName="file-pkg"
+          graphicName={getGraphicName(ext || "")}
           accept={ACCEPTED_EXTENSIONS}
           message={renderFileTypeMessage()}
           onFileUpload={onFileSelect}
@@ -322,9 +331,7 @@ const PackageForm = ({
           buttonType="brand-inverse-icon"
           className={`${baseClass}__file-uploader`}
           fileDetails={
-            formData.software
-              ? getFileDetails(formData.software, true)
-              : undefined
+            formData.software ? getFileDetails(formData.software) : undefined
           }
           gitopsCompatible={gitopsCompatible}
           gitOpsModeEnabled={gitOpsModeEnabled}

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -143,7 +143,7 @@ const SoftwareOptionsSelector = ({
       return (
         <>
           Fleet can&apos;t create a policy to detect existing installations of
-          payload-free packages. To automatically install these packages, add a
+          script-only packages. To automatically install these packages, add a
           custom policy and enable the install software automation on the{" "}
           <b>Policies</b> page.
         </>

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -446,7 +446,7 @@ const Advanced = ({
                     </>
                   )
                 }
-                helpText="Features that run scripts under-the-hood (e.g. software install, lock/wipe, payload-free packages) will still be available."
+                helpText="Features that run scripts under-the-hood (e.g. software install, lock/wipe, script-only packages) will still be available."
               >
                 Disable script execution features
               </Checkbox>

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -402,12 +402,12 @@ const DeviceUserPage = ({
       refetchIntervalInBackground: true,
       select: (response) => {
         // Marshal the response to include a `type` property so we can differentiate
-        // between software, payload-free software, and script setup steps in the UI.
+        // between software, script-only software, and script setup steps in the UI.
         return [
           ...(response.setup_experience_results.software ?? []).map((s) => ({
             ...s,
             type: isSoftwareScriptSetup(s)
-              ? "software_script_run" // used for payload-free software
+              ? "software_script_run" // used for script-only software
               : "software_install",
           })),
           ...(response.setup_experience_results.scripts ?? []).map((s) => ({

--- a/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
+++ b/frontend/pages/hosts/details/DeviceUserPage/helpers.ts
@@ -39,7 +39,7 @@ export const getFailedSoftwareInstall = (
   return firstWithError ?? failedSoftware[0];
 };
 
-/** Checks if the software is a payload-free script package (sh or ps1)
+/** Checks if the software is a script-only package (sh or ps1)
  * by examining the source field from the API */
 export const isSoftwareScriptSetup = (s: ISetupStep) => {
   if (!s.source) return false;

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -125,7 +125,7 @@ describe("InstallStatusCell - component", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders 'Ran' status for a payload-free package", async () => {
+  it("renders 'Ran' status for a script-only package", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -191,7 +191,7 @@ describe("InstallStatusCell - component", () => {
     });
   });
 
-  it("renders 'Running...' status for a payload-free package with tooltip if host is online", async () => {
+  it("renders 'Running...' status for a script-only package with tooltip if host is online", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -233,7 +233,7 @@ describe("InstallStatusCell - component", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("renders 'Run (pending)' for a payload-free package with tooltip if host is offline", async () => {
+  it("renders 'Run (pending)' for a script-only package with tooltip if host is offline", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -374,7 +374,7 @@ describe("InstallStatusCell - component", () => {
     });
   });
 
-  it("renders 'Failed' for a payload-free package that failed to run", async () => {
+  it("renders 'Failed' for a script-only package that failed to run", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{
@@ -662,7 +662,7 @@ describe("InstallStatusCell - component", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
-  it("renders '---' for a payload-free package available for run", async () => {
+  it("renders '---' for a script-only package available for run", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell
         software={{

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -427,7 +427,7 @@ const InstallStatusCell = ({
 
   const displayConfig = INSTALL_STATUS_DISPLAY_OPTIONS[displayStatus];
 
-  // This is only called for script packages (payload-free installers: .sh, .ps1)
+  // This is only called for script packages (script-only installers: .sh, .ps1)
   const onClickScriptStatus = () => {
     onShowScriptDetails(software);
   };

--- a/frontend/utilities/file/fileUtils.tsx
+++ b/frontend/utilities/file/fileUtils.tsx
@@ -72,10 +72,7 @@ export const getExtensionFromFileName = (fileName: string) => {
 /** This gets the platform display name from the file.
  * Includes nuance for .sh software installers only supported on Linux
  */
-export const getPlatformDisplayName = (
-  file: File,
-  isSoftwareInstaller = false
-) => {
+export const getPlatformDisplayName = (file: File) => {
   const fileExt = getExtensionFromFileName(file.name);
   if (!fileExt) {
     return undefined;
@@ -88,19 +85,14 @@ export const getPlatformDisplayName = (
     );
   }
 
-  if (fileExt === "sh" && isSoftwareInstaller) {
-    // Currently, .sh files for software installers are only supported for Linux
-    return "Linux";
-  }
-
   return FILE_EXTENSIONS_TO_PLATFORM_DISPLAY_NAME[fileExt];
 };
 
 /** This gets the file details from the file. */
-export const getFileDetails = (file: File, isSoftwareInstaller = false) => {
+export const getFileDetails = (file: File) => {
   return {
     name: file.name,
-    description: getPlatformDisplayName(file, isSoftwareInstaller),
+    description: getPlatformDisplayName(file),
   };
 };
 


### PR DESCRIPTION
## Issue
FE for #33951
Closes #39086

## Description
- Update copies from "payload-free" to "script-only package"
- Update `.sh` copy to include macOS, update icon for .sh and .ps1 to match Figma/existing icons

## Screenshots
<img width="1222" height="441" alt="Screenshot 2026-02-10 at 1 55 06 PM" src="https://github.com/user-attachments/assets/a1802156-5860-4a96-a239-eae38fc4c490" />
<img width="1221" height="464" alt="Screenshot 2026-02-10 at 1 55 11 PM" src="https://github.com/user-attachments/assets/f75f312c-3cf4-4a8a-9cb7-04ea2e5afe34" />
<img width="1220" height="498" alt="Screenshot 2026-02-10 at 1 49 55 PM" src="https://github.com/user-attachments/assets/42f35313-ca83-497e-9b4c-6fdd1ae5fae8" />

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
