### PR TITLE
Website: fix broken links

### DIFF
--- a/articles/entra-conditional-access-integration.md
+++ b/articles/entra-conditional-access-integration.md
@@ -8,7 +8,7 @@ Entra conditional access is supported even if you're not using MDM features in F
 
 Migrating from your current MDM solution to Fleet? The best practice is to switch to Fleet for Entra conditional access at the same time as your MDM migration. Why? While end users are taking action to migrate from your old MDM solution to Fleet, in the same sitting, they can re-register with Platform SSO. 
 
-Before you switch to Fleet, let your team know that there will be a gap in conditional access coverage. Microsoft only allows one compliance partner to be configured for macOS hosts. [Learn more]([#step-2-configure-fleet-in-intune]).
+Before you switch to Fleet, let your team know that there will be a gap in conditional access coverage. Microsoft only allows one compliance partner to be configured for macOS hosts. [Learn more](#step-2-configure-fleet-in-intune).
 
 ## Step 1: Create a "Fleet conditional access" group in Entra
 

--- a/articles/worldwide-security-and-authentication-platform-chooses-fleet-for-linux.md
+++ b/articles/worldwide-security-and-authentication-platform-chooses-fleet-for-linux.md
@@ -79,7 +79,7 @@ Fleet’s ability to scale horizontally allowed the company to manage thousands 
 
 By providing tools typically overlooked for Linux, Fleet's open-source platform completes the circle of high-security standards, compliance, and trust with a technically proficient and privacy-conscious Linux user base. Fleet’s automation and integration capabilities meant that IT could still use the tools they wanted, without leaving Linux behind. This proved vital for the company which continues to scale globally. 
 
-To learn more about how Fleet can support your organization, visit [fleetdm.com/mdm](fleetdm.com/mdm).
+To learn more about how Fleet can support your organization, visit [fleetdm.com/mdm](https://fleetdm.com/mdm).
 
 <call-to-action></call-to-action>
 

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -990,6 +990,7 @@ module.exports.routes = {
   'GET /software-catalog/vnc-viewer': '/software-catalog/vnc-viewer-darwin',
   'GET /apps': '/software-catalog',// This is mostly for mikermcneil who keeps trying to type the old url.
   'GET /register': '/login#register',
+  'GET /handbook/finance/security': '/handbook/it/security',
   //  ╔╦╗╦╔═╗╔═╗  ╦═╗╔═╗╔╦╗╦╦═╗╔═╗╔═╗╔╦╗╔═╗   ┬   ╔╦╗╔═╗╦ ╦╔╗╔╦  ╔═╗╔═╗╔╦╗╔═╗
   //  ║║║║╚═╗║    ╠╦╝║╣  ║║║╠╦╝║╣ ║   ║ ╚═╗  ┌┼─   ║║║ ║║║║║║║║  ║ ║╠═╣ ║║╚═╗
   //  ╩ ╩╩╚═╝╚═╝  ╩╚═╚═╝═╩╝╩╩╚═╚═╝╚═╝ ╩ ╚═╝  └┘   ═╩╝╚═╝╚╩╝╝╚╝╩═╝╚═╝╩ ╩═╩╝╚═╝

--- a/website/views/pages/testimonials.ejs
+++ b/website/views/pages/testimonials.ejs
@@ -141,7 +141,7 @@
         <div purpose="article-card" @click="goto('/announcements/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet')">
           <p><strong>Global workforce management software</strong></p>
           <p>A global workforce management company achieved compliance and clarity with Fleet — keeping shift work in sync.</p>
-          <a href="/announcements/articles/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet">Read their story</a>
+          <a href="/announcements/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet">Read their story</a>
         </div>
         <div purpose="article-card" @click="goto('/announcements/worldwide-security-and-authentication-platform-chooses-fleet-for-linux')">
           <p><strong>Security and authentication platform</strong></p>


### PR DESCRIPTION
Changes:
- Fixed a broken link on /customers (`/announcements/articles/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet` » `/announcements/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet`)
- Added a redirect for the security handbook page
- Fixed two broken links in articles