### PR TITLE
🤖 Add tests covering #39689

### DIFF
--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -1459,7 +1459,7 @@ func TestReplicaPasswordReadFromDisk(t *testing.T) {
 //
 // This is a regression test for https://github.com/fleetdm/fleet/pull/39689.
 // Before the fix, NewDBConnections called fromCommonMysqlConfig twice for the replica config.
-// The first call's config got TLSConfig="custom" via checkConfig, but that config was
+// The first call's config got TLSConfig="custom" via checkAndModifyConfig, but that config was
 // block-scoped and discarded. The second call created a fresh config where TLSConfig was
 // empty, so the replica silently connected without TLS.
 func TestReplicaTLSConfigPreserved(t *testing.T) {

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -1382,3 +1382,125 @@ func TestGetContextTryStmt(t *testing.T) {
 	})
 
 }
+
+// TestReplicaPasswordReadFromDisk verifies that when a replica config uses PasswordPath,
+// the password read from disk by checkAndModifyConfig is preserved for the actual DB connection.
+//
+// This is a regression test for https://github.com/fleetdm/fleet/pull/39689.
+// Before the fix, NewDBConnections called fromCommonMysqlConfig twice for the replica config,
+// and the second call created a fresh config where Password was empty (the mutation from
+// checkAndModifyConfig reading PasswordPath was lost). This caused the replica to connect
+// with an empty password instead of the one from disk.
+func TestReplicaPasswordReadFromDisk(t *testing.T) {
+	// Write the correct password to a temp file.
+	passwordFile, err := os.CreateTemp(t.TempDir(), "*.passwordtest")
+	require.NoError(t, err)
+	_, err = passwordFile.WriteString(testing_utils.TestPassword)
+	require.NoError(t, err)
+	require.NoError(t, passwordFile.Close())
+
+	dbName := t.Name()
+
+	// Create the test database using a direct connection.
+	db, err := sql.Open(
+		"mysql",
+		fmt.Sprintf("%s:%s@tcp(%s)/?multiStatements=true", testing_utils.TestUsername, testing_utils.TestPassword,
+			testing_utils.TestAddress),
+	)
+	require.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s; CREATE DATABASE %s;", dbName, dbName))
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+		db.Close()
+	}()
+
+	// Primary config uses Password directly — this always works.
+	primaryConfig := config.MysqlConfig{
+		Username: testing_utils.TestUsername,
+		Password: testing_utils.TestPassword,
+		Address:  testing_utils.TestAddress,
+		Database: dbName,
+	}
+
+	// Replica config uses PasswordPath instead of Password.
+	// checkAndModifyConfig must read the file and set Password on the config
+	// that is later passed to NewDB. Before the fix the mutation was discarded.
+	replicaConfig := config.MysqlConfig{
+		Username:     testing_utils.TestUsername,
+		PasswordPath: passwordFile.Name(),
+		Address:      testing_utils.TestAddress,
+		Database:     dbName,
+	}
+
+	conns, err := NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(log.NewNopLogger()))
+	require.NoError(t, err, "replica connection should succeed when PasswordPath is used — "+
+		"if this fails with 'Access denied' the password read from disk was not preserved for the replica")
+	defer conns.Primary.Close()
+	defer conns.Replica.Close()
+
+	// Verify the replica connection actually works.
+	require.NoError(t, conns.Replica.Ping())
+}
+
+// TestReplicaTLSConfigPreserved verifies that when a replica config has TLSCA set,
+// the TLSConfig="custom" mutation from checkAndModifyConfig is preserved so the
+// replica actually connects with TLS.
+//
+// This is a regression test for https://github.com/fleetdm/fleet/pull/39689.
+// Before the fix, NewDBConnections called fromCommonMysqlConfig twice for the replica config.
+// The first call's config got TLSConfig="custom" via checkConfig, but that config was
+// block-scoped and discarded. The second call created a fresh config where TLSConfig was
+// empty, so the replica silently connected without TLS.
+func TestReplicaTLSConfigPreserved(t *testing.T) {
+	dbName := t.Name()
+
+	// Create the test database using a direct connection.
+	db, err := sql.Open(
+		"mysql",
+		fmt.Sprintf("%s:%s@tcp(%s)/?multiStatements=true", testing_utils.TestUsername, testing_utils.TestPassword,
+			testing_utils.TestAddress),
+	)
+	require.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s; CREATE DATABASE %s;", dbName, dbName))
+	require.NoError(t, err)
+	defer func() {
+		_, _ = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbName))
+		db.Close()
+	}()
+
+	// Generate a test CA cert that does NOT match the MySQL server's cert.
+	ca, _ := generateTestCert(t)
+	cert, key := generateTestCert(t)
+
+	// Primary config without TLS — connects normally.
+	primaryConfig := config.MysqlConfig{
+		Username: testing_utils.TestUsername,
+		Password: testing_utils.TestPassword,
+		Address:  testing_utils.TestAddress,
+		Database: dbName,
+	}
+
+	// Replica config with TLS — checkAndModifyConfig should set TLSConfig="custom"
+	// and register the TLS profile. When NewDB builds the DSN it must include
+	// tls=custom so the driver actually uses TLS with our test CA.
+	replicaConfig := config.MysqlConfig{
+		Username: testing_utils.TestUsername,
+		Password: testing_utils.TestPassword,
+		Address:  testing_utils.TestAddress,
+		Database: dbName,
+		TLSCA:    ca,
+		TLSCert:  cert,
+		TLSKey:   key,
+	}
+
+	// After the fix the replica connection attempt uses TLS with our test CA,
+	// which doesn't match the MySQL server's certificate, so we expect a TLS error.
+	//
+	// Before the fix TLSConfig was empty for the replica's NewDB call, so the
+	// replica connected without TLS (no error) — meaning this assertion would fail.
+	_, err = NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(log.NewNopLogger()))
+	require.Error(t, err, "replica connection should fail with a TLS error when TLSCA is set — "+
+		"if this succeeds, TLS was silently not applied to the replica")
+	require.Regexp(t, "(x509|tls|EOF)", err.Error())
+}


### PR DESCRIPTION
Zed + Opus 4.6; prompts:

* Where was the bug fixed in b3618c351c6b2b153b7025fcd068407915f3f105 introduced?
* Add tests that fail before the fix commit and pass after.
* I stood up the database, so the tests should be runnable now. Test both the current code (should pass) and prior to b3618c351c6b2b153b7025fcd068407915f3f105 (will require renaming function calls in the test; should fail).

Had to add the last prompt because MySQL wasn't running at the time of the second prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression tests ensuring replica setups read passwords from disk and preserve TLS settings so connection behavior is validated.
  * Added a helper to create and clean up temporary test databases used by the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->