### PR TITLE
Avoid panics on VPP install command errors when command not initiated by Fleet VPP install -> 4.81.0

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3787,7 +3787,7 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 				if err != nil {
 					return nil, ctxerr.Wrap(r.Context, err, "fetching host vpp install by command uuid")
 				}
-				if vppInstall.RetryCount < 3 {
+				if vppInstall != nil && vppInstall.RetryCount < 3 {
 					// Requeue the app for installation
 					if err := svc.ds.RetryVPPInstall(r.Context, vppInstall); err != nil {
 						return nil, ctxerr.Wrap(r.Context, err, "retrying VPP install for host")


### PR DESCRIPTION
Pointing work from #40386 at 4.81.0. Resolves #40388 on 4.81.x (fix is implemented slightly differently in 4.82+).