### PR TITLE
Fix enroll secrets UI

### DIFF
--- a/changes/39260-fix-enroll-secrets-ui
+++ b/changes/39260-fix-enroll-secrets-ui
@@ -1,0 +1,1 @@
+- Fixed some styling issues for the UI when no enroll secret is present on a fleet.

--- a/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
+++ b/frontend/components/EnrollSecrets/EnrollSecretModal/_styles.scss
@@ -26,5 +26,6 @@
 
   .empty-table__container {
     margin: $pad-large auto $pad-medium;
+    gap: $pad-medium;
   }
 }

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -225,9 +225,6 @@ const ManageHostsPage = ({
     queryParams && queryParams.page ? parseInt(queryParams?.page, 10) : 0)();
 
   // ========= states
-  const [showNoEnrollSecretBanner, setShowNoEnrollSecretBanner] = useState(
-    true
-  );
   const [showDeleteSecretModal, setShowDeleteSecretModal] = useState(false);
   const [showSecretEditorModal, setShowSecretEditorModal] = useState(false);
   const [showEnrollSecretModal, setShowEnrollSecretModal] = useState(false);
@@ -711,11 +708,6 @@ const ManageHostsPage = ({
       setIsAllMatchingHostsSelected(!isAllMatchingHostsSelected);
     }
   };
-
-  // TODO: cleanup this effect
-  useEffect(() => {
-    setShowNoEnrollSecretBanner(true);
-  }, [teamIdForApi]);
 
   // TODO: cleanup this effect
   useEffect(() => {
@@ -1912,13 +1904,11 @@ const ManageHostsPage = ({
 
     return (
       ((canEnrollHosts && noTeamEnrollSecrets) ||
-        (canEnrollGlobalHosts && noGlobalEnrollSecrets)) &&
-      showNoEnrollSecretBanner && (
+        (canEnrollGlobalHosts && noGlobalEnrollSecrets)) && (
         <InfoBanner
           className={`${baseClass}__no-enroll-secret-banner`}
           pageLevel
-          closable
-          color="grey"
+          color="yellow"
         >
           <div>
             <span>

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1907,7 +1907,6 @@ const ManageHostsPage = ({
         (canEnrollGlobalHosts && noGlobalEnrollSecrets)) && (
         <InfoBanner
           className={`${baseClass}__no-enroll-secret-banner`}
-          pageLevel
           color="yellow"
         >
           <div>


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39260

# Details

Fixes the banner displayed when a team has no enroll secrets to match similar, non-dismissible warning banners, and corrects the padding between text and button in the "Add enroll secret" modal empty state.

<img width="773" height="221" alt="image" src="https://github.com/user-attachments/assets/490f49f1-ccaa-47c7-8ba3-a7de2896d932" />

---

<img width="662" height="380" alt="image" src="https://github.com/user-attachments/assets/0f73b9b8-d625-4f40-ac8d-edb71e9f2a22" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
n/a, styling only
- [X] QA'd all new/changed functionality manually
See screenshots above
