### PR TITLE
Add EV to allow bootstrap package install during migration (#39648)

### DIFF
--- a/changes/39634-bootstrap-migration
+++ b/changes/39634-bootstrap-migration
@@ -1,0 +1,1 @@
+* Added an environment variable to allow reverting to the old behavior of installing the bootstrap package during macOS MDM migration

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -160,7 +161,13 @@ func (a *AppleMDM) runPostDEPEnrollment(ctx context.Context, args appleMDMArgs) 
 			awaitCmdUUIDs = append(awaitCmdUUIDs, fleetdCmdUUID)
 		}
 
-		if args.FromMDMMigration {
+		allowBootstrapDuringMigration := false
+		allowBootstrapDuringMigrationEV := os.Getenv("FLEET_ALLOW_BOOTSTRAP_PACKAGE_DURING_MIGRATION")
+		if allowBootstrapDuringMigrationEV == "1" || strings.EqualFold(allowBootstrapDuringMigrationEV, "true") {
+			allowBootstrapDuringMigration = true
+		}
+
+		if args.FromMDMMigration && !allowBootstrapDuringMigration {
 			level.Info(a.Log).Log("info", "skipping bootstrap package installation during MDM migration", "host_uuid", args.HostUUID)
 			err = a.Datastore.RecordSkippedHostBootstrapPackage(ctx, args.HostUUID)
 			if err != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39634 and cherrypicks the fix into 4.81.0

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host
isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
