### PR TITLE
Fleet UI: Still show Reinstall instead of Install after failed uninstall

### DIFF
--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostInstallerActionCell/HostInstallerActionCell.tests.tsx
@@ -383,7 +383,7 @@ describe("HostInstallerActionCell component", () => {
         software={{
           ...defaultSoftware,
           status: "failed_install",
-          ui_status: "failed_install",
+          ui_status: "failed_install_installed",
         }}
         onClickInstallAction={noop}
         onClickUninstallAction={noop}
@@ -460,7 +460,7 @@ describe("HostInstallerActionCell component", () => {
         software={{
           ...defaultSoftware,
           status: "failed_uninstall",
-          ui_status: "failed_uninstall",
+          ui_status: "failed_uninstall_installed",
         }}
         onClickInstallAction={noop}
         onClickUninstallAction={noop}

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tests.tsx
@@ -440,6 +440,83 @@ describe("InstallStatusCell - component", () => {
     });
   });
 
+  it("renders 'Installed' with failed install tooltip for failed_install_installed", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        software={{
+          ...createMockHostSoftware({
+            status: "failed_install",
+            software_package: createMockHostSoftwarePackage({
+              last_install: {
+                installed_at: "2022-01-01T12:00:00Z",
+              } as any,
+            }),
+          }),
+          ui_status: "failed_install_installed",
+        }}
+        onShowUpdateDetails={noop}
+        onShowInstallDetails={noop}
+        onShowIpaInstallDetails={noop}
+        onShowScriptDetails={noop}
+        onShowUninstallDetails={noop}
+        onShowVPPInstallDetails={noop}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Installed/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("success-icon")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Installed"));
+    await waitFor(() => {
+      // Core failure message
+      expect(
+        screen.getByText(/Software failed to install/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders 'Installed' with failed uninstall tooltip for failed_uninstall_installed", async () => {
+    const { user } = renderWithSetup(
+      <InstallStatusCell
+        software={{
+          ...createMockHostSoftware({
+            status: "failed_uninstall",
+            software_package: createMockHostSoftwarePackage({
+              last_uninstall: {
+                script_execution_id: "123-abc",
+                uninstalled_at: "2022-01-01T12:00:00Z",
+              },
+            }),
+          }),
+          ui_status: "failed_uninstall_installed",
+        }}
+        onShowUpdateDetails={noop}
+        onShowInstallDetails={noop}
+        onShowIpaInstallDetails={noop}
+        onShowScriptDetails={noop}
+        onShowUninstallDetails={noop}
+        onShowVPPInstallDetails={noop}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Installed/i })
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("success-icon")).toBeInTheDocument();
+
+    await user.hover(screen.getByText("Installed"));
+    await waitFor(() => {
+      // Core failure message
+      expect(
+        screen.getByText(/Software failed to uninstall/i)
+      ).toBeInTheDocument();
+      // Ensure the “to uninstall again” part of the tooltip is present
+      expect(screen.getByText(/to uninstall again/i)).toBeInTheDocument();
+    });
+  });
+
   it("renders 'Update available' with failure tooltip for failed_install_update_available", async () => {
     const { user } = renderWithSetup(
       <InstallStatusCell

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -48,6 +48,7 @@ interface TooltipArgs {
   isSelfService?: boolean;
   softwareName?: string | null;
   lastInstalledAt?: string;
+  lastUninstalledAt?: string;
   isAppleAppStoreApp?: boolean;
   isHostOnline?: boolean;
 }
@@ -91,12 +92,12 @@ const failedInstallTooltip: IStatusDisplayConfig["tooltip"] = ({
 );
 
 const failedUninstallTooltip: IStatusDisplayConfig["tooltip"] = ({
-  lastInstalledAt = null,
+  lastUninstalledAt = null,
   isSelfService,
 }) => (
   <>
     Software failed to uninstall
-    {lastInstalledAt ? ` (${dateAgo(lastInstalledAt)})` : ""}. Select{" "}
+    {lastUninstalledAt ? ` (${dateAgo(lastUninstalledAt)})` : ""}. Select{" "}
     <b>Retry</b> to uninstall again
     {isSelfService && ", or contact your IT department"}.
   </>
@@ -128,8 +129,8 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   failed_uninstall_installed: {
     iconName: "success",
     displayText: "Installed", // Opens "Install details" modal
-    tooltip: ({ lastInstalledAt, isSelfService }) => {
-      return failedUninstallTooltip({ lastInstalledAt, isSelfService });
+    tooltip: ({ lastUninstalledAt, isSelfService }) => {
+      return failedUninstallTooltip({ lastUninstalledAt, isSelfService });
     },
   },
   recently_updated: {
@@ -555,6 +556,7 @@ const InstallStatusCell = ({
 
   const tooltipContent = displayConfig.tooltip({
     lastInstalledAt: lastInstall?.installed_at,
+    lastUninstalledAt: lastUninstall?.uninstalled_at,
     softwareName: softwarePackageName,
     isAppleAppStoreApp,
     isSelfService,

--- a/frontend/pages/hosts/details/cards/Software/helpers.tsx
+++ b/frontend/pages/hosts/details/cards/Software/helpers.tsx
@@ -362,6 +362,7 @@ export const getInstallerActionButtonConfig = (
       case "pending_uninstall":
       case "uninstalling":
       case "failed_uninstall":
+      case "failed_uninstall_installed":
       case "recently_installed":
       case "recently_updated":
         return { text: "Reinstall", icon: "refresh" };


### PR DESCRIPTION
## Issue
Closes unreleased #39269 

## Description
- Failed uninstall still should show "Reinstall" button for install button instead of switching to "Install" button
- Found another bug while testing this. The uninstall timestamp in the failed uninstall tooltip was showing the last install instead of the last uninstall. Fixed!

## Screenrecording of fixes

https://github.com/user-attachments/assets/9df5db4d-aff1-4465-8205-034d1016b07e

## Testing

- [x] Added/updated automated tests (added other tests)
- [x] QA'd all new/changed functionality manually
