### PR TITLE
Fleet UI: Back handles team id 0 (#40437)

### DIFF
--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -142,7 +142,7 @@ export default {
     return `${URL_PREFIX}/hosts/manage/labels/${labelId}`;
   },
   HOST_DETAILS: (id: number, teamId?: number): string => {
-    if (teamId) {
+    if (typeof teamId === "number") {
       return `${URL_PREFIX}/hosts/${id}/details?fleet_id=${teamId}`;
     }
     return `${URL_PREFIX}/hosts/${id}/details`;


### PR DESCRIPTION
## Issue
Followup for #33519 

## Description
This was merged into `main` with #40437 
This is for the 4.82 RC

```
 1224  git fetch fleetdm
 1225  git checkout fleetdm/rc-minor-fleet-v4.82.0
 1226  git branch
 1227  git checkout -b 33519-no-team-rc
 1228  git log main
 1229  git cherry-pick 8eb91600e3f7e670d8d6ebc644df17cdd6706116
 1230  git push -u fleetdm 33519-no-team-rc
```