### PR TITLE
Enforce GitOps setup experience when manual agent install is enabled

### DIFF
--- a/changes/38431-enforce-setup-experience-restrictions
+++ b/changes/38431-enforce-setup-experience-restrictions
@@ -1,0 +1,1 @@
+- Added error if GitOps/batch attempts to add setup experience software when manual agent install is enabled

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -116,6 +116,9 @@ func TestGitOpsBasicGlobalFree(t *testing.T) {
 	) (teamPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
 		return nil, nil, nil
 	}
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
 
 	// Mock appConfig
 	savedAppConfig := &fleet.AppConfig{}
@@ -369,6 +372,9 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 	}
 	ds.ListSoftwareAutoUpdateSchedulesFunc = func(ctx context.Context, teamID uint, source string, optionalFilter ...fleet.SoftwareAutoUpdateScheduleFilter) ([]fleet.SoftwareAutoUpdateSchedule, error) {
 		return []fleet.SoftwareAutoUpdateSchedule{}, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
 	}
 
 	// we'll use to mock datastore persistence
@@ -1936,6 +1942,8 @@ software:
 			return team.ToTeamLite(), nil
 		case teamToDeleteID:
 			return teamToDelete.ToTeamLite(), nil
+		case 0:
+			return &fleet.TeamLite{}, nil
 		}
 		assert.Fail(t, fmt.Sprintf("unexpected team ID %d", tid))
 		return teamToDelete.ToTeamLite(), nil

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -407,6 +407,9 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 		return nil, &notFoundError{}
 	}
 	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		if tid == 0 {
+			return &fleet.TeamLite{}, nil
+		}
 		for _, tm := range savedTeams {
 			if (*tm).ID == tid {
 				teamToCopy := *tm

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3382,45 +3382,8 @@ name: %s
 team_settings:
   %s
 `
-	testDarwinOffAllPlatformsOn := `
-controls:
-  macos_setup:
-    manual_agent_install: true
-software:
-  app_store_apps:
-    - app_store_id: "2"
-      platform: darwin
-    - app_store_id: "2"
-      setup_experience: true
-queries:
-policies:
-agent_options:
-name: %s
-team_settings:
-  %s
-`
-	testDarwinOffOtherPlatformsOn := `
-controls:
-  macos_setup:
-    manual_agent_install: true
-software:
-  app_store_apps:
-    - app_store_id: "2"
-      platform: darwin
-    - app_store_id: "2"
-      platform: ios
-      setup_experience: true
-    - app_store_id: "2"
-      platform: ipados
-      setup_experience: true
-queries:
-policies:
-agent_options:
-name: %s
-team_settings:
-  %s
-`
 
+	//nolint:gosec // test code
 	testPackagesFail := `
 controls:
   macos_setup:
@@ -3429,23 +3392,6 @@ software:
   app_store_apps:
   packages:
     - url: ${SOFTWARE_INSTALLER_URL}/dummy_installer.pkg
-      setup_experience: true
-queries:
-policies:
-agent_options:
-name: %s
-team_settings:
-  %s
-`
-
-	testPackagesPass := `
-controls:
-  macos_setup:
-    manual_agent_install: true
-software:
-  app_store_apps:
-  packages:
-    - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
       setup_experience: true
 queries:
 policies:
@@ -3472,22 +3418,6 @@ team_settings:
 			errContains:  ptr.String("Couldn't edit software."),
 		},
 		{
-			testName:     "Darwin off all platforms on",
-			VPPTeam:      "All teams",
-			teamName:     teamName,
-			teamTemplate: testDarwinOffAllPlatformsOn,
-			teamSettings: `secrets: [{"secret":"enroll_secret"}]`,
-			errContains:  ptr.String("Couldn't edit software."),
-		},
-		{
-			testName:     "Darwin off other platforms on",
-			VPPTeam:      "All teams",
-			teamName:     teamName,
-			teamTemplate: testDarwinOffOtherPlatformsOn,
-			teamSettings: `secrets: [{"secret":"enroll_secret"}]`,
-			errContains:  nil,
-		},
-		{
 			testName:     "Packages fail",
 			VPPTeam:      "All teams",
 			teamName:     teamName,
@@ -3496,20 +3426,13 @@ team_settings:
 			errContains:  ptr.String("Couldn't edit software."),
 		},
 		{
-			testName:     "Packages pass",
-			VPPTeam:      "All teams",
-			teamName:     teamName,
-			teamTemplate: testPackagesPass,
-			teamSettings: `secrets: [{"secret":"enroll_secret"}]`,
-			errContains:  nil,
-		},
-		{
 			testName:     "No team",
 			VPPTeam:      "No team",
 			teamName:     "No team",
 			teamTemplate: testAll,
 			errContains:  ptr.String("Couldn't edit software."),
 		},
+		// left out more possible combinations of setup experience being set for different platforms
 	}
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	appleMdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/tokenpki"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest/scep_server"
@@ -118,6 +119,10 @@ func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
 		{Name: fleet.MDMAssetSCEPChallenge, Value: []byte("scepchallenge")},
 	}, nil)
 	require.NoError(s.T(), err)
+
+	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
+		serverConfig.Logger = logging.NewNopLogger()
+	}
 	users, server := service.RunServerForTestsWithDS(s.T(), s.DS, &serverConfig)
 	s.T().Setenv("FLEET_SERVER_ADDRESS", server.URL) // fleetctl always uses this env var in tests
 	s.Server = server

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -312,6 +312,9 @@ func TestGitOpsNoTeamVPPPolicies(t *testing.T) {
 			ds.HardDeleteMDMConfigAssetFunc = func(ctx context.Context, assetName fleet.MDMAssetName) error {
 				return nil
 			}
+			ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+				return &fleet.TeamLite{}, nil
+			}
 
 			t.Setenv("APPLE_BM_DEFAULT_TEAM", "")
 			globalFile := "../../fleetctl/testdata/gitops/global_config_no_paths.yml"
@@ -446,6 +449,9 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 			}
 			ds.HardDeleteMDMConfigAssetFunc = func(ctx context.Context, assetName fleet.MDMAssetName) error {
 				return nil
+			}
+			ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+				return &fleet.TeamLite{}, nil
 			}
 
 			t.Setenv("APPLE_BM_DEFAULT_TEAM", "")
@@ -677,6 +683,9 @@ func TestGitOpsTeamVPPAndApp(t *testing.T) {
 	}
 	ds.HardDeleteMDMConfigAssetFunc = func(ctx context.Context, assetName fleet.MDMAssetName) error {
 		return nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
 	}
 
 	buf, err := fleetctl.RunAppNoChecks([]string{
@@ -993,6 +1002,9 @@ software:
 
 			ds.ListCertificateAuthoritiesFunc = func(ctx context.Context) ([]*fleet.CertificateAuthoritySummary, error) {
 				return nil, nil
+			}
+			ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+				return &fleet.TeamLite{}, nil
 			}
 
 			args := []string{"gitops"}

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2487,7 +2487,7 @@ func (svc *Service) softwareBatchUpload(
 
 			// if manual_agent_install is true, error if any macOS software is added to setup experience
 			// TODO(JK): I'm not totally sure if platform is 100% guaranteed here
-			if installer.Platform == string(fleet.MacOSPlatform) && ptr.ValOrZero(installer.InstallDuringSetup) && manualAgentInstall {
+			if fleet.IsMacOSPlatform(installer.Platform) && ptr.ValOrZero(installer.InstallDuringSetup) && manualAgentInstall {
 				return errors.New(`Couldn't edit software. "setup_experience" cannot be used for macOS software if "manual_agent_install" is enabled.`)
 			}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2259,9 +2259,6 @@ func (svc *Service) softwareBatchUpload(
 
 			installer.CategoryIDs = catIDs
 
-			// umm, can we check if InstallDuringSetup AND config.manualagentinstall, then fail here
-			// we will have to do this later on
-
 			// check if we already have the installer based on the SHA256 and URL
 			teamIDs, err := svc.ds.GetTeamsWithInstallerByHash(ctx, p.SHA256, p.URL)
 			if err != nil {
@@ -2485,8 +2482,6 @@ func (svc *Service) softwareBatchUpload(
 				installer.InstallScript = ""
 			}
 
-			// if manual_agent_install is true, error if any macOS software is added to setup experience
-			// TODO(JK): I'm not totally sure if platform is 100% guaranteed here
 			if fleet.IsMacOSPlatform(installer.Platform) && ptr.ValOrZero(installer.InstallDuringSetup) && manualAgentInstall {
 				return errors.New(`Couldn't edit software. "setup_experience" cannot be used for macOS software if "manual_agent_install" is enabled.`)
 			}

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -53,8 +53,8 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 		return nil, err
 	}
 
-	var manualAgentInstall bool
 	var teamID *uint
+	var manualAgentInstall bool
 	if teamName != "" {
 		tm, err := svc.ds.TeamByName(ctx, teamName)
 		if err != nil {
@@ -67,11 +67,11 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 		teamID = &tm.ID
 		manualAgentInstall = tm.Config.MDM.MacOSSetup.ManualAgentInstall.Value
 	} else {
-		noTeamConfig, err := svc.ds.DefaultTeamConfig(ctx)
+		ac, err := svc.ds.AppConfig(ctx)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting no-team config")
+			return nil, ctxerr.Wrap(ctx, err, "getting app config")
 		}
-		manualAgentInstall = noTeamConfig.MDM.MacOSSetup.ManualAgentInstall.Value
+		manualAgentInstall = ac.MDM.MacOSSetup.ManualAgentInstall.Value
 	}
 
 	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, fleet.ActionWrite); err != nil {

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -165,7 +165,6 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 					"It is automatically managed by Fleet when Android MDM is enabled.")
 			}
 
-			// TODO(JK): can we just check if macos platform here?
 			if payload.Platform == fleet.MacOSPlatform && ptr.ValOrZero(payload.InstallDuringSetup) && manualAgentInstall {
 				return nil, fleet.NewUserMessageError(
 					errors.New(`Couldn't edit software. "setup_experience" cannot be used for macOS software if "manual_agent_install" is enabled.`),

--- a/ee/server/service/vpp_test.go
+++ b/ee/server/service/vpp_test.go
@@ -23,6 +23,9 @@ func TestBatchAssociateVPPApps(t *testing.T) {
 		ds.GetVPPTokenByTeamIDFunc = func(ctx context.Context, teamID *uint) (*fleet.VPPTokenDB, error) {
 			return nil, sql.ErrNoRows
 		}
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
 		t.Run("dry run", func(t *testing.T) {
 			_, err := svc.BatchAssociateVPPApps(ctx, "", []fleet.VPPBatchPayload{
 				{

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -892,8 +892,6 @@ func (c *Client) ApplyGroup(
 					}
 				}
 
-				fmt.Printf("%#v\n-----------\n", app)
-
 				payload := fleet.VPPBatchPayload{
 					AppStoreID:          app.AppStoreID,
 					SelfService:         app.SelfService,

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -892,6 +892,8 @@ func (c *Client) ApplyGroup(
 					}
 				}
 
+				fmt.Printf("%#v\n-----------\n", app)
+
 				payload := fleet.VPPBatchPayload{
 					AppStoreID:          app.AppStoreID,
 					SelfService:         app.SelfService,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38431
Attempts to get the ManualAgentInstall config from `ds.TeamLite` in the case of software installers. In the VPP case, it attempts to get it from either `ds.TeamByName` or from global `ds.AppConfig` if no team name is provided.
I had to add some mock functions for TeamLite that were missing, or missing for the team 0 case. Also added FLEET_INTEGRATION_TESTS_DISABLE_LOG to disable logs in gitops integration tests. 
# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
