### PR TITLE
Update default category for Okta Verify

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/okta-verify.json
+++ b/ee/maintained-apps/inputs/homebrew/okta-verify.json
@@ -4,5 +4,5 @@
   "unique_identifier": "com.okta.mobile",
   "token": "okta-verify",
   "installer_format": "pkg",
-  "default_categories": ["Communication"]
+  "default_categories": ["Productivity"]
 }


### PR DESCRIPTION
This pull request makes a minor update to the `okta-verify.json` configuration file, changing the default category for Okta Verify from "Communication" to "Productivity".