### PR TITLE
fix whitespace wrapping on status table in mdm card on dashboard page

### DIFF
--- a/changes/issue-38654-table-wrapping-mdm-card
+++ b/changes/issue-38654-table-wrapping-mdm-card
@@ -1,0 +1,1 @@
+- fixed issue where the status name was wrapping at smaller viewport witdths on the mdm card on the Dashboard page

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -518,10 +518,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       try {
         if (
           formData.enabled !==
-            config?.webhook_settings.activities_webhook
-              .enable_activities_webhook ||
+          config?.webhook_settings.activities_webhook
+            .enable_activities_webhook ||
           formData.url !==
-            config?.webhook_settings.activities_webhook.destination_url
+          config?.webhook_settings.activities_webhook.destination_url
         ) {
           await configAPI.update({
             webhook_settings: {
@@ -619,10 +619,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     showTitle: showActivityFeedTitle,
     action: canEditActivityFeedAutomations
       ? {
-          type: "button",
-          text: "Manage automations",
-          onClick: () => setShowActivityFeedAutomationsModal(true),
-        }
+        type: "button",
+        text: "Manage automations",
+        onClick: () => setShowActivityFeedAutomationsModal(true),
+      }
       : undefined,
     children: (
       <ActivityFeed
@@ -745,7 +745,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           )}
         {(isSoftwareFetching || showSoftwareCard) && SoftwareCard}
         {!isAnyTeamSelected && isOnGlobalTeam && <>{ActivityFeedCard}</>}
-        {showMdmCard && <>{MDMCard}</>}
+        {true && <>{MDMCard}</>}
       </div>
     );
   };

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -518,10 +518,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       try {
         if (
           formData.enabled !==
-          config?.webhook_settings.activities_webhook
-            .enable_activities_webhook ||
+            config?.webhook_settings.activities_webhook
+              .enable_activities_webhook ||
           formData.url !==
-          config?.webhook_settings.activities_webhook.destination_url
+            config?.webhook_settings.activities_webhook.destination_url
         ) {
           await configAPI.update({
             webhook_settings: {
@@ -619,10 +619,10 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     showTitle: showActivityFeedTitle,
     action: canEditActivityFeedAutomations
       ? {
-        type: "button",
-        text: "Manage automations",
-        onClick: () => setShowActivityFeedAutomationsModal(true),
-      }
+          type: "button",
+          text: "Manage automations",
+          onClick: () => setShowActivityFeedAutomationsModal(true),
+        }
       : undefined,
     children: (
       <ActivityFeed

--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -745,7 +745,7 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           )}
         {(isSoftwareFetching || showSoftwareCard) && SoftwareCard}
         {!isAnyTeamSelected && isOnGlobalTeam && <>{ActivityFeedCard}</>}
-        {true && <>{MDMCard}</>}
+        {showMdmCard && <>{MDMCard}</>}
       </div>
     );
   };

--- a/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDM.tsx
@@ -96,7 +96,7 @@ const Mdm = ({
   selectedPlatformLabelId,
   selectedTeamId,
   onClickMdmSolution,
-}: IMdmCardProps): JSX.Element => {
+}: IMdmCardProps) => {
   const [navTabIndex, setNavTabIndex] = useState(0);
 
   const onTabChange = (index: number) => {

--- a/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
+++ b/frontend/pages/DashboardPage/cards/MDM/MDMStatusTableConfig.tsx
@@ -31,7 +31,10 @@ export const generateStatusTableHeaders = (
       !MDM_STATUS_TOOLTIP[status] ? (
         <TextCell value={status} />
       ) : (
-        <TooltipWrapper tipContent={MDM_STATUS_TOOLTIP[status]}>
+        <TooltipWrapper
+          className="status-cell"
+          tipContent={MDM_STATUS_TOOLTIP[status]}
+        >
           {MDM_ENROLLMENT_STATUS_UI_MAP[status].displayName}
         </TooltipWrapper>
       ),

--- a/frontend/pages/DashboardPage/cards/MDM/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/MDM/_styles.scss
@@ -7,7 +7,7 @@
       .data-table__wrapper {
         // this handles an edge case where the table is too wide for the
         // container at a smaller viewport width.
-        overflow: auto
+        overflow: auto;
       }
     }
   }

--- a/frontend/pages/DashboardPage/cards/MDM/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/MDM/_styles.scss
@@ -2,6 +2,16 @@
   position: relative;
   height: 100%; // centers loading spinner
 
+  &__mdm-status-table {
+    .data-table-block {
+      .data-table__wrapper {
+        // this handles an edge case where the table is too wide for the
+        // container at a smaller viewport width.
+        overflow: auto
+      }
+    }
+  }
+
   .tab-nav .table-container__header {
     display: none;
   }
@@ -12,6 +22,12 @@
         thead {
           .status__header {
             width: 30%;
+          }
+        }
+        tbody {
+          .status-cell .component__tooltip-wrapper__element {
+            // prevent status name from wrapping to multiple lines
+            white-space: nowrap;
           }
         }
       }


### PR DESCRIPTION
**Related issue:** Resolves #38654

# Checklist for submitter

This fixes an issue where the status name was wrapping at smaller viewport sizes on the mdm card of the dashboard page.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
