### PR TITLE
Fixes bug where Debian system tray settings are not persisted after a restart

### DIFF
--- a/orbit/changes/36526-fleet-desktop-does-not-stay-hidden
+++ b/orbit/changes/36526-fleet-desktop-does-not-stay-hidden
@@ -1,0 +1,1 @@
+* Added a system tray title to Fleet Desktop to make sure that the system tray ID is static, not dynamic.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -172,6 +172,15 @@ func main() {
 
 		systray.SetTooltip("Fleet Desktop")
 
+		if runtime.GOOS == "linux" {
+			// Set a static title to ensure a consistent System Tray ID across
+			// process restarts. By default, fyne.io/systray generates a dynamic
+			// ID using the process PID if the title is not set, which prevents
+			// the OS from persisting user settings (like 'Always Hidden' or 'Pinned')
+			// between sessions on Debian.
+			systray.SetTitle("Fleet Desktop")
+		}
+
 		// Default to dark theme icon because this seems to be a better fit on Linux (Ubuntu at
 		// least). On macOS this is used as a template icon anyway.
 		systray.SetTemplateIcon(iconDark, iconDark)


### PR DESCRIPTION
**Related issue:** Resolves #36526

Set static system tray title to avoid system tray settings not persisting across process restarts on Debian.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [X] Verified that fleetd runs on macOS, Linux and Windows