### PR TITLE
Fix adding/modifying enroll secrets in UI

### DIFF
--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -210,9 +210,10 @@ export default {
     return sendRequest("GET", path);
   },
   modifyEnrollSecrets: (teamId: number, secrets: IEnrollSecret[]) => {
+    const stripped = secrets.map((s) => pick(s, ["secret"]));
     const { TEAMS_ENROLL_SECRETS } = endpoints;
     const path = TEAMS_ENROLL_SECRETS(teamId);
 
-    return sendRequest("PATCH", path, { secrets });
+    return sendRequest("PATCH", path, { secrets: stripped });
   },
 };

--- a/frontend/services/entities/teams.ts
+++ b/frontend/services/entities/teams.ts
@@ -210,10 +210,11 @@ export default {
     return sendRequest("GET", path);
   },
   modifyEnrollSecrets: (teamId: number, secrets: IEnrollSecret[]) => {
-    const stripped = secrets.map((s) => pick(s, ["secret"]));
+    // The API only expects an array of objects with a "secret" property.
+    const payload = secrets.map((s) => pick(s, "secret"));
     const { TEAMS_ENROLL_SECRETS } = endpoints;
     const path = TEAMS_ENROLL_SECRETS(teamId);
 
-    return sendRequest("PATCH", path, { secrets: stripped });
+    return sendRequest("PATCH", path, { secrets: payload });
   },
 };


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40170

# Details

Fixes an unreleased issue where when attempting to modify a fleet enroll secret, you get a 400 response indicating that both team_id and fleet_id params are being sent.  The request was piping the "get enroll secrets" response back into the "modify enroll secrets"

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased bug

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

On main: reproduced issue when attempting to add secret to a fleet
On branch: secret added successfully

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
