### PR TITLE
Followup for enforcing manual agent install restrictions in gitops

### DIFF
--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3499,15 +3499,7 @@ team_settings:
 			testing_utils.StartAndServeVPPServer(t)
 
 			// Don't attempt dry runs because they would not actually create the team, so the config would not be found
-
 			_, err = fleetctl.RunAppNoChecks([]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "-f", teamFileName})
-
-			mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
-				mysql.DumpTable(t, q, "app_config_json")
-				mysql.DumpTable(t, q, "default_team_config_json")
-				mysql.DumpTable(t, q, "teams")
-				return nil
-			})
 
 			if tc.errContains != nil {
 				require.ErrorContains(t, err, *tc.errContains)

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2221,7 +2221,6 @@ func (svc *Service) softwareBatchUpload(
 	var manualAgentInstall bool
 	tmID := ptr.ValOrZero(teamID)
 	if tmID == 0 {
-		// use app config if team id null or 0
 		ac, err := svc.ds.AppConfig(ctx)
 		if err != nil {
 			batchErr = fmt.Errorf("Couldn't get app config: %w", err)
@@ -2236,8 +2235,6 @@ func (svc *Service) softwareBatchUpload(
 		}
 		manualAgentInstall = team.Config.MDM.MacOSSetup.ManualAgentInstall.Value
 	}
-
-	// Current problem: TeamLite pulls the config from default_team_config_json, but app_config_json is the one that is set correctly
 
 	var g errgroup.Group
 	g.SetLimit(1) // TODO: consider whether we can increase this limit, see https://github.com/fleetdm/fleet/issues/22704#issuecomment-2397407837

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2218,13 +2218,26 @@ func (svc *Service) softwareBatchUpload(
 		return resp, tfr, nil
 	}
 
+	var manualAgentInstall bool
 	tmID := ptr.ValOrZero(teamID)
-	team, err := svc.ds.TeamLite(ctx, tmID)
-	if err != nil {
-		batchErr = fmt.Errorf("Couldn't get team for team ID %d: %w", tmID, err)
-		return
+	if tmID == 0 {
+		// use app config if team id null or 0
+		ac, err := svc.ds.AppConfig(ctx)
+		if err != nil {
+			batchErr = fmt.Errorf("Couldn't get app config: %w", err)
+			return
+		}
+		manualAgentInstall = ac.MDM.MacOSSetup.ManualAgentInstall.Value
+	} else {
+		team, err := svc.ds.TeamLite(ctx, tmID)
+		if err != nil {
+			batchErr = fmt.Errorf("Couldn't get team for team ID %d: %w", tmID, err)
+			return
+		}
+		manualAgentInstall = team.Config.MDM.MacOSSetup.ManualAgentInstall.Value
 	}
-	manualAgentInstall := team.Config.MDM.MacOSSetup.ManualAgentInstall.Value
+
+	// Current problem: TeamLite pulls the config from default_team_config_json, but app_config_json is the one that is set correctly
 
 	var g errgroup.Group
 	g.SetLimit(1) // TODO: consider whether we can increase this limit, see https://github.com/fleetdm/fleet/issues/22704#issuecomment-2397407837


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40412 

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

- Individually or together setting vpp, software installers, or fleet maintained apps will send the correct error now when applied to no team with manual_agent_install enabled.