### PR TITLE
Flaky test fix: Skip worker jobs to avoid race conditions in tests

### DIFF
--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -583,6 +583,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowWithSoftwareAndScriptFo
 	t := s.T()
 	ctx := context.Background()
 
+	s.setSkipWorkerJobs(t)
+
 	teamDevice, enrolledHost, _ := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
 
 	// enroll the host
@@ -738,6 +740,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowWithSoftwareAndScriptFo
 func (s *integrationMDMTestSuite) TestSetupExperienceVPPInstallError() {
 	t := s.T()
 	ctx := context.Background()
+
+	s.setSkipWorkerJobs(t)
 
 	teamDevice, enrolledHost, team := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
 
@@ -1189,6 +1193,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowUpdateScript() {
 func (s *integrationMDMTestSuite) TestSetupExperienceFlowCancelScript() {
 	t := s.T()
 	ctx := context.Background()
+
+	s.setSkipWorkerJobs(t)
 
 	device, host, _ := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
 
@@ -2999,6 +3005,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceFlowWithRequireSoftware() {
 func (s *integrationMDMTestSuite) TestSetupExperienceFlowWithRequiredSoftwareVPP() {
 	t := s.T()
 	ctx := context.Background()
+
+	s.setSkipWorkerJobs(t)
 
 	teamDevice, enrolledHost, team := s.createTeamDeviceForSetupExperienceWithProfileSoftwareAndScript()
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40535

Fixes a flaky test (and possibly others) by turning off worker jobs while the test is running.  @gillespi314 did a similar fix recently in https://github.com/fleetdm/fleet/pull/39106; this adds it to other vulnerable tests including `TestSetupExperienceFlowWithRequiredSoftwareVPP` which I recently got a failure on in CI.
