### PR TITLE
Add warning message on gitops label rename

### DIFF
--- a/changes/38947-handle-renaming-labels-in-gitops
+++ b/changes/38947-handle-renaming-labels-in-gitops
@@ -1,0 +1,1 @@
+* Added warning message on gitops label rename to clarify to users that renaming a label implies a delete operation.

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2690,6 +2690,9 @@ func (c *Client) doGitOpsLabels(
 	nToUpdate := len(config.LabelChangesSummary.LabelsToUpdate)
 
 	if dryRun {
+		if len(toDelete) > 0 {
+			logFn("[-] would've deleted %s (This includes renames, since labels are identified by name in YAML.)\n", numberWithPluralization(len(toDelete), "label", "labels"))
+		}
 		for _, labelToDelete := range toDelete {
 			logFn("[-] would've deleted label '%s'\n", labelToDelete)
 		}
@@ -2705,6 +2708,9 @@ func (c *Client) doGitOpsLabels(
 		return nil
 	}
 
+	if len(toDelete) > 0 {
+		logFn("[-] deleting %s (This includes renames, since labels are identified by name in YAML.)\n", numberWithPluralization(len(toDelete), "label", "labels"))
+	}
 	for _, l := range toDelete {
 		logFn("[-] deleting label '%s'\n", l)
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38947 

Added warning message on gitops label rename to clarify to users that renaming a label implies a delete operation.

<img width="1814" height="717" alt="Screenshot From 2026-02-18 07-58-06" src="https://github.com/user-attachments/assets/ed4f2b62-e6bb-4444-9d41-e387392fe339" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually