### PR TITLE
Fleet UI: Disable cancel checkbox for manual agent install, copy change, ungate from Windows MDM 

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -157,27 +157,26 @@ const InstallSoftware = ({
         (platform === "macos" || platform === "ios" || platform === "ipados") &&
         !appleMdmAndAbmEnabled;
 
-      const turnOnWindowsMdm =
-        platform === "windows" &&
-        !globalConfig?.mdm.windows_enabled_and_configured;
-
       const turnOnAndroidMdm = platform === "android" && !isAndroidMdmEnabled;
 
-      const turnOnMdm = turnOnAppleMdm || turnOnWindowsMdm || turnOnAndroidMdm;
+      // Only Apple and Android setup experience require MDM
+      const turnOnMdm = turnOnAppleMdm || turnOnAndroidMdm;
 
       return (
         <SetupExperienceContentContainer>
           <PageDescription content="Install software on hosts that automatically enroll to Fleet." />
           {turnOnMdm ? (
             <GenericMsgWithNavButton
-              header={`${
+              header={
                 platform === "android"
                   ? "Turn on Android MDM"
                   : "Additional configuration required"
-              }`}
-              info={`To customize, first turn on ${
-                platform === "android" ? "Android MDM" : "automatic enrollment"
-              }.`}
+              }
+              info={
+                platform === "android"
+                  ? "Turn on MDM to install software during setup experience."
+                  : "Turn on MDM and automatic enrollment to install software during setup experience."
+              }
               buttonText="Turn on"
               path={PATHS.ADMIN_INTEGRATIONS_MDM}
               router={router}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -269,7 +269,10 @@ const InstallSoftwareForm = ({
         {platform === "macos" && (
           <div className={`${baseClass}__macos_options`}>
             <Checkbox
-              disabled={config?.gitops.gitops_mode_enabled}
+              disabled={
+                config?.gitops.gitops_mode_enabled ||
+                manualAgentInstallBlockingSoftware
+              }
               value={requireAllSoftwareMacOS}
               onChange={setRequireAllSoftwareMacOS}
             >

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/components/InstallSoftwareForm/InstallSoftwareForm.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useContext, useState, useMemo } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  useMemo,
+} from "react";
 import { isEqual } from "lodash";
 import { InjectedRouter } from "react-router";
 
@@ -131,10 +137,13 @@ const InstallSoftwareForm = ({
     [selectedSoftwareIds, initialSelectedSoftware]
   );
 
-  const isRequireAllSoftwareDirty = useMemo(
-    () => requireAllSoftwareMacOS !== initialRequireAllSoftwareMacOS,
-    [requireAllSoftwareMacOS, initialRequireAllSoftwareMacOS]
-  );
+  // Keep the local checkbox state in sync with the latest saved value
+  useEffect(() => {
+    setRequireAllSoftwareMacOS(savedRequireAllSoftwareMacOS ?? false);
+  }, [savedRequireAllSoftwareMacOS]);
+
+  const isRequireAllSoftwareDirty =
+    requireAllSoftwareMacOS !== (savedRequireAllSoftwareMacOS ?? false);
 
   const shouldUpdateSoftware = isSoftwareSelectionDirty;
   const shouldUpdateRequireAll =


### PR DESCRIPTION
## Issue
Closes #37828 

## Description
3 followups:
- Cancel checkbox should be disabled for manual agent install
- Copy change matches Figma and not previous copy text
- Ungate from Windows MDM (released bug since September 2025 caught by @iansltx 's thorough QA)

## Screenshots of fixes

- ungated
<img width="1377" height="629" alt="Screenshot 2026-02-27 at 4 24 09 PM" src="https://github.com/user-attachments/assets/dc6e2a21-ff32-4ad2-aa81-de07c8d4c538" />

- checkbox now disabled along with rest of form
<img width="1377" height="638" alt="Screenshot 2026-02-27 at 4 24 00 PM" src="https://github.com/user-attachments/assets/c2e8fe9e-9f4c-45e5-8934-28e0b5aa2908" />


## Testing

- [x] QA'd all new/changed functionality manually

