### PR TITLE
Move copy UI for `InputField`s with `type="textarea"` in line with the label

### DIFF
--- a/changes/35561-move-textarea-copy-icons
+++ b/changes/35561-move-textarea-copy-icons
@@ -1,0 +1,1 @@
+- Moved the copy button for text areas out of the text area itself and in line with its label

--- a/frontend/components/forms/fields/InputField/InputField.jsx
+++ b/frontend/components/forms/fields/InputField/InputField.jsx
@@ -147,7 +147,9 @@ class InputField extends Component {
     const { onClickCopy } = this;
 
     const copyButtonValue = <Icon name="copy" />;
-    const wrapperClasses = classnames(`${baseClass}__copy-wrapper`);
+    const wrapperClasses = classnames(`${baseClass}__copy-wrapper`, {
+      [`${baseClass}__copy-wrapper__text-area`]: this.props.type === "textarea",
+    });
 
     const copiedConfirmationClasses = classnames(
       `${baseClass}__copied-confirmation`

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -99,6 +99,10 @@
     right: 0;
     margin: 1px 4px;
     background-color: $core-fleet-white;
+
+    &__text-area {
+      top: -30px;
+    }
   }
 
   &__input-container.copy-enabled {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35561 

<img width="647" height="655" alt="Screenshot 2026-02-13 at 4 24 57 PM" src="https://github.com/user-attachments/assets/b191f8bb-e6b7-4f3d-8819-eccf23a408f8" />

- Spot checked all relevant instances of `InputField` (`type="textarea" and `enableCopy`)


- [x] Changes file added for user-visible changes in `changes/`
-  [x] QA'd all new/changed functionality manually