### PR TITLE
Remove ineffectual defaulting on MySQL database/username while in dev mode

### DIFF
--- a/cmd/fleet/main.go
+++ b/cmd/fleet/main.go
@@ -100,8 +100,8 @@ func applyDevFlags(cfg *config.FleetConfig) {
 		}
 	}
 
-	setIfEmpty(&cfg.Mysql.Username, "fleet")
-	setIfEmpty(&cfg.Mysql.Database, "fleet")
+	// We don't set defaults for database and username here because there are already defaults in config.go
+	// that match our default dev setup.
 	setIfEmpty(&cfg.Mysql.Password, "insecure")
 
 	setIfEmpty(&cfg.Prometheus.BasicAuth.Username, "fleet")


### PR DESCRIPTION
Due to config.go, username/database are defaulted to `fleet` rather than blank, which means that if you changed the defaults here they wouldn't apply (so it looked like the defaulting worked, but that was just a coincidence). Removing the code and explaining why makes it a bit clearer what's going on, so we know that we don't set a different set of defaults for these fields when running the Fleet server with `--dev`.

Thanks @AndreyKizimenko for catching this one! This reflects a change we paired on in QA.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results