### PR TITLE
Fleet UI: Remove host_id from query report table

### DIFF
--- a/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
@@ -50,6 +50,10 @@ const generateReportColumnConfigsFromResults = (
     string,
     boolean
   >;
+
+  // We are only using the host_id column for the hostname link, so we can remove it from the table.
+  colsAreNumTypes.delete("host_id");
+
   const columnConfigs = Array.from(colsAreNumTypes.keys()).map<
     Column<IWebSocketData>
   >((colName) => {

--- a/frontend/pages/queries/details/components/QueryReport/_styles.scss
+++ b/frontend/pages/queries/details/components/QueryReport/_styles.scss
@@ -10,6 +10,10 @@
       }
     }
 
+    .last_fetched__cell {
+      white-space: nowrap; // Prevent timestamp wrapping on multiple lines
+    }
+
     .data-table__wrapper {
       overflow-x: scroll;
     }


### PR DESCRIPTION
## Issue
Closes #37434 

## Description
- Remove host_id column
- Extra fix: Prevent wrapping of last timestamp


## Screenshot of fixes
<img width="1333" height="575" alt="Screenshot 2026-02-12 at 10 35 11 AM" src="https://github.com/user-attachments/assets/cea4dbad-7b51-4695-8745-e53bc9019d13" />



## Testing

- [x] QA'd all new/changed functionality manually
