### PR TITLE
Migrate platform/endpointer and platform/middleware/ratelimit to slog.

### DIFF
--- a/server/mdm/android/service/profiles_test.go
+++ b/server/mdm/android/service/profiles_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/mock"
 	"github.com/fleetdm/fleet/v4/server/mdm/android/service/androidmgmt"
-	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/google/uuid"
@@ -101,7 +100,7 @@ func TestReconcileProfiles(t *testing.T) {
 					Package:       "com.fleetdm.agent",
 					SigningSHA256: "abc123def456",
 				},
-				Logger: slog.New(logging.DiscardHandler{}),
+				Logger: slog.New(slog.DiscardHandler),
 			}
 
 			c.fn(t, ds, client, reconciler)
@@ -1008,7 +1007,7 @@ func testBuildAndSendFleetAgentConfigForEnrollment(t *testing.T, ds fleet.Datast
 	// Create service and call BuildAndSendFleetAgentConfig with skipHostsWithoutNewCerts=false
 	// This simulates the enrollment flow from software_worker.go
 	svc := &Service{
-		logger:           slog.New(logging.DiscardHandler{}),
+		logger:           slog.New(slog.DiscardHandler),
 		fleetDS:          ds,
 		ds:               ds.(fleet.AndroidDatastore),
 		androidAPIClient: client,

--- a/server/mdm/android/tests/testing_utils.go
+++ b/server/mdm/android/tests/testing_utils.go
@@ -220,7 +220,7 @@ func runServerForTests(t *testing.T, logger *logging.Logger, fleetSvc fleet.Serv
 			kithttp.PopulateRequestContext,
 			auth.SetRequestsContexts(fleetSvc),
 		),
-		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: logger}),
+		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: logger.SlogLogger()}),
 		kithttp.ServerErrorEncoder(androidErrorEncoder),
 		kithttp.ServerAfter(
 			kithttp.SetContentType("application/json; charset=utf-8"),

--- a/server/platform/logging/logging.go
+++ b/server/platform/logging/logging.go
@@ -149,21 +149,10 @@ func (h *OtelTracingHandler) WithGroup(name string) slog.Handler {
 // Ensure OtelTracingHandler implements slog.Handler at compile time.
 var _ slog.Handler = (*OtelTracingHandler)(nil)
 
-// DiscardHandler is a slog.Handler that discards all log records.
-type DiscardHandler struct{}
-
-func (DiscardHandler) Enabled(context.Context, slog.Level) bool  { return false }
-func (DiscardHandler) Handle(context.Context, slog.Record) error { return nil }
-func (d DiscardHandler) WithAttrs([]slog.Attr) slog.Handler      { return d }
-func (d DiscardHandler) WithGroup(string) slog.Handler           { return d }
-
-// Ensure DiscardHandler implements slog.Handler at compile time.
-var _ slog.Handler = DiscardHandler{}
-
 // NewNopLogger returns a no-op *Logger that discards all log output.
 // Use this in tests instead of kitlog.NewNopLogger() to maintain type safety.
 func NewNopLogger() *Logger {
-	return NewLogger(slog.New(DiscardHandler{}))
+	return NewLogger(slog.New(slog.DiscardHandler))
 }
 
 // NewLogfmtLogger creates a *Logger that outputs text-formatted logs to the given writer.

--- a/server/platform/middleware/ratelimit/ratelimit.go
+++ b/server/platform/middleware/ratelimit/ratelimit.go
@@ -3,14 +3,13 @@ package ratelimit
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/publicip"
 	"github.com/go-kit/kit/endpoint"
-	kitlog "github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/throttled/throttled/v2"
 )
 
@@ -86,7 +85,7 @@ func NewErrorMiddleware(ipBanner IPBanner) *ErrorMiddleware {
 	return &ErrorMiddleware{ipBanner: ipBanner}
 }
 
-func (m *ErrorMiddleware) Limit(logger kitlog.Logger) endpoint.Middleware {
+func (m *ErrorMiddleware) Limit(logger *slog.Logger) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, req interface{}) (response interface{}, err error) {
 			publicIP := publicip.FromContext(ctx)
@@ -111,22 +110,14 @@ func (m *ErrorMiddleware) Limit(logger kitlog.Logger) endpoint.Middleware {
 				if az, ok := authz_ctx.FromContext(ctx); ok {
 					az.SetChecked()
 				}
-				level.Warn(logger).Log(
-					"ip", publicIP,
-					"msg", "limit exceeded",
-				)
+				logger.WarnContext(ctx, "limit exceeded", "ip", publicIP)
 				return nil, ctxerr.Wrap(ctx, &rateLimitError{})
-
 			}
 
 			resp, err := next(ctx, req)
 
 			if rateErr := m.ipBanner.RunRequest(publicIP, err == nil); rateErr != nil {
-				level.Warn(logger).Log(
-					"ip", publicIP,
-					"msg", "fail to run request on IP banner",
-					"err", rateErr,
-				)
+				logger.WarnContext(ctx, "fail to run request on IP banner", "ip", publicIP, "err", rateErr)
 			}
 
 			return resp, err

--- a/server/service/endpoint_utils_test.go
+++ b/server/service/endpoint_utils_test.go
@@ -17,13 +17,11 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
-	platformlogging "github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
-	kitlog "github.com/go-kit/log"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -316,11 +314,11 @@ func TestEndpointer(t *testing.T) {
 			kithttp.PopulateRequestContext, // populate the request context with common fields
 			auth.SetRequestsContexts(svc),
 		),
-		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: kitlog.NewNopLogger()}),
+		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: slog.New(slog.DiscardHandler)}),
 		kithttp.ServerErrorEncoder(fleetErrorEncoder),
 		kithttp.ServerAfter(
 			kithttp.SetContentType("application/json; charset=utf-8"),
-			log.LogRequestEnd(slog.New(platformlogging.DiscardHandler{})),
+			log.LogRequestEnd(slog.New(slog.DiscardHandler)),
 			checkLicenseExpiration(svc),
 		),
 	}
@@ -436,11 +434,11 @@ func TestEndpointerCustomMiddleware(t *testing.T) {
 			kithttp.PopulateRequestContext,
 			auth.SetRequestsContexts(svc),
 		),
-		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: kitlog.NewNopLogger()}),
+		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: slog.New(slog.DiscardHandler)}),
 		kithttp.ServerErrorEncoder(fleetErrorEncoder),
 		kithttp.ServerAfter(
 			kithttp.SetContentType("application/json; charset=utf-8"),
-			log.LogRequestEnd(slog.New(platformlogging.DiscardHandler{})),
+			log.LogRequestEnd(slog.New(slog.DiscardHandler)),
 			checkLicenseExpiration(svc),
 		),
 	}

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -127,7 +127,7 @@ func MakeHandler(
 			auth.SetRequestsContexts(svc),
 			setCarveStoreInRequestContext(carveStore),
 		),
-		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: logger}),
+		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: logger.SlogLogger()}),
 		kithttp.ServerErrorEncoder(fleetErrorEncoder),
 		kithttp.ServerAfter(
 			kithttp.SetContentType("application/json; charset=utf-8"),
@@ -881,7 +881,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		deviceIPAllowedConsecutiveFailingRequestsTimeWindow,
 		deviceIPBanTime,
 	)
-	errorLimiter := ratelimit.NewErrorMiddleware(ipBanner).Limit(logger)
+	errorLimiter := ratelimit.NewErrorMiddleware(ipBanner).Limit(logger.SlogLogger())
 
 	// Device-authenticated endpoints.
 	de := newDeviceAuthenticatedEndpointer(svc, logger, opts, r, apiVersions...)

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
-	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
 	"github.com/fleetdm/fleet/v4/server/worker"
@@ -432,7 +431,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateSpecEndpointAndAMAPIFai
 	// Step: Queue and run the Android setup experience worker job
 	// Note: Pending certificate templates were created above (simulating pubsub). The worker will deliver them.
 	enterpriseName := "enterprises/" + enterpriseID
-	err = worker.QueueRunAndroidSetupExperience(ctx, s.ds, slog.New(logging.DiscardHandler{}), host.UUID, &teamID, enterpriseName)
+	err = worker.QueueRunAndroidSetupExperience(ctx, s.ds, slog.New(slog.DiscardHandler), host.UUID, &teamID, enterpriseName)
 	require.NoError(t, err)
 	s.runWorker()
 
@@ -534,7 +533,7 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateNoTeamWithIDPVariable()
 	// Step: Queue and run the Android setup experience worker job
 	// Note: Pending certificate templates were created above (simulating pubsub). The worker will deliver them.
 	enterpriseName := "enterprises/" + enterpriseID
-	err = worker.QueueRunAndroidSetupExperience(ctx, s.ds, slog.New(logging.DiscardHandler{}), host.UUID, nil, enterpriseName)
+	err = worker.QueueRunAndroidSetupExperience(ctx, s.ds, slog.New(slog.DiscardHandler), host.UUID, nil, enterpriseName)
 	require.NoError(t, err)
 	s.runWorker()
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38889 

Also delete the unnecessary logging.DiscardHandler and replace it with slog.DiscardHandler

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  - Changes file already present from previous PR

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modernized internal logging infrastructure by transitioning from a custom logging implementation to the standard library's structured logging approach across multiple services and middleware components.

* **Refactor**
  * Updated logging method signatures and error handling paths to use standardized logging interfaces consistently throughout the platform codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->