### PR TITLE
Refactored query used when bulk deleting Apple MDM profiles to rely only on primary keys.

### DIFF
--- a/changes/38955-bulk-team-transfer-cause-long-db-locks
+++ b/changes/38955-bulk-team-transfer-cause-long-db-locks
@@ -1,0 +1,1 @@
+* Refactored query used for deleting host_mdm_apple_profiles in bulk to use Primary keys only.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2492,7 +2492,7 @@ func (ds *Datastore) bulkDeleteMDMAppleHostsConfigProfilesDB(ctx context.Context
 	}
 
 	executeDeleteBatch := func(valuePart string, args []any) error {
-		stmt := fmt.Sprintf(`DELETE FROM host_mdm_apple_profiles WHERE (profile_identifier, host_uuid) IN (%s)`, strings.TrimSuffix(valuePart, ","))
+		stmt := fmt.Sprintf(`DELETE FROM host_mdm_apple_profiles WHERE (profile_uuid, host_uuid) IN (%s)`, strings.TrimSuffix(valuePart, ","))
 		if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "error deleting host_mdm_apple_profiles")
 		}
@@ -2518,7 +2518,7 @@ func (ds *Datastore) bulkDeleteMDMAppleHostsConfigProfilesDB(ctx context.Context
 	}
 
 	for _, p := range profs {
-		args = append(args, p.ProfileIdentifier, p.HostUUID)
+		args = append(args, p.ProfileUUID, p.HostUUID)
 		sb.WriteString("(?, ?),")
 		batchCount++
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38955 

The query that was causing the lock contention was identified as `DELETE FROM host_mdm_apple_profiles WHERE ( profile_identifier , host_uuid ) IN ( (...) /* , ... */ )` which corresponds to the query we use to delete the Apple profiles in Bulk. The query was refactored to utilize the primary key: (profile_uuid, host_uuid), which removes any kind of table scanning.

For testing this I loaded a huge amount of rows on `host_mdm_apple_profiles` and ran two delete loops, each using a batch of 1000 (same as the current backend implementation), after the refactoring no wait locks could be observed.

<img width="1580" height="807" alt="db_refactoring" src="https://github.com/user-attachments/assets/b13331b1-3c8e-4092-87c4-d7cc07cd6de5" />

The red squares indicate the timeframe of testing before the refactoring (high contention), while the blue square encompasses the timeframe after the refactoring (no contention).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal database operations for bulk profile deletions to improve system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->