### PR TITLE
Fix batch set installers not updating some fields

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2295,9 +2295,9 @@ ON DUPLICATE KEY UPDATE
 `
 
 	const updateInstaller = `
-UPDATE 
+UPDATE
 	software_installers
-SET 
+SET
 	install_during_setup = ?,
 	self_service = ?,
 	install_script_content_id = ?,

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2294,6 +2294,19 @@ ON DUPLICATE KEY UPDATE
   is_active = VALUES(is_active)
 `
 
+	const updateInstaller = `
+UPDATE 
+	software_installers
+SET 
+	install_during_setup = ?,
+	self_service = ?,
+	install_script_content_id = ?,
+	uninstall_script_content_id = ?,
+	post_install_script_content_id = ?,
+	pre_install_query = ?
+WHERE id = ?
+`
+
 	const loadSoftwareInstallerID = `
 SELECT
 	id
@@ -2715,8 +2728,8 @@ WHERE
 			// for this team+title. This prevents duplicate rows from repeated batch sets
 			// that re-download the same latest version.
 			var skipInsert bool
+			var existingID uint
 			if installer.FleetMaintainedAppID != nil {
-				var existingID uint
 				err := sqlx.GetContext(ctx, tx, &existingID, `
 					SELECT id FROM software_installers
 					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND version = ?
@@ -2729,7 +2742,21 @@ WHERE
 				}
 			}
 
-			if !skipInsert {
+			if skipInsert {
+				// some fields still need to be updated
+				args := []any{
+					installer.InstallDuringSetup,
+					installer.SelfService,
+					installScriptID,
+					uninstallScriptID,
+					postInstallScriptID,
+					installer.PreInstallQuery,
+					existingID,
+				}
+				if _, err := tx.ExecContext(ctx, updateInstaller, args...); err != nil {
+					return ctxerr.Wrapf(ctx, err, "updating existing installer with name %q", installer.Filename)
+				}
+			} else {
 				upsertQuery := insertNewOrEditedInstaller
 				if len(existing) > 0 && existing[0].IsPackageModified { // update uploaded_at for updated installer package
 					upsertQuery = fmt.Sprintf("%s, uploaded_at = NOW()", upsertQuery)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2298,7 +2298,7 @@ ON DUPLICATE KEY UPDATE
 UPDATE
 	software_installers
 SET
-	install_during_setup = ?,
+	install_during_setup = COALESCE(?, install_during_setup),
 	self_service = ?,
 	install_script_content_id = ?,
 	uninstall_script_content_id = ?,

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4313,6 +4313,7 @@ func testFleetMaintainedAppInstallerUpdates(t *testing.T, ds *Datastore) {
 
 	tmFilter := fleet.TeamFilter{User: test.UserAdmin}
 	titles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: ptr.Uint(0), Platform: "darwin", AvailableForInstall: true}, tmFilter)
+	require.NoError(t, err)
 	require.Len(t, titles, 1)
 	require.False(t, *titles[0].SoftwarePackage.InstallDuringSetup)
 	require.False(t, *titles[0].SoftwarePackage.SelfService)
@@ -4353,6 +4354,7 @@ func testFleetMaintainedAppInstallerUpdates(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	titles, _, _, err = ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: ptr.Uint(0), Platform: "darwin", AvailableForInstall: true}, tmFilter)
+	require.NoError(t, err)
 	require.Len(t, titles, 1)
 	require.True(t, *titles[0].SoftwarePackage.InstallDuringSetup)
 	require.True(t, *titles[0].SoftwarePackage.SelfService)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40549 
Fix some settings like setup experience, self service, scripts, not being updated in BatchSetSoftwareInstallers

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
- Tested that unlocked version FMA setup experience, self service, or script changes appropriately 
- Tested with version locked FMA

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed
