### PR TITLE
[TEST] Patch policy

### DIFF
--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -1,6 +1,7 @@
 - name: macOS - 1Password up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.2') < 0);
+  type: patch
   critical: false
-  description: The host may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Check for updates using 1Password's built-in update functionality or download the latest version from self-service. 
-  platform: darwin
+  description: Outdated software might introduce security vulnerabilities or compatibility issues.
+  resolution: Install the latest version from self-service.'s built-in update functionality or download the latest version from self-service. 
+  fleet_maintained_app_slug: 1password/darwin
+  install_software: true


### PR DESCRIPTION
Hey @allenhouchins, I created this PR to get your feedback on our design for #31914.

TLDR:
- New policy type: `patch`.
- Automatically updates query from Fleet-maintained [manifest](https://github.com/fleetdm/fleet/blob/main/ee/maintained-apps/outputs/1password/darwin.json).
- `install_software` is optional. We can keep the current behavior, so policy failure appears on my device, and it is up to the user to update it from self-service.
- In the future, we plan to enhance the end-user experience through improved notifications and calendar integration.