### PR TITLE
Converted osquery_utils to slog

### DIFF
--- a/cmd/maintained-apps/validate/app_commander.go
+++ b/cmd/maintained-apps/validate/app_commander.go
@@ -94,7 +94,7 @@ func (ac *AppCommander) uninstallApp(ctx context.Context) bool {
 	}
 	ac.appLogger.DebugContext(ctx, fmt.Sprintf("Output: %s", output))
 
-	existance, err := appExists(ctx, ac.cfg.logger, ac.Name, ac.UniqueIdentifier, ac.Version, ac.AppPath)
+	existance, err := appExists(ctx, ac.appLogger, ac.Name, ac.UniqueIdentifier, ac.Version, ac.AppPath)
 	if err != nil {
 		ac.appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if app exists after uninstall: %v", err))
 		return false

--- a/cmd/maintained-apps/validate/app_commander_test.go
+++ b/cmd/maintained-apps/validate/app_commander_test.go
@@ -4,11 +4,11 @@ package main
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
 
-	kitlog "github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 
@@ -24,7 +24,7 @@ func TestExpectToChangeFileSystem(t *testing.T) {
 			name:   "no changes",
 			before: func() {},
 			testFunc: func(t *testing.T) {
-				appPath, changerError, listError := ac.expectToChangeFileSystem(
+				appPath, changerError, listError := ac.expectToChangeFileSystem(t.Context(),
 					func() error {
 						return nil
 					},
@@ -38,7 +38,7 @@ func TestExpectToChangeFileSystem(t *testing.T) {
 			name:   "item added",
 			before: func() {},
 			testFunc: func(t *testing.T) {
-				appPath, changerError, listError := ac.expectToChangeFileSystem(
+				appPath, changerError, listError := ac.expectToChangeFileSystem(t.Context(),
 					func() error {
 						err := os.Mkdir(filepath.Join(ac.cfg.installationSearchDirectory, "app1"), 0o755)
 						if err != nil {
@@ -66,7 +66,7 @@ func TestExpectToChangeFileSystem(t *testing.T) {
 				}
 			},
 			testFunc: func(t *testing.T) {
-				appPath, changerError, listError := ac.expectToChangeFileSystem(
+				appPath, changerError, listError := ac.expectToChangeFileSystem(t.Context(),
 					func() error {
 						err := os.Remove(filepath.Join(ac.cfg.installationSearchDirectory, "app2"))
 						if err != nil {
@@ -85,7 +85,7 @@ func TestExpectToChangeFileSystem(t *testing.T) {
 			name:   "error inside change function",
 			before: func() {},
 			testFunc: func(t *testing.T) {
-				appPath, changerError, listError := ac.expectToChangeFileSystem(
+				appPath, changerError, listError := ac.expectToChangeFileSystem(t.Context(),
 					func() error {
 						return errors.New("simulated error in change function")
 					},
@@ -105,11 +105,11 @@ func TestExpectToChangeFileSystem(t *testing.T) {
 			defer os.RemoveAll(installationSearchDirectory)
 
 			cfg := &Config{
-				logger:                      kitlog.NewNopLogger(),
+				logger:                      slog.New(slog.DiscardHandler),
 				installationSearchDirectory: installationSearchDirectory,
 			}
 
-			ac = AppCommander{cfg: cfg, appLogger: kitlog.NewNopLogger()}
+			ac = AppCommander{cfg: cfg, appLogger: slog.New(slog.DiscardHandler)}
 			tc.before()
 			tc.testFunc(t)
 		})

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -163,7 +163,7 @@ func run(cfg *Config) error {
 			appWithWarning = append(appWithWarning, ac.Name)
 		}
 
-		existance, err := appExists(ctx, cfg.logger, ac.Name, ac.UniqueIdentifier, ac.Version, ac.AppPath)
+		existance, err := appExists(ctx, appLogger, ac.Name, ac.UniqueIdentifier, ac.Version, ac.AppPath)
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if app exists: %v", err))
 			appWithError = append(appWithError, ac.Name)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"mime/multipart"
 	"net/http"
@@ -19835,7 +19836,7 @@ func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedApps() {
 
 	err = detailQueries["software_windows"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: host.ID},
 		s.ds,
 		rows,

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"math/big"
 	"mime/multipart"
 	"net/http"
@@ -6144,7 +6145,7 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	}
 	err = detailQueries["mdm"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: hostResp.Host.ID},
 		s.ds,
 		rows,
@@ -6175,7 +6176,7 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	}
 	err = detailQueries["google_chrome_profiles"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: hostResp.Host.ID},
 		s.ds,
 		rows,
@@ -6241,7 +6242,7 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	// reporting google chrome profiles only clears chrome profiles from device mapping
 	err = detailQueries["google_chrome_profiles"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: hostResp.Host.ID},
 		s.ds,
 		[]map[string]string{},
@@ -6488,7 +6489,7 @@ func (s *integrationMDMTestSuite) TestSSOWithSCIM() {
 	}
 	err = detailQueries["mdm"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: hostResp.Host.ID},
 		s.ds,
 		rows,
@@ -6509,7 +6510,7 @@ func (s *integrationMDMTestSuite) TestSSOWithSCIM() {
 	}
 	err = detailQueries["google_chrome_profiles"].DirectIngestFunc(
 		context.Background(),
-		logging.NewNopLogger(),
+		slog.New(slog.DiscardHandler),
 		&fleet.Host{ID: hostResp.Host.ID},
 		s.ds,
 		rows,

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -1173,7 +1173,7 @@ func (svc *Service) SetOrUpdateDiskEncryptionKey(ctx context.Context, encryption
 	}
 
 	// Only archive the key if disk encryption is enabled for this host (team/globally)
-	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger, svc.ds, host) {
+	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger.SlogLogger(), svc.ds, host) {
 		level.Debug(svc.logger).Log(
 			"msg", "skipping key archival, disk encryption not enabled for host team/globally",
 			"host_id", host.ID,
@@ -1281,7 +1281,7 @@ func (svc *Service) EscrowLUKSData(ctx context.Context, passphrase string, salt 
 	}
 
 	// Only archive the key if disk encryption is enabled for this host (team/globally)
-	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger, svc.ds, host) {
+	if !osquery_utils.IsDiskEncryptionEnabledForHost(ctx, svc.logger.SlogLogger(), svc.ds, host) {
 		level.Debug(svc.logger).Log(
 			"msg", "skipping LUKS key archival, disk encryption not enabled for host team/globally",
 			"host_id", host.ID,

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -4588,7 +4589,7 @@ func TestPreProcessSoftwareResults(t *testing.T) {
 				host = tc.host
 			}
 			// mutates tc.resultsIn
-			preProcessSoftwareResults(host, tc.resultsIn, tc.statusesIn, tc.messagesIn, tc.overrides, platformlogging.NewNopLogger())
+			preProcessSoftwareResults(t.Context(), host, tc.resultsIn, tc.statusesIn, tc.messagesIn, tc.overrides, slog.New(slog.DiscardHandler))
 			require.Equal(t, tc.resultsExpected, tc.resultsIn)
 		})
 	}
@@ -4671,7 +4672,7 @@ func BenchmarkPreprocessUbuntuPythonPackageFilter(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		preProcessSoftwareResults(&fleet.Host{ID: 1, Platform: platform}, results, statuses, nil, nil, platformlogging.NewNopLogger())
+		preProcessSoftwareResults(context.Background(), &fleet.Host{ID: 1, Platform: platform}, results, statuses, nil, nil, slog.New(slog.DiscardHandler))
 	}
 }
 

--- a/server/service/osquery_utils/disk_encryption_helpers.go
+++ b/server/service/osquery_utils/disk_encryption_helpers.go
@@ -2,21 +2,19 @@ package osquery_utils
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 )
 
 // IsDiskEncryptionEnabledForHost checks if disk encryption is enabled for the
 // host team or globally if the host is not assigned to a team.
-func IsDiskEncryptionEnabledForHost(ctx context.Context, logger log.Logger, ds fleet.Datastore, host *fleet.Host) bool {
+func IsDiskEncryptionEnabledForHost(ctx context.Context, logger *slog.Logger, ds fleet.Datastore, host *fleet.Host) bool {
 	// team
 	if host.TeamID != nil {
 		teamMDM, err := ds.TeamMDMConfig(ctx, *host.TeamID)
 		if err != nil {
-			level.Debug(logger).Log(
-				"msg", "failed to get team MDM config for disk encryption check",
+			logger.DebugContext(ctx, "failed to get team MDM config for disk encryption check",
 				"host_id", host.ID,
 				"team_id", *host.TeamID,
 				"err", err,
@@ -32,8 +30,7 @@ func IsDiskEncryptionEnabledForHost(ctx context.Context, logger log.Logger, ds f
 	// global
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
-		level.Debug(logger).Log(
-			"msg", "failed to get app config for disk encryption check",
+		logger.DebugContext(ctx, "failed to get app config for disk encryption check",
 			"host_id", host.ID,
 			"err", err,
 		)

--- a/server/service/osquery_utils/disk_encryption_helpers_test.go
+++ b/server/service/osquery_utils/disk_encryption_helpers_test.go
@@ -2,19 +2,19 @@ package osquery_utils
 
 import (
 	"context"
+	"log/slog"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/ptr"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/require"
 )
 
 func TestIsDiskEncryptionEnabledForHost(t *testing.T) {
 	ctx := context.Background()
-	logger := log.NewNopLogger()
+	logger := slog.New(slog.DiscardHandler)
 
 	t.Run("team has disk encryption enabled", func(t *testing.T) {
 		ds := new(mock.Store)

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2903,7 +2903,7 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 
 		storedSalt, err := decrypter(dek.Base64EncryptedSalt)
 		if err != nil {
-			logger.DebugContext(ctx, "", "component", "service", "method", "luksVerifyQueryIngester", "host", host.ID, "err", err)
+			logger.DebugContext(ctx, "failed to decrypt stored salt", "component", "service", "method", "luksVerifyQueryIngester", "host", host.ID, "err", err)
 			return err
 		}
 		storedKeySlot := fmt.Sprintf("%d", *dek.KeySlot)
@@ -2914,11 +2914,10 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 			hostKeySlot, okKeySlot := row["key_slot"]
 
 			if !okSalt || !okKeySlot {
-				logger.ErrorContext(ctx, "",
+				logger.ErrorContext(ctx, "luks_verify expected some salt and a key_slot",
 					"component", "service",
 					"method", "luksVerifyQueryIngester",
-					"host", host.ID,
-					"err", "luks_verify expected some salt and a key_slot")
+					"host", host.ID)
 				continue
 			}
 			if hostSalt == storedSalt && hostKeySlot == storedKeySlot {

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/url"
 	"regexp"
@@ -23,11 +24,10 @@ import (
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
+	platformlogging "github.com/fleetdm/fleet/v4/server/platform/logging"
 
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/async"
-	"github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/google/uuid"
 	"github.com/spf13/cast"
 )
@@ -44,7 +44,7 @@ type DetailQuery struct {
 	Query string
 	// QueryFunc is optionally used to dynamically build a query. If false is returned, then the query should be
 	// ignored.
-	QueryFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool)
+	QueryFunc func(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool)
 	// Discovery is the SQL query that defines whether the query will run on the host or not.
 	// If not set, Fleet makes sure the query will always run.
 	Discovery string
@@ -61,15 +61,15 @@ type DetailQuery struct {
 	SoftwareProcessResults func(mainSoftwareResults []map[string]string, additionalSoftwareResults []map[string]string) []map[string]string
 	// IngestFunc translates a query result into an update to the host struct,
 	// around data that lives on the hosts table.
-	IngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error
+	IngestFunc func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error
 	// DirectIngestFunc gathers results from a query and directly works with the datastore to
 	// persist them. This is usually used for host data stored in a separate table.
 	// DirectTaskIngestFunc must not be set if this is set.
-	DirectIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error
+	DirectIngestFunc func(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error
 	// DirectTaskIngestFunc is similar to DirectIngestFunc except that it uses a task to
 	// ingest the results. This is for ingestion that can be either sync or async.
 	// DirectIngestFunc must not be set if this is set.
-	DirectTaskIngestFunc func(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error
+	DirectTaskIngestFunc func(ctx context.Context, logger *slog.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error
 }
 
 // RunsForPlatform determines whether this detail query should run on the given platform
@@ -201,10 +201,10 @@ var hostDetailQueries = map[string]DetailQuery{
 		// Note that data for `operating_system` and `host_operating_system` tables are ingested via
 		// the `os_unix_like` extra detail query below.
 		Query: "SELECT * FROM os_version LIMIT 1",
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
-				logger.Log("component", "service", "method", "IngestFunc", "err",
-					fmt.Sprintf("detail_query_os_version expected single result got %d", len(rows)))
+				logger.ErrorContext(ctx, fmt.Sprintf("detail_query_os_version expected single result got %d", len(rows)),
+					"component", "service", "method", "IngestFunc")
 				return nil
 			}
 
@@ -274,10 +274,10 @@ var hostDetailQueries = map[string]DetailQuery{
 		LEFT JOIN
 			ubr_table u`,
 		Platforms: []string{"windows"},
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
-				logger.Log("component", "service", "method", "IngestFunc", "err",
-					fmt.Sprintf("detail_query_os_version_windows expected single result got %d", len(rows)))
+				logger.ErrorContext(ctx, fmt.Sprintf("detail_query_os_version_windows expected single result got %d", len(rows)),
+					"component", "service", "method", "IngestFunc")
 				return nil
 			}
 
@@ -297,7 +297,7 @@ var hostDetailQueries = map[string]DetailQuery{
 		// distributed_interval (but it's not required), and typically
 		// do not control config_tls_refresh.
 		Query: `select name, value from osquery_flags where name in ("distributed_interval", "config_tls_refresh", "config_refresh", "logger_tls_period")`,
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			var configTLSRefresh, configRefresh uint
 			var configRefreshSeen, configTLSRefreshSeen bool
 			for _, row := range rows {
@@ -355,10 +355,10 @@ var hostDetailQueries = map[string]DetailQuery{
 	},
 	"osquery_info": {
 		Query: "select * from osquery_info limit 1",
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
-				logger.Log("component", "service", "method", "IngestFunc", "err",
-					fmt.Sprintf("detail_query_osquery_info expected single result got %d", len(rows)))
+				logger.ErrorContext(ctx, fmt.Sprintf("detail_query_osquery_info expected single result got %d", len(rows)),
+					"component", "service", "method", "IngestFunc")
 				return nil
 			}
 
@@ -369,10 +369,10 @@ var hostDetailQueries = map[string]DetailQuery{
 	},
 	"system_info": {
 		Query: "select * from system_info limit 1",
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
-				logger.Log("component", "service", "method", "IngestFunc", "err",
-					fmt.Sprintf("detail_query_system_info expected single result got %d", len(rows)))
+				logger.ErrorContext(ctx, fmt.Sprintf("detail_query_system_info expected single result got %d", len(rows)),
+					"component", "service", "method", "IngestFunc")
 				return nil
 			}
 
@@ -410,10 +410,10 @@ var hostDetailQueries = map[string]DetailQuery{
 	},
 	"uptime": {
 		Query: "select * from uptime limit 1",
-		IngestFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+		IngestFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 			if len(rows) != 1 {
-				logger.Log("component", "service", "method", "IngestFunc", "err",
-					fmt.Sprintf("detail_query_uptime expected single result got %d", len(rows)))
+				logger.ErrorContext(ctx, fmt.Sprintf("detail_query_uptime expected single result got %d", len(rows)),
+					"component", "service", "method", "IngestFunc")
 				return nil
 			}
 
@@ -458,8 +458,8 @@ FROM logical_drives WHERE file_system = 'NTFS' LIMIT 1;`,
 	},
 }
 
-func ingestNetworkInterface(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
-	logger = log.With(logger,
+func ingestNetworkInterface(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
+	logger = logger.With(
 		"component", "service",
 		"method", "IngestFunc",
 		"host", host.Hostname,
@@ -478,16 +478,16 @@ func ingestNetworkInterface(ctx context.Context, logger log.Logger, host *fleet.
 		if ip != nil {
 			host.PublicIP = ipStr
 		} else {
-			logger.Log("err", fmt.Sprintf("expected an IP address, got %s", ipStr))
+			logger.ErrorContext(ctx, fmt.Sprintf("expected an IP address, got %s", ipStr))
 		}
 	}
 
 	switch {
 	case len(rows) == 0:
-		level.Debug(logger).Log("err", "detail_query_network_interface did not find a private IP address")
+		logger.DebugContext(ctx, "detail_query_network_interface did not find a private IP address")
 		return nil
 	case len(rows) > 1:
-		level.Error(logger).Log("msg", fmt.Sprintf("detail_query_network_interface expected single result, got %d", len(rows)))
+		logger.ErrorContext(ctx, fmt.Sprintf("detail_query_network_interface expected single result, got %d", len(rows)))
 		return nil
 	}
 
@@ -497,10 +497,10 @@ func ingestNetworkInterface(ctx context.Context, logger log.Logger, host *fleet.
 	return nil
 }
 
-func directIngestDiskSpace(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestDiskSpace(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
-		logger.Log("component", "service", "method", "directIngestDiskSpace", "err",
-			fmt.Sprintf("detail_query_disk_space expected single result got %d", len(rows)))
+		logger.ErrorContext(ctx, fmt.Sprintf("detail_query_disk_space expected single result got %d", len(rows)),
+			"component", "service", "method", "directIngestDiskSpace")
 		return nil
 	}
 
@@ -534,7 +534,7 @@ func directIngestDiskSpace(ctx context.Context, logger log.Logger, host *fleet.H
 	return ds.SetOrUpdateHostDisksSpace(ctx, host.ID, gigsAvailable, percentAvailable, gigsTotal, gigsAllForFnCall)
 }
 
-func ingestKubequeryInfo(ctx context.Context, logger log.Logger, host *fleet.Host, rows []map[string]string) error {
+func ingestKubequeryInfo(ctx context.Context, logger *slog.Logger, host *fleet.Host, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return fmt.Errorf("kubernetes_info expected single result got: %d", len(rows))
 	}
@@ -1674,7 +1674,7 @@ var usersQueryChrome = DetailQuery{
 }
 
 // directIngestOrbitInfo ingests data from the orbit_info extension table.
-func directIngestOrbitInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestOrbitInfo(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOrbitInfo invalid number of rows: %d", len(rows))
 	}
@@ -1695,7 +1695,7 @@ func directIngestOrbitInfo(ctx context.Context, logger log.Logger, host *fleet.H
 }
 
 // directIngestOSWindows ingests selected operating system data from a host on a Windows platform
-func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestOSWindows(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOSWindows invalid number of rows: %d", len(rows))
 	}
@@ -1722,7 +1722,7 @@ func directIngestOSWindows(ctx context.Context, logger log.Logger, host *fleet.H
 
 // directIngestOSUnixLike ingests selected operating system data from a host on a Unix-like platform
 // (e.g., darwin, Linux or ChromeOS)
-func directIngestOSUnixLike(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestOSUnixLike(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) != 1 {
 		return ctxerr.Errorf(ctx, "directIngestOSUnixLike invalid number of rows: %d", len(rows))
 	}
@@ -1774,7 +1774,7 @@ func parseOSVersion(name string, version string, major string, minor string, pat
 	return osVersion
 }
 
-func directIngestChromeProfiles(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestChromeProfiles(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	mapping := make([]*fleet.HostDeviceMapping, 0, len(rows))
 	for _, row := range rows {
 		mapping = append(mapping, &fleet.HostDeviceMapping{
@@ -1792,13 +1792,13 @@ func directIngestChromeProfiles(ctx context.Context, logger log.Logger, host *fl
 // and the ommission of the `health` column on Windows, we are not leveraging the `health`
 // column in the query and instead aligning the definition of battery health between
 // macOS and Windows.
-func directIngestBattery(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestBattery(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	mapping := make([]*fleet.HostBattery, 0, len(rows))
 
 	for _, row := range rows {
-		health, cycleCount, err := generateBatteryHealth(row, logger)
+		health, cycleCount, err := generateBatteryHealth(ctx, row, logger)
 		if err != nil {
-			level.Error(logger).Log("op", "directIngestBattery", "hostID", host.ID, "err", err)
+			logger.ErrorContext(ctx, "directIngestBattery", "host_id", host.ID, "err", err)
 		}
 
 		mapping = append(mapping, &fleet.HostBattery{
@@ -1821,14 +1821,14 @@ const (
 )
 
 // generateBatteryHealth calculates the battery health based on the cycle count and capacity.
-func generateBatteryHealth(row map[string]string, logger log.Logger) (string, int, error) {
+func generateBatteryHealth(ctx context.Context, row map[string]string, logger *slog.Logger) (string, int, error) {
 	designedCapacity := row["designed_capacity"]
 	maxCapacity := row["max_capacity"]
 	cycleCount := row["cycle_count"]
 
 	count, err := strconv.Atoi(EmptyToZero(cycleCount))
 	if err != nil {
-		level.Error(logger).Log("op", "generateBatteryHealth", "err", err)
+		logger.ErrorContext(ctx, "generateBatteryHealth", "err", err)
 		// If we can't parse the cycle count, we'll assume it's 0
 		// and continue with the rest of the battery health check.
 		count = 0
@@ -1863,7 +1863,7 @@ func generateBatteryHealth(row map[string]string, logger log.Logger) (string, in
 
 func directIngestWindowsUpdateHistory(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
@@ -1880,7 +1880,7 @@ func directIngestWindowsUpdateHistory(
 		if err != nil {
 			// If the update failed to parse then we log a debug error and ignore it.
 			// E.g. we've seen KB updates with titles like "Logitech - Image - 1.4.40.0".
-			level.Debug(logger).Log("op", "directIngestWindowsUpdateHistory", "skipped", err)
+			logger.DebugContext(ctx, "directIngestWindowsUpdateHistory skipped", "err", err)
 			continue
 		}
 
@@ -1899,7 +1899,7 @@ func directIngestWindowsUpdateHistory(
 
 func directIngestEntraIDDetails(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
@@ -1925,23 +1925,17 @@ func directIngestEntraIDDetails(
 	return nil
 }
 
-func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error {
+func directIngestScheduledQueryStats(ctx context.Context, logger *slog.Logger, host *fleet.Host, task *async.Task, rows []map[string]string) error {
 	packs := map[string][]fleet.ScheduledQueryStats{}
 	for _, row := range rows {
 		providedName := row["name"]
 		if providedName == "" {
-			level.Debug(logger).Log(
-				"msg", "host reported scheduled query with empty name",
-				"host", host.Hostname,
-			)
+			logger.DebugContext(ctx, "host reported scheduled query with empty name", "host", host.Hostname)
 			continue
 		}
 		delimiter := row["delimiter"]
 		if delimiter == "" {
-			level.Debug(logger).Log(
-				"msg", "host reported scheduled query with empty delimiter",
-				"host", host.Hostname,
-			)
+			logger.DebugContext(ctx, "host reported scheduled query with empty delimiter", "host", host.Hostname)
 			continue
 		}
 
@@ -1949,10 +1943,7 @@ func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, hos
 		// It is normal for host to have no executions when the query just got scheduled.
 		executions := cast.ToUint64(row["executions"])
 		if executions == 0 {
-			level.Debug(logger).Log(
-				"msg", "host reported scheduled query with no executions",
-				"host", host.Hostname,
-			)
+			logger.DebugContext(ctx, "host reported scheduled query with no executions", "host", host.Hostname)
 			continue
 		}
 
@@ -1962,12 +1953,10 @@ func directIngestScheduledQueryStats(ctx context.Context, logger log.Logger, hos
 		trimmedName := strings.TrimPrefix(providedName, "pack"+delimiter)
 		parts := strings.SplitN(trimmedName, delimiter, 2)
 		if len(parts) != 2 {
-			level.Debug(logger).Log(
-				"msg", "could not split pack and query names",
+			logger.DebugContext(ctx, "could not split pack and query names",
 				"host", host.Hostname,
 				"name", providedName,
-				"delimiter", delimiter,
-			)
+				"delimiter", delimiter)
 			continue
 		}
 		packName, scheduledName := parts[0], parts[1]
@@ -2025,18 +2014,16 @@ var (
 	archKernelRegex = regexp.MustCompile(archKernelName)
 )
 
-func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestSoftware(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var software []fleet.Software
 	sPaths := map[string]struct{}{}
 
 	for _, row := range rows {
 		// Attempt to parse the last_opened_at and emit a debug log if it fails.
 		if _, err := fleet.ParseSoftwareLastOpenedAtRowValue(row["last_opened_at"]); err != nil {
-			level.Debug(logger).Log(
-				"msg", "host reported software with invalid last opened timestamp",
+			logger.DebugContext(ctx, "host reported software with invalid last opened timestamp",
 				"host_id", host.ID,
-				"row", fmt.Sprintf("%+v", row),
-			)
+				"row", fmt.Sprintf("%+v", row))
 		}
 
 		s, err := fleet.SoftwareFromOsqueryRow(
@@ -2054,12 +2041,10 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 			row["upgrade_code"],
 		)
 		if err != nil {
-			level.Debug(logger).Log(
-				"msg", "failed to parse software row",
+			logger.DebugContext(ctx, "failed to parse software row",
 				"host_id", host.ID,
 				"row", fmt.Sprintf("%+v", row),
-				"err", err,
-			)
+				"err", err)
 			continue
 		}
 
@@ -2067,7 +2052,7 @@ func directIngestSoftware(ctx context.Context, logger log.Logger, host *fleet.Ho
 			s.IsKernel = true
 		}
 
-		MutateSoftwareOnIngestion(s, logger)
+		MutateSoftwareOnIngestion(ctx, s, logger)
 
 		if shouldRemoveSoftware(host, s) {
 			continue
@@ -2126,11 +2111,11 @@ var (
 	basicAppSanitizers       = []struct {
 		matchBundleIdentifier string
 		matchName             string
-		mutate                func(*fleet.Software, log.Logger)
+		mutate                func(*fleet.Software, *slog.Logger)
 	}{
 		{
 			matchBundleIdentifier: "com.nicesoftware.dcvviewer",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				if versionMatches := dcvVersionFormat.FindStringSubmatch(s.Version); len(versionMatches) == 3 {
 					s.Version = fmt.Sprintf("%s.%s", versionMatches[1], versionMatches[2])
 				}
@@ -2140,69 +2125,69 @@ var (
 		{
 			matchBundleIdentifier: "com.synology.DSAssistant",
 			matchName:             "DSAssistant",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "SynologyAssistant"
 			},
 		},
 		{
 			matchBundleIdentifier: "com.now.gg.BlueStacksMIM",
 			matchName:             "HD-MultiInstanceManager",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "BlueStacksMIM"
 			},
 		},
 		{
 			matchBundleIdentifier: "jp.go.jpki.JPKIUninstall",
 			matchName:             "JPKIUninstall.scpt",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "JPKIUninstall"
 			},
 		},
 		{
 			matchBundleIdentifier: "com.oracle.OracleDataModeler",
 			matchName:             "datamodeler.sh",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "OracleDataModeler"
 			},
 		},
 		{
 			matchBundleIdentifier: "com.easeus.ntfsformacdaemon",
 			matchName:             "euntfsservice",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "EaseUS NTFS Service"
 			},
 		},
 		{
 			matchBundleIdentifier: "com.poly.lens.legacyhost.app",
 			matchName:             "legacyhost",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "Poly Lens Desktop (Legacy)"
 			},
 		},
 		{
 			matchBundleIdentifier: "app.zen-browser.plugincontainer",
 			matchName:             "plugin-container",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "Zen Browser Plugin Container"
 			},
 		},
 		{
 			matchBundleIdentifier: "org.mozilla.plugincontainer",
 			matchName:             "plugin-container",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "Mozilla Plugin Container"
 			},
 		},
 		{
 			matchBundleIdentifier: "com.google.chromeremotedesktop.me2me-host-uninstaller",
 			matchName:             "remoting_host_uninstaller",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "Chrome Remote Desktop Host Uninstaller"
 			},
 		},
 		{
 			matchName: "runemu",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				if s.BundleIdentifier == "" {
 					s.Name = "Android Emulator"
 				}
@@ -2211,13 +2196,13 @@ var (
 		{
 			matchBundleIdentifier: "com.oracle.SQLDeveloper",
 			matchName:             "sqldeveloper.sh/",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "Oracle SQLDeveloper"
 			},
 		},
 		{
 			matchBundleIdentifier: "net.tunnelblick.tunnelblick",
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				if versionMatches := tunnelblickVersionFormat.FindStringSubmatch(s.Version); len(versionMatches) == 2 {
 					s.Version = versionMatches[1]
 				}
@@ -2227,7 +2212,7 @@ var (
 	}
 	customAppSanitizers = []struct {
 		matches func(*fleet.Software) bool
-		mutate  func(*fleet.Software, log.Logger)
+		mutate  func(*fleet.Software, *slog.Logger)
 	}{
 		{
 			matches: func(s *fleet.Software) bool { // #34159
@@ -2235,7 +2220,7 @@ var (
 					strings.HasPrefix(s.BundleIdentifier, "TNMS_") &&
 					strings.Replace(s.BundleIdentifier, "_", " ", 1) == s.Name
 			},
-			mutate: func(s *fleet.Software, logger log.Logger) {
+			mutate: func(s *fleet.Software, logger *slog.Logger) {
 				s.Name = "TNMS"
 				s.Version = strings.Replace(s.BundleIdentifier, "TNMS_", "", 1)
 			},
@@ -2246,7 +2231,7 @@ var (
 // MutateSoftwareOnIngestion performs any tweaks required to the ingested software fields.
 //
 // Some fields are reported with known incorrect values and we need to fix them before using them.
-func MutateSoftwareOnIngestion(s *fleet.Software, logger log.Logger) {
+func MutateSoftwareOnIngestion(ctx context.Context, s *fleet.Software, logger *slog.Logger) {
 	// all of our current on-ingest mutations use this table,
 	// so might as well let other stuff go faster and save some redundant checks inside the matchers
 	if s != nil && s.Source == "apps" {
@@ -2256,7 +2241,7 @@ func MutateSoftwareOnIngestion(s *fleet.Software, logger log.Logger) {
 				(sanitizer.matchName == "" || sanitizer.matchName == s.Name) {
 				defer func() {
 					if r := recover(); r != nil {
-						level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
+						logger.WarnContext(ctx, "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
 					}
 				}()
 				sanitizer.mutate(s, logger)
@@ -2267,7 +2252,7 @@ func MutateSoftwareOnIngestion(s *fleet.Software, logger log.Logger) {
 			if sanitizer.matches(s) {
 				defer func() {
 					if r := recover(); r != nil {
-						level.Warn(logger).Log("msg", "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
+						logger.WarnContext(ctx, "panic during software mutation", "softwareName", s.Name, "softwareVersion", s.Version, "error", r)
 					}
 				}()
 				sanitizer.mutate(s, logger)
@@ -2294,7 +2279,7 @@ func shouldRemoveSoftware(h *fleet.Host, s *fleet.Software) bool {
 	return h.Platform == "darwin" && strings.HasPrefix(s.BundleIdentifier, "com.parallels.winapp")
 }
 
-func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestUsers(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	var users []fleet.HostUser
 	var appleManagedUsername, appleManagedUserUUID string
 	if host.Platform == "darwin" {
@@ -2352,20 +2337,21 @@ func directIngestUsers(ctx context.Context, logger log.Logger, host *fleet.Host,
 	return nil
 }
 
-func directIngestMDMMac(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestMDMMac(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) == 0 {
-		logger.Log("component", "service", "method", "ingestMDM", "warn",
-			fmt.Sprintf("mdm expected single result got %d", len(rows)))
+		logger.WarnContext(ctx, fmt.Sprintf("mdm expected single result got %d",
+			len(rows)), "component", "service", "method", "ingestMDM")
 		// assume the extension is not there
 		return nil
 	}
 	if len(rows) > 1 {
-		logger.Log("component", "service", "method", "ingestMDM", "warn",
-			fmt.Sprintf("mdm expected single result got %d", len(rows)))
+		logger.WarnContext(ctx, fmt.Sprintf("mdm expected single result got %d",
+			len(rows)), "component", "service", "method", "ingestMDM")
 	}
 
 	if host.RefetchCriticalQueriesUntil != nil {
-		level.Debug(logger).Log("msg", "ingesting macos mdm data during refetch critical queries window", "host_id", host.ID,
+		logger.DebugContext(ctx, "ingesting macos mdm data during refetch critical queries window",
+			"host_id", host.ID,
 			"data", fmt.Sprintf("%+v", rows))
 	}
 
@@ -2454,20 +2440,21 @@ func deduceMDMNameWindows(data map[string]string) string {
 	return fleet.MDMNameFromServerURL(serverURL)
 }
 
-func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestMDMWindows(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) == 0 {
 		// no mdm information in the registry
 		return ds.SetOrUpdateMDMData(ctx, host.ID, false, false, "", false, "", "", false)
 	}
 	if len(rows) > 1 {
-		logger.Log("component", "service", "method", "directIngestMDMWindows", "warn",
-			fmt.Sprintf("mdm expected single result got %d", len(rows)))
+		logger.WarnContext(ctx, fmt.Sprintf("mdm expected single result got %d",
+			len(rows)), "component", "service", "method", "directIngestMDMWindows")
 		// assume the extension is not there
 		return nil
 	}
 
 	if host.RefetchCriticalQueriesUntil != nil {
-		level.Debug(logger).Log("msg", "ingesting Windows mdm data during refetch critical queries window", "host_id", host.ID,
+		logger.DebugContext(ctx, "ingesting Windows mdm data during refetch critical queries window",
+			"host_id", host.ID,
 			"data", fmt.Sprintf("%+v", rows))
 	}
 
@@ -2517,14 +2504,14 @@ func directIngestMDMWindows(ctx context.Context, logger log.Logger, host *fleet.
 	)
 }
 
-func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestMunkiInfo(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) == 0 {
 		// munki is not there, and we need to mark it deleted if it was there before
 		return ds.SetOrUpdateMunkiInfo(ctx, host.ID, "", []string{}, []string{})
 	}
 	if len(rows) > 1 {
-		logger.Log("component", "service", "method", "ingestMunkiInfo", "warn",
-			fmt.Sprintf("munki_info expected single result got %d", len(rows)))
+		logger.WarnContext(ctx, fmt.Sprintf("munki_info expected single result got %d",
+			len(rows)), "component", "service", "method", "ingestMunkiInfo")
 	}
 
 	errors, warnings := rows[0]["errors"], rows[0]["warnings"]
@@ -2532,7 +2519,7 @@ func directIngestMunkiInfo(ctx context.Context, logger log.Logger, host *fleet.H
 	return ds.SetOrUpdateMunkiInfo(ctx, host.ID, rows[0]["version"], errList, warnList)
 }
 
-func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestDiskEncryptionLinux(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	encrypted := false
 	for _, row := range rows {
 		if row["path"] == "/" && row["encrypted"] == "1" {
@@ -2544,7 +2531,7 @@ func directIngestDiskEncryptionLinux(ctx context.Context, logger log.Logger, hos
 	return ds.SetOrUpdateHostDisksEncryption(ctx, host.ID, encrypted)
 }
 
-func directIngestDiskEncryption(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestDiskEncryption(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	encrypted := len(rows) > 0
 	return ds.SetOrUpdateHostDisksEncryption(ctx, host.ID, encrypted)
 }
@@ -2553,38 +2540,30 @@ func directIngestDiskEncryption(ctx context.Context, logger log.Logger, host *fl
 // extension table. It is the preferred method when a host has the extension table available.
 func directIngestDiskEncryptionKeyFileDarwin(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
 ) error {
 	if len(rows) == 0 {
 		// assume the extension is not there
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "no rows or failed",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileDarwin",
-			"msg", "no rows or failed",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
 	if len(rows) > 1 {
-		level.Debug(logger).Log(
-			"component", "service",
-			"method", "directIngestDiskEncryptionKeyFileDarwin",
-			"msg", fmt.Sprintf("filevault_prk should have a single row, but got %d", len(rows)),
-			"host", host.Hostname,
-		)
+		logger.DebugContext(ctx, fmt.Sprintf("filevault_prk should have a single row, but got %d", len(rows)),
+			"component", "service", "method", "directIngestDiskEncryptionKeyFileDarwin", "host", host.Hostname)
 	}
 
 	if rows[0]["encrypted"] != "1" {
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "host does not use disk encryption",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileDarwin",
-			"msg", "host does not use disk encryption",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
@@ -2600,12 +2579,10 @@ func directIngestDiskEncryptionKeyFileDarwin(
 
 	// Only archive the key if disk encryption is enabled for this host (team / globally)
 	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host (team/globally)",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileDarwin",
-			"msg", "skipping key archival, disk encryption not enabled for host (team/globally)",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
@@ -2622,31 +2599,27 @@ func directIngestDiskEncryptionKeyFileDarwin(
 // table is not available on the host.
 func directIngestDiskEncryptionKeyFileLinesDarwin(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
 ) error {
 	if len(rows) == 0 {
 		// assume the extension is not there
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "no rows or failed",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
-			"msg", "no rows or failed",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
 	var hexLines []string
 	for _, row := range rows {
 		if row["encrypted"] != "1" {
-			level.Debug(logger).Log(
+			logger.DebugContext(ctx, "host does not use disk encryption",
 				"component", "service",
 				"method", "directIngestDiskEncryptionKeyDarwin",
-				"msg", "host does not use disk encryption",
-				"host", host.Hostname,
-			)
+				"host", host.Hostname)
 			return nil
 		}
 		hexLines = append(hexLines, row["hex_line"])
@@ -2675,12 +2648,10 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 
 	// Only archive the key if disk encryption is enabled for this host (team/globally)
 	if !IsDiskEncryptionEnabledForHost(ctx, logger, ds, host) {
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "skipping key archival, disk encryption not enabled for host team/globally",
 			"component", "service",
 			"method", "directIngestDiskEncryptionKeyFileLinesDarwin",
-			"msg", "skipping key archival, disk encryption not enabled for host team/globally",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
@@ -2692,7 +2663,7 @@ func directIngestDiskEncryptionKeyFileLinesDarwin(
 	return nil
 }
 
-func buildConfigProfilesMacOSQuery(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool) {
+func buildConfigProfilesMacOSQuery(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool) {
 	query := `
 		SELECT
 			display_name,
@@ -2705,8 +2676,7 @@ func buildConfigProfilesMacOSQuery(ctx context.Context, logger log.Logger, host 
 
 	username, _, err := ds.GetNanoMDMUserEnrollmentUsernameAndUUID(ctx, host.UUID)
 	if err != nil {
-		logger.Log("component", "service",
-			"method", "QueryFunc - macos config profiles", "err", err)
+		logger.ErrorContext(ctx, "QueryFunc - macos config profiles", "component", "service", "err", err)
 		return "", false
 	}
 
@@ -2729,19 +2699,17 @@ func buildConfigProfilesMacOSQuery(ctx context.Context, logger log.Logger, host 
 
 func directIngestMacOSProfiles(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
 ) error {
 	if len(rows) == 0 {
 		// assume the extension is not there
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "no rows or failed",
 			"component", "service",
 			"method", "directIngestMacOSProfiles",
-			"msg", "no rows or failed",
-			"host", host.Hostname,
-		)
+			"host", host.Hostname)
 		return nil
 	}
 
@@ -2753,22 +2721,18 @@ func directIngestMacOSProfiles(
 		}
 		if installDate.IsZero() {
 			// this should never happen, but if it does, we should log it
-			level.Debug(logger).Log(
+			logger.DebugContext(ctx, "profile install date is zero value",
 				"component", "service",
 				"method", "directIngestMacOSProfiles",
-				"msg", "profile install date is zero value",
-				"host", host.Hostname,
-			)
+				"host", host.Hostname)
 		}
 		if _, ok := installed[row["identifier"]]; ok {
 			// this should never happen, but if it does, we should log it
-			level.Debug(logger).Log(
+			logger.DebugContext(ctx, "duplicate profile identifier",
 				"component", "service",
 				"method", "directIngestMacOSProfiles",
-				"msg", "duplicate profile identifier",
 				"host", host.Hostname,
-				"identifier", row["identifier"],
-			)
+				"identifier", row["identifier"])
 		}
 		installed[row["identifier"]] = &fleet.HostMacOSProfile{
 			DisplayName: row["display_name"],
@@ -2779,7 +2743,7 @@ func directIngestMacOSProfiles(
 	return apple_mdm.VerifyHostMDMProfiles(ctx, ds, host, installed)
 }
 
-func directIngestMDMDeviceIDWindows(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+func directIngestMDMDeviceIDWindows(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	if len(rows) == 0 {
 		// this registry key is only going to be present if the device is enrolled to mdm so assume that mdm is turned off
 		return nil
@@ -2828,13 +2792,13 @@ func directIngestMDMDeviceIDWindows(ctx context.Context, logger log.Logger, host
 				// This enables fields like idp_full_name, idp_groups, etc. to appear in the API
 				if err := ds.SetOrUpdateHostSCIMUserMapping(ctx, host.ID, scimUser.ID); err != nil {
 					// Log the error but don't fail the request since the main IDP mapping succeeded
-					level.Debug(logger).Log("msg", "failed to set SCIM user mapping", "err", err)
+					logger.DebugContext(ctx, "failed to set SCIM user mapping", "err", err)
 				}
 			} else {
 				// User doesn't exist in SCIM, remove any existing SCIM mapping for this host
 				if err := ds.DeleteHostSCIMUserMapping(ctx, host.ID); err != nil && !fleet.IsNotFound(err) {
 					// Log the error but don't fail the request
-					level.Debug(logger).Log("msg", "failed to delete SCIM user mapping", "err", err)
+					logger.DebugContext(ctx, "failed to delete SCIM user mapping", "err", err)
 				}
 			}
 		}
@@ -2849,7 +2813,7 @@ var luksVerifyQuery = DetailQuery{
 		discoveryTable("lsblk"),
 		discoveryTable("cryptsetup_luks_salt"),
 	),
-	QueryFunc: func(ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool) {
+	QueryFunc: func(ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore) (string, bool) {
 		if host.OrbitNodeKey == nil || *host.OrbitNodeKey == "" || !host.IsLUKSSupported() {
 			return "", false
 		}
@@ -2909,10 +2873,10 @@ var luksVerifyQuery = DetailQuery{
 
 // We need to define the ingest function inline like this because we need access to the server private key
 var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
-	ctx context.Context, logger log.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
+	ctx context.Context, logger *slog.Logger, host *fleet.Host, ds fleet.Datastore, rows []map[string]string) error {
 	return func(
 		ctx context.Context,
-		logger log.Logger,
+		logger *slog.Logger,
 		host *fleet.Host,
 		ds fleet.Datastore,
 		rows []map[string]string,
@@ -2924,20 +2888,13 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 		dek, err := ds.GetHostDiskEncryptionKey(ctx, host.ID)
 		if err != nil {
 			if fleet.IsNotFound(err) {
-				level.Error(logger).Log(
+				logger.ErrorContext(ctx, "unexpected missing LUKS2 disk encryption key",
 					"component", "service",
 					"method", "luksVerifyQueryIngester",
-					"msg", "unexpected missing LUKS2 disk encryption key",
-					"err", err,
-				)
+					"err", err)
 				return nil
 			}
-			level.Error(logger).Log(
-				"component", "service",
-				"method", "luksVerifyQueryIngester",
-				"msg", "unexpected error",
-				"err", err,
-			)
+			logger.ErrorContext(ctx, "unexpected error", "component", "service", "method", "luksVerifyQueryIngester", "err", err)
 			return err
 		}
 		if dek == nil || dek.Base64EncryptedSalt == "" || dek.KeySlot == nil {
@@ -2946,12 +2903,7 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 
 		storedSalt, err := decrypter(dek.Base64EncryptedSalt)
 		if err != nil {
-			level.Debug(logger).Log(
-				"component", "service",
-				"method", "luksVerifyQueryIngester",
-				"host", host.ID,
-				"err", err,
-			)
+			logger.DebugContext(ctx, "", "component", "service", "method", "luksVerifyQueryIngester", "host", host.ID, "err", err)
 			return err
 		}
 		storedKeySlot := fmt.Sprintf("%d", *dek.KeySlot)
@@ -2962,12 +2914,11 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 			hostKeySlot, okKeySlot := row["key_slot"]
 
 			if !okSalt || !okKeySlot {
-				level.Error(logger).Log(
+				logger.ErrorContext(ctx, "",
 					"component", "service",
 					"method", "luksVerifyQueryIngester",
 					"host", host.ID,
-					"err", "luks_verify expected some salt and a key_slot",
-				)
+					"err", "luks_verify expected some salt and a key_slot")
 				continue
 			}
 			if hostSalt == storedSalt && hostKeySlot == storedKeySlot {
@@ -2976,12 +2927,10 @@ var luksVerifyQueryIngester = func(decrypter func(string) (string, error)) func(
 			}
 		}
 		if !entryFound {
-			level.Info(logger).Log(
+			logger.InfoContext(ctx, "LUKS key do not match, deleting",
 				"component", "service",
 				"method", "luksVerifyQueryIngester",
-				"host", host.ID,
-				"msg", "LUKS key do not match, deleting",
-			)
+				"host", host.ID)
 			return ds.DeleteLUKSData(ctx, host.ID, *dek.KeySlot)
 		}
 		return nil
@@ -3018,16 +2967,13 @@ var tpmPINQueries = map[string]DetailQuery{
 		Query: "SELECT data FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SOFTWARE\\Policies\\Microsoft\\FVE\\UseTPMPIN'",
 		DirectIngestFunc: func(
 			ctx context.Context,
-			logger log.Logger,
+			logger *slog.Logger,
 			host *fleet.Host,
 			ds fleet.Datastore,
 			rows []map[string]string,
 		) error {
 			if host == nil || host.UUID == "" {
-				level.Debug(logger).Log(
-					"query", "tpm_pin_config_verify",
-					"msg", "Ingestion not run, host is nil or UUID is empty",
-				)
+				logger.DebugContext(ctx, "Ingestion not run, host is nil or UUID is empty", "query", "tpm_pin_config_verify")
 				return nil
 			}
 
@@ -3041,11 +2987,9 @@ var tpmPINQueries = map[string]DetailQuery{
 			// If no results are returned, then the policy setting is in a 'Not Configured' state.
 			// If the policy is 'Enabled', we need to make sure the proper setting is not in a 'Disallowed' state.
 			if len(rows) == 0 || rows[0]["data"] == fmt.Sprintf("%d", microsoft_mdm.PolicyOptDropdownDisallowed) {
-				level.Info(logger).Log(
+				logger.InfoContext(ctx, "Updating TPM PIN protector configuration via MDM",
 					"query", "tpm_pin_config_verify",
-					"msg", "Updating TPM PIN protector configuration via MDM",
-					"host_id", host.ID,
-				)
+					"host_id", host.ID)
 				cmd, err := microsoft_mdm.SystemDriveRequiresStartupAuthCmd(
 					microsoft_mdm.SystemDriveRequiresStartupAuthSpec{
 						CmdUUID:      uuid.NewString(),
@@ -3088,16 +3032,13 @@ var tpmPINQueries = map[string]DetailQuery{
 			WHERE criteria = 1`,
 		DirectIngestFunc: func(
 			ctx context.Context,
-			logger log.Logger,
+			logger *slog.Logger,
 			host *fleet.Host,
 			ds fleet.Datastore,
 			rows []map[string]string,
 		) error {
 			if host == nil || host.UUID == "" {
-				level.Debug(logger).Log(
-					"query", "tpm_pin_set_verify",
-					"msg", "Ingestion not run, host is nil or UUID is empty",
-				)
+				logger.DebugContext(ctx, "Ingestion not run, host is nil or UUID is empty", "query", "tpm_pin_set_verify")
 				return nil
 			}
 			return ds.SetOrUpdateHostDiskTpmPIN(ctx, host.ID, len(rows) > 0)
@@ -3236,14 +3177,14 @@ func splitCleanSemicolonSeparated(s string) []string {
 
 func buildConfigProfilesWindowsQuery(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 ) (string, bool) {
 	var sb strings.Builder
 	sb.WriteString("<SyncBody>")
 	gotProfiles := false
-	err := microsoft_mdm.LoopOverExpectedHostProfiles(ctx, logger, ds, host, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
+	err := microsoft_mdm.LoopOverExpectedHostProfiles(ctx, platformlogging.NewLogger(logger), ds, host, func(profile *fleet.ExpectedMDMProfile, hash, locURI, data string) {
 		// Per the [docs][1], to `<Get>` configurations you must
 		// replace `/Policy/Config/` with `Policy/Result/`
 		// [1]: https://learn.microsoft.com/en-us/windows/client-management/mdm/policy-configuration-service-provider
@@ -3261,20 +3202,14 @@ func buildConfigProfilesWindowsQuery(
 		gotProfiles = true
 	})
 	if err != nil {
-		logger.Log(
-			"component", "service",
-			"method", "QueryFunc - windows config profiles",
-			"err", err,
-		)
+		logger.ErrorContext(ctx, "QueryFunc - windows config profiles", "component", "service", "err", err)
 		return "", false
 	}
 	if !gotProfiles {
-		level.Debug(logger).Log(
+		logger.DebugContext(ctx, "host doesn't have profiles to check",
 			"component", "service",
 			"method", "QueryFunc - windows config profiles",
-			"msg", "host doesn't have profiles to check",
-			"host_id", host.ID,
-		)
+			"host_id", host.ID)
 		return "", false
 	}
 	sb.WriteString("</SyncBody>")
@@ -3283,7 +3218,7 @@ func buildConfigProfilesWindowsQuery(
 
 func directIngestWindowsProfiles(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
@@ -3300,21 +3235,21 @@ func directIngestWindowsProfiles(
 	if len(rawResponse) == 0 {
 		return ctxerr.Errorf(ctx, "directIngestWindowsProfiles host %s got an empty SyncML response", host.UUID)
 	}
-	return microsoft_mdm.VerifyHostMDMProfiles(ctx, logger, ds, host, rawResponse)
+	return microsoft_mdm.VerifyHostMDMProfiles(ctx, platformlogging.NewLogger(logger), ds, host, rawResponse)
 }
 
 var rxExtractUsernameFromHostCertPath = regexp.MustCompile(`^/Users/([^/]+)/Library/Keychains/login\.keychain\-db$`)
 
 func directIngestHostCertificatesDarwin(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
 ) error {
 	if len(rows) == 0 {
 		// if there are no results, it probably may indicate a problem so we log it
-		level.Debug(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "no rows returned", "host_id", host.ID)
+		logger.DebugContext(ctx, "no rows returned", "component", "service", "method", "directIngestHostCertificates", "host_id", host.ID)
 		return nil
 	}
 
@@ -3322,23 +3257,23 @@ func directIngestHostCertificatesDarwin(
 	for _, row := range rows {
 		csum, err := hex.DecodeString(row["sha1"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "decoding sha1", "err", err)
+			logger.ErrorContext(ctx, "decoding sha1", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 		subject, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(host.Platform, row["subject"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting subject details", "err", err)
+			logger.ErrorContext(ctx, "extracting subject details", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 		issuer, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(host.Platform, row["issuer"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting issuer details", "err", err)
+			logger.ErrorContext(ctx, "extracting issuer details", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 		source := fleet.HostCertificateSource(row["source"])
 		if !source.IsValid() {
 			// should never happen as the source is hard-coded in the query
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "invalid certificate source", "err", fmt.Errorf("invalid source %s", row["source"]))
+			logger.ErrorContext(ctx, "invalid certificate source", "component", "service", "method", "directIngestHostCertificates", "err", fmt.Errorf("invalid source %s", row["source"]))
 			continue
 		}
 
@@ -3350,7 +3285,7 @@ func directIngestHostCertificatesDarwin(
 				username = matches[1]
 			} else {
 				// if we cannot extract the username, we log it but continue
-				level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "could not extract username from path", "err", fmt.Errorf("no username found in path %q", row["path"]))
+				logger.ErrorContext(ctx, "could not extract username from path", "component", "service", "method", "directIngestHostCertificates", "err", fmt.Errorf("no username found in path %q", row["path"]))
 			}
 		}
 
@@ -3389,14 +3324,14 @@ func directIngestHostCertificatesDarwin(
 
 func directIngestHostCertificatesWindows(
 	ctx context.Context,
-	logger log.Logger,
+	logger *slog.Logger,
 	host *fleet.Host,
 	ds fleet.Datastore,
 	rows []map[string]string,
 ) error {
 	if len(rows) == 0 {
 		// if there are no results, it indicates we may have a problem so we log it
-		level.Debug(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "no rows returned", "host_id", host.ID)
+		logger.DebugContext(ctx, "no rows returned", "component", "service", "method", "directIngestHostCertificates", "host_id", host.ID)
 		return nil
 	}
 
@@ -3409,17 +3344,17 @@ func directIngestHostCertificatesWindows(
 	for _, row := range rows {
 		csum, err := hex.DecodeString(row["sha1"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "decoding sha1", "err", err)
+			logger.ErrorContext(ctx, "decoding sha1", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 		subject, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(host.Platform, row["subject"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting subject details", "err", err)
+			logger.ErrorContext(ctx, "extracting subject details", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 		issuer, err := fleet.ExtractDetailsFromOsqueryDistinguishedName(host.Platform, row["issuer"])
 		if err != nil {
-			level.Error(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg", "extracting issuer details", "err", err)
+			logger.ErrorContext(ctx, "extracting issuer details", "component", "service", "method", "directIngestHostCertificates", "err", err)
 			continue
 		}
 
@@ -3456,9 +3391,15 @@ func directIngestHostCertificatesWindows(
 		// deduplicate by SHA1 + Username
 		sha1UserKey := fmt.Sprintf("%x|%s", csum, username)
 		if exists := existsSha1User[sha1UserKey]; exists {
-			level.Debug(logger).Log("component", "service", "method", "directIngestHostCertificates", "msg",
-				"skipping duplicate certificate for sha1+user", "host_id", host.ID, "username", username, "sha1", fmt.Sprintf("%x", csum),
-				"issuer", cert.IssuerCommonName, "subject", cert.SubjectCommonName, "path", row["path"])
+			logger.DebugContext(ctx, "skipping duplicate certificate for sha1+user",
+				"component", "service",
+				"method", "directIngestHostCertificates",
+				"host_id", host.ID,
+				"username", username,
+				"sha1", fmt.Sprintf("%x", csum),
+				"issuer", cert.IssuerCommonName,
+				"subject", cert.SubjectCommonName,
+				"path", row["path"])
 			continue
 		}
 		existsSha1User[sha1UserKey] = true

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -53,7 +53,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 		Version:          "2024",
 	}
 
-	MutateSoftwareOnIngestion(t.Context(), dcvViewer, slog.New(slog.DiscardHandler))
+	MutateSoftwareOnIngestion(t.Context(), noOp, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2024", noOp.Version)
 
 	noMatch := &fleet.Software{

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"log/slog"
 	"regexp"
 	"slices"
 	"sort"
@@ -31,7 +32,6 @@ import (
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/async"
-	"github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
@@ -44,7 +44,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 		Version:          "2024.0 (r8004)",
 	}
 
-	MutateSoftwareOnIngestion(dcvViewer, log.NewNopLogger())
+	MutateSoftwareOnIngestion(t.Context(), dcvViewer, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2024.0.8004", dcvViewer.Version)
 
 	noOp := &fleet.Software{
@@ -53,7 +53,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 		Version:          "2024",
 	}
 
-	MutateSoftwareOnIngestion(dcvViewer, log.NewNopLogger())
+	MutateSoftwareOnIngestion(t.Context(), dcvViewer, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2024", noOp.Version)
 
 	noMatch := &fleet.Software{
@@ -62,7 +62,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 		Version:          "2024.0 (r8004)",
 	}
 
-	MutateSoftwareOnIngestion(noMatch, log.NewNopLogger())
+	MutateSoftwareOnIngestion(t.Context(), noMatch, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2024.0 (r8004)", noMatch.Version)
 
 	for expectedName, s := range map[string]*fleet.Software{
@@ -122,7 +122,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 			Source:           "apps",
 		},
 	} {
-		MutateSoftwareOnIngestion(s, log.NewNopLogger())
+		MutateSoftwareOnIngestion(t.Context(), s, slog.New(slog.DiscardHandler))
 		assert.Equal(t, expectedName, s.Name)
 	}
 
@@ -132,7 +132,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 		BundleIdentifier: "TNMS_21.10.0.590.1",
 		Source:           "apps",
 	}
-	MutateSoftwareOnIngestion(sw, log.NewNopLogger())
+	MutateSoftwareOnIngestion(t.Context(), sw, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "TNMS", sw.Name)
 	assert.Equal(t, "21.10.0.590.1", sw.Version)
 }
@@ -141,9 +141,9 @@ func TestDetailQueryNetworkInterfaces(t *testing.T) {
 	var initialHost fleet.Host
 	host := initialHost
 
-	ingest := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["network_interface_unix"].IngestFunc
+	ingest := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["network_interface_unix"].IngestFunc
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, nil))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, nil))
 	assert.Equal(t, initialHost, host)
 
 	var rows []map[string]string
@@ -154,7 +154,7 @@ func TestDetailQueryNetworkInterfaces(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "10.0.1.2", host.PrimaryIP)
 	assert.Equal(t, "bc:d0:74:4b:10:6d", host.PrimaryMac)
 
@@ -168,7 +168,7 @@ func TestDetailQueryNetworkInterfaces(t *testing.T) {
 			&rows,
 		),
 	)
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "fd7a:115c:a1e0::d401:6637", host.PrimaryIP)
 	assert.Equal(t, "b2:a2:e4:62:0f:1e", host.PrimaryMac)
 }
@@ -189,10 +189,10 @@ func TestDetailQueryScheduledQueryStats(t *testing.T) {
 		return nil
 	}
 
-	ingest := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, nil, Integrations{}, nil)["scheduled_query_stats"].DirectTaskIngestFunc
+	ingest := GetDetailQueries(t.Context(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, nil, Integrations{}, nil)["scheduled_query_stats"].DirectTaskIngestFunc
 
-	ctx := context.Background()
-	assert.NoError(t, ingest(ctx, log.NewNopLogger(), &host, task, nil))
+	ctx := t.Context()
+	assert.NoError(t, ingest(ctx, slog.New(slog.DiscardHandler), &host, task, nil))
 	assert.Len(t, host.PackStats, 0)
 
 	resJSON := `
@@ -274,7 +274,7 @@ func TestDetailQueryScheduledQueryStats(t *testing.T) {
 	var rows []map[string]string
 	require.NoError(t, json.Unmarshal([]byte(resJSON), &rows))
 
-	assert.NoError(t, ingest(ctx, log.NewNopLogger(), &host, task, rows))
+	assert.NoError(t, ingest(ctx, slog.New(slog.DiscardHandler), &host, task, rows))
 	assert.Len(t, gotPackStats, 2)
 	sort.Slice(gotPackStats, func(i, j int) bool {
 		return gotPackStats[i].PackName < gotPackStats[j].PackName
@@ -355,7 +355,7 @@ func TestDetailQueryScheduledQueryStats(t *testing.T) {
 		},
 	)
 
-	assert.NoError(t, ingest(ctx, log.NewNopLogger(), &host, task, nil))
+	assert.NoError(t, ingest(ctx, slog.New(slog.DiscardHandler), &host, task, nil))
 	assert.Len(t, gotPackStats, 0)
 }
 
@@ -368,7 +368,7 @@ func sortedKeysCompare(t *testing.T, m map[string]DetailQuery, expectedKeys []st
 }
 
 func TestGetDetailQueries(t *testing.T) {
-	queriesNoConfig := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, nil, Integrations{}, nil)
+	queriesNoConfig := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)
 
 	baseQueries := []string{
 		"network_interface_unix",
@@ -404,16 +404,16 @@ func TestGetDetailQueries(t *testing.T) {
 	require.Len(t, queriesNoConfig, len(baseQueries))
 	sortedKeysCompare(t, queriesNoConfig, baseQueries)
 
-	queriesWithoutWinOSVuln := GetDetailQueries(context.Background(), config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, nil, nil, Integrations{}, nil)
+	queriesWithoutWinOSVuln := GetDetailQueries(t.Context(), config.FleetConfig{Vulnerabilities: config.VulnerabilitiesConfig{DisableWinOSVulnerabilities: true}}, nil, nil, Integrations{}, nil)
 	require.Len(t, queriesWithoutWinOSVuln, 27)
 
-	queriesWithUsers := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true}, Integrations{}, nil)
+	queriesWithUsers := GetDetailQueries(t.Context(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true}, Integrations{}, nil)
 	qs := baseQueries
 	qs = append(qs, "users", "users_chrome", "scheduled_query_stats")
 	require.Len(t, queriesWithUsers, len(qs))
 	sortedKeysCompare(t, queriesWithUsers, qs)
 
-	queriesWithUsersAndSoftware := GetDetailQueries(context.Background(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true}, Integrations{}, nil)
+	queriesWithUsersAndSoftware := GetDetailQueries(t.Context(), config.FleetConfig{App: config.AppConfig{EnableScheduledQueryStats: true}}, nil, &fleet.Features{EnableHostUsers: true, EnableSoftwareInventory: true}, Integrations{}, nil)
 	qs = baseQueries
 	qs = append(qs, "users", "users_chrome", "software_macos", "software_linux", "software_windows", "software_vscode_extensions", "software_jetbrains_plugins", "software_linux_fleetd_pacman",
 		"software_chrome", "software_python_packages", "software_python_packages_with_users_dir", "scheduled_query_stats", "software_macos_firefox", "software_macos_codesign", "software_macos_executable_sha256", "software_windows_last_opened_at", "software_deb_last_opened_at", "software_rpm_last_opened_at", "software_windows_acrobat_dc")
@@ -433,14 +433,14 @@ func TestGetDetailQueries(t *testing.T) {
 	ac := fleet.AppConfig{}
 	ac.MDM.EnabledAndConfigured = true
 	// windows mdm is disabled by default, windows mdm queries should not be present
-	gotQueries := GetDetailQueries(context.Background(), config.FleetConfig{}, &ac, nil, Integrations{}, nil)
+	gotQueries := GetDetailQueries(t.Context(), config.FleetConfig{}, &ac, nil, Integrations{}, nil)
 	wantQueries := baseQueries
 	wantQueries = append(wantQueries, mdmQueriesBase...)
 	require.Len(t, gotQueries, len(wantQueries))
 	sortedKeysCompare(t, gotQueries, wantQueries)
 	// enable windows mdm, windows mdm queries should be present
 	ac.MDM.WindowsEnabledAndConfigured = true
-	gotQueries = GetDetailQueries(context.Background(), config.FleetConfig{}, &ac, nil, Integrations{}, nil)
+	gotQueries = GetDetailQueries(t.Context(), config.FleetConfig{}, &ac, nil, Integrations{}, nil)
 	wantQueries = append(wantQueries, mdmQueriesWindows...)
 	require.Len(t, gotQueries, len(wantQueries))
 	sortedKeysCompare(t, gotQueries, wantQueries)
@@ -488,7 +488,7 @@ func TestGetDetailQueries(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := GetDetailQueries(context.Background(), config.FleetConfig{}, &tt.ac, nil, Integrations{}, nil)
+			got := GetDetailQueries(t.Context(), config.FleetConfig{}, &tt.ac, nil, Integrations{}, nil)
 			for _, name := range tt.want {
 				_, ok := got[name]
 				require.True(t, ok)
@@ -501,9 +501,9 @@ func TestDetailQueriesOSVersionUnixLike(t *testing.T) {
 	var initialHost fleet.Host
 	host := initialHost
 
-	ingest := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version"].IngestFunc
+	ingest := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version"].IngestFunc
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, nil))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, nil))
 	assert.Equal(t, initialHost, host)
 
 	// Rolling release for archlinux
@@ -525,7 +525,7 @@ func TestDetailQueriesOSVersionUnixLike(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "Arch Linux rolling", host.OSVersion)
 
 	// Simulate a linux with a proper version
@@ -546,7 +546,7 @@ func TestDetailQueriesOSVersionUnixLike(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "Arch Linux 1.2.3", host.OSVersion)
 
 	// Simulate Ubuntu host with incorrect `patch` number
@@ -567,7 +567,7 @@ func TestDetailQueriesOSVersionUnixLike(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "Ubuntu 18.04.5 LTS", host.OSVersion)
 }
 
@@ -575,9 +575,9 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 	var initialHost fleet.Host
 	host := initialHost
 
-	ingest := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version_windows"].IngestFunc
+	ingest := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version_windows"].IngestFunc
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, nil))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, nil))
 	assert.Equal(t, initialHost, host)
 
 	var rows []map[string]string
@@ -600,7 +600,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "Windows 11 Enterprise 21H2 10.0.22000", host.OSVersion)
 
 	require.NoError(t, json.Unmarshal([]byte(`
@@ -622,7 +622,7 @@ func TestDetailQueriesOSVersionWindows(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "Windows 10 Enterprise LTSC 10.0.17763", host.OSVersion)
 }
 
@@ -630,9 +630,9 @@ func TestDetailQueriesOSVersionChrome(t *testing.T) {
 	var initialHost fleet.Host
 	host := initialHost
 
-	ingest := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version"].IngestFunc
+	ingest := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, nil, Integrations{}, nil)["os_version"].IngestFunc
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, nil))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, nil))
 	assert.Equal(t, initialHost, host)
 
 	var rows []map[string]string
@@ -653,7 +653,7 @@ func TestDetailQueriesOSVersionChrome(t *testing.T) {
 		&rows,
 	))
 
-	assert.NoError(t, ingest(context.Background(), log.NewNopLogger(), &host, rows))
+	assert.NoError(t, ingest(t.Context(), slog.New(slog.DiscardHandler), &host, rows))
 	assert.Equal(t, "chromeos 1.3.3.7", host.OSVersion)
 }
 
@@ -771,7 +771,7 @@ func TestDirectIngestMDMMac(t *testing.T) {
 				return nil
 			}
 
-			err := directIngestMDMMac(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{c.got})
+			err := directIngestMDMMac(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{c.got})
 			if c.wantErr != "" {
 				require.ErrorContains(t, err, c.wantErr)
 				require.False(t, ds.SetOrUpdateMDMDataFuncInvoked)
@@ -868,7 +868,7 @@ func TestDirectIngestMDMFleetEnrollRef(t *testing.T) {
 				}, nil
 			}
 
-			err := directIngestMDMMac(context.Background(), log.NewNopLogger(), &host, ds, tc.mdmData)
+			err := directIngestMDMMac(t.Context(), slog.New(slog.DiscardHandler), &host, ds, tc.mdmData)
 			require.NoError(t, err)
 			require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
 			ds.SetOrUpdateMDMDataFuncInvoked = false
@@ -899,7 +899,7 @@ func TestDirectIngestMDMFleetEnrollRef(t *testing.T) {
 		}
 
 		t.Run("no team", func(t *testing.T) {
-			err := directIngestMDMMac(context.Background(), log.NewNopLogger(), &host, ds, generateRows("https://test.example.com?enroll_reference=test-reference", apple_mdm.FleetPayloadIdentifier))
+			err := directIngestMDMMac(t.Context(), slog.New(slog.DiscardHandler), &host, ds, generateRows("https://test.example.com?enroll_reference=test-reference", apple_mdm.FleetPayloadIdentifier))
 			require.NoError(t, err)
 			require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
 			ds.SetOrUpdateMDMDataFuncInvoked = false
@@ -907,7 +907,7 @@ func TestDirectIngestMDMFleetEnrollRef(t *testing.T) {
 
 		t.Run("team", func(t *testing.T) {
 			host.TeamID = ptr.Uint(1)
-			err := directIngestMDMMac(context.Background(), log.NewNopLogger(), &host, ds, generateRows("https://test.example.com?enroll_reference=test-reference", apple_mdm.FleetPayloadIdentifier))
+			err := directIngestMDMMac(t.Context(), slog.New(slog.DiscardHandler), &host, ds, generateRows("https://test.example.com?enroll_reference=test-reference", apple_mdm.FleetPayloadIdentifier))
 			require.NoError(t, err)
 			require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
 			ds.SetOrUpdateMDMDataFuncInvoked = false
@@ -1141,7 +1141,7 @@ func TestDirectIngestMDMWindows(t *testing.T) {
 			ds.SetOrUpdateMDMDataFuncInvoked = false
 			ds.MDMWindowsGetEnrolledDeviceWithHostUUIDFuncInvoked = false
 
-			err := directIngestMDMWindows(context.Background(), log.NewNopLogger(), &fleet.Host{}, ds, c.data)
+			err := directIngestMDMWindows(t.Context(), slog.New(slog.DiscardHandler), &fleet.Host{}, ds, c.data)
 			require.NoError(t, err)
 			require.True(t, ds.SetOrUpdateMDMDataFuncInvoked)
 		})
@@ -1164,7 +1164,7 @@ func TestDirectIngestChromeProfiles(t *testing.T) {
 		ID: 1,
 	}
 
-	err := directIngestChromeProfiles(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
+	err := directIngestChromeProfiles(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{
 		{"email": "test@example.com"},
 		{"email": "test+2@example.com"},
 	})
@@ -1250,7 +1250,7 @@ func TestDirectIngestBattery(t *testing.T) {
 				ID: 1,
 			}
 
-			err := directIngestBattery(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{tt.input})
+			err := directIngestBattery(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{tt.input})
 			require.NoError(t, err)
 			require.True(t, ds.ReplaceHostBatteriesFuncInvoked)
 		})
@@ -1299,7 +1299,7 @@ func TestDirectIngestOSWindows(t *testing.T) {
 			return nil
 		}
 
-		err := directIngestOSWindows(context.Background(), log.NewNopLogger(), &host, ds, tt.data)
+		err := directIngestOSWindows(t.Context(), slog.New(slog.DiscardHandler), &host, ds, tt.data)
 		require.NoError(t, err)
 
 		require.True(t, ds.UpdateHostOperatingSystemFuncInvoked)
@@ -1444,7 +1444,7 @@ func TestDirectIngestOSUnixLike(t *testing.T) {
 				return nil
 			}
 
-			err := directIngestOSUnixLike(context.Background(), log.NewNopLogger(), &fleet.Host{ID: uint(i)}, //nolint:gosec // dismiss G115
+			err := directIngestOSUnixLike(t.Context(), slog.New(slog.DiscardHandler), &fleet.Host{ID: uint(i)}, //nolint:gosec // dismiss G115
 				ds, tc.data)
 
 			require.NoError(t, err)
@@ -1455,37 +1455,37 @@ func TestDirectIngestOSUnixLike(t *testing.T) {
 }
 
 func TestAppConfigReplaceQuery(t *testing.T) {
-	queries := GetDetailQueries(context.Background(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true}, Integrations{}, nil)
+	queries := GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true}, Integrations{}, nil)
 	originalQuery := queries["users"].Query
 
 	replacementMap := make(map[string]*string)
 	replacementMap["users"] = ptr.String("select 1 from blah")
-	queries = GetDetailQueries(context.Background(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
+	queries = GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
 	assert.NotEqual(t, originalQuery, queries["users"].Query)
 	assert.Equal(t, "select 1 from blah", queries["users"].Query)
 
 	replacementMap["users"] = nil
-	queries = GetDetailQueries(context.Background(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
+	queries = GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
 	_, exists := queries["users"]
 	assert.False(t, exists)
 
 	// put the query back again
 	replacementMap["users"] = ptr.String("select 1 from blah")
-	queries = GetDetailQueries(context.Background(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
+	queries = GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
 	assert.NotEqual(t, originalQuery, queries["users"].Query)
 	assert.Equal(t, "select 1 from blah", queries["users"].Query)
 
 	// empty strings are also ignored
 	replacementMap["users"] = ptr.String("")
-	queries = GetDetailQueries(context.Background(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
+	queries = GetDetailQueries(t.Context(), config.FleetConfig{}, nil, &fleet.Features{EnableHostUsers: true, DetailQueryOverrides: replacementMap}, Integrations{}, nil)
 	_, exists = queries["users"]
 	assert.False(t, exists)
 }
 
 func TestDirectIngestSoftware(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	host := fleet.Host{ID: uint(1)}
 
 	t.Run("ingesting installed software path", func(t *testing.T) {
@@ -1758,17 +1758,17 @@ func TestDirectIngestWindowsUpdateHistory(t *testing.T) {
 		{"date": "1657929207", "title": "Security Intelligence Update for Microsoft Defender Antivirus - KB2267602 (Version 1.371.203.0)"},
 	}
 
-	err := directIngestWindowsUpdateHistory(context.Background(), log.NewNopLogger(), &host, ds, payload)
+	err := directIngestWindowsUpdateHistory(t.Context(), slog.New(slog.DiscardHandler), &host, ds, payload)
 	require.NoError(t, err)
 	require.True(t, ds.InsertWindowsUpdatesFuncInvoked)
 }
 
 func TestIngestKubequeryInfo(t *testing.T) {
-	err := ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, nil)
+	err := ingestKubequeryInfo(t.Context(), slog.New(slog.DiscardHandler), &fleet.Host{}, nil)
 	require.Error(t, err)
-	err = ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, []map[string]string{})
+	err = ingestKubequeryInfo(t.Context(), slog.New(slog.DiscardHandler), &fleet.Host{}, []map[string]string{})
 	require.Error(t, err)
-	err = ingestKubequeryInfo(context.Background(), log.NewNopLogger(), &fleet.Host{}, []map[string]string{
+	err = ingestKubequeryInfo(t.Context(), slog.New(slog.DiscardHandler), &fleet.Host{}, []map[string]string{
 		{
 			"cluster_name": "foo",
 		},
@@ -1790,7 +1790,7 @@ func TestDirectDiskEncryption(t *testing.T) {
 
 	// set to true (osquery returned a row)
 	expectEncrypted = true
-	err := directIngestDiskEncryption(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
+	err := directIngestDiskEncryption(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{
 		{"col1": "1"},
 	})
 	require.NoError(t, err)
@@ -1799,7 +1799,7 @@ func TestDirectDiskEncryption(t *testing.T) {
 
 	// set to false (osquery returned nothing)
 	expectEncrypted = false
-	err = directIngestDiskEncryption(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{})
+	err = directIngestDiskEncryption(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{})
 	require.NoError(t, err)
 	require.True(t, ds.SetOrUpdateHostDisksEncryptionFuncInvoked)
 	ds.SetOrUpdateHostDisksEncryptionFuncInvoked = false
@@ -1817,13 +1817,13 @@ func TestDirectIngestDiskEncryptionLinux(t *testing.T) {
 	}
 
 	expectEncrypted = false
-	err := directIngestDiskEncryptionLinux(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{})
+	err := directIngestDiskEncryptionLinux(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{})
 	require.NoError(t, err)
 	require.True(t, ds.SetOrUpdateHostDisksEncryptionFuncInvoked)
 	ds.SetOrUpdateHostDisksEncryptionFuncInvoked = false
 
 	expectEncrypted = true
-	err = directIngestDiskEncryptionLinux(context.Background(), log.NewNopLogger(), &host, ds, []map[string]string{
+	err = directIngestDiskEncryptionLinux(t.Context(), slog.New(slog.DiscardHandler), &host, ds, []map[string]string{
 		{"path": "/etc/hosts", "encrypted": "0"},
 		{"path": "/tmp", "encrypted": "0"},
 		{"path": "/", "encrypted": "1"},
@@ -1834,8 +1834,8 @@ func TestDirectIngestDiskEncryptionLinux(t *testing.T) {
 
 func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	host := &fleet.Host{ID: 1}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -1958,8 +1958,8 @@ func TestDirectIngestDiskEncryptionKeyDarwin(t *testing.T) {
 
 func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	h := &fleet.Host{ID: 1}
 
 	toRows := func(profs []*fleet.HostMacOSProfile) []map[string]string {
@@ -2027,8 +2027,8 @@ func TestDirectIngestHostMacOSProfiles(t *testing.T) {
 
 func TestDirectIngestMDMDeviceIDWindows(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	host := &fleet.Host{ID: 1, UUID: "mdm-windows-hw-uuid"}
 
 	returnEnrollmentsUpdated := true
@@ -2221,8 +2221,8 @@ func TestDirectIngestMDMDeviceIDWindows(t *testing.T) {
 }
 
 func TestDirectIngestWindowsProfiles(t *testing.T) {
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	ds := new(mock.Store)
 
 	for _, tc := range []struct {
@@ -2339,7 +2339,7 @@ func TestIngestNetworkInterface(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			h := fleet.Host{PublicIP: "190.18.97.3"} // set to some old value that should always be overridden
-			err := ingestNetworkInterface(publicip.NewContext(context.Background(), tc.ip), log.NewNopLogger(), &h, nil)
+			err := ingestNetworkInterface(publicip.NewContext(t.Context(), tc.ip), slog.New(slog.DiscardHandler), &h, nil)
 			require.NoError(t, err)
 			if tc.valid {
 				require.Equal(t, tc.ip, h.PublicIP)
@@ -2353,13 +2353,13 @@ func TestIngestNetworkInterface(t *testing.T) {
 		h := fleet.Host{PublicIP: "190.18.97.3"} // set to some old value that should always be overridden
 		ip := "10.0.0.1"
 		var b bytes.Buffer
-		logger := log.NewLogfmtLogger(&b)
+		logger := slog.New(slog.NewTextHandler(&b, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 		// Happy path
 		rows := []map[string]string{
 			{"address": "address", "mac": "mac"},
 		}
-		err := ingestNetworkInterface(publicip.NewContext(context.Background(), ip), logger, &h, rows)
+		err := ingestNetworkInterface(publicip.NewContext(t.Context(), ip), logger, &h, rows)
 		require.NoError(t, err)
 		assert.Equal(t, ip, h.PublicIP)
 		assert.Equal(t, "mac", h.PrimaryMac)
@@ -2369,7 +2369,7 @@ func TestIngestNetworkInterface(t *testing.T) {
 		// No rows
 		b.Reset()
 		h = fleet.Host{PublicIP: "190.18.97.3"}
-		err = ingestNetworkInterface(publicip.NewContext(context.Background(), ip), logger, &h, []map[string]string{})
+		err = ingestNetworkInterface(publicip.NewContext(t.Context(), ip), logger, &h, []map[string]string{})
 		require.NoError(t, err)
 		assert.Equal(t, ip, h.PublicIP)
 		assert.Empty(t, h.PrimaryMac)
@@ -2383,7 +2383,7 @@ func TestIngestNetworkInterface(t *testing.T) {
 			{"address": "address", "mac": "mac"},
 			{"address": "address2", "mac": "mac2"},
 		}
-		err = ingestNetworkInterface(publicip.NewContext(context.Background(), ip), logger, &h, rows)
+		err = ingestNetworkInterface(publicip.NewContext(t.Context(), ip), logger, &h, rows)
 		require.NoError(t, err)
 		assert.Equal(t, ip, h.PublicIP)
 		assert.Empty(t, h.PrimaryMac)
@@ -2394,8 +2394,8 @@ func TestIngestNetworkInterface(t *testing.T) {
 
 func TestDirectIngestHostCertificates(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	host := &fleet.Host{ID: 1, UUID: "host-uuid", Platform: "darwin"}
 
 	row1 := map[string]string{
@@ -2488,8 +2488,8 @@ func TestDirectIngestHostCertificates(t *testing.T) {
 
 func TestDirectIngestHostCertificatesWindows(t *testing.T) {
 	ds := new(mock.Store)
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 	host := &fleet.Host{ID: 1, UUID: "host-uuid", Platform: "windows"}
 
 	// Fleet SCEP cert example based on data from a real Windows host
@@ -2665,8 +2665,8 @@ func TestLuksVerifyQueryIngester(t *testing.T) {
 	decrypter := func(encrypted string) (string, error) {
 		return encrypted, nil
 	}
-	ctx := context.Background()
-	logger := log.NewNopLogger()
+	ctx := t.Context()
+	logger := slog.New(slog.DiscardHandler)
 
 	nonLUKSHost := &fleet.Host{ID: 1, Platform: "skynet"}
 	luksHost := &fleet.Host{ID: 1, Platform: "ubuntu"}
@@ -2811,7 +2811,7 @@ func TestLuksVerifyQueryIngester(t *testing.T) {
 }
 
 func TestUserIngestNoUID(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	host := fleet.Host{ID: 1}
 	ds := new(mock.Store)
 	savedUsers := 0
@@ -2834,7 +2834,7 @@ func TestUserIngestNoUID(t *testing.T) {
 }
 
 func TestUserIngestMacosUpdateManagedUser(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	host := fleet.Host{ID: 1, UUID: "host-uuid", Platform: "darwin"}
 	ds := new(mock.Store)
 	userUUIDForUpdate := "uuid-1234"
@@ -3192,15 +3192,15 @@ func TestTPMPinSetVerifyIngest(t *testing.T) {
 
 			ingestFunc := tpmPINQueries["tpm_pin_set_verify"].DirectIngestFunc
 
-			require.NoError(t, ingestFunc(context.Background(), log.NewNopLogger(), tt.host, ds, tt.rows))
+			require.NoError(t, ingestFunc(t.Context(), slog.New(slog.DiscardHandler), tt.host, ds, tt.rows))
 			require.Equal(t, setPinCalled, tt.pinSet != nil)
 		})
 	}
 }
 
 func TestTPMPinConfigVerifyDirectIngest(t *testing.T) {
-	logger := log.NewNopLogger()
-	ctx := context.Background()
+	logger := slog.New(slog.DiscardHandler)
+	ctx := t.Context()
 
 	tests := []struct {
 		name      string


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38889 

Plan was to convert `osquery_utils` package to slog. Picked up some additional code that was related.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  - Already have changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

## Refactor
* Updated internal logging infrastructure to use improved system-level logging utilities

## Tests
* Updated test suite to align with internal logging changes

---

**Note:** This release contains internal infrastructure improvements with no user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->