### PR TITLE
Website: Update GitHub webhook exits

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -25,6 +25,11 @@ module.exports = {
     projects_v2_item: { type: {} }, //eslint-disable-line camelcase
   },
 
+  exits: {
+    success: {description: 'A GitHub event was successfully received.'},
+    invalidBotSecret: {description: 'The provided botSignature did not match', responseType: 'unauthorized' },
+  },
+
 
   fn: async function ({botSignature, action, sender, repository, changes, issue, comment, pull_request: pr, label, release, projects_v2_item: projectsV2Item}) {
 
@@ -141,7 +146,7 @@ module.exports = {
       throw new Error('No GitHub bot webhook secret configured!  (Please set `sails.config.custom.githubBotWebhookSecret`.)');
     }//•
     if (sails.config.custom.githubBotWebhookSecret !== botSignature) {
-      throw new Error('Received unexpected GitHub webhook request with botSignature set to: '+botSignature);
+      throw 'invalidBotSecret';
     }//•
 
     if (!sails.config.custom.githubAccessToken) {

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -27,7 +27,7 @@ module.exports = {
 
   exits: {
     success: {description: 'A GitHub event was successfully received.'},
-    invalidBotSecret: {description: 'The provided botSignature did not match', responseType: 'unauthorized' },
+    unexpectedBotSignature: {description: 'The provided botSignature was incorrect', responseType: 'unauthorized' },
   },
 
 
@@ -146,7 +146,7 @@ module.exports = {
       throw new Error('No GitHub bot webhook secret configured!  (Please set `sails.config.custom.githubBotWebhookSecret`.)');
     }//•
     if (sails.config.custom.githubBotWebhookSecret !== botSignature) {
-      throw 'invalidBotSecret';
+      throw 'unexpectedBotSignature';
     }//•
 
     if (!sails.config.custom.githubAccessToken) {


### PR DESCRIPTION
Changes:
- Added a new exit to the receive-from-github webhook that is used when a provided `botSignature` does not match the `githubBotWebhookSecret` config variable