### PR TITLE
add useFormValidation hook and sample usage

### DIFF
--- a/changes/use-form-validation-hook
+++ b/changes/use-form-validation-hook
@@ -1,0 +1,1 @@
+* Added a `useFormValidation` hook to centralize form validation state management, reducing repeated boilerplate across form components.

--- a/frontend/hooks/useFormValidation.tests.ts
+++ b/frontend/hooks/useFormValidation.tests.ts
@@ -1,0 +1,694 @@
+import { renderHook, act } from "@testing-library/react";
+
+import {
+  runValidation,
+  useFormValidation,
+  IValidationConfig,
+} from "./useFormValidation";
+
+// --- Test fixtures ---
+
+interface ITestFormData {
+  name: string;
+  description: string;
+}
+
+const REQUIRED_CONFIG: IValidationConfig<ITestFormData> = {
+  name: {
+    validations: [
+      {
+        name: "required",
+        isValid: (fd) => fd.name.length > 0,
+        message: "Name is required",
+      },
+    ],
+  },
+  description: {
+    validations: [
+      {
+        name: "required",
+        isValid: (fd) => fd.description.length > 0,
+        message: "Description is required",
+      },
+    ],
+  },
+};
+
+// --- runValidation tests ---
+
+describe("runValidation", () => {
+  it("returns isValid true when all fields pass", () => {
+    const result = runValidation(
+      { name: "hello", description: "world" },
+      REQUIRED_CONFIG
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.fields.name).toEqual({ isValid: true });
+    expect(result.fields.description).toEqual({ isValid: true });
+  });
+
+  it("returns isValid false with correct message for failing fields", () => {
+    const result = runValidation(
+      { name: "", description: "world" },
+      REQUIRED_CONFIG
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.fields.name).toEqual({
+      isValid: false,
+      message: "Name is required",
+    });
+    expect(result.fields.description).toEqual({ isValid: true });
+  });
+
+  it("reports multiple failing fields", () => {
+    const result = runValidation(
+      { name: "", description: "" },
+      REQUIRED_CONFIG
+    );
+    expect(result.isValid).toBe(false);
+    expect(result.fields.name?.isValid).toBe(false);
+    expect(result.fields.description?.isValid).toBe(false);
+  });
+
+  it("uses first failing rule (rule precedence)", () => {
+    const config: IValidationConfig<ITestFormData> = {
+      name: {
+        validations: [
+          {
+            name: "required",
+            isValid: (fd) => fd.name.length > 0,
+            message: "Name is required",
+          },
+          {
+            name: "maxLength",
+            isValid: (fd) => fd.name.length <= 10,
+            message: "Name too long",
+          },
+        ],
+      },
+    };
+
+    // Empty triggers "required" (first rule), not "maxLength"
+    const resultEmpty = runValidation({ name: "", description: "" }, config);
+    expect(resultEmpty.fields.name?.message).toBe("Name is required");
+
+    // Long name triggers "maxLength" (second rule)
+    const resultLong = runValidation(
+      { name: "a".repeat(11), description: "" },
+      config
+    );
+    expect(resultLong.fields.name?.message).toBe("Name too long");
+  });
+
+  it("resolves dynamic messages (function-based)", () => {
+    const config: IValidationConfig<ITestFormData> = {
+      name: {
+        validations: [
+          {
+            name: "maxLength",
+            isValid: (fd) => fd.name.length <= 5,
+            message: (fd) => `Name "${fd.name}" exceeds 5 characters`,
+          },
+        ],
+      },
+    };
+
+    const result = runValidation({ name: "toolong", description: "" }, config);
+    expect(result.fields.name?.message).toBe(
+      'Name "toolong" exceeds 5 characters'
+    );
+  });
+
+  it("supports cross-field validation via currentValidation parameter", () => {
+    interface ITimeForm {
+      startTime: string;
+      endTime: string;
+    }
+
+    const config: IValidationConfig<ITimeForm> = {
+      startTime: {
+        validations: [
+          {
+            name: "required",
+            isValid: (fd) => fd.startTime.length > 0,
+            message: "Start time required",
+          },
+        ],
+      },
+      endTime: {
+        validations: [
+          {
+            name: "afterStart",
+            isValid: (fd, currentValidation) => {
+              // Skip if startTime failed
+              if (
+                currentValidation?.startTime &&
+                !currentValidation.startTime.isValid
+              ) {
+                return true;
+              }
+              return fd.endTime > fd.startTime;
+            },
+            message: "End must be after start",
+          },
+        ],
+      },
+    };
+
+    // startTime invalid → endTime validation skipped (returns true)
+    const resultSkipped = runValidation(
+      { startTime: "", endTime: "01:00" },
+      config
+    );
+    expect(resultSkipped.fields.endTime?.isValid).toBe(true);
+
+    // Both valid, endTime before startTime → fails
+    const resultFailed = runValidation(
+      { startTime: "10:00", endTime: "09:00" },
+      config
+    );
+    expect(resultFailed.fields.endTime).toEqual({
+      isValid: false,
+      message: "End must be after start",
+    });
+
+    // Both valid, endTime after startTime → passes
+    const resultPassed = runValidation(
+      { startTime: "09:00", endTime: "10:00" },
+      config
+    );
+    expect(resultPassed.isValid).toBe(true);
+  });
+
+  it("skips fields when shouldValidateField returns false", () => {
+    const result = runValidation(
+      { name: "", description: "" },
+      REQUIRED_CONFIG,
+      (field) => field !== "description"
+    );
+    expect(result.fields.name?.isValid).toBe(false);
+    expect(result.fields.description).toBeUndefined();
+    expect(result.isValid).toBe(false);
+  });
+
+  it("passes formData to shouldValidateField", () => {
+    const result = runValidation(
+      { name: "", description: "" },
+      REQUIRED_CONFIG,
+      (_field, fd) => fd.name.length > 0 // skip all when name is empty
+    );
+    expect(result.isValid).toBe(true);
+    expect(result.fields.name).toBeUndefined();
+    expect(result.fields.description).toBeUndefined();
+  });
+
+  it("handles validation rule with no message", () => {
+    const config: IValidationConfig<ITestFormData> = {
+      name: {
+        validations: [
+          {
+            name: "required",
+            isValid: (fd) => fd.name.length > 0,
+            // no message
+          },
+        ],
+      },
+    };
+
+    const result = runValidation({ name: "", description: "" }, config);
+    expect(result.fields.name).toEqual({ isValid: false, message: undefined });
+  });
+
+  it("returns isValid true for empty config", () => {
+    const result = runValidation({ name: "", description: "" }, {});
+    expect(result.isValid).toBe(true);
+  });
+});
+
+// --- useFormValidation hook tests ---
+
+describe("useFormValidation", () => {
+  const initialFormData: ITestFormData = { name: "", description: "" };
+
+  it("initializes with correct formData and no shown errors", () => {
+    const { result } = renderHook(() =>
+      useFormValidation({
+        initialFormData,
+        validationConfig: REQUIRED_CONFIG,
+      })
+    );
+
+    expect(result.current.formData).toEqual(initialFormData);
+    expect(result.current.isValid).toBe(true);
+    expect(result.current.getFieldError("name")).toBeUndefined();
+    expect(result.current.getFieldError("description")).toBeUndefined();
+  });
+
+  describe("setField", () => {
+    it("updates formData for the given field", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => result.current.setField("name", "hello"));
+
+      expect(result.current.formData.name).toBe("hello");
+      expect(result.current.formData.description).toBe("");
+    });
+
+    it("does NOT add new errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      // Set an invalid value — no error should appear
+      act(() => result.current.setField("name", ""));
+
+      expect(result.current.getFieldError("name")).toBeUndefined();
+    });
+
+    it("clears an existing error when the field becomes valid", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      // Show all errors first via validateAll
+      act(() => result.current.validateAll());
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+
+      // Fix the name field
+      act(() => result.current.setField("name", "hello"));
+
+      expect(result.current.getFieldError("name")).toBeUndefined();
+    });
+
+    it("does NOT clear error if field is still invalid", () => {
+      const config: IValidationConfig<ITestFormData> = {
+        name: {
+          validations: [
+            {
+              name: "minLength",
+              isValid: (fd) => fd.name.length >= 3,
+              message: "Name must be at least 3 characters",
+            },
+          ],
+        },
+      };
+
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: config,
+        })
+      );
+
+      // Show errors
+      act(() => result.current.validateAll());
+      expect(result.current.getFieldError("name")).toBe(
+        "Name must be at least 3 characters"
+      );
+
+      // Still invalid (only 2 chars)
+      act(() => result.current.setField("name", "ab"));
+      expect(result.current.getFieldError("name")).toBe(
+        "Name must be at least 3 characters"
+      );
+
+      // Now valid
+      act(() => result.current.setField("name", "abc"));
+      expect(result.current.getFieldError("name")).toBeUndefined();
+    });
+
+    it("only clears the changed field's error, not others", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      // Show all errors
+      act(() => result.current.validateAll());
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+      expect(result.current.getFieldError("description")).toBe(
+        "Description is required"
+      );
+
+      // Fix name only
+      act(() => result.current.setField("name", "hello"));
+
+      expect(result.current.getFieldError("name")).toBeUndefined();
+      expect(result.current.getFieldError("description")).toBe(
+        "Description is required"
+      );
+    });
+  });
+
+  describe("validateAll", () => {
+    it("shows all errors for invalid fields", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => result.current.validateAll());
+
+      expect(result.current.isValid).toBe(false);
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+      expect(result.current.getFieldError("description")).toBe(
+        "Description is required"
+      );
+    });
+
+    it("shows no errors when all fields are valid", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData: { name: "hello", description: "world" },
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => result.current.validateAll());
+
+      expect(result.current.isValid).toBe(true);
+      expect(result.current.getFieldError("name")).toBeUndefined();
+      expect(result.current.getFieldError("description")).toBeUndefined();
+    });
+  });
+
+  describe("handleSubmit", () => {
+    it("calls preventDefault on the event", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData: { name: "hello", description: "world" },
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      const callback = jest.fn();
+      const preventDefault = jest.fn();
+      const handler = result.current.handleSubmit(callback);
+
+      act(() =>
+        handler(({
+          preventDefault,
+        } as unknown) as React.FormEvent<HTMLFormElement>)
+      );
+
+      expect(preventDefault).toHaveBeenCalled();
+    });
+
+    it("calls callback with formData when valid", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData: { name: "hello", description: "world" },
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      const callback = jest.fn();
+      const handler = result.current.handleSubmit(callback);
+
+      act(() =>
+        handler(({
+          preventDefault: jest.fn(),
+        } as unknown) as React.FormEvent<HTMLFormElement>)
+      );
+
+      expect(callback).toHaveBeenCalledWith({
+        name: "hello",
+        description: "world",
+      });
+    });
+
+    it("does NOT call callback when invalid, and shows all errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      const callback = jest.fn();
+      const handler = result.current.handleSubmit(callback);
+
+      act(() =>
+        handler(({
+          preventDefault: jest.fn(),
+        } as unknown) as React.FormEvent<HTMLFormElement>)
+      );
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+      expect(result.current.getFieldError("description")).toBe(
+        "Description is required"
+      );
+    });
+
+    it("uses latest formData after setField calls", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => {
+        result.current.setField("name", "hello");
+        result.current.setField("description", "world");
+      });
+
+      const callback = jest.fn();
+      const handler = result.current.handleSubmit(callback);
+
+      act(() =>
+        handler(({
+          preventDefault: jest.fn(),
+        } as unknown) as React.FormEvent<HTMLFormElement>)
+      );
+
+      expect(callback).toHaveBeenCalledWith({
+        name: "hello",
+        description: "world",
+      });
+    });
+  });
+
+  describe("setFormData", () => {
+    it("shows all current errors after update", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData: { name: "hello", description: "world" },
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      // Replace with invalid data
+      act(() => result.current.setFormData({ name: "", description: "world" }));
+
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+      expect(result.current.formData).toEqual({
+        name: "",
+        description: "world",
+      });
+    });
+
+    it("accepts a functional updater", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData: { name: "hello", description: "world" },
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() =>
+        result.current.setFormData((prev) => ({ ...prev, name: "updated" }))
+      );
+
+      expect(result.current.formData.name).toBe("updated");
+    });
+  });
+
+  describe("clearErrors", () => {
+    it("resets all shown errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      // Show errors
+      act(() => result.current.validateAll());
+      expect(result.current.isValid).toBe(false);
+
+      // Clear them
+      act(() => result.current.clearErrors());
+
+      expect(result.current.isValid).toBe(true);
+      expect(result.current.getFieldError("name")).toBeUndefined();
+      expect(result.current.getFieldError("description")).toBeUndefined();
+    });
+  });
+
+  describe("isValid", () => {
+    it("starts true when no errors are shown", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      expect(result.current.isValid).toBe(true);
+    });
+
+    it("becomes false after showing errors for invalid form", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => result.current.validateAll());
+      expect(result.current.isValid).toBe(false);
+    });
+
+    it("becomes true again after fixing all errors", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+        })
+      );
+
+      act(() => result.current.validateAll());
+      expect(result.current.isValid).toBe(false);
+
+      act(() => result.current.setField("name", "hello"));
+      act(() => result.current.setField("description", "world"));
+
+      expect(result.current.isValid).toBe(true);
+    });
+  });
+
+  describe("validationConfig changes", () => {
+    it("clears resolved errors when config changes", () => {
+      const strictConfig: IValidationConfig<ITestFormData> = {
+        name: {
+          validations: [
+            {
+              name: "minLength",
+              isValid: (fd) => fd.name.length >= 5,
+              message: "Name must be at least 5 characters",
+            },
+          ],
+        },
+      };
+
+      const lenientConfig: IValidationConfig<ITestFormData> = {
+        name: {
+          validations: [
+            {
+              name: "minLength",
+              isValid: (fd) => fd.name.length >= 1,
+              message: "Name is required",
+            },
+          ],
+        },
+      };
+
+      const { result, rerender } = renderHook(
+        ({ config }) =>
+          useFormValidation({
+            initialFormData: { name: "abc", description: "" },
+            validationConfig: config,
+          }),
+        { initialProps: { config: strictConfig } }
+      );
+
+      // Show error under strict config
+      act(() => result.current.validateAll());
+      expect(result.current.getFieldError("name")).toBe(
+        "Name must be at least 5 characters"
+      );
+
+      // Switch to lenient config - "abc" now passes
+      rerender({ config: lenientConfig });
+
+      expect(result.current.getFieldError("name")).toBeUndefined();
+    });
+
+    it("does NOT add new errors when config changes", () => {
+      const lenientConfig: IValidationConfig<ITestFormData> = {
+        name: {
+          validations: [
+            {
+              name: "minLength",
+              isValid: (fd) => fd.name.length >= 1,
+              message: "Name is required",
+            },
+          ],
+        },
+      };
+
+      const strictConfig: IValidationConfig<ITestFormData> = {
+        name: {
+          validations: [
+            {
+              name: "minLength",
+              isValid: (fd) => fd.name.length >= 5,
+              message: "Name must be at least 5 characters",
+            },
+          ],
+        },
+      };
+
+      const { result, rerender } = renderHook(
+        ({ config }) =>
+          useFormValidation({
+            initialFormData: { name: "abc", description: "" },
+            validationConfig: config,
+          }),
+        { initialProps: { config: lenientConfig } }
+      );
+
+      // No errors shown
+      expect(result.current.getFieldError("name")).toBeUndefined();
+
+      // Switch to strict config - "abc" now fails, but error should not appear
+      rerender({ config: strictConfig });
+
+      expect(result.current.getFieldError("name")).toBeUndefined();
+    });
+  });
+
+  describe("shouldValidateField", () => {
+    it("skips fields where shouldValidateField returns false", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({
+          initialFormData,
+          validationConfig: REQUIRED_CONFIG,
+          shouldValidateField: (field) => field !== "description",
+        })
+      );
+
+      act(() => result.current.validateAll());
+
+      expect(result.current.getFieldError("name")).toBe("Name is required");
+      expect(result.current.getFieldError("description")).toBeUndefined();
+    });
+  });
+});

--- a/frontend/hooks/useFormValidation.ts
+++ b/frontend/hooks/useFormValidation.ts
@@ -1,0 +1,281 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+// --- Shared types (exported for consumption by form helpers.ts files) ---
+
+export interface IFieldValidation {
+  isValid: boolean;
+  message?: string;
+}
+
+export type IValidationMessage<TFormData> =
+  | string
+  | ((formData: TFormData) => string);
+
+export interface IValidationRule<TFormData> {
+  name: string;
+  isValid: (
+    formData: TFormData,
+    currentValidation: Record<string, IFieldValidation | undefined>
+  ) => boolean;
+  message?: IValidationMessage<TFormData>;
+}
+
+export type IValidationConfig<TFormData> = Record<
+  string,
+  { validations: IValidationRule<TFormData>[] }
+>;
+
+export interface IValidationResult {
+  isValid: boolean;
+  fields: Record<string, IFieldValidation | undefined>;
+}
+
+// --- Hook options and return types ---
+
+interface IUseFormValidationOptions<TFormData> {
+  initialFormData: TFormData;
+  validationConfig: IValidationConfig<TFormData>;
+  /** Called before validating each field. Return false to skip that field entirely. */
+  shouldValidateField?: (fieldKey: string, formData: TFormData) => boolean;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+interface IUseFormValidationReturn<TFormData extends Record<string, any>> {
+  formData: TFormData;
+  /** Escape hatch: replaces formData and shows all current errors. */
+  setFormData: (
+    dataOrUpdater: TFormData | ((prev: TFormData) => TFormData)
+  ) => void;
+  /** True when no shown errors exist. */
+  isValid: boolean;
+  /** Returns the error message for a field, or undefined if no error is shown. */
+  getFieldError: (field: string) => string | undefined;
+  /** Updates a single field. Only clears the changed field's error if now valid (does not add new errors). */
+  setField: (
+    name: keyof TFormData & string,
+    value: TFormData[keyof TFormData]
+  ) => void;
+  /** Runs full validation and shows all errors. Wire to onBlur. */
+  validateAll: () => void;
+  /** Returns a form onSubmit handler that calls preventDefault, validates, and gates the callback. */
+  handleSubmit: (
+    callback: (formData: TFormData) => void | Promise<void>
+  ) => (evt: React.FormEvent<HTMLFormElement>) => void;
+  /** Clears all shown errors. */
+  clearErrors: () => void;
+}
+
+// --- Pure validation function ---
+
+function resolveMessage<TFormData>(
+  formData: TFormData,
+  message?: IValidationMessage<TFormData>
+): string | undefined {
+  if (message === undefined) {
+    return undefined;
+  }
+  if (typeof message === "string") {
+    return message;
+  }
+  return message(formData);
+}
+
+/**
+ * Runs validation rules against formData and returns per-field results.
+ *
+ * Fields are validated in config key insertion order. Each rule's `isValid`
+ * receives the in-progress `fields` object, enabling cross-field validation
+ * (e.g., field B can check whether field A passed).
+ */
+export function runValidation<TFormData>(
+  formData: TFormData,
+  config: IValidationConfig<TFormData>,
+  shouldValidateField?: (fieldKey: string, formData: TFormData) => boolean
+): IValidationResult {
+  const fields: Record<string, IFieldValidation | undefined> = {};
+  let isValid = true;
+
+  Object.keys(config).forEach((key) => {
+    if (shouldValidateField && !shouldValidateField(key, formData)) {
+      return; // skip this field
+    }
+
+    const fieldConfig = config[key];
+    const failedRule = fieldConfig.validations.find(
+      (rule) => !rule.isValid(formData, fields)
+    );
+
+    if (failedRule) {
+      isValid = false;
+      fields[key] = {
+        isValid: false,
+        message: resolveMessage(formData, failedRule.message),
+      };
+    } else {
+      fields[key] = { isValid: true };
+    }
+  });
+
+  return { isValid, fields };
+}
+
+// --- Hook ---
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useFormValidation<TFormData extends Record<string, any>>({
+  initialFormData,
+  validationConfig,
+  shouldValidateField,
+}: IUseFormValidationOptions<TFormData>): IUseFormValidationReturn<TFormData> {
+  const [formData, setFormDataState] = useState<TFormData>(initialFormData);
+  const [shownErrors, setShownErrors] = useState<
+    Record<string, IFieldValidation | undefined>
+  >({});
+
+  // Refs prevent stale closures in stable callbacks
+  const formDataRef = useRef(formData);
+  formDataRef.current = formData;
+
+  const validationConfigRef = useRef(validationConfig);
+  const shouldValidateFieldRef = useRef(shouldValidateField);
+  shouldValidateFieldRef.current = shouldValidateField;
+
+  // Re-validate when validationConfig changes: clear errors that resolved, keep others
+  useEffect(() => {
+    validationConfigRef.current = validationConfig;
+
+    const result = runValidation(
+      formDataRef.current,
+      validationConfig,
+      shouldValidateFieldRef.current
+    );
+
+    setShownErrors((prev) => {
+      let changed = false;
+      const next: Record<string, IFieldValidation | undefined> = {};
+
+      Object.keys(prev).forEach((key) => {
+        if (prev[key] && !prev[key]?.isValid && result.fields[key]?.isValid) {
+          // Error resolved under new config — clear it
+          changed = true;
+        } else {
+          next[key] = prev[key];
+        }
+      });
+
+      return changed ? next : prev;
+    });
+  }, [validationConfig]);
+
+  // Derive isValid from shownErrors (not full validation).
+  // Initially true (no shown errors). After blur/submit, reflects actual state.
+  const isValid = Object.keys(shownErrors).every(
+    (key) => !shownErrors[key] || shownErrors[key]?.isValid
+  );
+
+  const showAllErrors = useCallback(
+    (data: TFormData): IValidationResult => {
+      const result = runValidation(
+        data,
+        validationConfigRef.current,
+        shouldValidateFieldRef.current
+      );
+
+      setShownErrors(result.fields);
+
+      return result;
+    },
+    [] // stable: reads from refs
+  );
+
+  const setField = useCallback(
+    (name: keyof TFormData & string, value: TFormData[keyof TFormData]) => {
+      const newFormData = { ...formDataRef.current, [name]: value };
+      formDataRef.current = newFormData;
+      setFormDataState(newFormData);
+
+      const result = runValidation(
+        newFormData,
+        validationConfigRef.current,
+        shouldValidateFieldRef.current
+      );
+
+      setShownErrors((prev) => {
+        // Only clear the error for `name` if it was previously shown and is now valid
+        if (
+          prev[name] &&
+          !prev[name]?.isValid &&
+          result.fields[name]?.isValid
+        ) {
+          const next = { ...prev };
+          delete next[name];
+          return next;
+        }
+        return prev;
+      });
+    },
+    []
+  );
+
+  const setFormData = useCallback(
+    (dataOrUpdater: TFormData | ((prev: TFormData) => TFormData)) => {
+      const newData =
+        typeof dataOrUpdater === "function"
+          ? (dataOrUpdater as (prev: TFormData) => TFormData)(
+              formDataRef.current
+            )
+          : dataOrUpdater;
+
+      formDataRef.current = newData;
+      setFormDataState(newData);
+      showAllErrors(newData);
+    },
+    [showAllErrors]
+  );
+
+  const validateAll = useCallback(() => {
+    showAllErrors(formDataRef.current);
+  }, [showAllErrors]);
+
+  const handleSubmit = useCallback(
+    (callback: (data: TFormData) => void | Promise<void>) => {
+      return (evt: React.FormEvent<HTMLFormElement>) => {
+        evt.preventDefault();
+
+        const currentData = formDataRef.current;
+        const result = showAllErrors(currentData);
+
+        if (result.isValid) {
+          callback(currentData);
+        }
+      };
+    },
+    [showAllErrors]
+  );
+
+  const getFieldError = useCallback(
+    (fieldName: string): string | undefined => {
+      const field = shownErrors[fieldName];
+      if (field && !field.isValid) {
+        return field.message;
+      }
+      return undefined;
+    },
+    [shownErrors]
+  );
+
+  const clearErrors = useCallback(() => {
+    setShownErrors({});
+  }, []);
+
+  return {
+    formData,
+    setFormData,
+    isValid,
+    getFieldError,
+    setField,
+    validateAll,
+    handleSubmit,
+    clearErrors,
+  };
+}

--- a/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/helpers.ts
+++ b/frontend/pages/ManageControlsPage/Secrets/components/AddSecretModal/helpers.ts
@@ -1,47 +1,19 @@
-import { IAddSecretModalScheduleFormData } from "./AddSecretModal";
+import { IValidationConfig } from "hooks/useFormValidation";
+import { IAddSecretFormData } from "./AddSecretModal";
 
-// TODO: create a validator abstraction for this and the other form validation files
-
-export interface IAddSecretModalFormValidation {
-  isValid: boolean;
-  name?: { isValid: boolean; message?: string };
-  value?: { isValid: boolean; message?: string };
-}
-
-type IMessageFunc = (formData: IAddSecretModalScheduleFormData) => string;
-type IValidationMessage = string | IMessageFunc;
-type IFormValidationKey = keyof Omit<
-  IAddSecretModalScheduleFormData,
-  "isValid"
->;
-
-interface IValidation {
-  name: string;
-  isValid: (
-    formData: IAddSecretModalScheduleFormData,
-    validations?: IAddSecretModalFormValidation
-  ) => boolean;
-  message?: IValidationMessage;
-}
-
-type IFormValidations = Record<
-  IFormValidationKey,
-  { validations: IValidation[] }
->;
-
-const FORM_VALIDATIONS: IFormValidations = {
+const ADD_SECRET_VALIDATIONS: IValidationConfig<IAddSecretFormData> = {
   name: {
     validations: [
       {
         name: "required",
-        isValid: (formData: IAddSecretModalScheduleFormData) => {
+        isValid: (formData) => {
           return formData.name.length > 0;
         },
-        message: `Name is required`,
+        message: "Name is required",
       },
       {
         name: "validName",
-        isValid: (formData: IAddSecretModalScheduleFormData) => {
+        isValid: (formData) => {
           if (formData.name.length === 0) {
             return true; // Skip this validation if name is empty
           }
@@ -52,17 +24,17 @@ const FORM_VALIDATIONS: IFormValidations = {
       },
       {
         name: "notTooLong",
-        isValid: (formData: IAddSecretModalScheduleFormData) => {
+        isValid: (formData) => {
           return formData.name.length <= 255;
         },
         message: "Name may not exceed 255 characters",
       },
       {
         name: "doesNotIncludePrefix",
-        isValid: (formData: IAddSecretModalScheduleFormData) => {
+        isValid: (formData) => {
           return !formData.name.match(/^FLEET_SECRET_/);
         },
-        message: `Name should not include variable prefix`,
+        message: "Name should not include variable prefix",
       },
     ],
   },
@@ -70,55 +42,13 @@ const FORM_VALIDATIONS: IFormValidations = {
     validations: [
       {
         name: "required",
-        isValid: (formData: IAddSecretModalScheduleFormData) => {
+        isValid: (formData) => {
           return formData.value.length > 0;
         },
-        message: `Value is required`,
+        message: "Value is required",
       },
     ],
   },
 };
 
-const getErrorMessage = (
-  formData: IAddSecretModalScheduleFormData,
-  message?: IValidationMessage
-) => {
-  if (message === undefined || typeof message === "string") {
-    return message;
-  }
-  return message(formData);
-};
-
-export const validateFormData = (
-  formData: IAddSecretModalScheduleFormData,
-  isSaving = false
-) => {
-  const formValidation: IAddSecretModalFormValidation = {
-    isValid: true,
-  };
-  Object.keys(FORM_VALIDATIONS).forEach((key) => {
-    const objKey = key as keyof typeof FORM_VALIDATIONS;
-    const failedValidation = FORM_VALIDATIONS[objKey].validations.find(
-      (validation) => {
-        if (!isSaving && validation.name === "required") {
-          return false; // Skip this validation if not saving
-        }
-        return !validation.isValid(formData, formValidation);
-      }
-    );
-
-    if (!failedValidation) {
-      formValidation[objKey] = {
-        isValid: true,
-      };
-    } else {
-      formValidation.isValid = false;
-      formValidation[objKey] = {
-        isValid: false,
-        message: getErrorMessage(formData, failedValidation.message),
-      };
-    }
-  });
-
-  return formValidation;
-};
+export default ADD_SECRET_VALIDATIONS;


### PR DESCRIPTION
# `useFormValidation` hook

## Prompt

> My idea is that we could abstract **patterns.md Forms section** into a `useForm` hook (without using a library such as `react-hook-form`).
>
> If you see the pattern, it's followed but it's kind of repeated. Basically we always do this: `AddSecretModal/helpers.ts`, which you can find in similar cases in other components (e.g. `AddCertificateModal/helpers.ts`).
>
> There is one caveat though: we might want some specific conditions to return early or tweak the validation, as in `EditAutoUpdateConfigModal/helpers.tsx` (lines 163–165). I think the above point could be solved by passing in a callback or prop that is executed before the validation runs.
>
> My initial idea is that the `useForm` hook should expose:
> - `isValid` (whole form)
> - Each of its fields, if they're individually valid, and if they contain any error (I believe we expose them by calling `getErrorMessage` and passing in the field key)
> - `clearErrors` (nice-to-have -- or maybe `reset()` which internally clears errors?)
> - `isValid` in each field should provide access to other fields, because we might want to calculate validity depending on other fields
> - Handle the form validation state within the hook — this eliminates the need for boilerplate in each component (same applies to `e.preventDefault` and other repeated patterns)
> - For completeness, I think we should at least modify one of the components that currently follows the pattern. Maybe the `AddSecretModal`?

## Problem

16+ form components across the frontend repeat the same validation boilerplate:

- A `validateFormData` function with identical iteration/error-resolution logic
- Per-form type declarations (`IFormValidation`, `IValidation`, `IFormValidations`, `IMessageFunc`, `IValidationMessage`, `IFormValidationKey`)
- A `getErrorMessage` helper to resolve static or dynamic messages
- `useState` for both `formData` and `formValidation`
- Manual `onChange`/`onBlur`/`onSubmit` handler wiring with `setFormValidation` calls
- Inconsistent adherence to the documented validation UX in `frontend/docs/patterns.md`

The only thing that actually varies per form is the **validation config** (which fields, which rules, which messages).

## Solution

A `useFormValidation` hook (`frontend/hooks/useFormValidation.ts`) that centralizes validation state management.

### What the hook provides

| Export | Purpose |
|---|---|
| `formData` | Managed form state (eliminates separate `useState`) |
| `setField(name, value)` | Updates a single field. **Only clears** the changed field's error if now valid — never adds new errors. This is the patterns.md `onChange` behavior. |
| `setFormData(data)` | Escape hatch for multi-field or discrete updates (checkbox toggle, dropdown). Shows all current errors after update. |
| `isValid` | `true` when no errors are currently shown to the user. Starts `true` (Save button enabled), becomes `false` after blur/submit reveals errors. |
| `getFieldError(field)` | Returns the error message string for a field, or `undefined`. Replaces `formValidation.name?.message`. |
| `validateAll()` | Runs full validation and shows all errors. Wire to `onBlur`. |
| `handleSubmit(callback)` | Returns a form `onSubmit` handler that calls `preventDefault`, runs full validation, and only calls the callback if valid. |
| `clearErrors()` | Resets all shown errors. |

### What the hook accepts

| Option | Purpose |
|---|---|
| `initialFormData` | Initial form state object |
| `validationConfig` | The validation rules config — same `Record<field, { validations }>` structure already used across all forms |
| `shouldValidateField?` | Optional callback to skip entire fields based on form state (replaces `autoUpdateEnabled`/`runMode` early-return patterns) |

### Exported shared types

`IFieldValidation`, `IValidationRule`, `IValidationConfig`, `IValidationMessage`, `IValidationResult` — so form `helpers.ts` files can import these instead of redeclaring them.

### Exported pure function: `runValidation`

The core validation loop extracted from the duplicated `validateFormData` functions. Supports cross-field validation (each rule receives the in-progress validation result) and dynamic error messages (string or function).

`runValidation` is for forms that **derive validation via `useMemo` instead of managing validation state** — like the CA forms (`CustomESTForm`, `DigicertForm`, etc.). These are presentational components where the parent owns `formData` and the form just computes validation on every render:

```tsx
// CustomESTForm.tsx (current pattern)
const validations = useMemo(() => {
  return validateFormData(formData, validationsConfig);
}, [formData, validationsConfig]);
```

With the hook's export, this becomes:

```tsx
import { runValidation } from "hooks/useFormValidation";

const validations = useMemo(() => {
  return runValidation(formData, validationsConfig);
}, [formData, validationsConfig]);
```

The benefit is they stop needing their own `validateFormData` + `getErrorMessage` functions in `helpers.ts` — they just define the config and call `runValidation` directly. These forms don't need the full `useFormValidation` hook because they don't manage their own state (the parent does), and they always show all errors eagerly (no clear-only-on-change behavior).

## Key design decisions

**`isValid` is based on shown errors, not full validation.** This means the Save button starts enabled (no errors shown yet). Errors appear on blur or submit. As the user fixes errors via typing, they clear one by one. This matches `frontend/docs/patterns.md` and preserves the existing UX where Save starts enabled.

**`setField` vs `setFormData` have different error behavior.** `setField` is for text input typing — it only clears errors, never adds them (optimistic UX while typing). `setFormData` is for discrete actions (toggles, dropdowns, multi-field updates) — it shows all current errors because the interaction is complete.

**Stale closure prevention via refs.** `formDataRef`, `validationConfigRef`, and `shouldValidateFieldRef` ensure that stable callbacks (`setField`, `handleSubmit`, etc.) always read the latest values without needing to be recreated.

**Dynamic validation config support.** When `validationConfig` changes (e.g., from `useMemo` recomputing after new data loads), the hook clears errors that are now resolved under the new config, but does not add new errors.

## AddSecretModal migration

### `helpers.ts` (124 lines → 55 lines)

Removed:
- `IAddSecretModalFormValidation` interface
- `IMessageFunc`, `IValidationMessage`, `IFormValidationKey`, `IValidation`, `IFormValidations` types
- `getErrorMessage` function
- `validateFormData` function

Now just exports the validation config object, importing `IValidationConfig` from the hook.

### `AddSecretModal.tsx` (128 lines → 108 lines)

| Before | After | Why |
|---|---|---|
| 3 `useState` calls (`secretName`, `secretValue`, `formValidation`) | 1 `useFormValidation` call + 1 `useState` for `isSaving` | Hook manages formData and validation state internally |
| `<Button onClick={onClickSave}>` | `<form onSubmit={handleSubmit(onSave)}>` + `<Button type="submit">` | Follows patterns.md: use native form submission, not button click |
| No `onBlur` on inputs | `onBlur={validateAll}` on both inputs | Errors now appear when the user leaves a field (patterns.md behavior) |
| `validateFormData({...}, true)` with `isSaving` flag | `handleSubmit` handles validation gating | Hook's submit handler runs full validation and blocks if invalid |
| `error={formValidation.name?.message}` | `error={getFieldError("name")}` | Cleaner API, same result |
| `error: any` in catch | `error: unknown` | Safer typing |
| Manual `setFormValidation(validateFormData({...}))` in onChange | `setField(name, value)` | Hook handles validation internally with clear-only behavior |
