### PR TITLE
Fix TestGetAssets/always_times_out flaky test.

### DIFF
--- a/ee/server/service/digicert/digicert_test.go
+++ b/ee/server/service/digicert/digicert_test.go
@@ -36,5 +36,5 @@ func TestTimeout(t *testing.T) {
 	}
 	s := NewService(WithTimeout(1 * time.Millisecond))
 	err := s.VerifyProfileID(context.Background(), config)
-	assert.ErrorContains(t, err, "Client.Timeout exceeded while awaiting headers")
+	assert.ErrorContains(t, err, "exceeded")
 }

--- a/ee/server/service/digicert/digicert_test.go
+++ b/ee/server/service/digicert/digicert_test.go
@@ -36,5 +36,5 @@ func TestTimeout(t *testing.T) {
 	}
 	s := NewService(WithTimeout(1 * time.Millisecond))
 	err := s.VerifyProfileID(context.Background(), config)
-	assert.ErrorContains(t, err, "deadline exceeded")
+	assert.ErrorContains(t, err, "Client.Timeout exceeded while awaiting headers")
 }

--- a/server/mdm/apple/vpp/api_test.go
+++ b/server/mdm/apple/vpp/api_test.go
@@ -248,7 +248,7 @@ func TestGetAssets(t *testing.T) {
 				require.NoError(t, json.NewEncoder(w).Encode(assets))
 			},
 			expectedAssets:   nil,
-			expectedErrMsg:   "context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+			expectedErrMsg:   "Client.Timeout exceeded while awaiting headers",
 			expectedRequests: 3,
 		},
 		{


### PR DESCRIPTION
Root cause: Go's net/http client timeout triggers via two competing code paths: one produces "context deadline exceeded ..." and the other "net/http: request canceled ...".

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40638 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for timeout error handling validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->