### PR TITLE
Refactor marketing README to streamline content

### DIFF
--- a/handbook/marketing/README.md
+++ b/handbook/marketing/README.md
@@ -26,88 +26,9 @@ This handbook page details processes specific to working [with](#contact-us) and
 The Marketing department is directly responsible for achieving revenue pipeline targets, increasing market awareness about Fleet, customer training curriculums, prospect enablement, and nurturing the Fleet community through participation in video, sponsored events, and other [programs](https://fleetdm.com/handbook/company/communications#programs).
 
 
-### Marketing & Enablement Assets
+### Marketing Assets
 
-| Asset | Use for | Date&nbsp;updated&nbsp;&nbsp;&nbsp; |
-| :--- | :--- | :--- |
-| [Leave Behind Deck](https://docs.google.com/presentation/d/1Wxb4IedJ0cEXJQwvKCdYf8OatXk4sG1QTkiNLB3h11E/edit) | Presentation tool for internal teams to present Fleet's value. | Feb 18, 2026 |
-| [Additional slides for pitch deck](https://docs.google.com/presentation/d/1l6eh1ow4Izi9lv-IrrYV1UjNT4VKbfk5lJHDJUgnDVM/edit) | Customizable slides for tailored prospect presentations. | Feb 18, 2026 |
-| [Sagetap Deck](https://docs.google.com/presentation/d/10DbaNaMBxeYN8PcrxE-5XNX04N_v_lKJxSxHbPjoCXc/edit) | Messaging and positioning test deck for market validation. | Feb 18, 2026 |
-| [Safe Enough to Switch](https://docs.google.com/document/d/1JsHEzUru2KKs6h7SKYEI6OjunwrRWmeUDTOtl57Shv4/edit) | Overview of Fleet’s maturity for organizations switching tools. | Sep 15, 2025 |
-| [Jamf vs. Fleet terminology](https://docs.google.com/document/d/1RKojfpUMUiITPce5O7znYmxdQR9U6f5sVnVzQpPpp8Y/edit) | Mapping concepts between Jamf and Fleet for easier migration. | Sep 09, 2025 |
-| [Gartner IT Symposium Summary](https://drive.google.com/file/d/1HK1QXA2kOCeOoOG1E0-tk7-xwBhQ2QMa/view) | Executive summary of outcomes and value achieved via GitOps. | Oct 21, 2024 |
-| [ROI Spreadsheet](https://docs.google.com/spreadsheets/d/14Cfj77ynOB6z4pmb9DD7HNRGo0kcKJuEIifgnz-YO50/edit) | Financial value justification and ROI calculator. | Aug 14, 2023 |
-| [Battle card - Workspace ONE](https://docs.google.com/document/d/1dV9zooPnCnHa0UfZqXKWAi6Zmye2jfqRIr_UnX70Sq4/edit) | Strategic insights for VMware Workspace ONE competitive scenarios. | Sep 12, 2023 |
-| [Death to Extension Attributes](https://github.com/allenhouchins/death-to-extension-attributes) | Comparing Fleet queries to Jamf EA for technical simplicity. | Jun 15, 2023 |
-| [Fleet capabilities one-pager](https://docs.google.com/document/d/15nVnn2dalLnyJgfX3o-96jvFAzZPS9vrTaNo_lYNick/edit) | High-level summary of the platform's core capabilities. | Feb 14, 2022 |
-| [Fleet for IT Product Brochure](https://docs.google.com/document/d/1d_53iYU6O-uzaXnzjlXXGwByGRmpz3VMG6kWT6hMCkU/edit) | Marketing overview for IT teams in early sales cycles. | Oct 20, 2021 |
-| [Fleet for Security Product Brochure](https://docs.google.com/document/d/18ocTpuQlwd8RwZA-KsqzEmQkAEvKvV8LngeFbkJdFj4/edit) | Marketing overview for security teams in early sales cycles. | Oct 20, 2021 |
-| [Product Roadmap](https://docs.google.com/document/d/16si8Nkh0F25opUMpZYm6XwU8LEhGd7H4eOzPKFz8jGw/edit) | Future development vision and open roadmap opportunities. | Jan 20, 2021 |
-
-### Case Studies & Success Stories
-
-| Asset | Use for | Date&nbsp;updated&nbsp;&nbsp;&nbsp; |
-| :--- | :--- | :--- |
-| [Fastly Visibility Case Study](https://fleetdm.com/case-study/fastly) | Unified endpoint and infrastructure visibility. | Jan 29, 2025 |
-| [Foursquare ROI Case Study](https://fleetdm.com/case-study/foursquare) | Proving 114% ROI and rapid MDM migration. | Dec 11, 2025 |
-| [Stripe: Scaling to 10k Macs Case Study](https://fleetdm.com/case-study/stripe) | Massive cost savings for large-scale migrations. | Dec 11, 2025 |
-| [Faire: CIS Benchmark Security Case Study](https://fleetdm.com/case-study/faire) | Securing Macs with GitOps and compliance. | Dec 11, 2025 |
-| [Interactive Entertainment Case Study](https://fleetdm.com/announcements/interactive-entertainment-company-adopts-fleet-for-mdm) | Cross-platform MDM adoption. | Dec 23, 2024 |
-| [Cloud-based Data Leader Case Study](https://fleetdm.com/announcements/cloud-based-data-leader-choosed-fleet-for-orchestration) | Scaling global orchestration. | Dec 20, 2024 |
-| [Financial Services Case Study](https://fleetdm.com/announcements/fintech-company-migrates-to-fleet) | MDM and change management for regulated finance. | Dec 19, 2024 |
-| [Deputy: Global workforce management software Case Study](https://fleetdm.com/announcements/global-workforce-management-company-achieves-compliance-and-clarity-with-fleet) | Managing shift-work devices at global scale. | Dec 17, 2024 |
-| [Global Social Media Case Study](https://fleetdm.com/announcements/global-social-media-platform-switches-to-fleet) | High-scale network migration. | Dec 16, 2024 |
-| [Electric Vehicle Manufacturer Case Study](https://fleetdm.com/announcements/vehicle-manufacturer-transitions-to-fleet-for-endpoint-security) | Improved endpoint security posture for manufacturing. | Dec 12, 2024 |
-| [Online Gaming Company Case Study](https://fleetdm.com/announcements/large-gaming-company-enhances-server-observability-with-fleet) | Server observability in high-concurrency gaming. | Dec 11, 2024 |
-| [Security and authentication platform Case Study](https://fleetdm.com/announcements/worldwide-security-and-authentication-platform-chooses-fleet-for-linux) | Scaling Linux management for security organizations. | Dec 10, 2024 |
-
-
-### Articles & Blog Posts
-
-| Asset | Use for | Date&nbsp;updated&nbsp;&nbsp;&nbsp; |
-| :--- | :--- | :--- |
-| [OpenClaw: Open for work?](https://fleetdm.com/articles/openclaw-open-for-work) | Overview of OpenClaw and security risks of AI agents. | Feb 04, 2026 |
-| [The GitOps idea](https://fleetdm.com/articles/the-gitops-idea) | Managing systems reliably via version control and code. | Feb 04, 2026 |
-| [Fleet vs. Jamf comparison](https://fleetdm.com/compare/jamf) | Side-by-side comparison of capabilities and criteria. | Jan 27, 2026 |
-| [Redefining endpoint management](https://fleetdm.com/announcements/redefining-endpoint-management-at-scale) | Analysis of Fleet in the 2026 Gartner reports. | Jan 23, 2026 |
-| [Why enterprise Linux is important](https://fleetdm.com/articles/why-enterprise-linux-is-important-in-2026) | Security strategy for modern Linux endpoints. | Jan 21, 2026 |
-| [6 business benefits of Apple MDM](https://fleetdm.com/articles/business-benefits-of-apple-mdm-explained) | Business ROI for security and IT operations. | Jan 11, 2026 |
-| [Declarative device management](https://fleetdm.com/articles/declarative-device-management-a-primer) | Introduction to modern Apple DDM protocol. | Jan 11, 2026 |
-| [iPad MDM: a complete guide](https://fleetdm.com/articles/ipad-mdm-a-complete-guide) | Deployment models and management for iPadOS. | Jan 11, 2026 |
-| [Roadmap preview, January 2026](https://fleetdm.com/announcements/roadmap-preview-january-2026) | Product vision and platform opportunities. | Jan 05, 2026 |
-| [The MDM migration reality](https://fleetdm.com/articles/the-mdm-mirgration-reality) | Insights into executing smoother MDM migrations. | Nov 26, 2025 |
-| [9to5mac: Scripting features](https://9to5mac.com/2023/10/17/fleet-releases-open-source-cross-platform-scripting-based-on-osquery/) | External coverage of Fleet's scripting. | Oct 06, 2024 |
-| [Detect Log4j with osquery](https://fleetdm.com/securing/detect-log4j-with-osquery-and-fleet) | Rapid response patterns for critical vulnerabilities. | Dec 15, 2021 |
-
-### Guides
-
-| Asset | Use for | Date&nbsp;updated&nbsp;&nbsp;&nbsp; |
-| :--- | :--- | :--- |
-| [Fleet troubleshooting for IT admins](https://fleetdm.com/guides/fleet-troubleshooting-for-it-admins) | IT troubleshooting best practices. | Feb 13, 2026 |
-| [Okta Desktop MFA for Windows](https://fleetdm.com/guides/deploying-okta-desktop-mfa-with-fleet) | Configuring Okta MFA using Fleet MDM. | Feb 06, 2026 |
-| [Migrate Fleet server to a new deployment](https://fleetdm.com/guides/migrate-fleet-server) | Steps for moving server environments. | Feb 06, 2026 |
-| [Deploy custom Android apps (APK)](https://fleetdm.com/guides/deploy-custom-android-app-apk) | Distributing APKs via Play Console and Fleet. | Feb 04, 2026 |
-| [Set hostname via Fleet API](https://fleetdm.com/guides/set-device-hostname-via-fleet-api) | API-driven hostname management for Apple. | Jan 26, 2026 |
-| [Manage bootstrap packages with GitOps](https://fleetdm.com/guides/manage-boostrap-package-with-gitops) | Automated setup for new enrollments via code. | Jan 12, 2026 |
-| [Deploy Fleet with Docker Compose](https://fleetdm.com/guides/deploy-fleet-on-docker-compose) | Quick container-based Fleet deployment. | Dec 01, 2025 |
-| [Software self-service](https://fleetdm.com/guides/software-self-service) | Building an app store portal for end users. | Jun 20, 2025 |
-| [MITRE ATT&CK library](https://github.com/teoseller/osquery-attck/blob/master/README.md) | Mapping security results to MITRE. | Jan 30, 2023 |
-| [How to install osquery and enroll macOS devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-macos-devices-into-fleet) | Enrollment for macOS | Jan 13, 2022 |
-| [How to install osquery and enroll Linux devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-linux-devices-into-fleet) | Enrollment for Linux | Jan 13, 2022 |
-| [How to install osquery and enroll Windows devices into Fleet](https://fleetdm.com/guides/how-to-install-osquery-and-enroll-windows-devices-into-fleet) | Enrollment for windows | Jan 13, 2022 |
-
-
-### Release Notes
-
-| Asset | Use for | Date&nbsp;updated&nbsp;&nbsp;&nbsp; |
-| :--- | :--- | :--- |
-| [Fleet 4.80.0 Release](https://fleetdm.com/releases/fleet-4-80-0) | App updates and offboarding improvements. | Feb 02, 2026 |
-| [Fleet 4.79.0 Release](https://fleetdm.com/releases/fleet-4-79-0) | macOS updates and MDM history. | Jan 14, 2026 |
-| [Fleet 4.78.0 Release](https://fleetdm.com/releases/fleet-4-78-0) | iOS/Android self-service and cert deployment. | Dec 19, 2025 |
-| [Fleet 4.77.0 Release](https://fleetdm.com/releases/fleet-4-77-0) | Enterprise packages for mobile devices. | Dec 04, 2025 |
-| [Fleet 4.75.0 Release](https://fleetdm.com/releases/fleet-4-75-0) | Omarchy Linux and Android profiles. | Oct 17, 2025 |
-| [Fleet 4.65.0 Release](https://fleetdm.com/releases/fleet-4-65-0) | GitOps mode and automatic installation. | Mar 14, 2025 |
-| [Fleet 4.60.0 Release](https://fleetdm.com/releases/fleet-4-60-0) | Escrow Linux disk encryption keys. | Nov 27, 2024 |
+The complete list of all marketing assets is listed on [this handbook page](https://fleetdm.com/handbook/marketing/marketing-assets.dm).
 
 ### Press boilerplate text
 


### PR DESCRIPTION
Moved sections on marketing enablement assets, case studies, articles, and guides to its own handbook page under marketing
