### PR TITLE
Fleet UI: Show CTA to turn on Android MDM

### DIFF
--- a/changes/38514-android-mdm-empty-state
+++ b/changes/38514-android-mdm-empty-state
@@ -1,0 +1,1 @@
+- Fleet UI: Show CTA to turn on Android MDM for Android software setup experience if MDM is not configured

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -166,13 +166,21 @@ const InstallSoftware = ({
         platform === "windows" &&
         !globalConfig?.mdm.windows_enabled_and_configured;
 
-      const turnOnMdm = turnOnAppleMdm || turnOnWindowsMdm;
+      const turnOnAndroidMdm = platform === "android" && !isAndroidMdmEnabled;
+
+      const turnOnMdm = turnOnAppleMdm || turnOnWindowsMdm || turnOnAndroidMdm;
 
       if (turnOnMdm) {
         return (
           <GenericMsgWithNavButton
-            header="Additional configuration required"
-            info="To customize, first turn on automatic enrollment."
+            header={`${
+              platform === "android"
+                ? "Turn on Android MDM"
+                : "Additional configuration required"
+            }`}
+            info={`To customize, first turn on ${
+              platform === "android" ? "Android MDM" : "automatic enrollment"
+            }.`}
             buttonText="Turn on"
             path={PATHS.ADMIN_INTEGRATIONS_MDM}
             router={router}
@@ -236,11 +244,9 @@ const InstallSoftware = ({
               <Tab>
                 <TabText>iPadOS</TabText>
               </Tab>
-              {isAndroidMdmEnabled && (
-                <Tab>
-                  <TabText>Android</TabText>
-                </Tab>
-              )}
+              <Tab>
+                <TabText>Android</TabText>
+              </Tab>
             </TabList>
             {PLATFORM_BY_INDEX.map((platform) => {
               return (


### PR DESCRIPTION
## Issue
Closes #38514 

## Description
- Do not hide Android tab if not configured
- Show empty state with button to MDM page

## Screen recording of fix

https://github.com/user-attachments/assets/b8798dec-051f-4216-9b75-7b8fa834d50d

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] QA'd all new/changed functionality manually
