### PR TITLE
Fleet UI: Rollback follow-up re: default version selection

### DIFF
--- a/frontend/hooks/useSoftwareInstallerMeta.ts
+++ b/frontend/hooks/useSoftwareInstallerMeta.ts
@@ -13,6 +13,7 @@ import {
   getInstallerCardInfo,
   InstallerCardInfo,
 } from "pages/SoftwarePage/SoftwareTitleDetailsPage/helpers";
+import { compareVersions } from "utilities/helpers";
 
 export interface SoftwareInstallerMeta {
   installerType: InstallerType;
@@ -71,8 +72,14 @@ export const useSoftwareInstaller = (
       isFleetMaintainedApp &&
       "fleet_maintained_versions" in softwareInstaller &&
       !!softwareInstaller.fleet_maintained_versions &&
-      softwareInstaller.version ===
-        softwareInstaller.fleet_maintained_versions[0].version;
+      softwareInstaller.fleet_maintained_versions.every(
+        (fma) =>
+          // Verify that the installer version is not older than any known
+          // Fleet‑maintained version by requiring compareVersions to return
+          // 0 (equal) or 1 (greater) for every entry.
+          compareVersions(softwareInstaller.version ?? "", fma.version ?? "") >=
+          0
+      );
 
     const fmaVersions =
       isFleetMaintainedApp && "fleet_maintained_versions" in softwareInstaller

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -419,7 +419,7 @@ const PackageForm = ({
         const isLatest = index === 0;
 
         return {
-          label: `${v.version}${isLatest ? " (latest)" : ""}`,
+          label: isLatest ? `Latest (${v.version})` : `${v.version}`,
           value: v.version,
         };
       }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -8,11 +8,13 @@ import {
   getExtensionFromFileName,
   getFileDetails,
 } from "utilities/file/fileUtils";
+import { compareVersions } from "utilities/helpers";
 import getDefaultInstallScript from "utilities/software_install_scripts";
 import getDefaultUninstallScript from "utilities/software_uninstall_scripts";
 import { ILabelSummary } from "interfaces/label";
 
 import { ISoftwareVersion, SoftwareCategory } from "interfaces/software";
+
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import Button from "components/buttons/Button";
@@ -405,13 +407,23 @@ const PackageForm = ({
 
     const fmaVersions = defaultSoftware.fleet_maintained_versions || [];
 
-    // NOTE: Backend guarantees that the latest version always has id === 1
-    const versionOptions = fmaVersions.map((v: ISoftwareVersion) => {
-      return {
-        label: `${v.version}${v.id === 1 ? " (latest)" : ""}`,
-        value: v.version,
-      };
+    /** Ensures latest version is first, compatible with sorting n versions */
+    fmaVersions.sort((a: ISoftwareVersion, b: ISoftwareVersion) => {
+      const v1 = a.version ?? "";
+      const v2 = b.version ?? "";
+      return compareVersions(v2, v1);
     });
+
+    const versionOptions = fmaVersions.map(
+      (v: ISoftwareVersion, index: number) => {
+        const isLatest = index === 0;
+
+        return {
+          label: `${v.version}${isLatest ? " (latest)" : ""}`,
+          value: v.version,
+        };
+      }
+    );
 
     return (
       <PackageVersionSelector

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -13,6 +13,7 @@ import getDefaultUninstallScript from "utilities/software_uninstall_scripts";
 import { ILabelSummary } from "interfaces/label";
 
 import { ISoftwareVersion, SoftwareCategory } from "interfaces/software";
+import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
 
 import Button from "components/buttons/Button";
 import TooltipWrapper from "components/TooltipWrapper";
@@ -78,6 +79,31 @@ const renderFileTypeMessage = () => {
       <TooltipWrapper tipContent="Script-only package">.sh</TooltipWrapper>)
     </>
   );
+};
+
+/** Returns the version value to use as the dropdown's default:
+/ 1) If a previously selected version is still present in the options, reuse it.
+/ 2) Otherwise, fall back to the first option, which is assumed to be the latest.
+/ 3) Safe fallback if no options exist which should never happen */
+const getDefaultVersion = (
+  versionOptions: CustomOptionType[],
+  selectedVersion?: string
+) => {
+  // This shouldn't happen
+  if (!versionOptions.length) {
+    return "";
+  }
+
+  // If we already have a selected version and it exists in options, keep it
+  if (selectedVersion) {
+    const match = versionOptions.find((opt) => opt.value === selectedVersion);
+    if (match) {
+      return match.value;
+    }
+  }
+
+  // Otherwise, default to the first option (which should be latest)
+  return versionOptions[0].value;
 };
 
 interface IPackageFormProps {
@@ -218,11 +244,10 @@ const PackageForm = ({
 
   const onToggleAutomaticInstall = useCallback(
     (value?: boolean) => {
-      const newData = {
-        ...formData,
-        automaticInstall: !formData.automaticInstall,
-      };
-      setFormData(newData);
+      const automaticInstall =
+        typeof value === "boolean" ? value : !formData.automaticInstall;
+
+      setFormData({ ...formData, automaticInstall });
     },
     [formData]
   );
@@ -379,6 +404,8 @@ const PackageForm = ({
     }
 
     const fmaVersions = defaultSoftware.fleet_maintained_versions || [];
+
+    // NOTE: Backend guarantees that the latest version always has id === 1
     const versionOptions = fmaVersions.map((v: ISoftwareVersion) => {
       return {
         label: `${v.version}${v.id === 1 ? " (latest)" : ""}`,
@@ -388,7 +415,7 @@ const PackageForm = ({
 
     return (
       <PackageVersionSelector
-        selectedVersion={formData.version || versionOptions[1].value}
+        selectedVersion={getDefaultVersion(versionOptions, formData.version)}
         versionOptions={versionOptions}
         onSelectVersion={onSelectVersion}
         className={`${baseClass}__version-selector`}

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -407,16 +407,19 @@ const PackageForm = ({
 
     const fmaVersions = defaultSoftware.fleet_maintained_versions || [];
 
-    /** Ensures latest version is first, compatible with sorting n versions */
+    /** Ensures latest version is first, compatible with sorting n-number of versions */
     fmaVersions.sort((a: ISoftwareVersion, b: ISoftwareVersion) => {
       const v1 = a.version ?? "";
       const v2 = b.version ?? "";
       return compareVersions(v2, v1);
     });
 
+    const hasMultipleVersions = fmaVersions.length > 1;
+
     const versionOptions = fmaVersions.map(
       (v: ISoftwareVersion, index: number) => {
-        const isLatest = index === 0;
+        // If multiple versions, only adds "Latest" label to the first option
+        const isLatest = hasMultipleVersions && index === 0;
 
         return {
           label: isLatest ? `Latest (${v.version})` : `${v.version}`,

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -8,7 +8,6 @@ import {
   getExtensionFromFileName,
   getFileDetails,
 } from "utilities/file/fileUtils";
-import { compareVersions } from "utilities/helpers";
 import getDefaultInstallScript from "utilities/software_install_scripts";
 import getDefaultUninstallScript from "utilities/software_uninstall_scripts";
 import { ILabelSummary } from "interfaces/label";
@@ -32,7 +31,11 @@ import Card from "components/Card";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
-import { createTooltipContent, generateFormValidation } from "./helpers";
+import {
+  createTooltipContent,
+  generateFormValidation,
+  sortByVersionLatestFirst,
+} from "./helpers";
 import PackageVersionSelector from "../PackageVersionSelector";
 
 export const baseClass = "package-form";
@@ -405,24 +408,18 @@ const PackageForm = ({
       return null;
     }
 
-    const fmaVersions = defaultSoftware.fleet_maintained_versions || [];
+    const fmaVersionsSortedByLatestFirst = sortByVersionLatestFirst<ISoftwareVersion>(
+      defaultSoftware.fleet_maintained_versions || []
+    );
+    const hasMultipleVersions = fmaVersionsSortedByLatestFirst.length > 1;
 
-    /** Ensures latest version is first, compatible with sorting n-number of versions */
-    fmaVersions.sort((a: ISoftwareVersion, b: ISoftwareVersion) => {
-      const v1 = a.version ?? "";
-      const v2 = b.version ?? "";
-      return compareVersions(v2, v1);
-    });
-
-    const hasMultipleVersions = fmaVersions.length > 1;
-
-    const versionOptions = fmaVersions.map(
+    const versionOptions = fmaVersionsSortedByLatestFirst.map(
       (v: ISoftwareVersion, index: number) => {
         // If multiple versions, only adds "Latest" label to the first option
-        const isLatest = hasMultipleVersions && index === 0;
+        const labelLatestVersion = hasMultipleVersions && index === 0;
 
         return {
-          label: isLatest ? `Latest (${v.version})` : `${v.version}`,
+          label: labelLatestVersion ? `Latest (${v.version})` : `${v.version}`,
           value: v.version,
         };
       }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/helpers.tsx
@@ -1,9 +1,8 @@
 import React from "react";
 
 import { validateQuery } from "components/forms/validators/validate_query";
-
 import { getExtensionFromFileName } from "utilities/file/fileUtils";
-import { getGitOpsModeTipContent } from "utilities/helpers";
+import { compareVersions, getGitOpsModeTipContent } from "utilities/helpers";
 import { IPackageFormData, IPackageFormValidation } from "./PackageForm";
 
 type IMessageFunc = (formData: IPackageFormData) => string;
@@ -235,6 +234,18 @@ export const createTooltipContent = (
       ))}
     </>
   );
+};
+
+/** Keeps the latest (highest) version first and descends using compareVersions.
+ Works with any array of objects that expose a string `version` field. */
+export const sortByVersionLatestFirst = <T extends { version?: string }>(
+  items: T[]
+): T[] => {
+  return items.sort((a, b) => {
+    const v1 = a.version ?? "";
+    const v2 = b.version ?? "";
+    return compareVersions(v2, v1);
+  });
 };
 
 export default generateFormValidation;

--- a/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
@@ -9,7 +9,7 @@ describe("PackageVersionSelector component", () => {
   it("returns null when there are no version options", () => {
     const { container } = render(
       <PackageVersionSelector
-        selectedVersion="1.0.0"
+        selectedVersion="2.0.0"
         versionOptions={[]}
         onSelectVersion={noop}
       />
@@ -21,47 +21,114 @@ describe("PackageVersionSelector component", () => {
   it("renders the package version dropdown when there are package versions to choose from", () => {
     render(
       <PackageVersionSelector
-        selectedVersion="1.0.0"
+        selectedVersion="2.0.0"
         versionOptions={[
+          { value: "2.0.0", label: "Latest (2.0.0)" },
           { value: "1.0.0", label: "1.0.0" },
-          { value: "2.0.0", label: "2.0.0" },
         ]}
         onSelectVersion={noop}
       />
     );
 
-    expect(screen.getByText("1.0.0")).toBeInTheDocument();
+    // Renders the label for the selected (latest) version
+    expect(screen.getByText("Latest (2.0.0)")).toBeInTheDocument();
   });
 
-  it("disables the dropdown when the selected version is the first option", () => {
-    render(
+  it("disables all non-selected options when the latest version is selected", async () => {
+    const { user } = renderWithSetup(
       <PackageVersionSelector
-        selectedVersion="1.0.0"
+        selectedVersion="2.0.0"
         versionOptions={[
+          { value: "2.0.0", label: "Latest (2.0.0)" }, // selected
           { value: "1.0.0", label: "1.0.0" },
-          { value: "2.0.0", label: "2.0.0" },
         ]}
         onSelectVersion={noop}
       />
     );
 
     const combobox = screen.getByRole("combobox");
-    expect(combobox).toBeDisabled();
+    await user.click(combobox);
+
+    const optionInnerDivs = screen.getAllByTestId("dropdown-option");
+
+    const latestInner = optionInnerDivs.find(
+      (el) => el.textContent === "Latest (2.0.0)"
+    );
+    const oldInner = optionInnerDivs.find((el) => el.textContent === "1.0.0");
+
+    expect(latestInner).toBeDefined();
+    expect(oldInner).toBeDefined();
+
+    const latestOptionWrapper = latestInner?.closest(
+      ".react-select__option"
+    ) as HTMLElement | null;
+    const oldOptionWrapper = oldInner?.closest(
+      ".react-select__option"
+    ) as HTMLElement | null;
+
+    expect(latestOptionWrapper).not.toBeNull();
+    expect(oldOptionWrapper).not.toBeNull();
+
+    // Selected option (Latest 2.0.0) is enabled
+    expect(latestOptionWrapper).toHaveAttribute("aria-disabled", "false");
+    // Non-selected option (1.0.0) is disabled
+    expect(oldOptionWrapper).toHaveAttribute("aria-disabled", "true");
   });
 
-  it("shows the GitOps rollback tooltip text when the selected version is the first option", async () => {
+  it("disables all non-selected options when a non-latest version is selected", async () => {
     const { user } = renderWithSetup(
       <PackageVersionSelector
         selectedVersion="1.0.0"
         versionOptions={[
-          { value: "1.0.0", label: "1.0.0" },
-          { value: "2.0.0", label: "2.0.0" },
+          { value: "2.0.0", label: "Latest (2.0.0)" },
+          { value: "1.0.0", label: "1.0.0" }, // selected
         ]}
         onSelectVersion={noop}
       />
     );
 
-    // TooltipWrapper is wrapping the select; it attaches tooltip to this element:
+    const combobox = screen.getByRole("combobox");
+    await user.click(combobox);
+
+    const optionInnerDivs = screen.getAllByTestId("dropdown-option");
+
+    const latestInner = optionInnerDivs.find(
+      (el) => el.textContent === "Latest (2.0.0)"
+    );
+    const oldInner = optionInnerDivs.find((el) => el.textContent === "1.0.0");
+
+    expect(latestInner).toBeDefined();
+    expect(oldInner).toBeDefined();
+
+    const latestOptionWrapper = latestInner?.closest(
+      ".react-select__option"
+    ) as HTMLElement | null;
+    const oldOptionWrapper = oldInner?.closest(
+      ".react-select__option"
+    ) as HTMLElement | null;
+
+    expect(latestOptionWrapper).not.toBeNull();
+    expect(oldOptionWrapper).not.toBeNull();
+
+    // Selected option (1.0.0) is enabled
+    expect(oldOptionWrapper).toHaveAttribute("aria-disabled", "false");
+    // Non-selected option (Latest 2.0.0) is disabled
+    expect(latestOptionWrapper).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("shows the GitOps rollback tooltip text when the selected version is the first (latest) option", async () => {
+    const { user } = renderWithSetup(
+      <PackageVersionSelector
+        selectedVersion="2.0.0"
+        versionOptions={[
+          { value: "2.0.0", label: "Latest (2.0.0)" }, // first / latest
+          { value: "1.0.0", label: "1.0.0" },
+        ]}
+        onSelectVersion={noop}
+      />
+    );
+
+    // TooltipWrapper attaches tooltip to this element:
     const tooltipAnchor = document.querySelector(
       ".component__tooltip-wrapper__element"
     ) as HTMLElement;
@@ -78,13 +145,13 @@ describe("PackageVersionSelector component", () => {
     });
   });
 
-  it("shows the update-to-latest tooltip text when the selected version is not the first option", async () => {
+  it("shows the update-to-latest tooltip text when the selected version is not the first (latest) option", async () => {
     const { user } = renderWithSetup(
       <PackageVersionSelector
-        selectedVersion="2.0.0"
+        selectedVersion="1.0.0"
         versionOptions={[
+          { value: "2.0.0", label: "Latest (2.0.0)" }, // first / latest
           { value: "1.0.0", label: "1.0.0" },
-          { value: "2.0.0", label: "2.0.0" },
         ]}
         onSelectVersion={noop}
       />

--- a/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tests.tsx
@@ -18,6 +18,24 @@ describe("PackageVersionSelector component", () => {
     expect(container.firstChild).toBeNull();
   });
 
+  it("renders a plain version label when there is only one option", () => {
+    render(
+      <PackageVersionSelector
+        selectedVersion="2.0.0"
+        versionOptions={[{ value: "2.0.0", label: "2.0.0" }]}
+        onSelectVersion={noop}
+      />
+    );
+
+    // Shows just the raw version
+    expect(screen.getByText("2.0.0")).toBeInTheDocument();
+
+    // Does not show the \"Latest (...)\" decoration when there is only one option
+    expect(
+      screen.queryByText("Latest (2.0.0)", { exact: false })
+    ).not.toBeInTheDocument();
+  });
+
   it("renders the package version dropdown when there are package versions to choose from", () => {
     render(
       <PackageVersionSelector

--- a/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageVersionSelector/PackageVersionSelector.tsx
@@ -47,7 +47,6 @@ const PackageVersionSelector = ({
       onChange={(version) => onSelectVersion(version?.value || "")}
       options={disableAllUIOptions(versionOptions, selectedVersion)} // Replace with "versions" when we want to enable selecting versions in the UI
       placeholder="Select a version"
-      isDisabled={selectedVersion === versionOptions[0].value}
     />
   );
 


### PR DESCRIPTION
## Issue
Part of #31919

## Description
Tighten up rollback version shown in UI
- Orders version array by newest to oldest using `compareVersion`
- Ensure latest copy uses `compareVersion` to ensure it is the latest
- Allow dropdown to be open if latest is shown
- Do not have label `"Latest (x.x.x)"` if there is only one option in the dropdown, just have it as `"x.x.x"`

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually
