### PR TITLE
Comment out Slack post_install_script

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -262,8 +262,8 @@ software:
     - slug: slack/darwin # Slack for macOS
       self_service: true
       setup_experience: true
-      post_install_script:
-        path: ../lib/macos/scripts/migrate-slack-preferences.sh
+    # post_install_script:
+    #  path: ../lib/macos/scripts/migrate-slack-preferences.sh
       categories:
         - Communication
         - Productivity


### PR DESCRIPTION
Disable the Slack macOS post-install migration script by commenting out the post_install_script path to ../lib/macos/scripts/migrate-slack-preferences.sh. Slack entry and categories remain unchanged; the script can be re-enabled later if needed.
