### PR TITLE
Engineering handbook: Remove outdated bit

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -52,7 +52,7 @@ It's important to frame engineering-initiated user stories the same way we frame
 
 ### Draft an engineering-initiated story
 
-The engineering output and architecture DRI reviews and triages engineering-initiated stories weekly on the [Engineering board](https://github.com/orgs/fleetdm/projects/73) and selects stories to prioritize for drafting by adding the `:product` label, placing it in the "Ready" column, and assigning to the engineer listed as the product designer. 
+The engineering output and architecture DRI reviews and triages engineering-initiated stories weekly on the [Engineering board](https://github.com/orgs/fleetdm/projects/73) and selects stories to prioritize for drafting by adding the `:product` label, placing it in the "Ready" column, and assigning an engineer. 
 
 1. The assigned engineer is responsible for completing the user story drafting process by completing the specs and [defining done](https://fleetdm.com/handbook/company/product-groups#defining-done). Move the issue into "In progress" on the drafting board and populate all TODOs in the issue description, define implementation details, and draft the first version of the test plan.
 


### PR DESCRIPTION
There's no longer a "Product Designer" section in the user story template. Instead, it's up to the individual assigned to the story to move it forward.
