### PR TITLE
Per policy bypass is experimental

### DIFF
--- a/articles/okta-conditional-access-integration.md
+++ b/articles/okta-conditional-access-integration.md
@@ -157,6 +157,8 @@ This feature is enabled by default, but can be disabled by checking the **Disabl
 
 ### Per-policy bypass
 
+> **Experimental feature.** The per-policy bypass setting is experimental, and will be replaced with a reference to the policy's `critical` setting in Fleet 4.83.0. To ensure a seamless upgrade, please avoid enabling bypass for policies marked critical.
+
 By default, all conditional access policies allow bypassing. You can control which policies allow bypass individually in **Manage automations** > **Conditional access**. Each policy with conditional access enabled has an additional checkbox to allow or disallow bypass.
 
 If a host is failing multiple conditional access policies, the bypass option is only available if **every** failing policy allows bypass. If any one of the failing policies does not allow bypass, the end user will not see the option to bypass and must resolve the issue to regain access.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -141,7 +141,6 @@ policies:
     critical: false
     calendar_events_enabled: false
     conditional_access_enabled: true
-    conditional_access_bypass_enabled: true
     labels_include_any:
       - Engineering
       - Customer Support

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -8437,7 +8437,9 @@ Only one of `labels_include_any` or `labels_exclude_any` can be specified. If ne
 
 _Available in Fleet Premium_
 
-> **Experimental feature**. Software related features (like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
+> **Experimental features.** 
+> + The `conditional_access_bypass_enabled` setting is experimental, and will be replaced with a reference to the policy's `critical` setting in Fleet 4.83.0. To ensure a seamless upgrade, please avoid enabling bypass for policies marked `critical`.
+> + Software related features (like install software policy automation) are undergoing rapid improvement, which may result in breaking changes to the API or configuration surface. It is not recommended for use in automated workflows.
 
 `PATCH /api/v1/fleet/teams/:team_id/policies/:policy_id`
 


### PR DESCRIPTION
Add notes to docs/guide explaining that the `conditional_access_bypass_enabled` flag is experimental in 4.82, and will be replaced with `critical` in 4.83.