### PR TITLE
Fixed false positive CVE on emacs-common on Ubuntu.

### DIFF
--- a/changes/39370-emacs-false-positive
+++ b/changes/39370-emacs-false-positive
@@ -1,0 +1,1 @@
+Fixed false positive CVE on emacs-common on Ubuntu.

--- a/server/vulnerabilities/nvd/indexed_cpe_item_test.go
+++ b/server/vulnerabilities/nvd/indexed_cpe_item_test.go
@@ -1,0 +1,65 @@
+package nvd
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFmtStrEpochStripping(t *testing.T) {
+	item := &IndexedCPEItem{
+		Vendor:  "gnu",
+		Product: "emacs",
+	}
+
+	testCases := []struct {
+		name            string
+		software        fleet.Software
+		expectedVersion string // the version segment in the CPE string
+	}{
+		{
+			name: "deb package with epoch prefix strips epoch",
+			software: fleet.Software{
+				Name:    "emacs-common",
+				Version: "1:29.3+1-1ubuntu2",
+				Source:  "deb_packages",
+			},
+			expectedVersion: "29.3.1-1ubuntu2",
+		},
+		{
+			name: "rpm package with epoch strips epoch",
+			software: fleet.Software{
+				Name:    "some-package",
+				Version: "2:3.28.0-4.el9",
+				Source:  "rpm_packages",
+			},
+			expectedVersion: "3.28.0-4.el9",
+		},
+		{
+			name: "deb package without epoch unchanged",
+			software: fleet.Software{
+				Name:    "some-package",
+				Version: "29.3+1-1ubuntu2",
+				Source:  "deb_packages",
+			},
+			expectedVersion: "29.3.1-1ubuntu2",
+		},
+		{
+			name: "non-deb source does not strip epoch-like prefix",
+			software: fleet.Software{
+				Name:    "some-app",
+				Version: "1:2.3.4",
+				Source:  "programs",
+			},
+			expectedVersion: "1.2.3.4",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := item.FmtStr(&tc.software)
+			assert.Contains(t, result, ":"+tc.expectedVersion+":")
+		})
+	}
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39370 

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive CVE detection for emacs-common on Ubuntu.
  * Improved vulnerability version matching accuracy for Debian and RPM packages by properly handling version format variations.

* **Tests**
  * Added test coverage for version format handling in vulnerability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->