### PR TITLE
Fix orbit active GUI session detection to start Fleet Desktop and key escrowing on Linux

### DIFF
--- a/orbit/changes/34501-fix-fleet-desktop-gui-sessions
+++ b/orbit/changes/34501-fix-fleet-desktop-gui-sessions
@@ -1,0 +1,1 @@
+* Improved GUI user detection in orbit to use the correct active GUI user when starting Fleet Desktop.

--- a/orbit/changes/34501-fix-fleet-desktop-gui-sessions
+++ b/orbit/changes/34501-fix-fleet-desktop-gui-sessions
@@ -1,1 +1,1 @@
-* Improved GUI user detection in orbit to use the correct active GUI user when starting Fleet Desktop.
+* Improved GUI user detection in orbit to use the correct active GUI session when starting Fleet Desktop.

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1870,12 +1870,18 @@ func (d *desktopRunner) Execute() error {
 	for {
 		// First retry logic to start fleet-desktop.
 		if done := retry(30*time.Second, false, d.interruptCh, func() bool {
-			// On MacOS, if we attempt to run Fleet Desktop while the user is not logged in through
-			// the GUI, MacOS returns an error. See https://github.com/fleetdm/fleet/issues/14698
-			// for more details.
+			//
+			// - On MacOS, if we attempt to run Fleet Desktop while the user is not logged in through
+			//   the GUI, MacOS returns an error. See https://github.com/fleetdm/fleet/issues/14698
+			//   for more details.
+			// - On Linux, we also don't want to start the Fleet Desktop unless there's an active GUI session.
+			// - On Windows, user.UserLoggedInViaGui is a no-op, and execuser.Run will take care of
+			//   starting Fleet Desktop with the correct GUI user.
+			//
+
 			loggedInUser, err := user.UserLoggedInViaGui()
 			if err != nil {
-				log.Debug().Err(err).Msg("desktop.IsUserLoggedInGui")
+				log.Debug().Err(err).Msg("desktop.IsUserLoggedViaGui")
 				return true
 			}
 			if loggedInUser == nil {
@@ -1883,7 +1889,6 @@ func (d *desktopRunner) Execute() error {
 				return true
 			}
 			log.Debug().Msgf("found GUI user: %q, attempting fleet-desktop start", *loggedInUser)
-
 			if *loggedInUser != "" {
 				opts = append(opts, execuser.WithUser(*loggedInUser))
 			}

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1882,7 +1882,7 @@ func (d *desktopRunner) Execute() error {
 				log.Debug().Msg("No GUI user found, skipping fleet-desktop start")
 				return true
 			}
-			log.Debug().Msg(fmt.Sprintf("Found GUI user: %v, attempting fleet-desktop start", loggedInUser))
+			log.Debug().Msgf("found GUI user: %q, attempting fleet-desktop start", *loggedInUser)
 
 			if *loggedInUser != "" {
 				opts = append(opts, execuser.WithUser(*loggedInUser))
@@ -2418,7 +2418,7 @@ func executeFleetDesktopWithPermanentError(desktopPath string, errorMessage stri
 		log.Debug().Msg("No GUI user found, skipping fleet-desktop start")
 		return nil
 	}
-	log.Debug().Msg(fmt.Sprintf("Found GUI user: %v, attempting fleet-desktop start", loggedInUser))
+	log.Debug().Msgf("found GUI user: %q, attempting fleet-desktop start", *loggedInUser)
 
 	log.Info().Msg("killing any pre-existing fleet-desktop instances")
 	if err := platform.SignalProcessBeforeTerminate(constant.DesktopAppExecName); err != nil &&

--- a/orbit/pkg/execuser/execuser.go
+++ b/orbit/pkg/execuser/execuser.go
@@ -3,7 +3,6 @@
 package execuser
 
 import (
-	"io"
 	"time"
 )
 
@@ -69,12 +68,4 @@ func RunWithOutput(path string, opts ...Option) (output []byte, exitCode int, er
 		fn(&o)
 	}
 	return runWithOutput(path, o)
-}
-
-func RunWithStdin(path string, opts ...Option) (io.WriteCloser, error) {
-	var o eopts
-	for _, fn := range opts {
-		fn(&o)
-	}
-	return runWithStdin(path, o)
 }

--- a/orbit/pkg/execuser/execuser_darwin.go
+++ b/orbit/pkg/execuser/execuser_darwin.go
@@ -62,7 +62,3 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
 }
-
-func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
-	return nil, errors.New("not implemented")
-}

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -158,9 +158,10 @@ func getConfigForCommand(user string, path string) (args []string, env []string,
 		// Wayland is the default for most distributions,
 		// thus we assume wayland if we couldn't determine the session type.
 		log.Error().Err(err).Msg("assuming wayland session")
-		userDisplaySession = &userpkg.UserDisplaySession{Type: userpkg.GuiSessionTypeWayland}
-	}
-	if userDisplaySession.Type == userpkg.GuiSessionTypeTty {
+		userDisplaySession = &userpkg.UserDisplaySession{
+			Type: userpkg.GuiSessionTypeWayland,
+		}
+	} else if userDisplaySession.Type == userpkg.GuiSessionTypeTty {
 		return nil, nil, fmt.Errorf("user %q (%s) is not running a GUI session", user, userID)
 	}
 

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -19,6 +19,10 @@ import (
 
 // base command to setup an exec.Cmd using `runuser`
 func baserun(path string, opts eopts) (cmd *exec.Cmd, err error) {
+	if opts.user == "" {
+		return nil, errors.New("missing user")
+	}
+
 	args, env, err := getConfigForCommand(opts.user, path)
 	if err != nil {
 		return nil, fmt.Errorf("get args: %w", err)

--- a/orbit/pkg/execuser/execuser_linux.go
+++ b/orbit/pkg/execuser/execuser_linux.go
@@ -109,7 +109,7 @@ func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err er
 func getUserID(user string) (string, error) {
 	uid_, err := exec.Command("id", "-u", user).Output()
 	if err != nil {
-		return "", fmt.Errorf("failed to execute id command: %w", err)
+		return "", fmt.Errorf("failed to execute id command for %q: %w", user, err)
 	}
 	uid := strings.TrimSpace(string(uid_))
 	if uid == "" {

--- a/orbit/pkg/execuser/execuser_windows.go
+++ b/orbit/pkg/execuser/execuser_windows.go
@@ -9,7 +9,6 @@ package execuser
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
 	"unsafe"
@@ -134,10 +133,6 @@ func run(path string, opts eopts) (lastLogs string, err error) {
 
 func runWithOutput(path string, opts eopts) (output []byte, exitCode int, err error) {
 	return nil, 0, errors.New("not implemented")
-}
-
-func runWithStdin(path string, opts eopts) (io.WriteCloser, error) {
-	return nil, errors.New("not implemented")
 }
 
 // getCurrentUserSessionId will attempt to resolve

--- a/orbit/pkg/kdialog/kdialog.go
+++ b/orbit/pkg/kdialog/kdialog.go
@@ -90,7 +90,7 @@ func execCmdWithOutput(timeout time.Duration, args ...string) ([]byte, int, erro
 	if loggedInUser == nil || *loggedInUser == "" {
 		return nil, 0, errors.New("no GUI user found")
 	}
-	log.Debug().Msgf("found GUI user: %s, attempting zenity", *loggedInUser)
+	log.Debug().Msgf("found GUI user: %s, attempting kdialog", *loggedInUser)
 	opts = append(opts, execuser.WithUser(*loggedInUser))
 
 	output, exitCode, err := execuser.RunWithOutput(kdialogProcessName, opts...)

--- a/orbit/pkg/luks/luks_linux.go
+++ b/orbit/pkg/luks/luks_linux.go
@@ -135,7 +135,7 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 	device := luksdevice.New(luksdevice.AESXTSPlain64Cipher)
 
 	// Prompt user for existing LUKS passphrase
-	passphrase, err := lr.entryPrompt(ctx, entryDialogTitle, entryDialogText)
+	passphrase, err := lr.entryPrompt(entryDialogTitle, entryDialogText)
 	if err != nil {
 		return nil, nil, fmt.Errorf("Failed to show passphrase entry prompt: %w", err)
 	}
@@ -157,7 +157,7 @@ func (lr *LuksRunner) getEscrowKey(ctx context.Context, devicePath string) ([]by
 			break
 		}
 
-		passphrase, err = lr.entryPrompt(ctx, entryDialogTitle, retryEntryDialogText)
+		passphrase, err = lr.entryPrompt(entryDialogTitle, retryEntryDialogText)
 		if err != nil {
 			return nil, nil, fmt.Errorf("Failed re-prompting for passphrase: %w", err)
 		}
@@ -275,7 +275,7 @@ func generateRandomPassphrase() ([]byte, error) {
 	return passphrase, nil
 }
 
-func (lr *LuksRunner) entryPrompt(ctx context.Context, title, text string) ([]byte, error) {
+func (lr *LuksRunner) entryPrompt(title, text string) ([]byte, error) {
 	passphrase, err := lr.notifier.ShowEntry(dialog.EntryOptions{
 		Title:    title,
 		Text:     text,

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -57,16 +57,6 @@ func UserLoggedInViaGui() (*string, error) {
 	return nil, nil
 }
 
-// GetLoginUser returns the first logged-in user as reported by
-// `loginctl list-users`.
-func GetLoginUser() (*User, error) {
-	users, err := getLoginUsers()
-	if err != nil {
-		return nil, err
-	}
-	return &users[0], nil
-}
-
 // getLoginUsers returns all logged-in users as reported by
 // `loginctl list-users`.
 func getLoginUsers() ([]User, error) {
@@ -108,7 +98,7 @@ func parseLoginctlUsersOutput(s string) ([]User, error) {
 
 // UserDisplaySession holds the display session type and active status for a user.
 type UserDisplaySession struct {
-	Type   guiSessionType
+	Type   GuiSessionType
 	Active bool
 }
 
@@ -125,7 +115,7 @@ func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	}
 	guiSessionID := strings.TrimSpace(stdout.String())
 	if guiSessionID == "" {
-		return nil, nil
+		return nil, errors.New("empty display session")
 	}
 
 	// Get the "Type" of session.
@@ -135,7 +125,7 @@ func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	if err := cmd.Run(); err != nil {
 		return nil, fmt.Errorf("run 'loginctl' to get user GUI session type: %w", err)
 	}
-	var sessionType guiSessionType
+	var sessionType GuiSessionType
 	switch t := strings.TrimSpace(stdout.String()); t {
 	case "":
 		return nil, errors.New("empty GUI session type")
@@ -163,15 +153,15 @@ func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	}, nil
 }
 
-type guiSessionType int
+type GuiSessionType int
 
 const (
-	GuiSessionTypeX11 guiSessionType = iota + 1
+	GuiSessionTypeX11 GuiSessionType = iota + 1
 	GuiSessionTypeWayland
 	GuiSessionTypeTty
 )
 
-func (s guiSessionType) String() string {
+func (s GuiSessionType) String() string {
 	if s == GuiSessionTypeX11 {
 		return "x11"
 	}

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -72,7 +72,7 @@ func getLoginUsers() ([]User, error) {
 // Each line has the format: UID USERNAME
 func parseLoginctlUsersOutput(s string) ([]User, error) {
 	var users []User
-	for _, line := range strings.Split(strings.TrimSpace(s), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(s), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -54,6 +54,7 @@ func UserLoggedInViaGui() (*string, error) {
 		return &user.Name, nil
 	}
 
+	// No valid user found
 	return nil, nil
 }
 

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -39,10 +39,6 @@ func UserLoggedInViaGui() (*string, error) {
 			log.Debug().Err(err).Msgf("failed to get user display session for user %s", user.Name)
 			continue
 		}
-		if session == nil {
-			log.Debug().Msgf("no display session found for user %s", user.Name)
-			continue
-		}
 		if !session.Active {
 			log.Debug().Msgf("user %s has an inactive display session, skipping", user.Name)
 			continue
@@ -104,8 +100,8 @@ type UserDisplaySession struct {
 }
 
 // GetUserDisplaySessionType returns the display session type (X11 or Wayland)
-// and active status of the given user. Returns nil with no error if the user
-// has no display session.
+// and active status of the given user. Returns an error if the user doesn't have
+// a Display session.
 func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	// Get the "Display" session ID of the user.
 	cmd := exec.Command("loginctl", "show-user", uid, "-p", "Display", "--value")

--- a/orbit/pkg/user/user_linux.go
+++ b/orbit/pkg/user/user_linux.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -78,48 +77,6 @@ func getLoginUsers() ([]User, error) {
 	return parseLoginctlUsersOutput(string(out))
 }
 
-// GetSELinuxUserContext returns the SELinux context for the given user.
-// Example: `unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023`
-//
-// If SELinux is not enabled, the `runcon` command is not available,
-// or context cannot be determined, it returns nil.
-func GetSELinuxUserContext(user *User) *string {
-	// If SELinux is not enabled, return nil right away.
-	if _, err := os.Stat("/sys/fs/selinux/enforce"); err != nil {
-		return nil
-	}
-	// If runcon is not available, we won't be able to switch contexts,
-	// so return nil.
-	if _, err := exec.LookPath("runcon"); err != nil {
-		log.Warn().Msg("runcon not available, returning nil for user context since we can't switch contexts")
-		return nil
-	}
-	// Find the first systemd process for the user and read its SELinux context.
-	pidBytes, err := exec.Command("pgrep", "-u", strconv.FormatInt(user.ID, 10), "-nx", "systemd").Output() // #nosec G204
-	if err != nil {
-		log.Debug().Msgf("Error finding systemd process for user %s: %v", user.Name, err)
-		return nil
-	}
-	pid := strings.TrimSpace(string(pidBytes))
-	if pid == "" {
-		log.Debug().Msgf("No systemd process found for user %s", user.Name)
-		return nil
-	}
-	ctx, err := os.ReadFile("/proc/" + pid + "/attr/current")
-	if err != nil {
-		log.Debug().Msgf("Error reading SELinux context for user %s: %v", user.Name, err)
-		return nil
-	}
-	context := strings.TrimSpace(string(ctx))
-	// Remove any null byte at the end
-	context = strings.TrimSuffix(context, "\x00")
-	if context == "" {
-		log.Debug().Msg("Empty SELinux context for user " + user.Name)
-		return nil
-	}
-	return &context
-}
-
 // parseLoginctlUsersOutput parses the output of `loginctl list-users --no-legend`.
 // Each line has the format: UID USERNAME
 func parseLoginctlUsersOutput(s string) ([]User, error) {
@@ -170,6 +127,7 @@ func GetUserDisplaySessionType(uid string) (*UserDisplaySession, error) {
 	if guiSessionID == "" {
 		return nil, nil
 	}
+
 	// Get the "Type" of session.
 	cmd = exec.Command("loginctl", "show-session", guiSessionID, "-p", "Type", "--value")
 	stdout.Reset()

--- a/orbit/pkg/user/user_linux_test.go
+++ b/orbit/pkg/user/user_linux_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package user
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLoginctlUsersOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []User
+		wantErr string
+	}{
+		{
+			name:  "single user",
+			input: " 1000 alice\n",
+			want:  []User{{Name: "alice", ID: 1000}},
+		},
+		{
+			name:  "multiple users",
+			input: " 1000 alice\n 1001 bob\n",
+			want: []User{
+				{Name: "alice", ID: 1000},
+				{Name: "bob", ID: 1001},
+			},
+		},
+		{
+			name:  "includes system user",
+			input: "    0 root\n 1000 alice\n  120 gdm\n",
+			want: []User{
+				{Name: "root", ID: 0},
+				{Name: "alice", ID: 1000},
+				{Name: "gdm", ID: 120},
+			},
+		},
+		{
+			name:  "no leading whitespace",
+			input: "1000 alice\n1001 bob\n",
+			want: []User{
+				{Name: "alice", ID: 1000},
+				{Name: "bob", ID: 1001},
+			},
+		},
+		{
+			name:  "extra columns (some systemd versions)",
+			input: "1000 alice extra-stuff\n",
+			want:  []User{{Name: "alice", ID: 1000}},
+		},
+		{
+			name:    "empty output",
+			input:   "",
+			wantErr: "no user session found",
+		},
+		{
+			name:    "whitespace only",
+			input:   "   \n  \n",
+			wantErr: "no user session found",
+		},
+		{
+			name:  "skips malformed lines",
+			input: "not-a-uid alice\n1000 bob\n",
+			want:  []User{{Name: "bob", ID: 1000}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseLoginctlUsersOutput(tt.input)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/orbit/pkg/user/user_windows.go
+++ b/orbit/pkg/user/user_windows.go
@@ -1,11 +1,9 @@
 //go:build windows
-// +build windows
 
 package user
 
 // UserLoggedInViaGui returns the name of the user logged into the machine via the GUI. This
-// function is only relevant on MacOS, where it is used to prevent errors when launching Fleet
-// Desktop. For other platforms we return an empty string which can be ignored.
+// function is only relevant on MacOS and Linux, where it is used to prevent errors when launching Fleet Desktop.
 func UserLoggedInViaGui() (*string, error) {
 	user := ""
 	return &user, nil

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -95,13 +95,11 @@ func execCmdWithOutput(args ...string) ([]byte, int, error) {
 	if err != nil {
 		return nil, 0, fmt.Errorf("user logged in via GUI: %w", err)
 	}
-	if loggedInUser == nil {
+	if loggedInUser == nil || *loggedInUser == "" {
 		return nil, 0, errors.New("no GUI user found")
 	}
 	log.Debug().Msgf("found GUI user: %s, attempting zenity", *loggedInUser)
-	if *loggedInUser != "" {
-		opts = append(opts, execuser.WithUser(*loggedInUser))
-	}
+	opts = append(opts, execuser.WithUser(*loggedInUser))
 
 	// Execute zenity.
 	output, exitCode, err := execuser.RunWithOutput(zenityProcessName, opts...)

--- a/orbit/pkg/zenity/zenity.go
+++ b/orbit/pkg/zenity/zenity.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/fleetdm/fleet/v4/orbit/pkg/dialog"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/execuser"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/user"
+	"github.com/rs/zerolog/log"
 )
 
 const zenityProcessName = "zenity"
@@ -88,6 +90,20 @@ func execCmdWithOutput(args ...string) ([]byte, int, error) {
 		opts = append(opts, execuser.WithArg(arg, "")) // Using empty value for positional args
 	}
 
+	// Retrieve and set active GUI user.
+	loggedInUser, err := user.UserLoggedInViaGui()
+	if err != nil {
+		return nil, 0, fmt.Errorf("user logged in via GUI: %w", err)
+	}
+	if loggedInUser == nil {
+		return nil, 0, errors.New("no GUI user found")
+	}
+	log.Debug().Msgf("found GUI user: %s, attempting zenity", *loggedInUser)
+	if *loggedInUser != "" {
+		opts = append(opts, execuser.WithUser(*loggedInUser))
+	}
+
+	// Execute zenity.
 	output, exitCode, err := execuser.RunWithOutput(zenityProcessName, opts...)
 
 	// Trim the newline from zenity output


### PR DESCRIPTION
Resolves #36024 and #34501.

Main change is about stop using the first user in the `users` command output [*] and instead use `loginctl` commands to pick the correct current active GUI user.

[*] `users` was returning empty on some new distributions, and in multi-sessions we were always picking the first one (even if it wasn't active).

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Fleet Desktop startup to correctly detect and use the active GUI session on Linux systems.
  * Improved GUI user detection for dialog prompts, ensuring system dialogs run in the proper user context.

* **Improvements**
  * Enhanced error reporting and logging clarity for GUI session detection failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->