### PR TITLE
Website: update platforms filters on documentation pages

### DIFF
--- a/website/assets/js/pages/app-library.page.js
+++ b/website/assets/js/pages/app-library.page.js
@@ -16,7 +16,9 @@ parasails.registerPage('app-library', {
     if(bowser.windows){
       this.selectedPlatform = 'windows';
     }
+    // Add a scroll event listener to shift the platform filters upwards when the header is hidden.
     window.addEventListener('scroll', this.handleScrollingPlatformFilters);
+    this.handleScrollingPlatformFilters();
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/policy-library.page.js
+++ b/website/assets/js/pages/policy-library.page.js
@@ -16,7 +16,9 @@ parasails.registerPage('policy-library', {
     if(bowser.windows){
       this.selectedPlatform = 'windows';
     }
+    // Add a scroll event listener to shift the platform filters upwards when the header is hidden.
     window.addEventListener('scroll', this.handleScrollingPlatformFilters);
+    this.handleScrollingPlatformFilters();
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/query-library.page.js
+++ b/website/assets/js/pages/query-library.page.js
@@ -16,7 +16,9 @@ parasails.registerPage('query-library', {
     if(bowser.windows){
       this.selectedPlatform = 'windows';
     }
+    // Add a scroll event listener to shift the platform filters upwards when the header is hidden.
     window.addEventListener('scroll', this.handleScrollingPlatformFilters);
+    this.handleScrollingPlatformFilters();
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗

--- a/website/assets/js/pages/vital-details.page.js
+++ b/website/assets/js/pages/vital-details.page.js
@@ -91,7 +91,9 @@ parasails.registerPage('vital-details', {
       }, 2000);
       navigator.clipboard.writeText(code);
     });
+    // Add a scroll event listener to shift the platform filters upwards when the header is hidden.
     window.addEventListener('scroll', this.handleScrollingPlatformFilters);
+    this.handleScrollingPlatformFilters();
   },
 
   //  ╦╔╗╔╔╦╗╔═╗╦═╗╔═╗╔═╗╔╦╗╦╔═╗╔╗╔╔═╗


### PR DESCRIPTION
Changes:
- Updated platform filters on documentation pages to shift upwards if the website header is hidden when the page loads.