### PR TITLE
Cherry-pick: Remove "do not enqueue setup experience items >24 hours after enrollment" logic for macOS hosts (#40739)

### DIFF
--- a/changes/40725-fix-macos-setup
+++ b/changes/40725-fix-macos-setup
@@ -1,0 +1,1 @@
+* Fixed a bug where macOS systems previous enrolled in fleet wouldn't always go through setup experience after a wipe

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -24,32 +24,34 @@ func (ds *Datastore) ResetSetupExperienceItemsAfterFailure(ctx context.Context, 
 }
 
 func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatformLike string, hostUUID string, teamID uint, resetFailedSetupSteps bool) (bool, error) {
-	// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
-	// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
-	// Orbit version that didn't support setup experience to one that does.
-	// See https://github.com/fleetdm/fleet/issues/35717
-	stmtHost := `
-	SELECT
-		last_enrolled_at
-	FROM
-		hosts
-	WHERE uuid = ? AND platform = ?
-	`
-	var lastEnrolledAt sql.NullTime
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// This shouldn't happen but we don't check for it elsewhere,
-			// so we'll log a warning and continue.
-			level.Warn(ds.logger).Log("msg", "Host not found while enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike)
-		} else {
-			return false, ctxerr.Wrap(ctx, err, "finding host for enqueueing setup experience items")
+	if hostPlatformLike != "darwin" && hostPlatformLike != "ios" && hostPlatformLike != "ipados" {
+		// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
+		// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
+		// Orbit version that didn't support setup experience to one that does.
+		// See https://github.com/fleetdm/fleet/issues/35717
+		stmtHost := `
+		SELECT
+			last_enrolled_at
+		FROM
+			hosts
+		WHERE uuid = ? AND platform = ?
+		`
+		var lastEnrolledAt sql.NullTime
+		if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				// This shouldn't happen but we don't check for it elsewhere,
+				// so we'll log a warning and continue.
+				level.Warn(ds.logger).Log("msg", "Host not found while enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike)
+			} else {
+				return false, ctxerr.Wrap(ctx, err, "finding host for enqueueing setup experience items")
+			}
 		}
-	}
-	// If the host was enrolled more than 24 hours ago, don't enqueue any items.
-	// Note: if the last enroll date is our "zero date" (1/1/2000), treat it as if it's never enrolled.
-	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) && lastEnrolledAt.Time.After(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)) {
-		level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
-		return false, nil
+		// If the host was enrolled more than 24 hours ago, don't enqueue any items.
+		// Note: if the last enroll date is our "zero date" (1/1/2000), treat it as if it's never enrolled.
+		if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) && lastEnrolledAt.Time.After(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+			level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
+			return false, nil
+		}
 	}
 
 	// NOTE: currently, the Android platform does not use the "enqueue setup experience items" flow as it


### PR DESCRIPTION
Cherry-pick #40739 