### PR TITLE
Fleet Helm Chart - Additional CA support

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.7.12
+version: v6.8.0
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/_helpers.tpl
+++ b/charts/fleet/templates/_helpers.tpl
@@ -69,7 +69,5 @@ Create the name of the service account to use
 {{- define "fleet.additionalCAs.enabled" -}}
 {{- if and .Values.fleet.additionalCAs.enabled (or .Values.fleet.additionalCAs.configMaps .Values.fleet.additionalCAs.secrets) -}}
 true
-{{- else -}}
-false
 {{- end -}}
 {{- end -}}

--- a/charts/fleet/templates/_helpers.tpl
+++ b/charts/fleet/templates/_helpers.tpl
@@ -67,7 +67,9 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "fleet.additionalCAs.enabled" -}}
+{{- if hasKey .Values.fleet "additionalCAs" -}}
 {{- if and .Values.fleet.additionalCAs.enabled (or (and (.Values.fleet.additionalCAs.configMaps) (gt (len .Values.fleet.additionalCAs.configMaps) 0)) (and (.Values.fleet.additionalCAs.secrets) (gt (len .Values.fleet.additionalCAs.secrets) 0))) -}}
 true
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/fleet/templates/_helpers.tpl
+++ b/charts/fleet/templates/_helpers.tpl
@@ -65,3 +65,11 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{- define "fleet.additionalCAs.enabled" -}}
+{{- if and .Values.fleet.additionalCAs.enabled (or .Values.fleet.additionalCAs.configMaps .Values.fleet.additionalCAs.secrets) -}}
+true
+{{- else -}}
+false
+{{- end -}}
+{{- end -}}

--- a/charts/fleet/templates/_helpers.tpl
+++ b/charts/fleet/templates/_helpers.tpl
@@ -67,7 +67,7 @@ Create the name of the service account to use
 {{- end }}
 
 {{- define "fleet.additionalCAs.enabled" -}}
-{{- if and .Values.fleet.additionalCAs.enabled (or .Values.fleet.additionalCAs.configMaps .Values.fleet.additionalCAs.secrets) -}}
+{{- if and .Values.fleet.additionalCAs.enabled (or (and (.Values.fleet.additionalCAs.configMaps) (gt (len .Values.fleet.additionalCAs.configMaps) 0)) (and (.Values.fleet.additionalCAs.secrets) (gt (len .Values.fleet.additionalCAs.secrets) 0))) -}}
 true
 {{- end -}}
 {{- end -}}

--- a/charts/fleet/templates/cron-vulnprocessing.yaml
+++ b/charts/fleet/templates/cron-vulnprocessing.yaml
@@ -27,6 +27,43 @@ spec:
             heritage: {{ .Release.Service }}
             release: {{ .Release.Name }}
         spec:
+          initContainers:
+          {{- if include "fleet.additionalCAs.enabled" . }}
+          - name: install-trusted-cas
+            image: "{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
+            securityContext:
+              runAsUser: 0
+              runAsNonRoot: false
+              allowPrivilegeEscalation: false
+            command:
+              - sh
+              - -c
+              - |
+                set -e
+                apk add ca-certificates
+                echo "Installing trusted CA certificates..."
+
+                for dir in /custom-ca/*; do
+                  if [ -d "$dir" ]; then
+                    cp "$dir"/*.crt /usr/local/share/ca-certificates/
+                  fi
+                done
+
+                update-ca-certificates
+            volumeMounts:
+          {{- range .Values.fleet.additionalCAs.configMaps }}
+              - name: ca-configmap-{{ .name }}
+                mountPath: /custom-ca/configmap-{{ .name }}
+                readOnly: true
+          {{- end }}
+          {{- range .Values.fleet.additionalCAs.secrets }}
+              - name: ca-secret-{{ .name }}
+                mountPath: /custom-ca/secret-{{ .name }}
+                readOnly: true
+          {{- end }}
+              - name: ca-certs
+                mountPath: /etc/ssl/certs
+          {{- end }}
           restartPolicy: Never
           shareProcessNamespace: true
           containers:
@@ -246,6 +283,10 @@ spec:
                 readOnly: true
                 mountPath: /secrets/mysql
               {{- end }}
+              {{- if include "fleet.additionalCAs.enabled" . }}
+              - name: ca-certs
+                mountPath: /etc/ssl/certs
+              {{- end }}
           {{- if .Values.gke.cloudSQL.enableProxy }}
           - name: cloudsql-proxy
             image: "{{ .Values.gke.cloudSQL.imageRepository }}:{{ .Values.gke.cloudSQL.imageTag }}"
@@ -288,6 +329,20 @@ spec:
             - name: mysql-tls
               secret:
                 secretName: "{{ .Values.database.secretName }}"
+            {{- end }}
+            {{- if include "fleet.additionalCAs.enabled" . }}
+            {{- range .Values.fleet.additionalCAs.configMaps }}
+            - name: ca-configmap-{{ .name }}
+              configMap:
+                name: {{ .name }}
+            {{- end }}
+            {{- range .Values.fleet.additionalCAs.secrets }}
+            - name: ca-secret-{{ .name }}
+              secret:
+                secretName: {{ .name }}
+            {{- end }}
+            - name: ca-certs
+              emptyDir: {}
             {{- end }}
           {{- with .Values.nodeSelector }}
           nodeSelector:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -32,6 +32,43 @@ spec:
         heritage: {{ .Release.Service }}
         release: {{ .Release.Name }}
     spec:
+      initContainers:
+      {{- if include "fleet.additionalCAs.enabled" . }}
+      - name: install-trusted-cas
+        image: "{{ .Values.imageRepository }}:{{ .Values.imageTag }}"
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+          allowPrivilegeEscalation: false
+        command:
+          - sh
+          - -c
+          - |
+            set -e
+            apk add ca-certificates
+            echo "Installing trusted CA certificates..."
+
+            for dir in /custom-ca/*; do
+              if [ -d "$dir" ]; then
+                cp "$dir"/*.crt /usr/local/share/ca-certificates/
+              fi
+            done
+
+            update-ca-certificates
+        volumeMounts:
+      {{- range .Values.fleet.additionalCAs.configMaps }}
+          - name: ca-configmap-{{ .name }}
+            mountPath: /custom-ca/configmap-{{ .name }}
+            readOnly: true
+      {{- end }}
+      {{- range .Values.fleet.additionalCAs.secrets }}
+          - name: ca-secret-{{ .name }}
+            mountPath: /custom-ca/secret-{{ .name }}
+            readOnly: true
+      {{- end }}
+          - name: ca-certs
+            mountPath: /etc/ssl/certs
+      {{- end }}
       containers:
       - name: fleet
         command: [/usr/bin/fleet]
@@ -435,7 +472,7 @@ spec:
             {{- if .Values.fleet.tls.enabled }}
             scheme: HTTPS
             {{- end }}
-        {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
+        {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") (include "fleet.additionalCAs.enabled" .) }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
@@ -452,6 +489,10 @@ spec:
           {{- if or (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
           - name: osquery-logs
             mountPath: /logs
+          {{- end }}
+          {{- if include "fleet.additionalCAs.enabled" . }}
+          - name: ca-certs
+            mountPath: /etc/ssl/certs
           {{- end }}
           {{- with .Values.fleet.extraVolumeMounts }}
           {{- toYaml . | nindent 10 }}
@@ -520,6 +561,20 @@ spec:
         {{- end }}
         {{- with .Values.fleet.extraVolumes }}
         {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- if include "fleet.additionalCAs.enabled" . }}
+        {{- range .Values.fleet.additionalCAs.configMaps }}
+        - name: ca-configmap-{{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
+        {{- range .Values.fleet.additionalCAs.secrets }}
+        - name: ca-secret-{{ .name }}
+          secret:
+            secretName: {{ .name }}
+        {{- end }}
+        - name: ca-certs
+          emptyDir: {}
         {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -146,9 +146,9 @@ fleet:
   additionalCAs:
     enabled: false
     configMaps:
-    - name: fleet-ca-config
+    # - name: fleet-ca-config
     secrets:
-    - name: fleet-ca-secret
+    # - name: fleet-ca-secret
 
 # Whether to make fleet vulnerability processing run in a dedicated container
 # if you set dedicated=false, you need to increase the main resources section

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.80.1 # Version of Fleet to deploy
+imageTag: v4.79.1 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker
@@ -130,6 +130,26 @@ fleet:
     runAsNonRoot: true
     runAsUser: 3333
     runAsGroup: 3333
+  # Add additional CA's to the Fleet container truststore
+  # To add CA's, set enabled: true 
+  # Supports adding CA's from Config maps and Secrets
+  # configMaps:
+  #   - name: fleet-ca-config
+  #   - name: ca-config-map-2
+  #   - name: ca-config-map-3
+  #   - name: ca-config-map-N
+  # secrets:
+  #   - name: fleet-ca-secret
+  #   - name: ca-secret-2
+  #   - name: ca-secret-3
+  #   - name: ca-secret-N
+  additionalCAs:
+    enabled: false
+    configMaps:
+    - name: fleet-ca-config
+    secrets:
+    - name: fleet-ca-secret
+
 # Whether to make fleet vulnerability processing run in a dedicated container
 # if you set dedicated=false, you need to increase the main resources section
 # to 4Gi or the fleet container will be OOMKilled when vulnerability processing

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.79.1 # Version of Fleet to deploy
+imageTag: v4.80.1 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker


### PR DESCRIPTION
- Increments Helm chart to `6.8.0`
- Adds Fleet Helm chart support for adding additional CA certificates to the Fleet container's trust store
  - Allows adding additional CA certificates stored in kubernetes secrets and kubernetes config maps to
    - Fleet pods
    - Fleet vulnerability processing pods 