### PR TITLE
Fix issue with vuln jobs running in parallel.

### DIFF
--- a/changes/35044-2-vuln-jobs
+++ b/changes/35044-2-vuln-jobs
@@ -1,0 +1,1 @@
+Fixed a bug where 2 vulnerability jobs can run in parallel if one is taking longer than 2 hours.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -66,9 +66,6 @@ func newVulnerabilitiesSchedule(
 	var options []schedule.Option
 
 	options = append(options, schedule.WithLogger(vulnerabilitiesLogger))
-	// Use a long lock expiration when job can take longer than the default
-	// schedule interval. This will prevent the job from being cleaned up.
-	options = append(options, schedule.WithLockExpiration(12*time.Hour))
 
 	vulnFuncs := getVulnFuncs(ds, vulnerabilitiesLogger, config)
 	for _, fn := range vulnFuncs {

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -66,6 +66,9 @@ func newVulnerabilitiesSchedule(
 	var options []schedule.Option
 
 	options = append(options, schedule.WithLogger(vulnerabilitiesLogger))
+	// Use a long lock expiration when job can take longer than the default
+	// schedule interval. This will prevent the job from being cleaned up.
+	options = append(options, schedule.WithLockExpiration(12*time.Hour))
 
 	vulnFuncs := getVulnFuncs(ds, vulnerabilitiesLogger, config)
 	for _, fn := range vulnFuncs {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35044 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented parallel execution of vulnerability jobs when one job runs longer than two hours, improving job reliability and preventing concurrent conflicts.

* **Chores**
  * Enhanced cron job lock management to better handle long-running scheduled tasks and prevent premature expiration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->