### PR TITLE
Website: Update Vanta script to exclude built-in macOS applications in device inventory

### DIFF
--- a/website/scripts/send-data-to-vanta.js
+++ b/website/scripts/send-data-to-vanta.js
@@ -257,6 +257,16 @@ module.exports = {
                 }
                 macOsHostToSyncWithVanta.browserExtensions.push(softwareToAdd);
               } else if(software.source === 'apps'){
+                // Note: We're exclude most built-in macOS applications from the device inventory to reduce the size of the request sent to Vanta (which has a 10MB limit).
+                // With built-in software included, the request body size is ~2.5mb for 81 hosts and 32848 software items, when these items are excluded, it is reduced to 0.76 MB.
+                // See https://github.com/fleetdm/fleet/issues/39380 for more information about this.
+                if(_.startsWith(software.bundle_identifier, 'com.apple')) {
+                  // Note: Xprotect is included in the applications list becasue it is in the list of Antivirus solutions that Vanta detects (https://help.vanta.com/en/articles/11346109-antivirus-solutions-detected-by-vanta)
+                  // Note: Keychain is not included because Vanta does not consider it a password manager (https://help.vanta.com/en/articles/11346116-frequently-asked-questions-what-password-managers-does-vanta-detect)
+                  if(software.bundle_identifier !== 'com.apple.XProtectFramework.XProtect'){
+                    continue;
+                  }
+                }
                 softwareToAdd.name += ' '+software.version;// Add the version to the software name
                 softwareToAdd.bundleId = software.bundle_identifier ? software.bundle_identifier : ' '; // If the software is missing a bundle identifier, we'll set it to a blank string.
                 macOsHostToSyncWithVanta.applications.push(softwareToAdd);


### PR DESCRIPTION
Changes:
- Updated the send-data-to-vanta script to exclude built-in macOS applications (besides XProtect) when reporting device inventory for a Vanta Integration. This is done to reduce the size of the device inventory request and allow for more macOS hosts to be reported to Vanta.