### PR TITLE
Add a reference to Apple's MDM Migration in the mdm migration guide

### DIFF
--- a/articles/mdm-migration.md
+++ b/articles/mdm-migration.md
@@ -4,6 +4,8 @@ This guide provides instructions for migrating devices from your current MDM sol
 
 > For seamless MDM migration, [view this guide](https://fleetdm.com/guides/seamless-mdm-migration).
 
+> For Apple's native MDM migration support for ABM-registered devices running macOS, iOS or iPadOS 26, [consult Apple's documentation](https://support.apple.com/guide/deployment/migrate-managed-devices-dep4acb2aa44/web)
+
 ## Requirements
 
 - A [deployed Fleet instance](https://fleetdm.com/docs/deploy/deploy-fleet)


### PR DESCRIPTION
While reviewing documentation as part of oncall responsibilities I noted that there was no reference to Apple MDM migration in the migration guide. I don't think we need to document it directly since Apple's documentation is quite good here but it feels like it warrants a callout