### PR TITLE
Add callout for module build failures

### DIFF
--- a/docs/Contributing/reference/faq.md
+++ b/docs/Contributing/reference/faq.md
@@ -33,6 +33,25 @@ make: *** [fleet] Error 2
 
 If you get an `undefined: Asset` error, it is likely because you did not run `make generate` before `make build`. See [Building Fleet](https://fleetdm.com/docs/contributing/building-fleet) for additional documentation on compiling the `fleet` binary.
 
+### `Module build failed` or `Cannot find module` when running `make generate`
+
+```sh
+./frontend/index.jsx 39 bytes [built] [code generated] [1 error]
+
+ERROR in ./frontend/index.jsx
+Module build failed (from ./node_modules/babel-loader/lib/index.js):
+Error: [BABEL]: Cannot find module 'to-fast-properties'
+```
+
+When `make generate` fails with errors related to modules, it is often due to JS/TS dependencies having changed and can be fixed by running:
+
+```sh
+rm -rf node_modules
+make deps
+```
+
+and then running the failed `make generate` or `make generate-dev` again.
+
 ## Adding hosts for testing
 
 The `osquery` directory contains a docker-compose.yml and additional configuration files to start containerized osquery agents.


### PR DESCRIPTION
Reading docs as part of oncall responsibilities and was reminded of [this discussion](https://fleetdm.slack.com/archives/C019WG4GH0A/p1771252998086309) in Slack by Martin which referenced a recent JS module change that broke `make generate` until developers ran `rm -rf node_modules`, so I added a callout in the FAQ for it since I think this has happened a few times in the past year