### PR TITLE
Add FLEET_MYSQL_READ_REPLICA_TLS_CONFIG environment variable to dogfood and loadtesting

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -14,8 +14,9 @@ locals {
 
 
     # Load TLS Certificate for RDS Authentication
-    FLEET_MYSQL_TLS_CA              = local.cert_path
-    FLEET_MYSQL_READ_REPLICA_TLS_CA = local.cert_path
+    FLEET_MYSQL_TLS_CA                  = local.cert_path
+    FLEET_MYSQL_READ_REPLICA_TLS_CA     = local.cert_path
+    FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"
   }
 
   /* 

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -83,8 +83,9 @@ locals {
     FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"
 
     # Load TLS Certificate for RDS Authentication
-    FLEET_MYSQL_TLS_CA              = local.cert_path
-    FLEET_MYSQL_READ_REPLICA_TLS_CA = local.cert_path
+    FLEET_MYSQL_TLS_CA                  = local.cert_path
+    FLEET_MYSQL_READ_REPLICA_TLS_CA     = local.cert_path
+    FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"
   }
   entra_conditional_access_secrets = {
     # Entra Conditional Access Proxy API Key

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -46,6 +46,7 @@ locals {
       # Load TLS Certificate for RDS Authentication
       FLEET_MYSQL_TLS_CA              = local.cert_path
       FLEET_MYSQL_READ_REPLICA_TLS_CA = local.cert_path
+      FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"
     },
     local.otel_environment_variables,
     local.elastic_apm_environment_variables


### PR DESCRIPTION
- Adds `FLEET_MYSQL_READ_REPLICA_TLS_CONFIG = "custom"` to dogfood and loadtesting environments.