### PR TITLE
Fixed failing test on main

### DIFF
--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -174,8 +174,9 @@ func TestTranslateCPEToCVE(t *testing.T) {
 				{ID: "CVE-2021-3572", resolvedInVersion: "21.1"},
 				{ID: "CVE-2025-8869", resolvedInVersion: "25.3"},
 				{ID: "CVE-2023-5752", resolvedInVersion: "23.3"},
+				{ID: "CVE-2026-1703", resolvedInVersion: "26.0"},
 			},
-			continuesToUpdate: false,
+			continuesToUpdate: true,
 		},
 		"cpe:2.3:a:mozilla:firefox:93.0:*:*:*:*:windows:*:*": {
 			includedCVEs:      firefox93WindowsVulnerabilities,


### PR DESCRIPTION
  1. Added CVE-2026-1703 (resolved in version 26.0) to the expected CVE list for cpe:2.3:a:pypa:pip:9.0.3:*:*:*:*:python:*:*                                                                                                                                                                                       
  2. Changed continuesToUpdate from false to true; pip is an actively maintained package that continues to receive new CVE entries. Using continuesToUpdate: true makes the test check that the expected CVEs are a subset of found CVEs (via Contains) rather than requiring an exact match (via ElementsMatch), preventing this test from breaking again when the next pip CVE is published. 