### PR TITLE
Fix software group dropdown w/ fleet_id

### DIFF
--- a/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
+++ b/frontend/components/forms/fields/SelectTargetsDropdown/SelectTargetsMenu/SelectTargetsMenu.jsx
@@ -107,7 +107,7 @@ const SelectTargetsMenuWrapper = (
     const renderTargetGroups = (
       <>
         {renderTargets("all")}
-        {isPremiumTier && renderTargets("teams")}
+        {isPremiumTier && renderTargets("fleets")}
         {renderTargets("labels")}
         {renderTargets("hosts")}
       </>

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -349,7 +349,7 @@ export const useTeamIdParam = ({
   location?: {
     pathname: string;
     search: string;
-    query: { fleet_id?: string };
+    query: { fleet_id?: string; team_id?: string };
     hash?: string;
     [key: string]: any; // for other location properties that may be passed in
   };
@@ -397,8 +397,11 @@ export const useTeamIdParam = ({
 
   const currentTeam = useMemo(
     () =>
-      userTeams?.find((t) => t.id === coerceAllTeamsId(query?.fleet_id || "")),
-    [query?.fleet_id, userTeams]
+      userTeams?.find(
+        (t) =>
+          t.id === coerceAllTeamsId(query?.fleet_id || query?.team_id || "")
+      ),
+    [query?.fleet_id, query?.team_id, userTeams]
   );
 
   const handleTeamChange = useCallback(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/helpers.tsx
@@ -27,7 +27,7 @@ export const getErrorMessage = (e: unknown): string | ReactElement => {
 
     // TODO: What is the check for a Android app? assuming "VPPApp" check won't suffice
     if (reason.includes("VPPApp")) {
-      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install on this team.`;
+      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install in this fleet.`;
     }
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/helpers.tsx
@@ -47,7 +47,7 @@ export const getErrorMessage = (e: unknown): string | ReactElement => {
     }
 
     if (reason.includes("VPPApp")) {
-      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install on this team.`;
+      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install in this fleet.`;
     }
   }
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/helpers.tsx
@@ -47,7 +47,7 @@ export const getErrorMessage = (e: unknown): string | ReactElement => {
     }
 
     if (reason.includes("VPPApp")) {
-      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install on this team.`;
+      return `${ADD_SOFTWARE_ERROR_PREFIX} The software is already available to install in this fleet.`;
     }
   }
 

--- a/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/EmptyVulnerabilitiesTable/EmptyVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/EmptyVulnerabilitiesTable/EmptyVulnerabilitiesTable.tsx
@@ -92,7 +92,7 @@ const EmptyVulnerabilitiesTable: React.FC<IEmptyVulnerabilitiesTableProps> = ({
     : defaultEmptyState;
 
   if (emptyStateReason === "known-vuln" && teamId !== undefined) {
-    emptyState.header += " in this team";
+    emptyState.header += " in this fleet";
   }
 
   if (


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40077 

# Details

Fixes an unreleased bug where rewriting the location with `fleet_id` in the string would not properly set the current team in the useTeamParam hook.  This is because we haven't fully switched over to `fleet_id` internally yet, so we still need to check for `team_id` until we do.

Also updated a few lingering instances of "team" in the user-facing text.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased bug

## Testing

- [ ] Added/updated automated tests
no tests to speak of
- [X] QA'd all new/changed functionality manually
On main branch, was able to reproduce the issue where selecting an option from the "All software" dropdown on the Software page caused the selected fleet to be reset. On this branch, the selected fleet was maintained after making a selection.

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
