### PR TITLE
Ignore kiloconnect PRs in oncall script

### DIFF
--- a/tools/oncall/oncall.sh
+++ b/tools/oncall/oncall.sh
@@ -57,7 +57,7 @@ prs() {
 
 	ensure_gh_auth
 
-	members="$(curl -s -u "${username}:${token}" https://api.github.com/orgs/fleetdm/members?per_page=100 | jq -r 'map(.login) + ["app/dependabot"]')"
+	members="$(curl -s -u "${username}:${token}" https://api.github.com/orgs/fleetdm/members?per_page=100 | jq -r 'map(.login) + ["app/dependabot", "app/kiloconnect"]')"
 
 	# defaults to listing open prs
 	gh pr list --limit 1000 --repo fleetdm/fleet --json id,title,author,url,createdAt,isDraft |


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** None

Well hello there neighbor. If I may make a gentle suggestion, I think we should ignore Kiloconnect in the oncall script. Its contributions are valued but I assume another friendly neighbor initiated each wonderful PR it opens and we can be more kind to the oncall engineer by not showing these.

In all seriousness I just assume someone else at fleet initiated any Kiloconnect PR so we need not return them in the oncall script, but we also shouldn't add it to the list of humans