### PR TITLE
Update `macadmins/osquery-extensions` to v1.3.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -93,11 +93,11 @@ require (
 	github.com/klauspost/compress v1.18.3
 	github.com/kolide/launcher v1.0.12
 	github.com/lib/pq v1.10.9
-	github.com/macadmins/osquery-extension v1.2.7
+	github.com/macadmins/osquery-extension v1.3.2
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/micromdm/micromdm v1.9.0
 	github.com/micromdm/nanolib v0.2.0
-	github.com/micromdm/plist v0.2.1
+	github.com/micromdm/plist v0.2.3-0.20260123201933-667adaf87d87
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/mitchellh/gon v0.2.6-0.20231031204852-2d4f161ccecd
 	github.com/mna/redisc v1.3.2

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 h1:6E+4a0GO5zZEnZ
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/macadmins/osquery-extension v1.2.7 h1:7odgxsejWsagK699lIWppUfXBqj+uiKYk22RZRmbhao=
 github.com/macadmins/osquery-extension v1.2.7/go.mod h1:RqmyokbNDR423yqPj8GqnRcYfjT2qQeWoTPq485tveg=
+github.com/macadmins/osquery-extension v1.3.2 h1:X6x4jD6Te9uYW1s7LQPjrux5G6WC78UF/6p4qFw2Mb8=
+github.com/macadmins/osquery-extension v1.3.2/go.mod h1:/4WhG7sh9qyEi2WkacxOUJAmVciiDFmT468MbkiXBfE=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/matryer/is v1.4.0 h1:sosSmIWwkYITGrxZ25ULNDeKiMNzFSr4V/eqBQP0PeE=
 github.com/matryer/is v1.4.0/go.mod h1:8I/i5uYgLzgsgEloJE1U6xx5HkBQpAZvepWuujKwMRU=
@@ -635,6 +637,8 @@ github.com/micromdm/nanolib v0.2.0 h1:g5GHQuUpS82WIAB15LyenjF/0/WSUNJMe5XZfCJSXq
 github.com/micromdm/nanolib v0.2.0/go.mod h1:FwBKCvvphgYvbdUZ+qw5kay7NHJcg6zPi8W7kXNajmE=
 github.com/micromdm/plist v0.2.1 h1:4SoSMOVAyzv1ThT8IKLgXLJEKezLkcVDN6wivqTTFdo=
 github.com/micromdm/plist v0.2.1/go.mod h1:flkfm0od6GzyXBqI28h5sgEyi3iPO28W2t1Zm9LpwWs=
+github.com/micromdm/plist v0.2.3-0.20260123201933-667adaf87d87 h1:U9A+0ZED3cPxb5ufiTzyn2kyo6UFoR5bMggCR0Q/DOg=
+github.com/micromdm/plist v0.2.3-0.20260123201933-667adaf87d87/go.mod h1:flkfm0od6GzyXBqI28h5sgEyi3iPO28W2t1Zm9LpwWs=
 github.com/miekg/dns v1.1.57 h1:Jzi7ApEIzwEPLHWRcafCN9LZSBbqQpxjt/wpgvg7wcM=
 github.com/miekg/dns v1.1.57/go.mod h1:uqRjCRUuEAA6qsOiJvDd+CFo/vW+y5WR6SNmHE55hZk=
 github.com/minio/highwayhash v1.0.3 h1:kbnuUMoHYyVl7szWjSxJnxw11k2U709jqFPPmIUyD6Q=

--- a/orbit/changes/39642-update-macadmins-osquery-extensions
+++ b/orbit/changes/39642-update-macadmins-osquery-extensions
@@ -1,0 +1,1 @@
+* Updated macadmins/osquery-extensions to v1.3.2.


### PR DESCRIPTION
Resolves #39642.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

```sh
fleetd 1.51.1:
osquery> .schema munki_installs
CREATE TABLE munki_installs(`installed_version` TEXT, `installed` TEXT, `name` TEXT, `end_time` TEXT, `display_name` TEXT);

Using this branch:
osquery> .schema munki_installs
CREATE TABLE munki_installs(`installed_version` TEXT, `version_to_install` TEXT, `installed` TEXT, `name` TEXT, `end_time` TEXT, `display_name` TEXT);
```

## fleetd/orbit/Fleet Desktop

- [X] Verified that fleetd runs on macOS
- [X] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
