### PR TITLE
Remove "do not enqueue setup experience items >24 hours after enrollment" logic for macOS hosts

### DIFF
--- a/changes/40725-fix-macos-setup
+++ b/changes/40725-fix-macos-setup
@@ -1,0 +1,1 @@
+* Fixed a bug where macOS systems previous enrolled in fleet wouldn't always go through setup experience after a wipe

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -23,18 +23,18 @@ func (ds *Datastore) ResetSetupExperienceItemsAfterFailure(ctx context.Context, 
 }
 
 func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatformLike string, hostUUID string, teamID uint, resetFailedSetupSteps bool) (bool, error) {
-	// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
-	// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
-	// Orbit version that didn't support setup experience to one that does.
-	// See https://github.com/fleetdm/fleet/issues/35717
 	if hostPlatformLike != "darwin" && hostPlatformLike != "ios" && hostPlatformLike != "ipados" {
+		// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
+		// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
+		// Orbit version that didn't support setup experience to one that does.
+		// See https://github.com/fleetdm/fleet/issues/35717
 		stmtHost := `
-	SELECT
-		last_enrolled_at
-	FROM
-		hosts
-	WHERE uuid = ? AND platform = ?
-	`
+		SELECT
+			last_enrolled_at
+		FROM
+			hosts
+		WHERE uuid = ? AND platform = ?
+		`
 		var lastEnrolledAt sql.NullTime
 		if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40725

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
