### PR TITLE
Website: Update pricing page card link

### DIFF
--- a/website/views/pages/pricing.ejs
+++ b/website/views/pages/pricing.ejs
@@ -49,7 +49,7 @@
                   </div>
                 </div>
               </div>
-              <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/register">Get started</a>
+              <a purpose="card-button" class="btn btn-block btn-lg btn-primary mx-auto mb-0" href="/new-license">Get started</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/14265

Changes: 
- Updated the "Get started" link on the pricing page to go to the self-service license dispenser.