### PR TITLE
Update display names for 1Password, Slack, and Zoom

### DIFF
--- a/it-and-security/lib/linux/software/1password-deb.yml
+++ b/it-and-security/lib/linux/software/1password-deb.yml
@@ -1,1 +1,2 @@
 url: https://downloads.1password.com/linux/debian/amd64/stable/1password-latest.deb
+display_name: 1Password

--- a/it-and-security/lib/linux/software/1password-rpm.yml
+++ b/it-and-security/lib/linux/software/1password-rpm.yml
@@ -1,1 +1,2 @@
 url: https://downloads.1password.com/linux/rpm/stable/x86_64/1password-latest.rpm
+display_name: 1Password

--- a/it-and-security/lib/linux/software/slack-deb.yml
+++ b/it-and-security/lib/linux/software/slack-deb.yml
@@ -1,1 +1,2 @@
 url: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.47.69/slack-desktop-4.47.69-amd64.deb
+display_name: Slack

--- a/it-and-security/lib/linux/software/slack-rpm.yml
+++ b/it-and-security/lib/linux/software/slack-rpm.yml
@@ -1,1 +1,2 @@
 url: https://downloads.slack-edge.com/desktop-releases/linux/x64/4.47.69/slack-4.47.69-0.1.el8.x86_64.rpm
+display_name: Slack

--- a/it-and-security/lib/linux/software/zoom-deb.yml
+++ b/it-and-security/lib/linux/software/zoom-deb.yml
@@ -1,1 +1,2 @@
 url: https://cdn.zoom.us/prod/6.7.5.6891/zoom_amd64.deb
+display_name: Zoom

--- a/it-and-security/lib/linux/software/zoom-rpm.yml
+++ b/it-and-security/lib/linux/software/zoom-rpm.yml
@@ -1,1 +1,2 @@
 url: https://cdn.zoom.us/prod/6.7.5.6891/zoom_x86_64.rpm
+display_name: Zoom

--- a/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/nudge-configuration.mobileconfig
@@ -144,7 +144,7 @@ If you have any questions or need any assistance, please reach out via #help-it 
 						<key>mainHeader</key>
 						<string>Required software update now available</string>
 						<key>subHeader</key>
-						<string>A friendly reminder from the IT &amp; Enablement team</string>
+						<string>A friendly reminder from the IT team</string>
 						<key>customDeferralButtonText</key>
 						<string>Custom</string>
 						<key>customDeferralDropdownText</key>

--- a/it-and-security/lib/windows/software/zoom-arm.yml
+++ b/it-and-security/lib/windows/software/zoom-arm.yml
@@ -1,1 +1,2 @@
 url: https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=winarm64
+display_name: Zoom

--- a/it-and-security/lib/windows/software/zoom.yml
+++ b/it-and-security/lib/windows/software/zoom.yml
@@ -1,1 +1,2 @@
 url: https://zoom.us/client/latest/ZoomInstallerFull.msi?archType=x64
+display_name: Zoom


### PR DESCRIPTION
This pull request makes minor improvements to the software metadata for Linux and Windows installers, and updates messaging in a MacOS configuration profile. The main changes are the addition of display names for several software packages and a small wording update in the MacOS profile.

Software metadata improvements:

* Added the `display_name` field for 1Password, Slack, and Zoom installers in both `.deb` and `.rpm` formats for Linux, improving clarity in software listings. [[1]](diffhunk://#diff-74a6b317e1363bc4c856fc04b9532876ec6fbdaec1ae7745bc7ec00c164b5ee8R2) [[2]](diffhunk://#diff-a09b19aa20a36257dba104b182ec182a175198bf2b83b4c27bbe5b34e3f86a9cR2) [[3]](diffhunk://#diff-63cf9bff568593d4d6681597dc69b3c3741cbd53197cfa8056e66a8ce6aa65a3R2) [[4]](diffhunk://#diff-1c76fa28d50f586e4d7090a954db56d9235cdea759e8a613d2c5fb0ccdf28fdfR2) [[5]](diffhunk://#diff-d3b614ed0d7209d14d8f70170e4326d56e660fdb87ed585674be14c344a59d7fR2) [[6]](diffhunk://#diff-c5be3430c846b9b69a3d47f0157b0d1707a61dac731d823e38adbf78de4f5ebeR2)
* Added the `display_name` field for Zoom installers for Windows (`zoom-arm.yml` and `zoom.yml`), making software identification easier. [[1]](diffhunk://#diff-3f6d972edfe5bd7590c0cd9ffc76a416401410a4b6143e4d6b2d6a0f8efa83b5R2) [[2]](diffhunk://#diff-2ea34a1db8efdb13d238a064e9bd2e0ba1e4565aba849549e6182fcbe38cd388R2)

MacOS configuration profile update:

* Updated the `subHeader` in the `nudge-configuration.mobileconfig` file to reference the "IT team" instead of "IT & Enablement team," clarifying the responsible group in user notifications.