### PR TITLE
Fixes dead link for Windows

### DIFF
--- a/articles/scripts.md
+++ b/articles/scripts.md
@@ -21,7 +21,7 @@ If you don't use MDM features, to enable scripts, we'll [deploy Fleet's agent (f
 
 If you already deployed fleetd, instead of re-deploying it, you can update fleetd's configuration remotely to enable scripts. This requires a third-party tool (ex. [Chef](https://www.chef.io/)), other than Fleet, that can run scripts. 
 
-Using your separate third-party tool, run the enable scripts script for [macOS](https://github.com/fleetdm/fleet/blob/main/assets/scripts/enable-scripts-macos.sh), [Windows](https://github.com/fleetdm/fleet/blob/main/assets/windows/scripts/enable-scripts-windows.ps1), or [Linux](https://github.com/fleetdm/fleet/blob/main/assets/scripts/enable-scripts-linux.sh).
+Using your separate third-party tool, run the enable scripts script for [macOS](https://github.com/fleetdm/fleet/blob/main/assets/scripts/enable-scripts-macos.sh), [Windows](https://github.com/fleetdm/fleet/blob/main/assets/scripts/enable-scripts-windows.ps1), or [Linux](https://github.com/fleetdm/fleet/blob/main/assets/scripts/enable-scripts-linux.sh).
 
 ## Manually run scripts
 


### PR DESCRIPTION
The link to the script to enable scripts for Windows was incorrect.