### PR TITLE
Revert moving to `fleet_id` prematurely in API requests

### DIFF
--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -152,7 +152,7 @@ export const reconcileSoftwareParams = ({
     return {
       software_title_id: softwareTitleId,
       [HOSTS_QUERY_PARAMS.SOFTWARE_STATUS]: softwareStatus,
-      fleet_id: teamId,
+      team_id: teamId,
     };
   }
 
@@ -177,24 +177,24 @@ export const reconcileMutuallyInclusiveHostParams = ({
   macSettingsStatus,
   osSettings,
 }: IMutuallyInclusiveHostParams) => {
-  const reconciled: Record<string, unknown> = { fleet_id: teamId };
+  const reconciled: Record<string, unknown> = { team_id: teamId };
 
   if (label) {
-    // if label is present, include fleet_id in the query but exclude others
+    // if label is present, include team_id in the query but exclude others
     return reconciled;
   }
 
   if (macSettingsStatus) {
     // ensure macos_settings filter is always applied in
-    // conjunction with a fleet_id, 0 (no fleets) by default
+    // conjunction with a team_id, 0 (no fleets) by default
     reconciled.macos_settings = macSettingsStatus;
-    reconciled.fleet_id = teamId ?? 0;
+    reconciled.team_id = teamId ?? 0;
   }
   if (osSettings) {
     // ensure os_settings filter is always applied in
-    // conjunction with a fleet_id, 0 (no fleets) by default
+    // conjunction with a team_id, 0 (no fleets) by default
     reconciled[HOSTS_QUERY_PARAMS.OS_SETTINGS] = osSettings;
-    reconciled.fleet_id = teamId ?? 0;
+    reconciled.team_id = teamId ?? 0;
   }
 
   return reconciled;

--- a/frontend/utilities/url/url.tests.ts
+++ b/frontend/utilities/url/url.tests.ts
@@ -54,11 +54,11 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: 25,
-      fleet_id: 10,
+      team_id: 10,
       order_key: "issues",
     };
     expect(getPathWithQueryParams(endpoint, queryParams)).toBe(
-      "/hosts/manage?software_id=25&fleet_id=10&order_key=issues"
+      "/hosts/manage?software_id=25&team_id=10&order_key=issues"
     );
   });
 
@@ -66,7 +66,7 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: undefined,
-      fleet_id: null,
+      team_id: null,
       policy_response: "",
       policy_id: 4,
     };
@@ -79,7 +79,7 @@ describe("url utilities > getPathWithQueryParams", () => {
     const endpoint = "/hosts/manage";
     const queryParams = {
       software_id: undefined,
-      fleet_id: null,
+      team_id: null,
       policy_response: "",
     };
     expect(getPathWithQueryParams(endpoint, queryParams)).toBe("/hosts/manage");
@@ -93,7 +93,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
       reconcileMutuallyInclusiveHostParams({ macSettingsStatus, teamId })
     ).toEqual({
       macos_settings: "pending",
-      fleet_id: 1,
+      team_id: 1,
     });
   });
 
@@ -106,18 +106,18 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
       })
     ).toEqual({
       macos_settings: "pending",
-      fleet_id: 0,
+      team_id: 0,
     });
   });
 
-  it("adds fleet_id: 0 when macSettingsStatus is present and teamId is not", () => {
+  it("adds team_id: 0 when macSettingsStatus is present and teamId is not", () => {
     const [macSettingsStatus, teamId] = ["pending" as const, undefined];
     expect(
       reconcileMutuallyInclusiveHostParams({
         macSettingsStatus,
         teamId,
       })
-    ).toEqual({ macos_settings: "pending", fleet_id: 0 });
+    ).toEqual({ macos_settings: "pending", team_id: 0 });
   });
 
   it("does not add macos_settings when teamId is present and macSettingsStatus is not", () => {
@@ -125,7 +125,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
     expect(
       reconcileMutuallyInclusiveHostParams({ macSettingsStatus, teamId })
     ).toEqual({
-      fleet_id: 1,
+      team_id: 1,
     });
   });
 
@@ -145,7 +145,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
         osSettings: "pending",
       })
     ).toEqual({
-      fleet_id: 1,
+      team_id: 1,
     });
     expect(
       reconcileMutuallyInclusiveHostParams({
@@ -154,7 +154,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
         osSettings: "pending",
       })
     ).toEqual({
-      fleet_id: undefined,
+      team_id: undefined,
     });
   });
 });


### PR DESCRIPTION
Until backend updates are merged, we can't send `fleet_id` as a query parameter in API calls.  This PR reverts the code that switched to `fleet_id` so that the front end will continue to work while we finalize back-end changes in https://github.com/fleetdm/fleet/pull/39873.

On current main branch, switching between fleets in the dropdown on the Hosts page does nothing (always shows Unassigned hosts).  With this fix it switches between fleets as expected.