### PR TITLE
Create fleet modal: Remove purple banner

### DIFF
--- a/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/CreateTeamModal/CreateTeamModal.tsx
@@ -70,11 +70,6 @@ const CreateTeamModal = ({
           error={errors.name}
           ignore1password
         />
-        <InfoBanner className={`${baseClass}__sandbox-info`}>
-          To organize your hosts, create a team, like
-          &ldquo;Workstations,&rdquo; &ldquo;Servers,&rdquo; or &ldquo;Servers
-          (canary)&rdquo;.
-        </InfoBanner>
         <div className="modal-cta-wrap">
           <Button
             type="submit"


### PR DESCRIPTION
UPDATE: @noahtalerman: Closed this PR and opened up a new PR to the right branch: https://github.com/fleetdm/fleet/pull/39861

---

<img width="611" height="352" alt="Screenshot 2026-02-13 at 1 40 18 PM" src="https://github.com/user-attachments/assets/88e4b926-56c3-4cec-8c84-61585ed31bd1" />

- @noahtalerman: The [best practice teams](https://fleetdm.com/guides/teams#best-practice) are out of date. Instead of updating them, I think we can remove them. The plan is for new users to import the best practice teams.
