### PR TITLE
Updating scope of engineering-initiated stories.

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -41,7 +41,7 @@ Engineering-initiated stories are types of user stories created by engineers to 
 
 It's important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
 
-Engineering-initiated stories are for work that **no customer or product manager would directly ask for** but that makes Fleet healthier. If any of the following apply, the issue should go through normal product prioritization instead of being labeled `~engineering-initiated`:
+Engineering-initiated stories are for work that no customer or stakeholder has directly asked for but that makes Fleet better. If any of the following apply, the issue should go through normal product prioritization instead of being labeled `~engineering-initiated`:
 
 - The work was motivated by a **customer report or request** (has a `customer-*` label).
 - The issue is a **bug or defect** (has a `~released bug` or `bug` label).

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -41,9 +41,17 @@ Engineering-initiated stories are types of user stories created by engineers to 
 
 It's important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
 
+Engineering-initiated stories are for work that **no customer or PM would directly ask for** but that makes Fleet healthier. If any of the following apply, the issue should go through normal product prioritization instead of being labeled `~engineering-initiated`:
+
+- The work was motivated by a **customer report or request** (has a `customer-*` label).
+- The issue is a **bug or defect** (has a `~released bug` or `bug` label).
+- The issue is a **postmortem action item** (has a `~postmortem-action-item` label).
+
+These categories should compete for priority in the normal product pipeline so that product and customer stakeholders have full visibility into the work being done on their behalf.
+
 1. Create a new engineering-initiated story using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=lukeheath&labels=story,~engineering-initiated&projects=&template=story.md&title=). Make sure the `~engineering-initiated` label is added, the `:product` label is removed, and the engineering output and architecture DRI (@lukeheath) is assigned.
 
-2. Remove the "Product" section and checklist from the issue description. 
+2. Remove the "Product" section and checklist from the issue description.
 
 3. Create the issue. The new user story will be automatically placed in the "New Requests" column of the [engineering GitHub board](https://github.com/orgs/fleetdm/projects/73). If you feel the issue is urgent, tag your EM or the engineering output and architecture DRI (@lukeheath) in a comment.
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -41,7 +41,7 @@ Engineering-initiated stories are types of user stories created by engineers to 
 
 It's important to frame engineering-initiated user stories the same way we frame all user stories. Stay focused on how this technical change will drive value for our users.
 
-Engineering-initiated stories are for work that **no customer or PM would directly ask for** but that makes Fleet healthier. If any of the following apply, the issue should go through normal product prioritization instead of being labeled `~engineering-initiated`:
+Engineering-initiated stories are for work that **no customer or product manager would directly ask for** but that makes Fleet healthier. If any of the following apply, the issue should go through normal product prioritization instead of being labeled `~engineering-initiated`:
 
 - The work was motivated by a **customer report or request** (has a `customer-*` label).
 - The issue is a **bug or defect** (has a `~released bug` or `bug` label).

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -47,7 +47,7 @@ Engineering-initiated stories are for work that **no customer or product manager
 - The issue is a **bug or defect** (has a `~released bug` or `bug` label).
 - The issue is a **postmortem action item** (has a `~postmortem-action-item` label).
 
-These categories should compete for priority in the normal product pipeline so that product and customer stakeholders have full visibility into the work being done on their behalf.
+These categories compete for priority in the normal product pipeline so that product and customer stakeholders have full visibility into the work being done on their behalf.
 
 1. Create a new engineering-initiated story using the [new story template](https://github.com/fleetdm/fleet/issues/new?assignees=lukeheath&labels=story,~engineering-initiated&projects=&template=story.md&title=). Make sure the `~engineering-initiated` label is added, the `:product` label is removed, and the engineering output and architecture DRI (@lukeheath) is assigned.
 


### PR DESCRIPTION
# Engineering-initiated work: industry best practices

## 1. Strict categorization by origin, not by who picks it up

The industry standard litmus test:

> **If the work was motivated by a customer complaint, production incident, or product requirement, it is not engineering-initiated, regardless of who filed the issue.**

Engineering-initiated work should be limited to things that **no customer or produce manager would ever ask for** but that make the codebase healthier:
- Internal refactors with no user-visible change
- Developer tooling and CI improvements
- Test coverage for its own sake
- Dependency upgrades with no user-facing motivation
- Code health and linting

## 2. Separate capacity buckets with guardrails

Most organizations (Google, Spotify, Shopify, etc.) allocate a **fixed percentage** of engineering capacity (typically **15–20%**) for engineering-initiated work. The key rules:

- The engineering budget is **only for true engineering-initiated work**. Mislabeling customer work as engineering-initiated effectively steals capacity from the product roadmap without product's knowledge.
- **Bugs are never engineering-initiated.** A bug is a defect in something that was already committed to. It goes through normal triage.
- **Postmortem action items are reliability work**, not engineering-initiated. They represent production risk and should be prioritized by severity, often above feature work.

## 3. Clear taxonomy with no overlap

The industry-standard categories are:

| Category | Owned by | Prioritized by | Examples |
|----------|----------|---------------|----------|
| **Features** | Product | Product | New capabilities, customer requests |
| **Bugs / defects** | Product | Severity + product | Broken behavior, released bugs |
| **Reliability / incidents** | Engineering + Product | Severity | Postmortem items, scaling issues |
| **Engineering-initiated** | Engineering | Engineering | Refactors, tooling, test coverage, debt |

The mistake Fleet is making is collapsing a lot more into the bottom row.

## 4. Why this matters

When engineering-initiated becomes a catch-all:

1. **Product loses visibility.** Customer-impacting work isn't competing against other customer requests. Product can't make informed trade-offs.
2. **Engineering capacity is misrepresented.** If a lot of "engineering-initiated" work is actually customer-driven, the real engineering investment budget is much smaller than it appears. But leadership sees "20% engineering-initiated" and thinks the team has that much discretionary capacity.
3. **Customer urgency is muted.** A customer-driven scaling problem sitting in the engineering backlog doesn't carry the same urgency signals as one in the product backlog with customer labels driving prioritization.

