### PR TITLE
Remove hard-coded "(Firefox)" from software display names

### DIFF
--- a/frontend/interfaces/software.tests.ts
+++ b/frontend/interfaces/software.tests.ts
@@ -101,9 +101,9 @@ describe("formatSoftwareType", () => {
       },
       {
         source: "firefox_addons" as const,
-        extension_for: undefined,
+        extension_for: "firefox" as const,
         expected: "Browser plugin (Firefox)",
-        description: "Firefox add-ons without extension_for",
+        description: "Firefox add-ons",
       },
       {
         source: "safari_extensions" as const,

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -249,7 +249,7 @@ export const SOURCE_TYPE_CONVERSION = {
   ipados_apps: "Application (iPadOS)",
   android_apps: "Application (Android)",
   chrome_extensions: "Browser plugin", // chrome_extensions can include any chrome-based browser (e.g., edge), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
-  firefox_addons: "Browser plugin",
+  firefox_addons: "Browser plugin", // we rely on `extension_for` when computing which browser to show in firefox_addons display names.
   safari_extensions: "Browser plugin (Safari)",
   homebrew_packages: "Package (Homebrew)",
   programs: "Program (Windows)",

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -319,6 +319,7 @@ const EXTENSION_FOR_TYPE_CONVERSION = {
   brave: "Brave",
   edge: "Edge",
   edge_beta: "Edge Beta",
+  firefox: "Firefox",
 
   // vscode versions
   vscode: "VSCode",

--- a/frontend/interfaces/software.ts
+++ b/frontend/interfaces/software.ts
@@ -249,7 +249,7 @@ export const SOURCE_TYPE_CONVERSION = {
   ipados_apps: "Application (iPadOS)",
   android_apps: "Application (Android)",
   chrome_extensions: "Browser plugin", // chrome_extensions can include any chrome-based browser (e.g., edge), so we rely instead on the `extension_for` field computed by Fleet server and fallback to this value if it is not present.
-  firefox_addons: "Browser plugin (Firefox)",
+  firefox_addons: "Browser plugin",
   safari_extensions: "Browser plugin (Safari)",
   homebrew_packages: "Package (Homebrew)",
   programs: "Program (Windows)",


### PR DESCRIPTION
Potentially resolves #39943. (Needs to be tested; my local Fleet instance isn't fancy enough to have Firefox addons in software inventory, so this is just a hunch.)