### PR TITLE
Use 'Agent' dataset title and sort key for vanilla osquery hosts

### DIFF
--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -347,6 +347,26 @@ describe("Agent data", () => {
     });
   });
 
+  it("for vanilla osquery hosts, renders Agent header with osquery_version and no tooltip", async () => {
+    const osqVersion = "5.21.0";
+    const customRender = createCustomRenderer({});
+    const mockHost = createMockHost({
+      platform: "darwin",
+      orbit_version: DEFAULT_EMPTY_CELL_VALUE,
+      osquery_version: osqVersion,
+      fleet_desktop_version: DEFAULT_EMPTY_CELL_VALUE,
+    });
+
+    const { user } = customRender(<Vitals vitalsData={mockHost} />);
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText(osqVersion)).toBeInTheDocument();
+
+    await user.hover(screen.getByText(osqVersion));
+    expect(screen.queryByText(/Orbit/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Fleet Desktop/i)).not.toBeInTheDocument();
+  });
+
   it("for Chromebooks, render Agent header with osquery_version that is the fleetd chrome version and no tooltip", async () => {
     const customRender = createCustomRenderer({});
     const mockHost = createMockHost({

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -154,22 +154,19 @@ const Vitals = ({
         fleet_desktop_version,
       } = vitalsData;
 
-      // chromeOS and vanilla osquery hosts
-      if (isChromeHost || orbit_version === DEFAULT_EMPTY_CELL_VALUE)
-        vitals.push({
-          sortKey: "Agent",
-          element: (
-            <DataSet key="agent" title="Agent" value={osquery_version} />
-          ),
-        });
-      else {
-        vitals.push({
-          sortKey: "Agent",
-          element: (
-            <DataSet
-              key="agent"
-              title="Agent"
-              value={
+      const isChromeOrVanillaOsqueryHost =
+        isChromeHost || orbit_version === DEFAULT_EMPTY_CELL_VALUE;
+
+      vitals.push({
+        sortKey: "Agent",
+        element: (
+          <DataSet
+            key="agent"
+            title="Agent"
+            value={
+              isChromeOrVanillaOsqueryHost ? (
+                osquery_version
+              ) : (
                 <TooltipWrapper
                   tipContent={
                     <>
@@ -187,11 +184,11 @@ const Vitals = ({
                 >
                   {orbit_version}
                 </TooltipWrapper>
-              }
-            />
-          ),
-        });
-      }
+              )
+            }
+          />
+        ),
+      });
     }
 
     // Battery condition

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -154,14 +154,7 @@ const Vitals = ({
         fleet_desktop_version,
       } = vitalsData;
 
-      if (isChromeHost) {
-        vitals.push({
-          sortKey: "Agent",
-          element: (
-            <DataSet key="agent" title="Agent" value={osquery_version} />
-          ),
-        });
-      } else if (orbit_version !== DEFAULT_EMPTY_CELL_VALUE) {
+      if (orbit_version !== DEFAULT_EMPTY_CELL_VALUE) {
         vitals.push({
           sortKey: "Agent",
           element: (
@@ -191,10 +184,11 @@ const Vitals = ({
           ),
         });
       } else {
+        // chromeOS and vanilla osquery hosts
         vitals.push({
-          sortKey: "Osquery",
+          sortKey: "Agent",
           element: (
-            <DataSet key="osquery" title="Osquery" value={osquery_version} />
+            <DataSet key="agent" title="Agent" value={osquery_version} />
           ),
         });
       }

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -154,7 +154,15 @@ const Vitals = ({
         fleet_desktop_version,
       } = vitalsData;
 
-      if (orbit_version !== DEFAULT_EMPTY_CELL_VALUE) {
+      // chromeOS and vanilla osquery hosts
+      if (isChromeHost || orbit_version === DEFAULT_EMPTY_CELL_VALUE)
+        vitals.push({
+          sortKey: "Agent",
+          element: (
+            <DataSet key="agent" title="Agent" value={osquery_version} />
+          ),
+        });
+      else {
         vitals.push({
           sortKey: "Agent",
           element: (
@@ -181,14 +189,6 @@ const Vitals = ({
                 </TooltipWrapper>
               }
             />
-          ),
-        });
-      } else {
-        // chromeOS and vanilla osquery hosts
-        vitals.push({
-          sortKey: "Agent",
-          element: (
-            <DataSet key="agent" title="Agent" value={osquery_version} />
           ),
         });
       }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves # https://github.com/fleetdm/fleet/issues/39794#issuecomment-3916992159

Host with vanilla osquery installation lists "Agent" vital:
<img width="959" height="521" alt="Screenshot 2026-02-23 at 5 33 23 PM" src="https://github.com/user-attachments/assets/216a7209-19ca-46b2-ae1c-ff18bbad3bc7" />


- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually