### PR TITLE
Add Claude as Windows FMA

### DIFF
--- a/ee/maintained-apps/inputs/winget/claude.json
+++ b/ee/maintained-apps/inputs/winget/claude.json
@@ -1,0 +1,12 @@
+{
+  "name": "Claude",
+  "slug": "claude/windows",
+  "package_identifier": "Anthropic.Claude",
+  "unique_identifier": "Claude",
+  "install_script_path": "ee/maintained-apps/inputs/winget/scripts/claude_install.ps1",
+  "uninstall_script_path": "ee/maintained-apps/inputs/winget/scripts/claude_uninstall.ps1",
+  "installer_arch": "x64",
+  "installer_type": "exe",
+  "installer_scope": "user",
+  "default_categories": ["Productivity"]
+}

--- a/ee/maintained-apps/inputs/winget/scripts/claude_install.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/claude_install.ps1
@@ -1,0 +1,24 @@
+# Learn more about .exe install scripts:
+# http://fleetdm.com/learn-more-about/exe-install-scripts
+
+$exeFilePath = "${env:INSTALLER_PATH}"
+
+try {
+
+$processOptions = @{
+  FilePath = "$exeFilePath"
+  ArgumentList = "--silent"
+  PassThru = $true
+  Wait = $true
+}
+    
+$process = Start-Process @processOptions
+$exitCode = $process.ExitCode
+
+Write-Host "Install exit code: $exitCode"
+Exit $exitCode
+
+} catch {
+  Write-Host "Error: $_"
+  Exit 1
+}

--- a/ee/maintained-apps/inputs/winget/scripts/claude_uninstall.ps1
+++ b/ee/maintained-apps/inputs/winget/scripts/claude_uninstall.ps1
@@ -1,0 +1,69 @@
+$displayName = "Claude"
+$publisher = "Anthropic"
+
+$paths = @(
+  'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall',
+  'HKCU:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+)
+
+$uninstall = $null
+foreach ($p in $paths) {
+  $items = Get-ItemProperty "$p\*" -ErrorAction SilentlyContinue | Where-Object {
+    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like "$displayName*") -and ($publisher -eq "" -or $_.Publisher -like "$publisher*")
+  }
+  if ($items) { $uninstall = $items | Select-Object -First 1; break }
+}
+
+if (-not $uninstall -or -not $uninstall.UninstallString) {
+  Write-Host "Uninstall entry not found"
+  Exit 0
+}
+
+Stop-Process -Name "Claude" -Force -ErrorAction SilentlyContinue
+
+$uninstallString = $uninstall.UninstallString
+$exePath = ""
+$arguments = ""
+
+if ($uninstallString -match '^"([^"]+)"(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} elseif ($uninstallString -match '^([^\s]+)(.*)') {
+    $exePath = $matches[1]
+    $arguments = $matches[2].Trim()
+} else {
+    Write-Host "Error: Could not parse uninstall string: $uninstallString"
+    Exit 1
+}
+
+$argumentList = @()
+if ($arguments -ne '') {
+    $argumentList += $arguments -split '\s+'
+}
+if ($argumentList -notcontains "--silent" -and $argumentList -notcontains "-s") {
+    $argumentList += "--silent"
+}
+
+Write-Host "Uninstall executable: $exePath"
+Write-Host "Uninstall arguments: $($argumentList -join ' ')"
+
+try {
+    $processOptions = @{
+        FilePath = $exePath
+        ArgumentList = $argumentList
+        NoNewWindow = $true
+        PassThru = $true
+        Wait = $true
+    }
+    
+    $process = Start-Process @processOptions
+    $exitCode = $process.ExitCode
+    
+    Write-Host "Uninstall exit code: $exitCode"
+    Exit $exitCode
+} catch {
+    Write-Host "Error running uninstaller: $_"
+    Exit 1
+}

--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -373,6 +373,13 @@
       "description": "Claude is Anthropic's official Claude AI desktop app."
     },
     {
+      "name": "Claude",
+      "slug": "claude/windows",
+      "platform": "windows",
+      "unique_identifier": "Claude",
+      "description": "Claude is Anthropic's official Claude AI desktop app."
+    },
+    {
       "name": "CleanMyMac",
       "slug": "cleanmymac/darwin",
       "platform": "darwin",

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,0 +1,21 @@
+{
+  "versions": [
+    {
+      "version": "1.1.4088",
+      "queries": {
+        "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic PBC';"
+      },
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.1.4088/Claude-7e63fdb935ef758b2356a3d040ccd9176414cac7.exe",
+      "install_script_ref": "0abea82b",
+      "uninstall_script_ref": "d123575a",
+      "sha256": "59745f0fc722beea4b10cd5fe89c6237dfb7658ad5353e6271e4a5abb6eda0f1",
+      "default_categories": [
+        "Productivity"
+      ]
+    }
+  ],
+  "refs": {
+    "0abea82b": "# Learn more about .exe install scripts:\n# http://fleetdm.com/learn-more-about/exe-install-scripts\n\n$exeFilePath = \"${env:INSTALLER_PATH}\"\n\ntry {\n\n$processOptions = @{\n  FilePath = \"$exeFilePath\"\n  ArgumentList = \"--silent\"\n  PassThru = $true\n  Wait = $true\n}\n    \n$process = Start-Process @processOptions\n$exitCode = $process.ExitCode\n\nWrite-Host \"Install exit code: $exitCode\"\nExit $exitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n",
+    "d123575a": "$displayName = \"Claude\"\n$publisher = \"Anthropic\"\n\n$paths = @(\n  'HKLM:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKLM:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall',\n  'HKCU:\\SOFTWARE\\WOW6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall'\n)\n\n$uninstall = $null\nforeach ($p in $paths) {\n  $items = Get-ItemProperty \"$p\\*\" -ErrorAction SilentlyContinue | Where-Object {\n    $_.DisplayName -and ($_.DisplayName -eq $displayName -or $_.DisplayName -like \"$displayName*\") -and ($publisher -eq \"\" -or $_.Publisher -like \"$publisher*\")\n  }\n  if ($items) { $uninstall = $items | Select-Object -First 1; break }\n}\n\nif (-not $uninstall -or -not $uninstall.UninstallString) {\n  Write-Host \"Uninstall entry not found\"\n  Exit 0\n}\n\nStop-Process -Name \"Claude\" -Force -ErrorAction SilentlyContinue\n\n$uninstallString = $uninstall.UninstallString\n$exePath = \"\"\n$arguments = \"\"\n\nif ($uninstallString -match '^\"([^\"]+)\"(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} elseif ($uninstallString -match '^([^\\s]+)(.*)') {\n    $exePath = $matches[1]\n    $arguments = $matches[2].Trim()\n} else {\n    Write-Host \"Error: Could not parse uninstall string: $uninstallString\"\n    Exit 1\n}\n\n$argumentList = @()\nif ($arguments -ne '') {\n    $argumentList += $arguments -split '\\s+'\n}\nif ($argumentList -notcontains \"--silent\" -and $argumentList -notcontains \"-s\") {\n    $argumentList += \"--silent\"\n}\n\nWrite-Host \"Uninstall executable: $exePath\"\nWrite-Host \"Uninstall arguments: $($argumentList -join ' ')\"\n\ntry {\n    $processOptions = @{\n        FilePath = $exePath\n        ArgumentList = $argumentList\n        NoNewWindow = $true\n        PassThru = $true\n        Wait = $true\n    }\n    \n    $process = Start-Process @processOptions\n    $exitCode = $process.ExitCode\n    \n    Write-Host \"Uninstall exit code: $exitCode\"\n    Exit $exitCode\n} catch {\n    Write-Host \"Error running uninstaller: $_\"\n    Exit 1\n}\n"
+  }
+}


### PR DESCRIPTION
This pull request adds support for the Windows version of the Claude desktop app to the maintained apps system. The changes include new metadata, installation and uninstallation scripts, and integration into the outputs that track available apps and versions.

Integration of Claude for Windows:

* Added `claude/windows` entry to the maintained apps outputs (`ee/maintained-apps/outputs/apps.json`) to make the Windows version of Claude discoverable and manageable.
* Introduced version tracking and metadata for `claude/windows`, including installer URL, install/uninstall scripts, and SHA256 hash in `ee/maintained-apps/outputs/claude/windows.json`.

Install/uninstall scripting:

* Added a PowerShell install script (`ee/maintained-apps/inputs/winget/scripts/claude_install.ps1`) that runs the Claude installer in silent mode and handles errors gracefully.
* Added a PowerShell uninstall script (`ee/maintained-apps/inputs/winget/scripts/claude_uninstall.ps1`) that locates the Claude uninstall entry, parses uninstall arguments, ensures silent uninstallation, and terminates running processes.

Metadata for Windows app management:

* Created `claude.json` metadata file for Windows app management, specifying installer details, script paths, and default categories.