### PR TITLE
Website: Add related topics to handbook sidebar

### DIFF
--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -8,6 +8,7 @@ parasails.registerPage('basic-handbook', {
     breadcrumbs: [],
     subtopics: [],
     handbookIndexLinks: [],
+    relatedPages: [],
     hideEmojisOnPage: false,
     regexToMatchEmoji: /(?:(?!🥚|🐣|🐥|🦆|🦢)(?:[\u00A9\u00AE\u203C\u2049\u2122\u2139\u2194-\u21AA\u2300-\u23FF\u2460-\u24FF\u25AA-\u25FE\u2600-\u26FF\u2700-\u27BF\u2900-\u297F\u2934-\u2935\u2B05-\u2B07\u2B1B-\u2B1C\u2B50\u2B55\u3030\u303D\u3297\u3299]|\uD83C[\uDC04\uDCCF\uDD70-\uDD71\uDD7E-\uDD7F\uDE00-\uDE02\uDE1A\uDE2F\uDE30-\uDE39\uDE3A-\uDE3F\uDE50-\uDE51\uDF00-\uDF21\uDF24-\uDF93\uDF96-\uDF97\uDF99-\uDFF0\uDFF3-\uDFF5\uDFF7-\uDFFF]|\uD83D[\uDC00-\uDDFF\uDE00-\uDE4F\uDE80-\uDEFF\uDFE0-\uDFFF]|\uD83E[\uDD0D-\uDDFF\uDE00-\uDEFF]))\s{0,1}/g
   },
@@ -138,6 +139,23 @@ parasails.registerPage('basic-handbook', {
       return subtopics;
     })();
 
+    let pagesInFolder = (()=>{
+      let relatedPages = [];
+      if(!this.isHandbookLandingPage){
+        let thisPagesFolderInTheHandbookFolder = this.thisPage.sectionRelativeRepoPath.split('/')[0];
+        if(thisPagesFolderInTheHandbookFolder !== 'company'){
+          let pagesInThisFolder = _.filter(this.markdownPages, (page)=>{ return _.startsWith(page.sectionRelativeRepoPath, thisPagesFolderInTheHandbookFolder);});
+          relatedPages = pagesInThisFolder.map((page)=>{
+            return {
+              url: page.url,
+              title: _.trim(page.title.replace(this.regexToMatchEmoji, '')),
+            };
+          });
+        }
+        return relatedPages;
+      }
+    })();
+    this.relatedPages = pagesInFolder;
     // Set counters for items in ordered lists to be the value of their "start" attribute.
     document.querySelectorAll('ol[start]').forEach((ol)=> {
       let startValue = parseInt(ol.getAttribute('start'), 10) - 1;

--- a/website/assets/js/pages/handbook/basic-handbook.page.js
+++ b/website/assets/js/pages/handbook/basic-handbook.page.js
@@ -138,21 +138,21 @@ parasails.registerPage('basic-handbook', {
       });
       return subtopics;
     })();
-
+    // Create a list of "Related topics"
     let pagesInFolder = (()=>{
       let relatedPages = [];
-      if(!this.isHandbookLandingPage){
+      if(!this.isHandbookLandingPage) {
         let thisPagesFolderInTheHandbookFolder = this.thisPage.sectionRelativeRepoPath.split('/')[0];
-        if(thisPagesFolderInTheHandbookFolder !== 'company'){
-          let pagesInThisFolder = _.filter(this.markdownPages, (page)=>{ return _.startsWith(page.sectionRelativeRepoPath, thisPagesFolderInTheHandbookFolder);});
-          relatedPages = pagesInThisFolder.map((page)=>{
+        let pagesInThisFolder = _.filter(this.markdownPages, (page)=>{ return _.startsWith(page.sectionRelativeRepoPath, thisPagesFolderInTheHandbookFolder);});
+        relatedPages = pagesInThisFolder.map((page)=>{
+          if(!_.startsWith(page.url, '/handbook/company/open-positions') && !_.startsWith(page.url, '/handbook/company/legal') ){
             return {
               url: page.url,
-              title: _.trim(page.title.replace(this.regexToMatchEmoji, '')),
+              title: page.title.replace(this.regexToMatchEmoji, '').replace(/^\W/, ''),
             };
-          });
-        }
-        return relatedPages;
+          }
+        });
+        return _.filter(relatedPages, (page)=>{ return !! page; });
       }
     })();
     this.relatedPages = pagesInFolder;

--- a/website/assets/styles/pages/handbook/basic-handbook.less
+++ b/website/assets/styles/pages/handbook/basic-handbook.less
@@ -643,7 +643,7 @@
       padding-bottom: 0px;
     }
     [purpose='right-sidebar'] {
-      width: 100%;
+      width: fit-content;
       margin: 0;
       [purpose='subtopics'] {
         border-left: none;

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -18,7 +18,7 @@
             </ul>
           </div>
           <div purpose="related-pages-links" class="pt-3" v-if="relatedPages.length > 1">
-            <h4 class="font-weight-bold pb-2 m-0 mb-2" >Related pages:</h4>
+            <h4 class="font-weight-bold pb-2 m-0 mb-2" >Related topics:</h4>
             <div purpose="subtopics">
               <ul class="p-0 m-0">
                 <li v-for="(relatedPage, index) in relatedPages" class="subtopic" :key="index" v-if="relatedPage.url !== thisPage.url">

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -17,6 +17,16 @@
               </li>
             </ul>
           </div>
+          <div purpose="related-pages-links" class="pt-3" v-if="relatedPages.length > 1">
+            <h4 class="font-weight-bold pb-2 m-0 mb-2" >Related pages:</h4>
+            <div purpose="subtopics">
+              <ul class="p-0 m-0">
+                <li v-for="(relatedPage, index) in relatedPages" class="subtopic" :key="index" v-if="relatedPage.url !== thisPage.url">
+                  <a :href="relatedPage.url" class="pl-lg-3">{{_.trim(relatedPage.title)}}</a>
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
         <div class="border-bottom py-3 d-flex d-md-none"></div>
       </div>
@@ -86,9 +96,19 @@
                 </li>
               </ul>
             </div>
+            <div purpose="related-pages-links" class="pt-3" v-if="relatedPages.length > 1">
+              <h4>Related pages:</h4>
+              <div purpose="subtopics">
+                <ul class="p-0 m-0">
+                  <li v-for="(relatedPage, index) in relatedPages" class="subtopic" :key="index"  v-if="relatedPage.url !== thisPage.url">
+                    <a :href="relatedPage.url">{{_.trim(relatedPage.title)}}</a>
+                  </li>
+                </ul>
+              </div>
+            </div>
           </div>
           <div>
-            <a href="/contact" purpose="sidebar-cta" class="d-flex flex-row justify-content-start">
+            <a href="/contact" purpose="sidebar-cta" class="d-flex flex-row justify-content-start" no-underline>
             <div class="d-flex align-self-start">
               <img alt="Ask us anything" src="/images/icon-question-20x19@2x.png">
             </div>

--- a/website/views/pages/handbook/basic-handbook.ejs
+++ b/website/views/pages/handbook/basic-handbook.ejs
@@ -97,7 +97,7 @@
               </ul>
             </div>
             <div purpose="related-pages-links" class="pt-3" v-if="relatedPages.length > 1">
-              <h4>Related pages:</h4>
+              <h4>Related topics:</h4>
               <div purpose="subtopics">
                 <ul class="p-0 m-0">
                   <li v-for="(relatedPage, index) in relatedPages" class="subtopic" :key="index"  v-if="relatedPage.url !== thisPage.url">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/37626

Changes:
- Updated the sidebar on handbook department pages to include a list of related topics (pages in the same handbook folder)
