### PR TITLE
Decrease last opened time diff

### DIFF
--- a/changes/32026-last-opened-time
+++ b/changes/32026-last-opened-time
@@ -1,0 +1,1 @@
+- updated default last opened time diff to 2m to increase the chances of updating the last opened time for software that is opened frequently

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -3351,8 +3351,8 @@ func main() {
 		// This flag can be used to set the number of vulnerable software items reported by each host picked randomly from the
 		// list of vulnerable software.  Use -1 to load all vulnerable software.
 		vulnerableSoftwareCount     = flag.Int("vulnerable_software_count", 10, "Number of vulnerable installed applications reported to fleet.  Use -1 to load all vulnerable software.")
-		withLastOpenedSoftwareCount = flag.Int("with_last_opened_software_count", 10, "Number of applications that may report a last opened timestamp to fleet")
-		lastOpenedChangeProb        = flag.Float64("last_opened_change_prob", 0.1, "Probability of last opened timestamp to be reported as changed [0, 1]")
+		withLastOpenedSoftwareCount = flag.Int("with_last_opened_software_count", 50, "Number of applications that may report a last opened timestamp to fleet")
+		lastOpenedChangeProb        = flag.Float64("last_opened_change_prob", 0.5, "Probability of last opened timestamp to be reported as changed [0, 1]")
 		commonUserCount             = flag.Int("common_user_count", 10, "Number of common host users reported to fleet")
 		uniqueUserCount             = flag.Int("unique_user_count", 10, "Number of unique host users reported to fleet")
 		policyPassProb              = flag.Float64("policy_pass_prob", 1.0, "Probability of policies to pass [0, 1]")

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -373,8 +373,12 @@ type agent struct {
 	// Cached software indices (pointers into global softwareDB array for this agent's platform)
 	cachedSoftwareIndices []uint32
 
-	// Cached last_opened_at timestamps per software (keyed by software name)
-	cachedLastOpenedAt map[string]*time.Time
+	// Cached last_opened_at timestamps per software (keyed by software name).
+	// Note that this requires a mutex because both the runLoop and the live
+	// query goroutines may call DistributedWrite (which calls processQuery
+	// which calls genLastOpenedAt).
+	cachedLastOpenedAtMutex sync.RWMutex
+	cachedLastOpenedAt      map[string]*time.Time
 
 	// Host identity client for HTTP message signatures
 	hostIdentityClient *hostidentity.Client
@@ -2134,6 +2138,9 @@ var defaultQueryResult = []map[string]string{
 // value, occasionally updating it based on lastOpenedProb to simulate the app
 // being reopened.
 func (a *agent) genLastOpenedAt(softwareName string) *time.Time {
+	a.cachedLastOpenedAtMutex.Lock()
+	defer a.cachedLastOpenedAtMutex.Unlock()
+
 	// Check if we already have a cached value for this software
 	if cached, exists := a.cachedLastOpenedAt[softwareName]; exists {
 		if cached == nil {

--- a/infrastructure/loadtesting/terraform/infra/README.md
+++ b/infrastructure/loadtesting/terraform/infra/README.md
@@ -12,6 +12,10 @@ Additionally, refer to the [Reference Architecture sizing recommendations](https
 
 # Deploy with Github Actions
 
+## Prerequisites
+
+1. Run the [Docker publish GitHub action](https://github.com/fleetdm/fleet/actions/workflows/goreleaser-snapshot-fleet.yaml) on your branch to build and push the Fleet Docker image.
+
 ## Deploy/Destroy environment with Github Action
 
 1. [Navigate to the github action](https://github.com/fleetdm/fleet/actions/workflows/loadtest-infra.yml)

--- a/infrastructure/loadtesting/terraform/infra/README.md
+++ b/infrastructure/loadtesting/terraform/infra/README.md
@@ -12,10 +12,6 @@ Additionally, refer to the [Reference Architecture sizing recommendations](https
 
 # Deploy with Github Actions
 
-## Prerequisites
-
-1. Run the [Docker publish GitHub action](https://github.com/fleetdm/fleet/actions/workflows/goreleaser-snapshot-fleet.yaml) on your branch to build and push the Fleet Docker image.
-
 ## Deploy/Destroy environment with Github Action
 
 1. [Navigate to the github action](https://github.com/fleetdm/fleet/actions/workflows/loadtest-infra.yml)

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1298,7 +1298,7 @@ func (man Manager) addConfigs() {
 		"Batch size to pop items from redis in async collection")
 	man.addConfigInt("osquery.async_host_redis_scan_keys_count", 1000,
 		"Batch size to scan redis keys in async collection")
-	man.addConfigDuration("osquery.min_software_last_opened_at_diff", 1*time.Hour,
+	man.addConfigDuration("osquery.min_software_last_opened_at_diff", 2*time.Minute,
 		"Minimum time difference of the software's last opened timestamp (compared to the last one saved) to trigger an update to the database")
 
 	// Activities


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #32026 

This updates osquery-perf to treat updates to  "last opened time" more accurately to real host usage and updates the default last opened time diff from 1hr -> 2m.  This seems to have had no noticeable affect in loadtests: 

reader:
<img width="534" height="234" alt="image" src="https://github.com/user-attachments/assets/2c16c58f-d208-4838-a910-dd6dcf128742" />
writer:
<img width="539" height="235" alt="image" src="https://github.com/user-attachments/assets/69f27798-4614-4968-8f55-0e11170ea835" />
(spikes were during osquery-perf deployment)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests

- [X] QA'd all new/changed functionality manually
