### PR TITLE
Add GIMP as a Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/gimp.json
+++ b/ee/maintained-apps/inputs/winget/gimp.json
@@ -1,0 +1,12 @@
+{
+  "name": "GIMP",
+  "slug": "gimp/windows",
+  "package_identifier": "GIMP.GIMP.3",
+  "unique_identifier": "GIMP 3.0.8-2",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/gimp_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/gimp_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "machine",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/scripts/gimp_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/gimp_install.ps1
@@ -1,0 +1,27 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+# Inno Setup installer with /ALLUSERS for machine-scope installation
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS"
+  PassThru = $true
+  Wait = $true
+}
+
+# Start process and track exit code
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+# Prints the exit code
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/gimp_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/gimp_uninstall.ps1
@@ -1,0 +1,86 @@
+# Fleet extracts name from installer (EXE) and saves it to PACKAGE_ID
+# variable
+$softwareName = "GIMP"
+
+# It is recommended to use exact software name here if possible to avoid
+# uninstalling unintended software.
+$softwareNameLike = "GIMP 3*"
+
+# Inno Setup installers require /VERYSILENT flag for silent uninstall
+$uninstallArgs = "/VERYSILENT /SUPPRESSMSGBOXES /NORESTART"
+
+$machineKey = `
+ 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*'
+$machineKey32on64 = `
+ 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+
+$exitCode = 0
+
+try {
+
+[array]$uninstallKeys = Get-ChildItem `
+    -Path @($machineKey, $machineKey32on64) `
+    -ErrorAction SilentlyContinue |
+        ForEach-Object { Get-ItemProperty $_.PSPath }
+
+$foundUninstaller = $false
+foreach ($key in $uninstallKeys) {
+    if ($key.DisplayName -like $softwareNameLike) {
+        $foundUninstaller = $true
+        # Get the uninstall command. Some uninstallers do not include
+        # 'QuietUninstallString' and require a flag to run silently.
+        $uninstallCommand = if ($key.QuietUninstallString) {
+            $key.QuietUninstallString
+        } else {
+            $key.UninstallString
+        }
+
+        # The uninstall command may contain command and args, like:
+        # "C:\Program Files\Software\uninstall.exe" /SILENT
+        # Split the command and args
+        $splitArgs = $uninstallCommand.Split('"')
+        if ($splitArgs.Length -gt 1) {
+            if ($splitArgs.Length -eq 3) {
+                $uninstallArgs = "$( $splitArgs[2] ) $uninstallArgs".Trim()
+            } elseif ($splitArgs.Length -gt 3) {
+                Throw `
+                    "Uninstall command contains multiple quoted strings. " +
+                        "Please update the uninstall script.`n" +
+                        "Uninstall command: $uninstallCommand"
+            }
+            $uninstallCommand = $splitArgs[1]
+        }
+        Write-Host "Uninstall command: $uninstallCommand"
+        Write-Host "Uninstall args: $uninstallArgs"
+
+        $processOptions = @{
+            FilePath = $uninstallCommand
+            PassThru = $true
+            Wait = $true
+        }
+        if ($uninstallArgs -ne '') {
+            $processOptions.ArgumentList = "$uninstallArgs"
+        }
+
+        # Start process and track exit code
+        $process = Start-Process @processOptions
+        $exitCode = $process.ExitCode
+
+        # Prints the exit code
+        Write-Host "Uninstall exit code: $exitCode"
+        # Exit the loop once the software is found and uninstalled.
+        break
+    }
+}
+
+if (-not $foundUninstaller) {
+    Write-Host "Uninstaller for '$softwareName' not found."
+    $exitCode = 1
+}
+
+} catch {
+    Write-Host "Error: $_"
+    $exitCode = 1
+}
+
+Exit $exitCode

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -709,6 +709,13 @@
       "description": "GIMP is a free and open-source image editor."
     },
     {
+      "name": "GIMP",
+      "slug": "gimp/windows",
+      "platform": "windows",
+      "unique_identifier": "GIMP 3.0.8-2",
+      "description": "GIMP is a free and open-source image editor."
+    },
+    {
       "name": "GitHub Desktop",
       "slug": "github-desktop/windows",
       "platform": "windows",

--- a/ee/maintained-apps/outputs/gimp/windows.json
+++ b/ee/maintained-apps/outputs/gimp/windows.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "3.0.8.2",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'GIMP 3.0.8-2' AND publisher = 'The GIMP Team';"
+      },
+      "installer_url": "https://download.gimp.org/gimp/v3.0/windows/gimp-3.0.8-setup-2.exe",
+      "install_script_ref": "7e5269bc",
+      "uninstall_script_ref": "79fb181d",
+      "sha256": "3e4ff5845126a026e22302ab0aeecb0a79caff495f7675e254e1da4878cd3d72",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "79fb181d": "# Fleet extracts name from installer (EXE) and saves it to PACKAGE_ID\n# variable\n$softwareName = \"GIMP\"\n\n# It is recommended to use exact software name here if possible to avoid\n# uninstalling unintended software.\n$softwareNameLike = \"GIMP 3*\"\n\n# Inno Setup installers require /VERYSILENT flag for silent uninstall\n$uninstallArgs = \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART\"\n\n$machineKey = `\n 'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'\n$machineKey32on64 = `\n 'HKLM:\\SOFTWARE\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\*'\n\n$exitCode = 0\n\ntry {\n\n[array]$uninstallKeys = Get-ChildItem `\n    -Path @($machineKey, $machineKey32on64) `\n    -ErrorAction SilentlyContinue |\n        ForEach-Object { Get-ItemProperty $_.PSPath }\n\n$foundUninstaller = $false\nforeach ($key in $uninstallKeys) {\n    if ($key.DisplayName -like $softwareNameLike) {\n        $foundUninstaller = $true\n        # Get the uninstall command. Some uninstallers do not include\n        # 'QuietUninstallString' and require a flag to run silently.\n        $uninstallCommand = if ($key.QuietUninstallString) {\n            $key.QuietUninstallString\n        } else {\n            $key.UninstallString\n        }\n\n        # The uninstall command may contain command and args, like:\n        # \"C:\\Program Files\\Software\\uninstall.exe\" /SILENT\n        # Split the command and args\n        $splitArgs = $uninstallCommand.Split('\"')\n        if ($splitArgs.Length -gt 1) {\n            if ($splitArgs.Length -eq 3) {\n                $uninstallArgs = \"$( $splitArgs[2] ) $uninstallArgs\".Trim()\n            } elseif ($splitArgs.Length -gt 3) {\n                Throw `\n                    \"Uninstall command contains multiple quoted strings. \" +\n                        \"Please update the uninstall script.`n\" +\n                        \"Uninstall command: $uninstallCommand\"\n            }\n            $uninstallCommand = $splitArgs[1]\n        }\n        Write-Host \"Uninstall command: $uninstallCommand\"\n        Write-Host \"Uninstall args: $uninstallArgs\"\n\n        $processOptions = @{\n            FilePath = $uninstallCommand\n            PassThru = $true\n            Wait = $true\n        }\n        if ($uninstallArgs -ne '') {\n            $processOptions.ArgumentList = \"$uninstallArgs\"\n        }\n\n        # Start process and track exit code\n        $process = Start-Process @processOptions\n        $exitCode = $process.ExitCode\n\n        # Prints the exit code\n        Write-Host \"Uninstall exit code: $exitCode\"\n        # Exit the loop once the software is found and uninstalled.\n        break\n    }\n}\n\nif (-not $foundUninstaller) {\n    Write-Host \"Uninstaller for '$softwareName' not found.\"\n    $exitCode = 1\n}\n\n} catch {\n    Write-Host \"Error: $_\"\n    $exitCode = 1\n}\n\nExit $exitCode\n",
+    "7e5269bc": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n# Inno Setup installer with /ALLUSERS for machine-scope installation\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"/VERYSILENT /SUPPRESSMSGBOXES /NORESTART /ALLUSERS\"\n  PassThru = $true\n  Wait = $true\n}\n\n# Start process and track exit code\n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\n# Prints the exit code\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds Windows support for GIMP version 3.0.8-2 to the maintained apps. It introduces new install and uninstall scripts, updates the app metadata, and provides integration details for Fleet's package management.

New GIMP Windows app integration:

* App metadata: Added `gimp.json` in the `winget` inputs directory, specifying package details, installer type, architecture, and default categories.
* App listing: Updated `apps.json` to include the new GIMP Windows entry with platform, slug, unique identifier, and description.

Installer and uninstaller scripts:

* Install script: Added `gimp_install.ps1` for silent, machine-scope installation using Inno Setup installer flags.
* Uninstall script: Added `gimp_uninstall.ps1` for silent removal, including logic to locate the correct uninstaller and handle edge cases.

Fleet integration and versioning:

* App version definition: Created `gimp/windows.json` output file, detailing version, installer URL, install/uninstall script references, SHA256, and Fleet query for existence.