### PR TITLE
Website: update android proxy error handling

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -80,7 +80,7 @@ module.exports = {
       sails.log.warn(`p1: Android management API rate limit exceeded!`);
       return new Error(`When attempting to create an enrollment token for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     }).intercept((err)=>{
-      return new Error(`When attempting to create an enrollment token for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      return new Error(`When attempting to create an enrollment token for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/create-android-signup-url.js
+++ b/website/api/controllers/android-proxy/create-android-signup-url.js
@@ -80,7 +80,7 @@ module.exports = {
       sails.log.warn(`p1: Android management API rate limit exceeded!`);
       return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
     }).intercept((err)=>{
-      return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${err}`);
+      return new Error(`When attempting to create a singup url for a new Android enterprise, an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/delete-android-device.js
+++ b/website/api/controllers/android-proxy/delete-android-device.js
@@ -24,6 +24,7 @@ module.exports = {
     missingAuthHeader: { description: 'This request was missing an authorization header.', responseType: 'unauthorized'},
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound'},
+    deviceNoLongerManaged: { description: 'The specified device is no longer managed by the Android enterprise.', responseType: 'notFound' },
   },
 
 
@@ -84,7 +85,11 @@ module.exports = {
       sails.log.warn(`p1: Android management API rate limit exceeded!`);
       return new Error(`When attempting to delete a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     }).intercept((err)=>{
-      return new Error(`When attempting to delete a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      let errorString = err.toString();
+      if (errorString.includes('Device is no longer being managed')) {
+        return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};
+      }
+      return new Error(`When attempting to delete a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/delete-one-android-enterprise.js
+++ b/website/api/controllers/android-proxy/delete-one-android-enterprise.js
@@ -88,7 +88,7 @@ module.exports = {
         sails.log.warn(`p1: Android management API rate limit exceeded! Error: ${require('util').inspect(err)}`);
         return new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${err}`);
       }).intercept((err)=>{
-        return new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+        return new Error(`When attempting to delete android enterprise from Google (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
       });
     } catch (unusedErr) {
       // If Google API deletion fails (e.g., enterprise already deleted), continue with proxy cleanup

--- a/website/api/controllers/android-proxy/get-android-device.js
+++ b/website/api/controllers/android-proxy/get-android-device.js
@@ -90,7 +90,7 @@ module.exports = {
       if (errorString.includes('Device is no longer being managed')) {
         return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};
       }
-      return new Error(`When attempting to get a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      return new Error(`When attempting to get a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/get-android-devices.js
+++ b/website/api/controllers/android-proxy/get-android-devices.js
@@ -98,7 +98,7 @@ module.exports = {
       sails.log.warn(`p1: Android management API rate limit exceeded!`);
       return new Error(`When attempting to list devices for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     }).intercept((err)=>{
-      return new Error(`When attempting to list devices for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      return new Error(`When attempting to list devices for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
   }
 };

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -25,6 +25,7 @@ module.exports = {
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound' },
     deviceNoLongerManaged: { description: 'The device is no longer managed by the Android enterprise.', responseType: 'notFound' },
+    invalidPolicyName: {description: 'The specified policy_name is invalid', responseType: 'badRequest' }
   },
 
 
@@ -91,7 +92,10 @@ module.exports = {
       if (errorString.includes('Device is no longer being managed')) {
         return {'deviceNoLongerManaged': 'The device is no longer managed by the Android enterprise.'};
       }
-      return new Error(`When attempting to update a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      if(errorString.includes('policy_name is expected to start')) {
+        return {'invalidPolicyName': 'The request could not be completed because of an invalid policy name.'};
+      }
+      return new Error(`When attempting to update a device for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -25,7 +25,7 @@ module.exports = {
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound'},
     invalidPolicy: { description: 'Invalid patch policy request', responseType: 'badRequest' },
-    policyNotFound: { description: 'Invalid patch policy request', responseType: 'notFound' },
+    policyNotFound: { description: 'The specified policy was not found on this Android enterprise', responseType: 'notFound' },
   },
 
 

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -25,6 +25,7 @@ module.exports = {
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound'},
     invalidPolicy: { description: 'Invalid patch policy request', responseType: 'badRequest' },
+    policyNotFound: { description: 'Invalid patch policy request', responseType: 'notFound' },
   },
 
 
@@ -89,8 +90,10 @@ module.exports = {
       return new Error(`When attempting to update a policy for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
     }).intercept({ status: 400 }, (err) => {
       return {'invalidPolicy': `Attempted to update a policy with an invalid value for an Android enterprise (${androidEnterpriseId}): ${err}`};
+    }).intercept({ status: 404 }, (err) => {
+      return {'policyNotFound': `Specified policy not found on this Android enterprise (${androidEnterpriseId}): ${err}`};
     }).intercept((err) => {
-      return new Error(`When attempting to update a policy for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      return new Error(`When attempting to update a policy for an Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 

--- a/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
+++ b/website/api/controllers/android-proxy/modify-enterprise-app-policy.js
@@ -36,6 +36,7 @@ module.exports = {
     missingAuthHeader: { description: 'This request was missing an authorization header.', responseType: 'unauthorized'},
     unauthorized: { description: 'Invalid authentication token.', responseType: 'unauthorized'},
     notFound: { description: 'No Android enterprise found for this Fleet server.', responseType: 'notFound'},
+    policyNotFound: { description: 'Specified policy not found', responseType: 'notFound' },
   },
 
 
@@ -105,8 +106,10 @@ module.exports = {
           return response.data;
         }
       }
+    }).intercept({ status: 404 }, (err) => {
+      return {'policyNotFound': `Specified policy not found on this Android enterprise (${androidEnterpriseId}): ${err}`};
     }).intercept((err) => {
-      return new Error(`When attempting to update applications for a policy of Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${err}`);
+      return new Error(`When attempting to update applications for a policy of Android enterprise (${androidEnterpriseId}), an error occurred. Error: ${require('util').inspect(err)}`);
     });
 
 


### PR DESCRIPTION
Related to: https://github.com/fleetdm/fleet/issues/40127

Changes:
- Updated errors logged by Android proxy endpoints to include more information about the error.
- Added a `deviceNoLongerManaged` exit to the `delete-android-device` endpoint that is used when the Google API returns a "Device is no longer being managed" error.
- Added a `policyNotFound` exit to the `modify-android-policies` and `modify-enterprise-app-policy` endpoints that is used when the Google API returns a 404 response
- Added a `invalidPolicyName` exit to the `modify-android-device` endpoint that is used when the Google API returns an error related to the policy name sent in the request body.