### PR TITLE
Recategorize software

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -165,10 +165,14 @@ software:
     - path: ../lib/macos/software/1password.yml # 1Password for macOS
       self_service: true
       setup_experience: true
+      categories:
+        - Security
     - path: ../lib/macos/software/santa.yml # Santa for macOS
       self_service: true
       labels_include_any:
         - Santa test devices
+      categories:
+        - Security
     - path: ../lib/macos/software/zoom.yml # Zoom for macOS
       self_service: true
       setup_experience: true
@@ -179,14 +183,22 @@ software:
       self_service: true
       labels_include_any:
         - "Keynote 14 installed"
+      categories:
+        - Productivity
     - path: ../lib/macos/software/company-portal.yml # Company Portal for macOS
       self_service: true
       labels_include_any:
         - "Conditional access test group"
+      categories:
+        - Security
     - path: ../lib/macos/software/nudge.yml # Nudge for macOS
       self_service: false
+      categories:
+        - Utilities
     - path: ../lib/macos/software/nudge-assets.yml # Nudge assets for macOS
       self_service: false
+      categories:
+        - Utilities
     - path: ../lib/macos/software/fleet-desktop.yml # Fleet Desktop for macOS
       self_service: true
       categories:
@@ -262,11 +274,15 @@ software:
     - path: ../lib/windows/software/1password.yml # 1Password for Windows
       self_service: true
       setup_experience: true
+      categories:
+        - Security
   app_store_apps:
     - app_store_id: "361285480" # Keynote
       display_name: "Keynote"
       platform: darwin
       self_service: true
+      categories:
+        - Productivity
   fleet_maintained_apps:
     # macOS apps
     - slug: slack/darwin # Slack for macOS
@@ -284,27 +300,41 @@ software:
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+      categories:
+        - Browsers
     - slug: docker-desktop/darwin # Docker for macOS (ARM)
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+      categories:
+        - Developer tools
     - slug: microsoft-edge/darwin # Microsoft Edge for macOS
       self_service: true
+      categories:
+        - Browsers
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
       self_service: true
       labels_include_any:
         - Apple Silicon macOS hosts
+      categories:
+        - Developer tools
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true
+      categories:
+        - Communication
     - slug: okta-verify/darwin # Okta Verify for macOS
       self_service: true
       setup_experience: true
+      categories:
+        - Security
     # Windows apps
     - slug: okta-verify/windows # Okta Verify for Windows
       self_service: true
       setup_experience: true
       labels_include_any:
         - "x86-based Windows hosts"
+      categories:
+        - Security
     - slug: slack/windows # Slack for Windows
       self_service: true
       setup_experience: true
@@ -322,5 +352,9 @@ software:
         - "x86-based Windows hosts"
     - slug: brave-browser/windows # Brave for Windows
       self_service: true
+      categories:
+        - Browsers
     - slug: visual-studio-code/windows # Microsoft Visual Studio for Windows
       self_service: true
+      categories:
+        - Developer tools


### PR DESCRIPTION
Annotate many software, app_store_apps, and fleet_maintained_apps entries in it-and-security/teams/workstations.yml with a `categories` field (e.g., Security, Productivity, Utilities, Browsers, Developer tools, Communication). This adds metadata to better organize the self-service catalog and improve filtering/UX for workstation app management.