### PR TITLE
Batch select query in CleanupExcessQueryResultRows

### DIFF
--- a/changes/40476-fix-query-results-cleanup-placeholder-limit
+++ b/changes/40476-fix-query-results-cleanup-placeholder-limit
@@ -1,0 +1,1 @@
+* Fixed query results cleanup cron failing with "too many placeholders" error by filtering to only saved queries and batching the SQL IN clause.

--- a/changes/fix-query-results-cleanup-placeholder-limit
+++ b/changes/fix-query-results-cleanup-placeholder-limit
@@ -1,1 +1,1 @@
-* Fixed query results cleanup cron failing with "too many placeholders" error when there are a large number of queries.
+* Fixed query results cleanup cron failing with "too many placeholders" error by filtering to only saved queries and batching the SQL IN clause.

--- a/changes/fix-query-results-cleanup-placeholder-limit
+++ b/changes/fix-query-results-cleanup-placeholder-limit
@@ -1,0 +1,1 @@
+* Fixed query results cleanup cron failing with "too many placeholders" error when there are a large number of queries.

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -156,12 +156,14 @@ func (ds *Datastore) CleanupExcessQueryResultRows(ctx context.Context, maxQueryR
 		batchSize = opts[0].BatchSize
 	}
 
-	// Get all distinct query_ids that have results and are scheduled queries with discard_data = false
+	// Get all saved query IDs that could have query results to clean up.
+	// Only saved queries (scheduled reports) store rows in query_results;
+	// live queries do not, so there's nothing to clean up for them.
 	var queryIDs []uint
 	selectStmt := `
 		SELECT id
 		FROM queries
-		WHERE discard_data = false AND logging_type = 'snapshot'
+		WHERE saved = 1 AND discard_data = false AND logging_type = 'snapshot'
 	`
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &queryIDs, selectStmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "selecting query IDs for cleanup")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40476

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

Before:
- inserted 70k queries to my local DB, saw the cron failing:

```
INSERT INTO queries (name, description, query, author_id, logging_type, discard_data, saved)
  SELECT
    CONCAT('bulk_query_', seq),
    '',
    'SELECT 1',
    (SELECT id FROM users LIMIT 1),
    'snapshot',
    false,
    1
  FROM (
    SELECT a.N + b.N*10 + c.N*100 + d.N*1000 + e.N*10000 as seq
    FROM
      (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6
  UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) a,
      (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6
  UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) b,
      (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6
  UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) c,
      (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6
  UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) d,
      (SELECT 0 AS N UNION SELECT 1 UNION SELECT 2 UNION SELECT 3 UNION SELECT 4 UNION SELECT 5 UNION SELECT 6
  UNION SELECT 7 UNION SELECT 8 UNION SELECT 9) e
  ) numbers
  WHERE seq < 70000;
```

<img width="864" height="120" alt="Screenshot 2026-02-25 at 12 54 31 PM" src="https://github.com/user-attachments/assets/d1e19aa8-56aa-46a2-a437-7ae5da1e5b1e" />

- ran new test without code fix, it failed with the same error in the issue:

<img width="920" height="324" alt="Screenshot 2026-02-25 at 12 45 41 PM" src="https://github.com/user-attachments/assets/c7342d81-f223-449e-a861-c7bae58bbe9e" />

After: ran test again, it passed

<img width="1556" height="174" alt="Screenshot 2026-02-25 at 12 45 04 PM" src="https://github.com/user-attachments/assets/9eed3e6e-3ce6-4d69-aa70-9ebcfcf07623" />

