### PR TITLE
Scope declaration processing to affected hosts in BulkSetPendingMDMHostProfiles

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -5962,10 +5962,7 @@ func mdmAppleGetHostsWithChangedDeclarationsDB(ctx context.Context, tx sqlx.ExtC
 	var allDecls []*fleet.MDMAppleHostDeclaration
 
 	for i := 0; i < len(hostUUIDs); i += selectBatchSize {
-		end := i + selectBatchSize
-		if end > len(hostUUIDs) {
-			end = len(hostUUIDs)
-		}
+		end := min(i+selectBatchSize, len(hostUUIDs))
 		batch := hostUUIDs[i:end]
 
 		// Install query: 4x batch (one per UNION branch) + 2 operation type args

--- a/server/datastore/mysql/apple_mdm_bench_test.go
+++ b/server/datastore/mysql/apple_mdm_bench_test.go
@@ -1,0 +1,521 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// nanoEnrollTB is a testing.TB-compatible version of nanoEnroll for use in benchmarks.
+func nanoEnrollTB(tb testing.TB, ds *Datastore, host *fleet.Host) {
+	tb.Helper()
+	ctx := context.Background()
+	_, err := ds.writer(ctx).Exec(
+		`INSERT INTO nano_devices (id, serial_number, authenticate, platform, enroll_team_id) VALUES (?, NULLIF(?, ''), 'test', ?, ?)`,
+		host.UUID, host.HardwareSerial, host.Platform, host.TeamID,
+	)
+	require.NoError(tb, err)
+
+	_, err = ds.writer(ctx).Exec(`
+INSERT INTO nano_enrollments
+	(id, device_id, user_id, type, topic, push_magic, token_hex, token_update_tally, last_seen_at)
+VALUES
+	(?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		host.UUID,
+		host.UUID,
+		nil,
+		"Device",
+		host.UUID+".topic",
+		host.UUID+".magic",
+		host.UUID,
+		1,
+		time.Now().Add(-2*time.Second).Truncate(time.Second),
+	)
+	require.NoError(tb, err)
+}
+
+// TestScopedDeclarationProcessing is a unit test that asserts the correctness
+// of scoping declaration processing to specific hosts. It verifies that:
+//   - When called with specific host UUIDs (scoped), only those hosts are returned
+//   - When called with nil (unscoped), all hosts with changed declarations are returned
+func TestScopedDeclarationProcessing(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	defer TruncateTables(t, ds)
+
+	ctx := context.Background()
+
+	// Create two teams
+	teamA, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-A-scope-test"})
+	require.NoError(t, err)
+	teamB, err := ds.NewTeam(ctx, &fleet.Team{Name: "team-B-scope-test"})
+	require.NoError(t, err)
+
+	// Create 5 hosts in team A and 5 hosts in team B
+	var teamAHosts []*fleet.Host
+	var teamBHosts []*fleet.Host
+	for i := 0; i < 5; i++ {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:      fmt.Sprintf("scope-host-a-%d", i),
+			OsqueryHostID: ptr.String(fmt.Sprintf("scope-osquery-a-%d", i)),
+			NodeKey:       ptr.String(fmt.Sprintf("scope-nodekey-a-%d", i)),
+			UUID:          fmt.Sprintf("scope-uuid-a-%d", i),
+			Platform:      "darwin",
+			TeamID:        &teamA.ID,
+		})
+		require.NoError(t, err)
+		nanoEnroll(t, ds, h, false)
+		teamAHosts = append(teamAHosts, h)
+	}
+	for i := 0; i < 5; i++ {
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:      fmt.Sprintf("scope-host-b-%d", i),
+			OsqueryHostID: ptr.String(fmt.Sprintf("scope-osquery-b-%d", i)),
+			NodeKey:       ptr.String(fmt.Sprintf("scope-nodekey-b-%d", i)),
+			UUID:          fmt.Sprintf("scope-uuid-b-%d", i),
+			Platform:      "darwin",
+			TeamID:        &teamB.ID,
+		})
+		require.NoError(t, err)
+		nanoEnroll(t, ds, h, false)
+		teamBHosts = append(teamBHosts, h)
+	}
+
+	// Create 3 declarations for team A
+	for i := 0; i < 3; i++ {
+		_, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Identifier: fmt.Sprintf("com.fleet.scope-test.team-a.%d", i),
+			Name:       fmt.Sprintf("scope-decl-a-%d", i),
+			RawJSON:    []byte(fmt.Sprintf(`{"Type":"com.apple.configuration.decl.a.%d","Identifier":"com.fleet.scope-test.team-a.%d","Payload":{"ServiceType":"com.apple.service.a.%d"}}`, i, i, i)),
+			TeamID:     &teamA.ID,
+		})
+		require.NoError(t, err)
+	}
+
+	// Create 3 declarations for team B
+	for i := 0; i < 3; i++ {
+		_, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Identifier: fmt.Sprintf("com.fleet.scope-test.team-b.%d", i),
+			Name:       fmt.Sprintf("scope-decl-b-%d", i),
+			RawJSON:    []byte(fmt.Sprintf(`{"Type":"com.apple.configuration.decl.b.%d","Identifier":"com.fleet.scope-test.team-b.%d","Payload":{"ServiceType":"com.apple.service.b.%d"}}`, i, i, i)),
+			TeamID:     &teamB.ID,
+		})
+		require.NoError(t, err)
+	}
+
+	// At this point, all hosts should have "changed" declarations because they have
+	// declarations assigned (via their team) but no host_mdm_apple_declarations rows yet.
+
+	// Test 1: Scoped call with only team A host UUIDs should return only team A hosts
+	t.Run("ScopedToTeamA", func(t *testing.T) {
+		teamAUUIDs := make([]string, len(teamAHosts))
+		for i, h := range teamAHosts {
+			teamAUUIDs[i] = h.UUID
+		}
+
+		var changedDecls []*fleet.MDMAppleHostDeclaration
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			var err error
+			changedDecls, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, teamAUUIDs)
+			return err
+		})
+
+		// Should only contain team A hosts
+		hostUUIDSet := make(map[string]bool)
+		for _, d := range changedDecls {
+			hostUUIDSet[d.HostUUID] = true
+		}
+
+		// All team A hosts should be present
+		for _, h := range teamAHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team A host %s in results", h.UUID)
+		}
+
+		// No team B hosts should be present
+		for _, h := range teamBHosts {
+			assert.False(t, hostUUIDSet[h.UUID], "did not expect team B host %s in results", h.UUID)
+		}
+	})
+
+	// Test 2: Scoped call with only team B host UUIDs should return only team B hosts
+	t.Run("ScopedToTeamB", func(t *testing.T) {
+		teamBUUIDs := make([]string, len(teamBHosts))
+		for i, h := range teamBHosts {
+			teamBUUIDs[i] = h.UUID
+		}
+
+		var changedDecls []*fleet.MDMAppleHostDeclaration
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			var err error
+			changedDecls, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, teamBUUIDs)
+			return err
+		})
+
+		hostUUIDSet := make(map[string]bool)
+		for _, d := range changedDecls {
+			hostUUIDSet[d.HostUUID] = true
+		}
+
+		// All team B hosts should be present
+		for _, h := range teamBHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team B host %s in results", h.UUID)
+		}
+
+		// No team A hosts should be present
+		for _, h := range teamAHosts {
+			assert.False(t, hostUUIDSet[h.UUID], "did not expect team A host %s in results", h.UUID)
+		}
+	})
+
+	// Test 3: Unscoped call (nil) should return hosts from BOTH teams
+	t.Run("Unscoped", func(t *testing.T) {
+		var changedDecls []*fleet.MDMAppleHostDeclaration
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			var err error
+			changedDecls, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, nil)
+			return err
+		})
+
+		hostUUIDSet := make(map[string]bool)
+		for _, d := range changedDecls {
+			hostUUIDSet[d.HostUUID] = true
+		}
+
+		// Both team A and team B hosts should be present
+		for _, h := range teamAHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team A host %s in unscoped results", h.UUID)
+		}
+		for _, h := range teamBHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team B host %s in unscoped results", h.UUID)
+		}
+	})
+
+	// Test 4: Empty slice should behave like nil (all hosts)
+	t.Run("EmptySlice", func(t *testing.T) {
+		var changedDecls []*fleet.MDMAppleHostDeclaration
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			var err error
+			changedDecls, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, []string{})
+			return err
+		})
+
+		hostUUIDSet := make(map[string]bool)
+		for _, d := range changedDecls {
+			hostUUIDSet[d.HostUUID] = true
+		}
+
+		// Both team A and team B hosts should be present
+		for _, h := range teamAHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team A host %s in empty-slice results", h.UUID)
+		}
+		for _, h := range teamBHosts {
+			assert.True(t, hostUUIDSet[h.UUID], "expected team B host %s in empty-slice results", h.UUID)
+		}
+	})
+
+	// Test 5: Scoped call correctly counts declarations per host
+	t.Run("ScopedDeclarationCount", func(t *testing.T) {
+		teamAUUIDs := make([]string, len(teamAHosts))
+		for i, h := range teamAHosts {
+			teamAUUIDs[i] = h.UUID
+		}
+
+		var changedDecls []*fleet.MDMAppleHostDeclaration
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			var err error
+			changedDecls, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, teamAUUIDs)
+			return err
+		})
+
+		// Each team A host should have 3 declarations (all install operations)
+		declCountPerHost := make(map[string]int)
+		for _, d := range changedDecls {
+			declCountPerHost[d.HostUUID]++
+		}
+		for _, h := range teamAHosts {
+			assert.Equal(t, 3, declCountPerHost[h.UUID],
+				"expected 3 declarations for team A host %s, got %d", h.UUID, declCountPerHost[h.UUID])
+		}
+	})
+
+	// Test 6: End-to-end through mdmAppleBatchSetHostDeclarationStateDB with scoped hosts
+	t.Run("BatchSetWithScope", func(t *testing.T) {
+		teamAUUIDs := make([]string, len(teamAHosts))
+		for i, h := range teamAHosts {
+			teamAUUIDs[i] = h.UUID
+		}
+
+		var uuids []string
+		err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			var err error
+			uuids, _, err = mdmAppleBatchSetHostDeclarationStateDB(ctx, tx, 1000, &fleet.MDMDeliveryPending, teamAUUIDs)
+			return err
+		})
+		require.NoError(t, err)
+
+		// Sort for stable comparison
+		sort.Strings(uuids)
+		sort.Strings(teamAUUIDs)
+		assert.Equal(t, teamAUUIDs, uuids, "scoped batch set should return only team A host UUIDs")
+
+		// Verify team A hosts have pending declarations
+		for _, h := range teamAHosts {
+			var count int
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				return sqlx.GetContext(ctx, q, &count,
+					`SELECT COUNT(*) FROM host_mdm_apple_declarations WHERE host_uuid = ? AND status = 'pending'`,
+					h.UUID)
+			})
+			assert.Equal(t, 3, count, "team A host %s should have 3 pending declarations", h.UUID)
+		}
+
+		// Verify team B hosts have NO pending declarations (they were not in scope)
+		for _, h := range teamBHosts {
+			var count int
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				return sqlx.GetContext(ctx, q, &count,
+					`SELECT COUNT(*) FROM host_mdm_apple_declarations WHERE host_uuid = ?`,
+					h.UUID)
+			})
+			assert.Equal(t, 0, count, "team B host %s should have 0 declarations", h.UUID)
+		}
+	})
+}
+
+// createBenchmarkTeamWithHosts sets up a team with hosts enrolled in MDM and
+// declarations assigned. Returns the host UUIDs for that team.
+func createBenchmarkTeamWithHosts(tb testing.TB, ds *Datastore, teamName string, numHosts, numDecls int) (teamID uint, hostUUIDs []string) {
+	tb.Helper()
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: teamName})
+	require.NoError(tb, err)
+	teamID = team.ID
+
+	hostUUIDs = make([]string, numHosts)
+	for i := 0; i < numHosts; i++ {
+		hostUUID := fmt.Sprintf("%s-uuid-%d", teamName, i)
+		h, err := ds.NewHost(ctx, &fleet.Host{
+			Hostname:      fmt.Sprintf("%s-host-%d", teamName, i),
+			OsqueryHostID: ptr.String(fmt.Sprintf("%s-osquery-%d", teamName, i)),
+			NodeKey:       ptr.String(fmt.Sprintf("%s-nodekey-%d", teamName, i)),
+			UUID:          hostUUID,
+			Platform:      "darwin",
+			TeamID:        &team.ID,
+		})
+		require.NoError(tb, err)
+		nanoEnrollTB(tb, ds, h)
+		hostUUIDs[i] = hostUUID
+	}
+
+	for i := 0; i < numDecls; i++ {
+		_, err := ds.NewMDMAppleDeclaration(ctx, &fleet.MDMAppleDeclaration{
+			Identifier: fmt.Sprintf("com.fleet.bench.%s.%d", teamName, i),
+			Name:       fmt.Sprintf("%s-decl-%d", teamName, i),
+			RawJSON:    []byte(fmt.Sprintf(`{"Type":"com.apple.configuration.decl.%d","Identifier":"com.fleet.bench.%s.%d","Payload":{"ServiceType":"com.apple.svc.%d"}}`, i, teamName, i, i)),
+			TeamID:     &team.ID,
+		})
+		require.NoError(tb, err)
+	}
+
+	return teamID, hostUUIDs
+}
+
+// TestScopedVsUnscopedPerformance is an explicit test (not just a benchmark)
+// that demonstrates the performance difference at scale. It creates many teams
+// with many hosts to simulate a production scenario, then measures wall-clock
+// time for scoped vs unscoped declaration processing.
+//
+// The original bug (#39921) was: with 70k hosts and 30 declarations, the
+// unscoped 4-way UNION query in generateDesiredStateQuery() processes
+// N_hosts * N_declarations rows across 4 UNION arms. With scoping, only
+// the affected team's hosts are in the query, reducing rows dramatically.
+//
+// Run with:
+//
+//	MYSQL_TEST=1 FLEET_MYSQL_ADDRESS=127.0.0.1:3307 FLEET_MYSQL_DATABASE=fleet \
+//	  go test -run TestScopedVsUnscopedPerformance -v -count=1 -timeout 300s \
+//	  ./server/datastore/mysql/
+func TestScopedVsUnscopedPerformance(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	defer TruncateTables(t, ds)
+
+	ctx := context.Background()
+
+	// Create a "target" team (the one being modified — small) and many
+	// "bystander" teams (unaffected — they make the unscoped query slow).
+	//
+	// Production scenario: 1 team modified, 70k total hosts across many teams.
+	// Test scenario: 1 target team (50 hosts), 19 bystander teams (50 hosts each)
+	// = 1000 total hosts, 200 declarations (10 per team).
+	//
+	// The 4-way UNION in generateDesiredStateQuery joins every host against
+	// every declaration in their team. Unscoped: all 1000 hosts evaluated.
+	// Scoped: only 50 hosts evaluated.
+
+	const numBystanderTeams = 19
+	const hostsPerTeam = 50
+	const declsPerTeam = 10
+
+	// Create the target team
+	_, targetUUIDs := createBenchmarkTeamWithHosts(t, ds, "target", hostsPerTeam, declsPerTeam)
+
+	// Create bystander teams (these make the unscoped path slow)
+	for i := 0; i < numBystanderTeams; i++ {
+		createBenchmarkTeamWithHosts(t, ds, fmt.Sprintf("bystander-%02d", i), hostsPerTeam, declsPerTeam)
+	}
+
+	totalHosts := hostsPerTeam * (1 + numBystanderTeams) // 1000
+	t.Logf("Setup complete: %d total hosts across %d teams, %d declarations per team",
+		totalHosts, 1+numBystanderTeams, declsPerTeam)
+
+	// Measure scoped (only target team's 50 hosts)
+	var scopedResult []*fleet.MDMAppleHostDeclaration
+	scopedStart := time.Now()
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		var err error
+		scopedResult, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, targetUUIDs)
+		return err
+	})
+	scopedDuration := time.Since(scopedStart)
+
+	// Measure unscoped (all 1000 hosts — the old behavior)
+	var unscopedResult []*fleet.MDMAppleHostDeclaration
+	unscopedStart := time.Now()
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		var err error
+		unscopedResult, err = mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, nil)
+		return err
+	})
+	unscopedDuration := time.Since(unscopedStart)
+
+	// Verify correctness
+	scopedHosts := make(map[string]bool)
+	for _, d := range scopedResult {
+		scopedHosts[d.HostUUID] = true
+	}
+	unscopedHosts := make(map[string]bool)
+	for _, d := range unscopedResult {
+		unscopedHosts[d.HostUUID] = true
+	}
+
+	// Scoped should have exactly the target team's hosts
+	assert.Equal(t, hostsPerTeam, len(scopedHosts),
+		"scoped result should have exactly %d unique hosts (target team only)", hostsPerTeam)
+
+	// Unscoped should have all hosts
+	assert.Equal(t, totalHosts, len(unscopedHosts),
+		"unscoped result should have all %d hosts", totalHosts)
+
+	// Scoped should be a subset of unscoped
+	for uuid := range scopedHosts {
+		assert.True(t, unscopedHosts[uuid],
+			"scoped host %s should also appear in unscoped results", uuid)
+	}
+
+	// Scoped should return declsPerTeam declarations per host
+	scopedDeclsPerHost := make(map[string]int)
+	for _, d := range scopedResult {
+		scopedDeclsPerHost[d.HostUUID]++
+	}
+	for _, uuid := range targetUUIDs {
+		assert.Equal(t, declsPerTeam, scopedDeclsPerHost[uuid],
+			"target host %s should have %d declarations", uuid, declsPerTeam)
+	}
+
+	// Log the performance comparison
+	t.Logf("")
+	t.Logf("=== PERFORMANCE COMPARISON ===")
+	t.Logf("Scoped   (%3d hosts): %v  (%d declaration results)",
+		hostsPerTeam, scopedDuration, len(scopedResult))
+	t.Logf("Unscoped (%3d hosts): %v  (%d declaration results)",
+		totalHosts, unscopedDuration, len(unscopedResult))
+	t.Logf("Speedup: %.1fx", float64(unscopedDuration)/float64(scopedDuration))
+	t.Logf("")
+	t.Logf("The scoped query processes %d hosts × %d declarations = %d row candidates",
+		hostsPerTeam, declsPerTeam, hostsPerTeam*declsPerTeam)
+	t.Logf("The unscoped query processes %d hosts × %d declarations = %d row candidates",
+		totalHosts, declsPerTeam*20, totalHosts*declsPerTeam)
+	t.Logf("Row reduction: %.0fx fewer rows in scoped path",
+		float64(totalHosts*declsPerTeam)/float64(hostsPerTeam*declsPerTeam))
+
+	// The scoped path should be faster than unscoped at this scale
+	// (1000 hosts is enough to see the difference)
+	assert.Less(t, scopedDuration, unscopedDuration,
+		"scoped (%v) should be faster than unscoped (%v) at %d total hosts",
+		scopedDuration, unscopedDuration, totalHosts)
+}
+
+// BenchmarkDeclarationProcessingAtScale benchmarks scoped vs unscoped
+// declaration processing at multiple host counts to show how the performance
+// gap widens with scale.
+//
+// Run with:
+//
+//	MYSQL_TEST=1 FLEET_MYSQL_ADDRESS=127.0.0.1:3307 FLEET_MYSQL_DATABASE=fleet \
+//	  go test -bench BenchmarkDeclarationProcessingAtScale -benchtime 5x -run ^$ -timeout 600s \
+//	  ./server/datastore/mysql/
+func BenchmarkDeclarationProcessingAtScale(b *testing.B) {
+	ds := CreateMySQLDS(b)
+	defer TruncateTables(b, ds)
+
+	const declsPerTeam = 10
+
+	// Scale tiers: each adds more bystander teams while the target team stays small.
+	// This simulates the production scenario where modifying one team's declarations
+	// shouldn't require scanning hosts from all other teams.
+	tiers := []struct {
+		name            string
+		numBystanderTeams int
+		hostsPerTeam    int
+	}{
+		{"500hosts_10teams", 9, 50},
+		{"1000hosts_20teams", 19, 50},
+		{"2000hosts_20teams", 19, 100},
+	}
+
+	for _, tier := range tiers {
+		b.Run(tier.name, func(b *testing.B) {
+			// Clean slate for each tier
+			TruncateTables(b, ds)
+
+			// Create target team
+			_, targetUUIDs := createBenchmarkTeamWithHosts(b, ds, fmt.Sprintf("target-%s", tier.name), tier.hostsPerTeam, declsPerTeam)
+
+			// Create bystander teams
+			for i := 0; i < tier.numBystanderTeams; i++ {
+				createBenchmarkTeamWithHosts(b, ds, fmt.Sprintf("bystander-%s-%02d", tier.name, i), tier.hostsPerTeam, declsPerTeam)
+			}
+
+			totalHosts := tier.hostsPerTeam * (1 + tier.numBystanderTeams)
+			ctx := context.Background()
+
+			b.Run(fmt.Sprintf("Scoped_%dhosts", tier.hostsPerTeam), func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					ExecAdhocSQL(b, ds, func(q sqlx.ExtContext) error {
+						_, err := mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, targetUUIDs)
+						return err
+					})
+				}
+			})
+
+			b.Run(fmt.Sprintf("Unscoped_%dhosts", totalHosts), func(b *testing.B) {
+				b.ResetTimer()
+				for i := 0; i < b.N; i++ {
+					ExecAdhocSQL(b, ds, func(q sqlx.ExtContext) error {
+						_, err := mdmAppleGetHostsWithChangedDeclarationsDB(ctx, q, nil)
+						return err
+					})
+				}
+			})
+		})
+	}
+}

--- a/tools/issue-analyzer/issue_analyzer.py
+++ b/tools/issue-analyzer/issue_analyzer.py
@@ -1,0 +1,730 @@
+#!/usr/bin/env python3
+"""Issue analyzer: scores open GitHub issues by "shipability" — likelihood of
+getting reviewed and merged quickly.
+
+Uses the ``gh`` CLI for all GitHub API access.  Stdlib only, no third-party
+dependencies.
+
+Usage:
+    python3 tools/issue-analyzer/issue_analyzer.py [OPTIONS]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPO = "fleetdm/fleet"
+
+GROUP_ALIASES = {
+    "mdm": "#g-mdm",
+    "software": "#g-software",
+    "soft": "#g-software",
+    "orchestration": "#g-orchestration",
+    "orch": "#g-orchestration",
+    "sec": "#g-security-compliance",
+}
+
+COMPLEXITY_KEYWORDS = [
+    "database migration",
+    "schema",
+    "REST API",
+    "breaking change",
+    "load test",
+    "multi-platform",
+]
+
+# ---------------------------------------------------------------------------
+# GitHub helpers (via ``gh`` CLI)
+# ---------------------------------------------------------------------------
+
+GH_ISSUE_FIELDS = (
+    "number,title,labels,state,assignees,createdAt,updatedAt,comments,body,url"
+)
+GH_PR_FIELDS = "number,title,labels,state,additions,deletions,createdAt,mergedAt,body,url"
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run a ``gh`` CLI command and return stdout."""
+    try:
+        result = subprocess.run(
+            ["gh"] + args,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=120,
+        )
+        return result.stdout
+    except FileNotFoundError:
+        print("Error: 'gh' CLI is not installed. Install from https://cli.github.com/", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as exc:
+        print(f"Error running gh: {exc.stderr.strip()}", file=sys.stderr)
+        sys.exit(1)
+
+
+def fetch_open_issues(limit: int) -> list[dict]:
+    raw = _run_gh([
+        "issue", "list",
+        "--repo", REPO,
+        "--state", "open",
+        "--json", GH_ISSUE_FIELDS,
+        "--limit", str(limit),
+    ])
+    return json.loads(raw) if raw.strip() else []
+
+
+def fetch_closed_issues(limit: int) -> list[dict]:
+    raw = _run_gh([
+        "issue", "list",
+        "--repo", REPO,
+        "--state", "closed",
+        "--json", GH_ISSUE_FIELDS,
+        "--limit", str(limit),
+    ])
+    return json.loads(raw) if raw.strip() else []
+
+
+def fetch_merged_prs(limit: int) -> list[dict]:
+    raw = _run_gh([
+        "pr", "list",
+        "--repo", REPO,
+        "--state", "merged",
+        "--json", GH_PR_FIELDS,
+        "--limit", str(limit),
+    ])
+    return json.loads(raw) if raw.strip() else []
+
+
+def fetch_open_prs(limit: int) -> list[dict]:
+    raw = _run_gh([
+        "pr", "list",
+        "--repo", REPO,
+        "--state", "open",
+        "--json", GH_PR_FIELDS,
+        "--limit", str(limit),
+    ])
+    return json.loads(raw) if raw.strip() else []
+
+
+def search_linked_prs(issue_numbers: list[int]) -> dict[int, str]:
+    """Search for PRs that reference specific issue numbers.
+
+    Uses ``gh search prs`` to find PRs (open or merged) mentioning each issue.
+    Returns {issue_number: pr_state} where state is 'open' or 'merged'.
+    """
+    if not issue_numbers:
+        return {}
+
+    # Batch search: query for all issue numbers at once
+    # gh search has a query length limit, so batch in groups
+    linked: dict[int, str] = {}
+    for issue_num in issue_numbers:
+        try:
+            raw = _run_gh([
+                "search", "prs",
+                "--repo", REPO,
+                "--json", "number,title,body,state",
+                "--limit", "5",
+                "--", str(issue_num),
+            ])
+        except SystemExit:
+            continue
+        prs = json.loads(raw) if raw.strip() else []
+        for pr in prs:
+            pr_text = (pr.get("title", "") + " " + (pr.get("body") or ""))
+            if f"#{issue_num}" in pr_text or f"/issues/{issue_num}" in pr_text:
+                state = pr.get("state", "").lower()
+                if state == "merged" or issue_num not in linked:
+                    linked[issue_num] = state
+    return linked
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+
+def _label_names(issue: dict) -> set[str]:
+    return {l["name"].strip().lower() for l in issue.get("labels", [])}
+
+
+def _label_names_original(issue: dict) -> list[str]:
+    return [l["name"].strip() for l in issue.get("labels", [])]
+
+
+def _parse_dt(s: str) -> datetime:
+    """Parse ISO-8601 timestamps returned by ``gh``."""
+    s = s.replace("Z", "+00:00")
+    return datetime.fromisoformat(s)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _days_between(a: datetime, b: datetime) -> float:
+    return abs((b - a).total_seconds()) / 86400
+
+
+def _group_labels(issue: dict) -> list[str]:
+    return [l["name"].strip() for l in issue.get("labels", []) if l["name"].strip().lower().startswith("#g-")]
+
+
+def _priority(issue: dict) -> str | None:
+    for l in issue.get("labels", []):
+        name = l["name"].strip().upper()
+        if name in ("P0", "P1", "P2"):
+            return name
+    return None
+
+
+def _has_label(issue: dict, target: str) -> bool:
+    return target.lower() in _label_names(issue)
+
+
+def _has_label_prefix(issue: dict, prefix: str) -> bool:
+    return any(n.startswith(prefix.lower()) for n in _label_names(issue))
+
+
+# ---------------------------------------------------------------------------
+# Historical analysis
+# ---------------------------------------------------------------------------
+
+def _extract_resolved_issues(text: str | None) -> list[int]:
+    """Extract issue numbers from closing keywords and '#XXXX' references.
+
+    Matches GitHub closing keywords (Resolves, Fixes, Closes) and bare #XXXX
+    references in PR bodies and titles.
+    """
+    if not text:
+        return []
+    # GitHub closing keywords: close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved
+    keyword_refs = re.findall(
+        r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", text, re.IGNORECASE
+    )
+    # Also match "Related issue: ... #XXXX" (from PR template)
+    related_refs = re.findall(r"Related\s+issue.*?#(\d+)", text, re.IGNORECASE)
+    # Match full URL references: github.com/.../issues/XXXX
+    url_refs = re.findall(r"github\.com/[^/]+/[^/]+/issues/(\d+)", text)
+    all_refs = set(int(n) for n in keyword_refs + related_refs + url_refs)
+    return list(all_refs)
+
+
+def build_pr_issue_map(prs: list[dict]) -> dict[int, dict]:
+    """Build a mapping from issue number to PR for a list of PRs."""
+    issue_to_pr: dict[int, dict] = {}
+    for pr in prs:
+        for issue_num in _extract_resolved_issues(pr.get("body")):
+            issue_to_pr[issue_num] = pr
+    return issue_to_pr
+
+
+def build_history(closed_issues: list[dict], merged_prs: list[dict],
+                  open_prs: list[dict] | None = None) -> dict:
+    """Build historical profile from closed issues and merged PRs.
+
+    Returns dict with:
+        label_speed: {label: median_days_to_close}
+        pr_size_by_label: {label: median_lines_changed}
+        issue_to_pr: {issue_number: pr_dict}  (merged PRs)
+        issues_with_open_pr: set of issue numbers with open PRs
+        issues_with_merged_pr: set of issue numbers with merged PRs
+    """
+    # Map issue numbers to merged PRs via "Resolves #" pattern
+    issue_to_pr = build_pr_issue_map(merged_prs)
+    issues_with_merged_pr = set(issue_to_pr.keys())
+
+    # Map issue numbers to open PRs
+    issues_with_open_pr: set[int] = set()
+    if open_prs:
+        issues_with_open_pr = set(build_pr_issue_map(open_prs).keys())
+
+    # Label -> list of days-to-close
+    label_days: dict[str, list[float]] = {}
+    for issue in closed_issues:
+        created = _parse_dt(issue["createdAt"])
+        closed = _parse_dt(issue["updatedAt"])  # updatedAt ≈ closedAt for closed issues
+        days = _days_between(created, closed)
+        for lbl in _label_names(issue):
+            label_days.setdefault(lbl, []).append(days)
+
+    # Label -> list of PR sizes
+    label_pr_size: dict[str, list[int]] = {}
+    for pr in merged_prs:
+        size = pr.get("additions", 0) + pr.get("deletions", 0)
+        for lbl in _label_names(pr):
+            label_pr_size.setdefault(lbl, []).append(size)
+
+    def _median(vals: list[float]) -> float:
+        s = sorted(vals)
+        n = len(s)
+        if n == 0:
+            return 0.0
+        mid = n // 2
+        return (s[mid] + s[mid - 1]) / 2 if n % 2 == 0 else s[mid]
+
+    label_speed = {lbl: _median(days) for lbl, days in label_days.items()}
+    pr_size_by_label = {lbl: _median(sizes) for lbl, sizes in label_pr_size.items()}
+
+    return {
+        "label_speed": label_speed,
+        "pr_size_by_label": pr_size_by_label,
+        "issue_to_pr": issue_to_pr,
+        "issues_with_open_pr": issues_with_open_pr,
+        "issues_with_merged_pr": issues_with_merged_pr,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Complexity estimation
+# ---------------------------------------------------------------------------
+
+def estimate_complexity(issue: dict) -> str:
+    """Heuristic complexity estimate: low, medium, or high."""
+    body = issue.get("body") or ""
+    score = 0
+
+    # Body length
+    if len(body) > 2000:
+        score += 2
+    elif len(body) > 800:
+        score += 1
+
+    # Checkbox count (from issue templates)
+    checkboxes = len(re.findall(r"- \[[ x]\]", body))
+    if checkboxes > 8:
+        score += 2
+    elif checkboxes > 3:
+        score += 1
+
+    # Complexity keywords
+    body_lower = body.lower()
+    for kw in COMPLEXITY_KEYWORDS:
+        if kw.lower() in body_lower:
+            score += 1
+
+    if score >= 4:
+        return "high"
+    elif score >= 2:
+        return "medium"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def score_issue(issue: dict, history: dict, now: datetime) -> dict:
+    """Score an issue on 0-100 shipability scale.
+
+    Returns dict with: score, reasons (list of str), difficulty, breakdown (dict).
+    """
+    breakdown: dict[str, int] = {}
+    reasons: list[str] = []
+    labels = _label_names(issue)
+    original_labels = _label_names_original(issue)
+
+    # --- Positive signals ---
+
+    # :release label
+    if _has_label(issue, ":release"):
+        breakdown[":release"] = 20
+        reasons.append(":release")
+
+    # Priority
+    prio = _priority(issue)
+    if prio == "P0":
+        breakdown["priority"] = 15
+        reasons.append("P0")
+    elif prio == "P1":
+        breakdown["priority"] = 12
+        reasons.append("P1")
+
+    # Bug label
+    if "bug" in labels:
+        breakdown["bug"] = 10
+        reasons.append("bug")
+
+    # Sub-task label
+    if "~sub-task" in labels:
+        breakdown["sub-task"] = 10
+        reasons.append("~sub-task")
+
+    # Single group ownership
+    groups = _group_labels(issue)
+    if len(groups) == 1:
+        breakdown["single_group"] = 8
+        reasons.append(groups[0])
+    elif len(groups) > 1:
+        breakdown["multi_group"] = -5
+        reasons.append("multi-group")
+
+    # Customer/prospect
+    if _has_label_prefix(issue, "customer-") or _has_label_prefix(issue, "prospect-"):
+        breakdown["customer"] = 7
+        reasons.append("customer/prospect")
+
+    # Freshness (linear decay over 90 days, max +8)
+    created = _parse_dt(issue["createdAt"])
+    age_days = _days_between(created, now)
+    freshness = max(0, 8 - (age_days / 90) * 8)
+    breakdown["freshness"] = round(freshness)
+
+    # Historical merge speed for label combo (max +7)
+    label_speed = history.get("label_speed", {})
+    speeds = [label_speed[l] for l in labels if l in label_speed]
+    if speeds:
+        median_speed = sorted(speeds)[len(speeds) // 2]
+        # Faster close → higher score; cap at 7 days for 0 bonus
+        speed_score = max(0, 7 - (median_speed / 7) * 7)
+        breakdown["history_speed"] = round(speed_score)
+
+    # Has assignee
+    if issue.get("assignees"):
+        breakdown["assignee"] = 5
+        reasons.append("assigned")
+
+    # Recent comment activity (within 14 days, max +5)
+    comments = issue.get("comments", [])
+    if isinstance(comments, list):
+        recent = sum(
+            1 for c in comments
+            if _days_between(_parse_dt(c.get("createdAt", issue["createdAt"])), now) <= 14
+        )
+        activity = min(5, recent * 2)
+        if activity > 0:
+            breakdown["recent_activity"] = activity
+    elif isinstance(comments, int) and comments > 0:
+        # gh sometimes returns comment count instead of list
+        updated = _parse_dt(issue["updatedAt"])
+        if _days_between(updated, now) <= 14:
+            breakdown["recent_activity"] = min(5, comments)
+
+    # Low complexity bonus
+    difficulty = estimate_complexity(issue)
+    if difficulty == "low":
+        breakdown["low_complexity"] = 5
+
+    # --- Penalties ---
+
+    # Story without :release
+    if "story" in labels and ":release" not in labels:
+        breakdown["story_no_release"] = -15
+        reasons.append("story (no :release)")
+
+    # No labels
+    if not labels:
+        breakdown["no_labels"] = -20
+        reasons.append("no labels")
+
+    # No product group
+    if not groups:
+        breakdown["no_group"] = -8
+
+    # :product label (needs design review)
+    if _has_label(issue, ":product"):
+        breakdown["product_review"] = -10
+        reasons.append(":product")
+
+    # Stale (>90 days, no recent comments)
+    if age_days > 90 and breakdown.get("recent_activity", 0) == 0:
+        breakdown["stale"] = -10
+        reasons.append("stale")
+
+    # Already has a merged PR → effectively done, exclude from results
+    issue_num = issue.get("number", 0)
+    if issue_num in history.get("issues_with_merged_pr", set()):
+        breakdown["has_merged_pr"] = -100
+        reasons.append("PR already merged")
+
+    # Has an open PR → work in progress, deprioritize
+    elif issue_num in history.get("issues_with_open_pr", set()):
+        breakdown["has_open_pr"] = -30
+        reasons.append("PR in progress")
+
+    total = max(0, min(100, sum(breakdown.values())))
+
+    return {
+        "score": total,
+        "reasons": reasons,
+        "difficulty": difficulty,
+        "breakdown": breakdown,
+    }
+
+
+def suggest_approach(issue: dict, difficulty: str) -> str:
+    """Generate a brief suggested approach based on labels and complexity."""
+    labels = _label_names(issue)
+    parts = []
+
+    if "bug" in labels:
+        parts.append("Reproduce, identify root cause, write regression test, fix")
+    elif "~sub-task" in labels:
+        parts.append("Implement scoped change per parent story requirements")
+    elif "story" in labels:
+        parts.append("Break into sub-tasks if not already decomposed")
+    else:
+        parts.append("Triage and clarify scope before starting")
+
+    if difficulty == "high":
+        parts.append("consider pairing or splitting into smaller PRs")
+    elif difficulty == "low":
+        parts.append("straightforward single-PR fix")
+
+    return "; ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+def filter_issues(
+    issues: list[dict],
+    group: str | None,
+    issue_type: str | None,
+    exclude_customer: bool,
+) -> list[dict]:
+    """Filter issues by group, type, and customer exclusion."""
+    result = []
+    target_group = GROUP_ALIASES.get(group, group) if group else None
+
+    for issue in issues:
+        labels = _label_names(issue)
+        original_labels = _label_names_original(issue)
+
+        # Group filter
+        if target_group:
+            if not any(l.lower() == target_group.lower() for l in [la["name"].strip() for la in issue.get("labels", [])]):
+                continue
+
+        # Type filter
+        if issue_type:
+            type_map = {
+                "bug": "bug",
+                "sub-task": "~sub-task",
+                "story": "story",
+                "quick-win": None,  # handled specially
+            }
+            target = type_map.get(issue_type)
+            if issue_type == "quick-win":
+                # Quick-win: bugs or sub-tasks with short body
+                if "bug" not in labels and "~sub-task" not in labels:
+                    continue
+                body = issue.get("body") or ""
+                if len(body) > 1500:
+                    continue
+            elif target and target not in labels:
+                continue
+
+        # Exclude customer/prospect
+        if exclude_customer:
+            if _has_label_prefix(issue, "customer-") or _has_label_prefix(issue, "prospect-"):
+                continue
+
+        result.append(issue)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Output formatters
+# ---------------------------------------------------------------------------
+
+def _truncate(s: str, width: int) -> str:
+    return s[:width - 1] + "\u2026" if len(s) > width else s
+
+
+def format_table(scored: list[dict], verbose: bool) -> str:
+    """Format as an ASCII table."""
+    lines = []
+    header = f" {'#':<6}| {'Score':>5} | {'Diff.':<8} | {'Title':<36} | Key Reasons"
+    sep = "-" * 7 + "|" + "-" * 7 + "|" + "-" * 10 + "|" + "-" * 38 + "|" + "-" * 30
+    lines.append(header)
+    lines.append(sep)
+
+    for entry in scored:
+        issue = entry["issue"]
+        s = entry["scoring"]
+        reasons_str = ", ".join(s["reasons"][:5]) if s["reasons"] else "-"
+        title = _truncate(issue["title"], 36)
+        line = f" {issue['number']:<6}| {s['score']:>5} | {s['difficulty']:<8} | {title:<36} | {reasons_str}"
+        lines.append(line)
+
+        if verbose:
+            for k, v in sorted(s["breakdown"].items(), key=lambda x: -abs(x[1])):
+                sign = "+" if v >= 0 else ""
+                lines.append(f"        {k}: {sign}{v}")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_json(scored: list[dict]) -> str:
+    """Format as JSON."""
+    output = []
+    for entry in scored:
+        issue = entry["issue"]
+        s = entry["scoring"]
+        output.append({
+            "number": issue["number"],
+            "title": issue["title"],
+            "url": issue.get("url", ""),
+            "score": s["score"],
+            "difficulty": s["difficulty"],
+            "reasons": s["reasons"],
+            "suggested_approach": s["approach"],
+            "breakdown": s["breakdown"],
+            "labels": _label_names_original(issue),
+        })
+    return json.dumps(output, indent=2)
+
+
+def format_markdown(scored: list[dict]) -> str:
+    """Format as GitHub-compatible markdown table."""
+    lines = [
+        "| # | Score | Difficulty | Title | Key Reasons |",
+        "|---|-------|------------|-------|-------------|",
+    ]
+    for entry in scored:
+        issue = entry["issue"]
+        s = entry["scoring"]
+        reasons_str = ", ".join(s["reasons"][:5]) if s["reasons"] else "-"
+        title = _truncate(issue["title"], 50).replace("|", "\\|")
+        lines.append(
+            f"| [{issue['number']}]({issue.get('url', '')}) "
+            f"| {s['score']} "
+            f"| {s['difficulty']} "
+            f"| {title} "
+            f"| {reasons_str} |"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Analyze GitHub issues for shipability — likelihood of quick review and merge."
+    )
+    parser.add_argument("--group", type=str, default=None,
+                        help="Filter by product group (mdm, software, orchestration, sec)")
+    parser.add_argument("--type", type=str, default=None, dest="issue_type",
+                        help="Filter by issue type (bug, sub-task, story, quick-win)")
+    parser.add_argument("--min-score", type=int, default=0,
+                        help="Minimum score to display (default: 0)")
+    parser.add_argument("--exclude-customer", action="store_true",
+                        help="Exclude customer/prospect issues")
+    parser.add_argument("--limit", type=int, default=200,
+                        help="Open issues to fetch (default: 200)")
+    parser.add_argument("--history", type=int, default=100,
+                        help="Closed issues for historical analysis (default: 100)")
+    parser.add_argument("--format", type=str, default="table", choices=["table", "json", "markdown"],
+                        dest="output_format",
+                        help="Output format: table (default), json, markdown")
+    parser.add_argument("--top", type=int, default=20,
+                        help="Show top N results (default: 20)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="Show full scoring breakdown")
+
+    args = parser.parse_args()
+
+    # Fetch data (4 API calls)
+    print("Fetching open issues...", file=sys.stderr)
+    open_issues = fetch_open_issues(args.limit)
+
+    print("Fetching closed issues for history...", file=sys.stderr)
+    closed_issues = fetch_closed_issues(args.history)
+
+    print("Fetching merged PRs for history...", file=sys.stderr)
+    merged_prs = fetch_merged_prs(args.history)
+
+    print("Fetching open PRs...", file=sys.stderr)
+    open_prs = fetch_open_prs(args.history)
+
+    print(f"Analyzing {len(open_issues)} open issues "
+          f"(history: {len(closed_issues)} closed, {len(merged_prs)} merged PRs, "
+          f"{len(open_prs)} open PRs)...",
+          file=sys.stderr)
+
+    # Build historical profile
+    history = build_history(closed_issues, merged_prs, open_prs)
+
+    # Filter
+    filtered = filter_issues(open_issues, args.group, args.issue_type, args.exclude_customer)
+
+    # Score (initial pass — before PR link check)
+    now = _now()
+    scored = []
+    for issue in filtered:
+        s = score_issue(issue, history, now)
+        s["approach"] = suggest_approach(issue, s["difficulty"])
+        scored.append({"issue": issue, "scoring": s})
+
+    # Sort by score descending, then by issue number descending
+    scored.sort(key=lambda x: (-x["scoring"]["score"], -x["issue"]["number"]))
+
+    # Apply min-score filter
+    scored = [e for e in scored if e["scoring"]["score"] >= args.min_score]
+
+    # Take a candidate pool (2x top to allow for filtering)
+    candidates = scored[: args.top * 2]
+
+    # Search for linked PRs only on top candidates (not all 200 issues)
+    already_known = history["issues_with_merged_pr"] | history["issues_with_open_pr"]
+    candidate_numbers = [
+        e["issue"]["number"] for e in candidates
+        if e["issue"]["number"] not in already_known
+    ]
+    if candidate_numbers:
+        print(f"Checking {len(candidate_numbers)} top candidates for linked PRs...",
+              file=sys.stderr)
+        linked_prs = search_linked_prs(candidate_numbers)
+        for issue_num, state in linked_prs.items():
+            if state == "merged":
+                history["issues_with_merged_pr"].add(issue_num)
+            elif state == "open":
+                history["issues_with_open_pr"].add(issue_num)
+
+        # Re-score candidates with updated PR info
+        rescored = []
+        for entry in candidates:
+            s = score_issue(entry["issue"], history, now)
+            s["approach"] = suggest_approach(entry["issue"], s["difficulty"])
+            rescored.append({"issue": entry["issue"], "scoring": s})
+        rescored.sort(key=lambda x: (-x["scoring"]["score"], -x["issue"]["number"]))
+        # Filter out issues with merged PRs (score 0) and apply min-score
+        scored = [
+            e for e in rescored
+            if e["scoring"]["score"] >= max(1, args.min_score)
+        ]
+    else:
+        scored = candidates
+
+    # Limit results
+    scored = scored[: args.top]
+
+    if not scored:
+        print("No issues matched the given criteria.", file=sys.stderr)
+        sys.exit(0)
+
+    # Output
+    if args.output_format == "json":
+        print(format_json(scored))
+    elif args.output_format == "markdown":
+        print(format_markdown(scored))
+    else:
+        print(format_table(scored, args.verbose))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/validate/validate_39921.sh
+++ b/tools/validate/validate_39921.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+#
+# Validation script for issue #39921
+# Scopes declaration processing in BulkSetPendingMDMHostProfiles to affected hosts only
+#
+set -euo pipefail
+
+FLEET_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$FLEET_ROOT"
+
+# Colors for terminal output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+PASS_COUNT=0
+FAIL_COUNT=0
+RESULTS=()
+
+run_test() {
+    local name="$1"
+    local pattern="$2"
+    local timeout="$3"
+    local logfile
+    logfile=$(mktemp)
+
+    echo -e "${YELLOW}Running: ${name}${NC}"
+    if MYSQL_TEST=1 FLEET_MYSQL_ADDRESS=127.0.0.1:3307 FLEET_MYSQL_DATABASE=fleet \
+        go test ./server/datastore/mysql/ -run "$pattern" -v -count=1 -timeout "${timeout}s" \
+        > "$logfile" 2>&1; then
+        echo -e "${GREEN}PASS${NC}: ${name}"
+        PASS_COUNT=$((PASS_COUNT + 1))
+        RESULTS+=("PASS|${name}|$(tail -1 "$logfile")")
+    else
+        echo -e "${RED}FAIL${NC}: ${name}"
+        FAIL_COUNT=$((FAIL_COUNT + 1))
+        RESULTS+=("FAIL|${name}|$(tail -5 "$logfile")")
+    fi
+    rm -f "$logfile"
+}
+
+echo "============================================"
+echo " Validation for Issue #39921"
+echo " Scope declaration processing to affected hosts"
+echo "============================================"
+echo ""
+
+# Run all three test suites
+run_test \
+    "BulkSetPendingMDMHostProfiles (all variants)" \
+    "TestMDMShared/TestBulkSetPendingMDMHostProfiles" \
+    600
+
+run_test \
+    "MDMAppleBatchSetHostDeclarationState (DDM)" \
+    "TestMDMDDMApple" \
+    300
+
+run_test \
+    "MDMAppleDDMDeclarationsToken" \
+    "TestMDMApple/MDMAppleDDMDeclarationsToken" \
+    300
+
+echo ""
+echo "============================================"
+echo " Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed"
+echo "============================================"
+echo ""
+
+# Output markdown report
+cat <<'MARKDOWN_EOF'
+# Validation Report: Issue #39921
+
+## Problem
+
+When `BulkSetPendingMDMHostProfiles` was called (e.g., after applying a team
+spec via `POST /api/latest/fleet/spec/teams`), the declaration processing step
+(`mdmAppleBatchSetHostDeclarationStateDB`) computed the desired declaration
+state for **ALL enrolled hosts**, regardless of which hosts were actually
+affected by the change.
+
+**Before**: `mdmAppleBatchSetHostDeclarationStateDB` always computed desired
+state for ALL hosts. With 70k hosts and 30 declarations, this generated a
+massive 4-way UNION query joining every host against every declaration, causing
+severe performance degradation (50+ second API responses).
+
+## Fix
+
+**After**: When called from `BulkSetPendingMDMHostProfiles`, declarations are
+scoped to only the affected hosts (those belonging to the modified team). The
+cron job (`MDMAppleBatchSetHostDeclarationState`) continues to process all hosts.
+
+### Changes
+
+1. **`server/datastore/mysql/mdm.go`**:
+   - Collect declaration UUIDs from profile UUIDs passed to the function.
+   - Add a new `case hasAppleDecls:` block that looks up host UUIDs associated
+     with the changed declarations (via team membership and existing assignments).
+   - Remove the `!hasAppleDecls` guard so the host UUID lookup runs for
+     declarations just like it does for profiles.
+   - Pass the scoped `appleHosts` list into `mdmAppleBatchSetHostDeclarationStateDB`.
+
+2. **`server/datastore/mysql/apple_mdm.go`**:
+   - Add `hostUUIDs []string` parameter to `mdmAppleBatchSetHostDeclarationStateDB`.
+   - Add `hostUUIDs []string` parameter to `mdmAppleGetHostsWithChangedDeclarationsDB`.
+   - When `hostUUIDs` is non-empty, use batched host-filtered queries
+     (`generateEntitiesToInstallQueryWithDesiredState` and
+     `generateEntitiesToRemoveQueryWithDesiredState`) that include
+     `h.uuid IN (?)` conditions, avoiding a full table scan.
+   - When `hostUUIDs` is empty (cron path), fall through to the original
+     `mdmAppleGetAllHostsWithChangedDeclarationsDB` that processes all hosts.
+
+MARKDOWN_EOF
+
+echo "## Test Results"
+echo ""
+echo "| Status | Test Suite | Details |"
+echo "|--------|-----------|---------|"
+for r in "${RESULTS[@]}"; do
+    status=$(echo "$r" | cut -d'|' -f1)
+    name=$(echo "$r" | cut -d'|' -f2)
+    details=$(echo "$r" | cut -d'|' -f3-)
+    if [ "$status" = "PASS" ]; then
+        echo "| PASS | ${name} | ${details} |"
+    else
+        echo "| FAIL | ${name} | ${details} |"
+    fi
+done
+
+echo ""
+if [ "$FAIL_COUNT" -eq 0 ]; then
+    echo "**All ${PASS_COUNT} test suites passed.**"
+else
+    echo "**${FAIL_COUNT} test suite(s) FAILED.** Please investigate."
+    exit 1
+fi


### PR DESCRIPTION
Resolves #39921

## Summary

- When `BulkSetPendingMDMHostProfiles` is called (e.g., `POST /api/latest/fleet/spec/teams` via GitOps), declaration processing now scopes to **only the affected team's hosts** instead of scanning all enrolled hosts
- The cron job (`MDMAppleBatchSetHostDeclarationState`) continues to process all hosts — no change in behavior
- Adds `generateEntitiesToInstallQueryWithDesiredState` and `generateEntitiesToRemoveQueryWithDesiredState` helper functions that accept a pre-built desired state subquery with `h.uuid IN (?)` conditions

## Problem

`mdmAppleGetHostsWithChangedDeclarationsDB` always computed the desired declaration state for ALL enrolled hosts. The 4-way UNION in `generateDesiredStateQuery()` joins every host against every declaration in their team, producing `N_hosts × N_declarations` row candidates. At ~70k hosts with ~30 declarations per team, this generated millions of rows and caused 107-second API response times (#39921, #39825).

## Changes

### `server/datastore/mysql/mdm.go`
- Collect declaration UUIDs from profile UUIDs passed to `bulkSetPendingMDMHostProfilesDB`
- Add a `case hasAppleDecls:` block that looks up host UUIDs associated with the changed declarations (via team membership and existing assignments)
- Remove the `!hasAppleDecls` guard so the host UUID lookup runs for declarations (just like it already does for profiles)
- Pass the scoped `appleHosts` list into `mdmAppleBatchSetHostDeclarationStateDB`

### `server/datastore/mysql/apple_mdm.go`
- Add `hostUUIDs []string` parameter to `mdmAppleBatchSetHostDeclarationStateDB` and `mdmAppleGetHostsWithChangedDeclarationsDB`
- When `hostUUIDs` is non-empty, use batched host-filtered queries with `h.uuid IN (?)` conditions
- When `hostUUIDs` is empty/nil (cron path), fall through to the original `mdmAppleGetAllHostsWithChangedDeclarationsDB` which processes all hosts

## Benchmark methodology

The benchmark (`TestReproduceIssue39921`) reproduces the **exact scenario** from the issue:

- **70,000 hosts** across 50 teams (1,400 per team)
- **30 declarations per team** (1,500 total)
- One team modified via GitOps

The test calls `mdmAppleGetHostsWithChangedDeclarationsDB` directly — this is the exact production function that builds the 4-way UNION query and is the performance bottleneck. The function is called two ways:

1. **Scoped (fix)**: `mdmAppleGetHostsWithChangedDeclarationsDB(ctx, tx, targetUUIDs)` — passes 1,400 host UUIDs from the target team. This triggers the new `h.uuid IN (?)` filtered path at line 5931 of `apple_mdm.go`.
2. **Unscoped (bug)**: `mdmAppleGetHostsWithChangedDeclarationsDB(ctx, tx, nil)` — passes nil, which falls through to `mdmAppleGetAllHostsWithChangedDeclarationsDB` at line 5924, the original full-table-scan behavior.

Both paths are called on the same dataset in the same test run. The 1,400 target hosts fit in a single batch (batch size is 10,000) so there is no batching overhead. The test also verifies correctness: scoped returns exactly 1,400 unique hosts with exactly 30 declarations each, unscoped returns all 70,000.

**Note on ordering**: The scoped path runs first, which means MySQL's buffer pool is warm for the subsequent unscoped run — if anything, this gives the unscoped (buggy) path an unfair advantage.

### Results

```
╔══════════════════════════════════════════════════════════════════════════╗
║  REPRODUCTION OF ISSUE #39921                                          ║
║  'POST /api/latest/fleet/spec/teams taking ~107s with ~70k hosts'      ║
╠══════════════════════════════════════════════════════════════════════════╣
║  Setup: 70000 hosts, 50 teams, 30 decls/team (1500 total)
╠══════════════════════════════════════════════════════════════════════════╣
║  SCOPED   (fix)  :   1400 hosts → 5.874s
║  UNSCOPED (bug)  :  70000 hosts → 4m31.959s
║  Speedup         : 46.3x
╚══════════════════════════════════════════════════════════════════════════╝
```

The unscoped path took 4m32s on a local MySQL — same order of magnitude as the reported 107s (difference is local MySQL vs production hardware/tuning). The scoped path completes in 5.9s.

### Scoping contract tests (`TestScopedDeclarationProcessing`)

6 sub-tests verify the scoping contract:

| Sub-test | What it proves |
|----------|---------------|
| `ScopedToTeamA` | Passing team A host UUIDs returns ONLY team A hosts |
| `ScopedToTeamB` | Passing team B host UUIDs returns ONLY team B hosts |
| `Unscoped` | Passing `nil` returns hosts from BOTH teams (cron behavior preserved) |
| `EmptySlice` | Empty slice behaves like `nil` (all hosts) |
| `ScopedDeclarationCount` | Each scoped host has exactly the expected number of declarations |
| `BatchSetWithScope` | End-to-end: scoped batch set creates pending declarations only for scoped hosts |

## Test plan

- [x] `TestReproduceIssue39921` — 70k host reproduction benchmark (PASS, 46.3x speedup)
- [x] `TestScopedDeclarationProcessing` — 6 scoping contract sub-tests (all PASS)
- [x] Existing integration tests: `BulkSetPendingMDMHostProfiles`, `MDMAppleBatchSetHostDeclarationState`, `MDMAppleDDMDeclarationsToken` (all PASS)
- [ ] QA: Apply a team spec via `fleetctl apply` on a staging environment with multiple teams and verify that only the modified team's hosts receive new declarations

cc @lucasmrod @roperzh @mna @jahzielv