### PR TITLE
Remove stable scrollbar gutters from the UI

### DIFF
--- a/changes/34122-remove-stable-scrollbar-gutters
+++ b/changes/34122-remove-stable-scrollbar-gutters
@@ -1,0 +1,1 @@
+- Fixed an issue where some UI users saw a blank gutter on the right side of parts of the UI

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -4,9 +4,6 @@ html {
   // Because iOS hates us we must fight to the death!
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
   // End Apple War
-  // Because scrollbar widths hate us and we must prevent it taking up viewport width
-  scrollbar-gutter: stable;
-  // Ends War with Chrome and FF only
 }
 
 body {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
### **Related issue:** Resolves #34122 

#### When `classic` scrollbars are in effect, [desired tradeoff ](https://github.com/fleetdm/fleet/issues/34122#issuecomment-3898734128)is present:
- Gutter no longer reserved when DOM content not scrollable:
<img width="786" height="1033" alt="Screenshot 2026-02-13 at 10 41 53 AM" src="https://github.com/user-attachments/assets/9d840a5d-c37e-4d8e-9e80-a8781b60d60a" />
- Scrollbars remain visible when content is scrollable:
<img width="786" height="1033" alt="Screenshot 2026-02-13 at 10 42 41 AM" src="https://github.com/user-attachments/assets/6f9ce83f-29cc-474f-939f-0b3d0730e39f" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] QA'd all new/changed functionality manually