### PR TITLE
Fleet UI: Add 10 per page to install software setup

### DIFF
--- a/frontend/__mocks__/operatingSystemsMock.ts
+++ b/frontend/__mocks__/operatingSystemsMock.ts
@@ -47,23 +47,24 @@ const DEFAULT_LINUX_OS_VERSION: IOperatingSystemVersion = {
   generated_cpes: [],
   kernels: [
     {
-      id: 561703, // the software version ID of the kernel
+      id: 561703,
       version: "6.11.0-26.26~24.04.1",
+      // 14 total, some repeated
       vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
+        "CVE-2023-53034", // repeat
+        "CVE-2024-53222", // repeat
+        "CVE-2024-58092", // repeat
+        "CVE-2024-58093", // repeat
         "CVE-2025-21893",
         "CVE-2025-21894",
-        "CVE-2025-21902",
+        "CVE-2025-21902", // repeat
         "CVE-2025-21903",
         "CVE-2025-21904",
         "CVE-2025-21905",
         "CVE-2025-21906",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
+        "CVE-2025-21908", // repeat
+        "CVE-2025-21909", // repeat
+        "CVE-2025-21910", // repeat
       ],
       hosts_count: 1,
     },
@@ -74,283 +75,21 @@ const DEFAULT_LINUX_OS_VERSION: IOperatingSystemVersion = {
       hosts_count: 2,
     },
     {
-      id: 561709, // the software version ID of the kernel
+      id: 561709,
       version: "6.11.0-27.26~24.04.1",
+      // purposefully create some repeats
       vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21893",
-        "CVE-2025-21894",
-        "CVE-2025-21902",
-        "CVE-2025-21910",
+        "CVE-2023-53034", // repeat
+        "CVE-2024-53222", // repeat
+        "CVE-2024-58092", // repeat
+        "CVE-2024-58093", // repeat
+        "CVE-2025-21902", // repeat
+        "CVE-2025-21908", // repeat
+        "CVE-2025-21909", // repeat
+        "CVE-2025-21910", // repeat
+        "CVE-2025-21911",
       ],
       hosts_count: 1,
-    },
-    {
-      id: 561703, // the software version ID of the kernel
-      version: "6.11.0-25.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2025-21902",
-        "CVE-2025-21903",
-        "CVE-2025-21904",
-        "CVE-2025-21905",
-        "CVE-2025-21906",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 1,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-24.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 2,
-    },
-    {
-      id: 561703, // the software version ID of the kernel
-      version: "6.11.0-23.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21903",
-        "CVE-2025-21904",
-        "CVE-2025-21905",
-        "CVE-2025-21906",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 1,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 3,
-    },
-    {
-      id: 56173, // the software version ID of the kernel
-      version: "6.11.0-21.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21893",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 7,
-    },
-    {
-      id: 58096,
-      version: "6.11.0-22.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 20,
-    },
-    {
-      id: 61703, // the software version ID of the kernel
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2025-21910"],
-      hosts_count: 1,
-    },
-    {
-      id: 56806,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 10,
-    },
-    {
-      id: 56096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 2,
-    },
-    {
-      id: 56273,
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2023-53034", "CVE-2024-53222"],
-      hosts_count: 17,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-24.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 2,
-    },
-    {
-      id: 561703, // the software version ID of the kernel
-      version: "6.11.0-23.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21903",
-        "CVE-2025-21904",
-        "CVE-2025-21905",
-        "CVE-2025-21906",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 1,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 3,
-    },
-    {
-      id: 56173, // the software version ID of the kernel
-      version: "6.11.0-21.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21893",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 7,
-    },
-    {
-      id: 58096,
-      version: "6.11.0-22.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 20,
-    },
-    {
-      id: 61703, // the software version ID of the kernel
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2025-21910"],
-      hosts_count: 1,
-    },
-    {
-      id: 56806,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 10,
-    },
-    {
-      id: 56096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 2,
-    },
-    {
-      id: 56273,
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2023-53034", "CVE-2024-53222"],
-      hosts_count: 17,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-24.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 2,
-    },
-    {
-      id: 561703, // the software version ID of the kernel
-      version: "6.11.0-23.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21903",
-        "CVE-2025-21904",
-        "CVE-2025-21905",
-        "CVE-2025-21906",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 1,
-    },
-    {
-      id: 5686096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 3,
-    },
-    {
-      id: 57173, // the software version ID of the kernel
-      version: "6.11.0-21.26~24.04.1",
-      vulnerabilities: [
-        "CVE-2023-53034",
-        "CVE-2024-53222",
-        "CVE-2024-58092",
-        "CVE-2024-58093",
-        "CVE-2025-21893",
-        "CVE-2025-21908",
-        "CVE-2025-21909",
-        "CVE-2025-21910",
-      ],
-      hosts_count: 71,
-    },
-    {
-      id: 518096,
-      version: "6.11.0-22.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 20,
-    },
-    {
-      id: 612703, // the software version ID of the kernel
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2025-21910"],
-      hosts_count: 1,
-    },
-    {
-      id: 564806,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 1,
-    },
-    {
-      id: 560396,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 5,
-    },
-    {
-      id: 565273,
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2023-53034", "CVE-2024-53222"],
-      hosts_count: 37,
-    },
-    {
-      id: 568906,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 3,
-    },
-    {
-      id: 506096,
-      version: "6.11.0-29.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 12,
-    },
-    {
-      id: 516273,
-      version: "6.11.0-26.26~24.04.1",
-      vulnerabilities: ["CVE-2023-53034", "CVE-2024-53222"],
-      hosts_count: 117,
-    },
-    {
-      id: 568096,
-      version: "6.11.0-24.29~24.04.1",
-      vulnerabilities: null,
-      hosts_count: 22,
     },
   ],
   vulnerabilities: [
@@ -358,12 +97,12 @@ const DEFAULT_LINUX_OS_VERSION: IOperatingSystemVersion = {
       cve: "CVE-2023-53034",
       details_link: "https://nvd.nist.gov/vuln/detail/CVE-2023-53034",
       created_at: "2023-07-01T00:15:00Z",
-      cvss_score: 7.8, // Available in Fleet Premium
-      epss_probability: 0.9729, // Available in Fleet Premium
-      cisa_known_exploit: false, // Available in Fleet Premium
-      cve_published: "2023-06-01T00:15:00Z", // Available in Fleet Premium
-      cve_description: "A description", // Available in Fleet Premium
-      resolved_in_version: "", // Available in Fleet Premium
+      cvss_score: 7.8,
+      epss_probability: 0.9729,
+      cisa_known_exploit: false,
+      cve_published: "2023-06-01T00:15:00Z",
+      cve_description: "A description",
+      resolved_in_version: "",
     },
   ],
 };

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -67,7 +67,7 @@ interface IDataTableProps {
   searchQuery?: string;
   searchQueryColumn?: string;
   selectedDropdownFilter?: string;
-  /** Set to true to persist the row selections across table data filters */
+  /** Set to true to persist row selection across client-side filters and pagination */
   persistSelectedRows?: boolean;
   /** Set to `true` to not display the footer section of the table */
   hideFooter?: boolean;
@@ -180,7 +180,7 @@ const DataTable = ({
     {
       columns,
       data,
-      // Use stable row IDs when available (`row.id`), otherwise fall back to the default index-based IDs provided by react-table
+      // Use a stable row ID when available (row.id), otherwise fall back to the index-based ID (default of react-table)
       getRowId: (row: any, index: number) =>
         row && row.id != null ? String(row.id) : String(index),
       initialState: {

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -180,6 +180,9 @@ const DataTable = ({
     {
       columns,
       data,
+      // Use stable row IDs when available (`row.id`), otherwise fall back to the default index-based IDs provided by react-table
+      getRowId: (row: any, index: number) =>
+        row && row.id != null ? String(row.id) : String(index),
       initialState: {
         sortBy: initialSortBy,
         pageIndex: defaultPageIndex,
@@ -695,13 +698,13 @@ const DataTable = ({
               disablePrev={!canPreviousPage}
               disableNext={!canNextPage}
               onPrevPage={() => {
-                toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
+                !persistSelectedRows && toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
                 onClientSidePaginationChange
                   ? onClientSidePaginationChange(pageIndex - 1)
                   : previousPage();
               }}
               onNextPage={() => {
-                toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
+                !persistSelectedRows && toggleAllRowsSelected(false); // Resets row selection on pagination (client-side)
                 onClientSidePaginationChange
                   ? onClientSidePaginationChange(pageIndex + 1)
                   : nextPage();

--- a/frontend/components/TableContainer/DataTable/DataTable.tsx
+++ b/frontend/components/TableContainer/DataTable/DataTable.tsx
@@ -200,8 +200,8 @@ const DataTable = ({
       disableSortRemove: true,
       manualSortBy,
       autoResetPage,
-      // Resets row selection on (server-side) pagination
-      autoResetSelectedRows: true,
+      // Resets row selection on pagination
+      autoResetSelectedRows: !persistSelectedRows,
       // Expands the enumerated `filterTypes` for react-table
       // (see https://github.com/TanStack/react-table/blob/alpha/packages/react-table/src/filterTypes.ts)
       // with custom `filterTypes` defined for this `useTable` instance

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -117,7 +117,7 @@ interface ITableContainerProps<T = any> {
   renderTableHelpText?: () => JSX.Element | null;
   setExportRows?: (rows: Row[]) => void;
   disableTableHeader?: boolean;
-  /** Set to true to persist the row selections across table data filters */
+  /** Set to true to persist the row selections across table data filters (e.g. clientside pagination) */
   persistSelectedRows?: boolean;
   /** Set to `true` to not display the footer section of the table */
   hideFooter?: boolean;

--- a/frontend/components/TableContainer/TableContainer.tsx
+++ b/frontend/components/TableContainer/TableContainer.tsx
@@ -117,7 +117,7 @@ interface ITableContainerProps<T = any> {
   renderTableHelpText?: () => JSX.Element | null;
   setExportRows?: (rows: Row[]) => void;
   disableTableHeader?: boolean;
-  /** Set to true to persist the row selections across table data filters (e.g. clientside pagination) */
+  /** Set to true to persist row selection across client-side filters and pagination */
   persistSelectedRows?: boolean;
   /** Set to `true` to not display the footer section of the table */
   hideFooter?: boolean;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareTable/InstallSoftwareTable.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareTable/InstallSoftwareTable.tsx
@@ -19,7 +19,7 @@ const generateSelectedRows = (softwareTitles: ISoftwareTitle[]) => {
       software.app_store_app?.install_during_setup
     ) {
       if (software.id != null) {
-        acc[String(software.id)] = true; // matches getRowId fallback
+        acc[String(software.id)] = true; // key must match DataTable getRowId(row) for selection to persist
       }
     }
     return acc;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareTable/InstallSoftwareTable.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareTable/InstallSoftwareTable.tsx
@@ -8,15 +8,19 @@ import EmptyTable from "components/EmptyTable";
 
 import generateTableConfig from "./InstallSoftwareTableConfig";
 
+const DEFAULT_PAGE_SIZE = 10;
+
 const baseClass = "select-software-table";
 
 const generateSelectedRows = (softwareTitles: ISoftwareTitle[]) => {
-  return softwareTitles.reduce<Record<string, boolean>>((acc, software, i) => {
+  return softwareTitles.reduce<Record<string, boolean>>((acc, software) => {
     if (
       software.software_package?.install_during_setup ||
       software.app_store_app?.install_during_setup
     ) {
-      acc[i] = true;
+      if (software.id != null) {
+        acc[String(software.id)] = true; // matches getRowId fallback
+      }
     }
     return acc;
   }, {});
@@ -66,8 +70,9 @@ const InstallSoftwareTable = ({
       defaultSelectedRows={initialSelectedSoftwareRows}
       showMarkAllPages
       isAllPagesSelected={false}
-      persistSelectedRows
-      disablePagination
+      persistSelectedRows // Keeps selected rows across pagination (client-side)
+      isClientSidePagination
+      pageSize={DEFAULT_PAGE_SIZE}
       searchable
       searchQueryColumn="name"
       isClientSideFilter

--- a/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareOSDetailsPage/SoftwareOSDetailsPage.tests.tsx
@@ -87,10 +87,11 @@ describe("KernelsCard", () => {
     );
 
     expect(screen.getByText("Kernels")).toBeInTheDocument();
-    expect(screen.getByText("35 items")).toBeInTheDocument();
+    expect(screen.getByText("3 items")).toBeInTheDocument();
     expect(screen.getAllByText("6.11.0-26.26~24.04.1").length).toBeGreaterThan(
       0
     );
+
     expect(screen.getByText("14 vulnerabilities")).toBeInTheDocument();
   });
 

--- a/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/SelfService.tests.tsx
@@ -53,9 +53,9 @@ describe("SelfService", () => {
     mockServer.use(
       customDeviceSoftwareHandler({
         software: [
-          createMockDeviceSoftware({ name: "test1" }),
-          createMockDeviceSoftware({ name: "test2" }),
-          createMockDeviceSoftware({ name: "test3" }),
+          createMockDeviceSoftware({ id: 1, name: "test1" }),
+          createMockDeviceSoftware({ id: 2, name: "test2" }),
+          createMockDeviceSoftware({ id: 3, name: "test3" }),
         ],
         count: 3,
       })

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tests.tsx
@@ -65,6 +65,7 @@ describe("EditLabelPage", () => {
     mockServer.use(
       getLabelHostsHandler([
         {
+          id: 1,
           hostname: "hosty numero uno",
           display_name: "Test host #1",
           team_id: 2,
@@ -74,6 +75,7 @@ describe("EditLabelPage", () => {
           hardware_serial: "test-serial-1",
         },
         {
+          id: 2,
           hostname: "hosty numero dos",
           display_name: "Test host #2",
           team_id: 2,


### PR DESCRIPTION
## Issue
Followup for #37828 

## Description
- Design update to add pagination to design of 4.82 feature
- 10 per page
- Checked items persist across pages

## Screen recording of pagination

https://github.com/user-attachments/assets/93acd586-5878-446d-b0f4-9ea6153ba6d1

Selections persists with filters and pagination
https://github.com/user-attachments/assets/7168cf62-0eef-4d16-b066-e3e5e05e8765


## Testing

- [x] QA'd all new/changed functionality manually
