### PR TITLE
Fix stale data on host details page after subsequent navigations

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -308,9 +308,6 @@ const HostDetailsPage = ({
     () => teamAPI.loadAll(),
     {
       enabled: !!hostIdFromURL && !!isPremiumTier,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
       retry: false,
       select: (data: ILoadTeamsResponse) => data.teams,
     }
@@ -321,9 +318,6 @@ const HostDetailsPage = ({
     () => hostAPI.getMdm(hostIdFromURL),
     {
       enabled: !!hostIdFromURL,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
       retry: false,
       onError: (err) => {
         // no handling needed atm. data is simply not shown.
@@ -337,9 +331,6 @@ const HostDetailsPage = ({
     () => hostAPI.loadHostDetailsExtension(hostIdFromURL, "macadmins"),
     {
       enabled: !!hostIdFromURL, // TODO(android): disable for unsupported platforms?
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
       retry: false,
       select: (data: IMacadminsResponse) => data.macadmins,
     }
@@ -401,9 +392,6 @@ const HostDetailsPage = ({
     () => hostAPI.loadHostDetails(hostIdFromURL),
     {
       enabled: !!hostIdFromURL,
-      refetchOnMount: false,
-      refetchOnReconnect: false,
-      refetchOnWindowFocus: false,
       retry: false,
       select: (data: IHostResponse) => data.host,
       onSuccess: (returnedHost) => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40408

Part of the root cause for this issue is this commit: https://github.com/fleetdm/fleet/commit/5136d40e2721eba9e177c24826a7519244ddcea1

In summary, I moved the QueryClient instantiation out of AppWrapper because it needs to be a stable reference. I realized this was necessary when manipulating react-query's cache as part of that work.
(I was debugging react-query's cache using **getQueryData** and it was always returning **undefined** for every entry -- that was fixed by doing what I described just above).

When QueryClient was re-created on each AppWrapper mount, refetchOnMount: false had no effect.. there was never cached data to serve, so useQuery always fetched on every navigation to the host details page.

After moving it out of AppWrapper, refetchOnMount: false works as expected and the cached (stale) data is served instead of refetching.

The fix removes the refetchOnMount: false, refetchOnReconnect: false, and refetchOnWindowFocus: false overrides, restoring react-query's defaults so data is refreshed on navigation, tab focus, and reconnect.

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/fa3f90ef-46f4-4a30-acc6-2176a22e8299



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed
