### PR TITLE
Update resolution instructions for "macOS - All available software updates installed"

### DIFF
--- a/it-and-security/lib/macos/policies/all-software-updates-installed.yml
+++ b/it-and-security/lib/macos/policies/all-software-updates-installed.yml
@@ -5,5 +5,5 @@
   resolution: |
     Please take some time and run all available updates from Software Update ( > System Settings > Software Update) and all available app store updates ( > App Store > Updates). 
     
-    If you see a "This feature isn't available…" popup while trying to update, you will need to delete the software instead of updating it.
+    If you see the message "This feature isn't available with the Apple Account you're currently using." you will need to delete and re-install the app.
   platform: darwin

--- a/it-and-security/lib/macos/policies/all-software-updates-installed.yml
+++ b/it-and-security/lib/macos/policies/all-software-updates-installed.yml
@@ -5,5 +5,5 @@
   resolution: |
     Please take some time and run all available updates from Software Update ( > System Settings > Software Update) and all available app store updates ( > App Store > Updates). 
     
-    If you see a popup saying updates aren't available for your account, you will need to delete any software requiring an update.
+    If you see a "This feature isn't available…" popup while trying to update, you will need to delete the software instead of updating it.
   platform: darwin

--- a/it-and-security/lib/macos/policies/all-software-updates-installed.yml
+++ b/it-and-security/lib/macos/policies/all-software-updates-installed.yml
@@ -2,5 +2,8 @@
   query: SELECT 1 FROM software_update WHERE software_update_required = 0;
   critical: false
   description: This Mac may have outdated system software, which could lead to security vulnerabilities, performance issues, and incompatibility with other systems.
-  resolution: Please take some time and run all available updates from Software Update ( > System Settings > Software Update) and all available app store updates ( > App Store > Updates).
+  resolution: |
+    Please take some time and run all available updates from Software Update ( > System Settings > Software Update) and all available app store updates ( > App Store > Updates). 
+    
+    If you see a popup saying updates aren't available for your account, you will need to delete any software requiring an update.
   platform: darwin


### PR DESCRIPTION
I think the resolution is out-of-date; "Update all" isn't available:
<img width="360" height="263" alt="Screenshot 2026-02-27 at 11 35 50 AM" src="https://github.com/user-attachments/assets/89c68c81-23e6-427c-a742-88c8fce15564" />

([Slack thread](https://fleetdm.slack.com/archives/C09861YJUJ2/p1772150972961499))