### PR TITLE
Max per_page for activities is now 10,000

### DIFF
--- a/changes/36355-activities-max-per_page
+++ b/changes/36355-activities-max-per_page
@@ -1,0 +1,1 @@
+Fixed a bug where the list activities API endpoint would fail with a database error when there were more than 65,535 activities and no pagination parameters were specified. The maximum `per_page` for activities endpoints is now 10,000.

--- a/server/activity/internal/service/endpoint_utils.go
+++ b/server/activity/internal/service/endpoint_utils.go
@@ -86,7 +86,7 @@ func listOptionsFromRequest(r *http.Request) (api.ListOptions, error) {
 		}
 		if perPage > maxPerPage {
 			return api.ListOptions{}, ctxerr.Wrap(r.Context(), &platform_http.BadRequestError{
-				Message: fmt.Sprintf("Request could not be processed. Please set a per_page limit less than %d", maxPerPage),
+				Message: fmt.Sprintf("Request could not be processed. Please set a per_page limit of %d or less", maxPerPage),
 			})
 		}
 	}

--- a/server/activity/internal/service/endpoint_utils.go
+++ b/server/activity/internal/service/endpoint_utils.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"reflect"
@@ -21,9 +22,8 @@ const (
 	// defaultPerPage is used when per_page is not specified but page is specified.
 	defaultPerPage = 20
 
-	// unlimitedPerPage is used when neither page nor per_page is specified,
-	// effectively returning all results (legacy behavior for backwards compatibility).
-	unlimitedPerPage = 1000000
+	// maxPerPage is the maximum allowed value for per_page.
+	maxPerPage = 10000
 )
 
 // encodeResponse encodes the response as JSON.
@@ -83,6 +83,11 @@ func listOptionsFromRequest(r *http.Request) (api.ListOptions, error) {
 		}
 		if perPage <= 0 {
 			return api.ListOptions{}, ctxerr.Wrap(r.Context(), &platform_http.BadRequestError{Message: "invalid per_page value"})
+		}
+		if perPage > maxPerPage {
+			return api.ListOptions{}, ctxerr.Wrap(r.Context(), &platform_http.BadRequestError{
+				Message: fmt.Sprintf("Request could not be processed. Please set a per_page limit less than %d", maxPerPage),
+			})
 		}
 	}
 

--- a/server/activity/internal/service/handler_test.go
+++ b/server/activity/internal/service/handler_test.go
@@ -54,7 +54,7 @@ func TestListActivitiesValidation(t *testing.T) {
 		{
 			name:    "per_page exceeds maximum",
 			query:   "per_page=10001",
-			wantErr: "Request could not be processed. Please set a per_page limit less than 10000",
+			wantErr: "Request could not be processed. Please set a per_page limit of 10000 or less",
 		},
 		{
 			name:    "order_direction without order_key",

--- a/server/activity/internal/service/handler_test.go
+++ b/server/activity/internal/service/handler_test.go
@@ -52,6 +52,11 @@ func TestListActivitiesValidation(t *testing.T) {
 			wantErr: "invalid per_page value",
 		},
 		{
+			name:    "per_page exceeds maximum",
+			query:   "per_page=10001",
+			wantErr: "Request could not be processed. Please set a per_page limit less than 10000",
+		},
+		{
 			name:    "order_direction without order_key",
 			query:   "order_direction=desc",
 			wantErr: "order_key must be specified with order_direction",

--- a/server/activity/internal/service/service.go
+++ b/server/activity/internal/service/service.go
@@ -32,8 +32,8 @@ func applyListOptionsDefaults(opt *api.ListOptions, defaultOrderKey string) {
 	// Default PerPage based on whether pagination was requested
 	if opt.PerPage == 0 {
 		if opt.Page == 0 {
-			// No pagination requested - return all results (legacy behavior)
-			opt.PerPage = unlimitedPerPage
+			// No pagination requested - return up to maxPerPage results
+			opt.PerPage = maxPerPage
 		} else {
 			// Page specified without per_page - use sensible default
 			opt.PerPage = defaultPerPage

--- a/server/service/testing_client.go
+++ b/server/service/testing_client.go
@@ -679,7 +679,7 @@ func (ts *withServer) listActivities() []*fleet.Activity {
 	t := ts.s.T()
 	var resp listActivitiesResponse
 	ts.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &resp,
-		"order_key", "a.id", "order_direction", "asc", "per_page", "1000000")
+		"order_key", "a.id", "order_direction", "asc", "per_page", "10000")
 	require.NotNil(t, resp.Activities)
 	return resp.Activities
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #36355 

Docs PR: #39830

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed a database error that could occur when requesting large activity lists without specifying pagination parameters
* Enforced a maximum limit of 10,000 items per request for activities endpoints to improve API stability

## Tests
* Added validation test to ensure the per_page limit is properly enforced

<!-- end of auto-generated comment: release notes by coderabbit.ai -->