### PR TITLE
Add Okta Verify to Setup experience for "Employee-issued mobile devices"

### DIFF
--- a/it-and-security/teams/company-owned-mobile-devices.yml
+++ b/it-and-security/teams/company-owned-mobile-devices.yml
@@ -78,6 +78,7 @@ software:
     - app_store_id: "490179405" # Okta Verify
       display_name: "Okta Verify"
       self_service: true
+      setup_experience: true
       platform: ios
       auto_update_enabled: true
       auto_update_window_start: "21:00"


### PR DESCRIPTION
This pull request makes a minor update to the configuration for company-owned mobile devices. The change enables the `setup_experience` option for the Okta Verify app in the `it-and-security/teams/company-owned-mobile-devices.yml` file.