### PR TITLE
Bump Firefox version check to 147.0.3

### DIFF
--- a/it-and-security/lib/macos/policies/update-firefox.yml
+++ b/it-and-security/lib/macos/policies/update-firefox.yml
@@ -1,5 +1,5 @@
 - name: macOS - Firefox up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '140.0.2') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '147.0.3') < 0);
   critical: false
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: Download the latest version from self-service or check for updates using Firefox's built-in update functionality. You can also delete Firefox if you are no longer using it. 


### PR DESCRIPTION
Update macOS policy query to treat Firefox versions older than 147.0.3 as outdated (previously 140.0.2). This adjusts the apps version_compare threshold in it-and-security/lib/macos/policies/update-firefox.yml; no other policy fields were modified.
