### PR TITLE
Add compatibility note to upgrading docs

### DIFF
--- a/docs/Deploy/Upgrading-Fleet.md
+++ b/docs/Deploy/Upgrading-Fleet.md
@@ -78,7 +78,7 @@ Run `terraform apply` to apply the changes.
 
 ## Compatibility
 
-Upgrading to a new minor or patch version does not break compatiblity, except in these rare cases:
+Fleet follows [Semantic Versioning (SemVer)](https://semver.org/). This means that breaking changes are never introduced in a new minor or patch version, except in these rare cases:
 
 + **Experimental features:** [Experimental features](https://fleetdm.com/handbook/company/product-groups#experimental-features) are tagged as such in the API documentation. These features are being rapidly iterated on and are not for use in automated workflows.
 + **Security:** Fleet reserves the right to make breaking changes for security. When no alternative solution is available, security fixes may introduce backward-incompatible changes.

--- a/docs/Deploy/Upgrading-Fleet.md
+++ b/docs/Deploy/Upgrading-Fleet.md
@@ -76,5 +76,15 @@ If you are using Fleet's Terraform modules to manage your Fleet deployment to AW
 
 Run `terraform apply` to apply the changes.
 
+## Compatibility
+
+Upgrading to a new minor or patch version does not break compatiblity, except in these rare cases:
+
++ **Experimental features:** [Experimental features](https://fleetdm.com/handbook/company/product-groups#experimental-features) are tagged as such in the API documentation. These features are being rapidly iterated on and are not for use in automated workflows.
++ **Security:** Fleet reserves the right to make breaking changes for security. When no alternative solution is available, security fixes may introduce backward-incompatible changes.
+
+In each of these cases, breaking changes are clearly communicated in the version notes.
+
+
 <meta name="pageOrderInSection" value="300">
 <meta name="description" value="Learn how to upgrade your Fleet instance to the latest version.">


### PR DESCRIPTION
Clarify the rare cases when upgrading to a minor/patch version can break compatibility.