### PR TITLE
fix overflow of button off the table on the os settings modal

### DIFF
--- a/changes/issue-40697-fix-os-setting-overflow
+++ b/changes/issue-40697-fix-os-setting-overflow
@@ -1,0 +1,1 @@
+- fix the error resend button overflowing over the edge of the os settings modal table

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/_styles.scss
@@ -5,7 +5,9 @@
   gap: $pad-small;
 
   &__failed-message {
-    min-width: 168px; // Aligns resend button to right end
+    // allows the message to shrink and not push the
+    // resend button outside of the table cell
+    min-width: 0;
 
     .data-table__tooltip-truncated-text--cell {
       // for some reason this is need to vertically align the text and

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/_styles.scss
@@ -6,12 +6,21 @@
     &__wrapper {
       width: initial;
     }
+    tbody td.detail__cell {
+      // these styles are a little trick that allows the cell to 
+      // shrink while still follwing the auto width behavior of the table.
+      // This is needed to show the error text and button in the 
+      // error cell correctly without overflowing outside of the table.
+      max-width: 0;
+      width: 100%;
+    }
     tbody td {
       .os-settings-name-cell {
         max-width: 166px;
       }
       .os-settings-error-cell {
-        width: 237px;
+        min-width: 0;
+        width: 100%;
       }
     }
   }


### PR DESCRIPTION
**Related issue:** Resolves #39361

This fixes an issue of the overflow of the resend button off the edge of the os settting modal table.

We've changed the syling to grow and shrink the error text and column dynamically so that the table will always be pushed up against the right edge and the text will grow and shrink as needed so that it wont push the button any further right

<img width="838" height="436" alt="image" src="https://github.com/user-attachments/assets/a5acfd44-0d77-4062-92e4-909077827fee" />

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
