### PR TITLE
Remove duplicate VPP section from it-and-security default .yml

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -30,21 +30,6 @@ org_settings:
       ios_team: "🧪 Testing & QA"
       ipados_team: "🧪 Testing & QA"
     volume_purchasing_program:
-    - location: Fleet Device Management Inc.
-      teams:
-      - "💻 Workstations"
-      - "📱🏢 Employee-issued mobile devices"
-      - "📱🔐 Personal mobile devices"
-      - "🧪 Testing & QA"
-      - organization_name: Fleet Device Management Inc.
-        macos_team: "💻 Workstations"
-        ios_team: "📱🏢 Employee-issued mobile devices"
-        ipados_team: "📱🏢 Employee-issued mobile devices"
-      - organization_name: Mactivate LLC
-        macos_team: "🧪 Testing & QA"
-        ios_team: "🧪 Testing & QA"
-        ipados_team: "🧪 Testing & QA"
-    volume_purchasing_program:
       - location: Fleet Device Management Inc.
         teams:
           - "💻 Workstations"


### PR DESCRIPTION
While working on some GitOps updates I noticed that our current `default.yml` file is invalid, because it has a duplicate `volume_purchasing_program` section.  It looks like it was accidentally copied during an update to rename some teams.