### PR TITLE
Fix: Policy automations revert to old value in UI after saving

### DIFF
--- a/changes/38949-policy-automations-stale-data-after-save
+++ b/changes/38949-policy-automations-stale-data-after-save
@@ -1,0 +1,1 @@
+- Fixed an issue where policy automation settings in the Other Workflows modal reverted to stale values after saving when using a MySQL read replica.

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -29,7 +29,6 @@ import {
   API_ALL_TEAMS_ID,
   API_NO_TEAM_ID,
   APP_CONTEXT_ALL_TEAMS_ID,
-  ITeamConfig,
 } from "interfaces/team";
 import { TooltipContent } from "interfaces/dropdownOption";
 
@@ -379,34 +378,25 @@ const ManagePolicyPage = ({
     }
   );
 
-  const { data: teamConfig, isFetching: isFetchingTeamConfig } = useQuery<
+  const { data: teamData, isFetching: isFetchingTeamConfig } = useQuery<
     ILoadTeamResponse,
-    Error,
-    ITeamConfig
+    Error
   >(["teams", teamIdForApi], () => teamsAPI.load(teamIdForApi), {
     // Enable for all teams including "No team" (teamIdForApi === 0)
     enabled: isRouteOk && teamIdForApi !== undefined && canAddOrDeletePolicies,
-    select: (data) => data.team,
     staleTime: 5000,
   });
+  const teamConfig = teamData?.team;
 
-  const queryAutomationsConfig = isAllTeamsSelected ? globalConfig : teamConfig;
-  const [automationsConfig, setAutomationsConfig] = useState(
-    queryAutomationsConfig
-  );
-  useEffect(() => {
-    setAutomationsConfig(queryAutomationsConfig);
-  }, [queryAutomationsConfig]);
+  const automationsConfig = isAllTeamsSelected ? globalConfig : teamConfig;
 
   const updateGlobalConfig = (updatedConfig: IConfig) => {
     queryClient.setQueryData(["config"], updatedConfig);
     setConfig(updatedConfig);
-    setAutomationsConfig(updatedConfig);
   };
 
   const updateTeamConfig = (updatedTeamResponse: ILoadTeamResponse) => {
     queryClient.setQueryData(["teams", teamIdForApi], updatedTeamResponse);
-    setAutomationsConfig(updatedTeamResponse.team);
   };
 
   const refetchPolicies = (teamId?: number) => {

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -1,6 +1,6 @@
 // TODO: make 'queryParams', 'router', and 'tableQueryData' dependencies stable (aka, memoized)
 import React, { useCallback, useContext, useEffect, useState } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router/lib/Router";
 import PATHS from "router/paths";
 import { isEqual } from "lodash";
@@ -130,6 +130,7 @@ const ManagePolicyPage = ({
     ? "Okta or Microsoft Entra"
     : "Okta";
 
+  const queryClient = useQueryClient();
   const { renderFlash, renderMultiFlash } = useContext(NotificationContext);
   const { setResetSelectedRows } = useContext(TableContext);
   const {
@@ -361,11 +362,10 @@ const ManagePolicyPage = ({
     isGlobalAdmin || isGlobalMaintainer || isTeamMaintainer || isTeamAdmin;
   const canManageAutomations = canAddOrDeletePolicies;
 
-  const {
-    data: globalConfig,
-    isFetching: isFetchingGlobalConfig,
-    refetch: refetchGlobalConfig,
-  } = useQuery<IConfig, Error>(
+  const { data: globalConfig, isFetching: isFetchingGlobalConfig } = useQuery<
+    IConfig,
+    Error
+  >(
     ["config"],
     () => {
       return configAPI.loadAll();
@@ -379,20 +379,27 @@ const ManagePolicyPage = ({
     }
   );
 
-  const {
-    data: teamConfig,
-    isFetching: isFetchingTeamConfig,
-    refetch: refetchTeamConfig,
-  } = useQuery<ILoadTeamResponse, Error, ITeamConfig>(
-    ["teams", teamIdForApi],
-    () => teamsAPI.load(teamIdForApi),
-    {
-      // Enable for all teams including "No team" (teamIdForApi === 0)
-      enabled:
-        isRouteOk && teamIdForApi !== undefined && canAddOrDeletePolicies,
-      select: (data) => data.team,
-    }
+  const { data: teamConfig, isFetching: isFetchingTeamConfig } = useQuery<
+    ILoadTeamResponse,
+    Error,
+    ITeamConfig
+  >(["teams", teamIdForApi], () => teamsAPI.load(teamIdForApi), {
+    // Enable for all teams including "No team" (teamIdForApi === 0)
+    enabled: isRouteOk && teamIdForApi !== undefined && canAddOrDeletePolicies,
+    select: (data) => data.team,
+    staleTime: 5000,
+  });
+
+  // Derived from query data, but can be manually updated after PATCH to avoid
+  // stale reads from MySQL replicas (setQueryData alone doesn't trigger
+  // re-renders through react-query v3's select transform)
+  const queryAutomationsConfig = isAllTeamsSelected ? globalConfig : teamConfig;
+  const [automationsConfig, setAutomationsConfig] = useState(
+    queryAutomationsConfig
   );
+  useEffect(() => {
+    setAutomationsConfig(queryAutomationsConfig);
+  }, [queryAutomationsConfig]);
 
   const refetchPolicies = (teamId?: number) => {
     if (teamId !== undefined) {
@@ -518,10 +525,20 @@ const ManagePolicyPage = ({
     setIsUpdatingPolicies(true);
     try {
       if (isAllTeamsSelected) {
-        await configAPI.update(requestBody);
+        const updatedConfig = await configAPI.update(requestBody);
+        // Update cache and local state directly with the PATCH response to
+        // avoid stale reads from MySQL replicas
+        queryClient.setQueryData(["config"], updatedConfig);
+        setConfig(updatedConfig);
+        setAutomationsConfig(updatedConfig);
       } else {
         // For any team including "No team" (team ID 0), use the teams API
-        await teamsAPI.update(requestBody, teamIdForApi);
+        const updatedTeamResponse = await teamsAPI.update(
+          requestBody,
+          teamIdForApi
+        );
+        queryClient.setQueryData(["teams", teamIdForApi], updatedTeamResponse);
+        setAutomationsConfig(updatedTeamResponse.team);
       }
       renderFlash("success", DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG);
     } catch {
@@ -529,7 +546,6 @@ const ManagePolicyPage = ({
     } finally {
       toggleOtherWorkflowsModal();
       setIsUpdatingPolicies(false);
-      isAllTeamsSelected ? refetchGlobalConfig() : refetchTeamConfig();
     }
   };
 
@@ -681,34 +697,33 @@ const ManagePolicyPage = ({
 
     try {
       // update team config if either field has been changed
-      const responses: Promise<any>[] = [];
+      let teamConfigPromise: Promise<ILoadTeamResponse> | undefined;
+      const policyPromises = [];
       if (
         formData.enabled !==
           teamConfig?.integrations.google_calendar?.enable_calendar_events ||
         formData.url !== teamConfig?.integrations.google_calendar?.webhook_url
       ) {
-        responses.push(
-          teamsAPI.update(
-            {
-              integrations: {
-                google_calendar: {
-                  enable_calendar_events: formData.enabled,
-                  webhook_url: formData.url,
-                },
-                // These fields will never actually be changed here. See comment above
-                // IGlobalIntegrations definition.
-                zendesk: teamConfig?.integrations.zendesk || [],
-                jira: teamConfig?.integrations.jira || [],
+        teamConfigPromise = teamsAPI.update(
+          {
+            integrations: {
+              google_calendar: {
+                enable_calendar_events: formData.enabled,
+                webhook_url: formData.url,
               },
+              // These fields will never actually be changed here. See comment above
+              // IGlobalIntegrations definition.
+              zendesk: teamConfig?.integrations.zendesk || [],
+              jira: teamConfig?.integrations.jira || [],
             },
-            teamIdForApi
-          )
+          },
+          teamIdForApi
         );
       }
 
       // update changed policies calendar events enabled
-      responses.concat(
-        formData.changedPolicies.map((changedPolicy) => {
+      policyPromises.push(
+        ...formData.changedPolicies.map((changedPolicy) => {
           return teamPoliciesAPI.update(changedPolicy.id, {
             calendar_events_enabled: changedPolicy.calendar_events_enabled,
             team_id: teamIdForApi,
@@ -716,10 +731,18 @@ const ManagePolicyPage = ({
         })
       );
 
-      await Promise.all(responses);
+      await Promise.all([teamConfigPromise, ...policyPromises].filter(Boolean));
+
+      // Update cache and local state directly with the PATCH response to
+      // avoid stale reads from MySQL replicas
+      if (teamConfigPromise) {
+        const updatedTeamResponse = await teamConfigPromise; // already resolved
+        queryClient.setQueryData(["teams", teamIdForApi], updatedTeamResponse);
+        setAutomationsConfig(updatedTeamResponse.team);
+      }
+
       await wait(100); // Wait 100ms to avoid race conditions with refetch
       await refetchTeamPolicies();
-      await refetchTeamConfig();
 
       renderFlash("success", DEFAULT_AUTOMATION_UPDATE_SUCCESS_MSG);
     } catch {
@@ -737,9 +760,8 @@ const ManagePolicyPage = ({
     setIsUpdatingPolicies(true);
 
     try {
-      // TODO - narrow type for update policy responses
-      const responses: (Promise<ITeamConfig> | Promise<any>)[] = [];
-      let refetchConfig: any;
+      let globalConfigPromise: Promise<IConfig> | undefined;
+      let teamConfigPromise: Promise<ILoadTeamResponse> | undefined;
 
       // If enabling/disabling the feature, update appropriate config
       if (teamIdForApi === API_NO_TEAM_ID) {
@@ -752,8 +774,7 @@ const ManagePolicyPage = ({
               conditional_access_enabled: enableConditionalAccess,
             },
           };
-          responses.push(configAPI.update(payload));
-          refetchConfig = refetchGlobalConfig;
+          globalConfigPromise = configAPI.update(payload);
         }
       } else if (
         enableConditionalAccess !==
@@ -769,26 +790,37 @@ const ManagePolicyPage = ({
             conditional_access_enabled: enableConditionalAccess,
           },
         };
-        responses.push(teamsAPI.update(payload, teamIdForApi));
-        refetchConfig = refetchTeamConfig;
+        teamConfigPromise = teamsAPI.update(payload, teamIdForApi);
       }
 
       // handle any changed policies for no team or a team
-      responses.concat(
-        changedPolicies.map((changedPolicy) => {
-          return teamPoliciesAPI.update(changedPolicy.id, {
-            conditional_access_enabled:
-              changedPolicy.conditional_access_enabled,
-            conditional_access_bypass_enabled:
-              changedPolicy.conditional_access_bypass_enabled,
-            team_id: teamIdForApi,
-          });
-        })
+      const policyPromises = changedPolicies.map((changedPolicy) => {
+        return teamPoliciesAPI.update(changedPolicy.id, {
+          conditional_access_enabled: changedPolicy.conditional_access_enabled,
+          conditional_access_bypass_enabled:
+            changedPolicy.conditional_access_bypass_enabled,
+          team_id: teamIdForApi,
+        });
+      });
+
+      await Promise.all(
+        [globalConfigPromise, teamConfigPromise, ...policyPromises].filter(
+          Boolean
+        )
       );
-      await Promise.all(responses);
-      await wait(100); // helps avoid refetch race conditions
-      if (refetchConfig) {
-        await refetchConfig();
+
+      // Update cache and local state directly with the PATCH response to
+      // avoid stale reads from MySQL replicas
+      if (globalConfigPromise) {
+        const updatedConfig = await globalConfigPromise; // already resolved
+        queryClient.setQueryData(["config"], updatedConfig);
+        setConfig(updatedConfig);
+        setAutomationsConfig(updatedConfig);
+      }
+      if (teamConfigPromise) {
+        const updatedTeamResponse = await teamConfigPromise; // already resolved
+        queryClient.setQueryData(["teams", teamIdForApi], updatedTeamResponse);
+        setAutomationsConfig(updatedTeamResponse.team);
       }
       renderFlash(
         "success",
@@ -911,19 +943,6 @@ const ManagePolicyPage = ({
 
   // Show CTA buttons if there are no errors
   const showCtaButtons = !policiesErrors;
-
-  /**
-  all teams? -> globalConfig
-  any team (including "No team")? -> teamConfig
-   */
-
-  let automationsConfig;
-  if (isAllTeamsSelected) {
-    automationsConfig = globalConfig;
-  } else {
-    // For any team including "No team" (team ID 0), use the team config
-    automationsConfig = teamConfig;
-  }
 
   const hasPoliciesToAutomate = isAllTeamsSelected
     ? (globalPoliciesCount ?? 0) > 0

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -734,11 +734,13 @@ const ManagePolicyPage = ({
         })
       );
 
-      await Promise.all([teamConfigPromise, ...policyPromises].filter(Boolean));
+      const [teamConfigResult] = await Promise.all([
+        teamConfigPromise,
+        ...policyPromises,
+      ]);
 
-      if (teamConfigPromise) {
-        const updatedTeamResponse = await teamConfigPromise;
-        updateTeamConfig(updatedTeamResponse);
+      if (teamConfigResult) {
+        updateTeamConfig(teamConfigResult);
       }
 
       await wait(100); // Wait 100ms to avoid race conditions with refetch
@@ -803,19 +805,17 @@ const ManagePolicyPage = ({
         });
       });
 
-      await Promise.all(
-        [globalConfigPromise, teamConfigPromise, ...policyPromises].filter(
-          Boolean
-        )
-      );
+      const [globalConfigResult, teamConfigResult] = await Promise.all([
+        globalConfigPromise,
+        teamConfigPromise,
+        ...policyPromises,
+      ]);
 
-      if (globalConfigPromise) {
-        const updatedConfig = await globalConfigPromise;
-        updateGlobalConfig(updatedConfig);
+      if (globalConfigResult) {
+        updateGlobalConfig(globalConfigResult);
       }
-      if (teamConfigPromise) {
-        const updatedTeamResponse = await teamConfigPromise;
-        updateTeamConfig(updatedTeamResponse);
+      if (teamConfigResult) {
+        updateTeamConfig(teamConfigResult);
       }
       renderFlash(
         "success",

--- a/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/ManagePoliciesPage.tsx
@@ -390,9 +390,6 @@ const ManagePolicyPage = ({
     staleTime: 5000,
   });
 
-  // Derived from query data, but can be manually updated after PATCH to avoid
-  // stale reads from MySQL replicas (setQueryData alone doesn't trigger
-  // re-renders through react-query v3's select transform)
   const queryAutomationsConfig = isAllTeamsSelected ? globalConfig : teamConfig;
   const [automationsConfig, setAutomationsConfig] = useState(
     queryAutomationsConfig

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -115,11 +115,12 @@ interface IAppWrapperProps {
   location?: any;
 }
 
+const queryClient = new QueryClient();
+
 // App.tsx needs the context for user and config. We also wrap the application
-// component in the required query client priovider for react-query. This
+// component in the required query client provider for react-query. This
 // will allow us to use react-query hooks in the application component.
 const AppWrapper = ({ children, location }: IAppWrapperProps) => {
-  const queryClient = new QueryClient();
   return (
     <AppProvider>
       <RoutingProvider>

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -115,7 +115,7 @@ export default {
       host_expiry_settings,
     }: Partial<IUpdateTeamFormData>,
     teamId?: number
-  ): Promise<ITeamConfig> => {
+  ): Promise<ILoadTeamResponse> => {
     if (typeof teamId === "undefined") {
       return Promise.reject("Invalid usage: missing team id");
     }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38948 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually

Ran Fleet with **make db-replica-run**, previously set up the writer and reader DBs with **make db-replica-setup**.

#### Before


https://github.com/user-attachments/assets/13b1fb80-5a68-4780-825b-c6afb978f0e6



#### After


https://github.com/user-attachments/assets/1f70d016-a0b8-49e6-8690-4a9f077d5c99


