### PR TITLE
Match Windows Fleet maintained apps by similar name

### DIFF
--- a/changes/37802-fix-windows-fma-list
+++ b/changes/37802-fix-windows-fma-list
@@ -1,0 +1,1 @@
+- Fixed a bug where Fleet maintained apps for Windows won't show as available in the list when they actually are.

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -69,7 +69,8 @@ const teamFMATitlesJoin = `
 				OR (
 					team_titles.platform = fma.platform 
 					AND fma.platform = 'windows' 
-					AND team_titles.name LIKE CONCAT(fma.name, '%')
+					-- Box Drive is the only FMA at the point of writing this where unique_identifier is shorter than name
+					AND team_titles.name LIKE CONCAT(LEAST(fma.name, fma.unique_identifier), '%')
 				)
 `
 

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -47,7 +47,7 @@ ON DUPLICATE KEY UPDATE
 const teamFMATitlesJoin = `
 			team_titles.id software_title_id FROM fleet_maintained_apps fma
 			LEFT JOIN (
-				SELECT DISTINCT st.id, st.unique_identifier
+				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform
 				FROM software_titles st
 				LEFT JOIN
 					software_installers si
@@ -63,7 +63,15 @@ const teamFMATitlesJoin = `
 					AND vat.platform = va.platform
 					AND vat.global_or_team_id = ?
 				WHERE si.id IS NOT NULL OR vat.id IS NOT NULL
-			) team_titles ON team_titles.unique_identifier = fma.unique_identifier`
+			) team_titles 
+				ON team_titles.unique_identifier = fma.unique_identifier
+				-- pattern match fma name to title name, since upgrade_code is not surfaced in fma table
+				OR (
+					team_titles.platform = fma.platform 
+					AND fma.platform = 'windows' 
+					AND team_titles.name LIKE CONCAT(fma.name, '%')
+				)
+`
 
 func (ds *Datastore) GetMaintainedAppByID(ctx context.Context, appID uint, teamID *uint) (*fleet.MaintainedApp, error) {
 	stmt := `SELECT fma.id, fma.name, fma.platform, fma.unique_identifier, fma.slug, `

--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -65,7 +65,7 @@ const teamFMATitlesJoin = `
 				WHERE si.id IS NOT NULL OR vat.id IS NOT NULL
 			) team_titles 
 				ON team_titles.unique_identifier = fma.unique_identifier
-				-- pattern match fma name to title name, since upgrade_code is not surfaced in fma table
+				-- pattern match fma name to a similar title name, since upgrade_code is not surfaced in fma table
 				OR (
 					team_titles.platform = fma.platform 
 					AND fma.platform = 'windows' 

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -588,7 +588,7 @@ func testListAvailableAppsWindows(t *testing.T, ds *Datastore) {
 	require.Equal(t, expectedApps, apps)
 
 	// upload an installer that will create a title with a similar name, but with
-	// an upgrade_code so that unique_identifier doesn't match
+	// an upgrade code so that unique identifier doesn't match
 	_, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		Title:                "Maintained1 (MSI)",
 		UpgradeCode:          "{UPGRADE-CODE}",

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3453,8 +3453,9 @@ WHERE
 }
 
 func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload) error {
-	// if this is an in-house app, check if an installer exists
-	if payload.Extension == "ipa" {
+	// check appropriate installers/in-house apps/vpp apps for the payload type
+	switch {
+	case payload.Extension == "ipa":
 		// at the point where this method is called, we attempt to create both iOS and iPadOS entries
 		// for ipa apps, so check for conflicts on either platform.
 		for platform, source := range map[string]string{
@@ -3477,22 +3478,18 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 				return alreadyExists("VPP app", payload.Title)
 			}
 		}
-	} else {
+	case fleet.InstallableDevicePlatform(payload.Platform).IsApplePlatform():
 		// check if a VPP app already exists for that software title in the same
 		// platform and team.
-		if payload.Platform == string(fleet.MacOSPlatform) || payload.Platform == string(fleet.IOSPlatform) || payload.Platform == string(fleet.IPadOSPlatform) {
-			exists, err := ds.checkVPPAppExistsForTitleIdentifier(ctx, ds.reader(ctx), payload.TeamID, payload.Platform, payload.BundleIdentifier, payload.Source, "")
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if VPP app exists for title identifier")
-			}
-			if exists {
-				return alreadyExists("VPP app", payload.Title)
-			}
+		exists, err := ds.checkVPPAppExistsForTitleIdentifier(ctx, ds.reader(ctx), payload.TeamID, payload.Platform, payload.BundleIdentifier, payload.Source, "")
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "check if VPP app exists for title identifier")
+		}
+		if exists {
+			return alreadyExists("VPP app", payload.Title)
 		}
 
-		// Check if an in-house app with the same bundle id already exists.
-		// Also check if equivalent installers exist, since we relaxed the uniqueness constraints to allow
-		// multiple FMA installer versions.
+		// check if an in-house app with the same bundle id already exists.
 		if payload.BundleIdentifier != "" {
 			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.BundleIdentifier, payload.Platform, softwareTypeInHouseApp)
 			if err != nil {
@@ -3501,23 +3498,16 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 			if exists {
 				return alreadyExists("in-house app", payload.Title)
 			}
-
-			exists, err = ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.BundleIdentifier, payload.Platform, softwareTypeInstaller)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if installer exists for title identifier")
-			}
-			if exists {
-				return alreadyExists("installer", payload.Title)
-			}
 		}
-
-		if payload.Platform == "windows" {
-			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.Title, payload.Platform, softwareTypeInstaller)
+	default:
+		// check if an installer with this unique identifier exists
+		if payload.UniqueIdentifier() != "" {
+			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.UniqueIdentifier(), payload.Platform, softwareTypeInstaller)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if installer exists for title identifier")
+				return ctxerr.Wrap(ctx, err, "check if software installer exists for title identifier")
 			}
 			if exists {
-				return alreadyExists("installer", payload.Title)
+				return alreadyExists("in-house app", payload.Title)
 			}
 		}
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3500,16 +3500,7 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 			}
 		}
 	default:
-		// check if an installer with this unique identifier exists
-		if payload.UniqueIdentifier() != "" {
-			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.UniqueIdentifier(), payload.Platform, softwareTypeInstaller)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if software installer exists for title identifier")
-			}
-			if exists {
-				return alreadyExists("in-house app", payload.Title)
-			}
-		}
+		// we would need to use source to check for installer conflicts
 	}
 
 	return nil

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3499,8 +3499,14 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 				return alreadyExists("in-house app", payload.Title)
 			}
 		}
-	default:
-		// we would need to use source to check for installer conflicts
+	case payload.Platform == "windows":
+		exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.Title, payload.Platform, softwareTypeInstaller)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "check if installer exists for title identifier")
+		}
+		if exists {
+			return alreadyExists("installer", payload.Title)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
**Related issue:** Resolves #37802 
Attempt to fix Windows FMAs not showing up as available when the software titles they match to have upgrade codes. Since we don't surface upgrade codes in the `fleet_maintained_apps` table and matching exactly by name could miss some cases, this fix uses `team_titles.name LIKE CONCAT(LEAST(fma.name, fma.unique_identifier), '%')`. Note the LEAST there is only for the "Box Drive" app which has a longer name than unique_identifier, and just compares the strings and not their length. 

This isn't optimal for performance or correctness, but it only checks with titles already available to the team as installers so it shouldn't be terrible. Until upgrade_code is surfaced in the `fleet_maintained_apps` table this should be sufficient.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually