### PR TITLE
Controls > OS settings > Disk encryption: Consistent padding/styles

### DIFF
--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -129,7 +129,8 @@ const DiskEncryption = ({
         renderFlash(
           "error",
           <>
-            Couldn&apos;t enable disk encryption. Please configure a private key.{" "}
+            Couldn&apos;t enable disk encryption. Please configure a private
+            key.{" "}
             <CustomLink
               url={link}
               text="Learn how"
@@ -226,8 +227,8 @@ const DiskEncryption = ({
             className={`${baseClass}__checkbox`}
             helpText={
               <>
-                If turned on, hosts&apos; disk encryption keys will be
-                stored in Fleet.{" "}
+                If turned on, hosts&apos; disk encryption keys will be stored in
+                Fleet.{" "}
                 <CustomLink
                   text="Learn more"
                   url={`${LEARN_MORE_ABOUT_BASE_LINK}/mdm-disk-encryption`}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/DiskEncryption.tsx
@@ -129,9 +129,13 @@ const DiskEncryption = ({
         renderFlash(
           "error",
           <>
-            Could&apos;t enable disk encryption. Missing required private key.
-            Learn how to configure the private key here:{" "}
-            <a href={link}>{link}</a>
+            Couldn&apos;t enable disk encryption. Please configure a private key.{" "}
+            <CustomLink
+              url={link}
+              text="Learn how"
+              newTab
+              variant="flash-message-link"
+            />
           </>
         );
       } else {
@@ -220,18 +224,20 @@ const DiskEncryption = ({
             onChange={onToggleDiskEncryption}
             value={diskEncryptionEnabled}
             className={`${baseClass}__checkbox`}
+            helpText={
+              <>
+                If turned on, hosts&apos; disk encryption keys will be
+                stored in Fleet.{" "}
+                <CustomLink
+                  text="Learn more"
+                  url={`${LEARN_MORE_ABOUT_BASE_LINK}/mdm-disk-encryption`}
+                  newTab
+                />
+              </>
+            }
           >
             Turn on disk encryption
           </Checkbox>
-          <p>
-            If turned on, hosts&apos; disk encryption keys will be stored in
-            Fleet.{" "}
-            <CustomLink
-              text="Learn more"
-              url={`${LEARN_MORE_ABOUT_BASE_LINK}/mdm-disk-encryption`}
-              newTab
-            />
-          </p>
           <RevealButton
             className={`${baseClass}__accordion-title`}
             isShowing={showAdvancedOptions}

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -99,6 +99,7 @@ const DiskEncryptionTable = ({
         // these 2 properties allow linking on click anywhere in the row
         disableMultiRowSelect
         onSelectSingleRow={onSelectSingleRow}
+        hideFooter={true}
       />
     </div>
   );

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -99,7 +99,7 @@ const DiskEncryptionTable = ({
         // these 2 properties allow linking on click anywhere in the row
         disableMultiRowSelect
         onSelectSingleRow={onSelectSingleRow}
-        hideFooter={true}
+        hideFooter
       />
     </div>
   );


### PR DESCRIPTION
For the following quick win:
- https://github.com/fleetdm/fleet/issues/39803

Before:

<img width="926" height="660" alt="Screenshot 2026-02-12 at 5 05 55 PM" src="https://github.com/user-attachments/assets/e154080c-ec68-4ac1-8f0e-57d3187bae1d" />

After:

<img width="926" height="615" alt="Screenshot 2026-02-12 at 5 05 59 PM" src="https://github.com/user-attachments/assets/e3c1c5a7-0ece-420c-9c63-3a6e434ab1a0" />

<img width="652" height="98" alt="Screenshot 2026-02-12 at 5 06 19 PM" src="https://github.com/user-attachments/assets/09471f42-9c22-4c2c-8383-9aa645222489" />