### PR TITLE
Fix issue where MySQL read replicas were not using TLS. (#39689)

### DIFF
--- a/changes/39687-read-replica-tls
+++ b/changes/39687-read-replica-tls
@@ -1,0 +1,1 @@
+Fix issue where MySQL read replicas were not using TLS.

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -355,7 +355,7 @@ func setupRealReplica(t testing.TB, testName string, ds *Datastore, options *com
 		Database: testName,
 		Address:  testing_utils.TestReplicaAddress,
 	}
-	require.NoError(t, checkConfig(&replicaConfig))
+	require.NoError(t, checkAndModifyConfig(&replicaConfig))
 	replica, err := NewDB(&replicaConfig, options)
 	require.NoError(t, err)
 	ds.replica = replica


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves fleetdm/fleet#123, or remove if NA -->
**Related issue:** Resolves fleetdm/confidential#14268

The root cause was that the poorly named `checkConfig(replicaConf)` was mutating the config without it being obvious to developers.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Fixed an issue where MySQL read replica connections were not secured with TLS. Read replicas now properly use TLS encryption for secure database connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit 8f1cc5f90f461b7b1e47380e3f6eb0ceb51ed8ec)
