### PR TITLE
Navigate from vuln/version pages to software title page

### DIFF
--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -50,6 +50,7 @@ export interface ISoftware {
   extension_for?: string;
   vendor?: string;
   icon_url: string | null; // Only available on team view if an admin uploaded an icon to a team's software
+  software_title_id?: number;
 }
 
 export type IVulnerabilitySoftware = Omit<
@@ -229,6 +230,7 @@ export interface ISoftwareVersion {
   generated_cpe: string;
   vulnerabilities: ISoftwareVulnerability[] | null;
   hosts_count?: number;
+  software_title_id?: number;
   /** @deprecated Use extension_for instead */
   browser?: string;
 }

--- a/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVersionDetailsPage/SoftwareVersionDetailsPage.tsx
@@ -34,6 +34,9 @@ import MainContent from "components/MainContent";
 import TeamsHeader from "components/TeamsHeader";
 import Card from "components/Card";
 
+import PATHS from "router/paths";
+import { getPathWithQueryParams } from "utilities/url";
+
 import SoftwareDetailsSummary from "../components/cards/SoftwareDetailsSummary";
 import SoftwareVulnerabilitiesTable from "../components/tables/SoftwareVulnerabilitiesTable";
 import DetailsNoHosts from "../components/cards/DetailsNoHosts";
@@ -192,6 +195,16 @@ const SoftwareVersionDetailsPage = ({
                 }}
                 name={softwareVersion.name}
                 source={softwareVersion.source}
+                titleDetailsPath={
+                  softwareVersion.software_title_id
+                    ? getPathWithQueryParams(
+                        PATHS.SOFTWARE_TITLE_DETAILS(
+                          softwareVersion.software_title_id.toString()
+                        ),
+                        { team_id: teamIdForApi }
+                      )
+                    : undefined
+                }
               />
             </Card>
             <Card

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SoftwareVulnSoftwareVersions.tsx
@@ -21,6 +21,7 @@ const baseClass = "software-vuln-software-versions";
 interface IRowProps extends Row {
   original: {
     id?: number;
+    software_title_id?: number;
   };
 }
 
@@ -43,17 +44,19 @@ const SoftwareVulnSoftwareVersions = ({
   );
 
   const handleRowSelect = (row: IRowProps) => {
-    if (row.original.id) {
-      const softwareVersionId = row.original.id;
-
-      const softwareVersionDetailsPath = getPathWithQueryParams(
-        PATHS.SOFTWARE_VERSION_DETAILS(softwareVersionId.toString()),
+    const { software_title_id, id } = row.original;
+    const targetId = software_title_id || id;
+    if (targetId) {
+      const path = getPathWithQueryParams(
+        software_title_id
+          ? PATHS.SOFTWARE_TITLE_DETAILS(software_title_id.toString())
+          : PATHS.SOFTWARE_VERSION_DETAILS(id!.toString()),
         {
           team_id: teamIdForApi,
         }
       );
 
-      router.push(softwareVersionDetailsPath);
+      router.push(path);
     }
   };
 

--- a/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareVulnerabilityDetailsPage/SoftwareVulnSoftwareVersions/SwVulnSwTableConfig.tsx
@@ -34,10 +34,18 @@ const generateColumnConfigs = (
       disableSortBy: true,
       accessor: "name",
       Cell: ({ row }: ITableStringCellProps) => {
-        const { name, id } = row.original;
+        const { name, software_title_id } = row.original;
+        if (!software_title_id) {
+          return (
+            <span className="name-cell">
+              <SoftwareIcon name={name} />
+              <TextCell value={name} />
+            </span>
+          );
+        }
         // since No Teams not supported on this page, falsiness of 0 is okay
-        const path = getPathWithQueryParams(
-          PATHS.SOFTWARE_VERSION_DETAILS(id.toString()),
+        const titlePath = getPathWithQueryParams(
+          PATHS.SOFTWARE_TITLE_DETAILS(software_title_id.toString()),
           { team_id: teamIdForApi }
         );
 
@@ -45,7 +53,7 @@ const generateColumnConfigs = (
         // Cleanup: Refactor to use SoftwareNameCell when icon_url is available
         return (
           <LinkCell
-            path={path}
+            path={titlePath}
             tooltipTruncate
             prefix={<SoftwareIcon name={name} />}
             value={name}
@@ -57,9 +65,14 @@ const generateColumnConfigs = (
       Header: "Version",
       disableSortBy: true,
       accessor: "version",
-      Cell: ({ cell }: ITableStringCellProps) => (
-        <TextCell value={cell.value} />
-      ),
+      Cell: ({ row }: ITableStringCellProps) => {
+        const { id, version } = row.original;
+        const versionPath = getPathWithQueryParams(
+          PATHS.SOFTWARE_VERSION_DETAILS(id.toString()),
+          { team_id: teamIdForApi }
+        );
+        return <LinkCell path={versionPath} value={version} />;
+      },
     },
     {
       Header: () => (

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -134,6 +134,8 @@ interface ISoftwareDetailsSummaryProps {
   iconPreviewUrl?: string | null;
   /** timestamp of when icon was last uploaded, used to force refresh of cached icon */
   iconUploadedAt?: string;
+  /** Path to the software title details page. When provided, the display name becomes a clickable link. */
+  titleDetailsPath?: string;
 }
 
 const SoftwareDetailsSummary = ({
@@ -154,6 +156,7 @@ const SoftwareDetailsSummary = ({
   onClickEditAutoUpdateConfig,
   iconPreviewUrl,
   iconUploadedAt,
+  titleDetailsPath,
 }: ISoftwareDetailsSummaryProps) => {
   const hostCountPath = getPathWithQueryParams(paths.MANAGE_HOSTS, queryParams);
 
@@ -236,6 +239,8 @@ const SoftwareDetailsSummary = ({
                   {displayName.slice(0, -8)}
                   <TooltipWrapperArchLinuxRolling />
                 </>
+              ) : titleDetailsPath ? (
+                <CustomLink url={titleDetailsPath} text={displayName} />
               ) : (
                 <TooltipTruncatedText value={displayName} />
               )}

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -247,9 +247,7 @@ const SoftwareDetailsSummary = ({
         )}
         <dl className={`${baseClass}__info`}>
           <div className={`${baseClass}__title-actions`}>
-            <h1 aria-label="software display name">
-              {renderDisplayName()}
-            </h1>
+            <h1 aria-label="software display name">{renderDisplayName()}</h1>
             {canManageSoftware && (
               <div className={`${baseClass}__actions-wrapper`}>
                 <DropdownWrapper

--- a/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
+++ b/frontend/pages/SoftwarePage/components/cards/SoftwareDetailsSummary/SoftwareDetailsSummary.tsx
@@ -214,6 +214,21 @@ const SoftwareDetailsSummary = ({
     );
   };
 
+  const renderDisplayName = () => {
+    if (isRollingArch) {
+      return (
+        <>
+          {displayName.slice(0, -8)}
+          <TooltipWrapperArchLinuxRolling />
+        </>
+      );
+    }
+    if (titleDetailsPath) {
+      return <CustomLink url={titleDetailsPath} text={displayName} />;
+    }
+    return <TooltipTruncatedText value={displayName} />;
+  };
+
   const actionOptions = buildActionOptions(
     gitOpsModeEnabled,
     repoURL,
@@ -233,17 +248,7 @@ const SoftwareDetailsSummary = ({
         <dl className={`${baseClass}__info`}>
           <div className={`${baseClass}__title-actions`}>
             <h1 aria-label="software display name">
-              {isRollingArch ? (
-                // wrap a tooltip around the "rolling" suffix
-                <>
-                  {displayName.slice(0, -8)}
-                  <TooltipWrapperArchLinuxRolling />
-                </>
-              ) : titleDetailsPath ? (
-                <CustomLink url={titleDetailsPath} text={displayName} />
-              ) : (
-                <TooltipTruncatedText value={displayName} />
-              )}
+              {renderDisplayName()}
             </h1>
             {canManageSoftware && (
               <div className={`${baseClass}__actions-wrapper`}>

--- a/server/datastore/mysql/vulnerabilities.go
+++ b/server/datastore/mysql/vulnerabilities.go
@@ -187,7 +187,8 @@ func (ds *Datastore) SoftwareByCVE(ctx context.Context, cve string, teamID *uint
 			s.extension_for,
 			COALESCE(scpe.cpe, '') as generated_cpe,
 			COALESCE(shc.hosts_count, 0) as hosts_count,
-			COALESCE(sc.resolved_in_version, '') as resolved_in_version
+			COALESCE(sc.resolved_in_version, '') as resolved_in_version,
+			s.title_id as software_title_id
 		FROM software s
 		JOIN software_cve sc ON sc.software_id = s.id
 		LEFT JOIN software_cpe scpe ON scpe.software_id = s.id

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -129,7 +129,7 @@ type Software struct {
 
 	// TitleID is the ID of the associated software title, representing a unique combination of name
 	// and source.
-	TitleID *uint `json:"-" db:"title_id"`
+	TitleID *uint `json:"software_title_id,omitempty" db:"title_id"`
 	// NameSource indicates whether the name for this Software was changed during the migration to
 	// Fleet 4.67.0
 	NameSource string `json:"-" db:"name_source"`
@@ -252,6 +252,7 @@ type VulnerableSoftware struct {
 	GenerateCPE       string  `json:"generated_cpe" db:"generated_cpe"`
 	HostsCount        int     `json:"hosts_count,omitempty" db:"hosts_count"`
 	ResolvedInVersion *string `json:"resolved_in_version" db:"resolved_in_version"`
+	SoftwareTitleID   *uint   `json:"software_title_id,omitempty" db:"software_title_id"`
 }
 
 type VulnSoftwareFilter struct {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -12640,6 +12640,7 @@ func (s *integrationMDMTestSuite) TestRefetchIOSIPadOS() {
 
 	for index := range hostResp.Host.Software {
 		hostResp.Host.Software[index].ID = 0
+		hostResp.Host.Software[index].TitleID = nil
 	}
 	assert.ElementsMatch(t, expectedSoftware, hostResp.Host.Software)
 
@@ -12692,6 +12693,7 @@ func (s *integrationMDMTestSuite) TestRefetchIOSIPadOS() {
 
 	for index := range hostResp.Host.Software {
 		hostResp.Host.Software[index].ID = 0
+		hostResp.Host.Software[index].TitleID = nil
 	}
 	assert.ElementsMatch(t, expectedSoftware, hostResp.Host.Software)
 
@@ -12760,6 +12762,7 @@ func (s *integrationMDMTestSuite) TestRefetchIOSIPadOS() {
 
 	for index := range hostResp.Host.Software {
 		hostResp.Host.Software[index].ID = 0
+		hostResp.Host.Software[index].TitleID = nil
 	}
 	assert.ElementsMatch(t, expectedSoftware, hostResp.Host.Software)
 


### PR DESCRIPTION
## Summary
- Expose `software_title_id` in `GET /software/versions/:id` and `GET /software/vulnerabilities/:cve` API responses
- On the vulnerability detail page, software **name** now links to the **title** page (`/software/titles/:id`), and **version** now links to the **version** page (`/software/versions/:id`)
- On the software version detail page, the display name now links to the **title** page
- Row click on the vulnerable software table navigates to the title page

Closes #27825

## Test plan
- [x] `TestVulnerabilities` (all 13 subtests) pass locally against MySQL
- [ ] Navigate to `/software/vulnerabilities`, click a CVE
- [ ] Click a software name → should go to `/software/titles/:id`
- [ ] Click a version number → should go to `/software/versions/:id`
- [ ] On the version page, click the software title name → should go to `/software/titles/:id`

## Changes

### Backend
| File | Change |
|---|---|
| `server/fleet/software.go` | Unhide `TitleID` JSON tag; add `SoftwareTitleID` to `VulnerableSoftware` |
| `server/datastore/mysql/vulnerabilities.go` | Add `s.title_id as software_title_id` to `SoftwareByCVE` query |
| `server/datastore/mysql/vulnerabilities_test.go` | Strengthen test to verify exact title ID from DB |

### Frontend
| File | Change |
|---|---|
| `frontend/interfaces/software.ts` | Add `software_title_id` to `ISoftware` and `ISoftwareVersion` |
| `frontend/.../SwVulnSwTableConfig.tsx` | Name column → title page link; Version column → version page link |
| `frontend/.../SoftwareVulnSoftwareVersions.tsx` | Row click → title page |
| `frontend/.../SoftwareDetailsSummary.tsx` | New `titleDetailsPath` prop for clickable display name |
| `frontend/.../SoftwareVersionDetailsPage.tsx` | Pass `titleDetailsPath` to summary |