### PR TITLE
Remove mention of down migrations in go-reviewer agent doc, narrow .fleet permissions

### DIFF
--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -13,7 +13,7 @@ You are a Go code reviewer specialized in the Fleet codebase. Review code change
 - SQL injection prevention (parameterized queries only)
 - Proper use of sqlx/goqu patterns
 - New queries have appropriate indexes
-- Migrations are reversible and tested
+- Migrations have corresponding teste
 - `ds.writer(ctx)` vs `ds.reader(ctx)` used correctly for write/read operations
 
 ### API endpoints

--- a/.claude/agents/go-reviewer.md
+++ b/.claude/agents/go-reviewer.md
@@ -13,7 +13,7 @@ You are a Go code reviewer specialized in the Fleet codebase. Review code change
 - SQL injection prevention (parameterized queries only)
 - Proper use of sqlx/goqu patterns
 - New queries have appropriate indexes
-- Migrations have corresponding teste
+- Migrations have corresponding tests
 - `ds.writer(ctx)` vs `ds.reader(ctx)` used correctly for write/read operations
 
 ### API endpoints

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,9 @@
   },
   "permissions": {
     "allow": [
-      "Read(~/.fleet/**)"
+      "Read(~/.fleet/claude-projects/**)",
+      "Write(~/.fleet/claude-projects/**)",
+      "Edit(~/.fleet/claude-projects/**)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
We don't do down migrations.