### PR TITLE
Change Datastore.logger type to *logging.Logger

### DIFF
--- a/server/activity/arch_test.go
+++ b/server/activity/arch_test.go
@@ -68,6 +68,7 @@ func TestActivityPackageDependencies(t *testing.T) {
 				m + "/server/activity/internal/types",
 				m + "/server/activity/internal/testutils",
 				m + "/server/platform/http",
+				m + "/server/platform/logging",
 				m + "/server/platform/mysql",
 				m + "/server/platform/mysql/testing_utils",
 				m + "/server/contexts/ctxerr",

--- a/server/datastore/mysql/android_mysql.go
+++ b/server/datastore/mysql/android_mysql.go
@@ -7,20 +7,20 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
-	"github.com/go-kit/log"
 	"github.com/jmoiron/sqlx"
 )
 
 // AndroidDatastore is an implementation of android.Datastore interface backed by MySQL
 type AndroidDatastore struct {
-	logger  log.Logger
+	logger  *logging.Logger
 	primary *sqlx.DB
 	replica fleet.DBReader // so it cannot be used to perform writes
 }
 
 // NewAndroidDatastore creates a new Android Datastore
-func NewAndroidDatastore(logger log.Logger, primary *sqlx.DB, replica fleet.DBReader) android.Datastore {
+func NewAndroidDatastore(logger *logging.Logger, primary *sqlx.DB, replica fleet.DBReader) android.Datastore {
 	return &AndroidDatastore{
 		logger:  logger,
 		primary: primary,

--- a/server/datastore/mysql/config.go
+++ b/server/datastore/mysql/config.go
@@ -4,8 +4,8 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
-	"github.com/go-kit/log"
 	"github.com/ngrok/sqlmw"
 )
 
@@ -18,7 +18,7 @@ const (
 type DBOption func(o *common_mysql.DBOptions) error
 
 // Logger adds a Logger to the datastore.
-func Logger(l log.Logger) DBOption {
+func Logger(l *logging.Logger) DBOption {
 	return func(o *common_mysql.DBOptions) error {
 		o.Logger = l
 		return nil

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	nano_push "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
 	scep_depot "github.com/fleetdm/fleet/v4/server/mdm/scep/depot"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/service/modules/activities"
 	"github.com/go-kit/log"
@@ -63,7 +64,7 @@ type Datastore struct {
 	replica fleet.DBReader // so it cannot be used to perform writes
 	primary *sqlx.DB
 
-	logger log.Logger
+	logger *logging.Logger
 	clock  clock.Clock
 	config config.MysqlConfig
 	pusher nano_push.Pusher
@@ -233,7 +234,7 @@ func NewDBConnections(cfg config.MysqlConfig, opts ...DBOption) (*common_mysql.D
 	options := &common_mysql.DBOptions{
 		MinLastOpenedAtDiff: defaultMinLastOpenedAtDiff,
 		MaxAttempts:         defaultMaxAttempts,
-		Logger:              log.NewNopLogger(),
+		Logger:              logging.NewNopLogger(),
 	}
 
 	for _, setOpt := range opts {

--- a/server/datastore/mysql/mysql_test.go
+++ b/server/datastore/mysql/mysql_test.go
@@ -22,9 +22,9 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/platform/mysql/testing_utils"
 	"github.com/fleetdm/fleet/v4/server/ptr"
-	"github.com/go-kit/log"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -247,7 +247,7 @@ func mockDatastore(t *testing.T) (sqlmock.Sqlmock, *Datastore) {
 	ds := &Datastore{
 		primary: dbmock,
 		replica: dbmock,
-		logger:  log.NewNopLogger(),
+		logger:  logging.NewNopLogger(),
 	}
 
 	return mock, ds
@@ -596,7 +596,7 @@ func TestWhereFilterHostsByTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			ds := &Datastore{logger: log.NewNopLogger()}
+			ds := &Datastore{logger: logging.NewNopLogger()}
 			sql := ds.whereFilterHostsByTeams(tt.filter, "hosts")
 			assert.Equal(t, tt.expected, sql)
 		})
@@ -631,7 +631,7 @@ func TestWhereOmitIDs(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			ds := &Datastore{logger: log.NewNopLogger()}
+			ds := &Datastore{logger: logging.NewNopLogger()}
 			sql := ds.whereOmitIDs("id", tt.omits)
 			assert.Equal(t, tt.expected, sql)
 		})
@@ -736,7 +736,7 @@ func newDSWithConfig(t *testing.T, dbName string, config config.MysqlConfig) (*D
 	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s; CREATE DATABASE %s;", dbName, dbName))
 	require.NoError(t, err)
 
-	ds, err := New(config, clock.NewMockClock(), Logger(log.NewNopLogger()), LimitAttempts(1))
+	ds, err := New(config, clock.NewMockClock(), Logger(logging.NewNopLogger()), LimitAttempts(1))
 	return ds, err
 }
 
@@ -856,7 +856,7 @@ func TestWhereFilterTeams(t *testing.T) {
 	for _, tt := range testCases {
 		tt := tt
 		t.Run("", func(t *testing.T) {
-			ds := &Datastore{logger: log.NewNopLogger()}
+			ds := &Datastore{logger: logging.NewNopLogger()}
 			sql := ds.whereFilterTeams(tt.filter, "t")
 			assert.Equal(t, tt.expected, sql)
 		})
@@ -1242,7 +1242,7 @@ func TestWhereFilterTeamWithGlobalStats(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ds := &Datastore{logger: log.NewNopLogger()}
+			ds := &Datastore{logger: logging.NewNopLogger()}
 			sql := ds.whereFilterTeamWithGlobalStats(tt.filter, "hosts")
 			assert.Equal(t, tt.expected, sql)
 		})
@@ -1443,7 +1443,7 @@ func TestReplicaPasswordReadFromDisk(t *testing.T) {
 		Database:     dbName,
 	}
 
-	conns, err := NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(log.NewNopLogger()))
+	conns, err := NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(logging.NewNopLogger()))
 	require.NoError(t, err, "replica connection should succeed when PasswordPath is used — "+
 		"if this fails with 'Access denied' the password read from disk was not preserved for the replica")
 	defer conns.Primary.Close()
@@ -1498,7 +1498,7 @@ func TestReplicaTLSConfigPreserved(t *testing.T) {
 	//
 	// Before the fix TLSConfig was empty for the replica's NewDB call, so the
 	// replica connected without TLS (no error) — meaning this assertion would fail.
-	_, err := NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(log.NewNopLogger()))
+	_, err := NewDBConnections(primaryConfig, Replica(&replicaConfig), LimitAttempts(1), Logger(logging.NewNopLogger()))
 	require.Error(t, err, "replica connection should fail with a TLS error when TLSCA is set — "+
 		"if this succeeds, TLS was silently not applied to the replica")
 	require.Regexp(t, "(x509|tls|EOF)", err.Error())

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -16,11 +16,11 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
-	kitlog "github.com/go-kit/log"
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -1362,7 +1362,7 @@ func testSoftwareSyncHostsSoftware(t *testing.T, ds *Datastore) {
 	// this call will remove team2 from the software host counts table,
 	// and would normally log because we have a zero software_id
 	realLogger := ds.logger
-	ds.logger = kitlog.NewNopLogger()
+	ds.logger = logging.NewNopLogger()
 	require.NoError(t, ds.SyncHostsSoftware(ctx, time.Now()))
 	ds.logger = realLogger
 
@@ -2012,8 +2012,7 @@ func testUpdateHostSoftware(t *testing.T, ds *Datastore) {
 	// Test logging criteria for LastOpenedAt == nil
 	oldLogger := ds.logger
 	buf := &bytes.Buffer{}
-	newLogger := kitlog.NewLogfmtLogger(buf)
-	ds.logger = newLogger
+	ds.logger = logging.NewLogfmtLogger(buf)
 
 	sw = []fleet.Software{
 		{Name: "foo", Version: "0.0.1", Source: "test"},

--- a/server/datastore/mysql/testing_utils.go
+++ b/server/datastore/mysql/testing_utils.go
@@ -34,6 +34,7 @@ import (
 	nanodep_client "github.com/fleetdm/fleet/v4/server/mdm/nanodep/client"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
 	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/fleetdm/fleet/v4/server/platform/mysql/testing_utils"
 	"github.com/go-kit/log"
@@ -65,9 +66,11 @@ func connectMySQL(t testing.TB, testName string, opts *testing_utils.DatastoreTe
 	// TODO: for some reason we never log datastore messages when running integration tests, why?
 	//
 	// Changes below assume that we want to follows the same pattern as the rest of the codebase.
-	dslogger := log.NewLogfmtLogger(os.Stdout)
+	var dslogger *logging.Logger
 	if os.Getenv("FLEET_INTEGRATION_TESTS_DISABLE_LOG") != "" {
-		dslogger = log.NewNopLogger()
+		dslogger = logging.NewNopLogger()
+	} else {
+		dslogger = logging.NewLogfmtLogger(os.Stdout)
 	}
 
 	// Use TestSQLMode which combines ANSI mode components with MySQL 8 strict modes
@@ -83,7 +86,7 @@ func connectMySQL(t testing.TB, testName string, opts *testing_utils.DatastoreTe
 		replicaOpts := &common_mysql.DBOptions{
 			MinLastOpenedAtDiff: defaultMinLastOpenedAtDiff,
 			MaxAttempts:         1,
-			Logger:              log.NewNopLogger(),
+			Logger:              logging.NewNopLogger(),
 			SqlMode:             common_mysql.TestSQLMode,
 		}
 		setupRealReplica(t, testName, ds, replicaOpts)

--- a/server/platform/arch_test.go
+++ b/server/platform/arch_test.go
@@ -104,6 +104,7 @@ func TestMysqlPackageDependencies(t *testing.T) {
 			m+"/server/platform/mysql...",
 			// Other infra packages
 			m+"/server/platform/http",
+			m+"/server/platform/logging",
 			m+"/server/contexts/ctxerr",
 		).
 		Check()

--- a/server/platform/mysql/common.go
+++ b/server/platform/mysql/common.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/go-kit/log"
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
@@ -30,7 +31,7 @@ const TestSQLMode = "'REAL_AS_FLOAT,PIPES_AS_CONCAT,ANSI_QUOTES,IGNORE_SPACE,ONL
 type DBOptions struct {
 	// MaxAttempts configures the number of retries to connect to the DB
 	MaxAttempts         int
-	Logger              log.Logger
+	Logger              *logging.Logger
 	ReplicaConfig       *MysqlConfig
 	Interceptor         sqlmw.Interceptor
 	TracingConfig       *LoggingConfig

--- a/tools/dbutils/schema_generator.go
+++ b/tools/dbutils/schema_generator.go
@@ -12,7 +12,7 @@ import (
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
-	"github.com/go-kit/log"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 )
 
 const (
@@ -62,7 +62,7 @@ func main() {
 		Address:  testAddress,
 		Database: "schemadb",
 	}
-	ds, err := mysql.New(config, clock.NewMockClock(), mysql.Logger(log.NewNopLogger()), mysql.LimitAttempts(1))
+	ds, err := mysql.New(config, clock.NewMockClock(), mysql.Logger(logging.NewNopLogger()), mysql.LimitAttempts(1))
 	panicif(err)
 	defer ds.Close()
 	panicif(ds.MigrateTables(context.Background()))

--- a/tools/mdm/apple/applebmapi/main.go
+++ b/tools/mdm/apple/applebmapi/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanodep/godep"
-	kitlog "github.com/go-kit/log"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 )
 
 func main() {
@@ -58,7 +58,7 @@ func main() {
 		MaxIdleConns:    50,
 		ConnMaxLifetime: 0,
 	}
-	logger := kitlog.NewLogfmtLogger(os.Stderr)
+	logger := logging.NewLogfmtLogger(os.Stderr)
 	opts := []mysql.DBOption{
 		mysql.Logger(logger),
 		mysql.WithFleetConfig(&config.FleetConfig{

--- a/tools/mdm/apple/setupexperience/main.go
+++ b/tools/mdm/apple/setupexperience/main.go
@@ -18,9 +18,8 @@ import (
 	"github.com/WatchBeam/clock"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	"github.com/jmoiron/sqlx"
-
-	kitlog "github.com/go-kit/log"
 )
 
 func main() {
@@ -145,7 +144,7 @@ func main() {
 		}
 	}
 
-	logger := kitlog.NewLogfmtLogger(os.Stderr)
+	logger := logging.NewLogfmtLogger(os.Stderr)
 	opts := []mysql.DBOption{
 		mysql.Logger(logger),
 		mysql.WithFleetConfig(&config.FleetConfig{

--- a/tools/mysql-tests/rds/iam_auth.go
+++ b/tools/mysql-tests/rds/iam_auth.go
@@ -10,9 +10,8 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
+	"github.com/fleetdm/fleet/v4/server/platform/logging"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
-	kitlog "github.com/go-kit/log"
-	"github.com/go-kit/log/level"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -36,7 +35,7 @@ func main() {
 		log.Fatal("Username is required (-user flag)")
 	}
 
-	logger := level.NewFilter(kitlog.NewLogfmtLogger(os.Stderr), level.AllowDebug())
+	logger := logging.NewLogfmtLogger(os.Stderr)
 
 	// Configure MySQL connection with IAM auth
 	mysqlConfig := &config.MysqlConfig{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38889

This is preparatory work before incrementally converting datastore/mysql files to directly use *slog.Logger.
This will be done by using `logger.SlogLogger()` to get the underlying `*slog.Logger`

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  - Changes file already exists from previous PR

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal logging infrastructure to use a standardized platform logging package across database and utility components. This consolidates logging dependencies and improves system consistency without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->