### PR TITLE
Left align Critical checkbox in Save policy modal

### DIFF
--- a/changes/39423-left-align-critical-checkbox-save-policy
+++ b/changes/39423-left-align-critical-checkbox-save-policy
@@ -1,1 +1,1 @@
-- Left-align "Critical" checkbox in Save policy form.
+- Left-aligned "Critical" checkbox in Save policy form.

--- a/changes/39423-left-align-critical-checkbox-save-policy
+++ b/changes/39423-left-align-critical-checkbox-save-policy
@@ -1,0 +1,1 @@
+- Left-align "Critical" checkbox in Save policy form.

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -318,7 +318,7 @@ const SaveNewPolicyModal = ({
                     </p>
                   }
                 >
-                  Critical:
+                  Critical
                 </TooltipWrapper>
               </Checkbox>
             </div>

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tsx
@@ -308,7 +308,6 @@ const SaveNewPolicyModal = ({
                 name="critical-policy"
                 onChange={(value: boolean) => setLastEditedQueryCritical(value)}
                 value={lastEditedQueryCritical}
-                isLeftLabel
                 disabled={disableForm}
               >
                 <TooltipWrapper

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/_styles.scss
@@ -1,0 +1,3 @@
+.fleet-checkbox__label {
+  font-weight: $bold;
+}

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/_styles.scss
@@ -1,3 +1,3 @@
-.fleet-checkbox__label {
+.critical-checkbox-wrapper .fleet-checkbox__label {
   font-weight: $bold;
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39423 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

### Before

<img width="693" height="808" alt="Screenshot 2026-02-12 at 4 53 53 PM" src="https://github.com/user-attachments/assets/ba60d010-2e1b-4a10-86c3-b229bdd9eddc" />


### After

<img width="712" height="809" alt="Screenshot 2026-02-12 at 4 57 36 PM" src="https://github.com/user-attachments/assets/d4271b5f-b721-4081-8cff-d48821a635e9" />

