### PR TITLE
Enable setup experience for Slack and Zoom on iPadOS

### DIFF
--- a/it-and-security/teams/company-owned-mobile-devices.yml
+++ b/it-and-security/teams/company-owned-mobile-devices.yml
@@ -81,12 +81,14 @@ software:
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       self_service: true
+      setup_experience: true
       platform: ipados
       categories:
         - "Productivity"
         - "Communication"
     - app_store_id: "546505307" # Zoom
       self_service: true
+      setup_experience: true
       platform: ipados
       auto_update_enabled: true
       auto_update_window_start: "21:00"

--- a/it-and-security/teams/personal-mobile-devices.yml
+++ b/it-and-security/teams/personal-mobile-devices.yml
@@ -79,12 +79,14 @@ software:
     # iPadOS apps
     - app_store_id: "618783545" # Slack
       self_service: true
+      setup_experience: true
       platform: ipados
       categories:
         - "Productivity"
         - "Communication"
     - app_store_id: "546505307" # Zoom
       self_service: true
+      setup_experience: true
       platform: ipados
       auto_update_enabled: true
       auto_update_window_start: "21:00"


### PR DESCRIPTION
Add setup_experience: true for Slack (618783545) and Zoom (546505307) in the iPadOS app entries for both company-owned and personal mobile device team configs. This ensures these apps are offered during the iPad setup experience; no other settings were modified.
