### PR TITLE
Cherry-pick #40520: Deprecate URLs with "team" and "query" terminology

### DIFF
--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -3,11 +3,13 @@ package endpointer
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
@@ -122,4 +124,105 @@ func (n nopEP) CallHandlerFunc(f testHandlerFunc, ctx context.Context, request a
 
 func (n nopEP) Service() any {
 	return nil
+}
+
+func TestRegisterDeprecatedPathAliases(t *testing.T) {
+	// Set up a router and register a primary endpoint via CommonEndpointer.
+	r := mux.NewRouter()
+	registry := NewHandlerRegistry()
+	versions := []string{"v1", "2022-04"}
+
+	authMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint {
+		return func(ctx context.Context, req any) (any, error) {
+			if authctx, ok := authz_ctx.FromContext(ctx); ok {
+				authctx.SetChecked()
+			}
+			return next(ctx, req)
+		}
+	}
+
+	ce := &CommonEndpointer[testHandlerFunc]{
+		EP: nopEP{},
+		MakeDecoderFn: func(iface any, requestBodySizeLimit int64) kithttp.DecodeRequestFunc {
+			return func(ctx context.Context, r *http.Request) (request any, err error) {
+				return nopRequest{}, nil
+			}
+		},
+		EncodeFn: func(ctx context.Context, w http.ResponseWriter, i any) error {
+			w.WriteHeader(http.StatusOK)
+			return nil
+		},
+		AuthMiddleware:  authMiddleware,
+		Router:          r,
+		Versions:        versions,
+		HandlerRegistry: registry,
+	}
+
+	// Register the primary endpoint.
+	ce.GET("/api/_version_/fleet/fleets", func(ctx context.Context, request any) (platform_http.Errorer, error) {
+		return nopResponse{}, nil
+	}, nil)
+
+	// Register a deprecated alias for it.
+	RegisterDeprecatedPathAliases(r, versions, registry, []DeprecatedPathAlias{
+		{
+			Method:          "GET",
+			PrimaryPath:     "/api/_version_/fleet/fleets",
+			DeprecatedPaths: []string{"/api/_version_/fleet/teams"},
+		},
+	})
+
+	s := httptest.NewServer(r)
+	t.Cleanup(s.Close)
+
+	// Both the primary and deprecated paths should return 200.
+	for _, path := range []string{"/api/v1/fleet/fleets", "/api/v1/fleet/teams", "/api/latest/fleet/teams"} {
+		resp, err := http.Get(s.URL + path)
+		require.NoError(t, err)
+		resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode, "path %s should return 200", path)
+	}
+}
+
+func TestLogDeprecatedPathAlias(t *testing.T) {
+	// Without deprecated path info in context, LogDeprecatedPathAlias is a no-op.
+	lc := &logging.LoggingContext{}
+	ctx := logging.NewContext(context.Background(), lc)
+	ctx2 := LogDeprecatedPathAlias(ctx, nil)
+	require.Equal(t, ctx, ctx2, "should return same context when no deprecated path info")
+	require.Empty(t, lc.Extras)
+
+	// With deprecated path info, it should set warn level and extras.
+	ctx = context.WithValue(ctx, deprecatedPathInfoKey{}, deprecatedPathInfo{
+		deprecatedPath: "/api/_version_/fleet/teams",
+		primaryPath:    "/api/_version_/fleet/fleets",
+	})
+	LogDeprecatedPathAlias(ctx, nil)
+
+	// Extras is a flat []interface{} of key-value pairs.
+	require.Len(t, lc.Extras, 4) // "deprecated_path", value, "deprecation_warning", value
+	require.Equal(t, "deprecated_path", lc.Extras[0])
+	require.Equal(t, "/api/_version_/fleet/teams", lc.Extras[1])
+	require.Equal(t, "deprecation_warning", lc.Extras[2])
+	require.Contains(t, lc.Extras[3], "deprecated")
+
+	// ForceLevel should be set to Warn.
+	require.NotNil(t, lc.ForceLevel)
+	require.Equal(t, slog.LevelWarn, *lc.ForceLevel)
+}
+
+func TestRegisterDeprecatedPathAliasesPanicsOnMissing(t *testing.T) {
+	r := mux.NewRouter()
+	registry := NewHandlerRegistry()
+	versions := []string{"v1"}
+
+	require.Panics(t, func() {
+		RegisterDeprecatedPathAliases(r, versions, registry, []DeprecatedPathAlias{
+			{
+				Method:          "GET",
+				PrimaryPath:     "/api/_version_/fleet/nonexistent",
+				DeprecatedPaths: []string{"/api/_version_/fleet/old"},
+			},
+		})
+	})
 }

--- a/server/service/handler_deprecated_paths.go
+++ b/server/service/handler_deprecated_paths.go
@@ -1,0 +1,223 @@
+package service
+
+import (
+	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
+)
+
+// deprecatedPathAliases defines deprecated URL path aliases that map old
+// (deprecated) paths to their canonical (primary) paths. Each entry causes
+// the deprecated path(s) to serve the same handler as the primary path.
+//
+// These are organized by category:
+//   - teams → fleets: team CRUD, secrets, agent_options, users, spec
+//   - team/teams → fleets: policies, schedule (both singular and plural deprecated)
+//   - queries → reports: query CRUD, spec, report data
+//   - host queries → reports
+//   - live queries → reports: run, run_by_identifiers, run_by_names
+//   - ABM/VPP token teams → fleets
+var deprecatedPathAliases = []eu.DeprecatedPathAlias{
+	// ---- teams → fleets ----
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/spec/fleets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/spec/teams"},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id:[0-9]+}/secrets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{fleet_id:[0-9]+}/secrets"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/fleets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}"},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}"},
+	},
+	{
+		Method: "DELETE", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}/agent_options",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}/agent_options"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}/users",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}/users"},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}/users",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}/users"},
+	},
+	{
+		Method: "DELETE", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}/users",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}/users"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{id:[0-9]+}/secrets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{id:[0-9]+}/secrets"},
+	},
+
+	// ---- team/teams → fleets (policies) ----
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/policies",
+			"/api/_version_/fleet/teams/{fleet_id}/policies",
+		},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/policies",
+			"/api/_version_/fleet/teams/{fleet_id}/policies",
+		},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies/count",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/policies/count",
+			"/api/_version_/fleet/teams/{fleet_id}/policies/count",
+		},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies/{policy_id}",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/policies/{policy_id}",
+			"/api/_version_/fleet/teams/{fleet_id}/policies/{policy_id}",
+		},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies/delete",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/policies/delete",
+			"/api/_version_/fleet/teams/{fleet_id}/policies/delete",
+		},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/policies/{policy_id}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/teams/{fleet_id}/policies/{policy_id}"},
+	},
+
+	// ---- queries → reports ----
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/reports/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/{id:[0-9]+}"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/reports",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/reports/{id:[0-9]+}/report",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/{id:[0-9]+}/report"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries"},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/reports/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/{id:[0-9]+}"},
+	},
+	{
+		Method: "DELETE", PrimaryPath: "/api/_version_/fleet/reports/{name}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/{name}"},
+	},
+	{
+		Method: "DELETE", PrimaryPath: "/api/_version_/fleet/reports/id/{id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/id/{id:[0-9]+}"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports/delete",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/delete"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/spec/reports",
+		DeprecatedPaths: []string{"/api/_version_/fleet/spec/queries"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/spec/reports",
+		DeprecatedPaths: []string{"/api/_version_/fleet/spec/queries"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/spec/reports/{name}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/spec/queries/{name}"},
+	},
+
+	// ---- host queries → reports ----
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/hosts/{id:[0-9]+}/reports/{report_id:[0-9]+}",
+		DeprecatedPaths: []string{"/api/_version_/fleet/hosts/{id:[0-9]+}/queries/{report_id:[0-9]+}"},
+	},
+
+	// ---- live queries → reports ----
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports/{id:[0-9]+}/run",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/{id:[0-9]+}/run"},
+	},
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/reports/run",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/run"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports/run",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/run"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports/run_by_identifiers",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/run_by_identifiers"},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/reports/run_by_names",
+		DeprecatedPaths: []string{"/api/_version_/fleet/queries/run_by_names"},
+	},
+
+	// ---- team/teams → fleets (schedule) ----
+	{
+		Method: "GET", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/schedule",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/schedule",
+			"/api/_version_/fleet/teams/{fleet_id}/schedule",
+		},
+	},
+	{
+		Method: "POST", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/schedule",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/schedule",
+			"/api/_version_/fleet/teams/{fleet_id}/schedule",
+		},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/schedule/{report_id}",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/schedule/{report_id}",
+			"/api/_version_/fleet/teams/{fleet_id}/schedule/{report_id}",
+		},
+	},
+	{
+		Method: "DELETE", PrimaryPath: "/api/_version_/fleet/fleets/{fleet_id}/schedule/{report_id}",
+		DeprecatedPaths: []string{
+			"/api/_version_/fleet/team/{fleet_id}/schedule/{report_id}",
+			"/api/_version_/fleet/teams/{fleet_id}/schedule/{report_id}",
+		},
+	},
+
+	// ---- ABM/VPP token teams → fleets ----
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/abm_tokens/{id:[0-9]+}/fleets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/abm_tokens/{id:[0-9]+}/teams"},
+	},
+	{
+		Method: "PATCH", PrimaryPath: "/api/_version_/fleet/vpp_tokens/{id}/fleets",
+		DeprecatedPaths: []string{"/api/_version_/fleet/vpp_tokens/{id}/teams"},
+	},
+}

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -95,12 +95,14 @@ func (s *integrationLoggerTestSuite) TestLogger() {
 			assert.Equal(t, "/api/latest/fleet/config", attrs["uri"])
 			assert.Equal(t, "admin1@example.com", attrs["user"])
 		case 2:
-			assert.Equal(t, slog.LevelDebug, rec.Level)
+			assert.Equal(t, slog.LevelWarn, rec.Level) // Warn because /queries is a deprecated path
 			assert.Equal(t, "POST", attrs["method"])
 			assert.Equal(t, "/api/latest/fleet/queries", attrs["uri"])
 			assert.Equal(t, "admin1@example.com", attrs["user"])
 			assert.Equal(t, "somequery", attrs["name"])
 			assert.Equal(t, "select 1 from osquery;", attrs["sql"])
+			assert.Equal(t, "/api/_version_/fleet/queries", attrs["deprecated_path"])
+			assert.Contains(t, attrs["deprecation_warning"], "deprecated")
 		default:
 			t.Fail()
 		}


### PR DESCRIPTION
Cherry-pick of #40520 into `rc-minor-fleet-v4.82.0`.