### PR TITLE
Fix end user auth form: allow saving cleared IdP settings

### DIFF
--- a/changes/fix-end-user-auth-clear-form
+++ b/changes/fix-end-user-auth-clear-form
@@ -1,0 +1,1 @@
+* Fixed end user authentication form to allow saving cleared IdP settings.

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tests.tsx
@@ -1,0 +1,128 @@
+import React, { MutableRefObject } from "react";
+import { noop } from "lodash";
+import { screen } from "@testing-library/react";
+
+import { createMockConfig } from "__mocks__/configMock";
+import { createCustomRenderer } from "test/test-utils";
+
+import EndUserAuthSection, {
+  IEndUserAuthSectionProps,
+} from "./EndUserAuthSection";
+import { IFormDataIdp } from "./helpers";
+
+const EMPTY_FORM_DATA: IFormDataIdp = {
+  idp_name: "",
+  entity_id: "",
+  metadata_url: "",
+  metadata: "",
+};
+
+const FILLED_FORM_DATA: IFormDataIdp = {
+  idp_name: "Okta",
+  entity_id: "https://fleet.example.com",
+  metadata_url: "https://idp.example.com/metadata",
+  metadata: "",
+};
+
+const createTestRenderer = () => {
+  return createCustomRenderer({
+    context: {
+      app: {
+        isPremiumTier: true,
+        config: createMockConfig(),
+      },
+      notification: {
+        renderFlash: jest.fn(),
+      },
+    },
+  });
+};
+
+const renderEndUserAuthSection = (
+  overrides?: Partial<IEndUserAuthSectionProps>
+) => {
+  const defaultProps: IEndUserAuthSectionProps = {
+    setDirty: jest.fn(),
+    formData: FILLED_FORM_DATA,
+    setFormData: jest.fn(),
+    originalFormData: {
+      current: FILLED_FORM_DATA,
+    } as MutableRefObject<IFormDataIdp>,
+    onSubmit: noop,
+    ...overrides,
+  };
+
+  const render = createTestRenderer();
+  return render(<EndUserAuthSection {...defaultProps} />);
+};
+
+describe("EndUserAuthSection", () => {
+  it("enables Save when all fields are cleared but original data had values", () => {
+    renderEndUserAuthSection({
+      formData: EMPTY_FORM_DATA,
+      originalFormData: {
+        current: FILLED_FORM_DATA,
+      } as MutableRefObject<IFormDataIdp>,
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("disables Save when form starts empty and remains empty", () => {
+    renderEndUserAuthSection({
+      formData: EMPTY_FORM_DATA,
+      originalFormData: {
+        current: EMPTY_FORM_DATA,
+      } as MutableRefObject<IFormDataIdp>,
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("enables Save when all required fields are filled with valid data", () => {
+    renderEndUserAuthSection({
+      formData: FILLED_FORM_DATA,
+      originalFormData: {
+        current: FILLED_FORM_DATA,
+      } as MutableRefObject<IFormDataIdp>,
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("disables Save when required fields are partially filled", () => {
+    renderEndUserAuthSection({
+      formData: {
+        idp_name: "Okta",
+        entity_id: "",
+        metadata_url: "",
+        metadata: "",
+      },
+      originalFormData: {
+        current: FILLED_FORM_DATA,
+      } as MutableRefObject<IFormDataIdp>,
+    });
+
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("clears form errors when user clears all fields", async () => {
+    const setFormData = jest.fn();
+    const { user } = renderEndUserAuthSection({
+      formData: FILLED_FORM_DATA,
+      setFormData,
+      originalFormData: {
+        current: FILLED_FORM_DATA,
+      } as MutableRefObject<IFormDataIdp>,
+    });
+
+    // Clear the Identity provider name field
+    const idpNameInput = screen.getByLabelText("Identity provider name");
+    await user.clear(idpNameInput);
+
+    // setFormData should have been called with idp_name cleared
+    expect(setFormData).toHaveBeenCalledWith(
+      expect.objectContaining({ idp_name: "" })
+    );
+  });
+});

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/EndUserAuthSection.tsx
@@ -21,6 +21,7 @@ import PremiumFeatureMessage from "components/PremiumFeatureMessage";
 import {
   IFormDataIdp,
   IFormErrorsIdp,
+  isEmptyFormData,
   isMissingAnyRequiredField,
   validateFormDataIdp,
 } from "./helpers";
@@ -50,10 +51,11 @@ const EndUserAuthSection = ({
   const { renderFlash } = useContext(NotificationContext);
   const [formErrors, setFormErrors] = useState<IFormErrorsIdp | null>(null);
 
+  const isFormCleared =
+    isEmptyFormData(formData) && !isEmptyFormData(originalFormData.current);
+
   const enableSaveButton =
-    // TODO: it seems like we should allow saving an empty form so that the user can clear their IdP info
-    // isEmptyFormData(formData) ||
-    !isMissingAnyRequiredField(formData) && !formErrors;
+    isFormCleared || (!isMissingAnyRequiredField(formData) && !formErrors);
 
   const onInputChange = useCallback(
     ({ name, value }: { name: keyof IFormDataIdp; value: string }) => {

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.tests.ts
@@ -1,11 +1,45 @@
 import { IEndUserAuthentication } from "interfaces/config";
 import {
+  isEmptyFormData,
   isMissingAnyRequiredField,
   newFormDataIdp,
   validateFormDataIdp,
 } from "./helpers";
 
 describe("IdPSection helpers", () => {
+  describe("isEmptyFormData", () => {
+    it("returns true when all fields are empty", () => {
+      expect(
+        isEmptyFormData({
+          entity_id: "",
+          idp_name: "",
+          metadata: "",
+          metadata_url: "",
+        })
+      ).toBe(true);
+    });
+
+    it("returns false when any field is non-empty", () => {
+      expect(
+        isEmptyFormData({
+          entity_id: "entityId",
+          idp_name: "",
+          metadata: "",
+          metadata_url: "",
+        })
+      ).toBe(false);
+
+      expect(
+        isEmptyFormData({
+          entity_id: "",
+          idp_name: "idpName",
+          metadata: "",
+          metadata_url: "",
+        })
+      ).toBe(false);
+    });
+  });
+
   describe("isMissingAnyRequiredField", () => {
     it("returns true if missing any required field", () => {
       expect(
@@ -82,12 +116,7 @@ describe("IdPSection helpers", () => {
           metadata: "",
           metadata_url: "",
         })
-      ).toEqual({
-        entity_id: "Entity ID must be present.",
-        idp_name: "Identity provider name must be present.",
-        metadata: "Metadata or Metadata URL must be present.",
-        metadata_url: "Metadata or Metadata URL must be present.",
-      }); // all fields missing
+      ).toEqual(null); // all fields empty is valid (allows clearing settings)
 
       expect(
         validateFormDataIdp({

--- a/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/IdentityProviders/components/EndUserAuthSection/helpers.ts
@@ -20,11 +20,11 @@ export const newFormDataIdp = (
   };
 };
 
-// export const isEmptyFormData = (data: IFormDataIdp) => {
-//   return (
-//     !data.idp_name && !data.entity_id && !data.metadata && !data.metadata_url
-//   );
-// };
+export const isEmptyFormData = (data: IFormDataIdp) => {
+  return (
+    !data.idp_name && !data.entity_id && !data.metadata && !data.metadata_url
+  );
+};
 
 export const isMissingAnyRequiredField = (data: IFormDataIdp) => {
   return (
@@ -83,12 +83,9 @@ export const validateFormDataIdp = (
   data: IFormDataIdp
 ): IFormErrorsIdp | null => {
   let formErrors: IFormErrorsIdp | null = null;
-  // if (isEmptyFormData(data)) {
-  //   // TODO: confirm whether we want to allow user to save an empty form or if should be treated
-  //   // as a form error (what happens is they have enabled end user auth for the team (which located in another
-  //   // part of the UI) and then try to delete the idp settings here?)
-  //   return formErrors;
-  // }
+  if (isEmptyFormData(data)) {
+    return formErrors;
+  }
   Object.entries(validators).forEach(([k, v]) => {
     const err = v(data);
     if (err) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32835

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- Verify that settings can only be cleared if some settings were stored previously (at least one of the form fields were filled).

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/522ec6e3-1826-459e-9649-314c4d5f7190

