### PR TITLE
Website: Update article meta tags to fix failing website deploy

### DIFF
--- a/articles/rethinking-endpoint-management.md
+++ b/articles/rethinking-endpoint-management.md
@@ -78,4 +78,4 @@ In part 3 of this series, we will explore how emerging AI coding assistants and 
 <meta name="authorGitHubUsername" value="akuthiala">  
 <meta name="category" value="articles">  
 <meta name="publishedOn" value="2026-02-26">  
-<meta name="description" value="Part 2 of 3 \- Article series on modernizing device management.">
+<meta name="description" value="Part 2 of 3 - Article series on modernizing device management.">

--- a/articles/rethinking-endpoint-management.md
+++ b/articles/rethinking-endpoint-management.md
@@ -73,9 +73,9 @@ There is a catch: moving to code-based management requires new skills. How do yo
 
 In part 3 of this series, we will explore how emerging AI coding assistants and event-driven automation bridge that gap, making this powerful stack accessible to teams of any size.
 
-\<meta name="articleTitle" value="Rethinking endpoint management: Fleet, osquery and Infrastructure as Code"\>  
-\<meta name="authorFullName" value="Ashish Kuthiala, CMO, Fleet Device Management"\>  
-\<meta name="authorGitHubUsername" value="akuthiala"\>  
-\<meta name="category" value="articles"\>  
-\<meta name="publishedOn" value="2026-02-26"\>  
-\<meta name="description" value="Part 2 of 3 \- Article series on modernizing device management."\>
+<meta name="articleTitle" value="Rethinking endpoint management: Fleet, osquery and Infrastructure as Code">  
+<meta name="authorFullName" value="Ashish Kuthiala, CMO, Fleet Device Management">  
+<meta name="authorGitHubUsername" value="akuthiala">  
+<meta name="category" value="articles">  
+<meta name="publishedOn" value="2026-02-26">  
+<meta name="description" value="Part 2 of 3 \- Article series on modernizing device management.">


### PR DESCRIPTION
Changes:
- Updated the meta tags in rethinking-endpoint-management.md to fix the website's failing deploy workflow