### PR TITLE
Update macOS Slack policy to v4.47.72

### DIFF
--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -1,5 +1,5 @@
 - name: macOS - Slack up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.43.52') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.47.72') < 0);
   critical: false
   description: The host may be running an outdated version of Slack, which could pose security vulnerabilities or compatibility issues.
   resolution: Slack can be updated by downloading the latest version from the App Store or by using Slack's built-in update functionality.


### PR DESCRIPTION
## Summary
- Update the macOS Slack policy minimum version from 4.43.52 to 4.47.72 to match the latest Fleet maintained app version

## Test plan
- [ ] Verify the policy query correctly flags hosts running Slack versions older than 4.47.72
- [ ] Confirm hosts with Slack 4.47.72+ pass the policy check

🤖 Generated with [Claude Code](https://claude.com/claude-code)