### PR TITLE
Add `renameto` tags to prepare for deprecating team and query API params

### DIFF
--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -412,8 +412,8 @@ func (a ActivityTypeAppliedSpecPack) Documentation() (activity string, details s
 type ActivityTypeCreatedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   *int64  `json:"team_id,omitempty"`
-	TeamName *string `json:"team_name,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedPolicy) ActivityName() string {
@@ -437,8 +437,8 @@ func (a ActivityTypeCreatedPolicy) Documentation() (activity string, details str
 type ActivityTypeEditedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   *int64  `json:"team_id,omitempty"`
-	TeamName *string `json:"team_name,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedPolicy) ActivityName() string {
@@ -462,8 +462,8 @@ func (a ActivityTypeEditedPolicy) Documentation() (activity string, details stri
 type ActivityTypeDeletedPolicy struct {
 	ID       uint    `json:"policy_id"`
 	Name     string  `json:"policy_name"`
-	TeamID   *int64  `json:"team_id,omitempty"`
-	TeamName *string `json:"team_name,omitempty"`
+	TeamID   *int64  `json:"team_id,omitempty" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedPolicy) ActivityName() string {
@@ -525,10 +525,10 @@ func (a ActivityTypeAppliedSpecPolicy) Documentation() (activity string, details
 }
 
 type ActivityTypeCreatedSavedQuery struct {
-	ID       uint    `json:"query_id"`
-	Name     string  `json:"query_name"`
-	TeamID   int64   `json:"team_id"`
-	TeamName *string `json:"team_name,omitempty"`
+	ID       uint    `json:"query_id" renameto:"report_id"`
+	Name     string  `json:"query_name" renameto:"report_name"`
+	TeamID   int64   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedSavedQuery) ActivityName() string {
@@ -550,10 +550,10 @@ func (a ActivityTypeCreatedSavedQuery) Documentation() (activity string, details
 }
 
 type ActivityTypeEditedSavedQuery struct {
-	ID       uint    `json:"query_id"`
-	Name     string  `json:"query_name"`
-	TeamID   int64   `json:"team_id"`
-	TeamName *string `json:"team_name,omitempty"`
+	ID       uint    `json:"query_id" renameto:"report_id"`
+	Name     string  `json:"query_name" renameto:"report_name"`
+	TeamID   int64   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedSavedQuery) ActivityName() string {
@@ -575,9 +575,9 @@ func (a ActivityTypeEditedSavedQuery) Documentation() (activity string, details 
 }
 
 type ActivityTypeDeletedSavedQuery struct {
-	Name     string  `json:"query_name"`
-	TeamID   int64   `json:"team_id"`
-	TeamName *string `json:"team_name,omitempty"`
+	Name     string  `json:"query_name" renameto:"report_name"`
+	TeamID   int64   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedSavedQuery) ActivityName() string {
@@ -597,9 +597,9 @@ func (a ActivityTypeDeletedSavedQuery) Documentation() (activity string, details
 }
 
 type ActivityTypeDeletedMultipleSavedQuery struct {
-	IDs      []uint  `json:"query_ids"`
-	Teamid   int64   `json:"team_id"`
-	TeamName *string `json:"team_name,omitempty"`
+	IDs      []uint  `json:"query_ids" renameto:"report_ids"`
+	Teamid   int64   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name,omitempty" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedMultipleSavedQuery) ActivityName() string {
@@ -644,8 +644,8 @@ func (a ActivityTypeAppliedSpecSavedQuery) Documentation() (activity string, det
 }
 
 type ActivityTypeCreatedTeam struct {
-	ID   uint   `json:"team_id"`
-	Name string `json:"team_name"`
+	ID   uint   `json:"team_id" renameto:"fleet_id"`
+	Name string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedTeam) ActivityName() string {
@@ -663,8 +663,8 @@ func (a ActivityTypeCreatedTeam) Documentation() (activity string, details strin
 }
 
 type ActivityTypeDeletedTeam struct {
-	ID   uint   `json:"team_id"`
-	Name string `json:"team_name"`
+	ID   uint   `json:"team_id" renameto:"fleet_id"`
+	Name string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedTeam) ActivityName() string {
@@ -687,7 +687,7 @@ type TeamActivityDetail struct {
 }
 
 type ActivityTypeAppliedSpecTeam struct {
-	Teams []TeamActivityDetail `json:"teams"`
+	Teams []TeamActivityDetail `json:"teams" renameto:"fleets"`
 }
 
 func (a ActivityTypeAppliedSpecTeam) ActivityName() string {
@@ -709,8 +709,8 @@ func (a ActivityTypeAppliedSpecTeam) Documentation() (activity string, details s
 }
 
 type ActivityTypeTransferredHostsToTeam struct {
-	TeamID           *uint    `json:"team_id"`
-	TeamName         *string  `json:"team_name"`
+	TeamID           *uint    `json:"team_id" renameto:"fleet_id"`
+	TeamName         *string  `json:"team_name" renameto:"fleet_name"`
 	HostIDs          []uint   `json:"host_ids"`
 	HostDisplayNames []string `json:"host_display_names"`
 }
@@ -735,8 +735,8 @@ func (a ActivityTypeTransferredHostsToTeam) Documentation() (activity, details, 
 
 type ActivityTypeEditedAgentOptions struct {
 	Global   bool    `json:"global"`
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedAgentOptions) ActivityName() string {
@@ -757,8 +757,8 @@ func (a ActivityTypeEditedAgentOptions) Documentation() (activity string, detail
 
 type ActivityTypeLiveQuery struct {
 	TargetsCount uint             `json:"targets_count"`
-	QuerySQL     string           `json:"query_sql"`
-	QueryName    *string          `json:"query_name,omitempty"`
+	QuerySQL     string           `json:"query_sql" renameto:"report_sql"`
+	QueryName    *string          `json:"query_name,omitempty" renameto:"report_name"`
 	Stats        *AggregatedStats `json:"stats,omitempty"`
 }
 
@@ -967,8 +967,8 @@ type ActivityTypeChangedUserTeamRole struct {
 	UserName  string `json:"user_name"`
 	UserEmail string `json:"user_email"`
 	Role      string `json:"role"`
-	TeamID    uint   `json:"team_id"`
-	TeamName  string `json:"team_name"`
+	TeamID    uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName  string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeChangedUserTeamRole) ActivityName() string {
@@ -998,8 +998,8 @@ type ActivityTypeDeletedUserTeamRole struct {
 	UserName  string `json:"user_name"`
 	UserEmail string `json:"user_email"`
 	Role      string `json:"role"`
-	TeamID    uint   `json:"team_id"`
-	TeamName  string `json:"team_name"`
+	TeamID    uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName  string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedUserTeamRole) ActivityName() string {
@@ -1108,8 +1108,8 @@ func (a ActivityTypeMDMUnenrolled) Documentation() (activity string, details str
 }
 
 type ActivityTypeEditedMacOSMinVersion struct {
-	TeamID         *uint   `json:"team_id"`
-	TeamName       *string `json:"team_name"`
+	TeamID         *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName       *string `json:"team_name" renameto:"fleet_name"`
 	MinimumVersion string  `json:"minimum_version"`
 	Deadline       string  `json:"deadline"`
 }
@@ -1133,8 +1133,8 @@ func (a ActivityTypeEditedMacOSMinVersion) Documentation() (activity string, det
 }
 
 type ActivityTypeEnabledMacosUpdateNewHosts struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEnabledMacosUpdateNewHosts) ActivityName() string {
@@ -1152,8 +1152,8 @@ func (a ActivityTypeEnabledMacosUpdateNewHosts) Documentation() (activity string
 }
 
 type ActivityTypeDisabledMacosUpdateNewHosts struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDisabledMacosUpdateNewHosts) ActivityName() string {
@@ -1171,8 +1171,8 @@ func (a ActivityTypeDisabledMacosUpdateNewHosts) Documentation() (activity strin
 }
 
 type ActivityTypeEditedWindowsUpdates struct {
-	TeamID          *uint   `json:"team_id"`
-	TeamName        *string `json:"team_name"`
+	TeamID          *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName        *string `json:"team_name" renameto:"fleet_name"`
 	DeadlineDays    *int    `json:"deadline_days"`
 	GracePeriodDays *int    `json:"grace_period_days"`
 }
@@ -1196,8 +1196,8 @@ func (a ActivityTypeEditedWindowsUpdates) Documentation() (activity string, deta
 }
 
 type ActivityTypeEditedIOSMinVersion struct {
-	TeamID         *uint   `json:"team_id"`
-	TeamName       *string `json:"team_name"`
+	TeamID         *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName       *string `json:"team_name" renameto:"fleet_name"`
 	MinimumVersion string  `json:"minimum_version"`
 	Deadline       string  `json:"deadline"`
 }
@@ -1221,8 +1221,8 @@ func (a ActivityTypeEditedIOSMinVersion) Documentation() (activity string, detai
 }
 
 type ActivityTypeEditedIPadOSMinVersion struct {
-	TeamID         *uint   `json:"team_id"`
-	TeamName       *string `json:"team_name"`
+	TeamID         *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName       *string `json:"team_name" renameto:"fleet_name"`
 	MinimumVersion string  `json:"minimum_version"`
 	Deadline       string  `json:"deadline"`
 }
@@ -1271,8 +1271,8 @@ func (a ActivityTypeReadHostDiskEncryptionKey) Documentation() (activity string,
 type ActivityTypeCreatedMacosProfile struct {
 	ProfileName       string  `json:"profile_name"`
 	ProfileIdentifier string  `json:"profile_identifier"`
-	TeamID            *uint   `json:"team_id"`
-	TeamName          *string `json:"team_name"`
+	TeamID            *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName          *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedMacosProfile) ActivityName() string {
@@ -1296,8 +1296,8 @@ func (a ActivityTypeCreatedMacosProfile) Documentation() (activity, details, det
 type ActivityTypeDeletedMacosProfile struct {
 	ProfileName       string  `json:"profile_name"`
 	ProfileIdentifier string  `json:"profile_identifier"`
-	TeamID            *uint   `json:"team_id"`
-	TeamName          *string `json:"team_name"`
+	TeamID            *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName          *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedMacosProfile) ActivityName() string {
@@ -1319,8 +1319,8 @@ func (a ActivityTypeDeletedMacosProfile) Documentation() (activity, details, det
 }
 
 type ActivityTypeEditedMacosProfile struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedMacosProfile) ActivityName() string {
@@ -1339,8 +1339,8 @@ func (a ActivityTypeEditedMacosProfile) Documentation() (activity, details, deta
 
 type ActivityTypeChangedMacosSetupAssistant struct {
 	Name     string  `json:"name"`
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeChangedMacosSetupAssistant) ActivityName() string {
@@ -1361,8 +1361,8 @@ func (a ActivityTypeChangedMacosSetupAssistant) Documentation() (activity, detai
 
 type ActivityTypeDeletedMacosSetupAssistant struct {
 	Name     string  `json:"name"`
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedMacosSetupAssistant) ActivityName() string {
@@ -1382,8 +1382,8 @@ func (a ActivityTypeDeletedMacosSetupAssistant) Documentation() (activity, detai
 }
 
 type ActivityTypeEnabledMacosDiskEncryption struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEnabledMacosDiskEncryption) ActivityName() string {
@@ -1401,8 +1401,8 @@ func (a ActivityTypeEnabledMacosDiskEncryption) Documentation() (activity, detai
 }
 
 type ActivityTypeDisabledMacosDiskEncryption struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDisabledMacosDiskEncryption) ActivityName() string {
@@ -1441,8 +1441,8 @@ func (a ActivityTypeDisabledGitOpsMode) Documentation() (activity, details, deta
 
 type ActivityTypeAddedBootstrapPackage struct {
 	BootstrapPackageName string  `json:"bootstrap_package_name"`
-	TeamID               *uint   `json:"team_id"`
-	TeamName             *string `json:"team_name"`
+	TeamID               *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName             *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeAddedBootstrapPackage) ActivityName() string {
@@ -1463,8 +1463,8 @@ func (a ActivityTypeAddedBootstrapPackage) Documentation() (activity, details, d
 
 type ActivityTypeDeletedBootstrapPackage struct {
 	BootstrapPackageName string  `json:"bootstrap_package_name"`
-	TeamID               *uint   `json:"team_id"`
-	TeamName             *string `json:"team_name"`
+	TeamID               *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName             *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedBootstrapPackage) ActivityName() string {
@@ -1484,8 +1484,8 @@ func (a ActivityTypeDeletedBootstrapPackage) Documentation() (activity, details,
 }
 
 type ActivityTypeEnabledMacosSetupEndUserAuth struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEnabledMacosSetupEndUserAuth) ActivityName() string {
@@ -1503,8 +1503,8 @@ func (a ActivityTypeEnabledMacosSetupEndUserAuth) Documentation() (activity, det
 }
 
 type ActivityTypeDisabledMacosSetupEndUserAuth struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDisabledMacosSetupEndUserAuth) ActivityName() string {
@@ -1617,8 +1617,8 @@ func (a ActivityTypeRanScript) Documentation() (activity, details, detailsExampl
 
 type ActivityTypeAddedScript struct {
 	ScriptName string  `json:"script_name"`
-	TeamID     *uint   `json:"team_id"`
-	TeamName   *string `json:"team_name"`
+	TeamID     *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName   *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeAddedScript) ActivityName() string {
@@ -1639,8 +1639,8 @@ func (a ActivityTypeAddedScript) Documentation() (activity, details, detailsExam
 
 type ActivityTypeUpdatedScript struct {
 	ScriptName string  `json:"script_name"`
-	TeamID     *uint   `json:"team_id"`
-	TeamName   *string `json:"team_name"`
+	TeamID     *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName   *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeUpdatedScript) ActivityName() string {
@@ -1661,8 +1661,8 @@ func (a ActivityTypeUpdatedScript) Documentation() (activity, details, detailsEx
 
 type ActivityTypeDeletedScript struct {
 	ScriptName string  `json:"script_name"`
-	TeamID     *uint   `json:"team_id"`
-	TeamName   *string `json:"team_name"`
+	TeamID     *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName   *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedScript) ActivityName() string {
@@ -1682,8 +1682,8 @@ func (a ActivityTypeDeletedScript) Documentation() (activity, details, detailsEx
 }
 
 type ActivityTypeEditedScript struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedScript) ActivityName() string {
@@ -1702,8 +1702,8 @@ func (a ActivityTypeEditedScript) Documentation() (activity, details, detailsExa
 
 type ActivityTypeCreatedWindowsProfile struct {
 	ProfileName string  `json:"profile_name"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedWindowsProfile) ActivityName() string {
@@ -1724,8 +1724,8 @@ func (a ActivityTypeCreatedWindowsProfile) Documentation() (activity, details, d
 
 type ActivityTypeDeletedWindowsProfile struct {
 	ProfileName string  `json:"profile_name"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedWindowsProfile) ActivityName() string {
@@ -1745,8 +1745,8 @@ func (a ActivityTypeDeletedWindowsProfile) Documentation() (activity, details, d
 }
 
 type ActivityTypeEditedWindowsProfile struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedWindowsProfile) ActivityName() string {
@@ -1841,8 +1841,8 @@ func (a ActivityTypeWipedHost) Documentation() (activity, details, detailsExampl
 type ActivityTypeCreatedDeclarationProfile struct {
 	ProfileName string  `json:"profile_name"`
 	Identifier  string  `json:"identifier"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedDeclarationProfile) ActivityName() string {
@@ -1866,8 +1866,8 @@ func (a ActivityTypeCreatedDeclarationProfile) Documentation() (activity string,
 type ActivityTypeDeletedDeclarationProfile struct {
 	ProfileName string  `json:"profile_name"`
 	Identifier  string  `json:"identifier"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedDeclarationProfile) ActivityName() string {
@@ -1889,8 +1889,8 @@ func (a ActivityTypeDeletedDeclarationProfile) Documentation() (activity string,
 }
 
 type ActivityTypeEditedDeclarationProfile struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedDeclarationProfile) ActivityName() string {
@@ -2061,8 +2061,8 @@ type ActivitySoftwareLabel struct {
 type ActivityTypeAddedSoftware struct {
 	SoftwareTitle    string                  `json:"software_title"`
 	SoftwarePackage  string                  `json:"software_package"`
-	TeamName         *string                 `json:"team_name"`
-	TeamID           *uint                   `json:"team_id"`
+	TeamName         *string                 `json:"team_name" renameto:"fleet_name"`
+	TeamID           *uint                   `json:"team_id" renameto:"fleet_id"`
 	SelfService      bool                    `json:"self_service"`
 	SoftwareTitleID  uint                    `json:"software_title_id"`
 	LabelsIncludeAny []ActivitySoftwareLabel `json:"labels_include_any,omitempty"`
@@ -2105,8 +2105,8 @@ func (a ActivityTypeAddedSoftware) Documentation() (string, string, string) {
 type ActivityTypeEditedSoftware struct {
 	SoftwareTitle       string                  `json:"software_title"`
 	SoftwarePackage     *string                 `json:"software_package"`
-	TeamName            *string                 `json:"team_name"`
-	TeamID              *uint                   `json:"team_id"`
+	TeamName            *string                 `json:"team_name" renameto:"fleet_name"`
+	TeamID              *uint                   `json:"team_id" renameto:"fleet_id"`
 	SelfService         bool                    `json:"self_service"`
 	SoftwareIconURL     *string                 `json:"software_icon_url"`
 	LabelsIncludeAny    []ActivitySoftwareLabel `json:"labels_include_any,omitempty"`
@@ -2154,8 +2154,8 @@ func (a ActivityTypeEditedSoftware) Documentation() (string, string, string) {
 type ActivityTypeDeletedSoftware struct {
 	SoftwareTitle    string                  `json:"software_title"`
 	SoftwarePackage  string                  `json:"software_package"`
-	TeamName         *string                 `json:"team_name"`
-	TeamID           *uint                   `json:"team_id"`
+	TeamName         *string                 `json:"team_name" renameto:"fleet_name"`
+	TeamID           *uint                   `json:"team_id" renameto:"fleet_id"`
 	SelfService      bool                    `json:"self_service"`
 	SoftwareIconURL  *string                 `json:"software_icon_url"`
 	LabelsIncludeAny []ActivitySoftwareLabel `json:"labels_include_any,omitempty"`
@@ -2309,8 +2309,8 @@ type ActivityAddedAppStoreApp struct {
 	SoftwareTitle    string                    `json:"software_title"`
 	SoftwareTitleId  uint                      `json:"software_title_id"`
 	AppStoreID       string                    `json:"app_store_id"`
-	TeamName         *string                   `json:"team_name"`
-	TeamID           *uint                     `json:"team_id"`
+	TeamName         *string                   `json:"team_name" renameto:"fleet_name"`
+	TeamID           *uint                     `json:"team_id" renameto:"fleet_id"`
 	Platform         InstallableDevicePlatform `json:"platform"`
 	SelfService      bool                      `json:"self_service"`
 	LabelsIncludeAny []ActivitySoftwareLabel   `json:"labels_include_any,omitempty"`
@@ -2356,8 +2356,8 @@ func (a ActivityAddedAppStoreApp) Documentation() (activity string, details stri
 type ActivityDeletedAppStoreApp struct {
 	SoftwareTitle    string                    `json:"software_title"`
 	AppStoreID       string                    `json:"app_store_id"`
-	TeamName         *string                   `json:"team_name"`
-	TeamID           *uint                     `json:"team_id"`
+	TeamName         *string                   `json:"team_name" renameto:"fleet_name"`
+	TeamID           *uint                     `json:"team_id" renameto:"fleet_id"`
 	Platform         InstallableDevicePlatform `json:"platform"`
 	SoftwareIconURL  *string                   `json:"software_icon_url"`
 	LabelsIncludeAny []ActivitySoftwareLabel   `json:"labels_include_any,omitempty"`
@@ -2461,8 +2461,8 @@ type ActivityEditedAppStoreApp struct {
 	SoftwareTitle       string                    `json:"software_title"`
 	SoftwareTitleID     uint                      `json:"software_title_id"`
 	AppStoreID          string                    `json:"app_store_id"`
-	TeamName            *string                   `json:"team_name"`
-	TeamID              *uint                     `json:"team_id"`
+	TeamName            *string                   `json:"team_name" renameto:"fleet_name"`
+	TeamID              *uint                     `json:"team_id" renameto:"fleet_id"`
 	Platform            InstallableDevicePlatform `json:"platform"`
 	SelfService         bool                      `json:"self_service"`
 	SoftwareIconURL     *string                   `json:"software_icon_url"`
@@ -2905,7 +2905,7 @@ type ActivityTypeRanScriptBatch struct {
 	ScriptName       string `json:"script_name"`
 	BatchExecutionID string `json:"batch_execution_id"`
 	HostCount        uint   `json:"host_count"`
-	TeamID           *uint  `json:"team_id"`
+	TeamID           *uint  `json:"team_id" renameto:"fleet_id"`
 }
 
 func (a ActivityTypeRanScriptBatch) ActivityName() string {
@@ -2928,7 +2928,7 @@ type ActivityTypeBatchScriptScheduled struct {
 	BatchExecutionID string     `json:"batch_execution_id"`
 	ScriptName       *string    `json:"script_name,omitempty"`
 	HostCount        uint       `json:"host_count"`
-	TeamID           *uint      `json:"team_id"`
+	TeamID           *uint      `json:"team_id" renameto:"fleet_id"`
 	NotBefore        *time.Time `json:"not_before"`
 }
 
@@ -3020,8 +3020,8 @@ func (a ActivityTypeDeletedConditionalAccessOkta) Documentation() (string, strin
 }
 
 type ActivityTypeEnabledConditionalAccessAutomations struct {
-	TeamID   *uint  `json:"team_id"`
-	TeamName string `json:"team_name"`
+	TeamID   *uint  `json:"team_id" renameto:"fleet_id"`
+	TeamName string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEnabledConditionalAccessAutomations) ActivityName() string {
@@ -3039,8 +3039,8 @@ func (a ActivityTypeEnabledConditionalAccessAutomations) Documentation() (string
 }
 
 type ActivityTypeDisabledConditionalAccessAutomations struct {
-	TeamID   *uint  `json:"team_id"`
-	TeamName string `json:"team_name"`
+	TeamID   *uint  `json:"team_id" renameto:"fleet_id"`
+	TeamName string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDisabledConditionalAccessAutomations) ActivityName() string {
@@ -3158,8 +3158,8 @@ func (a ActivityDeletedCustomVariable) Documentation() (activity string, details
 
 type ActivityEditedSetupExperienceSoftware struct {
 	Platform string `json:"platform"`
-	TeamID   uint   `json:"team_id"`
-	TeamName string `json:"team_name"`
+	TeamID   uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityEditedSetupExperienceSoftware) ActivityName() string {
@@ -3180,8 +3180,8 @@ func (a ActivityEditedSetupExperienceSoftware) Documentation() (activity string,
 
 type ActivityTypeCreatedAndroidProfile struct {
 	ProfileName string  `json:"profile_name"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeCreatedAndroidProfile) ActivityName() string {
@@ -3202,8 +3202,8 @@ func (a ActivityTypeCreatedAndroidProfile) Documentation() (activity, details, d
 
 type ActivityTypeDeletedAndroidProfile struct {
 	ProfileName string  `json:"profile_name"`
-	TeamID      *uint   `json:"team_id"`
-	TeamName    *string `json:"team_name"`
+	TeamID      *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName    *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedAndroidProfile) ActivityName() string {
@@ -3223,8 +3223,8 @@ func (a ActivityTypeDeletedAndroidProfile) Documentation() (activity, details, d
 }
 
 type ActivityTypeEditedAndroidProfile struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedAndroidProfile) ActivityName() string {
@@ -3242,8 +3242,8 @@ func (a ActivityTypeEditedAndroidProfile) Documentation() (activity, details, de
 }
 
 type ActivityTypeEditedAndroidCertificate struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedAndroidCertificate) ActivityName() string {
@@ -3284,8 +3284,8 @@ func (a ActivityTypeEditedHostIdpData) Documentation() (activity, details, detai
 
 type ActivityTypeAddedCertificate struct {
 	Name     string  `json:"name"`
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeAddedCertificate) ActivityName() string {
@@ -3306,8 +3306,8 @@ func (a ActivityTypeAddedCertificate) Documentation() (activity string, details 
 
 type ActivityTypeDeletedCertificate struct {
 	Name     string  `json:"name"`
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeDeletedCertificate) ActivityName() string {
@@ -3359,8 +3359,8 @@ func (a ActivityTypeDeletedMicrosoftEntraTenant) Documentation() (activity strin
 }
 
 type ActivityTypeEditedEnrollSecrets struct {
-	TeamID   *uint   `json:"team_id"`
-	TeamName *string `json:"team_name"`
+	TeamID   *uint   `json:"team_id" renameto:"fleet_id"`
+	TeamName *string `json:"team_name" renameto:"fleet_name"`
 }
 
 func (a ActivityTypeEditedEnrollSecrets) ActivityName() string {

--- a/server/fleet/android.go
+++ b/server/fleet/android.go
@@ -21,7 +21,7 @@ type MDMAndroidConfigProfile struct {
 	// ProfileUUID is the unique identifier of the configuration profile in
 	// Fleet. For Android profiles, it is the letter "g" followed by a uuid.
 	ProfileUUID      string                      `db:"profile_uuid" json:"profile_uuid"`
-	TeamID           *uint                       `db:"team_id" json:"team_id"`
+	TeamID           *uint                       `db:"team_id" json:"team_id" renameto:"fleet_id"`
 	Name             string                      `db:"name" json:"name"`
 	RawJSON          []byte                      `db:"raw_json" json:"-"`
 	AutoIncrement    int64                       `db:"auto_increment" json:"auto_increment"`

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -167,16 +167,16 @@ type VulnerabilitySettings struct {
 // hosts when they're ingested during the ABM sync.
 type MDMAppleABMAssignmentInfo struct {
 	OrganizationName string `json:"organization_name"`
-	MacOSTeam        string `json:"macos_team"`
-	IOSTeam          string `json:"ios_team"`
-	IpadOSTeam       string `json:"ipados_team"`
+	MacOSTeam        string `json:"macos_team" renameto:"macos_fleet"`
+	IOSTeam          string `json:"ios_team" renameto:"ios_fleet"`
+	IpadOSTeam       string `json:"ipados_team" renameto:"ipados_fleet"`
 }
 
 // MDMAppleVolumePurchasingProgramInfo represents an user definition of the association
 // between a VPP token (via location) and the team associations.
 type MDMAppleVolumePurchasingProgramInfo struct {
 	Location string   `json:"location"`
-	Teams    []string `json:"teams"`
+	Teams    []string `json:"teams" renameto:"fleets"`
 }
 
 // MDM is part of AppConfig and defines the mdm settings.
@@ -1152,14 +1152,14 @@ const DefaultOrgInfoContactURL = "https://fleetdm.com/company/contact"
 // ServerSettings contains general settings about the Fleet application.
 type ServerSettings struct {
 	ServerURL            string `json:"server_url"`
-	LiveQueryDisabled    bool   `json:"live_query_disabled"`
+	LiveQueryDisabled    bool   `json:"live_query_disabled" renameto:"live_report_disabled"`
 	EnableAnalytics      bool   `json:"enable_analytics"`
 	DebugHostIDs         []uint `json:"debug_host_ids,omitempty"`
 	DeferredSaveHost     bool   `json:"deferred_save_host"`
-	QueryReportsDisabled bool   `json:"query_reports_disabled"`
+	QueryReportsDisabled bool   `json:"query_reports_disabled" renameto:"reports_disabled"`
 	ScriptsDisabled      bool   `json:"scripts_disabled"`
 	AIFeaturesDisabled   bool   `json:"ai_features_disabled"`
-	QueryReportCap       int    `json:"query_report_cap"`
+	QueryReportCap       int    `json:"query_report_cap" renameto:"report_cap"`
 }
 
 const DefaultMaxQueryReportRows int = 1000
@@ -1410,7 +1410,7 @@ type EnrollSecret struct {
 	CreatedAt time.Time `json:"created_at" db:"created_at"`
 	// TeamID is the ID for the associated team. If no ID is set, then this is a
 	// global enroll secret.
-	TeamID *uint `json:"team_id,omitempty" db:"team_id"`
+	TeamID *uint `json:"team_id,omitempty" renameto:"fleet_id" db:"team_id"`
 }
 
 func (e *EnrollSecret) GetTeamID() *uint {

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -197,7 +197,7 @@ type MDMAppleConfigProfile struct {
 	ProfileID uint `db:"profile_id" json:"profile_id"`
 	// TeamID is the id of the team with which the configuration is associated. A nil team id
 	// represents a configuration profile that is not associated with any team.
-	TeamID *uint `db:"team_id" json:"team_id"`
+	TeamID *uint `db:"team_id" json:"team_id" renameto:"fleet_id"`
 	// Identifier corresponds to the payload identifier of the associated mobileconfig payload.
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.
 	Identifier string `db:"identifier" json:"identifier"`
@@ -666,7 +666,7 @@ type MDMAppleDeclaration struct {
 
 	// TeamID is the id of the team with which the declaration is associated. A nil team id
 	// represents a declaration that is not associated with any team.
-	TeamID *uint `db:"team_id" json:"team_id"`
+	TeamID *uint `db:"team_id" json:"team_id" renameto:"fleet_id"`
 
 	// Identifier corresponds to the "Identifier" key of the associated declaration.
 	// Fleet requires that Identifier must be unique in combination with the Name and TeamID.

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -496,7 +496,7 @@ type MDMApplePreassignProfile struct {
 // MDMAppleSettingsPayload describes the payload accepted by the endpoint to
 // update specific MDM macos settings for a team (or no team).
 type MDMAppleSettingsPayload struct {
-	TeamID               *uint `json:"team_id"`
+	TeamID               *uint `json:"team_id" renameto:"fleet_id"`
 	EnableDiskEncryption *bool `json:"enable_disk_encryption"`
 }
 
@@ -508,7 +508,7 @@ func (p MDMAppleSettingsPayload) AuthzType() string {
 // MDMAppleSetupPayload describes the payload accepted by the endpoint to
 // update specific MDM macos setup values for a team (or no team).
 type MDMAppleSetupPayload struct {
-	TeamID                      *uint `json:"team_id"`
+	TeamID                      *uint `json:"team_id" renameto:"fleet_id"`
 	EnableEndUserAuthentication *bool `json:"enable_end_user_authentication"`
 	EnableReleaseDeviceManually *bool `json:"enable_release_device_manually"`
 	ManualAgentInstall          *bool `json:"manual_agent_install"`
@@ -614,7 +614,7 @@ type MDMAppleCommand struct {
 // or no team.
 type MDMAppleSetupAssistant struct {
 	ID         uint            `json:"-" db:"id"`
-	TeamID     *uint           `json:"team_id" db:"team_id"`
+	TeamID     *uint           `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	Name       string          `json:"name" db:"name"`
 	Profile    json.RawMessage `json:"enrollment_profile" db:"profile"`
 	UploadedAt time.Time       `json:"uploaded_at" db:"uploaded_at"`

--- a/server/fleet/campaigns.go
+++ b/server/fleet/campaigns.go
@@ -16,7 +16,7 @@ type DistributedQueryCampaign struct {
 	UpdateCreateTimestamps
 	Metrics TargetMetrics
 	ID      uint                   `json:"id"`
-	QueryID uint                   `json:"query_id" db:"query_id"`
+	QueryID uint                   `json:"query_id" renameto:"report_id" db:"query_id"`
 	Status  DistributedQueryStatus `json:"status"`
 	UserID  uint                   `json:"user_id" db:"user_id"`
 }
@@ -39,7 +39,7 @@ type DistributedQueryCampaignTarget struct {
 // thus it should be kept as small as possible.
 type DistributedQueryResult struct {
 	// DistributedQueryCampaignID is the unique ID of the live query campaign.
-	DistributedQueryCampaignID uint `json:"distributed_query_execution_id"`
+	DistributedQueryCampaignID uint `json:"distributed_query_execution_id" renameto:"distributed_report_execution_id"`
 	// Host holds the host's data from where the query result comes from.
 	Host  ResultHostData      `json:"host"`
 	Rows  []map[string]string `json:"rows"`
@@ -67,7 +67,7 @@ type QueryResult struct {
 }
 
 type QueryCampaignResult struct {
-	QueryID uint          `json:"query_id"`
+	QueryID uint          `json:"query_id" renameto:"report_id"`
 	Error   *string       `json:"error,omitempty"`
 	Results []QueryResult `json:"results"`
 	Err     error         `json:"-"`

--- a/server/fleet/certificate_templates.go
+++ b/server/fleet/certificate_templates.go
@@ -2,14 +2,14 @@ package fleet
 
 type CertificateRequestSpec struct {
 	Name                   string `json:"name"`
-	Team                   string `json:"team,omitempty"`
+	Team                   string `json:"team,omitempty" renameto:"fleet"`
 	CertificateAuthorityId uint   `json:"certificate_authority_id"`
 	SubjectName            string `json:"subject_name"`
 }
 
 type CertificateTemplate struct {
 	Name                   string `json:"name"`
-	TeamID                 uint   `json:"team_id"`
+	TeamID                 uint   `json:"team_id" renameto:"fleet_id"`
 	CertificateAuthorityID uint   `json:"certificate_authority_id"`
 	SubjectName            string `json:"subject_name"`
 }

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -330,12 +330,12 @@ type Host struct {
 	DistributedInterval       uint                `json:"distributed_interval" db:"distributed_interval" csv:"distributed_interval"`
 	ConfigTLSRefresh          uint                `json:"config_tls_refresh" db:"config_tls_refresh" csv:"config_tls_refresh"`
 	LoggerTLSPeriod           uint                `json:"logger_tls_period" db:"logger_tls_period" csv:"logger_tls_period"`
-	TeamID                    *uint               `json:"team_id" db:"team_id" csv:"team_id"`
+	TeamID                    *uint               `json:"team_id" renameto:"fleet_id" db:"team_id" csv:"team_id"`
 
 	// Loaded via JOIN in DB
 	PackStats []PackStats `json:"pack_stats" csv:"-"`
 	// TeamName is the name of the team, loaded by JOIN to the teams table.
-	TeamName *string `json:"team_name" db:"team_name" csv:"team_name"`
+	TeamName *string `json:"team_name" renameto:"fleet_name" db:"team_name" csv:"team_name"`
 	// Additional is the additional information from the host
 	// additional_queries. This should be stored in a separate DB table.
 	Additional *json.RawMessage `json:"additional,omitempty" db:"additional" csv:"-"`
@@ -497,8 +497,8 @@ type HostHealth struct {
 	FailingCriticalPoliciesCount *int                           `json:"failing_critical_policies_count,omitempty"` // Fleet Premium Only
 	VulnerableSoftware           []HostHealthVulnerableSoftware `json:"vulnerable_software,omitempty"`
 	FailingPolicies              []*HostHealthFailingPolicy     `json:"failing_policies,omitempty"`
-	Platform                     string                         `json:"-" db:"platform"`                // Needed to fetch failing policies. Not returned in HTTP responses.
-	TeamID                       *uint                          `json:"team_id,omitempty" db:"team_id"` // Needed to verify that user can access this host's health data. Not returned in HTTP responses.
+	Platform                     string                         `json:"-" db:"platform"`                                    // Needed to fetch failing policies. Not returned in HTTP responses.
+	TeamID                       *uint                          `json:"team_id,omitempty" renameto:"fleet_id" db:"team_id"` // Needed to verify that user can access this host's health data. Not returned in HTTP responses.
 }
 
 type HostHealthVulnerableSoftware struct {
@@ -919,7 +919,7 @@ const (
 // set of hosts in the database. This structure is returned by the HostService
 // method GetHostSummary
 type HostSummary struct {
-	TeamID             *uint                  `json:"team_id,omitempty" db:"-"`
+	TeamID             *uint                  `json:"team_id,omitempty" renameto:"fleet_id" db:"-"`
 	TotalsHostsCount   uint                   `json:"totals_hosts_count" db:"total"`
 	OnlineCount        uint                   `json:"online_count" db:"online"`
 	OfflineCount       uint                   `json:"offline_count" db:"offline"`
@@ -1431,7 +1431,7 @@ type HostMDMCheckinInfo struct {
 	HardwareSerial     string `json:"hardware_serial" db:"hardware_serial"`
 	InstalledFromDEP   bool   `json:"installed_from_dep" db:"installed_from_dep"`
 	DisplayName        string `json:"display_name" db:"display_name"`
-	TeamID             uint   `json:"team_id" db:"team_id"`
+	TeamID             uint   `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	DEPAssignedToFleet bool   `json:"dep_assigned_to_fleet" db:"dep_assigned_to_fleet"`
 	OsqueryEnrolled    bool   `json:"osquery_enrolled" db:"osquery_enrolled"`
 

--- a/server/fleet/invites.go
+++ b/server/fleet/invites.go
@@ -12,7 +12,7 @@ type InvitePayload struct {
 	SSOEnabled *bool       `json:"sso_enabled"`
 	MFAEnabled *bool       `json:"mfa_enabled"`
 	GlobalRole null.String `json:"global_role"`
-	Teams      []UserTeam  `json:"teams"`
+	Teams      []UserTeam  `json:"teams" renameto:"fleets"`
 }
 
 // Invite represents an invitation for a user to join Fleet.
@@ -27,7 +27,7 @@ type Invite struct {
 	SSOEnabled bool        `json:"sso_enabled" db:"sso_enabled"`
 	MFAEnabled bool        `json:"mfa_enabled" db:"mfa_enabled"`
 	GlobalRole null.String `json:"global_role" db:"global_role"`
-	Teams      []UserTeam  `json:"teams"`
+	Teams      []UserTeam  `json:"teams" renameto:"fleets"`
 }
 
 func (i Invite) AuthzType() string {

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -151,12 +151,12 @@ type Label struct {
 	LabelType           LabelType           `json:"label_type" db:"label_type"`
 	LabelMembershipType LabelMembershipType `json:"label_membership_type" db:"label_membership_type"`
 	HostCount           int                 `json:"host_count,omitempty" db:"host_count"`
-	TeamID              *uint               `json:"team_id" db:"team_id"`
+	TeamID              *uint               `json:"team_id" renameto:"fleet_id" db:"team_id"`
 }
 
 type LabelWithTeamName struct {
 	Label
-	TeamName *string `json:"team_name" db:"team_name"`
+	TeamName *string `json:"team_name" renameto:"fleet_name" db:"team_name"`
 }
 
 // Implement the HostVitalsLabel interface.
@@ -168,7 +168,7 @@ type LabelSummary struct {
 	ID          uint      `json:"id"`
 	Name        string    `json:"name"`
 	Description string    `json:"description"`
-	TeamID      *uint     `json:"team_id" db:"team_id"`
+	TeamID      *uint     `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	LabelType   LabelType `json:"label_type" db:"label_type"`
 }
 
@@ -230,7 +230,7 @@ type LabelSpec struct {
 	LabelMembershipType LabelMembershipType `json:"label_membership_type" db:"label_membership_type"`
 	Hosts               HostsSlice          `json:"hosts"`
 	HostVitalsCriteria  *json.RawMessage    `json:"criteria,omitempty" db:"criteria"`
-	TeamID              *uint               `json:"team_id" db:"team_id"`
+	TeamID              *uint               `json:"team_id" renameto:"fleet_id" db:"team_id"`
 }
 
 const (

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -128,7 +128,7 @@ type AppleBM struct {
 	OrgName      string    `json:"org_name"`
 	MDMServerURL string    `json:"mdm_server_url"`
 	RenewDate    time.Time `json:"renew_date"`
-	DefaultTeam  string    `json:"default_team"`
+	DefaultTeam  string    `json:"default_team" renameto:"default_fleet"`
 }
 
 func (a AppleBM) AuthzType() string {
@@ -161,14 +161,14 @@ type ABMToken struct {
 	IPadOSTeamName string `db:"ipados_team" json:"-"`
 
 	// These fields are composed of the ID and name fields above, and are used in API responses.
-	MacOSTeam  ABMTokenTeam `json:"macos_team"`
-	IOSTeam    ABMTokenTeam `json:"ios_team"`
-	IPadOSTeam ABMTokenTeam `json:"ipados_team"`
+	MacOSTeam  ABMTokenTeam `json:"macos_team" renameto:"macos_fleet"`
+	IOSTeam    ABMTokenTeam `json:"ios_team" renameto:"ios_fleet"`
+	IPadOSTeam ABMTokenTeam `json:"ipados_team" renameto:"ipados_fleet"`
 }
 
 type ABMTokenTeam struct {
 	Name string `json:"name"`
-	ID   uint   `json:"team_id"`
+	ID   uint   `json:"team_id" renameto:"fleet_id"`
 }
 
 type AppleCSR struct {
@@ -204,7 +204,7 @@ type MDMIdPAccount struct {
 
 type MDMAppleBootstrapPackage struct {
 	Name      string    `json:"name"`
-	TeamID    uint      `json:"team_id" db:"team_id"`
+	TeamID    uint      `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	Bytes     []byte    `json:"bytes,omitempty" db:"bytes"`
 	Sha256    []byte    `json:"sha256" db:"sha256"`
 	Token     string    `json:"token"`
@@ -313,7 +313,7 @@ type CommandEnqueueResult struct {
 // MDMCommandAuthz is used to check user authorization to read/write an
 // MDM command.
 type MDMCommandAuthz struct {
-	TeamID *uint `json:"team_id"` // required for authorization by team
+	TeamID *uint `json:"team_id" renameto:"fleet_id"` // required for authorization by team
 }
 
 // SetTeamID implements the TeamIDSetter interface.
@@ -544,7 +544,7 @@ func (o MDMOperationType) IsValid() bool {
 // MDMConfigProfileAuthz is used to check user authorization to read/write an
 // MDM configuration profile.
 type MDMConfigProfileAuthz struct {
-	TeamID *uint `json:"team_id"` // required for authorization by team
+	TeamID *uint `json:"team_id" renameto:"fleet_id"` // required for authorization by team
 }
 
 // AuthzType implements authz.AuthzTyper.
@@ -556,7 +556,7 @@ func (m MDMConfigProfileAuthz) AuthzType() string {
 // endpoints that return MDM configuration profiles (get/list profiles).
 type MDMConfigProfilePayload struct {
 	ProfileUUID string `json:"profile_uuid" db:"profile_uuid"`
-	TeamID      *uint  `json:"team_id" db:"team_id"` // null for no-team
+	TeamID      *uint  `json:"team_id" renameto:"fleet_id" db:"team_id"` // null for no-team
 	Name        string `json:"name" db:"name"`
 	Platform    string `json:"platform" db:"platform"`               // "windows", "android" or "darwin"
 	Identifier  string `json:"identifier,omitempty" db:"identifier"` // only set for macOS
@@ -1063,13 +1063,13 @@ type VPPTokenDB struct {
 	// Token is the token dowloaded from ABM. It is the base64 encoded
 	// JSON object with the structure of `VPPTokenRaw`
 	Token string      `db:"token" json:"-"`
-	Teams []TeamTuple `json:"teams"`
+	Teams []TeamTuple `json:"teams" renameto:"fleets"`
 	// CreatedAt    time.Time `json:"created_at" db:"created_at"`
 	// UpdatedAt    time.Time `json:"updated_at" db:"updated_at"`
 }
 
 type TeamTuple struct {
-	ID   uint   `json:"team_id"`
+	ID   uint   `json:"team_id" renameto:"fleet_id"`
 	Name string `json:"name"`
 }
 

--- a/server/fleet/packs.go
+++ b/server/fleet/packs.go
@@ -39,9 +39,9 @@ type Pack struct {
 	LabelIDs []uint   `json:"label_ids"`
 	Hosts    []Target `json:"hosts"`
 	HostIDs  []uint   `json:"host_ids"`
-	Teams    []Target `json:"teams"`
+	Teams    []Target `json:"teams" renameto:"fleets"`
 	// TeamIDs holds the ID of the teams this pack should target.
-	TeamIDs []uint `json:"team_ids"`
+	TeamIDs []uint `json:"team_ids" renameto:"fleet_ids"`
 
 	/////////////////////////////////////////////////////////////////
 	// WARNING: If you add to this struct make sure it's taken into
@@ -157,7 +157,7 @@ type PackPayload struct {
 	Disabled    *bool   `json:"disabled"`
 	HostIDs     *[]uint `json:"host_ids"`
 	LabelIDs    *[]uint `json:"label_ids"`
-	TeamIDs     *[]uint `json:"team_ids"`
+	TeamIDs     *[]uint `json:"team_ids" renameto:"fleet_ids"`
 }
 
 var (
@@ -182,7 +182,7 @@ type PackSpec struct {
 	Platform    string          `json:"platform,omitempty"`
 	Disabled    bool            `json:"disabled"`
 	Targets     PackSpecTargets `json:"targets,omitempty"`
-	Queries     []PackSpecQuery `json:"queries,omitempty"`
+	Queries     []PackSpecQuery `json:"queries,omitempty" renameto:"reports"`
 }
 
 // Verify verifies the pack's spec fields are valid.
@@ -200,11 +200,11 @@ func (p *PackSpec) Verify() error {
 
 type PackSpecTargets struct {
 	Labels []string `json:"labels"`
-	Teams  []string `json:"teams"`
+	Teams  []string `json:"teams" renameto:"fleets"`
 }
 
 type PackSpecQuery struct {
-	QueryName   string  `json:"query" db:"query_name"`
+	QueryName   string  `json:"query" renameto:"report" db:"query_name"`
 	Name        string  `json:"name"`
 	Description string  `json:"description"`
 	Interval    uint    `json:"interval"`
@@ -224,5 +224,5 @@ type PackStats struct {
 	//	- "team-$ID" is returned for team packs.
 	//	- "pack" means it is a user created pack.
 	Type       string                `json:"type"`
-	QueryStats []ScheduledQueryStats `json:"query_stats"`
+	QueryStats []ScheduledQueryStats `json:"query_stats" renameto:"report_stats"`
 }

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -260,7 +260,7 @@ type PolicyData struct {
 	AuthorEmail string `json:"author_email" db:"author_email"`
 	// TeamID is the ID of the team the policy belongs to.
 	// If TeamID is nil, then this is a global policy.
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// Resolution describes how to solve a failing policy.
 	Resolution *string `json:"resolution,omitempty" db:"resolution"`
 	// Platform is a comma-separated string to indicate the target platforms.
@@ -386,7 +386,7 @@ type PolicySpec struct {
 	// Resolution describes how to solve a failing policy.
 	Resolution string `json:"resolution,omitempty"`
 	// Team is the name of the team.
-	Team string `json:"team,omitempty"`
+	Team string `json:"team,omitempty" renameto:"fleet"`
 	// Platform is a comma-separated string to indicate the target platforms.
 	//
 	// Empty string targets all platforms.

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -26,7 +26,7 @@ type QueryPayload struct {
 	ObserverCanRun *bool `json:"observer_can_run"`
 	// TeamID is only used when creating a query. When modifying a query
 	// TeamID is ignored.
-	TeamID *uint `json:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id"`
 	// Interval is the interval to set on the query. If not set when creating
 	// a query, then the default value 0 is set on the query.
 	Interval *uint `json:"interval"`
@@ -64,7 +64,7 @@ type Query struct {
 	// team_id and their name, but since team_id can be null (and (NULL == NULL) != true), we need
 	// to use something else to guarantee uniqueness, hence the use of team_id_char. team_id_char
 	// will be computed as string(team_id), if team_id IS NULL then team_char_id will be ''.
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// Interval frequency of execution (in seconds), if 0 then, this query will never run.
 	Interval uint `json:"interval" db:"schedule_interval"`
 	// Platform if set, specifies the platform(s) this query will target.
@@ -355,7 +355,7 @@ type QuerySpec struct {
 	// TeamName is the team's name, the default "" means the query will be
 	// created globally. This field is only used when creating a query,
 	// when editing a query this field is ignored.
-	TeamName string `json:"team"`
+	TeamName string `json:"team" renameto:"fleet"`
 	// Interval is set to 0 if not set.
 	Interval uint `json:"interval"`
 	// ObserverCanRun is set to false if not set.
@@ -429,7 +429,7 @@ type QueryStats struct {
 	ID          uint   `json:"id" db:"id"`
 	Name        string `json:"name" db:"name"`
 	Description string `json:"description,omitempty" db:"description"`
-	TeamID      *uint  `json:"team_id" db:"team_id"`
+	TeamID      *uint  `json:"team_id" renameto:"fleet_id" db:"team_id"`
 
 	// From osquery directly
 	AverageMemory uint64 `json:"average_memory" db:"average_memory"`

--- a/server/fleet/scheduled_queries.go
+++ b/server/fleet/scheduled_queries.go
@@ -19,8 +19,8 @@ type ScheduledQuery struct {
 	ID          uint   `json:"id"`
 	PackID      uint   `json:"pack_id" db:"pack_id"`
 	Name        string `json:"name"`
-	QueryID     uint   `json:"query_id" db:"query_id"`
-	QueryName   string `json:"query_name" db:"query_name"`
+	QueryID     uint   `json:"query_id" renameto:"report_id" db:"query_id"`
+	QueryName   string `json:"query_name" renameto:"report_name" db:"query_name"`
 	Query       string `json:"query"` // populated via a join on queries
 	Description string `json:"description,omitempty"`
 	// Interval specifies query frequency, in seconds.
@@ -129,7 +129,7 @@ type AggregatedStats struct {
 
 type ScheduledQueryPayload struct {
 	PackID   *uint     `json:"pack_id"`
-	QueryID  *uint     `json:"query_id"`
+	QueryID  *uint     `json:"query_id" renameto:"report_id"`
 	Interval *uint     `json:"interval"`
 	Snapshot *bool     `json:"snapshot"`
 	Removed  *bool     `json:"removed"`
@@ -140,10 +140,10 @@ type ScheduledQueryPayload struct {
 }
 
 type ScheduledQueryStats struct {
-	ScheduledQueryName string `json:"scheduled_query_name,omitempty" db:"scheduled_query_name"`
-	ScheduledQueryID   uint   `json:"scheduled_query_id,omitempty" db:"scheduled_query_id"`
+	ScheduledQueryName string `json:"scheduled_query_name,omitempty" renameto:"scheduled_report_name" db:"scheduled_query_name"`
+	ScheduledQueryID   uint   `json:"scheduled_query_id,omitempty" renameto:"scheduled_report_id" db:"scheduled_query_id"`
 
-	QueryName   string `json:"query_name,omitempty" db:"query_name"`
+	QueryName   string `json:"query_name,omitempty" renameto:"report_name" db:"query_name"`
 	Description string `json:"description,omitempty" db:"description"`
 
 	PackName string `json:"pack_name,omitempty" db:"pack_name"`

--- a/server/fleet/scripts.go
+++ b/server/fleet/scripts.go
@@ -16,7 +16,7 @@ import (
 // Script represents a saved script that can be executed on a host.
 type Script struct {
 	ID     uint   `json:"id" db:"id"`
-	TeamID *uint  `json:"team_id" db:"team_id"`
+	TeamID *uint  `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	Name   string `json:"name" db:"name"`
 	// ScriptContents is not returned in payloads nor is it returned
 	// from reading from the database, it is only used as payload to
@@ -144,7 +144,7 @@ type HostScriptRequestPayload struct {
 	ScriptContents  string `json:"script_contents"`
 	ScriptContentID uint   `json:"-"`
 	ScriptName      string `json:"script_name"`
-	TeamID          uint   `json:"team_id,omitempty"`
+	TeamID          uint   `json:"team_id,omitempty" renameto:"fleet_id"`
 	// UserID is filled automatically from the context's user (the authenticated
 	// user that made the API request).
 	UserID *uint `json:"-"`
@@ -250,7 +250,7 @@ type HostScriptResult struct {
 
 	// TeamID is only used for authorization, it must be set to the team id of
 	// the host when checking authorization and is otherwise not set.
-	TeamID *uint `json:"team_id" db:"-"` // TODO: should we omit this from the json result?
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"-"` // TODO: should we omit this from the json result?
 
 	// Message is the UserMessage associated with a response from an execution.
 	// It may be set by the endpoint and included in the resulting JSON but it is
@@ -486,7 +486,7 @@ type HostLockWipeStatus struct {
 type ScriptResponse struct {
 	// TeamID is the id of the team.
 	// A value of nil means it is scoped to hosts that are assigned to "No team".
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// ID is the id of the script
 	ID uint `json:"id" db:"id"`
 	// Name is the name of the script
@@ -623,8 +623,8 @@ var (
 
 type BatchExecutionStatusFilter struct {
 	ScriptID *uint   `json:"script_id,omitempty"`
-	TeamID   *uint   `json:"team_id,omitempty"` // if nil, it is scoped to hosts that are assigned to "No team"
-	Status   *string `json:"status,omitempty"`  // e.g. "pending", "ran", "errored", "canceled", "incompatible-platform", "incompatible-fleetd"
+	TeamID   *uint   `json:"team_id,omitempty" renameto:"fleet_id"` // if nil, it is scoped to hosts that are assigned to "No team"
+	Status   *string `json:"status,omitempty"`                      // e.g. "pending", "ran", "errored", "canceled", "incompatible-platform", "incompatible-fleetd"
 	// ExecutionID is the unique identifier for a single execution of the script.
 	ExecutionID *string `json:"execution_id,omitempty"`
 	// Limit is the maximum number of results to return.
@@ -650,7 +650,7 @@ type BatchActivity struct {
 	ActivityType     BatchExecutionActivityType    `json:"-" db:"activity_type"`
 	ScriptID         *uint                         `json:"script_id" db:"script_id"`
 	ScriptName       string                        `json:"script_name" db:"script_name"`
-	TeamID           *uint                         `json:"team_id" db:"team_id"`
+	TeamID           *uint                         `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	CreatedAt        time.Time                     `json:"created_at" db:"created_at"`
 	UpdatedAt        time.Time                     `json:"updated_at" db:"updated_at"`
 	NotBefore        *time.Time                    `json:"not_before,omitempty" db:"not_before"`

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -325,7 +325,7 @@ type SoftwareAutoUpdateConfig struct {
 
 type SoftwareAutoUpdateSchedule struct {
 	TitleID uint `json:"title_id" db:"title_id"`
-	TeamID  uint `json:"team_id" db:"team_id"`
+	TeamID  uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	SoftwareAutoUpdateConfig
 }
 
@@ -503,7 +503,7 @@ type SoftwareTitleListOptions struct {
 	// ListOptions cannot be embedded in order to unmarshall with validation.
 	ListOptions ListOptions `url:"list_options"`
 
-	TeamID              *uint   `query:"team_id,optional"`
+	TeamID              *uint   `query:"team_id,optional" renameto:"fleet_id"`
 	VulnerableOnly      bool    `query:"vulnerable,optional"`
 	AvailableForInstall bool    `query:"available_for_install,optional"`
 	SelfServiceOnly     bool    `query:"self_service,optional"`
@@ -555,7 +555,7 @@ type HostSoftwareTitleListOptions struct {
 // AuthzSoftwareInventory is used for access controls on software inventory.
 type AuthzSoftwareInventory struct {
 	// TeamID is the ID of the team. A value of nil means global scope.
-	TeamID *uint `json:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id"`
 }
 
 // AuthzType implements authz.AuthzTyper.
@@ -643,7 +643,7 @@ type SoftwareListOptions struct {
 
 	// HostID filters software to the specified host if not nil.
 	HostID                      *uint
-	TeamID                      *uint `query:"team_id,optional"`
+	TeamID                      *uint `query:"team_id,optional" renameto:"fleet_id"`
 	VulnerableOnly              bool  `query:"vulnerable,optional"`
 	WithoutVulnerabilityDetails bool  `query:"without_vulnerability_details,optional"`
 	IncludeCVEScores            bool

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -66,7 +66,7 @@ type SoftwareInstallerURL struct {
 type SoftwareInstaller struct {
 	// TeamID is the ID of the team. A value of nil means it is scoped to hosts that are assigned to
 	// no team.
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// TitleID is the id of the software title associated with the software installer.
 	TitleID *uint `json:"title_id" db:"title_id"`
 	// Name is the name of the software package.
@@ -137,7 +137,7 @@ type SoftwareInstaller struct {
 type SoftwarePackageResponse struct {
 	// TeamID is the ID of the team.
 	// A value of nil means it is scoped to hosts that are assigned to "No team".
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// TitleID is the id of the software title associated with the software installer.
 	TitleID *uint `json:"title_id" db:"title_id"`
 	// URL is the source URL for this installer (set when uploading via batch/gitops).
@@ -177,7 +177,7 @@ func (p SoftwarePackageResponse) GetLocalIconPath() string { return p.LocalIconP
 type VPPAppResponse struct {
 	// TeamID is the ID of the team.
 	// A value of nil means it is scoped to hosts that are assigned to "No team".
-	TeamID *uint `json:"team_id" db:"team_id"`
+	TeamID *uint `json:"team_id" renameto:"fleet_id" db:"team_id"`
 	// TitleID is the id of the software title associated with the software installer.
 	TitleID *uint `json:"title_id" db:"title_id"`
 	// AppStoreID is the ADAM ID for this app (set when uploading via batch/gitops).
@@ -482,7 +482,7 @@ func (h *HostSoftwareInstallerResult) EnhanceOutputDetails() {
 }
 
 type HostSoftwareInstallerResultAuthz struct {
-	HostTeamID *uint `json:"host_team_id"`
+	HostTeamID *uint `json:"host_team_id" renameto:"host_fleet_id"`
 }
 
 // AuthzType implements authz.AuthzTyper.
@@ -983,7 +983,7 @@ const (
 // SoftwareInstallerTokenMetadata is the metadata stored in Redis for a software installer token.
 type SoftwareInstallerTokenMetadata struct {
 	TitleID uint `json:"title_id"`
-	TeamID  uint `json:"team_id"`
+	TeamID  uint `json:"team_id" renameto:"fleet_id"`
 }
 
 const SoftwareInstallerURLMaxLength = 4000

--- a/server/fleet/software_title_icons.go
+++ b/server/fleet/software_title_icons.go
@@ -26,7 +26,7 @@ type SoftwareTitleIcon struct {
 	// can properly check team ownership (rego marshals the struct to JSON to pass it to
 	// the rego policies script). This struct is never marshalled directly to JSON in
 	// API responses at this time so it doesn't affect anything else.
-	TeamID          uint   `db:"team_id" json:"team_id"`
+	TeamID          uint   `db:"team_id" json:"team_id"` // TODO -- rename to `fleet_id` when authz code switches to using `fleet_id` instead of `team_id`
 	SoftwareTitleID uint   `db:"software_title_id"`
 	StorageID       string `db:"storage_id"`
 	Filename        string `db:"filename"`

--- a/server/fleet/targets.go
+++ b/server/fleet/targets.go
@@ -62,7 +62,7 @@ type HostTargets struct {
 	// LabelIDs is the IDs of labels to be targeted.
 	LabelIDs []uint `json:"labels"`
 	// TeamIDs is the IDs of teams to be targeted.
-	TeamIDs []uint `json:"teams"`
+	TeamIDs []uint `json:"teams" renameto:"fleets"`
 }
 
 type TargetType int

--- a/server/fleet/user_roles.go
+++ b/server/fleet/user_roles.go
@@ -10,10 +10,10 @@ type UsersRoleSpec struct {
 
 type UserRoleSpec struct {
 	GlobalRole *string        `json:"global_role"`
-	Teams      []TeamRoleSpec `json:"teams"`
+	Teams      []TeamRoleSpec `json:"teams" renameto:"fleets"`
 }
 
 type TeamRoleSpec struct {
-	Name string `json:"team"`
+	Name string `json:"team" renameto:"fleet"`
 	Role string `json:"role"`
 }

--- a/server/fleet/users.go
+++ b/server/fleet/users.go
@@ -40,7 +40,7 @@ type User struct {
 	APIOnly    bool    `json:"api_only" db:"api_only"`
 
 	// Teams is the teams this user has roles in. For users with a global role, Teams is expected to be empty.
-	Teams []UserTeam `json:"teams"`
+	Teams []UserTeam `json:"teams" renameto:"fleets"`
 
 	// Only used to to prevent duplicate invite acceptance
 	InviteID *uint `json:"-" db:"invite_id"`
@@ -193,7 +193,7 @@ type UserPayload struct {
 	GlobalRole               *string       `json:"global_role,omitempty"`
 	AdminForcedPasswordReset *bool         `json:"admin_forced_password_reset,omitempty"`
 	APIOnly                  *bool         `json:"api_only,omitempty"`
-	Teams                    *[]UserTeam   `json:"teams,omitempty"`
+	Teams                    *[]UserTeam   `json:"teams,omitempty" renameto:"fleets"`
 	NewPassword              *string       `json:"new_password,omitempty"`
 	Settings                 *UserSettings `json:"settings,omitempty"`
 	InviteID                 *uint         `json:"-"`

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -85,7 +85,7 @@ type VPPApp struct {
 	// TeamID is used for authorization, it must be json serialized to be available
 	// to the rego script. We don't set it outside authorization anyway, so it
 	// won't render otherwise.
-	TeamID  *uint `db:"-" json:"team_id,omitempty"`
+	TeamID  *uint `db:"-" json:"team_id,omitempty" renameto:"fleet_id"`
 	TitleID uint  `db:"title_id" json:"-"`
 
 	CreatedAt time.Time `db:"created_at" json:"-"`

--- a/server/fleet/vulnerabilities.go
+++ b/server/fleet/vulnerabilities.go
@@ -150,7 +150,7 @@ type VulnListOptions struct {
 	ListOptions      ListOptions `url:"list_options"`
 	IsEE             bool
 	ValidSortColumns []string
-	TeamID           *uint `query:"team_id,optional"`
+	TeamID           *uint `query:"team_id,optional" renameto:"fleet_id"`
 	KnownExploit     bool  `query:"exploit,optional"`
 }
 

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -36,7 +36,7 @@ type MDMWindowsConfigProfile struct {
 	// ProfileUUID is the unique identifier of the configuration profile in
 	// Fleet. For Windows profiles, it is the letter "w" followed by a uuid.
 	ProfileUUID      string                      `db:"profile_uuid" json:"profile_uuid"`
-	TeamID           *uint                       `db:"team_id" json:"team_id"`
+	TeamID           *uint                       `db:"team_id" json:"team_id" renameto:"fleet_id"`
 	Name             string                      `db:"name" json:"name"`
 	SyncML           []byte                      `db:"syncml" json:"-"`
 	LabelsIncludeAll []ConfigurationProfileLabel `db:"-" json:"labels_include_all,omitempty"`

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1007,7 +1007,7 @@ func (svc *Service) validateDeclarationLabels(ctx context.Context, labelNames []
 }
 
 type listMDMAppleConfigProfilesRequest struct {
-	TeamID uint `query:"team_id,optional"`
+	TeamID uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type listMDMAppleConfigProfilesResponse struct {
@@ -1328,7 +1328,7 @@ func (svc *Service) DeleteMDMAppleDeclaration(ctx context.Context, declUUID stri
 }
 
 type getMDMAppleFileVaultSummaryRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMAppleFileVaultSummaryResponse struct {
@@ -1365,7 +1365,7 @@ func (svc *Service) GetMDMAppleFileVaultSummary(ctx context.Context, teamID *uin
 }
 
 type getMDMAppleProfilesSummaryRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMAppleProfilesSummaryResponse struct {
@@ -2905,7 +2905,7 @@ func (svc *Service) GetMDMAppleBootstrapPackageBytes(ctx context.Context, token 
 ////////////////////////////////////////////////////////////////////////////////
 
 type bootstrapPackageMetadataRequest struct {
-	TeamID uint `url:"team_id"`
+	TeamID uint `url:"fleet_id"`
 
 	// ForUpdate is used to indicate that the authorization should be for a
 	// "write" instead of a "read", this is needed specifically for the gitops
@@ -2951,7 +2951,7 @@ func (svc *Service) GetMDMAppleBootstrapPackageMetadata(ctx context.Context, tea
 ////////////////////////////////////////////////////////////////////////////////
 
 type deleteBootstrapPackageRequest struct {
-	TeamID uint `url:"team_id"`
+	TeamID uint `url:"fleet_id"`
 	DryRun bool `query:"dry_run,optional"` // if true, apply validation but do not delete
 }
 
@@ -2982,7 +2982,7 @@ func (svc *Service) DeleteMDMAppleBootstrapPackage(ctx context.Context, teamID *
 ////////////////////////////////////////////////////////////////////////////////
 
 type getMDMAppleBootstrapPackageSummaryRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMAppleBootstrapPackageSummaryResponse struct {
@@ -3014,7 +3014,7 @@ func (svc *Service) GetMDMAppleBootstrapPackageSummary(ctx context.Context, team
 ////////////////////////////////////////////////////////////////////////////////
 
 type createMDMAppleSetupAssistantRequest struct {
-	TeamID            *uint           `json:"team_id"`
+	TeamID            *uint           `json:"team_id" renameto:"fleet_id"`
 	Name              string          `json:"name"`
 	EnrollmentProfile json.RawMessage `json:"enrollment_profile"`
 }
@@ -3052,7 +3052,7 @@ func (svc *Service) SetOrUpdateMDMAppleSetupAssistant(ctx context.Context, asst 
 ////////////////////////////////////////////////////////////////////////////////
 
 type getMDMAppleSetupAssistantRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMAppleSetupAssistantResponse struct {
@@ -3084,7 +3084,7 @@ func (svc *Service) GetMDMAppleSetupAssistant(ctx context.Context, teamID *uint)
 ////////////////////////////////////////////////////////////////////////////////
 
 type deleteMDMAppleSetupAssistantRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type deleteMDMAppleSetupAssistantResponse struct {
@@ -6883,9 +6883,9 @@ func (svc *Service) CountABMTokens(ctx context.Context) (int, error) {
 
 type updateABMTokenTeamsRequest struct {
 	TokenID      uint  `url:"id"`
-	MacOSTeamID  *uint `json:"macos_team_id"`
-	IOSTeamID    *uint `json:"ios_team_id"`
-	IPadOSTeamID *uint `json:"ipados_team_id"`
+	MacOSTeamID  *uint `json:"macos_team_id" renameto:"macos_fleet_id"`
+	IOSTeamID    *uint `json:"ios_team_id" renameto:"ios_fleet_id"`
+	IPadOSTeamID *uint `json:"ipados_team_id" renameto:"ipados_fleet_id"`
 }
 
 type updateABMTokenTeamsResponse struct {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2465,8 +2465,8 @@ func (svc *Service) MDMListHostConfigurationProfiles(ctx context.Context, hostID
 ////////////////////////////////////////////////////////////////////////////////
 
 type batchSetMDMAppleProfilesRequest struct {
-	TeamID   *uint    `json:"-" query:"team_id,optional"`
-	TeamName *string  `json:"-" query:"team_name,optional"`
+	TeamID   *uint    `json:"-" query:"team_id,optional" renameto:"fleet_id"`
+	TeamName *string  `json:"-" query:"team_name,optional" renameto:"fleet_name"`
 	DryRun   bool     `json:"-" query:"dry_run,optional"` // if true, apply validation but do not save changes
 	Profiles [][]byte `json:"profiles"`
 }

--- a/server/service/campaigns.go
+++ b/server/service/campaigns.go
@@ -19,7 +19,7 @@ import (
 
 type createDistributedQueryCampaignRequest struct {
 	QuerySQL string            `json:"query"`
-	QueryID  *uint             `json:"query_id"`
+	QueryID  *uint             `json:"query_id" renameto:"report_id"`
 	Selected fleet.HostTargets `json:"selected"`
 }
 
@@ -175,7 +175,7 @@ func (svc *Service) NewDistributedQueryCampaign(ctx context.Context, queryString
 
 type createDistributedQueryCampaignByIdentifierRequest struct {
 	QuerySQL string                                       `json:"query"`
-	QueryID  *uint                                        `json:"query_id"`
+	QueryID  *uint                                        `json:"query_id" renameto:"report_id"`
 	Selected distributedQueryCampaignTargetsByIdentifiers `json:"selected"`
 }
 
@@ -186,7 +186,8 @@ type distributedQueryCampaignTargetsByIdentifiers struct {
 }
 
 func createDistributedQueryCampaignByIdentifierEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer,
-	error) {
+	error,
+) {
 	req := request.(*createDistributedQueryCampaignByIdentifierRequest)
 	campaign, err := svc.NewDistributedQueryCampaignByIdentifiers(ctx, req.QuerySQL, req.QueryID, req.Selected.Hosts, req.Selected.Labels)
 	if err != nil {

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -50,7 +50,7 @@ func validateCertificateTemplateName(name string) error {
 
 type createCertificateTemplateRequest struct {
 	Name                   string `json:"name"`
-	TeamID                 uint   `json:"team_id"` // If not provided, intentionally defaults to 0 aka "No team"
+	TeamID                 uint   `json:"team_id" renameto:"fleet_id"` // If not provided, intentionally defaults to 0 aka "No team"
 	CertificateAuthorityId uint   `json:"certificate_authority_id"`
 	SubjectName            string `json:"subject_name"`
 }
@@ -151,7 +151,7 @@ type listCertificateTemplatesRequest struct {
 	fleet.ListOptions
 
 	// If not provided, intentionally defaults to 0 aka "No team"
-	TeamID uint `query:"team_id,optional"`
+	TeamID uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type listCertificateTemplatesResponse struct {
@@ -524,7 +524,7 @@ func (svc *Service) ApplyCertificateTemplateSpecs(ctx context.Context, specs []*
 
 type deleteCertificateTemplateSpecsRequest struct {
 	IDs    []uint `json:"ids"`
-	TeamID uint   `json:"team_id"` // If not provided, intentionally defaults to 0 aka "No team"
+	TeamID uint   `json:"team_id" renameto:"fleet_id"` // If not provided, intentionally defaults to 0 aka "No team"
 }
 
 type deleteCertificateTemplateSpecsResponse struct {

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -25,7 +25,7 @@ import (
 /////////////////////////////////////////////////////////////////////////////////
 
 type globalPolicyRequest struct {
-	QueryID          *uint    `json:"query_id"`
+	QueryID          *uint    `json:"query_id" renameto:"report_id"`
 	Query            string   `json:"query"`
 	Name             string   `json:"name"`
 	Description      string   `json:"description"`
@@ -350,7 +350,7 @@ func (svc *Service) ModifyGlobalPolicy(ctx context.Context, id uint, p fleet.Mod
 /////////////////////////////////////////////////////////////////////////////////
 
 type resetAutomationRequest struct {
-	TeamIDs   []uint `json:"team_ids" premium:"true"`
+	TeamIDs   []uint `json:"team_ids" premium:"true" renameto:"fleet_ids"`
 	PolicyIDs []uint `json:"policy_ids"`
 }
 
@@ -519,7 +519,7 @@ func applyPolicySpecsEndpoint(ctx context.Context, request interface{}, svc flee
 // policies defined in the spec, and returns a map from team names to team IDs if successful
 func (svc *Service) checkPolicySpecAuthorization(ctx context.Context, policies []*fleet.PolicySpec) (map[string]uint, error) {
 	checkGlobalPolicyAuth := false
-	var teamIDsByName = make(map[string]uint)
+	teamIDsByName := make(map[string]uint)
 	for _, policy := range policies {
 		if policy.Team != "" && policy.Team != "No team" {
 			team, err := svc.ds.TeamByName(ctx, policy.Team)

--- a/server/service/global_schedule.go
+++ b/server/service/global_schedule.go
@@ -53,7 +53,7 @@ func (svc *Service) GetGlobalScheduledQueries(ctx context.Context, opts fleet.Li
 ////////////////////////////////////////////////////////////////////////////////
 
 type globalScheduleQueryRequest struct {
-	QueryID  uint    `json:"query_id"`
+	QueryID  uint    `json:"query_id" renameto:"report_id"`
 	Interval uint    `json:"interval"`
 	Snapshot *bool   `json:"snapshot"`
 	Removed  *bool   `json:"removed"`

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -301,18 +301,18 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	ue.POST("/api/_version_/fleet/users/roles/spec", applyUserRoleSpecsEndpoint, applyUserRoleSpecsRequest{})
 	ue.POST("/api/_version_/fleet/translate", translatorEndpoint, translatorRequest{})
-	ue.WithRequestBodySizeLimit(5*units.MiB).POST("/api/_version_/fleet/spec/teams", applyTeamSpecsEndpoint, applyTeamSpecsRequest{})
-	ue.PATCH("/api/_version_/fleet/teams/{team_id:[0-9]+}/secrets", modifyTeamEnrollSecretsEndpoint, modifyTeamEnrollSecretsRequest{})
-	ue.POST("/api/_version_/fleet/teams", createTeamEndpoint, createTeamRequest{})
-	ue.GET("/api/_version_/fleet/teams", listTeamsEndpoint, listTeamsRequest{})
-	ue.GET("/api/_version_/fleet/teams/{id:[0-9]+}", getTeamEndpoint, getTeamRequest{})
-	ue.PATCH("/api/_version_/fleet/teams/{id:[0-9]+}", modifyTeamEndpoint, modifyTeamRequest{})
-	ue.DELETE("/api/_version_/fleet/teams/{id:[0-9]+}", deleteTeamEndpoint, deleteTeamRequest{})
-	ue.WithRequestBodySizeLimit(2*units.MiB).POST("/api/_version_/fleet/teams/{id:[0-9]+}/agent_options", modifyTeamAgentOptionsEndpoint, modifyTeamAgentOptionsRequest{})
-	ue.GET("/api/_version_/fleet/teams/{id:[0-9]+}/users", listTeamUsersEndpoint, listTeamUsersRequest{})
-	ue.PATCH("/api/_version_/fleet/teams/{id:[0-9]+}/users", addTeamUsersEndpoint, modifyTeamUsersRequest{})
-	ue.DELETE("/api/_version_/fleet/teams/{id:[0-9]+}/users", deleteTeamUsersEndpoint, modifyTeamUsersRequest{})
-	ue.GET("/api/_version_/fleet/teams/{id:[0-9]+}/secrets", teamEnrollSecretsEndpoint, teamEnrollSecretsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/spec/teams").WithRequestBodySizeLimit(5*units.MiB).POST("/api/_version_/fleet/spec/fleets", applyTeamSpecsEndpoint, applyTeamSpecsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{fleet_id:[0-9]+}/secrets").PATCH("/api/_version_/fleet/fleets/{fleet_id:[0-9]+}/secrets", modifyTeamEnrollSecretsEndpoint, modifyTeamEnrollSecretsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams").POST("/api/_version_/fleet/fleets", createTeamEndpoint, createTeamRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams").GET("/api/_version_/fleet/fleets", listTeamsEndpoint, listTeamsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}").GET("/api/_version_/fleet/fleets/{id:[0-9]+}", getTeamEndpoint, getTeamRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}").PATCH("/api/_version_/fleet/fleets/{id:[0-9]+}", modifyTeamEndpoint, modifyTeamRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}").DELETE("/api/_version_/fleet/fleets/{id:[0-9]+}", deleteTeamEndpoint, deleteTeamRequest{})
+	ue.WithRequestBodySizeLimit(2*units.MiB).WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}/agent_options").POST("/api/_version_/fleet/fleets/{id:[0-9]+}/agent_options", modifyTeamAgentOptionsEndpoint, modifyTeamAgentOptionsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}/users").GET("/api/_version_/fleet/fleets/{id:[0-9]+}/users", listTeamUsersEndpoint, listTeamUsersRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}/users").PATCH("/api/_version_/fleet/fleets/{id:[0-9]+}/users", addTeamUsersEndpoint, modifyTeamUsersRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}/users").DELETE("/api/_version_/fleet/fleets/{id:[0-9]+}/users", deleteTeamUsersEndpoint, modifyTeamUsersRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{id:[0-9]+}/secrets").GET("/api/_version_/fleet/fleets/{id:[0-9]+}/secrets", teamEnrollSecretsEndpoint, teamEnrollSecretsRequest{})
 
 	ue.GET("/api/_version_/fleet/users", listUsersEndpoint, listUsersRequest{})
 	ue.POST("/api/_version_/fleet/users/admin", createUserEndpoint, createUserRequest{})
@@ -348,17 +348,17 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/automations/reset", resetAutomationEndpoint, resetAutomationRequest{})
 
 	// Alias /api/_version_/fleet/team/ -> /api/_version_/fleet/teams/
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/policies").
-		POST("/api/_version_/fleet/teams/{team_id}/policies", teamPolicyEndpoint, teamPolicyRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/policies").
-		GET("/api/_version_/fleet/teams/{team_id}/policies", listTeamPoliciesEndpoint, listTeamPoliciesRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/policies/count").
-		GET("/api/_version_/fleet/teams/{team_id}/policies/count", countTeamPoliciesEndpoint, countTeamPoliciesRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/policies/{policy_id}").
-		GET("/api/_version_/fleet/teams/{team_id}/policies/{policy_id}", getTeamPolicyByIDEndpoint, getTeamPolicyByIDRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/policies/delete").
-		POST("/api/_version_/fleet/teams/{team_id}/policies/delete", deleteTeamPoliciesEndpoint, deleteTeamPoliciesRequest{})
-	ue.PATCH("/api/_version_/fleet/teams/{team_id}/policies/{policy_id}", modifyTeamPolicyEndpoint, modifyTeamPolicyRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/policies", "/api/_version_/fleet/teams/{fleet_id}/policies").
+		POST("/api/_version_/fleet/fleets/{fleet_id}/policies", teamPolicyEndpoint, teamPolicyRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/policies", "/api/_version_/fleet/teams/{fleet_id}/policies").
+		GET("/api/_version_/fleet/fleets/{fleet_id}/policies", listTeamPoliciesEndpoint, listTeamPoliciesRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/policies/count", "/api/_version_/fleet/teams/{fleet_id}/policies/count").
+		GET("/api/_version_/fleet/fleets/{fleet_id}/policies/count", countTeamPoliciesEndpoint, countTeamPoliciesRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/policies/{policy_id}", "/api/_version_/fleet/teams/{fleet_id}/policies/{policy_id}").
+		GET("/api/_version_/fleet/fleets/{fleet_id}/policies/{policy_id}", getTeamPolicyByIDEndpoint, getTeamPolicyByIDRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/policies/delete", "/api/_version_/fleet/teams/{fleet_id}/policies/delete").
+		POST("/api/_version_/fleet/fleets/{fleet_id}/policies/delete", deleteTeamPoliciesEndpoint, deleteTeamPoliciesRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/teams/{fleet_id}/policies/{policy_id}").PATCH("/api/_version_/fleet/fleets/{fleet_id}/policies/{policy_id}", modifyTeamPolicyEndpoint, modifyTeamPolicyRequest{})
 	ue.WithRequestBodySizeLimit(fleet.MaxSpecSize).POST("/api/_version_/fleet/spec/policies", applyPolicySpecsEndpoint, applyPolicySpecsRequest{})
 
 	ue.POST("/api/_version_/fleet/certificates", createCertificateTemplateEndpoint, createCertificateTemplateRequest{})
@@ -368,17 +368,17 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.POST("/api/_version_/fleet/spec/certificates", applyCertificateTemplateSpecsEndpoint, applyCertificateTemplateSpecsRequest{})
 	ue.DELETE("/api/_version_/fleet/spec/certificates", deleteCertificateTemplateSpecsEndpoint, deleteCertificateTemplateSpecsRequest{})
 
-	ue.GET("/api/_version_/fleet/queries/{id:[0-9]+}", getQueryEndpoint, getQueryRequest{})
-	ue.GET("/api/_version_/fleet/queries", listQueriesEndpoint, listQueriesRequest{})
-	ue.GET("/api/_version_/fleet/queries/{id:[0-9]+}/report", getQueryReportEndpoint, getQueryReportRequest{})
-	ue.POST("/api/_version_/fleet/queries", createQueryEndpoint, createQueryRequest{})
-	ue.PATCH("/api/_version_/fleet/queries/{id:[0-9]+}", modifyQueryEndpoint, modifyQueryRequest{})
-	ue.DELETE("/api/_version_/fleet/queries/{name}", deleteQueryEndpoint, deleteQueryRequest{})
-	ue.DELETE("/api/_version_/fleet/queries/id/{id:[0-9]+}", deleteQueryByIDEndpoint, deleteQueryByIDRequest{})
-	ue.POST("/api/_version_/fleet/queries/delete", deleteQueriesEndpoint, deleteQueriesRequest{})
-	ue.WithRequestBodySizeLimit(fleet.MaxSpecSize).POST("/api/_version_/fleet/spec/queries", applyQuerySpecsEndpoint, applyQuerySpecsRequest{})
-	ue.GET("/api/_version_/fleet/spec/queries", getQuerySpecsEndpoint, getQuerySpecsRequest{})
-	ue.GET("/api/_version_/fleet/spec/queries/{name}", getQuerySpecEndpoint, getQuerySpecRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/{id:[0-9]+}").GET("/api/_version_/fleet/reports/{id:[0-9]+}", getQueryEndpoint, getQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries").GET("/api/_version_/fleet/reports", listQueriesEndpoint, listQueriesRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/{id:[0-9]+}/report").GET("/api/_version_/fleet/reports/{id:[0-9]+}/report", getQueryReportEndpoint, getQueryReportRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries").POST("/api/_version_/fleet/reports", createQueryEndpoint, createQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/{id:[0-9]+}").PATCH("/api/_version_/fleet/reports/{id:[0-9]+}", modifyQueryEndpoint, modifyQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/{name}").DELETE("/api/_version_/fleet/reports/{name}", deleteQueryEndpoint, deleteQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/id/{id:[0-9]+}").DELETE("/api/_version_/fleet/reports/id/{id:[0-9]+}", deleteQueryByIDEndpoint, deleteQueryByIDRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/delete").POST("/api/_version_/fleet/reports/delete", deleteQueriesEndpoint, deleteQueriesRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/spec/queries").WithRequestBodySizeLimit(fleet.MaxSpecSize).POST("/api/_version_/fleet/spec/reports", applyQuerySpecsEndpoint, applyQuerySpecsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/spec/queries").GET("/api/_version_/fleet/spec/reports", getQuerySpecsEndpoint, getQuerySpecsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/spec/queries/{name}").GET("/api/_version_/fleet/spec/reports/{name}", getQuerySpecEndpoint, getQuerySpecRequest{})
 
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}", getPackEndpoint, getPackRequest{})
 	ue.POST("/api/_version_/fleet/packs", createPackEndpoint, createPackRequest{})
@@ -475,7 +475,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/hosts/report", hostsReportEndpoint, hostsReportRequest{})
 	ue.GET("/api/_version_/fleet/os_versions", osVersionsEndpoint, osVersionsRequest{})
 	ue.GET("/api/_version_/fleet/os_versions/{id:[0-9]+}", getOSVersionEndpoint, getOSVersionRequest{})
-	ue.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/queries/{query_id:[0-9]+}", getHostQueryReportEndpoint, getHostQueryReportRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/hosts/{id:[0-9]+}/queries/{report_id:[0-9]+}").GET("/api/_version_/fleet/hosts/{id:[0-9]+}/reports/{report_id:[0-9]+}", getHostQueryReportEndpoint, getHostQueryReportRequest{})
 	ue.GET("/api/_version_/fleet/hosts/{id:[0-9]+}/health", getHostHealthEndpoint, getHostHealthRequest{})
 	ue.POST("/api/_version_/fleet/hosts/{id:[0-9]+}/labels", addLabelsToHostEndpoint, addLabelsToHostRequest{})
 	ue.DELETE("/api/_version_/fleet/hosts/{id:[0-9]+}/labels", removeLabelsFromHostEndpoint, removeLabelsFromHostRequest{})
@@ -498,16 +498,16 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.GET("/api/_version_/fleet/spec/labels/{name}", getLabelSpecEndpoint, getGenericSpecRequest{})
 
 	// This endpoint runs live queries synchronously (with a configured timeout).
-	ue.POST("/api/_version_/fleet/queries/{id:[0-9]+}/run", runOneLiveQueryEndpoint, runOneLiveQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/{id:[0-9]+}/run").POST("/api/_version_/fleet/reports/{id:[0-9]+}/run", runOneLiveQueryEndpoint, runOneLiveQueryRequest{})
 	// Old endpoint, removed from docs. This GET endpoint runs live queries synchronously (with a configured timeout).
-	ue.GET("/api/_version_/fleet/queries/run", runLiveQueryEndpoint, runLiveQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/run").GET("/api/_version_/fleet/reports/run", runLiveQueryEndpoint, runLiveQueryRequest{})
 	// The following two POST APIs are the asynchronous way to run live queries.
 	// The live queries are created with these two endpoints and their results can be queried via
 	// websockets via the `GET /api/_version_/fleet/results/` endpoint.
-	ue.POST("/api/_version_/fleet/queries/run", createDistributedQueryCampaignEndpoint, createDistributedQueryCampaignRequest{})
-	ue.POST("/api/_version_/fleet/queries/run_by_identifiers", createDistributedQueryCampaignByIdentifierEndpoint, createDistributedQueryCampaignByIdentifierRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/run").POST("/api/_version_/fleet/reports/run", createDistributedQueryCampaignEndpoint, createDistributedQueryCampaignRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/run_by_identifiers").POST("/api/_version_/fleet/reports/run_by_identifiers", createDistributedQueryCampaignByIdentifierEndpoint, createDistributedQueryCampaignByIdentifierRequest{})
 	// This endpoint is deprecated and maintained for backwards compatibility. This and above endpoint are functionally equivalent
-	ue.POST("/api/_version_/fleet/queries/run_by_names", createDistributedQueryCampaignByIdentifierEndpoint, createDistributedQueryCampaignByIdentifierRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/queries/run_by_names").POST("/api/_version_/fleet/reports/run_by_names", createDistributedQueryCampaignByIdentifierEndpoint, createDistributedQueryCampaignByIdentifierRequest{})
 
 	ue.GET("/api/_version_/fleet/packs/{id:[0-9]+}/scheduled", getScheduledQueriesInPackEndpoint, getScheduledQueriesInPackRequest{})
 	ue.EndingAtVersion("v1").POST("/api/_version_/fleet/schedule", scheduleQueryEndpoint, scheduleQueryRequest{})
@@ -528,14 +528,14 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.StartingAtVersion("2022-04").DELETE("/api/_version_/fleet/schedule/{id:[0-9]+}", deleteGlobalScheduleEndpoint, deleteGlobalScheduleRequest{})
 
 	// Alias /api/_version_/fleet/team/ -> /api/_version_/fleet/teams/
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/schedule").
-		GET("/api/_version_/fleet/teams/{team_id}/schedule", getTeamScheduleEndpoint, getTeamScheduleRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/schedule").
-		POST("/api/_version_/fleet/teams/{team_id}/schedule", teamScheduleQueryEndpoint, teamScheduleQueryRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/schedule/{scheduled_query_id}").
-		PATCH("/api/_version_/fleet/teams/{team_id}/schedule/{scheduled_query_id}", modifyTeamScheduleEndpoint, modifyTeamScheduleRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{team_id}/schedule/{scheduled_query_id}").
-		DELETE("/api/_version_/fleet/teams/{team_id}/schedule/{scheduled_query_id}", deleteTeamScheduleEndpoint, deleteTeamScheduleRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule", "/api/_version_/fleet/teams/{fleet_id}/schedule").
+		GET("/api/_version_/fleet/fleets/{fleet_id}/schedule", getTeamScheduleEndpoint, getTeamScheduleRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule", "/api/_version_/fleet/teams/{fleet_id}/schedule").
+		POST("/api/_version_/fleet/fleets/{fleet_id}/schedule", teamScheduleQueryEndpoint, teamScheduleQueryRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{scheduled_report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{scheduled_report_id}").
+		PATCH("/api/_version_/fleet/fleets/{fleet_id}/schedule/{scheduled_report_id}", modifyTeamScheduleEndpoint, modifyTeamScheduleRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{scheduled_report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{scheduled_report_id}").
+		DELETE("/api/_version_/fleet/fleets/{fleet_id}/schedule/{scheduled_report_id}", deleteTeamScheduleEndpoint, deleteTeamScheduleRequest{})
 
 	ue.GET("/api/_version_/fleet/carves", listCarvesEndpoint, listCarvesRequest{})
 	ue.GET("/api/_version_/fleet/carves/{id:[0-9]+}", getCarveEndpoint, getCarveRequest{})
@@ -676,13 +676,13 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 
 	// Deprecated: GET /mdm/bootstrap/:team_id/metadata is now deprecated, replaced by the
 	// GET /bootstrap/:team_id/metadata endpoint.
-	mdmAppleMW.GET("/api/_version_/fleet/mdm/bootstrap/{team_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
-	mdmAppleMW.GET("/api/_version_/fleet/bootstrap/{team_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
+	mdmAppleMW.GET("/api/_version_/fleet/mdm/bootstrap/{fleet_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
+	mdmAppleMW.GET("/api/_version_/fleet/bootstrap/{fleet_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
 
 	// Deprecated: DELETE /mdm/bootstrap/:team_id is now deprecated, replaced by the
 	// DELETE /bootstrap/:team_id endpoint.
-	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/bootstrap/{team_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
-	mdmAppleMW.DELETE("/api/_version_/fleet/bootstrap/{team_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
+	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/bootstrap/{fleet_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
+	mdmAppleMW.DELETE("/api/_version_/fleet/bootstrap/{fleet_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
 
 	// Deprecated: GET /mdm/bootstrap/summary is now deprecated, replaced by the
 	// GET /bootstrap/summary endpoint.
@@ -693,9 +693,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// Bootstrap endpoints are already max size limited to installer size in serve.go
 	mdmAppleMW.SkipRequestBodySizeLimit().POST("/api/_version_/fleet/mdm/apple/bootstrap", uploadBootstrapPackageEndpoint, uploadBootstrapPackageRequest{})
 	// Deprecated: GET /mdm/apple/bootstrap/:team_id/metadata is now deprecated, replaced by the platform agnostic /mdm/bootstrap/:team_id/metadata
-	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
+	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/{fleet_id:[0-9]+}/metadata", bootstrapPackageMetadataEndpoint, bootstrapPackageMetadataRequest{})
 	// Deprecated: DELETE /mdm/apple/bootstrap/:team_id is now deprecated, replaced by the platform agnostic /mdm/bootstrap/:team_id
-	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/apple/bootstrap/{team_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
+	mdmAppleMW.DELETE("/api/_version_/fleet/mdm/apple/bootstrap/{fleet_id:[0-9]+}", deleteBootstrapPackageEndpoint, deleteBootstrapPackageRequest{})
 	// Deprecated: GET /mdm/apple/bootstrap/summary is now deprecated, replaced by the platform agnostic /mdm/bootstrap/summary
 	mdmAppleMW.GET("/api/_version_/fleet/mdm/apple/bootstrap/summary", getMDMAppleBootstrapPackageSummaryEndpoint, getMDMAppleBootstrapPackageSummaryRequest{})
 
@@ -829,7 +829,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ue.DELETE("/api/_version_/fleet/abm_tokens/{id:[0-9]+}", deleteABMTokenEndpoint, deleteABMTokenRequest{})
 	ue.GET("/api/_version_/fleet/abm_tokens", listABMTokensEndpoint, nil)
 	ue.GET("/api/_version_/fleet/abm_tokens/count", countABMTokensEndpoint, nil)
-	ue.PATCH("/api/_version_/fleet/abm_tokens/{id:[0-9]+}/teams", updateABMTokenTeamsEndpoint, updateABMTokenTeamsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/abm_tokens/{id:[0-9]+}/teams").PATCH("/api/_version_/fleet/abm_tokens/{id:[0-9]+}/fleets", updateABMTokenTeamsEndpoint, updateABMTokenTeamsRequest{})
 	ue.PATCH("/api/_version_/fleet/abm_tokens/{id:[0-9]+}/renew", renewABMTokenEndpoint, renewABMTokenRequest{})
 
 	ue.GET("/api/_version_/fleet/mdm/apple/request_csr", getMDMAppleCSREndpoint, getMDMAppleCSRRequest{})
@@ -839,7 +839,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	// VPP Tokens
 	ue.GET("/api/_version_/fleet/vpp_tokens", getVPPTokens, getVPPTokensRequest{})
 	ue.POST("/api/_version_/fleet/vpp_tokens", uploadVPPTokenEndpoint, uploadVPPTokenRequest{})
-	ue.PATCH("/api/_version_/fleet/vpp_tokens/{id}/teams", patchVPPTokensTeams, patchVPPTokensTeamsRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/vpp_tokens/{id}/teams").PATCH("/api/_version_/fleet/vpp_tokens/{id}/fleets", patchVPPTokensTeams, patchVPPTokensTeamsRequest{})
 	ue.PATCH("/api/_version_/fleet/vpp_tokens/{id}/renew", patchVPPTokenRenewEndpoint, patchVPPTokenRenewRequest{})
 	ue.DELETE("/api/_version_/fleet/vpp_tokens/{id}", deleteVPPToken, deleteVPPTokenRequest{})
 

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -532,10 +532,10 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		GET("/api/_version_/fleet/fleets/{fleet_id}/schedule", getTeamScheduleEndpoint, getTeamScheduleRequest{})
 	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule", "/api/_version_/fleet/teams/{fleet_id}/schedule").
 		POST("/api/_version_/fleet/fleets/{fleet_id}/schedule", teamScheduleQueryEndpoint, teamScheduleQueryRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{scheduled_report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{scheduled_report_id}").
-		PATCH("/api/_version_/fleet/fleets/{fleet_id}/schedule/{scheduled_report_id}", modifyTeamScheduleEndpoint, modifyTeamScheduleRequest{})
-	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{scheduled_report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{scheduled_report_id}").
-		DELETE("/api/_version_/fleet/fleets/{fleet_id}/schedule/{scheduled_report_id}", deleteTeamScheduleEndpoint, deleteTeamScheduleRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{report_id}").
+		PATCH("/api/_version_/fleet/fleets/{fleet_id}/schedule/{report_id}", modifyTeamScheduleEndpoint, modifyTeamScheduleRequest{})
+	ue.WithAltPaths("/api/_version_/fleet/team/{fleet_id}/schedule/{report_id}", "/api/_version_/fleet/teams/{fleet_id}/schedule/{report_id}").
+		DELETE("/api/_version_/fleet/fleets/{fleet_id}/schedule/{report_id}", deleteTeamScheduleEndpoint, deleteTeamScheduleRequest{})
 
 	ue.GET("/api/_version_/fleet/carves", listCarvesEndpoint, listCarvesRequest{})
 	ue.GET("/api/_version_/fleet/carves/{id:[0-9]+}", getCarveEndpoint, getCarveRequest{})

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -724,7 +724,7 @@ type searchHostsRequest struct {
 	MatchQuery string `json:"query"`
 	// QueryID is the ID of a saved query to run (used to determine if this is a
 	// query that observers can run).
-	QueryID *uint `json:"query_id"`
+	QueryID *uint `json:"query_id" renameto:"report_id"`
 	// ExcludedHostIDs is the list of IDs selected on the caller side
 	// (e.g. the UI) that will be excluded from the returned payload.
 	ExcludedHostIDs []uint `json:"excluded_host_ids"`
@@ -911,7 +911,7 @@ func (svc *Service) GetHostLite(ctx context.Context, id uint) (*fleet.Host, erro
 ////////////////////////////////////////////////////////////////////////////////
 
 type getHostSummaryRequest struct {
-	TeamID       *uint   `query:"team_id,optional"`
+	TeamID       *uint   `query:"team_id,optional" renameto:"fleet_id"`
 	Platform     *string `query:"platform,optional"`
 	LowDiskSpace *int    `query:"low_disk_space,optional"`
 }
@@ -1146,7 +1146,7 @@ func (svc *Service) CleanupExpiredHosts(ctx context.Context) ([]fleet.DeletedHos
 ////////////////////////////////////////////////////////////////////////////////
 
 type addHostsToTeamRequest struct {
-	TeamID  *uint  `json:"team_id"`
+	TeamID  *uint  `json:"team_id" renameto:"fleet_id"`
 	HostIDs []uint `json:"hosts"`
 }
 
@@ -1282,7 +1282,7 @@ func (svc *Service) createTransferredHostsActivity(ctx context.Context, teamID *
 ////////////////////////////////////////////////////////////////////////////////
 
 type addHostsToTeamByFilterRequest struct {
-	TeamID  *uint                   `json:"team_id"`
+	TeamID  *uint                   `json:"team_id" renameto:"fleet_id"`
 	Filters *map[string]interface{} `json:"filters"`
 }
 
@@ -1782,11 +1782,11 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 
 type getHostQueryReportRequest struct {
 	ID      uint `url:"id"`
-	QueryID uint `url:"query_id"`
+	QueryID uint `url:"report_id"`
 }
 
 type getHostQueryReportResponse struct {
-	QueryID       uint                          `json:"query_id"`
+	QueryID       uint                          `json:"query_id" renameto:"report_id"`
 	HostID        uint                          `json:"host_id"`
 	HostName      string                        `json:"host_name"`
 	LastFetched   *time.Time                    `json:"last_fetched"`
@@ -2172,7 +2172,7 @@ type getHostMDMSummaryResponse struct {
 }
 
 type getHostMDMSummaryRequest struct {
-	TeamID   *uint  `query:"team_id,optional"`
+	TeamID   *uint  `query:"team_id,optional" renameto:"fleet_id"`
 	Platform string `query:"platform,optional"`
 }
 
@@ -2277,7 +2277,7 @@ func (svc *Service) MacadminsData(ctx context.Context, id uint) (*fleet.Macadmin
 ////////////////////////////////////////////////////////////////////////////////
 
 type getAggregatedMacadminsDataRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getAggregatedMacadminsDataResponse struct {
@@ -2568,7 +2568,7 @@ func (svc *Service) ListLabelsForHost(ctx context.Context, hostID uint) ([]*flee
 
 type osVersionsRequest struct {
 	fleet.ListOptions
-	TeamID             *uint   `query:"team_id,optional"`
+	TeamID             *uint   `query:"team_id,optional" renameto:"fleet_id"`
 	Platform           *string `query:"platform,optional"`
 	Name               *string `query:"os_name,optional"`
 	Version            *string `query:"os_version,optional"`
@@ -2761,7 +2761,7 @@ func paginateOSVersions(slice []fleet.OSVersion, opts fleet.ListOptions) ([]flee
 
 type getOSVersionRequest struct {
 	ID                 uint  `url:"id"`
-	TeamID             *uint `query:"team_id,optional"`
+	TeamID             *uint `query:"team_id,optional" renameto:"fleet_id"`
 	MaxVulnerabilities *int  `query:"max_vulnerabilities,optional"`
 }
 

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -291,7 +291,7 @@ func (svc *Service) GetLabel(ctx context.Context, id uint) (*fleet.LabelWithTeam
 
 type listLabelsRequest struct {
 	ListOptions       fleet.ListOptions `url:"list_options"`
-	TeamID            *string           `query:"team_id,optional"` // string because it's an int or "global"
+	TeamID            *string           `query:"team_id,optional" renameto:"fleet_id"` // string because it's an int or "global"
 	IncludeHostCounts *bool             `query:"include_host_counts,optional"`
 }
 
@@ -388,7 +388,7 @@ func labelResponseForLabelWithTeamName(label *fleet.LabelWithTeamName, hostIDs [
 ////////////////////////////////////////////////////////////////////////////////
 
 type getLabelsSummaryRequest struct {
-	TeamID *string `query:"team_id,optional"` // string because it's an int or "global"
+	TeamID *string `query:"team_id,optional" renameto:"fleet_id"` // string because it's an int or "global"
 }
 
 type getLabelsSummaryResponse struct {
@@ -772,7 +772,7 @@ type getLabelSpecsResponse struct {
 func (r getLabelSpecsResponse) Error() error { return r.Err }
 
 type getLabelSpecsRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 func getLabelSpecsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {

--- a/server/service/labels.go
+++ b/server/service/labels.go
@@ -630,7 +630,7 @@ func (svc *Service) DeleteLabelByID(ctx context.Context, id uint) error {
 
 type applyLabelSpecsRequest struct {
 	Specs       []*fleet.LabelSpec `json:"specs"`
-	TeamID      *uint              `json:"-" query:"team_id,optional"`
+	TeamID      *uint              `json:"-" query:"team_id,optional" renameto:"fleet_id"`
 	NamesToMove []string           `json:"names_to_move,omitempty"`
 }
 

--- a/server/service/live_queries.go
+++ b/server/service/live_queries.go
@@ -19,7 +19,7 @@ import (
 )
 
 type runLiveQueryRequest struct {
-	QueryIDs []uint `json:"query_ids"`
+	QueryIDs []uint `json:"query_ids" renameto:"report_ids"`
 	HostIDs  []uint `json:"host_ids"`
 }
 
@@ -47,13 +47,13 @@ type runLiveQueryResponse struct {
 	Summary summaryPayload `json:"summary"`
 	Err     error          `json:"error,omitempty"`
 
-	Results []fleet.QueryCampaignResult `json:"live_query_results"`
+	Results []fleet.QueryCampaignResult `json:"live_query_results" renameto:"live_report_results"`
 }
 
 func (r runLiveQueryResponse) Error() error { return r.Err }
 
 type runOneLiveQueryResponse struct {
-	QueryID            uint                `json:"query_id"`
+	QueryID            uint                `json:"query_id" renameto:"report_id"`
 	TargetedHostCount  int                 `json:"targeted_host_count"`
 	RespondedHostCount int                 `json:"responded_host_count"`
 	Results            []fleet.QueryResult `json:"results"`

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -11,7 +11,7 @@ import (
 )
 
 type addFleetMaintainedAppRequest struct {
-	TeamID            *uint    `json:"team_id"`
+	TeamID            *uint    `json:"team_id" renameto:"fleet_id"`
 	AppID             uint     `json:"fleet_maintained_app_id"`
 	InstallScript     string   `json:"install_script"`
 	PreInstallQuery   string   `json:"pre_install_query"`
@@ -103,7 +103,7 @@ func (svc *Service) AddFleetMaintainedApp(ctx context.Context, _ *uint, _ uint, 
 
 type listFleetMaintainedAppsRequest struct {
 	fleet.ListOptions
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type listFleetMaintainedAppsResponse struct {
@@ -140,7 +140,7 @@ func (svc *Service) ListFleetMaintainedApps(ctx context.Context, teamID *uint, o
 
 type getFleetMaintainedAppRequest struct {
 	AppID  uint  `url:"app_id"`
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getFleetMaintainedAppResponse struct {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1884,8 +1884,8 @@ func (svc *Service) validateProfileLabels(ctx context.Context, teamID *uint, lab
 }
 
 type batchModifyMDMConfigProfilesRequest struct {
-	TeamID                *uint                                      `json:"-" query:"team_id,optional"`
-	TeamName              *string                                    `json:"-" query:"team_name,optional"`
+	TeamID                *uint                                      `json:"-" query:"team_id,optional" renameto:"fleet_id"`
+	TeamName              *string                                    `json:"-" query:"team_name,optional" renameto:"fleet_name"`
 	DryRun                bool                                       `json:"-" query:"dry_run,optional"` // if true, apply validation but do not save changes
 	ConfigurationProfiles []fleet.BatchModifyMDMConfigProfilePayload `json:"configuration_profiles"`
 }
@@ -1924,8 +1924,8 @@ func batchModifyMDMConfigProfilesEndpoint(ctx context.Context, request interface
 ////////////////////////////////////////////////////////////////////////////////
 
 type batchSetMDMProfilesRequest struct {
-	TeamID        *uint                        `json:"-" query:"team_id,optional"`
-	TeamName      *string                      `json:"-" query:"team_name,optional"`
+	TeamID        *uint                        `json:"-" query:"team_id,optional" renameto:"fleet_id"`
+	TeamName      *string                      `json:"-" query:"team_name,optional" renameto:"fleet_name"`
 	DryRun        bool                         `json:"-" query:"dry_run,optional"`        // if true, apply validation but do not save changes
 	AssumeEnabled *bool                        `json:"-" query:"assume_enabled,optional"` // if true, assume MDM is enabled
 	Profiles      backwardsCompatProfilesParam `json:"profiles"`

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1103,7 +1103,7 @@ func (svc *Service) ListMDMCommands(ctx context.Context, opts *fleet.MDMCommandL
 ////////////////////////////////////////////////////////////////////////////////
 
 type getMDMDiskEncryptionSummaryRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMDiskEncryptionSummaryResponse struct {
@@ -1140,7 +1140,7 @@ func (svc *Service) GetMDMDiskEncryptionSummary(ctx context.Context, teamID *uin
 ////////////////////////////////////////////////////////////////////////////////
 
 type getMDMProfilesSummaryRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getMDMProfilesSummaryResponse struct {
@@ -2703,7 +2703,7 @@ func validateProfiles(profiles map[int]fleet.MDMProfileBatchPayload) error {
 ////////////////////////////////////////////////////////////////////////////////
 
 type listMDMConfigProfilesRequest struct {
-	TeamID      *uint             `query:"team_id,optional"`
+	TeamID      *uint             `query:"team_id,optional" renameto:"fleet_id"`
 	ListOptions fleet.ListOptions `url:"list_options"`
 }
 
@@ -2761,7 +2761,7 @@ func (svc *Service) ListMDMConfigProfiles(ctx context.Context, teamID *uint, opt
 ////////////////////////////////////////////////////////////////////////////////
 
 type updateDiskEncryptionRequest struct {
-	TeamID               *uint `json:"team_id"`
+	TeamID               *uint `json:"team_id" renameto:"fleet_id"`
 	EnableDiskEncryption bool  `json:"enable_disk_encryption"`
 	RequireBitLockerPIN  bool  `json:"windows_require_bitlocker_pin"`
 }

--- a/server/service/packs.go
+++ b/server/service/packs.go
@@ -13,7 +13,7 @@ import (
 
 type packResponse struct {
 	fleet.Pack
-	QueryCount uint `json:"query_count"`
+	QueryCount uint `json:"query_count" renameto:"report_count"`
 
 	// All current hosts in the pack. Hosts which are selected explicty and
 	// hosts which are part of a label.
@@ -22,7 +22,7 @@ type packResponse struct {
 	// IDs of hosts which were explicitly selected.
 	HostIDs  []uint `json:"host_ids"`
 	LabelIDs []uint `json:"label_ids"`
-	TeamIDs  []uint `json:"team_ids"`
+	TeamIDs  []uint `json:"team_ids" renameto:"fleet_ids"`
 }
 
 func userIsGitOpsOnly(ctx context.Context) (bool, error) {

--- a/server/service/queries.go
+++ b/server/service/queries.go
@@ -24,7 +24,7 @@ type getQueryRequest struct {
 }
 
 type getQueryResponse struct {
-	Query *fleet.Query `json:"query,omitempty"`
+	Query *fleet.Query `json:"query,omitempty" renameto:"report"`
 	Err   error        `json:"error,omitempty"`
 }
 
@@ -59,16 +59,16 @@ func (svc *Service) GetQuery(ctx context.Context, id uint) (*fleet.Query, error)
 type listQueriesRequest struct {
 	ListOptions fleet.ListOptions `url:"list_options"`
 	// TeamID url argument set to 0 means global.
-	TeamID         uint `query:"team_id,optional"`
+	TeamID         uint `query:"team_id,optional" renameto:"fleet_id"`
 	MergeInherited bool `query:"merge_inherited,optional"`
 	// only return queries targeted to run on this platform
 	Platform string `query:"platform,optional"`
 }
 
 type listQueriesResponse struct {
-	Queries             []fleet.Query             `json:"queries"`
+	Queries             []fleet.Query             `json:"queries" renameto:"reports"`
 	Count               int                       `json:"count"`
-	InheritedQueryCount int                       `json:"inherited_query_count"`
+	InheritedQueryCount int                       `json:"inherited_query_count" renameto:"inherited_report_count"`
 	Meta                *fleet.PaginationMetadata `json:"meta"`
 	Err                 error                     `json:"error,omitempty"`
 }
@@ -155,11 +155,11 @@ func (svc *Service) ListQueries(ctx context.Context, opt fleet.ListOptions, team
 
 type getQueryReportRequest struct {
 	ID     uint  `url:"id"`
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getQueryReportResponse struct {
-	QueryID       uint                       `json:"query_id"`
+	QueryID       uint                       `json:"query_id" renameto:"report_id"`
 	Results       []fleet.HostQueryResultRow `json:"results"`
 	ReportClipped bool                       `json:"report_clipped"`
 	Err           error                      `json:"error,omitempty"`
@@ -251,7 +251,7 @@ type createQueryRequest struct {
 }
 
 type createQueryResponse struct {
-	Query *fleet.Query `json:"query,omitempty"`
+	Query *fleet.Query `json:"query,omitempty" renameto:"report"`
 	Err   error        `json:"error,omitempty"`
 }
 
@@ -384,7 +384,7 @@ type modifyQueryRequest struct {
 }
 
 type modifyQueryResponse struct {
-	Query *fleet.Query `json:"query,omitempty"`
+	Query *fleet.Query `json:"query,omitempty" renameto:"report"`
 	Err   error        `json:"error,omitempty"`
 }
 
@@ -551,7 +551,7 @@ func comparePlatforms(platform1, platform2 string) bool {
 type deleteQueryRequest struct {
 	Name string `url:"name"`
 	// TeamID if not set is assumed to be 0 (global).
-	TeamID uint `url:"team_id,optional"`
+	TeamID uint `url:"fleet_id,optional"`
 }
 
 type deleteQueryResponse struct {
@@ -950,7 +950,7 @@ type getQuerySpecsResponse struct {
 }
 
 type getQuerySpecsRequest struct {
-	TeamID uint `url:"team_id,optional"`
+	TeamID uint `url:"fleet_id,optional"`
 }
 
 func (r getQuerySpecsResponse) Error() error { return r.Err }
@@ -1027,7 +1027,7 @@ type getQuerySpecResponse struct {
 
 type getQuerySpecRequest struct {
 	Name   string `url:"name"`
-	TeamID uint   `query:"team_id,optional"`
+	TeamID uint   `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 func (r getQuerySpecResponse) Error() error { return r.Err }

--- a/server/service/scheduled_queries.go
+++ b/server/service/scheduled_queries.go
@@ -65,7 +65,7 @@ func (svc *Service) GetScheduledQueriesInPack(ctx context.Context, id uint, opts
 
 type scheduleQueryRequest struct {
 	PackID   uint    `json:"pack_id"`
-	QueryID  uint    `json:"query_id"`
+	QueryID  uint    `json:"query_id" renameto:"report_id"`
 	Interval uint    `json:"interval"`
 	Snapshot *bool   `json:"snapshot"`
 	Removed  *bool   `json:"removed"`

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -36,7 +36,7 @@ type runScriptRequest struct {
 	ScriptID       *uint  `json:"script_id"`
 	ScriptContents string `json:"script_contents"`
 	ScriptName     string `json:"script_name"`
-	TeamID         uint   `json:"team_id"`
+	TeamID         uint   `json:"team_id" renameto:"fleet_id"`
 }
 
 type runScriptResponse struct {
@@ -74,7 +74,7 @@ type runScriptSyncRequest struct {
 	ScriptID       *uint  `json:"script_id"`
 	ScriptContents string `json:"script_contents"`
 	ScriptName     string `json:"script_name"`
-	TeamID         uint   `json:"team_id"`
+	TeamID         uint   `json:"team_id" renameto:"fleet_id"`
 }
 
 type runScriptSyncResponse struct {
@@ -634,7 +634,7 @@ func (svc *Service) DeleteScript(ctx context.Context, scriptID uint) error {
 ////////////////////////////////////////////////////////////////////////////////
 
 type listScriptsRequest struct {
-	TeamID      *uint             `query:"team_id,optional"`
+	TeamID      *uint             `query:"team_id,optional" renameto:"fleet_id"`
 	ListOptions fleet.ListOptions `url:"list_options"`
 }
 
@@ -959,7 +959,7 @@ type batchScriptExecutionStatusRequest struct {
 }
 
 type batchScriptExecutionListRequest struct {
-	TeamID  uint    `query:"team_id,required"`
+	TeamID  uint    `query:"team_id,required" renameto:"fleet_id"`
 	Status  *string `query:"status,optional"`
 	Page    *uint   `query:"page,optional"`
 	PerPage *uint   `query:"per_page,optional"`
@@ -976,7 +976,7 @@ type (
 	batchScriptExecutionSummaryResponse struct {
 		ScriptID    uint      `json:"script_id" db:"script_id"`
 		ScriptName  string    `json:"script_name" db:"script_name"`
-		TeamID      *uint     `json:"team_id" db:"team_id"`
+		TeamID      *uint     `json:"team_id" db:"team_id" renameto:"fleet_id"`
 		CreatedAt   time.Time `json:"created_at" db:"created_at"`
 		NumTargeted *uint     `json:"targeted" db:"num_targeted"`
 		NumPending  *uint     `json:"pending" db:"num_pending"`

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -941,8 +941,8 @@ func (svc *Service) GetHostScriptDetails(ctx context.Context, hostID uint, opt f
 ////////////////////////////////////////////////////////////////////////////////
 
 type batchSetScriptsRequest struct {
-	TeamID   *uint                 `json:"-" query:"team_id,optional"`
-	TeamName *string               `json:"-" query:"team_name,optional"`
+	TeamID   *uint                 `json:"-" query:"team_id,optional" renameto:"fleet_id"`
+	TeamName *string               `json:"-" query:"team_name,optional" renameto:"fleet_name"`
 	DryRun   bool                  `json:"-" query:"dry_run,optional"` // if true, apply validation but do not save changes
 	Scripts  []fleet.ScriptPayload `json:"scripts"`
 }

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -118,7 +118,7 @@ func (svc *Service) DeleteSession(ctx context.Context, id uint) error {
 
 type loginResponse struct {
 	User           *fleet.User          `json:"user,omitempty"`
-	AvailableTeams []*fleet.TeamSummary `json:"available_teams"`
+	AvailableTeams []*fleet.TeamSummary `json:"available_teams" renameto:"available_fleets"`
 	Token          string               `json:"token,omitempty"`
 	Err            error                `json:"error,omitempty"`
 }

--- a/server/service/setup_experience.go
+++ b/server/service/setup_experience.go
@@ -20,7 +20,7 @@ import (
 
 type putSetupExperienceSoftwareRequest struct {
 	Platform string `json:"platform"`
-	TeamID   uint   `json:"team_id"`
+	TeamID   uint   `json:"team_id" renameto:"fleet_id"`
 	TitleIDs []uint `json:"software_title_ids"`
 }
 
@@ -56,7 +56,7 @@ type getSetupExperienceSoftwareRequest struct {
 	// Platforms can be a comma separated list
 	Platforms string `query:"platform,optional"`
 	fleet.ListOptions
-	TeamID uint `query:"team_id"`
+	TeamID uint `query:"team_id" renameto:"fleet_id"`
 }
 
 func (r *getSetupExperienceSoftwareRequest) ValidateRequest() error {
@@ -91,7 +91,7 @@ func (svc *Service) ListSetupExperienceSoftware(ctx context.Context, platform st
 }
 
 type getSetupExperienceScriptRequest struct {
-	TeamID *uint  `query:"team_id,optional"`
+	TeamID *uint  `query:"team_id,optional" renameto:"fleet_id"`
 	Alt    string `query:"alt,optional"`
 }
 
@@ -197,7 +197,7 @@ func (svc *Service) SetSetupExperienceScript(ctx context.Context, teamID *uint, 
 }
 
 type deleteSetupExperienceScriptRequest struct {
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type deleteSetupExperienceScriptResponse struct {

--- a/server/service/software.go
+++ b/server/service/software.go
@@ -135,7 +135,7 @@ func (svc *Service) ListSoftware(ctx context.Context, opt fleet.SoftwareListOpti
 
 type getSoftwareRequest struct {
 	ID     uint  `url:"id"`
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getSoftwareResponse struct {

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -775,8 +775,8 @@ func (svc *Service) GetSelfServiceUninstallScriptResult(ctx context.Context, hos
 ////////////////////////////////////////////////////////////////////////////////
 
 type batchSetSoftwareInstallersRequest struct {
-	TeamName string                            `json:"-" query:"team_name,optional" renameto:"fleet_name"` // optional team name to limit the scope of the operation, if empty applies to all teams
-	DryRun   bool                              `json:"-" query:"dry_run,optional"`                         // if true, apply validation but do not save changes
+	TeamName string                            `json:"-" query:"team_name,optional" renameto:"fleet_name"`
+	DryRun   bool                              `json:"-" query:"dry_run,optional"` // if true, apply validation but do not save changes
 	Software []*fleet.SoftwareInstallerPayload `json:"software"`
 }
 

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -934,7 +934,7 @@ func (svc *Service) HasSelfServiceSoftwareInstallers(ctx context.Context, host *
 //////////////////////////////////////////////////////////////////////////////
 
 type batchAssociateAppStoreAppsRequest struct {
-	TeamName string                  `json:"-" query:"team_name,optional"`
+	TeamName string                  `json:"-" query:"team_name,optional" renameto:"fleet_name"`
 	DryRun   bool                    `json:"-" query:"dry_run,optional"`
 	Apps     []fleet.VPPBatchPayload `json:"app_store_apps"`
 }

--- a/server/service/software_installers.go
+++ b/server/service/software_installers.go
@@ -454,7 +454,7 @@ func (svc *Service) UploadSoftwareInstaller(ctx context.Context, payload *fleet.
 }
 
 type deleteSoftwareInstallerRequest struct {
-	TeamID  *uint `query:"team_id"`
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
 	TitleID uint  `url:"title_id"`
 }
 
@@ -484,7 +484,7 @@ func (svc *Service) DeleteSoftwareInstaller(ctx context.Context, titleID uint, t
 
 type getSoftwareInstallerRequest struct {
 	Alt     string `query:"alt,optional"`
-	TeamID  *uint  `query:"team_id"`
+	TeamID  *uint  `query:"team_id" renameto:"fleet_id"`
 	TitleID uint   `url:"title_id"`
 }
 
@@ -775,8 +775,8 @@ func (svc *Service) GetSelfServiceUninstallScriptResult(ctx context.Context, hos
 ////////////////////////////////////////////////////////////////////////////////
 
 type batchSetSoftwareInstallersRequest struct {
-	TeamName string                            `json:"-" query:"team_name,optional"`
-	DryRun   bool                              `json:"-" query:"dry_run,optional"` // if true, apply validation but do not save changes
+	TeamName string                            `json:"-" query:"team_name,optional" renameto:"fleet_name"` // optional team name to limit the scope of the operation, if empty applies to all teams
+	DryRun   bool                              `json:"-" query:"dry_run,optional"`                         // if true, apply validation but do not save changes
 	Software []*fleet.SoftwareInstallerPayload `json:"software"`
 }
 
@@ -807,7 +807,7 @@ func (svc *Service) BatchSetSoftwareInstallers(ctx context.Context, tmName strin
 
 type batchSetSoftwareInstallersResultRequest struct {
 	RequestUUID string `url:"request_uuid"`
-	TeamName    string `query:"team_name,optional"`
+	TeamName    string `query:"team_name,optional" renameto:"fleet_name"`
 	DryRun      bool   `query:"dry_run,optional"` // if true, apply validation but do not save changes
 }
 
@@ -976,7 +976,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 
 type getInHouseAppManifestRequest struct {
 	TitleID uint  `url:"title_id"`
-	TeamID  *uint `query:"team_id"`
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
 }
 
 type getInHouseAppManifestResponse struct {
@@ -1024,7 +1024,7 @@ func (svc *Service) GetInHouseAppManifest(ctx context.Context, titleID uint, tea
 
 type getInHouseAppPackageRequest struct {
 	TitleID uint  `url:"title_id"`
-	TeamID  *uint `query:"team_id"`
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
 }
 
 type getInHouseAppPackageResponse struct {

--- a/server/service/software_title_icons.go
+++ b/server/service/software_title_icons.go
@@ -20,7 +20,7 @@ import (
 
 type getSoftwareTitleIconsRequest struct {
 	TitleID uint  `url:"title_id"`
-	TeamID  *uint `query:"team_id"`
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
 }
 type getSoftwareTitleIconsResponse struct {
 	Err         error  `json:"error,omitempty"`
@@ -98,7 +98,7 @@ func (svc *Service) GetSoftwareTitleIcon(ctx context.Context, teamID uint, title
 
 type putSoftwareTitleIconRequest struct {
 	TitleID    uint  `url:"title_id"`
-	TeamID     *uint `query:"team_id"`
+	TeamID     *uint `query:"team_id" renameto:"fleet_id"`
 	File       *multipart.FileHeader
 	HashSHA256 *string
 	Filename   *string
@@ -278,7 +278,7 @@ func ValidateIcon(file io.ReadSeeker) error {
 
 type deleteSoftwareTitleIconRequest struct {
 	TitleID uint  `url:"title_id"`
-	TeamID  *uint `query:"team_id"`
+	TeamID  *uint `query:"team_id" renameto:"fleet_id"`
 }
 
 type deleteSoftwareTitleIconResponse struct {

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -116,7 +116,7 @@ func (svc *Service) ListSoftwareTitles(
 
 type getSoftwareTitleRequest struct {
 	ID     uint  `url:"id"`
-	TeamID *uint `query:"team_id,optional"`
+	TeamID *uint `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getSoftwareTitleResponse struct {

--- a/server/service/targets.go
+++ b/server/service/targets.go
@@ -18,7 +18,7 @@ type searchTargetsRequest struct {
 	MatchQuery string `json:"query"`
 	// QueryID is the ID of a saved query to run (used to determine if this is a
 	// query that observers can run).
-	QueryID *uint `json:"query_id"`
+	QueryID *uint `json:"query_id" renameto:"report_id"`
 	// Selected is the list of IDs that are already selected on the caller side
 	// (e.g. the UI), so those are IDs that will be omitted from the returned
 	// payload.
@@ -112,7 +112,7 @@ func (t *teamSearchResult) UnmarshalJSON(b []byte) error {
 type targetsData struct {
 	Hosts  []*fleet.HostResponse `json:"hosts"`
 	Labels []labelSearchResult   `json:"labels"`
-	Teams  []teamSearchResult    `json:"teams"`
+	Teams  []teamSearchResult    `json:"teams" renameto:"fleets"`
 }
 
 type searchTargetsResponse struct {
@@ -254,7 +254,7 @@ func (svc *Service) CountHostsInTargets(ctx context.Context, queryID *uint, targ
 
 type countTargetsRequest struct {
 	Selected fleet.HostTargets `json:"selected"`
-	QueryID  *uint             `json:"query_id"`
+	QueryID  *uint             `json:"query_id" renameto:"report_id"`
 }
 
 type countTargetsResponse struct {

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -20,8 +20,8 @@ import (
 /////////////////////////////////////////////////////////////////////////////////
 
 type teamPolicyRequest struct {
-	TeamID                         uint     `url:"team_id"`
-	QueryID                        *uint    `json:"query_id"`
+	TeamID                         uint     `url:"fleet_id"`
+	QueryID                        *uint    `json:"query_id" renameto:"report_id"`
 	Query                          string   `json:"query"`
 	Name                           string   `json:"name"`
 	Description                    string   `json:"description"`
@@ -221,7 +221,7 @@ func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, tea
 /////////////////////////////////////////////////////////////////////////////////
 
 type listTeamPoliciesRequest struct {
-	TeamID                  uint                 `url:"team_id"`
+	TeamID                  uint                 `url:"fleet_id"`
 	Opts                    fleet.ListOptions    `url:"list_options"`
 	InheritedPage           uint                 `query:"inherited_page,optional"`
 	InheritedPerPage        uint                 `query:"inherited_per_page,optional"`
@@ -306,7 +306,7 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 
 type countTeamPoliciesRequest struct {
 	ListOptions    fleet.ListOptions `url:"list_options"`
-	TeamID         uint              `url:"team_id"`
+	TeamID         uint              `url:"fleet_id"`
 	MergeInherited bool              `query:"merge_inherited,optional"`
 }
 
@@ -366,7 +366,7 @@ func (svc *Service) CountTeamPolicies(ctx context.Context, teamID uint, matchQue
 /////////////////////////////////////////////////////////////////////////////////
 
 type getTeamPolicyByIDRequest struct {
-	TeamID   uint `url:"team_id"`
+	TeamID   uint `url:"fleet_id"`
 	PolicyID uint `url:"policy_id"`
 }
 
@@ -415,7 +415,7 @@ func (svc Service) GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, po
 /////////////////////////////////////////////////////////////////////////////////
 
 type deleteTeamPoliciesRequest struct {
-	TeamID uint   `url:"team_id"`
+	TeamID uint   `url:"fleet_id"`
 	IDs    []uint `json:"ids"`
 }
 
@@ -531,7 +531,7 @@ func (svc Service) DeleteTeamPolicies(ctx context.Context, teamID uint, ids []ui
 /////////////////////////////////////////////////////////////////////////////////
 
 type modifyTeamPolicyRequest struct {
-	TeamID   uint `url:"team_id"`
+	TeamID   uint `url:"fleet_id"`
 	PolicyID uint `url:"policy_id"`
 	fleet.ModifyPolicyPayload
 }

--- a/server/service/team_schedule.go
+++ b/server/service/team_schedule.go
@@ -136,7 +136,7 @@ func (svc Service) TeamScheduleQuery(ctx context.Context, teamID uint, scheduled
 
 type modifyTeamScheduleRequest struct {
 	TeamID           uint `url:"fleet_id"`
-	ScheduledQueryID uint `url:"scheduled_report_id"`
+	ScheduledQueryID uint `url:"report_id"`
 	fleet.ScheduledQueryPayload
 }
 
@@ -175,7 +175,7 @@ func (svc Service) ModifyTeamScheduledQueries(
 
 type deleteTeamScheduleRequest struct {
 	TeamID           uint `url:"fleet_id"`
-	ScheduledQueryID uint `url:"scheduled_report_id"`
+	ScheduledQueryID uint `url:"report_id"`
 }
 
 type deleteTeamScheduleResponse struct {

--- a/server/service/team_schedule.go
+++ b/server/service/team_schedule.go
@@ -16,7 +16,7 @@ import (
 /////////////////////////////////////////////////////////////////////////////////
 
 type getTeamScheduleRequest struct {
-	TeamID      uint              `url:"team_id"`
+	TeamID      uint              `url:"fleet_id"`
 	ListOptions fleet.ListOptions `url:"list_options"`
 }
 
@@ -63,7 +63,7 @@ func (svc Service) GetTeamScheduledQueries(ctx context.Context, teamID uint, opt
 /////////////////////////////////////////////////////////////////////////////////
 
 type teamScheduleQueryRequest struct {
-	TeamID uint `url:"team_id"`
+	TeamID uint `url:"fleet_id"`
 	fleet.ScheduledQueryPayload
 }
 
@@ -135,8 +135,8 @@ func (svc Service) TeamScheduleQuery(ctx context.Context, teamID uint, scheduled
 /////////////////////////////////////////////////////////////////////////////////
 
 type modifyTeamScheduleRequest struct {
-	TeamID           uint `url:"team_id"`
-	ScheduledQueryID uint `url:"scheduled_query_id"`
+	TeamID           uint `url:"fleet_id"`
+	ScheduledQueryID uint `url:"scheduled_report_id"`
 	fleet.ScheduledQueryPayload
 }
 
@@ -174,8 +174,8 @@ func (svc Service) ModifyTeamScheduledQueries(
 /////////////////////////////////////////////////////////////////////////////////
 
 type deleteTeamScheduleRequest struct {
-	TeamID           uint `url:"team_id"`
-	ScheduledQueryID uint `url:"scheduled_query_id"`
+	TeamID           uint `url:"fleet_id"`
+	ScheduledQueryID uint `url:"scheduled_report_id"`
 }
 
 type deleteTeamScheduleResponse struct {

--- a/server/service/teams.go
+++ b/server/service/teams.go
@@ -25,7 +25,7 @@ type listTeamsRequest struct {
 }
 
 type listTeamsResponse struct {
-	Teams []fleet.Team `json:"teams"`
+	Teams []fleet.Team `json:"teams" renameto:"fleets"`
 	Err   error        `json:"error,omitempty"`
 }
 
@@ -62,14 +62,14 @@ type getTeamRequest struct {
 }
 
 type getTeamResponse struct {
-	Team *fleet.Team `json:"team"`
+	Team *fleet.Team `json:"team" renameto:"fleet"`
 	Err  error       `json:"error,omitempty"`
 }
 
 func (r getTeamResponse) Error() error { return r.Err }
 
 type defaultTeamResponse struct {
-	Team *fleet.DefaultTeam `json:"team"`
+	Team *fleet.DefaultTeam `json:"team" renameto:"fleet"`
 	Err  error              `json:"error,omitempty"`
 }
 
@@ -121,7 +121,7 @@ type createTeamRequest struct {
 }
 
 type teamResponse struct {
-	Team *fleet.Team `json:"team,omitempty"`
+	Team *fleet.Team `json:"team,omitempty" renameto:"fleet"`
 	Err  error       `json:"error,omitempty"`
 }
 
@@ -278,7 +278,7 @@ func (req *applyTeamSpecsRequest) DecodeBody(ctx context.Context, r io.Reader, u
 
 type applyTeamSpecsResponse struct {
 	Err           error           `json:"error,omitempty"`
-	TeamIDsByName map[string]uint `json:"team_ids_by_name,omitempty"`
+	TeamIDsByName map[string]uint `json:"team_ids_by_name,omitempty" renameto:"fleet_ids_by_name"`
 }
 
 func (r applyTeamSpecsResponse) Error() error { return r.Err }
@@ -468,7 +468,7 @@ func (svc *Service) TeamEnrollSecrets(ctx context.Context, teamID uint) ([]*flee
 ////////////////////////////////////////////////////////////////////////////////
 
 type modifyTeamEnrollSecretsRequest struct {
-	TeamID  uint                 `url:"team_id"`
+	TeamID  uint                 `url:"fleet_id"`
 	Secrets []fleet.EnrollSecret `json:"secrets"`
 }
 

--- a/server/service/users.go
+++ b/server/service/users.go
@@ -311,7 +311,7 @@ type getUserRequest struct {
 
 type getUserResponse struct {
 	User           *fleet.User          `json:"user,omitempty"`
-	AvailableTeams []*fleet.TeamSummary `json:"available_teams"`
+	AvailableTeams []*fleet.TeamSummary `json:"available_teams" renameto:"available_fleets"`
 	Settings       *fleet.UserSettings  `json:"settings,omitempty"`
 	Err            error                `json:"error,omitempty"`
 }

--- a/server/service/vpp.go
+++ b/server/service/vpp.go
@@ -19,7 +19,7 @@ import (
 //////////////////////////////////////////////////////////////////////////////
 
 type getAppStoreAppsRequest struct {
-	TeamID uint `query:"team_id"`
+	TeamID uint `query:"team_id" renameto:"fleet_id"`
 }
 
 type getAppStoreAppsResponse struct {
@@ -52,7 +52,7 @@ func (svc *Service) GetAppStoreApps(ctx context.Context, teamID *uint) ([]*fleet
 //////////////////////////////////////////////////////////////////////////////
 
 type addAppStoreAppRequest struct {
-	TeamID           *uint                           `json:"team_id"`
+	TeamID           *uint                           `json:"team_id" renameto:"fleet_id"`
 	AppStoreID       string                          `json:"app_store_id"`
 	Platform         fleet.InstallableDevicePlatform `json:"platform"`
 	SelfService      bool                            `json:"self_service"`
@@ -102,7 +102,7 @@ func (svc *Service) AddAppStoreApp(ctx context.Context, _ *uint, _ fleet.VPPAppT
 
 type updateAppStoreAppRequest struct {
 	TitleID           uint            `url:"title_id"`
-	TeamID            *uint           `json:"team_id"`
+	TeamID            *uint           `json:"team_id" renameto:"fleet_id"`
 	SelfService       *bool           `json:"self_service"`
 	LabelsIncludeAny  []string        `json:"labels_include_any"`
 	LabelsExcludeAny  []string        `json:"labels_exclude_any"`
@@ -332,7 +332,7 @@ func (svc *Service) UpdateVPPToken(ctx context.Context, tokenID uint, token io.R
 
 type patchVPPTokensTeamsRequest struct {
 	ID      uint   `url:"id"`
-	TeamIDs []uint `json:"teams"`
+	TeamIDs []uint `json:"teams" renameto:"fleets"`
 }
 
 type patchVPPTokensTeamsResponse struct {

--- a/server/service/vulnerabilities.go
+++ b/server/service/vulnerabilities.go
@@ -122,7 +122,7 @@ func (svc *Service) IsCVEKnownToFleet(ctx context.Context, cve string) (bool, er
 
 type getVulnerabilityRequest struct {
 	CVE    string `url:"cve"`
-	TeamID *uint  `query:"team_id,optional"`
+	TeamID *uint  `query:"team_id,optional" renameto:"fleet_id"`
 }
 
 type getVulnerabilityResponse struct {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #39344

# Details

As a first step to deprecating API params like `team_id` in favor of `fleet_id` and `query_id` in favor of `report_id`, this PR adds `renameto` tags to all deprecated keys. There is no logic in this PR to actually use these tags in any way. The logic and test fixes will be in the next PR, but in the interest of keeping things manageable I'm pushing this out first.

There were definitely params with "query" in them that we don't want to change (mainly osquery-related), and I think I kept them all out but it's worth double-checking here.  The team -> fleet changes are pretty safe in comparison.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
Deferring changelog to PR with logic changes

## Testing

- [ ] Added/updated automated tests
This should be a no-op.  All existing tests shoud pass.
- [X] QA'd all new/changed functionality manually
