### PR TITLE
Added Country:US to new CA certs created by Fleet.

### DIFF
--- a/changes/38699-ca-cert-country
+++ b/changes/38699-ca-cert-country
@@ -1,0 +1,1 @@
+- Added Country:US to new CA certs created by Fleet.

--- a/ee/server/service/condaccess/config.go
+++ b/ee/server/service/condaccess/config.go
@@ -37,6 +37,7 @@ func initAssets(ctx context.Context, ds fleet.Datastore) error {
 			depot.WithCommonName("Fleet conditional access CA"),
 			// Signal that the CA is local to the deployment and not necessarily managed by Fleet or another external vendor
 			depot.WithOrganization("Local certificate authority"),
+			depot.WithCountry("US"),
 		)
 		scepCert, scepKey, err := depot.NewCACertKey(caCert)
 		if err != nil {
@@ -69,6 +70,7 @@ func initAssets(ctx context.Context, ds fleet.Datastore) error {
 			depot.WithYears(10),
 			depot.WithCommonName("Fleet conditional access IdP"),
 			depot.WithOrganization("Local certificate authority"),
+			depot.WithCountry("US"),
 		)
 		idpCertX509, idpKey, err := depot.NewCACertKey(idpCert)
 		if err != nil {

--- a/ee/server/service/hostidentity/config.go
+++ b/ee/server/service/hostidentity/config.go
@@ -30,6 +30,7 @@ func initAssets(ds fleet.Datastore) error {
 			depot.WithCommonName("Fleet Host Identity CA"),
 			// Signal that the CA is local to the deployment and not necessarily managed by Fleet or another external vendor
 			depot.WithOrganization("Local Certificate Authority"),
+			depot.WithCountry("US"),
 		)
 		scepCert, scepKey, err := depot.NewCACertKey(caCert)
 		if err != nil {

--- a/server/mdm/scep/depot/fleet.go
+++ b/server/mdm/scep/depot/fleet.go
@@ -33,6 +33,7 @@ func NewSCEPCACertKey() (*x509.Certificate, *rsa.PrivateKey, error) {
 	caCert := NewCACert(
 		WithYears(10),
 		WithCommonName("Fleet"),
+		WithCountry("US"),
 	)
 	return NewCACertKey(caCert)
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38699 

The fix will only apply to new Fleet instances. To fix existing Fleet instances, we need to support rotation: https://github.com/fleetdm/fleet/issues/40080

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually
