### PR TITLE
Add incident.io app to personal mobile devices config

### DIFF
--- a/it-and-security/teams/personal-mobile-devices.yml
+++ b/it-and-security/teams/personal-mobile-devices.yml
@@ -29,6 +29,13 @@ queries:
 software:
   app_store_apps:
     # iOS apps
+    - app_store_id: "6471268530" # incident.io
+      display_name: "incident.io"
+      self_service: true
+      setup_experience: false
+      platform: ios
+      categories:
+        - "Communication"
     - app_store_id: "618783545" # Slack
       display_name: "Slack"
       self_service: true


### PR DESCRIPTION
@allenhouchins Since we're [using incident.io for incident response](https://fleetdm.com/handbook/engineering#incident-response-process), it seems like adding the iOS app as a self-service install for personally owned devices is a good opportunity to Dogfood VPP installs.

We'll need to add licenses in ABM before merging this in, which I don't have permission to do.

App Store URL: https://apps.apple.com/us/app/incident-io/id6471268530