### PR TITLE
Cherry-pick #40586: Support report/fleet as spec "kinds"

### DIFF
--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -309,13 +309,13 @@ func TestApplyTeamSpecs(t *testing.T) {
 	filename := writeTmpYml(t, `
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team2
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     agent_options:
@@ -360,7 +360,7 @@ spec:
 	filename = writeTmpYml(t, `
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -389,7 +389,7 @@ spec:
 	mobileCfgPath := writeTmpMobileconfig(t, "N1")
 	filename = writeTmpYml(t, fmt.Sprintf(`
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -428,7 +428,7 @@ spec:
 
 	filename = writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     agent_options:
@@ -483,7 +483,7 @@ spec:
 
 	filename = writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     agent_options:
@@ -504,7 +504,7 @@ spec:
 
 	filename = writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -519,7 +519,7 @@ spec:
 
 	filename = writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -577,7 +577,7 @@ spec:
 	filename = writeTmpYml(
 		t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -608,7 +608,7 @@ spec:
 	filename = writeTmpYml(
 		t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -631,7 +631,7 @@ spec:
 	filename = writeTmpYml(
 		t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -654,7 +654,7 @@ spec:
 	filename = writeTmpYml(
 		t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -1273,7 +1273,7 @@ spec:
 `
 	queriesSpec = `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   description: Retrieves the list of application scheme/protocol-based IPC handlers.
   name: app_schemes
@@ -1650,7 +1650,7 @@ spec:
 	// Apply team config.
 	name = writeTmpYml(t, fmt.Sprintf(`
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     agent_options:
@@ -1703,7 +1703,7 @@ spec:
 	// add macos setup assistant to team
 	name = writeTmpYml(t, fmt.Sprintf(`
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: Team1
@@ -1743,7 +1743,7 @@ spec:
 	// add bootstrap package to team
 	name = writeTmpYml(t, fmt.Sprintf(`
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: Team1
@@ -2370,7 +2370,7 @@ spec:
 `
 		team1Spec = `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: tm1
@@ -2385,7 +2385,7 @@ spec:
 `
 		team1NoKeySpec = `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: tm1
@@ -2394,7 +2394,7 @@ spec:
 `
 		team1And2Spec = `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: tm1
@@ -2404,7 +2404,7 @@ spec:
         macos_setup_assistant: %s
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: tm2
@@ -2415,7 +2415,7 @@ spec:
 `
 		team1SpecEnableEndUserAuth = `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: tm1
@@ -3074,7 +3074,7 @@ func TestApplySpecs(t *testing.T) {
 			desc: "empty team spec",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
 `,
 			wantOutput: "[+] applied 1 team",
@@ -3083,7 +3083,7 @@ spec:
 			desc: "empty team name",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: ""
@@ -3094,7 +3094,7 @@ spec:
 			desc: "invalid agent options for existing team",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3108,7 +3108,7 @@ spec:
 			desc: "invalid top-level key for team",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3120,7 +3120,7 @@ spec:
 			desc: "invalid known key's value type for team cannot be forced",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: 123
@@ -3132,7 +3132,7 @@ spec:
 			desc: "unknown key for team can be forced",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3145,7 +3145,7 @@ spec:
 			desc: "invalid agent options for new team",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3159,7 +3159,7 @@ spec:
 			desc: "invalid agent options dry-run",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3174,7 +3174,7 @@ spec:
 			desc: "invalid agent options force",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3189,7 +3189,7 @@ spec:
 			desc: "invalid agent options field type",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3205,7 +3205,7 @@ spec:
 			desc: "invalid team agent options command-line flag",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3219,7 +3219,7 @@ spec:
 			desc: "valid team agent options command-line flag",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3233,7 +3233,7 @@ spec:
 			desc: "invalid agent options field type in overrides",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3395,7 +3395,7 @@ spec:
 			desc: "dry-run set with various specs, appconfig warning for legacy",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3420,7 +3420,7 @@ spec:
 			desc: "dry-run set with various specs, no errors",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: teamNEW
@@ -3446,7 +3446,7 @@ spec:
 			desc: "macos_updates deadline set but minimum_version empty",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3460,7 +3460,7 @@ spec:
 			desc: "macos_updates minimum_version set but deadline empty",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3474,7 +3474,7 @@ spec:
 			desc: "macos_updates.minimum_version with build version",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3489,7 +3489,7 @@ spec:
 			desc: "macos_updates.deadline with timestamp",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3504,7 +3504,7 @@ spec:
 			desc: "macos_updates.deadline with invalid date",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3519,7 +3519,7 @@ spec:
 			desc: "macos_updates.deadline with incomplete date",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3534,7 +3534,7 @@ spec:
 			desc: "windows_updates.deadline_days but grace period empty",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3548,7 +3548,7 @@ spec:
 			desc: "windows_updates.grace_period_days but deadline empty",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3562,7 +3562,7 @@ spec:
 			desc: "windows_updates.deadline_days out of range",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3577,7 +3577,7 @@ spec:
 			desc: "windows_updates.grace_period_days out of range",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3592,7 +3592,7 @@ spec:
 			desc: "windows_updates.deadline_days not a number",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3607,7 +3607,7 @@ spec:
 			desc: "windows_updates.grace_period_days not a number",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3622,7 +3622,7 @@ spec:
 			desc: "windows_updates valid",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -3637,7 +3637,7 @@ spec:
 			desc: "windows_updates unset valid",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4007,7 +4007,7 @@ spec:
 			desc: "team config macos_settings.enable_disk_encryption without a value",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4021,7 +4021,7 @@ spec:
 			desc: "team config macos_settings.enable_disk_encryption with invalid value type",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4035,7 +4035,7 @@ spec:
 			desc: "team config macos_settings.enable_disk_encryption true",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4049,7 +4049,7 @@ spec:
 			desc: "team config macos_settings.enable_disk_encryption false",
 			spec: `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4063,7 +4063,7 @@ spec:
 			desc: "team config mac setup assistant",
 			spec: fmt.Sprintf(`
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: team1
@@ -4329,7 +4329,7 @@ func TestApplyWindowsUpdates(t *testing.T) {
 
 		filename := writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: Team1
@@ -4358,7 +4358,7 @@ spec:
 
 		filename := writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: Team1
@@ -4386,7 +4386,7 @@ spec:
 
 		filename := writeTmpYml(t, `
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   team:
     name: Team1

--- a/cmd/fleetctl/fleetctl/convert.go
+++ b/cmd/fleetctl/fleetctl/convert.go
@@ -219,7 +219,7 @@ func convertCommand() *cli.Command {
 				}
 
 				meta := spec.Metadata{
-					Kind:    fleet.QueryKind,
+					Kind:    fleet.ReportKind,
 					Version: fleet.ApiVersion,
 					Spec:    specBytes,
 				}

--- a/cmd/fleetctl/fleetctl/get.go
+++ b/cmd/fleetctl/fleetctl/get.go
@@ -104,7 +104,7 @@ func printLabel(c *cli.Context, label *fleet.LabelSpec) error {
 
 func printQuerySpec(c *cli.Context, query *fleet.QuerySpec) error {
 	spec := specGeneric{
-		Kind:    fleet.QueryKind,
+		Kind:    fleet.ReportKind,
 		Version: fleet.ApiVersion,
 		Spec:    query,
 	}
@@ -259,7 +259,7 @@ func printTeams(c *cli.Context, teams []fleet.Team) error {
 			teamItem = teamSpec
 		}
 		spec := specGeneric{
-			Kind:    fleet.TeamKind,
+			Kind:    fleet.FleetKind,
 			Version: fleet.ApiVersion,
 			Spec: map[string]interface{}{
 				"team": teamItem,

--- a/cmd/fleetctl/fleetctl/get_test.go
+++ b/cmd/fleetctl/fleetctl/get_test.go
@@ -1616,7 +1616,7 @@ func TestGetQueries(t *testing.T) {
 
 	expectedYAMLGlobal := `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc
@@ -1632,7 +1632,7 @@ spec:
   team: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc 2
@@ -1651,7 +1651,7 @@ spec:
   team: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: true
   description: some desc 4
@@ -1666,9 +1666,9 @@ spec:
   query: select 4;
   team: ""
 `
-	expectedJSONGlobal := `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
-{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":true,"fleet":"","interval":0,"labels_include_any":["label1","label2"],"logging":"","min_osquery_version":"","name":"query2","observer_can_run":false,"platform":"","query":"select 2;","team":""}}
-{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":true,"description":"some desc 4","discard_data":false,"fleet":"","interval":60,"logging":"differential_ignore_removals","min_osquery_version":"5.3.0","name":"query4","observer_can_run":true,"platform":"darwin,windows","query":"select 4;","team":""}}
+	expectedJSONGlobal := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
+{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":true,"fleet":"","interval":0,"labels_include_any":["label1","label2"],"logging":"","min_osquery_version":"","name":"query2","observer_can_run":false,"platform":"","query":"select 2;","team":""}}
+{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":true,"description":"some desc 4","discard_data":false,"fleet":"","interval":60,"logging":"differential_ignore_removals","min_osquery_version":"5.3.0","name":"query4","observer_can_run":true,"platform":"darwin,windows","query":"select 4;","team":""}}
 `
 
 	expectedTeam := `+--------+-------------+-----------+--------+----------------------------+
@@ -1690,7 +1690,7 @@ spec:
 
 	expectedYAMLTeam := `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc 3
@@ -1705,7 +1705,7 @@ spec:
   query: select 3;
   team: Foobar
 `
-	expectedJSONTeam := `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 3","discard_data":false,"fleet":"Foobar","interval":3600,"logging":"snapshot","min_osquery_version":"5.4.0","name":"query3","observer_can_run":true,"platform":"darwin","query":"select 3;","team":"Foobar"}}
+	expectedJSONTeam := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 3","discard_data":false,"fleet":"Foobar","interval":3600,"logging":"snapshot","min_osquery_version":"5.4.0","name":"query3","observer_can_run":true,"platform":"darwin","query":"select 3;","team":"Foobar"}}
 `
 
 	assert.Equal(t, expectedGlobal, RunAppForTest(t, []string{"get", "queries"}))
@@ -1786,7 +1786,7 @@ func TestGetQuery(t *testing.T) {
 
 	expectedYaml := `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc
@@ -1801,7 +1801,7 @@ spec:
   query: select 1;
   team: ""
 `
-	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"globalQuery1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
+	expectedJson := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"globalQuery1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
 `
 
 	assert.Equal(t, expectedYaml, RunAppForTest(t, []string{"get", "query", "globalQuery1"}))
@@ -1810,7 +1810,7 @@ spec:
 
 	expectedYaml = `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: true
   description: some team desc
@@ -1825,7 +1825,7 @@ spec:
   query: select 2;
   team: Foobar
 `
-	expectedJson = `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":true,"description":"some team desc","discard_data":false,"fleet":"Foobar","interval":3600,"logging":"differential","min_osquery_version":"5.2.0","name":"teamQuery1","observer_can_run":true,"platform":"linux","query":"select 2;","team":"Foobar"}}
+	expectedJson = `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":true,"description":"some team desc","discard_data":false,"fleet":"Foobar","interval":3600,"logging":"differential","min_osquery_version":"5.2.0","name":"teamQuery1","observer_can_run":true,"platform":"linux","query":"select 2;","team":"Foobar"}}
 `
 
 	assert.Equal(t, expectedYaml, RunAppForTest(t, []string{"get", "query", "--team", "1", "teamQuery1"}))
@@ -1931,7 +1931,7 @@ func TestGetQueriesAsObserver(t *testing.T) {
 `
 			expectedYaml := `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc 2
@@ -1946,7 +1946,7 @@ spec:
   query: select 2;
   team: ""
 `
-			expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query2","observer_can_run":true,"platform":"","query":"select 2;","team":""}}
+			expectedJson := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query2","observer_can_run":true,"platform":"","query":"select 2;","team":""}}
 `
 
 			assert.Equal(t, expected, RunAppForTest(t, []string{"get", "queries"}))
@@ -2016,7 +2016,7 @@ spec:
 `
 	expectedYaml := `---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc
@@ -2032,7 +2032,7 @@ spec:
   team: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc 2
@@ -2048,7 +2048,7 @@ spec:
   team: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: some desc 3
@@ -2063,9 +2063,9 @@ spec:
   query: select 3;
   team: ""
 `
-	expectedJson := `{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
-{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query2","observer_can_run":true,"platform":"","query":"select 2;","team":""}}
-{"kind":"query","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 3","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query3","observer_can_run":false,"platform":"","query":"select 3;","team":""}}
+	expectedJson := `{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query1","observer_can_run":false,"platform":"","query":"select 1;","team":""}}
+{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 2","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query2","observer_can_run":true,"platform":"","query":"select 2;","team":""}}
+{"kind":"report","apiVersion":"v1","spec":{"automations_enabled":false,"description":"some desc 3","discard_data":false,"fleet":"","interval":0,"logging":"","min_osquery_version":"","name":"query3","observer_can_run":false,"platform":"","query":"select 3;","team":""}}
 `
 
 	assert.Equal(t, expected, RunAppForTest(t, []string{"get", "queries"}))

--- a/cmd/fleetctl/fleetctl/testdata/convert_output.yml
+++ b/cmd/fleetctl/fleetctl/testdata/convert_output.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the list of application scheme/protocol-based IPC handlers.
@@ -15,7 +15,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
@@ -30,7 +30,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the current disk encryption status for the target system.
@@ -45,7 +45,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieve basic information about the physical disks of a system.
@@ -60,7 +60,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the current filters and chains per filter in the target system.
@@ -75,7 +75,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description:
@@ -92,7 +92,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the list of listening ports.
@@ -107,7 +107,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Retrieves the list of listening ports.
@@ -122,7 +122,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
@@ -137,7 +137,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: System resource usage limits.
@@ -152,7 +152,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: System uptime.
@@ -167,7 +167,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: System uptime.
@@ -182,7 +182,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: System uptime.
@@ -197,7 +197,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: System uptime.
@@ -212,7 +212,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Lists the application bundle that owns a sandbox label.
@@ -227,7 +227,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -242,7 +242,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -257,7 +257,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -272,7 +272,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -287,7 +287,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -302,7 +302,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -317,7 +317,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -332,7 +332,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: List of all user groups.
@@ -347,7 +347,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: Extracted information from Windows crash logs (Minidumps).
@@ -362,7 +362,7 @@ spec:
   fleet: ""
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description:

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
@@ -1,5 +1,5 @@
 {
-  "kind": "team",
+  "kind": "fleet",
   "apiVersion": "v1",
   "spec": {
     "fleet": {
@@ -155,7 +155,7 @@
   }
 }
 {
-  "kind": "team",
+  "kind": "fleet",
   "apiVersion": "v1",
   "spec": {
     "fleet": {

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:
@@ -104,7 +104,7 @@ spec:
     name: team1
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     agent_options:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:
@@ -104,7 +104,7 @@ spec:
     name: tm1
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:
@@ -104,7 +104,7 @@ spec:
     name: tm1
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     host_expiry_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: team
+kind: fleet
 spec:
   fleet:
     features:

--- a/cmd/fleetctl/fleetctl/upgrade_packs.go
+++ b/cmd/fleetctl/fleetctl/upgrade_packs.go
@@ -131,7 +131,7 @@ func writeQuerySpecsToFile(filename string, specs []*fleet.QuerySpec) error {
 		qYaml := fleet.QueryObject{
 			ObjectMetadata: fleet.ObjectMetadata{
 				ApiVersion: fleet.ApiVersion,
-				Kind:       fleet.QueryKind,
+				Kind:       fleet.ReportKind,
 			},
 			Spec: *spec,
 		}

--- a/cmd/fleetctl/fleetctl/upgrade_packs_test.go
+++ b/cmd/fleetctl/fleetctl/upgrade_packs_test.go
@@ -325,7 +325,7 @@ func TestFleetctlUpgradePacks_NonEmpty(t *testing.T) {
 
 	const expected = `
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: false
   description: (converted from pack "p1", query "q1")
@@ -340,7 +340,7 @@ spec:
   query: select 1
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: true
   description: (converted from pack "p2", query "q2")
@@ -355,7 +355,7 @@ spec:
   query: select 2
 ---
 apiVersion: v1
-kind: query
+kind: report
 spec:
   automations_enabled: true
   description: (converted from pack "p2", query "q2")

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -92,7 +92,10 @@ func GroupFromBytes(b []byte, options ...GroupFromBytesOpts) (*Group, error) {
 
 		var deprecatedKeysMap map[string]string
 		switch kind {
-		case fleet.QueryKind:
+		case fleet.QueryKind, fleet.ReportKind:
+			if logFn != nil && kind == fleet.QueryKind {
+				logFn("[!] `kind: query` is deprecated, please use `kind: report` instead.\n")
+			}
 			var err error
 			s.Spec, deprecatedKeysMap, err = rewriteNewToOldKeys(s.Spec, fleet.QuerySpec{})
 			if err != nil {
@@ -179,7 +182,10 @@ func GroupFromBytes(b []byte, options ...GroupFromBytesOpts) (*Group, error) {
 			}
 			specs.UsersRoles = userRoleSpec
 
-		case fleet.TeamKind:
+		case fleet.TeamKind, fleet.FleetKind:
+			if logFn != nil && kind == fleet.TeamKind {
+				logFn("[!] `kind: team` is deprecated, please use `kind: fleet` instead.\n")
+			}
 			// unmarshal to a raw map as we don't want to strip away unknown/invalid
 			// fields at this point - that validation is done in the apply spec/teams
 			// endpoint so that it is enforced for both the API and the CLI.

--- a/server/fleet/queries.go
+++ b/server/fleet/queries.go
@@ -334,7 +334,8 @@ func verifyQueryPlatforms(platforms string) error {
 }
 
 const (
-	QueryKind = "query"
+	QueryKind  = "query"
+	ReportKind = "report"
 )
 
 type QueryObject struct {
@@ -407,7 +408,7 @@ func WriteQueriesToYaml(queries []*Query) (string, error) {
 		qYaml := QueryObject{
 			ObjectMetadata: ObjectMetadata{
 				ApiVersion: ApiVersion,
-				Kind:       QueryKind,
+				Kind:       ReportKind,
 			},
 			Spec: QuerySpec{
 				Name:        q.Name,

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -621,7 +621,8 @@ func (f TeamFilter) UserCanAccessSelectedTeam() bool {
 }
 
 const (
-	TeamKind = "team"
+	TeamKind  = "team"
+	FleetKind = "fleet"
 )
 
 type TeamSpec struct {


### PR DESCRIPTION
Cherry-pick of #40586 into `rc-minor-fleet-v4.82.0`.