### PR TITLE
Fleet UI: Allow 'textarea' onBlur, clean to never race

### DIFF
--- a/frontend/components/forms/fields/InputField/InputField.jsx
+++ b/frontend/components/forms/fields/InputField/InputField.jsx
@@ -216,9 +216,6 @@ class InputField extends Component {
       "labelTooltipPosition",
     ]);
 
-    // FIXME: Why doesn't this pass onBlur and other props down if the type is textarea. Do we want
-    // to change that? What might break if we do?
-
     const inputContainerClasses = classnames(`${baseClass}__input-container`, {
       "copy-enabled": enableCopy,
     });
@@ -235,6 +232,8 @@ class InputField extends Component {
               name={name}
               id={name}
               onChange={onInputChange}
+              onBlur={onBlur}
+              onFocus={onFocus}
               className={inputClasses}
               disabled={readOnly || disabled}
               placeholder={placeholder}

--- a/frontend/pages/labels/components/LabelForm/LabelForm.tsx
+++ b/frontend/pages/labels/components/LabelForm/LabelForm.tsx
@@ -66,9 +66,9 @@ const LabelForm = ({
 
   const currentData = { name, description };
 
-  const onFormChange = (update: { name: string; value: string }) => {
-    const { name: fieldName, value } = update;
+  type ParsedTarget = { name: string; value: string };
 
+  const onFormChange = ({ name: fieldName, value }: ParsedTarget) => {
     const nextData =
       fieldName === "name"
         ? { name: value, description }
@@ -110,9 +110,14 @@ const LabelForm = ({
     });
   };
 
-  const onInputBlur = () => {
-    // on blur, show all current errors (set all)
-    const fullValidation = validateLabelFormData(currentData);
+  const onInputBlur = ({ name: fieldName, value }: ParsedTarget) => {
+    const nextData =
+      fieldName === "name"
+        ? { name: value, description }
+        : { name, description: value };
+
+    // full validation for new data
+    const fullValidation = validateLabelFormData(nextData);
     setFormValidation(fullValidation);
   };
 


### PR DESCRIPTION
## Issue
Closes #34167 

## Followup
- Add missing onBlur to text area inputs app wide
- Update onBlur function to not race with onChange

## Screenshot of fix

https://github.com/user-attachments/assets/9abfbef9-af0d-4247-a18e-e2ea1b4abd4d



## Testing

- [x] QA'd all new/changed functionality manually
