### PR TITLE
POC: ACME for MDM (protocol) certificates

### DIFF
--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -782,6 +782,9 @@ type Service interface {
 	// [1]: https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/Introduction/Introduction.html#//apple_ref/doc/uid/TP40009505-CH1-SW1
 	MDMAppleProcessOTAEnrollment(ctx context.Context, certificates []*x509.Certificate, rootSigner *x509.Certificate, enrollSecret, idpUUID string, deviceInfo MDMAppleMachineInfo) ([]byte, error)
 
+	// MaybeAllowMDMACMEWebhook determines whether an MDM ACME webhook request should be allowed.
+	MaybeAllowMDMACMEWebhook(ctx context.Context, permanentIdentifier string) (allow bool, data any, err error)
+
 	// /////////////////////////////////////////////////////////////////////////////
 	// Vulnerabilities
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -885,7 +885,7 @@ type Service interface {
 	GetMDMAppleProfilesSummary(ctx context.Context, teamID *uint) (*MDMProfilesSummary, error)
 
 	// GetMDMAppleEnrollmentProfileByToken returns the Apple enrollment from its secret token.
-	GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error)
+	GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string, idents *HostMDMIdentifiers) (profile []byte, err error)
 
 	// GetMDMAppleEnrollmentProfileByToken returns the Apple account-driven user enrollment profile for a given enrollment reference.
 	GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enrollReference string) (profile []byte, err error)
@@ -1068,6 +1068,10 @@ type Service interface {
 
 	// CheckMDMAppleEnrollmentWithMinimumOSVersion checks if the minimum OS version is met for a MDM enrollment
 	CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *MDMAppleMachineInfo) (*MDMAppleSoftwareUpdateRequired, error)
+
+	// GetHostMDMIdentifiersFromMachineInfo looks up MDM identifiers from the serial number in given
+	// machine info. It performs additional checks to verify the host is eligible for MDM enrollment and returns an error if not.
+	GetHostMDMIdentifiersFromMachineInfo(ctx context.Context, m *MDMAppleMachineInfo) (*HostMDMIdentifiers, error)
 
 	// GetOTAProfile gets the OTA (over-the-air) profile for a given team based on the enroll secret provided.
 	GetOTAProfile(ctx context.Context, enrollSecret, idpUUID string) ([]byte, error)

--- a/server/mdm/acme/apple_mdm.go
+++ b/server/mdm/acme/apple_mdm.go
@@ -1,0 +1,153 @@
+package acme
+
+import (
+	"bytes"
+	"fmt"
+	"html/template"
+	"net/url"
+	"os"
+
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
+)
+
+const (
+	// DirectoryPath is the path for the ACME directory service.
+	DirectoryPath = "acme/acme/directory" // TODO: this will need to be updated to use the Fleet server URL when we have the ACME endpoints routed in the server.
+)
+
+func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, deviceSerial, topic string) ([]byte, error) {
+	discoveryURL, err := ResolveAppleACMEURL()
+	if err != nil {
+		return nil, fmt.Errorf("resolve Apple SCEP url: %w", err)
+	}
+	serverURL, err := apple_mdm.ResolveAppleMDMURL(fleetURL)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Apple MDM url: %w", err)
+	}
+
+	var buf bytes.Buffer
+	if err := acmeEnrollmentProfileMobileconfigTemplate.Funcs(funcMap).Execute(&buf, struct {
+		Organization     string
+		DirectoryURL     string
+		Topic            string
+		ServerURL        string
+		ClientIdentifier string
+		SerialTemplate   string
+	}{
+		Organization:     orgName,
+		DirectoryURL:     discoveryURL,
+		Topic:            topic,
+		ServerURL:        serverURL,
+		ClientIdentifier: deviceSerial,
+		SerialTemplate:   `%SerialNumber%`, // Apple replaces this placeholder with the device's serial number during enrollment
+	}); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+	return buf.Bytes(), nil
+}
+
+// TODO: this will need to be updated to use the Fleet server URL when we have the ACME endpoints routed in the server.
+func ResolveAppleACMEURL() (string, error) {
+	base := os.Getenv("FLEET_DEV_STEP_CA_SERVER")
+	if base == "" {
+		return "", fmt.Errorf("FLEET_DEV_STEP_CA_SERVER environment variable is not set")
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("parse FLEET_DEV_STEP_CA_SERVER: %w", err)
+	}
+	u.Path = DirectoryPath
+	return u.String(), nil
+}
+
+var funcMap = map[string]any{
+	"xml": mobileconfig.XMLEscapeString,
+}
+
+// acmeEnrollmentProfileMobileconfigTemplate is the template Fleet uses to assemble a .mobileconfig enrollment profile to serve to devices.
+//
+// During a profile replacement, the system updates payloads with the same PayloadIdentifier and
+// PayloadUUID in the old and new profiles.
+var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>Attest</key>
+			<true/>
+			<key>ClientIdentifier</key>
+			<string>{{ .ClientIdentifier | xml }}</string>
+			<key>DirectoryURL</key>
+			<string>{{ .DirectoryURL | xml }}</string>
+			<key>HardwareBound</key>
+			<true/>
+			<key>KeySize</key>
+			<integer>384</integer>
+			<key>KeyType</key>
+			<string>ECSECPrimeRandom</string>
+			<key>PayloadDisplayName</key>
+			<string>Fleet Identity ACME</string>
+			<key>PayloadIdentifier</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.acme</string>
+			<key>PayloadUUID</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Subject</key>
+			<array>
+				<array>
+					<array>
+						<string>CN</string>
+						<string>{{ .SerialTemplate | xml }}</string>
+					</array>
+				</array>
+			</array>
+		</dict>
+		<dict>
+			<key>AccessRights</key>
+			<integer>8191</integer>
+			<key>CheckOutWhenRemoved</key>
+			<true/>
+			<key>IdentityCertificateUUID</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.fleet.mdm.apple.mdm</string>
+			<key>PayloadType</key>
+			<string>com.apple.mdm</string>
+			<key>PayloadUUID</key>
+			<string>29713130-1602-4D27-90C9-B822A295E44E</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ServerCapabilities</key>
+			<array>
+				<string>com.apple.mdm.per-user-connections</string>
+				<string>com.apple.mdm.bootstraptoken</string>
+			</array>
+			<key>ServerURL</key>
+			<string>{{ .ServerURL | xml }}</string>
+			<key>SignMessage</key>
+			<true/>
+			<key>Topic</key>
+			<string>{{ .Topic | xml }}</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>{{ .Organization | xml }} enrollment</string>
+	<key>PayloadIdentifier</key>
+	<string>` + apple_mdm.FleetPayloadIdentifier + `</string>
+	<key>PayloadOrganization</key>
+	<string>{{ .Organization | xml }}</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5ACABE91-CE30-4C05-93E3-B235C152404E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`))

--- a/server/mdm/acme/apple_mdm.go
+++ b/server/mdm/acme/apple_mdm.go
@@ -44,7 +44,10 @@ func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, deviceSerial, topi
 	}); err != nil {
 		return nil, fmt.Errorf("execute template: %w", err)
 	}
-	return buf.Bytes(), nil
+
+	// TODO: Figure out why the generated profile escaopes the left angle bracket in the opening
+	// `<?xml` tag and remove the need for this replacement.
+	return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
 }
 
 // TODO: this will need to be updated to use the Fleet server URL when we have the ACME endpoints routed in the server.

--- a/server/mdm/acme/apple_mdm.go
+++ b/server/mdm/acme/apple_mdm.go
@@ -154,3 +154,81 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 	<integer>1</integer>
 </dict>
 </plist>`))
+
+// // TODO: Based on prelimanary testing, we can't use ACME for the first phase of OTA enrollment and
+// // need to retain SCEP for that phase, but we can use ACME for the second phase (the actual
+// // enrollment profile). When attempting to deliver this in the first phase, Apple gives this error:
+// // "ACME: Hardware bound keys not supported for 'Profiles Service' profiles."
+// // See also https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/iPhoneOTAConfiguration/OTASecurity/OTASecurity.htm
+// func GenerateOTAProfileMobileconfig(deviceSerial string) ([]byte, error) {
+// 	discoveryURL, err := ResolveAppleACMEURL()
+// 	if err != nil {
+// 		return nil, fmt.Errorf("resolve Apple SCEP url: %w", err)
+// 	}
+
+// 	var buf bytes.Buffer
+// 	if err := acmeOTAProfileTemplate.Funcs(funcMap).Execute(&buf, struct {
+// 		DirectoryURL     string
+// 		ClientIdentifier string
+// 		SerialTemplate   string
+// 	}{
+// 		DirectoryURL:     discoveryURL,
+// 		ClientIdentifier: deviceSerial,
+// 		SerialTemplate:   `%SerialNumber%`, // Apple replaces this placeholder with the device's serial number during enrollment
+// 	}); err != nil {
+// 		return nil, fmt.Errorf("execute template: %w", err)
+// 	}
+
+// 	return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
+// }
+
+// var acmeOTAProfileTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`<?xml version="1.0" encoding="UTF-8"?>
+// <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+// <plist version="1.0">
+// <dict>
+//     <key>PayloadVersion</key>
+//     <integer>1</integer>
+//     <key>PayloadType</key>
+//     <string>Configuration</string>
+//     <key>PayloadIdentifier</key>
+//     <string>Ignored</string>
+//     <key>PayloadUUID</key>
+//     <string>Ignored</string>
+//     <key>PayloadContent</key>
+// 	<array>
+// 		<dict>
+// 			<key>Attest</key>
+// 			<true/>
+// 			<key>ClientIdentifier</key>
+// 			<string>{{ .ClientIdentifier | xml }}</string>
+// 			<key>DirectoryURL</key>
+// 			<string>{{ .DirectoryURL | xml }}</string>
+// 			<key>HardwareBound</key>
+// 			<true/>
+// 			<key>KeySize</key>
+// 			<integer>384</integer>
+// 			<key>KeyType</key>
+// 			<string>ECSECPrimeRandom</string>
+// 			<key>PayloadDisplayName</key>
+// 			<string>Fleet Identity ACME</string>
+// 			<key>PayloadIdentifier</key>
+// 			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+// 			<key>PayloadType</key>
+// 			<string>com.apple.security.acme</string>
+// 			<key>PayloadUUID</key>
+// 			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+// 			<key>PayloadVersion</key>
+// 			<integer>1</integer>
+// 			<key>Subject</key>
+// 			<array>
+// 				<array>
+// 					<array>
+// 						<string>CN</string>
+// 						<string>{{ .SerialTemplate | xml }}</string>
+// 					</array>
+// 				</array>
+// 			</array>
+// 		</dict>
+// 	</array>
+// </dict>
+// </plist>`))

--- a/server/mdm/acme/apple_mdm.go
+++ b/server/mdm/acme/apple_mdm.go
@@ -165,7 +165,6 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 // 	if err != nil {
 // 		return nil, fmt.Errorf("resolve Apple SCEP url: %w", err)
 // 	}
-
 // 	var buf bytes.Buffer
 // 	if err := acmeOTAProfileTemplate.Funcs(funcMap).Execute(&buf, struct {
 // 		DirectoryURL     string
@@ -178,7 +177,6 @@ var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").F
 // 	}); err != nil {
 // 		return nil, fmt.Errorf("execute template: %w", err)
 // 	}
-
 // 	return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
 // }
 

--- a/server/mdm/acme/service.go
+++ b/server/mdm/acme/service.go
@@ -172,6 +172,11 @@ func newStepCA(root *x509.Certificate, intermediate *x509.Certificate, signer cr
 	stepCfg.Root = []string{filepath.Join(tmpPath, "root0.crt")}
 	stepCfg.IntermediateCert = filepath.Join(tmpPath, "int0.crt")
 	stepCfg.IntermediateKey = filepath.Join(tmpPath, "int0.key")
+	if len(stepCfg.AuthorityConfig.Provisioners) != 1 {
+		return nil, fmt.Errorf("expected exactly one provisioner in step-ca config, got %d", len(stepCfg.AuthorityConfig.Provisioners))
+	}
+	// TODO: if we're going to stick with the approach of standalone step-ca instance, we'll want to
+	// flesh out the config more with appropriate secrets/tokens for the webhook provisioner.
 
 	return stepca.New(&stepCfg)
 }

--- a/server/mdm/acme/service.go
+++ b/server/mdm/acme/service.go
@@ -1,0 +1,205 @@
+package acme
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	kitlog "github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/assets"
+	httpmdm "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/http/mdm"
+
+	stepconfig "github.com/smallstep/certificates/authority/config"
+	stepca "github.com/smallstep/certificates/ca"
+	"go.step.sm/crypto/keyutil"
+	"go.step.sm/crypto/pemutil"
+	"go.step.sm/crypto/x509util"
+)
+
+type Service interface {
+	Stop() error
+	Verify(ctx context.Context, cert *x509.Certificate) error
+}
+
+type acmeService struct {
+	stepca       *stepca.CA
+	root         *x509.Certificate
+	intermediate *x509.Certificate
+	signer       crypto.Signer
+}
+
+// compile-time assertion that acmeService implements the Service and httpmdm.CertVerifier interfaces.
+var (
+	_ Service              = (*acmeService)(nil)
+	_ httpmdm.CertVerifier = (*acmeService)(nil)
+)
+
+func (a *acmeService) Verify(ctx context.Context, cert *x509.Certificate) error {
+	opts := x509.VerifyOptions{
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		Roots:         x509.NewCertPool(),
+		Intermediates: x509.NewCertPool(),
+	}
+	opts.Roots.AddCert(a.root)
+	opts.Intermediates.AddCert(a.intermediate)
+	if _, err := cert.Verify(opts); err != nil {
+		return ctxerr.Wrap(ctx, err, "acmer verifier")
+	}
+	return nil
+}
+
+func (a *acmeService) Stop() error {
+	if a.stepca == nil {
+		return nil
+	}
+	return a.stepca.Stop()
+}
+
+func StartNewService(ctx context.Context, ds fleet.Datastore, logger kitlog.Logger) (Service, error) {
+	root, intermediate, signer, err := setupAssets(ctx, ds)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "start acme: setup assets")
+	}
+
+	ca, err := newStepCA(root, intermediate, signer)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "start acme: new step CA")
+	}
+
+	// TODO: There's plenty more we'll want to do to make this production ready, but for this PoC
+	// we'll just spin out a go routine to run an instance of step-ca with an ACME provisioner.
+	// Most likley, we want to orchestrate this differently, but that requires some deeper thinking about
+	// our architecture and some more unpacking of the step-ca codebase. As currently implemented,
+	// step-ca listens on its own port and does it own routing. For the PoC it is creating its own MySQL
+	// database, but it could be configured to use the main Fleet DB if we want to add the step-ca
+	// schema.
+	go func() {
+		if err := ca.Run(); err != nil {
+			level.Error(logger).Log("msg", "step-ca error", "err", err)
+			ctxerr.Handle(ctx, err)
+		}
+	}()
+
+	return &acmeService{stepca: ca, root: root, intermediate: intermediate, signer: signer}, nil
+}
+
+// TODO: we'll likely need to persist the intermediate certificate and signer in order to be able to
+// verify certs issued by the ACME provisioner across restarts.
+func setupAssets(ctx context.Context, ds fleet.Datastore) (*x509.Certificate, *x509.Certificate, crypto.Signer, error) {
+	kp, err := assets.CAKeyPair(ctx, ds)
+	if err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "loading CA key pair")
+	}
+	signer, err := keyutil.GenerateDefaultSigner()
+	if err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "generating CA signer")
+	}
+
+	intCR, err := x509util.CreateCertificateRequest("Fleet ACME Intermediate CA", []string{}, signer)
+	if err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "create acme intermediate cert request")
+	}
+
+	cert, err := x509util.NewCertificate(intCR, x509util.WithTemplate(x509util.DefaultIntermediateTemplate, x509util.CreateTemplateData("Fleet ACME Intermediate CA", []string{})))
+	if err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "create new acme intermediate cert")
+	}
+
+	template := cert.GetCertificate()
+	template.NotBefore = time.Now()
+	template.NotAfter = time.Now().Add(24 * time.Hour)
+
+	intermediate, err := x509util.CreateCertificate(template, kp.Leaf, signer.Public(), kp.PrivateKey.(crypto.Signer))
+	if err != nil {
+		return nil, nil, nil, ctxerr.Wrap(ctx, err, "create acme intermediate cert")
+	}
+
+	return kp.Leaf, intermediate, signer, nil
+}
+
+func newStepCA(root *x509.Certificate, intermediate *x509.Certificate, signer crypto.Signer) (*stepca.CA, error) {
+	// read step-ca config from file path specified in FLEET_DEV_STEP_CA_CONFIG environment variable
+	stepFilepath := os.Getenv("FLEET_DEV_STEP_CA_CONFIG")
+	if stepFilepath == "" {
+		return nil, fmt.Errorf("FLEET_DEV_STEP_CA_CONFIG environment variable not set")
+	}
+	var stepCfg stepconfig.Config
+	b, err := os.ReadFile(stepFilepath)
+	if err != nil {
+		return nil, fmt.Errorf("reading step-ca config from file: %w", err)
+	}
+	if err := json.Unmarshal(b, &stepCfg); err != nil {
+		return nil, fmt.Errorf("unmarshalling step-ca config: %w", err)
+	}
+
+	// TODO: there is certainly a better way to do all this, but for now we'll write the certs and key
+	// to disk and point step-ca to those files because step-ca expects file paths for the root and
+	// intermediate certs and keys
+	tmpPath := os.TempDir()
+	writeCert := func(fn string, certs ...*x509.Certificate) error {
+		var b []byte
+		for _, crt := range certs {
+			b = append(b, pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: crt.Raw,
+			})...)
+		}
+		return os.WriteFile(filepath.Join(tmpPath, fn), b, 0o600)
+	}
+	writeKey := func(fn string, signer crypto.Signer) error {
+		_, err := pemutil.Serialize(signer, pemutil.ToFile(filepath.Join(tmpPath, fn), 0o600))
+		return err
+	}
+	if err := writeCert("root0.crt", root); err != nil {
+		return nil, err
+	}
+	if err := writeCert("int0.crt", intermediate); err != nil {
+		return nil, err
+	}
+	if err := writeKey("int0.key", signer); err != nil {
+		return nil, err
+	}
+	stepCfg.Root = []string{filepath.Join(tmpPath, "root0.crt")}
+	stepCfg.IntermediateCert = filepath.Join(tmpPath, "int0.crt")
+	stepCfg.IntermediateKey = filepath.Join(tmpPath, "int0.key")
+
+	return stepca.New(&stepCfg)
+}
+
+// // minica is a handy utility that I found from smallstep to create a simple CA for testing purposes.
+// func setupMiniCA() (*minica.CA, error) {
+// 	mca, err := minica.New()
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return mca, nil
+// }
+
+// // stepRouter is a experimental adapter to map step-ca routes (which use go-chi) to our existing
+// // patterns (which use gorilla/mux). It worked OK in testing as far as routing, but there's quite a
+// // bit of middleware and context-based dependency-iinjection in step-ca that would need to be
+// // replicated in order to refine this approach.
+// type stepRouter struct {
+// 	router *mux.Router
+// 	logger kitlog.Logger
+// }
+
+// // MethodFunc implements the smallstep api.Router interface and registers the given
+// // handler for the given method and path to an underlying gorilla/mux Router.
+// func (sr *stepRouter) MethodFunc(method, path string, fn http.HandlerFunc) {
+// 	sr.router.Path(path).Methods(method).HandlerFunc(fn)
+// }
+
+// func newStepRouter(logger kitlog.Logger) *stepRouter {
+// 	return &stepRouter{router: mux.NewRouter(), logger: logger}
+// }

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -491,6 +491,8 @@ type GetInHouseAppPackageFunc func(ctx context.Context, titleID uint, teamID *ui
 
 type MDMAppleProcessOTAEnrollmentFunc func(ctx context.Context, certificates []*x509.Certificate, rootSigner *x509.Certificate, enrollSecret string, idpUUID string, deviceInfo fleet.MDMAppleMachineInfo) ([]byte, error)
 
+type MaybeAllowMDMACMEWebhookFunc func(ctx context.Context, permanentIdentifier string) (allow bool, data any, err error)
+
 type ListVulnerabilitiesFunc func(ctx context.Context, opt fleet.VulnListOptions) ([]fleet.VulnerabilityWithMetadata, *fleet.PaginationMetadata, error)
 
 type VulnerabilityFunc func(ctx context.Context, cve string, teamID *uint, useCVSScores bool) (vuln *fleet.VulnerabilityWithMetadata, known bool, err error)
@@ -1589,6 +1591,9 @@ type Service struct {
 
 	MDMAppleProcessOTAEnrollmentFunc        MDMAppleProcessOTAEnrollmentFunc
 	MDMAppleProcessOTAEnrollmentFuncInvoked bool
+
+	MaybeAllowMDMACMEWebhookFunc        MaybeAllowMDMACMEWebhookFunc
+	MaybeAllowMDMACMEWebhookFuncInvoked bool
 
 	ListVulnerabilitiesFunc        ListVulnerabilitiesFunc
 	ListVulnerabilitiesFuncInvoked bool
@@ -3828,6 +3833,13 @@ func (s *Service) MDMAppleProcessOTAEnrollment(ctx context.Context, certificates
 	s.MDMAppleProcessOTAEnrollmentFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMAppleProcessOTAEnrollmentFunc(ctx, certificates, rootSigner, enrollSecret, idpUUID, deviceInfo)
+}
+
+func (s *Service) MaybeAllowMDMACMEWebhook(ctx context.Context, permanentIdentifier string) (allow bool, data any, err error) {
+	s.mu.Lock()
+	s.MaybeAllowMDMACMEWebhookFuncInvoked = true
+	s.mu.Unlock()
+	return s.MaybeAllowMDMACMEWebhookFunc(ctx, permanentIdentifier)
 }
 
 func (s *Service) ListVulnerabilities(ctx context.Context, opt fleet.VulnListOptions) ([]fleet.VulnerabilityWithMetadata, *fleet.PaginationMetadata, error) {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -567,7 +567,7 @@ type GetMDMAppleFileVaultSummaryFunc func(ctx context.Context, teamID *uint) (*f
 
 type GetMDMAppleProfilesSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error)
 
-type GetMDMAppleEnrollmentProfileByTokenFunc func(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error)
+type GetMDMAppleEnrollmentProfileByTokenFunc func(ctx context.Context, enrollmentToken string, enrollmentRef string, idents *fleet.HostMDMIdentifiers) (profile []byte, err error)
 
 type GetMDMAppleAccountEnrollmentProfileFunc func(ctx context.Context, enrollReference string) (profile []byte, err error)
 
@@ -672,6 +672,8 @@ type GetMDMManualEnrollmentProfileFunc func(ctx context.Context) ([]byte, error)
 type TriggerLinuxDiskEncryptionEscrowFunc func(ctx context.Context, host *fleet.Host) error
 
 type CheckMDMAppleEnrollmentWithMinimumOSVersionFunc func(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error)
+
+type GetHostMDMIdentifiersFromMachineInfoFunc func(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.HostMDMIdentifiers, error)
 
 type GetOTAProfileFunc func(ctx context.Context, enrollSecret string, idpUUID string) ([]byte, error)
 
@@ -1860,6 +1862,9 @@ type Service struct {
 
 	CheckMDMAppleEnrollmentWithMinimumOSVersionFunc        CheckMDMAppleEnrollmentWithMinimumOSVersionFunc
 	CheckMDMAppleEnrollmentWithMinimumOSVersionFuncInvoked bool
+
+	GetHostMDMIdentifiersFromMachineInfoFunc        GetHostMDMIdentifiersFromMachineInfoFunc
+	GetHostMDMIdentifiersFromMachineInfoFuncInvoked bool
 
 	GetOTAProfileFunc        GetOTAProfileFunc
 	GetOTAProfileFuncInvoked bool
@@ -4091,11 +4096,11 @@ func (s *Service) GetMDMAppleProfilesSummary(ctx context.Context, teamID *uint) 
 	return s.GetMDMAppleProfilesSummaryFunc(ctx, teamID)
 }
 
-func (s *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error) {
+func (s *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string, idents *fleet.HostMDMIdentifiers) (profile []byte, err error) {
 	s.mu.Lock()
 	s.GetMDMAppleEnrollmentProfileByTokenFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetMDMAppleEnrollmentProfileByTokenFunc(ctx, enrollmentToken, enrollmentRef)
+	return s.GetMDMAppleEnrollmentProfileByTokenFunc(ctx, enrollmentToken, enrollmentRef, idents)
 }
 
 func (s *Service) GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enrollReference string) (profile []byte, err error) {
@@ -4460,6 +4465,13 @@ func (s *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Contex
 	s.CheckMDMAppleEnrollmentWithMinimumOSVersionFuncInvoked = true
 	s.mu.Unlock()
 	return s.CheckMDMAppleEnrollmentWithMinimumOSVersionFunc(ctx, m)
+}
+
+func (s *Service) GetHostMDMIdentifiersFromMachineInfo(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.HostMDMIdentifiers, error) {
+	s.mu.Lock()
+	s.GetHostMDMIdentifiersFromMachineInfoFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostMDMIdentifiersFromMachineInfoFunc(ctx, m)
 }
 
 func (s *Service) GetOTAProfile(ctx context.Context, enrollSecret string, idpUUID string) ([]byte, error) {

--- a/server/service/acme.go
+++ b/server/service/acme.go
@@ -1,0 +1,129 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+
+	stepwh "github.com/smallstep/certificates/webhook"
+)
+
+type mdmACMEWebhookRequest struct {
+	PermanentIdentifier string `json:"permanent_identifier"`
+}
+
+func (mdmACMEWebhookRequest) DecodeRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	// TODO: there's lots more that we should do here in terms of authenticating the incoming
+	// request assuming that decide to stick with the standalone step-ca provisioner rather than
+	// building an ACME provision into Fleet iteself
+	// See https://github.com/smallstep/webhooks/blob/main/pkg/server/server.go#L34
+
+	defer r.Body.Close()
+	body, err := io.ReadAll(io.LimitReader(r.Body, limit10KiB))
+	if err != nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "unable to read request body",
+			InternalErr: err,
+		}
+	}
+
+	var decoded stepwh.RequestBody
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "unable to decode webhook request body",
+			InternalErr: err,
+		}
+	}
+
+	return &mdmACMEWebhookRequest{PermanentIdentifier: decoded.AttestationData.PermanentIdentifier}, nil
+}
+
+type mdmACMEWebhookResponse struct {
+	Allow bool `json:"allow"`
+	Data  any  `json:"data,omitempty"`
+
+	Err error `json:"-"`
+}
+
+func (r mdmACMEWebhookResponse) Error() error { return r.Err }
+
+func mdmACMEWebhookEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
+	req := request.(*mdmACMEWebhookRequest)
+	allow, data, err := svc.MaybeAllowMDMACMEWebhook(ctx, req.PermanentIdentifier)
+	if err != nil {
+		return mdmACMEWebhookResponse{Err: err}, nil
+	}
+
+	return mdmACMEWebhookResponse{Allow: allow, Data: data}, nil
+}
+
+func (svc *Service) MaybeAllowMDMACMEWebhook(ctx context.Context, permanentIdentifier string) (bool, any, error) {
+	// level.Info(svc.logger).Log("msg", "received MDM ACME webhook request", "permanent_identifier", permanentIdentifier)
+
+	svc.authz.SkipAuthorization(ctx) // TODO: update this when we have a better idea of how we want to do auth for the ACME endpoints
+
+	if permanentIdentifier == "" {
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "missing permanent identifier in attestation data"),
+		}
+	}
+
+	idents, err := svc.ds.GetHostMDMIdentifiers(ctx, permanentIdentifier, fleet.TeamFilter{User: &fleet.User{
+		Name:       fleet.ActivityAutomationAuthor,
+		GlobalRole: ptr.String(fleet.RoleAdmin),
+	}})
+	switch {
+	case err != nil:
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.Wrap(ctx, err, "getting host MDM identifiers from the database"),
+		}
+	case len(idents) != 1:
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, fmt.Sprintf("expected to find exactly 1 host with the given serial number, but found %d", len(idents))),
+		}
+	case idents[0] == nil:
+		// this should never happen, but sanity check just in case
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number has nil MDM identifiers"),
+		}
+	case idents[0].HardwareSerial != permanentIdentifier:
+		// this should never happen since we're querying by the serial number, but we check just to
+		// be safe and to avoid any potential shenanigans like matching on a different identifier
+		// and then having a mismatch on the serial number
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different serial number than the one provided in the machine info"),
+		}
+	// case idents[0].UUID != "" && idents[0].UUID != machineInfo.UDID:
+	// 	// Similar to the hardware serial check above, this is a sanity check to ensure that if we
+	// 	// have stored a UDID for the host (i.e., not a pending DEP host), it matches the UDID provided in the machine info
+	// 	return nil, &fleet.BadRequestError{
+	// 		Message:     "machine info is required",
+	// 		InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different UDID than the one provided in the machine info"),
+	// 	}
+	case idents[0].Platform != "darwin":
+		// TODO: expand this to work for iOS/iPadOS as well
+		return false, nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number is not a darwin device"),
+		}
+	}
+
+	// TODO: there's lots more we could do here to authorize the incoming request [1] beyond
+	// just checking the serial number in the permanent identifier; additionally we might want to
+	// enrich the response [2] with data that can be used for the certificate template by the ACME provisioner
+	// [1] https://github.com/smallstep/webhooks/blob/main/pkg/server/server.go#L126
+	// [2] https://smallstep.com/docs/step-ca/webhooks/#webhook-server-response
+
+	return true, nil, nil
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1858,10 +1858,15 @@ func (svc *Service) GetHostMDMIdentifiersFromMachineInfo(ctx context.Context, ma
 		}
 	}
 
-	idents, err := svc.ds.GetHostMDMIdentifiers(ctx, machineInfo.Serial, fleet.TeamFilter{User: &fleet.User{
-		Name:       fleet.ActivityAutomationAuthor,
-		GlobalRole: ptr.String(fleet.RoleAdmin),
-	}})
+	// TODO: make this datastore call plus switch into a service method that can be mocked and tested more easily; we want to be able to test various scenarios around the returned idents and how we handle them in the enrollment flow
+	idents, err := svc.ds.GetHostMDMIdentifiers(ctx, machineInfo.Serial, fleet.TeamFilter{
+		// TODO: do we have specific team filter for system users (e.g., cron, MDM enroll handlers, ACME
+		// webhook, etc.)
+		User: &fleet.User{
+			Name:       fleet.ActivityAutomationAuthor,
+			GlobalRole: ptr.String(fleet.RoleAdmin),
+		},
+	})
 	switch {
 	case err != nil:
 		return nil, &fleet.BadRequestError{

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -338,8 +338,7 @@ func TestAppleMDMAuthorization(t *testing.T) {
 	ctx = test.UserContext(ctx, test.UserNoRoles)
 	_, err := svc.GetMDMAppleInstallerByToken(ctx, "foo")
 	require.NoError(t, err)
-	_, err = svc.GetMDMAppleEnrollmentProfileByToken(ctx, "foo", "")
-	require.NoError(t, err)
+	_, err = svc.GetMDMAppleEnrollmentProfileByToken(ctx, "foo", "", &fleet.HostMDMIdentifiers{HardwareSerial: "FIXME"}) // TODO: update test to use realistic inputs after PoC
 	_, err = svc.GetMDMAppleInstallerDetailsByToken(ctx, "foo")
 	require.NoError(t, err)
 	_, err = svc.MDMGetEULABytes(ctx, "foo")

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -963,6 +963,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne.WithAltPaths("/api/v1/osquery/enroll").
 		POST("/api/osquery/enroll", enrollAgentEndpoint, contract.EnrollOsqueryAgentRequest{})
 
+	ne.POST("/api/_version_/fleet/mdm/acme/webhook", mdmACMEWebhookEndpoint, mdmACMEWebhookRequest{})
+
 	// These endpoint are token authenticated.
 	// NOTE: remember to update
 	// `service.mdmConfigurationRequiredEndpoints` when you add an

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -37,6 +37,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
@@ -494,6 +495,9 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		redisPool = redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
 	}
 
+	acmeService, err := acme.StartNewService(context.Background(), ds, logger)
+	require.NoError(t, err)
+
 	if len(opts) > 0 {
 		mdmStorage := opts[0].MDMStorage
 		scepStorage := opts[0].SCEPStorage
@@ -515,6 +519,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 					logger: logger,
 				},
 				commander,
+				acmeService,
 				"https://test-url.com",
 				cfg,
 			)


### PR DESCRIPTION
Resolves #31454

## Key takeaway

While there's no obvious turn-key library like we had with micromdm/scep, there are several paths we can take:
- Integration with a standalone CA that supports webhook-based authorization in ACME provisioning
  - This would look more like a conventional integration similar to our SCEP proxy integrations
  - Pros:
    - Relatively simple for Fleet to support integration with third-partyCA vendor like SmallStep
    - Offloads complexity of CA management and security to third-party CA
    - Some customers may prefer to choose their own CA
  - Cons: 
    - Higher onboarding/setup barriers for customers (more legwork/cost for them to procure necessary CA) 
    - Ongoing burdens for Fleet to support an increasing array of CA-specific integrations depending
      on each customer
    - Lower visibility/influence for Fleet on critical MDM enrollment steps may impede Fleet
      feature development in the future
- Hybrid approach with CA instantiated/orchestrated by Fleet using shared infrastructure
  - PoC follows this approach with Fleet instantiating step-ca backed by MySQL 
  - Pros:
    - Higher visibility for Fleet on critical MDM enrollment steps although Fleet may still be
      limited in future development by underlying architecture of step-ca
    - Uses Fleet's existing infra stack (e.g., MySQL)
    - Relies on open source project and benefits from PKI expertise of step-ca contributors
    - Relatively seamless from the customer perspective
  - Cons:
    - Increased complexity for Fleet managing configuration and security, for example locking down features
      of step-ca that aren't relevant to Fleet's particular ACME needs
    - Scaling issues become more challenging to address the more Fleet depends on the [architecture
      of step-ca](https://smallstep.com/docs/step-ca/provisioners/#-read-before-digging)
- *Recommended approach*: Fleet-tailored ACME provisioner
  - This approach requires us to build the missing pieces needed for an ACME package that can be
    plugged into Fleet directly, which may be a combination of selected pieces from step-ca with Fleet
    providing the rest.
  - Pros:
    - Fleet can address scaling issues directly, buildinng around architectural limitations of
      step-ca when necessary 
    - Highest visibility for Fleet on critical MDM enrollment steps and open path to feature development in the future
    - Uses Fleet's existing infra stack
    - Relies on open source project and benefits from PKI expertise of step-ca contributors wherever practicable
    - Virtually seamless from the customer perspective
  - Cons:
    - Complexity for Fleet encompassing the full scope of our implementation
    - Burden of maintaining our implementation grows the more it diverges from step-ca

## Key questions and areas for follow up
- What do we think we need to actually productionize and secure ACME certs for enrollment? 
  - Hybrid approach (launching step-ca from inside `fleet serve`) enabled fast PoC implementation that
    allowed us to dig into the details of how ACME works and how it fits within our existing enrollment and
    renewal flows, but we learned there are downsides to this approach that make it less viable as a
    production-worthy solution.  
  - Our requirements are not as extensive for our expected use cases (e.g., not going to support ACME
    challenge types such as DNS, TLS, HTTP) and we'd want to pare down much of functionality
    exposed by step-ca in our implementation.
  - Based on what we learned in the PoC, we think the better approach for our needs to build a Fleet-tailored
    solution that exposes ACME protocol endpoints directly in Fleet using selected pieces drawn
    from step-ca and other open source projects; however, using well-maintained third-party packages where we can
    should also be prioritized.
  - Next steps for Fleet-tailored solution:
    - We need to extract/reimplement a significant chunk of functionality for route handlers and
      associated middleware from step-ca.
    - We need to write our own MySQL implementation in order to address limitations and scaling
      concerns that stem from the fact that step-ca was primarially architected with a NoSQL paradigm
    - We need to rework aspects of ACME provisioner authorization from step-ca to become service layer methods
      inside of Fleet instead of external webhook connections.
    - To the extent practicable, we should try to import packages that define ACME protocol and other
      core CA functionality from step-ca (or other well-maintained open source repos)
    - User-facing errors (surfaced by the Apple mdmclient) from step-ca responses (i.e. ACME protocol
      rejections) are generally opaque messages along the lines of "internal error' and need refinement in our
      production solution that will require investigation/experimentation to find what works best with
      the Apple mdmclient.
    - Horizontal scaling isn't well supported in the open source version of step-ca so we need to watch for inherent
      concurrency limitations that we'll need to address (e.g., how are well are ACME nonces supported across
      instances)

- How should we curate the list of serials numbers that Fleet trusts for ACME enrollment? 
  - PoC assumes that any serial number of an Apple device in the `hosts` table is trusted. Is that
    approach too broad or too narrow? How would we want to refine that approach?
  - Some possibilities:
    - Only trust serial numbers that came from DEP sync?
    - Trust serials that came from fleetd with additional caveats based on other info associated
      with that serial in Fleet (e.g., require IdP association or other posture check based on Fleet data)
    - Allow admins to upload supplemental list of serials (i.e. alternate path to pre-clear
      employee-owned OTA enrollments)
    - Integrate with external sources for device inventory?

- How should we do SCEP going forward?
  - Required for OTA (possibly account-driven user enrollment too)
  - Probably required to support various MDM-first flows (anywhere fleetd is installed after MDM
    enrollment) unless we have alternate path for admins to upload non-DEP serial numbers to Fleet
  - Probably required to support customers using the `GET /enrollment_profiles/manual` [endpoint](https://fleetdm.com/docs/rest-api/rest-api#get-manual-enrollment-profile)
  - Dynamic challenges strongly recommended going forward and would be low effort to implement

- How do we want to handle account-driven user enrollment where Apple doesn't make serial numbers
  available?

- How/when do we want to supplement initial device attestation (at enrollment) with ongoing device attestation (via periodic DeviceInformation MDM commands)?

- What are our medium-term plans to expand support into managed device attestation workflows and other identity-aware use cases?

### Subtasks

- [x] Initial ACME support in Fleet [#38794](https://github.com/fleetdm/fleet/issues/38794)
- [x] Validate device attestations [#38795](https://github.com/fleetdm/fleet/issues/38795)
- [x] Test and document behavior against various scenarios [#38796](https://github.com/fleetdm/fleet/issues/38796)

#### Initial ACME support and validation of device attestation

##### PoC capabilities
- DEP device enrolls via ACME with device attestation cross-checked against serial number
  ingested from DEP sync (as stored in the `hosts` table)
- OTA device enrolls via ACME with device attestation cross-checked against serial number
  ingested pre-existing fleetd enrollment (as stored in the `hosts` table)
- Existing devices renew enrollment profile via ACME (including devices originally enrolled via
  SCEP) with device attestation cross-checked against serial number (as stored in the `hosts` table)
- Attempted enrollment/re-enrollment is rejected if device fails ACME device attestation challenge, for example:
  - Device tries to use enrollment profile that doesn't match its serial number
  - Device tries to use enrollment profile with unknown serial number (i.e. not already stored in
    the `hosts` table)
  - Device doesn't support device attestation (see [Apple docs](https://developer.apple.com/documentation/devicemanagement/acmecertificate#ACME-attestation-hardware-support) for matrix of supported devices)

##### PoC limitations
- Validation of device identity/posture during enrollment only covers device serial number
- Serial number is the primary identifier available for use in device attestation during ACME enrollment
- Device UUID presents various challenges for use in device attestation during ACME enrollment
  - For macOS devices, the attested Provisioning UUID isn't the same as UDID ([more
    info](https://jedda.me/managed-device-attestation-a-technical-exploration/#:~:text=makes%20natural%20sense.-,Device%20UDIDs,-Another%20difference%20in))
- Apple enrollment flows that omit/anonymize identifiers like serial number and UDID and won't work
  for device attestation during ACME enrollment 
- OTA enrollment supports ACME for second phase but requires SCEP for first phase

##### Miscellaneous implementation details
- step-ca launches in go routine from the main `fleet serve` command (stopping the Fleet server also
  stops the step-ca server)
- Endpoints are served by step-ca listening on a port separate from main Fleet server
- Persistent storage is managed by step-ca in a separate MySQL database alongside main Fleet database
- Intermediate CA is required for step-ca (currently autocreated during Fleet server launch using
  Fleet `ca_cert` from `mdm_config_assets`)
- FLEET_DEV_STEP_CA_CONFIG environment variable sets the path to the step-ca [json config](https://github.com/smallstep/certificates/blob/34edaa245436ac45819359a511705a3cd5d924bc/authority/config/config.go#L159)
- FLEET_DEV_STEP_CA_SERVER environment variable sets the base url for the step-ca server (i.e. the
  url of a second ngrok proxy listening on the port specified for the step-ca server)
- Intermediate CA in the current PoC isn't persisted to DB across server starts (we'd need to address
  this assuming if decide to follow the hybrid approach).

#### Test and document behavior

* Enrolling an existing SCEP client, then renewing with ACME

Renewal of MDM enrollment is successful so long as Fleet has a record in the `hosts` table that
matches the device-attested serial number. ACME cert is installed and used to verify subsquent
requests to MDM protocol endpoints. 

Open questions: Do other Fleet features depend on SCEP cert for identity? If so, what needs to be
done to keep those working?

* Enrolling a "personal" device

OTA enrollment is successful so long as Fleet has a record in the `hosts` table that
matches the device-attested serial number, for example, if the OTA enrollment happens after fleetd
enrollment.

Account-driven user enrollment does not work with ACME device attestation because Apple doesn't
provide the serial number.

See "Key questions" above.

* Re-using the enrollment profile. Does it fail?

An enrollment profile can be reused by the same device because the serial number in the profile
matches the attested device serial.

It will fail if a device with a differnt serial number tries to use it because that other device can't satisfy the device
attestation challenge.

Open questions: If there is a product requirement to prevent the same device from reusing an enrollment profile, it
may be possible to control for this using some combination of cert templates/policies/workflows (not specific to ACME);
however, the simplest approach would be advising admins to delete the host from Fleet (and unassign from Fleet in ABM, if
applicable).

* What about a VM? What do its attestations look like if any? Can it generate hardware-bound keys

TODO

* Test enrolling an iPhone, iPad, mac running Apple Silicon on 14, 15 and Tahoe, intel Mac(if
  possible - I have one we can test) running Tahoe

TODO

* Test all above enrollment scenarios with a profile-based enrollment plus an ADE enrollment. Do we see unexpected differences?

TODO

* Can fleet stop supporting SCEP? 

tl;dr - No, we still need to support SCEP for certain flows like the first phase of OTA enrollment. See "Key questions" above.

* How secure is ACME for personal(user-based) enrollments? What about VM enrollments? What about T2
  Intel Mac enrollments(which ignore attestation)? What are we going to be relying on? Just the
  client identifier as far as I can tell which can be seen as reasonably secure(as secure as a SCEP
  secret probably) but it isn't perfect 

tl;dr - ACME device attestation by itself can't establish trust beyond the fact that the request originated from bona
fide hardware with the serial number attested by Apple. Whether the hardware is controlled by a
particular individual or organization is a distinct question that generally requires a deeper level
of integration between the ACME provisioner and other trusted sources.

* How much of the things we store during the ACME exchange do we need to keep around longer term?
  I'm specifically thinking about things like accounts. It seems like any device that can access an
  ACME server can create an account. The actual order process will be gated behind the client
  identifier most likely but what stops an external attacker from creating an obnoxious number of
  accounts? If we do the ACME equivalent of a SCEP renewal, does it need to use the same account or
  can it use a new one?

Behavior observed during the PoC indicqates that the Apple mdmclient requests a new account during renewal so
there are most likely some artifacts of the ACME order that are safe to clean up in the longer term.

Rate-limiting and other strategies to mitigate external attacks is something we should definitely
include in the production requirements. Smallstep also suggests path obfuscation and additional
measures for [public endpoints](https://smallstep.com/docs/step-ca/certificate-authority-server-production/#exposing-step-ca-to-the-internet).

* Can we "spoof" attestations in any reasonable way for testing purposes?

This [test pattern from Smallstep](https://github.com/smallstep/certificates/blob/34edaa245436ac45819359a511705a3cd5d924bc/acme/challenge_test.go#L3438-L3439) is a good starting point for our testing purposes.

* Add code to the POC branch actually validate the device attestation, meaning: update the ACME
  payload to require an attestation and verify the attestation. It can be as simple as logging that
  the attestation is properly signed and basic properties like serial, UUID and os version. 

In the PoC, attestation data is relayed to the Fleet server by step-ca in the [webhook payload](https://github.com/fleetdm/fleet/blob/8a10714e2a4b02fc868e523ca9a49567e677fb3d/server/service/acme.go#L36-L37).

It's also possible to extract info from ngrok logs for the ACME endpoints in the PoC. 

And here's the underlying [Smallstep validation of ACME device attestation for Apple](https://github.com/smallstep/certificates/blob/34edaa245436ac45819359a511705a3cd5d924bc/acme/challenge.go#L850-L851).

