### PR TITLE
Dogfood and loadtest - mysql require secure transport on

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -77,6 +77,9 @@ module "free" {
       # 8mb up from 262144 (256k) default
       sort_buffer_size = 8388608
     }
+    db_cluster_parameters = {
+      require_secure_transport = "ON"
+    }
     # VPN
     allowed_cidr_blocks     = ["10.255.1.0/24", "10.255.2.0/24", "10.255.3.0/24"]
     subnets                 = module.main.vpc.database_subnets

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -79,7 +79,7 @@ locals {
     # Webhook Results & Status Logging Destination
     FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"
     FLEET_SERVER_GZIP_RESPONSES     = "true"
-
+    
     # Load TLS Certificate for RDS Authentication
     FLEET_MYSQL_TLS_CA                  = local.cert_path
     FLEET_MYSQL_READ_REPLICA_TLS_CA     = local.cert_path
@@ -153,6 +153,9 @@ module "main" {
     db_parameters = {
       # 8mb up from 262144 (256k) default
       sort_buffer_size = 8388608
+    }
+    db_cluster_parameters = {
+      require_secure_transport = "ON"
     }
     # VPN
     allowed_cidr_blocks     = ["10.255.1.0/24", "10.255.2.0/24", "10.255.3.0/24"]

--- a/infrastructure/loadtesting/terraform/infra/locals.tf
+++ b/infrastructure/loadtesting/terraform/infra/locals.tf
@@ -42,8 +42,10 @@ locals {
       FLEET_OSQUERY_ASYNC_HOST_REDIS_SCAN_KEYS_COUNT = "10000"
       FLEET_REDIS_MAX_OPEN_CONNS                     = "500"
       FLEET_REDIS_MAX_IDLE_CONNS                     = "500"
+      FLEET_AUTH_SSO_SESSION_VALIDITY_PERIOD         = "15m"
+      FLEET_MDM_SSO_RATE_LIMIT_PER_MINUTE            = "500"
       FLEET_SERVER_GZIP_RESPONSES                    = "true"
-
+      
 
       # Load TLS Certificate for RDS Authentication
       FLEET_MYSQL_TLS_CA              = local.cert_path

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -52,6 +52,9 @@ module "loadtest" {
       # 8mb up from 262144 (256k) default
       sort_buffer_size = 8388608
     }
+    db_cluster_parameters = {
+      require_secure_transport = "ON"
+    }
   }
   redis_config = {
     name                          = local.customer


### PR DESCRIPTION
- Adds require_secure_transport for mysql connections to the db_cluster parameter group for dogfood and loadtest environments.

```
    db_cluster_parameters = {
      require_secure_transport = "ON"
    }
```