### PR TITLE
Website: fix search on blog category page

### DIFF
--- a/website/assets/js/pages/articles/articles.page.js
+++ b/website/assets/js/pages/articles/articles.page.js
@@ -58,7 +58,7 @@ parasails.registerPage('articles', {
   },
 
   mounted: async function() {
-    if(['Articles', 'News', 'Guides', 'Releases'].includes(this.articleCategory)) {
+    if(['Blog', 'News', 'Guides', 'Releases'].includes(this.articleCategory)) {
       if(this.algoliaPublicKey) {// Note: Docsearch will only be enabled if sails.config.custom.algoliaPublicKey is set. If the value is undefined, the handbook search will be disabled.
         docsearch({
           appId: 'NZXAYZXDGH',


### PR DESCRIPTION
Changes:
- Updated the article categories that DocSearch is enabled on.