### PR TITLE
Handle upgrade code in installer software title matching

### DIFF
--- a/changes/39858-use-upgrade-code-for-title-matching
+++ b/changes/39858-use-upgrade-code-for-title-matching
@@ -1,2 +1,1 @@
 - Fixed adding Windows Fleet maintained apps failing when a software title with the same upgrade code already exists.
-- Made Fleet maintained apps update software title names if an upgrade code is present.

--- a/changes/39858-use-upgrade-code-for-title-matching
+++ b/changes/39858-use-upgrade-code-for-title-matching
@@ -1,0 +1,2 @@
+- Fixed adding Windows Fleet maintained apps failing when a software title with the same upgrade code already exists.
+- Added ability for Fleet maintained apps to update software title names if an upgrade code is present.

--- a/changes/39858-use-upgrade-code-for-title-matching
+++ b/changes/39858-use-upgrade-code-for-title-matching
@@ -1,2 +1,2 @@
 - Fixed adding Windows Fleet maintained apps failing when a software title with the same upgrade code already exists.
-- Added ability for Fleet maintained apps to update software title names if an upgrade code is present.
+- Made Fleet maintained apps update software title names if an upgrade code is present.

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -561,7 +561,7 @@ func (ds *Datastore) addSoftwareTitleToMatchingSoftware(ctx context.Context, tit
 	whereClause := "WHERE (s.name, s.source, s.extension_for) = (?, ?, '')"
 	whereArgs := []any{payload.Title, payload.Source}
 	if payload.BundleIdentifier != "" {
-		whereClause += "WHERE s.bundle_identifier = ?"
+		whereClause = "WHERE s.bundle_identifier = ?"
 		whereArgs = []any{payload.BundleIdentifier}
 	}
 	if payload.UpgradeCode != "" {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -512,7 +512,7 @@ func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, 
 
 	// upgrade_code should be set to NULL for non-Windows software, empty or non-empty string for Windows software
 	if payload.Source == "programs" {
-		// try to find by either name or upgrade code, preferring upgrade code
+		// select by either name or upgrade code, preferring upgrade code
 		if payload.UpgradeCode != "" {
 			selectStmt = `SELECT id FROM software_titles WHERE (name = ? AND source = ? AND extension_for = '' AND upgrade_code = '') OR upgrade_code = ? ORDER BY upgrade_code = ? DESC LIMIT 1`
 			selectArgs = []any{payload.Title, payload.Source, payload.UpgradeCode, payload.UpgradeCode}
@@ -551,7 +551,10 @@ func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, 
 			updateStmt = `UPDATE software_titles SET name = ?, upgrade_code = ? WHERE id = ?`
 			updateArgs = []any{payload.Title, payload.UpgradeCode, titleID}
 		}
-		ds.writer(ctx).ExecContext(ctx, updateStmt, updateArgs...)
+		_, err := ds.writer(ctx).ExecContext(ctx, updateStmt, updateArgs...)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	return titleID, nil

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -543,14 +543,10 @@ func (ds *Datastore) getOrGenerateSoftwareInstallerTitleID(ctx context.Context, 
 		return 0, err
 	}
 
-	// update the upgrade code for a title, and name if this installer is a fleet maintained app
+	// update the upgrade code for a title, since optimisticGetOrInsert uses only the select if it already exists
 	if payload.Source == "programs" && payload.UpgradeCode != "" {
 		updateStmt := `UPDATE software_titles SET upgrade_code = ? WHERE id = ?`
 		updateArgs := []any{payload.UpgradeCode, titleID}
-		if payload.FleetMaintainedAppID != nil {
-			updateStmt = `UPDATE software_titles SET name = ?, upgrade_code = ? WHERE id = ?`
-			updateArgs = []any{payload.Title, payload.UpgradeCode, titleID}
-		}
 		_, err := ds.writer(ctx).ExecContext(ctx, updateStmt, updateArgs...)
 		if err != nil {
 			return 0, err

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -2502,14 +2502,6 @@ func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
 		{Name: "Win Title 4", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("12345")},
 		{Name: "Win Title 5", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("ABCDEF")},
 		{Name: "Win Title 6", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("GHIJKL")},
-
-		// WINDOWS software
-		// installer: no upgrade code,  existing title: same name, no upgrade code
-		// installer: no upgrade code,  existing title: same name, has upgrade code
-		// installer: has upgrade code, existing title: same name, no upgrade code
-		// installer: has upgrade code, existing title: same name, different upgrade code
-		// installer: has upgrade code, existing title: same name, same upgrade code
-		// installer: has upgrade code, existing title: different name, same upgrade code
 	}
 
 	_, err := ds.UpdateHostSoftware(ctx, host1.ID, software1)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -2502,7 +2502,6 @@ func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
 		{Name: "Win Title 3", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("")},
 		{Name: "Win Title 4", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("12345")},
 		{Name: "Win Title 5", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("ABCDEF")},
-		{Name: "Win Title 6", Version: "11.0", Source: "programs", UpgradeCode: ptr.String("GHIJKL")},
 	}
 
 	_, err := ds.UpdateHostSoftware(ctx, host1.ID, software1)
@@ -2642,18 +2641,6 @@ func testGetOrGenerateSoftwareInstallerTitleID(t *testing.T, ds *Datastore) {
 			expectedName:        "Win Title 5",
 			expectedSource:      "programs",
 			expectedUpgradeCode: ptr.String("ABCDEF"),
-		},
-		{
-			name: "installer: has upgrade code and FMA, existing title: different name, same upgrade code",
-			payload: &fleet.UploadSoftwareInstallerPayload{
-				Title:                "New Name",
-				Source:               "programs",
-				UpgradeCode:          "GHIJKL",
-				FleetMaintainedAppID: ptr.Uint(1), // FMAs should overwrite name for upgrade code
-			},
-			expectedName:        "New Name",
-			expectedSource:      "programs",
-			expectedUpgradeCode: ptr.String("GHIJKL"),
 		},
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39858
~~Also implements the idea from this comment: https://github.com/fleetdm/fleet/issues/37802#issuecomment-3715729822~~

Decided to move the FMA name overriding idea to another PR.

## Changes
- `getOrGenerateSoftwareInstallerTitleID` now attempts to find existing titles by name or by upgrade code if possible. It will update the upgrade code if possible. 
- also updated `addSoftwareTitleToMatchingSoftware` to match _only_ by upgrade code if the installer has an upgrade code

These are the assumptions (and tests mostly) I made:
| installer        | existing title                    | result                                                                     |
|------------------|-----------------------------------|----------------------------------------------------------------------------|
| no upgrade code  | same name, no upgrade code         | uses existing                                                              |
| no upgrade code  | same name, has upgrade code       | uses existing, existing upgrade code stays                                 |
| has upgrade code | same name, no upgrade code        | uses existing, existing title is updated with the incoming upgrade code |
| has upgrade code | same name, different upgrade code | new title is created with same name                                        |
| has upgrade code | same name, same upgrade code      | uses existing                                                              |
| has upgrade code | different name, same upgrade code | uses existing, ~~existing title's name is updated~~                                           |
	
# Checklist for submitter
If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually
- Tested having the title `7-Zip 23.01 (x64)` with an upgrade code in the db, added 7-Zip FMA, title became the existing `7-Zip 23.01 (x64)` title with the same upgrade code.
- Trying to add it again fails with the correct error message
