### PR TITLE
Draft: Fleet vs. Jamf Pro and NinjaOne: Choose the Right MDM

### DIFF
--- a/articles/fleet-vs-jamf-pro-ninjaone.md
+++ b/articles/fleet-vs-jamf-pro-ninjaone.md
@@ -1,0 +1,312 @@
+---
+title: "Fleet vs. Jamf Pro and NinjaOne: Choose the Right MDM"
+slug: "/fleet-vs-jamf-pro-ninjaone"
+meta_title: "Fleet vs. Jamf Pro and NinjaOne: Choose the Right MDM"
+meta_description: "Compare Fleet, Jamf Pro, and NinjaOne across deployment, cross-platform support, GitOps workflows, and pricing to find the right MDM for your organization."
+---
+
+# Fleet vs. Jamf Pro and NinjaOne: How do they compare?
+
+Organizations with Mac-heavy environments often start with Jamf Pro, then need additional tools when Windows and Linux devices enter the fleet. Those evaluating NinjaOne's cross-platform RMM often want deeper security visibility and infrastructure control than a cloud-only platform provides. Fleet offers an alternative: open-source [device management](https://fleetdm.com/) with full Apple MDM parity, cross-platform support, self-hosting options, and real-time SQL queries. This guide compares enrollment, security, API access, and pricing to help you choose.
+
+## Overview
+
+Fleet is an open-source, cross-platform device management solution supporting macOS, Windows, Linux, iOS, iPadOS, ChromeOS, and Android. Fleet provides zero-touch deployment through Apple Business Manager and Declarative Device Management (DDM), with native GitOps workflows for version-controlled configuration management. The [osquery](https://fleetdm.com/guides/osquery-a-tool-to-easily-ask-questions-about-operating-systems) foundation delivers sub-30-second device reporting and SQL-based real-time queries across all platforms. Organizations can self-host or use managed cloud deployment, with [MDM migration](https://fleetdm.com/guides/mdm-migration) support for gradual transitions from existing solutions.
+
+Jamf Pro is an Apple-focused MDM solution supporting macOS, iOS, iPadOS, tvOS, visionOS, and watchOS devices. Jamf Pro provides zero-touch deployment through Apple Business Manager, SSO/SAML integration, and configuration profile management for Apple ecosystems. Jamf Pro doesn't [support Windows](https://fleetdm.com/announcements/fleet-introduces-windows-mdm) or Linux devices natively, so organizations with mixed environments need additional management tools alongside Jamf.
+
+NinjaOne is a cloud-native IT management tool combining remote monitoring and management (RMM) with MDM capabilities for Windows, macOS, Linux, iOS, iPadOS, and Android devices. NinjaOne provides cross-platform coverage and patch management through a unified console. NinjaOne operates as cloud-only with no self-hosting option and uses proprietary closed-source software, which limits infrastructure control and prevents organizations from auditing the code running on their devices. NinjaOne also lacks GitOps support for configuration-as-code workflows.
+
+## Key differences
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+**Attribute**
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+**Fleet**
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+**Jamf Pro**
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+**NinjaOne**
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Architecture
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+API-first design, unified REST API
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+GUI-first with Apple integrations
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Cloud-native RMM/MDM console
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Source code
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Open-source
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Proprietary
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Proprietary
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Platform support
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+macOS, Windows, Linux, iOS, iPadOS, ChromeOS, Android
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+macOS, iOS, iPadOS, tvOS, visionOS, watchOS
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Windows, macOS, Linux, iOS, iPadOS, Android
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+GitOps support
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Native GitOps workflow management
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Requires third-party tools (Terraform providers, external CI/CD)
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Not available
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Declarative Device Management (DDM)
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Supported
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Supported
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Supported
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Self-hosting
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Full self-hosting support
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Cloud-hosted with hybrid elements available
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Cloud-only
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Device reporting
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Sub-30-second device state reporting
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+MDM check-in intervals
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Agent-based monitoring intervals
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Queries
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+SQL-based real-time queries across all devices
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Pre-built reports and scheduled inventory collection
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Agent-based monitoring and scripting capabilities
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Vulnerability detection
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Built-in software vulnerability reporting
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Requires additional tools or integrations
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Built-in patching and antivirus integrations
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+MDM migration
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Native migration support from existing MDM solutions
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Migration tools available
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Not documented
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Scope transparency
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+End users can see what data is collected
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Not available
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Not available
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+File integrity monitoring
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Built-in
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Requires Jamf Protect (separate product)
+
+<table><tbody><tr><td></td></tr></tbody></table>
+
+Not available
+
+## Device management workflow comparisons
+
+### Enrollment and provisioning
+
+Fleet and Jamf Pro both support zero-touch deployment through Apple Business Manager integration, allowing organizations to configure multiple ABM and Apps and Books (VPP) connections. Fleet extends zero-touch enrollment to [Windows](https://fleetdm.com/guides/windows-mdm-setup) via native Autopilot integration, while Jamf Pro's zero-touch capabilities cover macOS, iOS/iPadOS, tvOS, visionOS, and watchOS.
+
+NinjaOne supports zero-touch enrollment for Apple devices through Apple Business Manager and for Android devices through Android Zero-Touch Enrollment. For Windows, NinjaOne relies primarily on agent-based deployment or requires organizations to use Microsoft Intune separately for Autopilot provisioning. Fleet's native Windows Autopilot support means organizations can manage zero-touch enrollment for both Apple and Windows devices from a single console without requiring additional tools.
+
+### Configuration management
+
+Fleet, Jamf Pro, and NinjaOne provide device organization through grouping mechanisms. Fleet uses Teams and Labels, Jamf Pro provides group-based organization, and NinjaOne offers policy-based grouping by device attributes. These groupings control the scope of configuration profile delivery and management automations.
+
+Fleet supports custom configuration profiles across all platforms with native GitOps integration, enabling version-controlled, auditable configuration changes stored in Git repositories. Fleet's osquery integration also enables SQL-based queries for device configuration verification. Jamf Pro's configuration profiles are limited to Apple devices, requiring additional tools for Windows and Linux.
+
+Jamf Pro can only achieve GitOps-style workflows through third-party Terraform providers and external CI/CD tools. NinjaOne deploys configuration changes through its agent and relies primarily on console-based management, with no documented GitOps or configuration-as-code support.
+
+### Software management
+
+Software deployment and patching work differently across these three solutions. Fleet combines software deployment with built-in vulnerability detection, identifying CVEs across all platforms and enabling policy-based automatic remediation when vulnerable software is detected.
+
+Jamf Pro handles software deployment for Apple devices through Apple Business Manager integration. NinjaOne includes OS patch management for Windows, macOS, and Linux, plus third-party application patching primarily for Windows, with deployment flowing through its agent. NinjaOne recently added vulnerability visibility, but Fleet's approach integrates CVE detection with CISA KEV and EPSS scoring to help security teams prioritize what to patch first.
+
+All three support custom software packages and scripting for automation, which lets you customize complex installations like security applications during deployment.
+
+### Security and compliance
+
+Fleet provides sub-30-second device reporting with SQL-based real-time queries, enabling rapid incident response when delays can give attackers time to move laterally. Fleet includes built-in vulnerability detection, file integrity monitoring, file carving for investigations, and policy scoring for compliance measurement in the core product.
+
+Jamf Pro requires Jamf Protect, a separate purchase, for equivalent security capabilities. NinjaOne relies on third-party antivirus integrations (Webroot, Malwarebytes, Bitdefender) for device protection.
+
+For Apple devices, Fleet and Jamf Pro both support FileVault management and Gatekeeper configuration through MDM protocols. All three integrate with directory systems, and both Fleet and NinjaOne enable SIEM integration for streaming device telemetry. Fleet's API-first architecture also enables custom integrations with identity providers and network access control systems. Fleet provides scope transparency, letting end users see exactly what data is being collected from their devices.
+
+### API and integration capabilities
+
+How you integrate device management with your existing tools depends heavily on API depth. Fleet's API-first architecture means every function available in the UI is also accessible programmatically, so you can automate device enrollment, trigger queries from CI/CD pipelines, or sync compliance data with your ticketing system.
+
+Jamf Pro's API focuses on Apple ecosystem workflows like syncing with Apple Business Manager and pushing data to Active Directory or Cisco ISE. NinjaOne integrates with PSA tools like ConnectWise and remote support platforms like Splashtop, fitting MSP workflows.
+
+Each solution supports SIEM integration for streaming device telemetry to security operations tools, letting you correlate device state with other security data during investigations.
+
+### Pricing and licensing
+
+Fleet's [open-source edition](https://fleetdm.com/) is free to self-host with full functionality, letting you evaluate Fleet before committing to a managed cloud option with enterprise support. This works well for teams that want to test device management workflows without upfront licensing costs.
+
+Jamf Pro publishes per-device pricing on their site (around $10/month per macOS device, $5.75/month per mobile device, billed annually with minimums). The real cost consideration for mixed environments: since Jamf Pro only supports Apple devices, you'll need separate tools for Windows and Linux, which adds licensing fees and administrative overhead.
+
+NinjaOne uses per-device pricing that tends to work well for SMBs and MSPs. The cloud-only model means no infrastructure to maintain, but you give up self-hosting flexibility and the ability to audit the code running on your devices.
+
+## Open-source device management
+
+Organizations evaluating MDM solutions often face a choice between vendor lock-in and operational flexibility. Fleet offers a different approach with complete source code transparency, self-hosting options, and cross-platform support that doesn't compromise on Apple device management capabilities.
+
+Fleet combines real-time device visibility with the API-first architecture that IT and security teams need for modern workflows. Whether you're managing a fleet of 500 devices or 50,000, Fleet's osquery foundation delivers the same sub-30-second reporting and SQL-based query capabilities. [Schedule a demo](https://fleetdm.com/demo) to see how Fleet handles your device management needs.
+
+## FAQ
+
+**What's the main difference between open-source and proprietary device management?**
+
+Open-source tools like Fleet provide code that organizations can audit, modify, and self-host, while proprietary SaaS tools use closed-source code that can't be independently verified. This means security teams can verify exactly what code runs on managed devices with open-source tools. Try Fleet to experience the difference.
+
+**How do cross-platform MDM tools compare with Apple-only options for managing Apple devices?**
+
+Cross-platform tools like Fleet provide complete Apple device management capabilities at parity with Apple-focused tools, including zero-touch enrollment through Apple Business Manager, MDM Configuration Profiles, and Apps and Books (VPP) distribution. Organizations using multiple operating systems can consolidate tools rather than running separate solutions for each platform. Schedule a demo to see how Fleet manages Apple devices alongside Windows and Linux.
+
+**Can I migrate from Jamf Pro to Fleet without disrupting device management?**
+
+Fleet supports gradual migration from Jamf Pro and other MDM solutions. You can run Fleet alongside your existing MDM during the transition, moving devices incrementally while maintaining management continuity. Fleet's Apple Business Manager integration means your zero-touch enrollment workflows transfer over, and configuration profiles can be deployed through Fleet's GitOps workflows. Schedule a demo to discuss your Jamf migration timeline.
+
+**How does Fleet's security visibility compare to Jamf Pro and NinjaOne?**
+
+Fleet provides built-in file integrity monitoring, vulnerability detection, and real-time SQL queries across all platforms in the core product. Jamf Pro requires Jamf Protect (a separate product) for equivalent security capabilities, while NinjaOne relies on third-party antivirus integrations. Fleet's sub-30-second device reporting enables faster incident response compared to traditional MDM check-in intervals. Schedule a demo to see Fleet's security capabilities.
+
+**How does osquery-based querying differ from traditional MDM reporting?**
+
+Osquery-based querying lets teams run SQL queries for device state information on-demand, supporting more agile security investigations compared to scheduled inventory collection cycles. Traditional MDM provides scheduled inventory collection and agent-based monitoring, while SQL-based approaches give security teams flexibility to investigate incidents with real-time queries. Schedule a demo to see how Fleet's query capabilities work with your device fleet.
+
+**What are the cost implications of using Jamf Pro for mixed Windows and Mac environments?**
+
+Jamf Pro only supports Apple devices, so organizations with Windows and Linux devices need additional tools, which increases total licensing costs and administrative overhead. Fleet manages all platforms from a single console. The open-source edition is available for self-hosting at no licensing cost, and the managed cloud option provides enterprise support with predictable pricing. Schedule a demo to discuss pricing for your environment.
+
+**How long does migration from an existing MDM take?**
+
+Migration timeframes vary based on fleet size and complexity. Fleet supports gradual migration alongside existing MDM tools, allowing you to transition devices incrementally while maintaining visibility across your entire fleet during the transition. Schedule a demo to discuss your specific migration requirements and timeline.


### PR DESCRIPTION
## Summary

Adds a new Fleet comparison article via Atlas pipeline.

## Metadata

- Slug: `/fleet-vs-jamf-pro-ninjaone`
- Meta Title: `Fleet vs. Jamf Pro and NinjaOne: Choose the Right MDM`
- Meta Description: `Compare Fleet, Jamf Pro, and NinjaOne across deployment, cross-platform support, GitOps workflows, and pricing to find the right MDM for your organization.`
