### PR TITLE
Fixed false negative CVE-2026-20841 on Windows Notepad.

### DIFF
--- a/changes/39745-notepad-cve
+++ b/changes/39745-notepad-cve
@@ -1,0 +1,1 @@
+Fixed false negative CVE-2026-20841 on Windows Notepad.

--- a/server/vulnerabilities/customcve/matching_rules.go
+++ b/server/vulnerabilities/customcve/matching_rules.go
@@ -80,6 +80,14 @@ func getCVEMatchingRules() CVEMatchingRules {
 			CVEs:              []string{"CVE-2025-27613", "CVE-2025-27614", "CVE-2025-46835"},
 			ResolvedInVersion: "2.50.1",
 		},
+		// Windows Notepad command injection vulnerability
+		// https://cveawg.mitre.org/api/cve/CVE-2026-20841
+		{
+			NameLikeMatch:     "Microsoft.WindowsNotepad",
+			SourceMatch:       "programs",
+			CVEs:              []string{"CVE-2026-20841"},
+			ResolvedInVersion: "11.2510",
+		},
 	}
 }
 

--- a/server/vulnerabilities/customcve/matching_rules_test.go
+++ b/server/vulnerabilities/customcve/matching_rules_test.go
@@ -309,6 +309,20 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 			Version: "2.2601.6000.0",
 			Source:  "programs",
 		},
+		// Windows Notepad vulnerable version should match CVE-2026-20841
+		{
+			ID:      8,
+			Name:    "Microsoft.WindowsNotepad",
+			Version: "11.2409.10.0",
+			Source:  "programs",
+		},
+		// Windows Notepad patched version should not match CVE-2026-20841
+		{
+			ID:      9,
+			Name:    "Microsoft.WindowsNotepad",
+			Version: "11.2510.14.0",
+			Source:  "programs",
+		},
 	}
 
 	t.Run("New Vulns return all inserted", func(t *testing.T) {
@@ -318,6 +332,9 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 			}
 			if filter.Name == "git-gui" && filter.Source == "homebrew_packages" {
 				return []fleet.Software{sw[4], sw[5]}, nil
+			}
+			if filter.Name == "Microsoft.WindowsNotepad" && filter.Source == "programs" {
+				return []fleet.Software{sw[7], sw[8]}, nil
 			}
 			return nil, nil
 		}
@@ -338,8 +355,8 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 		ctx := context.Background()
 		vulns, err := CheckCustomVulnerabilities(ctx, ds, log.NewNopLogger(), time.Now().UTC().Add(-time.Hour))
 		require.NoError(t, err)
-		require.Equal(t, 34, insertCount)
-		require.Len(t, vulns, 34)
+		require.Equal(t, 35, insertCount)
+		require.Len(t, vulns, 35)
 		require.True(t, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
 
 		expected := []fleet.SoftwareVulnerability{
@@ -513,6 +530,11 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 				CVE:               "CVE-2025-46835",
 				ResolvedInVersion: ptr.String("2.50.1"),
 			},
+			{
+				SoftwareID:        8,
+				CVE:               "CVE-2026-20841",
+				ResolvedInVersion: ptr.String("11.2510"),
+			},
 		}
 
 		cmpSoftwareVulnerability := func(v []fleet.SoftwareVulnerability) func(i, j int) bool {
@@ -541,6 +563,9 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 			if filter.Name == "git-gui" && filter.Source == "homebrew_packages" {
 				return []fleet.Software{sw[4], sw[5]}, nil
 			}
+			if filter.Name == "Microsoft.WindowsNotepad" && filter.Source == "programs" {
+				return []fleet.Software{sw[7], sw[8]}, nil
+			}
 			return nil, nil
 		}
 
@@ -561,7 +586,7 @@ func TestCheckCustomVulnerabilities(t *testing.T) {
 		vulns, err := CheckCustomVulnerabilities(ctx, ds, log.NewNopLogger(), time.Now().UTC().Add(-time.Hour))
 		require.NoError(t, err)
 		require.True(t, ds.DeleteOutOfDateVulnerabilitiesFuncInvoked)
-		require.Equal(t, 34, insertCount)
+		require.Equal(t, 35, insertCount)
 		require.Len(t, vulns, 0)
 	})
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39745

Needed to add a custom matching rule because the Notepad CPE does not exist in NVD (yet?).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added detection and resolution tracking for CVE-2026-20841 affecting Windows Notepad, resolved in version 11.2510.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->