### PR TITLE
Fix report creation response timestamp values

### DIFF
--- a/changes/fix-report-creation-timestamps
+++ b/changes/fix-report-creation-timestamps
@@ -1,0 +1,1 @@
+* Fixed report creation API returning zero timestamps for `created_at` and `updated_at` fields.

--- a/server/datastore/mysql/queries.go
+++ b/server/datastore/mysql/queries.go
@@ -7,6 +7,7 @@ import (
 	"maps"
 	"slices"
 	"strings"
+	"time"
 
 	"golang.org/x/text/unicode/norm"
 
@@ -290,6 +291,9 @@ func (ds *Datastore) NewQuery(
 	id, _ := result.LastInsertId()
 	query.ID = uint(id) //nolint:gosec // dismiss G115
 	query.Packs = []fleet.Pack{}
+	now := time.Now().UTC().Truncate(time.Second)
+	query.CreatedAt = now
+	query.UpdatedAt = now
 
 	if err := ds.updateQueryLabels(ctx, query); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "saving labels for query")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -346,6 +346,10 @@ func (s *integrationTestSuite) TestQueryCreationLogsActivity() {
 	var createQueryResp createQueryResponse
 	s.DoJSON("POST", "/api/latest/fleet/queries", &params, http.StatusOK, &createQueryResp)
 	defer s.cleanupQuery(createQueryResp.Query.ID)
+	assert.False(t, createQueryResp.Query.CreatedAt.IsZero())
+	assert.WithinDuration(t, time.Now(), createQueryResp.Query.CreatedAt, time.Minute)
+	assert.False(t, createQueryResp.Query.UpdatedAt.IsZero())
+	assert.WithinDuration(t, time.Now(), createQueryResp.Query.UpdatedAt, time.Minute)
 
 	activities := listActivitiesResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/activities", nil, http.StatusOK, &activities)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39257

Similar fix to the one applied here: https://github.com/fleetdm/fleet/pull/38846

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/2feb6b0b-aad5-41e5-a2c0-430a1d40883b


