### PR TITLE
Fixed python package false positives on Ubuntu

### DIFF
--- a/changes/40021-ubuntu-python-false-positive
+++ b/changes/40021-ubuntu-python-false-positive
@@ -1,1 +1,1 @@
-* Fixed python package false positives on Ubuntu, such as `python3-setuptools` on Ubuntu 20.04 with version 68.1.2-2ubuntu1.2
+* Fixed python package false positives on Ubuntu, such as `python3-setuptools` on Ubuntu 24.04 with version 68.1.2-2ubuntu1.2

--- a/changes/40021-ubuntu-python-false-positive
+++ b/changes/40021-ubuntu-python-false-positive
@@ -1,0 +1,1 @@
+* Fixed python package false positives on Ubuntu, such as `python3-setuptools` on Ubuntu 20.04 with version 68.1.2-2ubuntu1.2

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1509,8 +1509,10 @@ func pythonPackageFilter(platform string, results fleet.OsqueryDistributedQueryR
 
 	// Extract the Python and Debian packages from the software list for filtering
 	// pre-allocating space for 40 packages based on number of package found in
-	// a fresh ubuntu 24.04 install
-	pythonPackages := make(map[string]int, 40)
+	// a fresh ubuntu 24.04 install.
+	// A python package name may appear multiple times (e.g. from multiple user directories),
+	// so we track all indexes for each name.
+	pythonPackages := make(map[string][]int, 40)
 	debPackages := make(map[string]struct{}, 40)
 	rpmPackages := make(map[string]struct{}, 60)
 
@@ -1521,7 +1523,7 @@ func pythonPackageFilter(platform string, results fleet.OsqueryDistributedQueryR
 		switch row["source"] {
 		case pythonSource:
 			loweredName := strings.ToLower(row["name"])
-			pythonPackages[loweredName] = i
+			pythonPackages[loweredName] = append(pythonPackages[loweredName], i)
 			row["name"] = loweredName
 		case debSource:
 			// Only append python3 deb packages
@@ -1541,17 +1543,19 @@ func pythonPackageFilter(platform string, results fleet.OsqueryDistributedQueryR
 	}
 
 	// Loop through pythonPackages map to identify any that should be removed
-	for name, index := range pythonPackages {
+	for name, indexes := range pythonPackages {
 		convertedName := pythonPrefix + name
 
-		// Filter out Python packages that are also Debian packages
+		// Filter out Python packages that are also Debian or RPM packages
 		if _, found := debPackages[convertedName]; found {
-			indexesToRemove = append(indexesToRemove, index)
+			indexesToRemove = append(indexesToRemove, indexes...)
 		} else if _, found := rpmPackages[convertedName]; found {
-			indexesToRemove = append(indexesToRemove, index)
+			indexesToRemove = append(indexesToRemove, indexes...)
 		} else {
 			// Update remaining Python package names to match OVAL definitions
-			sw[index]["name"] = convertedName
+			for _, index := range indexes {
+				sw[index]["name"] = convertedName
+			}
 		}
 	}
 

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -4677,6 +4677,24 @@ func BenchmarkPreprocessUbuntuPythonPackageFilter(b *testing.B) {
 	}
 }
 
+func TestPythonPackageFilterDuplicateUserDirs(t *testing.T) {
+	const swLinux = hostDetailQueryPrefix + "software_linux"
+
+	results := fleet.OsqueryDistributedQueryResults{
+		swLinux: []map[string]string{
+			{"name": "python3-cryptography", "version": "41.0.7-4ubuntu0.1", "source": "deb_packages"},
+			{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
+			{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
+		},
+	}
+	statuses := map[string]fleet.OsqueryStatus{swLinux: fleet.StatusOK}
+
+	pythonPackageFilter("ubuntu", results, statuses)
+
+	require.Len(t, results[swLinux], 1, "both duplicate python_packages entries should be removed")
+	require.Equal(t, "python3-cryptography", results[swLinux][0]["name"])
+}
+
 func TestUpdateFleetdVersion(t *testing.T) {
 	const (
 		orbitInfoQuery     = hostDetailQueryPrefix + "orbit_info"

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -4677,22 +4677,45 @@ func BenchmarkPreprocessUbuntuPythonPackageFilter(b *testing.B) {
 	}
 }
 
+// TestPythonPackageFilterDuplicateUserDirs verifies that when osquery
+// reports the same python package multiple times (once per user via CROSS JOIN users),
+// all duplicates are handled correctly. The old code used map[string]int which only
+// tracked the last index, leaving earlier duplicates unfiltered or unrenamed.
 func TestPythonPackageFilterDuplicateUserDirs(t *testing.T) {
 	const swLinux = hostDetailQueryPrefix + "software_linux"
 
-	results := fleet.OsqueryDistributedQueryResults{
-		swLinux: []map[string]string{
-			{"name": "python3-cryptography", "version": "41.0.7-4ubuntu0.1", "source": "deb_packages"},
-			{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
-			{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
-		},
-	}
-	statuses := map[string]fleet.OsqueryStatus{swLinux: fleet.StatusOK}
+	t.Run("matched duplicates are all removed", func(t *testing.T) {
+		results := fleet.OsqueryDistributedQueryResults{
+			swLinux: []map[string]string{
+				{"name": "python3-cryptography", "version": "41.0.7-4ubuntu0.1", "source": "deb_packages"},
+				{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
+				{"name": "cryptography", "version": "41.0.7", "source": "python_packages"},
+			},
+		}
+		statuses := map[string]fleet.OsqueryStatus{swLinux: fleet.StatusOK}
 
-	pythonPackageFilter("ubuntu", results, statuses)
+		pythonPackageFilter("ubuntu", results, statuses)
 
-	require.Len(t, results[swLinux], 1, "both duplicate python_packages entries should be removed")
-	require.Equal(t, "python3-cryptography", results[swLinux][0]["name"])
+		require.Len(t, results[swLinux], 1, "both duplicate python_packages entries should be removed")
+		require.Equal(t, "python3-cryptography", results[swLinux][0]["name"])
+	})
+
+	t.Run("unmatched duplicates are all renamed", func(t *testing.T) {
+		results := fleet.OsqueryDistributedQueryResults{
+			swLinux: []map[string]string{
+				{"name": "flask", "version": "3.0.0", "source": "python_packages"},
+				{"name": "flask", "version": "3.0.0", "source": "python_packages"},
+			},
+		}
+		statuses := map[string]fleet.OsqueryStatus{swLinux: fleet.StatusOK}
+
+		pythonPackageFilter("ubuntu", results, statuses)
+
+		require.Len(t, results[swLinux], 2)
+		for _, row := range results[swLinux] {
+			require.Equal(t, "python3-flask", row["name"], "all duplicates should be renamed")
+		}
+	})
 }
 
 func TestUpdateFleetdVersion(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40021 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false positive detections for Python packages on Ubuntu systems, addressing misclassification scenarios that were affecting package detection accuracy on Ubuntu 20.04 and other versions.
  * Enhanced handling of duplicate Python package entries to correctly identify and consolidate multiple occurrences, preventing incorrect over-reporting of installed packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->