### PR TITLE
[DO NOT MERGE] Fix non-VPP installs on 4.80.3

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3792,7 +3792,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 				if err != nil {
 					return nil, ctxerr.Wrap(r.Context, err, "fetching host vpp install by command uuid")
 				}
-				if vppInstall.RetryCount < 3 {
+				if vppInstall != nil && vppInstall.RetryCount < 3 {
 					// Requeue the app for installation
 					if err := svc.ds.RetryVPPInstall(r.Context, vppInstall); err != nil {
 						return nil, ctxerr.Wrap(r.Context, err, "retrying VPP install for host")

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -6524,3 +6524,38 @@ func TestToValidSemVer(t *testing.T) {
 		}
 	}
 }
+
+// Verify that CommandAndReportResults does not crash on a non-VPP InstallApplication command result
+func TestMDMCommandAndReportResultsNonVPPInstallApplication(t *testing.T) {
+	ctx := context.Background()
+	hostUUID := "ABC-DEF-GHI"
+	commandUUID := "UUID-1234"
+
+	ds := new(mock.Store)
+	svc := MDMAppleCheckinAndCommandService{ds: ds, logger: kitlog.NewNopLogger()}
+
+	ds.GetHostVPPInstallByCommandUUIDFunc = func(ctx context.Context, commandUUID string) (*fleet.HostVPPSoftwareInstallLite, error) {
+		return nil, nil
+	}
+	ds.GetMDMAppleCommandRequestTypeFunc = func(ctx context.Context, targetCmd string) (string, error) {
+		require.Equal(t, commandUUID, targetCmd)
+		return "InstallApplication", nil
+	}
+	ds.MaybeUpdateSetupExperienceVPPStatusFunc = func(ctx context.Context, hostUUID string, commandUUID string, status fleet.SetupExperienceStatusResultStatus) (bool, error) {
+		return false, nil
+	}
+	ds.GetPastActivityDataForVPPAppInstallFunc = func(ctx context.Context, commandResults *mdm.CommandResults) (*fleet.User, *fleet.ActivityInstalledAppStoreApp, error) {
+		return nil, nil, newNotFoundError()
+	}
+	_, err := svc.CommandAndReportResults(&mdm.Request{Context: ctx},
+		&mdm.CommandResults{
+			Enrollment:  mdm.Enrollment{UDID: hostUUID},
+			CommandUUID: commandUUID,
+			Status:      fleet.MDMAppleStatusError,
+			ErrorChain: []mdm.ErrorChain{
+				{ErrorCode: apple_mdm.VPPLicenseNotFound, ErrorDomain: "testDomain", USEnglishDescription: "testMessage"},
+			},
+		},
+	)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40388
InstallApplication commands failing with certain errors were crashing when they didn't directly originate from Fleet VPP instals(e.g. customers sending commands manually) due to a nil pointer deref. Fixing this directly against 4.80.3 as it has already been fixed in main and 4.82 I believe but exists in 4.81 and 4.80. I don't know how to repro this non-synthetically, however the test with the fix commented out crashes

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)