### PR TITLE
Docs for upcoming technician role w/ "coming soon" message

### DIFF
--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -13,7 +13,7 @@ Users with the admin role receive all permissions.
 Maintainers can manage most entities in Fleet, like queries, policies, and labels.
 Unlike admins, maintainers cannot edit higher level settings like application configuration, teams or users.
 
-### Technician ([Coming soon](https://github.com/fleetdm/fleet/issues/35696))
+### Technician ([coming soon](https://github.com/fleetdm/fleet/issues/35696))
 
 `Applies only to Fleet Premium`
 

--- a/articles/role-based-access.md
+++ b/articles/role-based-access.md
@@ -13,6 +13,12 @@ Users with the admin role receive all permissions.
 Maintainers can manage most entities in Fleet, like queries, policies, and labels.
 Unlike admins, maintainers cannot edit higher level settings like application configuration, teams or users.
 
+### Technician ([Coming soon](https://github.com/fleetdm/fleet/issues/35696))
+
+`Applies only to Fleet Premium`
+
+Technicians have the ability to run scripts, view their results, and install/uninstall software.
+
 ### Observer
 
 The observer role is a read-only role. It can access most entities in Fleet, like queries, policies, labels, application configuration, teams, etc.
@@ -33,84 +39,88 @@ GitOps is an API-only and write-only role that can be used on CI/CD pipelines.
 
 ## User permissions
 
-| **Action**                                                                                                                                 | Observer | Observer+* | Maintainer | Admin | GitOps* |
-| ------------------------------------------------------------------------------------------------------------------------------------------ | :------: | :--------: | :--------: | :---: | :-----: |
-| View all [activity](https://fleetdm.com/docs/using-fleet/rest-api#activities)                                                              | ✅       | ✅         | ✅         | ✅    |         |
-| Cancel [hosts' upcoming activity](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity)                                  |          |            | ✅         | ✅    |         |
-| Manage [activity automations](https://fleetdm.com/docs/using-fleet/audit-logs)                                                             |          |            |            | ✅    | ✅      |
-| View all hosts                                                                                                                             | ✅       | ✅         | ✅         | ✅    |         |
-| View a host by identifier                                                                                                                  | ✅       | ✅         | ✅         | ✅    | ✅      |
-| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅       | ✅         | ✅         | ✅    |         |
-| Target hosts using labels                                                                                                                  | ✅       | ✅         | ✅         | ✅    |         |
-| Add/remove manual labels to/from hosts                                                                                                     |          |            | ✅         | ✅    | ✅      |
-| Add and delete hosts                                                                                                                       |          |            | ✅         | ✅    |         |
-| Transfer hosts between teams\*                                                                                                             |          |            | ✅         | ✅    | ✅      |
-| Add user information from IdP to hosts\*                                                                                                   |          |            | ✅         | ✅    |         |
-| Create, edit, and delete labels                                                                                                            |          |            | ✅         | ✅    | ✅      |
-| View all software                                                                                                                          | ✅       | ✅         | ✅         | ✅    |         |
-| Add, edit, and delete software                                                                                                             |          | ✅         | ✅         | ✅    |         |
-| Download added software                                                                                                                    |          |            | ✅         | ✅    |         |
-| Install/uninstall software on hosts                                                                                                        |          |            | ✅         | ✅    |         |
-| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)               | ✅       | ✅         | ✅         | ✅    |         |
-| Filter hosts by software                                                                                                                   | ✅       | ✅         | ✅         | ✅    |         |
-| Filter software by team\*                                                                                                                  | ✅       | ✅         | ✅         | ✅    |         |
-| Manage [vulnerability automations](https://fleetdm.com/docs/using-fleet/automations#vulnerability-automations)                             |          |            |            | ✅    | ✅      |
-| Run queries designated "**observer can run**" as live queries against all hosts                                                            | ✅       | ✅         | ✅         | ✅    |         |
-| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                 |          | ✅         | ✅         | ✅    |         |
-| Create, edit, and delete queries                                                                                                           |          |            | ✅         | ✅    | ✅      |
-| View all queries and their reports                                                                                                         | ✅       | ✅         | ✅         | ✅    | ✅      |
-| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                                 |          |            | ✅         | ✅    | ✅      |
-| Create, edit, view, and delete packs                                                                                                       |          |            | ✅         | ✅    | ✅      |
-| View all policies                                                                                                                          | ✅       | ✅         | ✅         | ✅    | ✅      |
-| Run all policies                                                                                                                           |          | ✅         | ✅         | ✅    |         |
-| Filter hosts using policies                                                                                                                | ✅       | ✅         | ✅         | ✅    |         |
-| Create, edit, and delete policies for all hosts                                                                                            |          |            | ✅         | ✅    | ✅      |
-| Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |            | ✅         | ✅    | ✅      |
-| Edit global ("All teams") policy automations                                                                                               |          |            |            | ✅    | ✅      |
-| Edit team policy automations: calendar events, install software, and run script\*                                                          |          |            | ✅         | ✅    | ✅      |
-| Edit team policy automations: other workflows (tickets and webhooks)\*                                                                     |          |            |            | ✅    | ✅      |
-| Edit "No team" policy automations                                                                                                          |          |            |            | ✅    | ✅      |
-| View users\**                                                                                                                              | ✅       | ✅         | ✅         | ✅    |         |
-| Create, edit, and delete users                                                                                                             |          |            |            | ✅    |         |
-| Add and remove team users\*                                                                                                                |          |            |            | ✅    | ✅      |
-| Create, edit, and delete teams\*                                                                                                           |          |            |            | ✅    | ✅      |
-| Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts) |          |            | ✅         | ✅    | ✅      |
-| Create, edit, and delete [enroll secrets for teams](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)\*         |          |            | ✅         | ✅    |         |
-| Read organization settings\**                                                                                                              | ✅       | ✅         | ✅         | ✅    | ✅      |
-| Read Single Sign-On settings\**                                                                                                            |          |            |            | ✅    |         |
-| Read SMTP settings\**                                                                                                                      |          |            |            | ✅    |         |
-| Read osquery agent options\**                                                                                                              |          |            |            | ✅    |         |
-| Edit organization settings                                                                                                                 |          |            |            | ✅    | ✅      |
-| Edit agent options                                                                                                                         |          |            |            | ✅    | ✅      |
-| Edit agent options for hosts assigned to teams\*                                                                                           |          |            |            | ✅    | ✅      |
-| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                        |          |            | ✅         | ✅    |         |
-| Retrieve contents from file carving                                                                                                        |          |            |            | ✅    |         |
-| Create Apple Push Certificates service (APNs) certificate signing request (CSR)                                                            |          |            |            | ✅    |         |
-| View, edit, and delete APNs certificate                                                                                                    |          |            |            | ✅    |         |
-| View, edit, and delete Apple Business Manager (ABM) connections                                                                            |          |            |            | ✅    |         |
-| View, edit, and delete Volume Purchasing Program (VPP) connections                                                                         |          |            |            | ✅    |         |
-| Connect Android Enterprise                                                                                                                 |          |            |            | ✅    |         |
-| View disk encryption key for macOS, Windows, and Linux hosts                                                                               | ✅       | ✅         | ✅         | ✅    |         |
-| Edit OS updates for macOS, Windows, iOS, and iPadOS hosts                                                                                  |          |            |            | ✅    | ✅      |
-| Create, edit, resend and delete configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                            |          |            | ✅         | ✅    | ✅      |
-| Execute MDM commands on macOS and Windows hosts\**                                                                                         |          |            | ✅         | ✅    | ✅      |
-| View results of MDM commands executed on macOS and Windows hosts\**                                                                        | ✅       | ✅         | ✅         | ✅    |         |
-| View and edit [OS settings](https://fleetdm.com/docs/rest-api/rest-api#os-settings)                                                        |          |            | ✅         | ✅    | ✅      |
-| Edit [setup experience](https://fleetdm.com/guides/setup-experience)\*                                                                     |          |            | ✅         | ✅    | ✅      |
-| Add and edit identity provider for end user authentication, end user license agreement (EULA), and end user migration workflow\*           |          |            |            | ✅    |         |
-| Add and edit certificate authorities (CA)\*                                                                                                |          |            |            | ✅    | ✅      |
-| Request certificates (CA)\*                                                                                                                |          |            |            | ✅    | ✅      |
-| Schedule and run scripts on hosts                                                                                                          |          |            | ✅         | ✅    |         |
-| View saved scripts\*                                                                                                                       | ✅       | ✅         | ✅         | ✅    |         |
-| Edit/upload saved scripts\*                                                                                                                |          |            | ✅         | ✅    | ✅      |
-| Lock, unlock, and wipe hosts\*                                                                                                             |          |            | ✅         | ✅    |         |
-| Turn off MDM for specific hosts                                                                                                            |          |            | ✅         | ✅    |         |
-| Configure Microsoft Entra conditional access integration                                                                                   |          |            |            | ✅    |         |
-| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                                  | ✅       | ✅         | ✅         | ✅    |         |
-| Create, edit, and delete custom variables                                                                                                  | ✅       | ✅         | ✅         | ✅    |         |
+| **Action**                                                                                                                                 | Observer | Observer+* | Technician* | Maintainer | Admin | GitOps* |
+| ------------------------------------------------------------------------------------------------------------------------------------------ | :------: | :--------: | :--------: | :--------: | :---: | :-----: |
+| View all [activity](https://fleetdm.com/docs/using-fleet/rest-api#activities)                                                              | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Cancel [hosts' upcoming activity](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity)                                  |          |            |            | ✅         | ✅    |         |
+| Manage [activity automations](https://fleetdm.com/docs/using-fleet/audit-logs)                                                             |          |            |            |            | ✅    | ✅      |
+| View all hosts                                                                                                                             | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| View a host by identifier                                                                                                                  | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                          | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Target hosts using labels                                                                                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Add/remove manual labels to/from hosts                                                                                                     |          |            | ✅         | ✅         | ✅    | ✅      |
+| Add and delete hosts                                                                                                                       |          |            |            | ✅         | ✅    |         |
+| Transfer hosts between teams\*                                                                                                             |          |            |            | ✅         | ✅    | ✅      |
+| Add user information from IdP to hosts\*                                                                                                   |          |            |            | ✅         | ✅    |         |
+| Create, edit, and delete labels                                                                                                            |          |            | ✅         | ✅         | ✅    | ✅      |
+| View all software                                                                                                                          | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Add, edit, and delete software                                                                                                             |          |            |            | ✅         | ✅    | ✅      |
+| Download added software                                                                                                                    |          |            | ✅         | ✅         | ✅    |         |
+| Install/uninstall software on hosts                                                                                                        |          |            | ✅         | ✅         | ✅    |         |
+| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)               | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Filter hosts by software                                                                                                                   | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Filter software by team\*                                                                                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Manage [vulnerability automations](https://fleetdm.com/docs/using-fleet/automations#vulnerability-automations)                             |          |            |            |            | ✅    | ✅      |
+| Run queries designated "**observer can run**" as live queries against all hosts                                                            | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query) against all hosts                                 |          | ✅         | ✅         | ✅         | ✅    |         |
+| Create, edit, and delete queries                                                                                                           |          |            |            | ✅         | ✅    | ✅      |
+| View all queries and their reports                                                                                                         | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                                 |          |            |            | ✅         | ✅    | ✅      |
+| Create, edit, view, and delete packs                                                                                                       |          |            |            | ✅         | ✅    | ✅      |
+| View all policies                                                                                                                          | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Run all policies                                                                                                                           |          | ✅         | ✅         | ✅         | ✅    |         |
+| Filter hosts using policies                                                                                                                | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Create, edit, and delete policies for all hosts                                                                                            |          |            |            | ✅         | ✅    | ✅      |
+| Create, edit, and delete policies for all hosts assigned to team\*                                                                         |          |            |            | ✅         | ✅    | ✅      |
+| Edit global ("All teams") policy automations                                                                                               |          |            |            |            | ✅    | ✅      |
+| Edit team policy automations: calendar events, install software, and run script\*                                                          |          |            |            | ✅         | ✅    | ✅      |
+| Edit team policy automations: other workflows (tickets and webhooks)\*                                                                     |          |            |            |            | ✅    | ✅      |
+| Edit "No team" policy automations                                                                                                          |          |            |            |            | ✅    | ✅      |
+| View users\**                                                                                                                              | ✅       | ✅        | ✅         |  ✅        | ✅    |         |
+| Create, edit, view, and delete users                                                                                                       |          |            |            |            | ✅    |         |
+| Add and remove team users\*                                                                                                                |          |            |            |            | ✅    | ✅      |
+| Create, edit, and delete teams\*                                                                                                           |          |            |            |            | ✅    | ✅      |
+| Create, edit, and delete [enroll secrets](https://fleetdm.com/docs/deploying/faq#when-do-i-need-to-deploy-a-new-enroll-secret-to-my-hosts) |          |            |            | ✅         | ✅    | ✅      |
+| Create, edit, and delete [enroll secrets for teams](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)\*         |          |            |            | ✅         | ✅    |         |
+| Read organization settings\**                                                                                                              | ✅       | ✅         | ✅         | ✅         | ✅    | ✅      |
+| Read Single Sign-On settings\**                                                                                                            |          |            |            |            | ✅    |         |
+| Read SMTP settings\**                                                                                                                      |          |            |            |            | ✅    |         |
+| Read osquery agent options\**                                                                                                              |          |            |            |            | ✅    |         |
+| Edit organization settings                                                                                                                 |          |            |            |            | ✅    | ✅      |
+| Edit agent options                                                                                                                         |          |            |            |            | ✅    | ✅      |
+| Edit agent options for hosts assigned to teams\*                                                                                           |          |            |            |            | ✅    | ✅      |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                                        |          |            |            | ✅         | ✅    |         |
+| Retrieve contents from file carving                                                                                                        |          |            |            |            | ✅    |         |
+| Create Apple Push Certificates service (APNs) certificate signing request (CSR)                                                            |          |            |            |            | ✅    |         |
+| View, edit, and delete APNs certificate                                                                                                    |          |            |            |            | ✅    |         |
+| View, edit, and delete Apple Business Manager (ABM) connections                                                                            |          |            |            |            | ✅    |         |
+| View, edit, and delete Volume Purchasing Program (VPP) connections                                                                         |          |            |            |            | ✅    |         |
+| Connect Android Enterprise                                                                                                                 |          |            |            |            | ✅    |         |
+| View disk encryption key for macOS, Windows, and Linux hosts                                                                               | ✅       | ✅         | ✅         | ✅        | ✅    |         |
+| Edit OS updates for macOS, Windows, iOS, and iPadOS hosts                                                                                  |          |            |            |            | ✅    | ✅      |
+| Create, edit, resend and delete configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                            |          |            |            | ✅         | ✅    | ✅      |
+| View and resend configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                                            |          |            | ✅         | ✅         | ✅    | ✅      |
+| Execute MDM commands on macOS and Windows hosts\**                                                                                         |          |            |            | ✅         | ✅    | ✅      |
+| View results of MDM commands executed on macOS and Windows hosts\**                                                                        | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Edit [OS settings](https://fleetdm.com/docs/rest-api/rest-api#os-settings)                                                                 |          |            |            | ✅         | ✅    | ✅      |
+| View all [OS settings](https://fleetdm.com/docs/rest-api/rest-api#os-settings)                                                             |          |            | ✅         | ✅         | ✅    | ✅      |
+| Edit [setup experience](https://fleetdm.com/guides/setup-experience)\*                                                                     |          |            |            | ✅         | ✅    | ✅      |
+| Add and edit identity provider for end user authentication, end user license agreement (EULA), and end user migration workflow\*           |          |            |            |            | ✅    |         |
+| Add and edit certificate authorities (CA)\*                                                                                                |          |            |            |            | ✅    | ✅      |
+| Request certificates (CA)\*                                                                                                                |          |            |            |            | ✅    | ✅      |
+| Run scripts on hosts                                                                                                                       |          |            | ✅         | ✅         | ✅    |         |
+| Schedule scripts on hosts                                                                                                                  |          |            |            | ✅         | ✅    |         |
+| View saved scripts\*                                                                                                                       | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Edit/upload saved scripts\*                                                                                                                |          |            |            | ✅         | ✅    | ✅      |
+| Lock, unlock, and wipe hosts\*                                                                                                             |          |            |            | ✅         | ✅    |         |
+| Turn off MDM for specific hosts                                                                                                            |          |            |            | ✅         | ✅    |         |
+| Configure Microsoft Entra conditional access integration                                                                                   |          |            |            |            | ✅    |         |
+| Add Microsoft Entra tenant                                                                                                                 |          |            |            |            | ✅    |         |
+| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
+| Create, edit, and delete custom variables                                                                                                  | ✅       | ✅         | ✅         | ✅         | ✅    |         |
 
 
-\* Applies only to Fleet Premium
+\* Applies only to Fleet Premium. Technician role ([coming soon](https://github.com/fleetdm/fleet/issues/35696)).
 
 \** Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 
@@ -131,59 +141,61 @@ Users can be assigned to multiple teams in Fleet.
 
 Users with access to multiple teams can be assigned different roles for each team. For example, a user can be given access to the "Workstations" team and assigned the "Observer" role. This same user can be given access to the "Servers" team and assigned the "Maintainer" role.
 
-| **Action**                                                                                                                       | Team observer | Team observer+ | Team maintainer | Team admin | Team GitOps |
-| -------------------------------------------------------------------------------------------------------------------------------- | :-----------: | :------------: | :-------------: | :--------: | :---------: |
-| View hosts                                                                                                                       | ✅            | ✅             | ✅              | ✅         |             |
-| View a host by identifier                                                                                                        | ✅            | ✅             | ✅              | ✅         | ✅          |
-| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅            | ✅             | ✅              | ✅         |             |
-| Target hosts using labels                                                                                                        | ✅            | ✅             | ✅              | ✅         |             |
-| View hosts' [past](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-past-activity) and [upcoming](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity) activity   | ✅            | ✅             | ✅              | ✅         |             |
-| Cancel hosts' [upcoming](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity) activity                        |               |                | ✅              | ✅         |             |
-| Add/remove manual labels to/from hosts                                                                                           |               |                | ✅              | ✅         | ✅          |
-| Create and edit self-authored labels                                                                                             |               |                |                 |            | ✅          |
-| Add and delete hosts                                                                                                             |               |                | ✅              | ✅         |             |
-| View software                                                                                                                    | ✅            | ✅             | ✅              | ✅         |             |
-| Add, edit, and delete software                                                                                                   |               |                | ✅              | ✅         | ✅          |
-| Download added software                                                                                                          |               |                | ✅              | ✅         |             |
-| Install/uninstall software on hosts                                                                                              |               |                | ✅              | ✅         |             |
-| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)     | ✅            | ✅             | ✅              | ✅         |             |
-| Filter hosts by software                                                                                                         | ✅            | ✅             | ✅              | ✅         |             |
-| Filter software                                                                                                                  | ✅            | ✅             | ✅              | ✅         |             |
-| Run queries designated "**observer can run**" as live queries against hosts                                                      | ✅            | ✅             | ✅              | ✅         |             |
-| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                         |               | ✅             | ✅              | ✅         |             |
-| Create, edit, and delete self-authored queries                                                                                   |               |                | ✅              | ✅         | ✅          |
-| View team queries and their reports                                                                                              | ✅            | ✅             | ✅              | ✅         |             |
-| View global (inherited) queries and their reports\**                                                                             | ✅            | ✅             | ✅              | ✅         |             |
-| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                       |               |                | ✅              | ✅         | ✅          |
-| View team policies                                                                                                               | ✅            | ✅             | ✅              | ✅         |             |
-| Run team policies as a live policy                                                                                               |               | ✅             | ✅              | ✅         |             |
-| View global (inherited) policies                                                                                                 | ✅            | ✅             | ✅              | ✅         |             |
-| Run global (inherited) policies as a live policy                                                                                 |               | ✅             | ✅              | ✅         |             |
-| Filter hosts using policies                                                                                                      | ✅            | ✅             | ✅              | ✅         |             |
-| Create, edit, and delete team policies                                                                                           |               |                | ✅              | ✅         | ✅          |
-| Edit team policy automations: calendar events, install software, and run script                                                  |               |                | ✅              | ✅         | ✅          |
-| Edit team policy automations: other workflows (tickets and webhooks)                                                             |               |                |                 | ✅         | ✅          |
-| Add and remove team users                                                                                                        |               |                |                 | ✅         | ✅          |
-| Edit team name                                                                                                                   |               |                |                 | ✅         | ✅          |
-| Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)      |               |                | ✅              | ✅         |             |
-| Read organization settings\*                                                                                                     | ✅            | ✅             | ✅              | ✅         | ✅          |
-| Read agent options\*                                                                                                             | ✅            | ✅             | ✅              | ✅         |             |
-| Edit agent options                                                                                                               |               |                |                 | ✅         | ✅          |
-| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               |                | ✅              | ✅         |             |
-| View disk encryption key for macOS hosts                                                                                         | ✅            | ✅             | ✅              | ✅         |             |
-| Edit OS updates for macOS, Windows, iOS, and iPadOS hosts                                                                        |               |                |                 | ✅         | ✅          |
-| Create, edit, resend and delete configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                  |               |                | ✅              | ✅         | ✅          |
-| Execute MDM commands on macOS and Windows hosts*                                                                                 |               |                | ✅              | ✅         |             |
-| View results of MDM commands executed on macOS and Windows hosts*                                                                | ✅            | ✅             | ✅              | ✅         |             |
-| View and edit [OS settings](https://fleetdm.com/docs/rest-api/rest-api#os-settings)                                              |               |                | ✅              | ✅         | ✅          |
-| Edit [setup experience](https://fleetdm.com/guides/setup-experience)\*                                                           |               |                | ✅              | ✅         | ✅          |
-| Schedule and run scripts on hosts                                                                                                |               |                | ✅              | ✅         |             |
-| View saved scripts                                                                                                               | ✅            | ✅             | ✅              | ✅         |             |
-| Edit/upload saved scripts                                                                                                        |               |                | ✅              | ✅         |             |
-| View script details by host                                                                                                      | ✅            | ✅             | ✅              | ✅         |             |
-| Lock, unlock, and wipe hosts                                                                                                     |               |                | ✅              | ✅         |             |
-| Turn off MDM for specific hosts                                                                                                  |               |                | ✅              | ✅         |             |
-| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                        | ✅            | ✅             | ✅              | ✅         |             |
+| **Action**                                                                                                                       | Team observer | Team observer+ | Team technician | Team maintainer | Team admin | Team GitOps |
+| -------------------------------------------------------------------------------------------------------------------------------- | :-----------: | :------------: | :-------------: | :-------------: | :--------: | :---------: |
+| View hosts                                                                                                                       | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| View a host by identifier                                                                                                        | ✅            | ✅             | ✅              | ✅              | ✅         | ✅          |
+| Filter hosts using [labels](https://fleetdm.com/docs/using-fleet/rest-api#labels)                                                | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Target hosts using labels                                                                                                        | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| View hosts' [past](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-past-activity) and [upcoming](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity) activity | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Cancel hosts' [upcoming](https://fleetdm.com/docs/rest-api/rest-api#get-hosts-upcoming-activity) activity                        |               |                |                 | ✅              | ✅         |             |
+| Add/remove manual labels to/from hosts                                                                                           |               |                | ✅              | ✅              | ✅         | ✅          |
+| Create and edit self-authored labels                                                                                             |               |                | ✅              | ✅              | ✅         | ✅          |
+| Add and delete hosts                                                                                                             |               |                |                 | ✅              | ✅         |             |
+| View software                                                                                                                    | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Add, edit, and delete software                                                                                                   |               |                |                 | ✅              | ✅         | ✅          |
+| Download added software                                                                                                          |               |                | ✅              | ✅              | ✅         |             |
+| Install/uninstall software on hosts                                                                                              |               |                | ✅              | ✅              | ✅         |             |
+| Filter software by [vulnerabilities](https://fleetdm.com/docs/using-fleet/vulnerability-processing#vulnerability-processing)     | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Filter hosts by software                                                                                                         | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Filter software                                                                                                                  | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Run queries designated "**observer can run**" as live queries against hosts                                                      | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Run any query as [live query](https://fleetdm.com/docs/using-fleet/fleet-ui#run-a-query)                                         |               | ✅             | ✅              | ✅              | ✅         |             |
+| Create, edit, and delete self-authored queries                                                                                   |               |                |                 | ✅              | ✅         | ✅          |
+| View team queries and their reports                                                                                              | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| View global (inherited) queries and their reports\**                                                                             | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Manage [query automations](https://fleetdm.com/docs/using-fleet/fleet-ui#schedule-a-query)                                       |               |                |                 | ✅              | ✅         | ✅          |
+| View team policies                                                                                                               | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Run team policies as a live policy                                                                                               |               | ✅             | ✅              | ✅              | ✅         |             |
+| View global (inherited) policies                                                                                                 | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Run global (inherited) policies as a live policy                                                                                 |               | ✅             | ✅              | ✅              | ✅         |             |
+| Filter hosts using policies                                                                                                      | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Create, edit, and delete team policies                                                                                           |               |                |                 | ✅              | ✅         | ✅          |
+| Edit team policy automations: calendar events, install software, and run script                                                  |               |                |                 | ✅              | ✅         | ✅          |
+| Edit team policy automations: other workflows (tickets and webhooks)                                                             |               |                |                 |                 | ✅         | ✅          |
+| Add and remove team users                                                                                                        |               |                |                 |                 | ✅         | ✅          |
+| Edit team name                                                                                                                   |               |                |                 |                 | ✅         | ✅          |
+| Create, edit, and delete [team enroll secrets](https://fleetdm.com/docs/using-fleet/rest-api#get-enroll-secrets-for-a-team)      |               |                |                 | ✅              | ✅         |             |
+| Read organization settings\*                                                                                                     | ✅            | ✅             | ✅              | ✅              | ✅         | ✅          |
+| Read agent options\*                                                                                                             | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Edit agent options                                                                                                               |               |                |                 |                 | ✅         | ✅          |
+| Initiate [file carving](https://fleetdm.com/docs/using-fleet/rest-api#file-carving)                                              |               |                |                 | ✅              | ✅         |             |
+| View disk encryption key for macOS hosts                                                                                         | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Edit OS updates for macOS, Windows, iOS, and iPadOS hosts                                                                        |               |                |                 |                 | ✅         | ✅          |
+| Create, edit, resend and delete configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                  |               |                |                 | ✅              | ✅         | ✅          |
+| View and resend configuration profiles for Apple (macOS/iOS/iPadOS), Windows, and Android hosts                                  |               |                | ✅              | ✅              | ✅         | ✅          |
+| Execute MDM commands on macOS and Windows hosts*                                                                                 |               |                |                 | ✅              | ✅         |             |
+| View results of MDM commands executed on macOS and Windows hosts*                                                                | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Edit [team OS settings](https://fleetdm.com/docs/rest-api/rest-api#os-settings)                                                  |               |                |                 | ✅              | ✅         | ✅          |
+| Edit [setup experience](https://fleetdm.com/guides/setup-experience)\*                                                           |               |                |                 | ✅              | ✅         | ✅          |
+| Run scripts on hosts                                                                                                             |               |                | ✅              | ✅              | ✅         |             |
+| Schedule scripts on hosts                                                                                                        |               |                |                 | ✅              | ✅         |             |
+| View saved scripts                                                                                                               | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Edit/upload saved scripts                                                                                                        |               |                |                 | ✅              | ✅         |             |
+| View script details by host                                                                                                      | ✅            | ✅             | ✅              | ✅              | ✅         |             |
+| Lock, unlock, and wipe hosts                                                                                                     |               |                |                 | ✅              | ✅         |             |
+| Turn off MDM for specific hosts                                                                                                  |               |                |                 | ✅              | ✅         |             |
+| View [custom variables](https://fleetdm.com/docs/rest-api/rest-api#list-custom-variables)                                        | ✅            | ✅             | ✅             | ✅              | ✅         |             |
 
 \* Applies only to [Fleet REST API](https://fleetdm.com/docs/using-fleet/rest-api)
 


### PR DESCRIPTION
If we're comfortable with advertising the new role on the website a bit early, I think adding the updated permissions table to `main` as soon as possible will help avoid some nasty merge conflicts in upcoming release branches.

Changes:
+ Copied over updated roles table from @melpike's [PR](https://github.com/fleetdm/fleet/pull/37861)
+ Added "coming soon" note w/ link to the user story