### PR TITLE
Apple OS udpates: Available OS versions

### DIFF
--- a/articles/enforce-os-updates.md
+++ b/articles/enforce-os-updates.md
@@ -4,7 +4,7 @@ _Available in Fleet Premium_
 
 In Fleet, you can enforce OS updates on your macOS, Windows, iOS, and iPadOS hosts remotely using the Fleet UI, Fleet API, or Fleet's GitOps workflow.
 
-For Apple (macOS, iOS, and iPadOS) hosts, Apple requires that the OS version is one from the [list of available OS versions](https://sofa.macadmins.io/). The update will only be enforced if you use a version in that list.
+For Apple (macOS, iOS, and iPadOS) hosts, Apple requires that the OS version is one from the [list of available OS versions](https://gdmf.apple.com/v2/pmv). The update will only be enforced if you use a version in that list.
 
 ## Fleet UI
 


### PR DESCRIPTION
- @noahtalerman: I think we have to link to this scary page because it's accurate: https://gdmf.apple.com/v2/pmv
  - Accuracy is important because OS updates only work if you specify a version in [this list](https://gdmf.apple.com/v2/pmv)
- I can't find the same list on the the [SOFA site](https://sofa.macadmins.io/macos/tahoe) (could be missing something)
