### PR TITLE
Fleet UI: Add loading spinner to labels dropdown

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -410,14 +410,18 @@ const ManageHostsPage = ({
   const canRunScriptBatch =
     isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
 
-  const { data: labels, refetch: refetchLabels } = useQuery<
-    ILabelsResponse,
-    Error,
-    ILabel[]
-  >(["labels", currentTeamId], () => labelsAPI.loadAll(currentTeamId), {
-    enabled: isRouteOk,
-    select: (data: ILabelsResponse) => data.labels,
-  });
+  const {
+    data: labels,
+    refetch: refetchLabels,
+    isLoading: isLoadingLabels,
+  } = useQuery<ILabelsResponse, Error, ILabel[]>(
+    ["labels", currentTeamId],
+    () => labelsAPI.loadAll(currentTeamId),
+    {
+      enabled: isRouteOk,
+      select: (data: ILabelsResponse) => data.labels,
+    }
+  );
 
   const {
     isLoading: isGlobalSecretsLoading,
@@ -1678,6 +1682,7 @@ const ManageHostsPage = ({
           selectedLabel={selectedDropdownLabel ?? null}
           onChange={handleLabelChange}
           onAddLabel={onAddLabelClick}
+          isLoading={isLoadingLabels}
         />
       </div>
     );

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -10,6 +10,7 @@ import {
   PLATFORM_TYPE_ICONS,
 } from "utilities/constants";
 import Icon from "components/Icon";
+import Spinner from "components/Spinner";
 
 import CustomLabelGroupHeading from "../CustomLabelGroupHeading";
 import { createDropdownOptions, IEmptyOption, IGroupOption } from "./helpers";
@@ -66,6 +67,16 @@ const formatOptionLabel = (data: ILabel | IEmptyOption) => {
   );
 };
 
+const LoadingMenu = (props: any) => {
+  return (
+    <components.Menu {...props}>
+      <div className="label-filter-select__menu-loading">
+        <Spinner includeContainer={false} />
+      </div>
+    </components.Menu>
+  );
+};
+
 interface ILabelFilterSelectProps {
   labels: ILabel[];
   selectedLabel: ILabel | null;
@@ -73,6 +84,7 @@ interface ILabelFilterSelectProps {
   className?: string;
   onChange: (labelId: ILabel) => void;
   onAddLabel: () => void;
+  isLoading?: boolean;
 }
 
 const LabelFilterSelect = ({
@@ -82,6 +94,7 @@ const LabelFilterSelect = ({
   className,
   onChange,
   onAddLabel,
+  isLoading = false,
 }: ILabelFilterSelectProps) => {
   const [labelQuery, setLabelQuery] = useState("");
 
@@ -189,6 +202,7 @@ const LabelFilterSelect = ({
           GroupHeading: CustomLabelGroupHeading,
           DropdownIndicator: CustomDropdownIndicator,
           ValueContainer,
+          Menu: isLoading ? LoadingMenu : components.Menu,
         }}
         onChange={handleChange}
         closeMenuOnSelect
@@ -207,6 +221,7 @@ const LabelFilterSelect = ({
           onClickLabelSearchInput,
           onBlurLabelSearchInput,
         }}
+        isLoading={isLoading}
       />
     </div>
   );

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -1,5 +1,10 @@
 import React, { useMemo, useRef, useState } from "react";
-import Select, { GroupBase, SelectInstance, components } from "react-select-5";
+import Select, {
+  GroupBase,
+  SelectInstance,
+  components,
+  MenuProps,
+} from "react-select-5";
 import classnames from "classnames";
 
 import { ILabel } from "interfaces/label";
@@ -67,10 +72,12 @@ const formatOptionLabel = (data: ILabel | IEmptyOption) => {
   );
 };
 
-const LoadingMenu = (props: any) => {
+const LoadingMenu = (
+  props: MenuProps<ILabel | IEmptyOption, false, IGroupOption>
+) => {
   return (
     <components.Menu {...props}>
-      <div className="label-filter-select__menu-loading">
+      <div className={`${baseClass}__menu-loading`}>
         <Spinner includeContainer={false} />
       </div>
     </components.Menu>

--- a/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/LabelFilterSelect/LabelFilterSelect.tsx
@@ -221,7 +221,6 @@ const LabelFilterSelect = ({
           onClickLabelSearchInput,
           onBlurLabelSearchInput,
         }}
-        isLoading={isLoading}
       />
     </div>
   );


### PR DESCRIPTION
## Issue
closes #35377 

## Description
- Adds a loading spinner for the labels dropdown if labels is still loading (no box around the spinner, too busy looking)

## Screen recording

https://github.com/user-attachments/assets/101b0ef3-ea05-4d49-8c3f-4e5efcd6572f


## Testing

- [x] QA'd all new/changed functionality manually
