### PR TITLE
Website: remove broken image on GitOps page

### DIFF
--- a/website/views/pages/fleet-gitops.ejs
+++ b/website/views/pages/fleet-gitops.ejs
@@ -119,11 +119,6 @@
           <p>Iterate more quickly by reducing friction and hand-offs. Instead of ticket queues, easily propose changes with natural language.* Use any LLM — even airgapped — and easily integrate tools like <a href="https://kilo.ai" target="_blank">Kilocode</a> that work with Slack and Microsoft Teams.</p>
           <p purpose="footnote"><em>* Use any LLM, even airgapped, and easily integrate tools like Kilocode that work with Slack and Microsoft Teams.</em></p>
         </div>
-        <div purpose="feature">
-          <div purpose="image-container">
-            <img alt="Kilocode screenshot showing a natural-language device management change proposed in a chat interface, reviewed and merged via GitOps" src="/images/kilocode-screenshot-gitops-760x560@2x.png">
-          </div>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
Changes:
- Removed an `<img>` tag that references an image that does not exist on the /fleet-gitops page