### PR TITLE
Add note about compatibility to security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,3 +17,7 @@ The fingerprint of the key is `23A1 9D1F 16D7 1846 57D1  6D67 320D B57D�
 GitHub issues concerning vulnerabilities will be tagged with the **security** label to differentiate them from other issues and maintain SOC2 compliance.  
 
 See [security/README.md](./security/README.md) for more information on our process to keep Fleet products secure.
+
+### Compatibility
+
+Fleet reserves the right to make breaking changes for security. Security fixes may introduce backward-incompatible changes and may be released in minor or patch versions.


### PR DESCRIPTION
Add language clarifying that Fleet may occasionally break semver conventions when addressing security issues. 