### PR TITLE
Add multi-platform mobile apps and macOS update

### DIFF
--- a/it-and-security/teams/company-owned-mobile-devices.yml
+++ b/it-and-security/teams/company-owned-mobile-devices.yml
@@ -30,20 +30,127 @@ policies:
 queries:
 software:
   app_store_apps:
+    # iOS apps
     - app_store_id: "618783545" # Slack
-      setup_experience: true
       self_service: true
+      setup_experience: true
+      platform: ios
+      categories:
+        - "Communication"
     - app_store_id: "546505307" # Zoom
-      setup_experience: true
       self_service: true
+      setup_experience: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "842842640" # Google Docs
-      setup_experience: true
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
-      setup_experience: true
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
-      setup_experience: true
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
+      self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Security"
+    # iPadOS apps
+    - app_store_id: "618783545" # Slack
+      self_service: true
+      platform: ipados
+      categories:
+        - "Productivity"
+        - "Communication"
+    - app_store_id: "546505307" # Zoom
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
+    - app_store_id: "842842640" # Google Docs
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    - app_store_id: "842849113" # Google Sheets
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    - app_store_id: "507874739" # Google Drive
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    # Android apps
+    - app_store_id: "us.zoom.videomeetings" # Zoom
+      platform: android
+      display_name: "Zoom"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.Slack" # Slack
+      platform: android
+      display_name: "Slack"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.onepassword.android" # 1Password
+      platform: android
+      display_name: "Slack"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.google.android.apps.docs" # Google Drive
+      platform: android
+      display_name: "Google Drive"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.google.android.apps.docs.editors.sheets" # Google Sheets
+      platform: android
+      display_name: "Google Sheets"
+      self_service: true
+    - app_store_id: "com.google.android.apps.docs.editors.docs" # Google Docs
+      platform: android
+      display_name: "Google Docs"
+      self_service: true
+    - app_store_id: "com.google.android.apps.docs.editors.slides" # Google Slides
+      platform: android
+      display_name: "Google Slides"
+      self_service: true
+    - app_store_id: "com.okta.android.auth" # Okta Verify
+      platform: android
+      display_name: "Okta Verify"
       self_service: true

--- a/it-and-security/teams/personal-mobile-devices.yml
+++ b/it-and-security/teams/personal-mobile-devices.yml
@@ -28,15 +28,127 @@ policies:
 queries:
 software:
   app_store_apps:
+    # iOS apps
     - app_store_id: "618783545" # Slack
       self_service: true
+      setup_experience: true
+      platform: ios
+      categories:
+        - "Communication"
     - app_store_id: "546505307" # Zoom
       self_service: true
+      setup_experience: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
     - app_store_id: "842842640" # Google Docs
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "842849113" # Google Sheets
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "507874739" # Google Drive
       self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
     - app_store_id: "490179405" # Okta Verify
+      self_service: true
+      platform: ios
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Security"
+    # iPadOS apps
+    - app_store_id: "618783545" # Slack
+      self_service: true
+      platform: ipados
+      categories:
+        - "Productivity"
+        - "Communication"
+    - app_store_id: "546505307" # Zoom
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Communication"
+    - app_store_id: "842842640" # Google Docs
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    - app_store_id: "842849113" # Google Sheets
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    - app_store_id: "507874739" # Google Drive
+      self_service: true
+      platform: ipados
+      auto_update_enabled: true
+      auto_update_window_start: "21:00"
+      auto_update_window_end: "05:00"
+      categories:
+        - "Productivity"
+    # Android apps
+    - app_store_id: "us.zoom.videomeetings" # Zoom
+      platform: android
+      display_name: "Zoom"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.Slack" # Slack
+      platform: android
+      display_name: "Slack"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.onepassword.android" # 1Password
+      platform: android
+      display_name: "Slack"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.google.android.apps.docs" # Google Drive
+      platform: android
+      display_name: "Google Drive"
+      self_service: true
+      setup_experience: true
+    - app_store_id: "com.google.android.apps.docs.editors.sheets" # Google Sheets
+      platform: android
+      display_name: "Google Sheets"
+      self_service: true
+    - app_store_id: "com.google.android.apps.docs.editors.docs" # Google Docs
+      platform: android
+      display_name: "Google Docs"
+      self_service: true
+    - app_store_id: "com.google.android.apps.docs.editors.slides" # Google Slides
+      platform: android
+      display_name: "Google Slides"
+      self_service: true
+    - app_store_id: "com.okta.android.auth" # Okta Verify
+      platform: android
+      display_name: "Okta Verify"
       self_service: true

--- a/it-and-security/teams/testing-and-qa.yml
+++ b/it-and-security/teams/testing-and-qa.yml
@@ -52,40 +52,6 @@ queries:
 software:
   packages:
     # Linux apps
-    - path: ../lib/linux/software/zoom-deb.yml # Zoom for Ubuntu
-      self_service: true
-      categories:
-        - Communication
-      labels_include_any:
-        - "Debian-based Linux hosts"
-    - path: ../lib/linux/software/zoom-rpm.yml # Zoom for RHEL
-      self_service: true
-      categories:
-        - Communication
-      labels_include_any:
-        - "RPM-based Linux hosts"
-    - path: ../lib/linux/software/slack-deb.yml # Slack for Ubuntu
-      self_service: true
-      categories:
-        - Productivity
-        - Communication
-      labels_include_any:
-        - "Debian-based Linux hosts"
-    - path: ../lib/linux/software/slack-rpm.yml # Slack for RHEL
-      self_service: true
-      categories:
-        - Productivity
-        - Communication
-      labels_include_any:
-        - "RPM-based Linux hosts"
   fleet_maintained_apps:
     # macOS apps
-    - slug: privileges/darwin # Privileges for macOS
-      self_service: true
-    - slug: cursor/darwin # Cursor for macOS
-      self_service: true
     # Windows apps
-    - slug: google-chrome/windows # Google Chrome for Windows
-      self_service: true
-    - slug: slack/windows # Slack for Windows
-      self_service: true

--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -98,6 +98,7 @@ controls:
   macos_updates:
     deadline:
     minimum_version:
+    update_new_hosts: true
   windows_settings:
     custom_settings:
       - path: ../lib/windows/configuration-profiles/Enable firewall.xml


### PR DESCRIPTION
Add comprehensive app entries to company-owned and personal mobile device configs: iOS, iPadOS, and Android definitions for Slack, Zoom, Google Docs/Sheets/Drive/Slides, Okta Verify, 1Password, etc., including platform, self_service, setup_experience, categories, and auto-update windows where applicable to standardize provisioning and update behavior. Also enable update_new_hosts: true under macos_updates in workstations.yml so new mac hosts will receive updates automatically.