### PR TITLE
Update URL params in UI to use fleet naming instead of team

### DIFF
--- a/frontend/components/PlatformSelector/PlatformSelector.tsx
+++ b/frontend/components/PlatformSelector/PlatformSelector.tsx
@@ -55,7 +55,7 @@ export const PlatformSelector = ({
     const softwareId = installSoftware.software_title_id.toString();
     const softwareLink = getPathWithQueryParams(
       paths.SOFTWARE_TITLE_DETAILS(softwareId),
-      { team_id: currentTeamId }
+      { fleet_id: currentTeamId }
     );
 
     return (

--- a/frontend/components/TableContainer/DataTable/InstallerActionCell/InstallerActionCell.tsx
+++ b/frontend/components/TableContainer/DataTable/InstallerActionCell/InstallerActionCell.tsx
@@ -44,7 +44,7 @@ const InstallerActionCell = ({
   const onClick = () => {
     const path = getPathWithQueryParams(
       PATHS.SOFTWARE_FLEET_MAINTAINED_DETAILS(id),
-      { team_id: teamId }
+      { fleet_id: teamId }
     );
     if (router && path) {
       router?.push(path);

--- a/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
+++ b/frontend/components/top_nav/SiteTopNav/SiteTopNav.tsx
@@ -127,9 +127,9 @@ const SiteTopNav = ({
   const currentQueryParams = { ...query };
   if (isActiveGlobalPage || isActiveDetailPage) {
     // detail pages (e.g., host details) and some manage pages (e.g., queries) aren't guaranteed to
-    // have a team_id in the URL that we can simply append to the top nav links so instead we need grab the team
+    // have a fleet_id in the URL that we can simply append to the top nav links so instead we need grab the team
     // id from context
-    currentQueryParams.team_id =
+    currentQueryParams.fleet_id =
       currentTeam?.id === APP_CONTEXT_ALL_TEAMS_ID
         ? API_ALL_TEAMS_ID
         : currentTeam?.id;
@@ -153,7 +153,7 @@ const SiteTopNav = ({
             className={`${navItemBaseClass}__logo-wrapper`}
             currentQueryParams={currentQueryParams}
             to={navItem.location.pathname}
-            withParams={{ type: "query", names: ["team_id"] }}
+            withParams={{ type: "query", names: ["fleet_id"] }}
           >
             <div className={`${navItemBaseClass}__logo`}>
               <OrgLogoIcon className="logo" src={orgLogoURL} />
@@ -168,9 +168,9 @@ const SiteTopNav = ({
         ? navItem.location.pathname
         : currentPath;
 
-      if (currentQueryParams.team_id !== API_ALL_TEAMS_ID) {
+      if (currentQueryParams.fleet_id !== API_ALL_TEAMS_ID) {
         path = getPathWithQueryParams(path, {
-          team_id: currentQueryParams.team_id,
+          fleet_id: currentQueryParams.fleet_id,
         });
       }
 
@@ -198,7 +198,7 @@ const SiteTopNav = ({
           <LinkWithContext
             className={`${navItemBaseClass}__link`}
             withParams={withParams}
-            currentQueryParams={{ team_id: currentQueryParams.team_id }}
+            currentQueryParams={{ fleet_id: currentQueryParams.fleet_id }}
             to={navItem.location.pathname}
           >
             <span

--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -58,7 +58,7 @@ export default (
         regex: new RegExp(`^${URL_PREFIX}/hosts/`),
         pathname: PATHS.MANAGE_HOSTS,
       },
-      withParams: { type: "query", names: ["team_id"] },
+      withParams: { type: "query", names: ["fleet_id"] },
     },
     {
       name: "Controls",
@@ -68,7 +68,7 @@ export default (
       },
       exclude: !isMaintainerOrAdmin,
       alwaysToPathname: true,
-      withParams: { type: "query", names: ["team_id"] },
+      withParams: { type: "query", names: ["fleet_id"] },
     },
     {
       name: "Software",
@@ -77,7 +77,7 @@ export default (
         pathname: PATHS.SOFTWARE_TITLES,
       },
       alwaysToPathname: true,
-      withParams: { type: "query", names: ["team_id"] },
+      withParams: { type: "query", names: ["fleet_id"] },
     },
     {
       name: "Reports",
@@ -85,7 +85,7 @@ export default (
         regex: new RegExp(`^${URL_PREFIX}/queries/`),
         pathname: PATHS.MANAGE_QUERIES,
       },
-      withParams: { type: "query", names: ["team_id"] },
+      withParams: { type: "query", names: ["fleet_id"] },
     },
     {
       name: "Policies",
@@ -93,7 +93,7 @@ export default (
         regex: new RegExp(`^${URL_PREFIX}/(policies)/`),
         pathname: PATHS.MANAGE_POLICIES,
       },
-      withParams: { type: "query", names: ["team_id"] },
+      withParams: { type: "query", names: ["fleet_id"] },
     },
   ];
 

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -361,6 +361,16 @@ export const useTeamIdParam = ({
   overrideParamsOnTeamChange?: IConfigOverrideParamsOnTeamChange;
 }) => {
   const { hash, pathname, query, search } = location;
+
+  // Backward compat: redirect legacy ?team_id= URLs to ?fleet_id=
+  if (search.includes("team_id=")) {
+    router.replace(
+      pathname
+        .concat(search.replace(/\bteam_id=/g, "fleet_id="))
+        .concat(hash || "")
+    );
+  }
+
   const {
     availableTeams,
     currentTeam: contextTeam,

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -362,14 +362,7 @@ export const useTeamIdParam = ({
 }) => {
   const { hash, pathname, query, search } = location;
 
-  // Backward compat: redirect legacy ?team_id= URLs to ?fleet_id=
-  if (search.includes("team_id=")) {
-    router.replace(
-      pathname
-        .concat(search.replace(/\bteam_id=/g, "fleet_id="))
-        .concat(hash || "")
-    );
-  }
+  const hasLegacyTeamIdParam = search.includes("team_id=");
 
   const {
     availableTeams,
@@ -446,7 +439,15 @@ export const useTeamIdParam = ({
 
   // reconcile router location and redirect to default team as applicable
   let isRouteOk = false;
-  if (isFreeTier) {
+  if (hasLegacyTeamIdParam) {
+    // Backward compat: redirect legacy ?team_id= URLs to ?fleet_id=
+    // Skip other reconciliation to avoid a second redirect overwriting this one.
+    router.replace(
+      pathname
+        .concat(search.replace(/\bteam_id=/g, "fleet_id="))
+        .concat(hash || "")
+    );
+  } else if (isFreeTier) {
     // free tier should never have fleet_id param, so change to "All teams"
     if (query.fleet_id) {
       handleTeamChange(-1); // -1 because all pages on Free actually function as if on "All teams", even when not supported e.g. Controls

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -76,10 +76,20 @@ const rebuildQueryStringWithTeamId = (
     parts.splice(pageIndex, 1, "page=0");
   }
 
-  const teamIndex = parts.findIndex((p) => p.startsWith("team_id="));
-  // URLs for the app represent "All teams" by the absence of the team id param
+  // Backward compat: rewrite legacy team_id= to fleet_id=
+  const legacyIndex = parts.findIndex((p) => p.startsWith("team_id="));
+  if (legacyIndex !== -1) {
+    parts.splice(
+      legacyIndex,
+      1,
+      parts[legacyIndex].replace("team_id=", "fleet_id=")
+    );
+  }
+
+  const teamIndex = parts.findIndex((p) => p.startsWith("fleet_id="));
+  // URLs for the app represent "All teams" by the absence of the fleet id param
   const newTeamPart =
-    newTeamId > APP_CONTEXT_ALL_TEAMS_ID ? `team_id=${newTeamId}` : "";
+    newTeamId > APP_CONTEXT_ALL_TEAMS_ID ? `fleet_id=${newTeamId}` : "";
 
   if (teamIndex === -1) {
     // nothing to remove/replace so add the new part (if any) and rejoin
@@ -88,9 +98,9 @@ const rebuildQueryStringWithTeamId = (
     );
   }
 
-  if (teamIndex !== findLastIndex(parts, (p) => p.startsWith("team_id="))) {
+  if (teamIndex !== findLastIndex(parts, (p) => p.startsWith("fleet_id="))) {
     console.warn(
-      `URL contains more than one team_id parameter: ${queryString}`
+      `URL contains more than one fleet_id parameter: ${queryString}`
     );
   }
 
@@ -303,13 +313,13 @@ const shouldRedirectToDefaultTeam = ({
   userTeams: ITeamSummary[];
   includeAllTeams: boolean;
   includeNoTeam: boolean;
-  query: { team_id?: string };
+  query: { fleet_id?: string };
   isPrimoMode: boolean;
 }) => {
-  const teamIdString = query?.team_id || "";
+  const teamIdString = query?.fleet_id || "";
   const parsedTeamId = parseInt(teamIdString, 10);
 
-  // redirect non-numeric strings and negative numbers to default (e.g., `/hosts?team_id=-1` should
+  // redirect non-numeric strings and negative numbers to default (e.g., `/hosts?fleet_id=-1` should
   // be redirected to `/hosts`)
   if (teamIdString.length && (isNaN(parsedTeamId) || parsedTeamId < 0)) {
     return true;
@@ -339,7 +349,7 @@ export const useTeamIdParam = ({
   location?: {
     pathname: string;
     search: string;
-    query: { team_id?: string };
+    query: { fleet_id?: string };
     hash?: string;
     [key: string]: any; // for other location properties that may be passed in
   };
@@ -384,8 +394,8 @@ export const useTeamIdParam = ({
 
   const currentTeam = useMemo(
     () =>
-      userTeams?.find((t) => t.id === coerceAllTeamsId(query?.team_id || "")),
-    [query?.team_id, userTeams]
+      userTeams?.find((t) => t.id === coerceAllTeamsId(query?.fleet_id || "")),
+    [query?.fleet_id, userTeams]
   );
 
   const handleTeamChange = useCallback(
@@ -427,8 +437,8 @@ export const useTeamIdParam = ({
   // reconcile router location and redirect to default team as applicable
   let isRouteOk = false;
   if (isFreeTier) {
-    // free tier should never have team_id param, so change to "All teams"
-    if (query.team_id) {
+    // free tier should never have fleet_id param, so change to "All teams"
+    if (query.fleet_id) {
       handleTeamChange(-1); // -1 because all pages on Free actually function as if on "All teams", even when not supported e.g. Controls
     } else {
       isRouteOk = true;
@@ -483,7 +493,7 @@ export const useTeamIdParam = ({
       !!currentTeam?.id &&
       !!currentUser &&
       permissions.isObserverPlus(currentUser, currentTeam.id),
-    teamIdForApi: getTeamIdForApi({ currentTeam, includeNoTeam }), // for everywhere except AppContext: team_id=0 for No team (same as currentTeamId), undefined for All teams
+    teamIdForApi: getTeamIdForApi({ currentTeam, includeNoTeam }), // for everywhere except AppContext: fleet_id=0 for No team (same as currentTeamId), undefined for All teams
     userTeams,
     handleTeamChange,
   };

--- a/frontend/interfaces/team_subnav.ts
+++ b/frontend/interfaces/team_subnav.ts
@@ -5,7 +5,7 @@ export interface ITeamSubnavProps {
     pathname: string;
     search: string;
     hash?: string;
-    query: { team_id?: string };
+    query: { fleet_id?: string };
   };
   router: InjectedRouter;
 }

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -91,7 +91,7 @@ interface IDashboardProps {
     search: string;
     hash?: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
     };
   };
 }

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/components/ScriptBatchHostCountCell/ScriptBatchHostCountCell.tsx
@@ -25,7 +25,7 @@ const ScriptBatchHostCountCell = ({
   const hostPath = `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
     script_batch_execution_status: status,
     script_batch_execution_id: batchExecutionId,
-    team_id: teamId,
+    fleet_id: teamId,
   })}`;
 
   const renderCancelButton = () => {

--- a/frontend/pages/DashboardPage/cards/LowDiskSpaceHosts/LowDiskSpaceHosts.tsx
+++ b/frontend/pages/DashboardPage/cards/LowDiskSpaceHosts/LowDiskSpaceHosts.tsx
@@ -29,7 +29,7 @@ const LowDiskSpaceHosts = ({
     : PATHS.MANAGE_HOSTS;
   const path = getPathWithQueryParams(endpoint, {
     low_disk_space: lowDiskSpaceGb,
-    team_id: currentTeamId,
+    fleet_id: currentTeamId,
   });
 
   const tooltipText = notSupported

--- a/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
@@ -57,7 +57,7 @@ export const generateStatusTableHeaders = (
             mdm_enrollment_status:
               MDM_ENROLLMENT_STATUS_UI_MAP[cellProps.row.original.status]
                 .filterValue,
-            team_id: teamId,
+            fleet_id: teamId,
           }}
           className="mdm-solution-link"
           platformLabelId={cellProps.row.original.selectedPlatformLabelId}

--- a/frontend/pages/DashboardPage/cards/MissingHosts/MissingHosts.tsx
+++ b/frontend/pages/DashboardPage/cards/MissingHosts/MissingHosts.tsx
@@ -21,7 +21,7 @@ const MissingHosts = ({
   // build the manage hosts URL filtered by missing and platform
   const queryParams = {
     status: "missing",
-    team_id: currentTeamId,
+    fleet_id: currentTeamId,
   };
 
   const endpoint = selectedPlatformLabelId

--- a/frontend/pages/DashboardPage/cards/Munki/MunkiIssuesTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/Munki/MunkiIssuesTableConfig.tsx
@@ -91,7 +91,7 @@ const generateMunkiIssuesTableHeaders = (teamId?: number): IDataColumn[] => [
             <ViewAllHostsLink
               queryParams={{
                 munki_issue_id: cellProps.row.original.id,
-                team_id: teamId,
+                fleet_id: teamId,
               }}
               className="munki-issue-link"
             />

--- a/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/OperatingSystems/OSTableConfig.tsx
@@ -75,7 +75,7 @@ const generateDefaultTableHeaders = (
 
       const softwareOsDetailsPath = getPathWithQueryParams(
         PATHS.SOFTWARE_OS_DETAILS(os_version_id),
-        { team_id: teamId }
+        { fleet_id: teamId }
       );
 
       const onClickSoftware = (e: React.MouseEvent) => {
@@ -181,7 +181,7 @@ const generateDefaultTableHeaders = (
         <ViewAllHostsLink
           queryParams={{
             os_version_id,
-            team_id: teamId,
+            fleet_id: teamId,
           }}
           className="os-hosts-link"
           rowHover

--- a/frontend/pages/DashboardPage/cards/Software/Software.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/Software.tsx
@@ -61,7 +61,7 @@ const Software = ({
   const handleRowSelect = (row: IRowProps) => {
     const path = getPathWithQueryParams(PATHS.MANAGE_HOSTS, {
       software_id: row.original.id,
-      team_id: teamId,
+      fleet_id: teamId,
     });
 
     router.push(path);

--- a/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/Software/SoftwareTableConfig.tsx
@@ -74,7 +74,7 @@ const generateTableHeaders = (teamId?: number): IDataColumn[] => [
     Cell: (cellProps: ICellProps) => {
       return (
         <ViewAllHostsLink
-          queryParams={{ software_id: cellProps.cell.value, team_id: teamId }} // TODO: Should redirect with the current team id?
+          queryParams={{ software_id: cellProps.cell.value, fleet_id: teamId }} // TODO: Should redirect with the current team id?
           className="software-link"
           condensed
         />

--- a/frontend/pages/DashboardPage/cards/TotalHosts/TotalHosts.tsx
+++ b/frontend/pages/DashboardPage/cards/TotalHosts/TotalHosts.tsx
@@ -26,7 +26,7 @@ const TotalHosts = ({
     ? PATHS.MANAGE_HOSTS_LABEL(selectedPlatformLabelId)
     : PATHS.MANAGE_HOSTS;
   const path = getPathWithQueryParams(endpoint, {
-    team_id: currentTeamId,
+    fleet_id: currentTeamId,
   });
 
   return (

--- a/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
+++ b/frontend/pages/DashboardPage/components/MdmSolutionModal/MdmSolutionModalTableConfig.tsx
@@ -75,7 +75,7 @@ export const generateSolutionsTableHeaders = (
       <div className="host-count-cell">
         <TextCell value={cellProps.cell.value} className="" />
         <ViewAllHostsLink
-          queryParams={{ mdm_id: cellProps.row.original.id, team_id: teamId }}
+          queryParams={{ mdm_id: cellProps.row.original.id, fleet_id: teamId }}
           className="view-mdm-solution-link"
           platformLabelId={cellProps.row.original.selectedPlatformLabelId}
           rowHover

--- a/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
+++ b/frontend/pages/DashboardPage/sections/PlatformHostCounts/PlatformHostCounts.tsx
@@ -68,7 +68,7 @@ const PlatformHostCounts = ({
         count={macCount}
         title="macOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(macLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -90,7 +90,7 @@ const PlatformHostCounts = ({
         count={windowsCount}
         title="Windows"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(windowsLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -112,7 +112,7 @@ const PlatformHostCounts = ({
         count={linuxCount}
         title="Linux"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(linuxLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -135,7 +135,7 @@ const PlatformHostCounts = ({
         count={chromeCount}
         title="ChromeOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(chromeLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -158,7 +158,7 @@ const PlatformHostCounts = ({
         count={iosCount}
         title="iOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(iosLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -181,7 +181,7 @@ const PlatformHostCounts = ({
         count={ipadosCount}
         title="iPadOS"
         path={getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(ipadosLabelId), {
-          team_id: teamId,
+          fleet_id: teamId,
         })}
       />
     );
@@ -204,7 +204,7 @@ const PlatformHostCounts = ({
         count={androidCount}
         title="Android"
         path={PATHS.MANAGE_HOSTS_LABEL(androidLabelId).concat(
-          teamId !== undefined ? `?team_id=${teamId}` : ""
+          teamId !== undefined ? `?fleet_id=${teamId}` : ""
         )}
       />
     );

--- a/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
+++ b/frontend/pages/ManageControlsPage/ManageControlsPage.tsx
@@ -55,7 +55,7 @@ interface IManageControlsPageProps {
     search: string;
     hash?: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
       page?: string;
       order_key?: string;
       order_direction?: "asc" | "desc";

--- a/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/ProfileStatusAggregate/ProfileStatusAggregate.tsx
@@ -79,7 +79,7 @@ const ProfileStatusAggregate = ({
     const count = aggregateProfileStatusData[value];
 
     const hostsByStatusParams = {
-      team_id: teamId,
+      fleet_id: teamId,
       [HOSTS_QUERY_PARAMS.OS_SETTINGS]: value,
     };
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -94,7 +94,7 @@ const Certificates = ({
 
   // pagination controls
   const path = PATHS.CONTROLS_CERTIFICATES;
-  const queryString = isPremiumTier ? `?team_id=${currentTeamId}&` : "?";
+  const queryString = isPremiumTier ? `?fleet_id=${currentTeamId}&` : "?";
 
   const onPrevPage = useCallback(() => {
     router.push(path.concat(`${queryString}page=${currentPage - 1}`));

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -133,7 +133,7 @@ const CustomSettings = ({
 
   // pagination controls
   const path = PATHS.CONTROLS_CUSTOM_SETTINGS;
-  const queryString = isPremiumTier ? `?team_id=${currentTeamId}&` : "?";
+  const queryString = isPremiumTier ? `?fleet_id=${currentTeamId}&` : "?";
 
   const onPrevPage = useCallback(() => {
     router.push(path.concat(`${queryString}page=${currentPage - 1}`));

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ConfigProfileHostCountCell/ConfigProfileHostCountCell.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/components/ConfigProfileHostCountCell/ConfigProfileHostCountCell.tsx
@@ -27,7 +27,7 @@ const ConfigProfileHostCountCell = ({
   onClickResend,
 }: IConfigProfileHostCountCellProps) => {
   const hostPath = `${PATHS.MANAGE_HOSTS}?${buildQueryStringFromParams({
-    team_id: teamId,
+    fleet_id: teamId,
     profile_uuid: uuid,
     profile_status: status,
   })}`;

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/DiskEncryption/components/DiskEncryptionTable/DiskEncryptionTable.tsx
@@ -58,7 +58,7 @@ const DiskEncryptionTable = ({
 
       const queryParams = {
         [HOSTS_QUERY_PARAMS.DISK_ENCRYPTION]: status?.value,
-        team_id: teamId,
+        fleet_id: teamId,
       };
       const path = getPathWithQueryParams(PATHS.MANAGE_HOSTS, queryParams);
 

--- a/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/OSUpdates.tsx
@@ -106,7 +106,7 @@ const OSUpdates = ({ router, teamIdForApi, queryParams }: IOSUpdates) => {
   if (!isGlobalAdmin && !isTeamAdmin) {
     router.replace(
       getPathWithQueryParams(PATHS.CONTROLS_OS_SETTINGS, {
-        team_id: teamIdForApi,
+        fleet_id: teamIdForApi,
       })
     );
   }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTable.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTable.tsx
@@ -55,7 +55,7 @@ const OSVersionTable = ({
   const generateNewQueryParams = useCallback(
     (newTableQuery: ITableQueryData, changedParam: string) => {
       const newQueryParam: Record<string, string | number | undefined> = {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSVersionTable/OSVersionTableConfig.tsx
@@ -77,7 +77,7 @@ export const generateTableHeaders = (teamId: number) => {
                 queryParams={{
                   os_name: cellProps.row.original.name_only,
                   os_version: cellProps.row.original.version,
-                  team_id: teamId,
+                  fleet_id: teamId,
                 }}
                 className="os-hosts-link"
                 rowHover

--- a/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptBatchDetailsPage/ScriptBatchDetailsPage.tsx
@@ -125,7 +125,7 @@ const ScriptBatchDetailsPage = ({
   const pathToProgress = useMemo(() => {
     const params = buildQueryStringFromParams({
       status: batchDetails?.status,
-      team_id: batchDetails?.team_id,
+      fleet_id: batchDetails?.team_id,
     });
 
     return paths.CONTROLS_SCRIPTS_BATCH_PROGRESS + (params ? `?${params}` : "");

--- a/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/Scripts.tsx
@@ -18,7 +18,7 @@ export interface ScriptsLocation {
   search: string;
   pathname: string;
   query: {
-    team_id?: string;
+    fleet_id?: string;
     status?: string;
     page?: string;
   };

--- a/frontend/pages/ManageControlsPage/Scripts/ScriptsNavItems.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/ScriptsNavItems.tsx
@@ -28,13 +28,15 @@ const useScriptNavItems = (
       {
         title: "Library",
         urlSection: "library",
-        path: `${PATHS.CONTROLS_SCRIPTS_LIBRARY}?team_id=${teamId || 0}`,
+        path: `${PATHS.CONTROLS_SCRIPTS_LIBRARY}?fleet_id=${teamId || 0}`,
         Card: ScriptLibrary,
       },
       {
         title: "Batch progress",
         urlSection: "progress",
-        path: `${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?team_id=${teamId || 0}`,
+        path: `${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?fleet_id=${
+          teamId || 0
+        }`,
         Card: ScriptBatchProgress,
       },
     ],

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
@@ -76,7 +76,7 @@ const ScriptLibrary = ({ router, teamId, location }: IScriptLibraryProps) => {
 
   // pagination controls
   const path = PATHS.CONTROLS_SCRIPTS_LIBRARY;
-  const queryString = isPremiumTier ? `?team_id=${teamId}&` : "?";
+  const queryString = isPremiumTier ? `?fleet_id=${teamId}&` : "?";
   const onPrevPage = useCallback(() => {
     router.push(path.concat(`${queryString}page=${currentPage - 1}`));
   }, [router, path, currentPage, queryString]);

--- a/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/components/EditScriptModal/EditScriptModal.tsx
@@ -182,7 +182,7 @@ const EditScriptModal = ({
             <CustomLink
               text="Hosts"
               url={getPathWithQueryParams(paths.MANAGE_HOSTS, {
-                team_id: currentTeam?.id,
+                fleet_id: currentTeam?.id,
               })}
             />{" "}
             page and select a host.
@@ -192,7 +192,7 @@ const EditScriptModal = ({
             <CustomLink
               text="Policies"
               url={getPathWithQueryParams(paths.MANAGE_POLICIES, {
-                team_id: currentTeam?.id,
+                fleet_id: currentTeam?.id,
               })}
             />{" "}
             page.

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageTable/BootstrapPackageTableConfig.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapPackageTable/BootstrapPackageTableConfig.tsx
@@ -102,7 +102,7 @@ export const COLUMN_CONFIGS: IColumnConfig[] = [
               className="view-hosts-link"
               queryParams={{
                 bootstrap_package: cellProps.row.original.status.value,
-                team_id: cellProps.row.original.teamId,
+                fleet_id: cellProps.row.original.teamId,
               }}
               rowHover
             />

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -54,7 +54,7 @@ export interface InstallSoftwareLocation {
   search: string;
   pathname: string;
   query: {
-    team_id?: string;
+    fleet_id?: string;
   };
 }
 

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/AddInstallSoftware/AddInstallSoftware.tsx
@@ -56,7 +56,7 @@ const getAddSoftwareUrl = (
   }
 
   const params = {
-    team_id: teamId,
+    fleet_id: teamId,
     // Add android param to preselect Android dropdown on the Add App store page
     ...(platform === "android" && { platform }),
   };

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -47,7 +47,7 @@ const getTabIndex = (path: string): number => {
 };
 
 export interface ISoftwareAddPageQueryParams {
-  team_id?: string;
+  fleet_id?: string;
   query?: string;
   page?: string;
   order_key?: string;
@@ -75,20 +75,20 @@ const SoftwareAddPage = ({
       setSidePanelOpen(false);
       // Only query param to persist between tabs is team id
       const navPath = getPathWithQueryParams(addSoftwareSubNav[i].pathname, {
-        team_id: location.query.team_id,
+        fleet_id: location.query.fleet_id,
       });
       router.replace(navPath);
     },
-    [location.query.team_id, router, setSidePanelOpen]
+    [location.query.fleet_id, router, setSidePanelOpen]
   );
 
-  // Quick exit if no team_id param. This page must have a team id to function
+  // Quick exit if no fleet_id param. This page must have a team id to function
   // correctly. We redirect to the same page with the "No team" context if it
   // is not provieded.
-  if (!location.query.team_id) {
+  if (!location.query.fleet_id) {
     router.replace(
       getPathWithQueryParams(location.pathname, {
-        team_id: APP_CONTEXT_NO_TEAM_ID,
+        fleet_id: APP_CONTEXT_NO_TEAM_ID,
       })
     );
     return null;
@@ -99,7 +99,7 @@ const SoftwareAddPage = ({
   };
 
   const backUrl = getPathWithQueryParams(PATHS.SOFTWARE_TITLES, {
-    team_id: location.query.team_id,
+    fleet_id: location.query.fleet_id,
   });
 
   return (
@@ -132,7 +132,7 @@ const SoftwareAddPage = ({
           </TabNav>
           {React.cloneElement(children, {
             router,
-            currentTeamId: parseInt(location.query.team_id, 10),
+            currentTeamId: parseInt(location.query.fleet_id, 10),
             isSidePanelOpen,
             setSidePanelOpen,
           })}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStore.tsx
@@ -17,7 +17,7 @@ interface ISoftwareAppStoreProps {
   location: {
     pathname: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
       platform?: string;
     };
     search?: string;
@@ -41,7 +41,7 @@ const SoftwareAppStore = ({
   ) => {
     router.push(
       getPathWithQueryParams(PATHS.SOFTWARE_ADD_APP_STORE, {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         platform: selectedPlatform?.value,
       })
     );

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -41,7 +41,7 @@ const SoftwareAppStoreAndroid = ({
 
   const goBackToSoftwareTitles = (showAvailableForInstallOnly = false) => {
     const queryParams = {
-      team_id: currentTeamId,
+      fleet_id: currentTeamId,
       ...(showAvailableForInstallOnly && { available_for_install: true }),
     };
 
@@ -79,7 +79,7 @@ const SoftwareAppStoreAndroid = ({
       router.push(
         getPathWithQueryParams(
           PATHS.SOFTWARE_TITLE_DETAILS(softwareAppStoreTitleId.toString()),
-          { team_id: currentTeamId }
+          { fleet_id: currentTeamId }
         )
       );
     } catch (e) {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -150,7 +150,7 @@ const SoftwareAppStoreVpp = ({
 
   const goBackToSoftwareTitles = (showAvailableForInstallOnly = false) => {
     const queryParams = {
-      team_id: currentTeamId,
+      fleet_id: currentTeamId,
       ...(showAvailableForInstallOnly && { available_for_install: true }),
     };
 
@@ -185,7 +185,7 @@ const SoftwareAppStoreVpp = ({
       router.push(
         getPathWithQueryParams(
           PATHS.SOFTWARE_TITLE_DETAILS(softwareVppTitleId.toString()),
-          { team_id: currentTeamId }
+          { fleet_id: currentTeamId }
         )
       );
     } catch (e) {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -99,7 +99,7 @@ const SoftwareCustomPackage = ({
   const onCancel = () => {
     router.push(
       getPathWithQueryParams(PATHS.SOFTWARE_TITLES, {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
       })
     );
   };
@@ -144,7 +144,7 @@ const SoftwareCustomPackage = ({
       }
 
       const newQueryParams: QueryParams = {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         gitops_yaml: gitOpsModeEnabled ? "true" : undefined,
       };
       router.push(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -33,7 +33,7 @@ export const softwareAlreadyAddedTipContent = (
     ? getPathWithQueryParams(
         paths.SOFTWARE_TITLE_DETAILS(softwareTitleId.toString()),
         {
-          team_id: teamId,
+          fleet_id: teamId,
         }
       )
     : "";

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -107,7 +107,7 @@ const FleetAppSummary = ({
 };
 
 export interface IFleetMaintainedAppDetailsQueryParams {
-  team_id?: string;
+  fleet_id?: string;
 }
 
 interface IFleetMaintainedAppDetailsRouteParams {
@@ -131,7 +131,7 @@ const FleetMaintainedAppDetailsPage = ({
   router,
   routeParams,
 }: IFleetMaintainedAppDetailsPageProps) => {
-  const teamId = location.query.team_id;
+  const teamId = location.query.fleet_id;
   const appId = parseInt(routeParams.id, 10);
   if (isNaN(appId)) {
     router.push(PATHS.SOFTWARE_ADD_FLEET_MAINTAINED);
@@ -204,7 +204,7 @@ const FleetMaintainedAppDetailsPage = ({
 
   const backToAddSoftwareUrl = getPathWithQueryParams(
     PATHS.SOFTWARE_ADD_FLEET_MAINTAINED,
-    { team_id: teamId }
+    { fleet_id: teamId }
   );
 
   const onCancel = () => {
@@ -229,7 +229,7 @@ const FleetMaintainedAppDetailsPage = ({
         getPathWithQueryParams(
           PATHS.SOFTWARE_TITLE_DETAILS(softwareFmaTitleId.toString()),
           {
-            team_id: teamId,
+            fleet_id: teamId,
           }
         )
       );

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -134,7 +134,7 @@ const FleetMaintainedAppsTable = ({
     ) => {
       const newQueryParam: Record<string, string | number | undefined> = {
         query: newTableQuery.searchQuery,
-        team_id: teamId,
+        fleet_id: teamId,
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,

--- a/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOS/SoftwareOSTable/SoftwareOSTable.tsx
@@ -120,7 +120,7 @@ const SoftwareOSTable = ({
   const generateNewQueryParams = useCallback(
     (newTableQuery: ITableQueryData, changedParam: string) => {
       return {
-        team_id: teamId,
+        fleet_id: teamId,
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
@@ -162,7 +162,7 @@ const SoftwareOSTable = ({
   const handleRowSelect = (row: IRowProps) => {
     const path = getPathWithQueryParams(
       PATHS.SOFTWARE_OS_DETAILS(Number(row.original.os_version_id)),
-      { team_id: teamId }
+      { fleet_id: teamId }
     );
 
     router.push(path);
@@ -216,7 +216,7 @@ const SoftwareOSTable = ({
       getNextLocationPath({
         pathPrefix: PATHS.SOFTWARE_OS,
         queryParams: {
-          team_id: teamId,
+          fleet_id: teamId,
           order_direction: orderDirection,
           order_key: orderKey,
           page: 0,

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tsx
@@ -139,7 +139,7 @@ export const KernelsCard = ({
 
 interface ISoftwareOSDetailsRouteParams {
   id: string;
-  team_id?: string;
+  fleet_id?: string;
 }
 
 type ISoftwareOSDetailsPageProps = RouteComponentProps<

--- a/frontend/pages/SoftwarePage/SoftwarePage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwarePage.tsx
@@ -101,7 +101,7 @@ interface ISoftwarePageProps {
     pathname: string;
     search: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
       available_for_install?: string;
       self_service?: string;
       vulnerable?: string;
@@ -274,7 +274,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     } else {
       router.push(
         getPathWithQueryParams(PATHS.SOFTWARE_ADD_FLEET_MAINTAINED, {
-          team_id: currentTeamId,
+          fleet_id: currentTeamId,
         })
       );
     }
@@ -312,7 +312,7 @@ const SoftwarePage = ({ children, router, location }: ISoftwarePageProps) => {
     (i: number): void => {
       // Only query param to persist between tabs is team id
       const teamIdParam = {
-        team_id: location?.query.team_id,
+        fleet_id: location?.query.fleet_id,
         page: 0, // Fixes flakey page reset in API call when switching between tabs
       };
 

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTable.tsx
@@ -100,7 +100,7 @@ const TitleVersionsTable = ({
 
       const softwareVersionDetailsPath = getPathWithQueryParams(
         PATHS.SOFTWARE_VERSION_DETAILS(softwareVersionId.toString()),
-        { team_id: teamIdForApi }
+        { fleet_id: teamIdForApi }
       );
 
       router.push(softwareVersionDetailsPath);

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareSummaryCard/TitleVersionsTable/TitleVersionsTableConfig.tsx
@@ -44,7 +44,7 @@ const generateSoftwareTitleVersionsTableConfig = ({
         const { id } = cellProps.row.original;
         const softwareVersionDetailsPath = getPathWithQueryParams(
           PATHS.SOFTWARE_VERSION_DETAILS(id.toString()),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         return (
@@ -96,7 +96,7 @@ const generateSoftwareTitleVersionsTableConfig = ({
               <ViewAllHostsLink
                 queryParams={{
                   software_version_id: cellProps.row.original.id,
-                  team_id: teamId,
+                  fleet_id: teamId,
                 }}
                 className="software-link"
                 rowHover

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareTitleDetailsPage.tsx
@@ -120,7 +120,7 @@ const SoftwareTitleDetailsPage = ({
     // redirect to software titles page if no versions are available
     router.push(
       getPathWithQueryParams(paths.SOFTWARE_TITLES, {
-        team_id: teamIdForApi,
+        fleet_id: teamIdForApi,
       })
     );
   }, [refetchSoftwareTitle, router, softwareTitle, teamIdForApi]);

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -128,7 +128,7 @@ const SoftwareTable = ({
     (newTableQuery: ITableQueryData, changedParam: string) => {
       const newQueryParam: Record<string, string | number | undefined> = {
         query: newTableQuery.searchQuery,
-        team_id: teamId,
+        fleet_id: teamId,
         order_direction: newTableQuery.sortDirection,
         order_key: newTableQuery.sortHeader,
         page: changedParam === "pageIndex" ? newTableQuery.pageIndex : 0,
@@ -203,7 +203,7 @@ const SoftwareTable = ({
   const handleShowVersionsToggle = () => {
     const queryParams: Record<string, string | number | boolean | undefined> = {
       query,
-      team_id: teamId,
+      fleet_id: teamId,
       order_direction: orderDirection,
       order_key: orderKey,
       page: 0, // resets page index
@@ -251,7 +251,7 @@ const SoftwareTable = ({
       ? PATHS.SOFTWARE_VERSION_DETAILS(row.original.id.toString())
       : PATHS.SOFTWARE_TITLE_DETAILS(row.original.id.toString());
 
-    router.push(getPathWithQueryParams(detailsPath, { team_id: teamId }));
+    router.push(getPathWithQueryParams(detailsPath, { fleet_id: teamId }));
   };
 
   const renderSoftwareCount = () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTitlesTableConfig.tsx
@@ -47,7 +47,7 @@ const getSoftwareNameCellData = (
 ) => {
   const softwareTitleDetailsPath = getPathWithQueryParams(
     PATHS.SOFTWARE_TITLE_DETAILS(softwareTitle.id.toString()),
-    { team_id: teamId }
+    { fleet_id: teamId }
   );
 
   const { software_package, app_store_app } = softwareTitle;
@@ -206,7 +206,7 @@ const generateTableHeaders = (
           <ViewAllHostsLink
             queryParams={{
               software_title_id: cellProps.row.original.id,
-              team_id: teamId,
+              fleet_id: teamId,
             }}
             className="software-link"
             rowHover

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -44,7 +44,7 @@ const baseClass = "software-version-details-page";
 
 interface ISoftwareVersionDetailsRouteParams {
   id: string;
-  team_id?: string;
+  fleet_id?: string;
 }
 
 type ISoftwareTitleDetailsPageProps = RouteComponentProps<

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilities/SoftwareVulnerabilitiesTable/VulnerabilitiesTableConfig.tsx
@@ -80,7 +80,7 @@ const generateTableHeaders = (
 
         const softwareVulnerabilitiesDetailsPath = getPathWithQueryParams(
           PATHS.SOFTWARE_VULNERABILITY_DETAILS(cve),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         const onClickVulnerability = (e: React.MouseEvent) => {
@@ -263,7 +263,7 @@ const generateTableHeaders = (
               <ViewAllHostsLink
                 queryParams={{
                   vulnerability: cellProps.row.original.cve,
-                  team_id: teamId,
+                  fleet_id: teamId,
                 }}
                 className="vulnerabilities-link"
                 rowHover

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SoftwareVulnOSVersions.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SoftwareVulnOSVersions.tsx
@@ -46,7 +46,7 @@ const SoftwareVulnOSVersions = ({
 
       const softwareOsDetailsPath = getPathWithQueryParams(
         PATHS.SOFTWARE_OS_DETAILS(softwareOsVersionId),
-        { team_id: teamIdForApi }
+        { fleet_id: teamIdForApi }
       );
 
       router.push(softwareOsDetailsPath);

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnOSVersions/SwVulnOSTableConfig.tsx
@@ -39,7 +39,7 @@ const generateColumnConfigs = (
         // since No Teams not supported on this page, falsiness of 0 is okay
         const path = getPathWithQueryParams(
           PATHS.SOFTWARE_OS_DETAILS(os_version_id),
-          { team_id: teamIdForApi }
+          { fleet_id: teamIdForApi }
         );
 
         return (

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
@@ -49,7 +49,7 @@ const SoftwareVulnSoftwareVersions = ({
       const softwareVersionDetailsPath = getPathWithQueryParams(
         PATHS.SOFTWARE_VERSION_DETAILS(softwareVersionId.toString()),
         {
-          team_id: teamIdForApi,
+          fleet_id: teamIdForApi,
         }
       );
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -38,7 +38,7 @@ const generateColumnConfigs = (
         // since No Teams not supported on this page, falsiness of 0 is okay
         const path = getPathWithQueryParams(
           PATHS.SOFTWARE_VERSION_DETAILS(id.toString()),
-          { team_id: teamIdForApi }
+          { fleet_id: teamIdForApi }
         );
 
         // Currently does not support icon_url

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSummary/SoftwareVulnSummary.tsx
@@ -42,7 +42,7 @@ const SoftwareVulnSummary = ({
 
   const hostCountPath = getPathWithQueryParams(paths.MANAGE_HOSTS, {
     vulnerability: cve,
-    team_id: teamIdForApi,
+    fleet_id: teamIdForApi,
   });
 
   return (

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnerabilityDetailsPage.tsx
@@ -31,7 +31,7 @@ const baseClass = "software-vulnerability-details-page";
 
 interface ISoftwareVulnerabilityDetailsRouteParams {
   cve: string;
-  team_id?: string;
+  fleet_id?: string;
 }
 
 type ISoftwareVulnerabilityDetailsPageProps = RouteComponentProps<

--- a/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/OSKernelsTable/OSKernelsTableConfig.tsx
@@ -48,7 +48,7 @@ const generateTableConfig = ({
         const { id } = cellProps.row.original;
         const softwareVersionDetailsPath = getPathWithQueryParams(
           PATHS.SOFTWARE_VERSION_DETAILS(id.toString()),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         return (
@@ -106,7 +106,7 @@ const generateTableConfig = ({
               <ViewAllHostsLink
                 queryParams={{
                   software_version_id: cellProps.row.original.id,
-                  team_id: teamId,
+                  fleet_id: teamId,
                   os_name: osName,
                   os_version: osVersion,
                 }}

--- a/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTableConfig.tsx
@@ -62,7 +62,7 @@ const generateTableConfig = (
 
         const softwareVulnerabilityDetailsPath = getPathWithQueryParams(
           paths.SOFTWARE_VULNERABILITY_DETAILS(cveName),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         return (
@@ -218,7 +218,7 @@ const generateTableConfig = (
               <ViewAllHostsLink
                 queryParams={{
                   vulnerability: cellProps.row.original.cve,
-                  team_id: teamId,
+                  fleet_id: teamId,
                 }}
                 className="vulnerabilities-link"
                 rowHover

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -65,7 +65,7 @@ interface ITeamDetailsPageProps {
     pathname: string;
     search: string;
     hash?: string;
-    query: { team_id?: string };
+    query: { fleet_id?: string };
   };
   router: InjectedRouter;
 }

--- a/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
@@ -31,7 +31,7 @@ const DeleteTeamModal = ({
           <span className={`${baseClass}__name`}>{name}</span> from Fleet.
         </p>
         <p>
-          Users in this fleet who are not assigned to other fleets will lose
+          Users in this fleet who aren&apos;t assigned to other fleets will lose
           access to Fleet.
         </p>
         <p className={`${baseClass}__warning`}>This action cannot be undone.</p>

--- a/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/DeleteTeamModal/DeleteTeamModal.tsx
@@ -31,7 +31,8 @@ const DeleteTeamModal = ({
           <span className={`${baseClass}__name`}>{name}</span> fleet.
         </p>
         <p>
-          Users on this fleet who are not assigned to other fleets won't be able to login.
+          Users on this fleet who are not assigned to other fleets won&apos;t be
+          able to login.
         </p>
         <div className="modal-cta-wrap">
           <Button

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -2,7 +2,7 @@ import { HOSTS_QUERY_PARAMS } from "services/entities/hosts";
 
 export const MANAGE_HOSTS_PAGE_FILTER_KEYS = [
   "query",
-  "team_id",
+  "fleet_id",
   "policy_id",
   "policy_response",
   "macos_settings",

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1033,7 +1033,7 @@ const ManageHostsPage = ({
       newQueryParams.order_direction =
         sort[0].direction || DEFAULT_SORT_DIRECTION;
 
-      newQueryParams.team_id = teamIdForApi;
+      newQueryParams.fleet_id = teamIdForApi;
 
       if (status) {
         newQueryParams.status = status;
@@ -1603,10 +1603,10 @@ const ManageHostsPage = ({
     };
 
     if (
-      queryParams.team_id !== API_ALL_TEAMS_ID &&
-      queryParams.team_id !== ""
+      queryParams.fleet_id !== API_ALL_TEAMS_ID &&
+      queryParams.fleet_id !== ""
     ) {
-      options.teamId = queryParams.team_id;
+      options.teamId = queryParams.fleet_id;
     }
 
     try {
@@ -1682,7 +1682,7 @@ const ManageHostsPage = ({
 
   const includesFilterQueryParam = MANAGE_HOSTS_PAGE_FILTER_KEYS.some(
     (filter) =>
-      filter !== "team_id" &&
+      filter !== "fleet_id" &&
       typeof queryParams === "object" &&
       filter in queryParams // TODO: replace this with `Object.hasOwn(queryParams, filter)` when we upgrade to es2022
   );

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tsx
@@ -177,7 +177,7 @@ const RunScriptBatchModal = ({
             <>
               Successfully scheduled script.{" "}
               <Link
-                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=scheduled&fleet_id=${teamId})`}
+                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=scheduled&fleet_id=${teamId}`}
               >
                 Show schedule
               </Link>
@@ -189,7 +189,7 @@ const RunScriptBatchModal = ({
             <>
               Successfully ran script.{" "}
               <Link
-                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=started&fleet_id=${teamId})`}
+                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=started&fleet_id=${teamId}`}
               >
                 Show script activity
               </Link>

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tsx
@@ -177,7 +177,7 @@ const RunScriptBatchModal = ({
             <>
               Successfully scheduled script.{" "}
               <Link
-                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=scheduled&team_id=${teamId})`}
+                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=scheduled&fleet_id=${teamId})`}
               >
                 Show schedule
               </Link>
@@ -189,7 +189,7 @@ const RunScriptBatchModal = ({
             <>
               Successfully ran script.{" "}
               <Link
-                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=started&team_id=${teamId})`}
+                to={`${PATHS.CONTROLS_SCRIPTS_BATCH_PROGRESS}?status=started&fleet_id=${teamId})`}
               >
                 Show script activity
               </Link>
@@ -228,7 +228,7 @@ const RunScriptBatchModal = ({
                 href={
                   isFreeTier
                     ? "/controls/scripts"
-                    : `/controls/scripts?team_id=${teamId}`
+                    : `/controls/scripts?fleet_id=${teamId}`
                 }
               >
                 here

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -112,7 +112,7 @@ const HostQueryReport = ({
   const HQRHeader = useCallback(() => {
     const fullReportPath = getPathWithQueryParams(
       PATHS.QUERY_DETAILS(queryId),
-      { team_id: currentTeam?.id }
+      { fleet_id: currentTeam?.id }
     );
     return (
       <div className={`${baseClass}__header`}>

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/HostSoftwareLibraryTable/HostSoftwareLibraryTableConfig.tsx
@@ -103,7 +103,7 @@ export const generateHostSWLibraryTableHeaders = ({
 
         const softwareTitleDetailsPath = getPathWithQueryParams(
           PATHS.SOFTWARE_TITLE_DETAILS(id.toString()),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         const hasInstaller = !!app_store_app || !!software_package;

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tests.tsx
@@ -28,7 +28,7 @@ describe("Host Summary section", () => {
     });
   });
 
-  describe("Team data", () => {
+  describe("Fleet data", () => {
     it("renders the team name when present", () => {
       const render = createCustomRenderer({
         context: {
@@ -41,7 +41,7 @@ describe("Host Summary section", () => {
       });
       const summaryData = createMockHostSummary({ team_name: "Engineering" });
       render(<HostSummary summaryData={summaryData} isPremiumTier />);
-      expect(screen.getByText("Team").nextElementSibling).toHaveTextContent(
+      expect(screen.getByText("Fleet").nextElementSibling).toHaveTextContent(
         "Engineering"
       );
     });
@@ -57,7 +57,7 @@ describe("Host Summary section", () => {
   });
 
   describe("iOS and iPadOS data", () => {
-    it("for iOS, renders Team data only", async () => {
+    it("for iOS, renders Fleet data only", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -79,11 +79,11 @@ describe("Host Summary section", () => {
 
       render(<HostSummary summaryData={summaryData} isPremiumTier />);
 
-      expect(screen.getByText("Team").nextElementSibling).toHaveTextContent(
+      expect(screen.getByText("Fleet").nextElementSibling).toHaveTextContent(
         teamName
       );
     });
-    it("for iPadOS, renders Team data only", async () => {
+    it("for iPadOS, renders Fleet data only", async () => {
       const render = createCustomRenderer({
         context: {
           app: {
@@ -105,7 +105,7 @@ describe("Host Summary section", () => {
 
       render(<HostSummary summaryData={summaryData} isPremiumTier />);
 
-      expect(screen.getByText("Team").nextElementSibling).toHaveTextContent(
+      expect(screen.getByText("Fleet").nextElementSibling).toHaveTextContent(
         teamName
       );
     });

--- a/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
+++ b/frontend/pages/hosts/details/cards/Software/HostSoftwareTableConfig.tsx
@@ -77,7 +77,7 @@ export const generateSoftwareTableHeaders = ({
 
         const softwareTitleDetailsPath = getPathWithQueryParams(
           PATHS.SOFTWARE_TITLE_DETAILS(id.toString()),
-          { team_id: teamId }
+          { fleet_id: teamId }
         );
 
         const hasInstaller = !!app_store_app || !!software_package;

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -84,7 +84,7 @@ interface IManagePoliciesPageProps {
     key: string;
     pathname: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
       query?: string;
       order_key?: string;
       order_direction?: "asc" | "desc";
@@ -446,7 +446,7 @@ const ManagePolicyPage = ({
       }
 
       if (isRouteOk && teamIdForApi !== undefined) {
-        newQueryParams.team_id = teamIdForApi;
+        newQueryParams.fleet_id = teamIdForApi;
       }
 
       const locationPath = getNextLocationPath({
@@ -815,7 +815,7 @@ const ManagePolicyPage = ({
     router.push(
       currentTeamId === API_ALL_TEAMS_ID
         ? PATHS.NEW_POLICY
-        : `${PATHS.NEW_POLICY}?team_id=${currentTeamId}`
+        : `${PATHS.NEW_POLICY}?fleet_id=${currentTeamId}`
     );
   };
 

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -43,7 +43,7 @@ interface IPolicyPageProps {
   location: {
     pathname: string;
     search: string;
-    query: { host_ids: string; team_id: string };
+    query: { host_ids: string; fleet_id: string };
     hash?: string;
   };
 }
@@ -223,11 +223,11 @@ const PolicyPage = ({
     !isStoredPolicyLoading &&
     storedPolicy?.team_id !== undefined &&
     storedPolicy?.team_id !== null &&
-    !(storedPolicy?.team_id?.toString() === location.query.team_id)
+    !(storedPolicy?.team_id?.toString() === location.query.fleet_id)
   ) {
     router.push(
       getPathWithQueryParams(location.pathname, {
-        team_id: storedPolicy?.team_id?.toString(),
+        fleet_id: storedPolicy?.team_id?.toString(),
       })
     );
   }

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -168,7 +168,7 @@ const QueryEditor = ({
       setIsUpdatingPolicy(false);
       router.push(
         getPathWithQueryParams(PATHS.EDIT_POLICY(policy.id), {
-          team_id: policy.team_id,
+          fleet_id: policy.team_id,
         })
       );
       renderFlash("success", "Policy created!");
@@ -243,7 +243,7 @@ const QueryEditor = ({
 
   // Function instead of constant eliminates race condition with filteredPoliciesPath
   const backToPoliciesPath = () => {
-    const queryParams = { team_id: teamIdForApi };
+    const queryParams = { fleet_id: teamIdForApi };
 
     return (
       filteredPoliciesPath ||

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -60,7 +60,7 @@ interface IManageQueriesPageProps {
       query?: string;
       order_key?: string;
       order_direction?: "asc" | "desc";
-      team_id?: string;
+      fleet_id?: string;
     };
     search: string;
   };
@@ -194,7 +194,7 @@ const ManageQueriesPage = ({
   const onCreateQueryClick = useCallback(() => {
     setLastEditedQueryBody(DEFAULT_QUERY.query);
     router.push(
-      getPathWithQueryParams(PATHS.NEW_QUERY, { team_id: currentTeamId })
+      getPathWithQueryParams(PATHS.NEW_QUERY, { fleet_id: currentTeamId })
     );
   }, [currentTeamId, router, setLastEditedQueryBody]);
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -41,7 +41,7 @@ export interface IQueriesTableProps {
     query?: string;
     order_key?: string;
     order_direction?: "asc" | "desc";
-    team_id?: string;
+    fleet_id?: string;
   };
   currentTeamId?: number;
   isPremiumTier?: boolean;
@@ -152,7 +152,7 @@ const QueriesTable = ({
       ) {
         newQueryParams.page = "0";
       }
-      newQueryParams.team_id = queryParams?.team_id;
+      newQueryParams.fleet_id = queryParams?.fleet_id;
 
       const locationPath = getNextLocationPath({
         pathPrefix: PATHS.MANAGE_QUERIES,
@@ -230,7 +230,7 @@ const QueriesTable = ({
     if (row.original.id) {
       router?.push(
         getPathWithQueryParams(PATHS.QUERY_DETAILS(row.original.id), {
-          team_id: currentTeamId,
+          fleet_id: currentTeamId,
         })
       );
     }

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -52,7 +52,7 @@ interface IQueryDetailsPageProps {
   location: {
     pathname: string;
     query: {
-      team_id?: string;
+      fleet_id?: string;
       order_key?: string;
       order_direction?: string;
       host_id?: string;
@@ -178,11 +178,11 @@ const QueryDetailsPage = ({
     !isOnGlobalTeam &&
     !isStoredQueryLoading &&
     storedQuery?.team_id &&
-    !(storedQuery?.team_id?.toString() === location.query.team_id)
+    !(storedQuery?.team_id?.toString() === location.query.fleet_id)
   ) {
     router.push(
       getPathWithQueryParams(location.pathname, {
-        team_id: storedQuery?.team_id?.toString(),
+        fleet_id: storedQuery?.team_id?.toString(),
       })
     );
   }
@@ -256,7 +256,7 @@ const QueryDetailsPage = ({
       if (hostId) return getPathWithQueryParams(PATHS.HOST_DETAILS(hostId));
 
       return getPathWithQueryParams(PATHS.MANAGE_QUERIES, {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
       });
     };
 
@@ -304,7 +304,7 @@ const QueryDetailsPage = ({
                                 PATHS.LIVE_QUERY(queryId),
                                 {
                                   host_id: hostId,
-                                  team_id: currentTeamId,
+                                  fleet_id: currentTeamId,
                                 }
                               )
                             );
@@ -332,7 +332,7 @@ const QueryDetailsPage = ({
                       queryId &&
                         router.push(
                           getPathWithQueryParams(PATHS.EDIT_QUERY(queryId), {
-                            team_id: currentTeamId,
+                            fleet_id: currentTeamId,
                             host_id: hostId,
                           })
                         );

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -42,7 +42,7 @@ import EditQueryForm from "./components/EditQueryForm";
 interface IEditQueryPageProps {
   router: InjectedRouter;
   params: Params;
-  location: Location<{ host_id: string; team_id?: string }>;
+  location: Location<{ host_id: string; fleet_id?: string }>;
 }
 
 const baseClass = "edit-query-page";
@@ -171,11 +171,11 @@ const EditQueryPage = ({
     !isOnGlobalTeam &&
     !isStoredQueryLoading &&
     storedQuery?.team_id &&
-    !(storedQuery?.team_id?.toString() === location.query.team_id)
+    !(storedQuery?.team_id?.toString() === location.query.fleet_id)
   ) {
     router.push(
       getPathWithQueryParams(location.pathname, {
-        team_id: storedQuery?.team_id?.toString(),
+        fleet_id: storedQuery?.team_id?.toString(),
         host_id: hostId,
       })
     );
@@ -216,7 +216,7 @@ const EditQueryPage = ({
       router.push(
         getPathWithQueryParams(PATHS.QUERY_DETAILS(queryId), {
           host_id: location.query.host_id,
-          team_id: location.query.team_id,
+          fleet_id: location.query.fleet_id,
         })
       );
     }
@@ -266,7 +266,7 @@ const EditQueryPage = ({
         const { query } = await queryAPI.create(formData);
         router.push(
           getPathWithQueryParams(PATHS.QUERY_DETAILS(query.id), {
-            team_id: query.team_id,
+            fleet_id: query.team_id,
             host_id: hostId,
           })
         );
@@ -375,7 +375,7 @@ const EditQueryPage = ({
   const backPath = () => {
     if (queryId) {
       return getPathWithQueryParams(PATHS.QUERY_DETAILS(queryId), {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         host_id: hostId,
       });
     }
@@ -387,7 +387,7 @@ const EditQueryPage = ({
     if (filteredQueriesPath) return filteredQueriesPath;
 
     return getPathWithQueryParams(PATHS.MANAGE_QUERIES, {
-      team_id: currentTeamId,
+      fleet_id: currentTeamId,
     });
   };
 

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -29,7 +29,7 @@ interface IRunQueryPageProps {
   params: Params;
   location: {
     pathname: string;
-    query: { host_id: string; team_id?: string };
+    query: { host_id: string; fleet_id?: string };
     search: string;
   };
 }
@@ -90,7 +90,7 @@ const RunQueryPage = ({
 
     router.push(
       getPathWithQueryParams(path, {
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
       })
     );
   }
@@ -163,7 +163,7 @@ const RunQueryPage = ({
   const goToQueryEditor = useCallback(() => {
     const path = queryId ? PATHS.EDIT_QUERY(queryId) : PATHS.NEW_QUERY;
 
-    router.push(getPathWithQueryParams(path, { team_id: currentTeamId }));
+    router.push(getPathWithQueryParams(path, { fleet_id: currentTeamId }));
   }, []);
 
   const renderScreen = () => {

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -182,19 +182,19 @@ export default {
 
   TEAM_DETAILS_USERS: (teamId?: number): string => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/users?team_id=${teamId}`;
+      return `${URL_PREFIX}/settings/teams/users?fleet_id=${teamId}`;
     }
     return `${URL_PREFIX}/settings/teams`;
   },
   TEAM_DETAILS_OPTIONS: (teamId?: number): string => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/options?team_id=${teamId}`;
+      return `${URL_PREFIX}/settings/teams/options?fleet_id=${teamId}`;
     }
     return `${URL_PREFIX}/settings/teams`;
   },
   TEAM_DETAILS_SETTINGS: (teamId?: number) => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/settings?team_id=${teamId}`;
+      return `${URL_PREFIX}/settings/teams/settings?fleet_id=${teamId}`;
     }
     return `${URL_PREFIX}/settings/teams`;
   },

--- a/frontend/utilities/url/url.tests.ts
+++ b/frontend/utilities/url/url.tests.ts
@@ -54,11 +54,11 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: 25,
-      team_id: 10,
+      fleet_id: 10,
       order_key: "issues",
     };
     expect(getPathWithQueryParams(endpoint, queryParams)).toBe(
-      "/hosts/manage?software_id=25&team_id=10&order_key=issues"
+      "/hosts/manage?software_id=25&fleet_id=10&order_key=issues"
     );
   });
 
@@ -66,7 +66,7 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: undefined,
-      team_id: null,
+      fleet_id: null,
       policy_response: "",
       policy_id: 4,
     };
@@ -79,7 +79,7 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: undefined,
-      team_id: null,
+      fleet_id: null,
       policy_response: "",
     };
     expect(getPathWithQueryParams(endpoint, queryParams)).toBe("/hosts/manage");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Renamed URL query parameter from `team_id` to `fleet_id` across the application for improved terminology clarity.
  * Added backward compatibility to automatically redirect legacy URLs using the old parameter name to the new parameter format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->