### PR TITLE
Website: Update user record

### DIFF
--- a/website/api/models/User.js
+++ b/website/api/models/User.js
@@ -289,6 +289,11 @@ without necessarily having a billing card.`
         'render trial',
         'local trial',
       ],
+    },
+
+    fleetPremiumTrialEmailSentAt: {
+      type: 'number',
+      description: 'A JS timestamp representing when this user was sent an email about their Fleet Premium trial',
     }
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗

--- a/website/scripts/deliver-expired-local-trial-emails.js
+++ b/website/scripts/deliver-expired-local-trial-emails.js
@@ -20,6 +20,7 @@ module.exports = {
       fleetPremiumTrialLicenseKeyExpiresAt: {
         '>=': oneDayAgoAt,
         '<': nowAt,
+      },
     });
 
 
@@ -42,7 +43,7 @@ module.exports = {
           sails.log.warn(`When sending an email to a user with a newly expired Fleet Premium local trial (email: ${expiredTrialUser.emailAddress}) an error occured. Full error: ${require('util').inspect(err)}`);
           return;
         });
-        // Update the timestamp for this user.
+        // Update the fleetPremiumTrialEmailSentAt for this user.
         await User.updateOne({id: expiredTrialUser.id}).set({fleetPremiumTrialEmailSentAt: Date.now()});
 
       }

--- a/website/scripts/manage-fleet-premium-trial-instances.js
+++ b/website/scripts/manage-fleet-premium-trial-instances.js
@@ -652,7 +652,7 @@ module.exports = {
         sails.log.warn(`When sending an email to a user with a newly expired Fleet Premium trial (email: ${user.emailAddress}) an error occured. Full error: ${util.inspect(err)}`);
         return;
       });
-
+      await User.updateOne({id: user.id}).set({fleetPremiumTrialEmailSentAt: nowAt});
       await RenderProofOfValue.updateOne({id: expiringInstance.id}).set({status: 'expired'});
     }//∞
 

--- a/website/scripts/manage-fleet-premium-trial-instances.js
+++ b/website/scripts/manage-fleet-premium-trial-instances.js
@@ -652,6 +652,7 @@ module.exports = {
         sails.log.warn(`When sending an email to a user with a newly expired Fleet Premium trial (email: ${user.emailAddress}) an error occured. Full error: ${util.inspect(err)}`);
         return;
       });
+      // Set the fleetPremiumTrialEmailSentAt value on this user record.
       await User.updateOne({id: user.id}).set({fleetPremiumTrialEmailSentAt: nowAt});
       await RenderProofOfValue.updateOne({id: expiringInstance.id}).set({status: 'expired'});
     }//∞


### PR DESCRIPTION
Changes:
- Added a new attribute to the user record: `fleetPremiumTrialEmailSentAt` - A JS timestamp representing when a user was sent an email about their Fleet Premium trial
- Updated the `deliver-expired-local-trial-emails` and `manage-fleet-premium-trial-instances` scripts to set this value when users are sent an email about their expired trial.