### PR TITLE
Add GoogleAds gtag to layout.ejs

### DIFF
--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -64,6 +64,8 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-JC3DRNY1GV"></script>
     <script>
       window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-JC3DRNY1GV');
+	// Google Ads configuration (including Enhanced Conversions) 
+	  gtag('config', 'AW-10788733823', {'allow_enhanced_conversions': true});
     </script>
     <%/* LinkedIn insight tag*/%>
     <script type="text/javascript">


### PR DESCRIPTION
In order to get accurate webconversion data in Google Ads (in addition to Google Analytics), we want to add this additional google tag:


See:
https://support.google.com/google-ads/answer/16560108?visit_id=639069358231688816-411240971&rd=2

and

https://support.google.com/google-ads/answer/6331314

Separately, we will be adding specific conversion tags to our "Conversion Pages".  More to come
