### PR TITLE
Fix attempt for TestFleetDesktopSettingsBrowserAlternativeHost flaky test

### DIFF
--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -114,7 +114,7 @@ func (e *InvalidArgumentError) Appendf(name, reasonFmt string, args ...interface
 // WithStatus returns an error that combines the InvalidArgumentError
 // with a custom status code.
 func (e InvalidArgumentError) WithStatus(code int) error {
-	return invalidArgWithStatusError{e, code}
+	return &invalidArgWithStatusError{e, code}
 }
 
 func (e *InvalidArgumentError) HasErrors() bool {
@@ -122,7 +122,7 @@ func (e *InvalidArgumentError) HasErrors() bool {
 }
 
 // Error implements the error interface.
-func (e InvalidArgumentError) Error() string {
+func (e *InvalidArgumentError) Error() string {
 	switch len(e.Errors) {
 	case 0:
 		return "validation failed"

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -96,7 +96,7 @@ func NewInvalidArgumentError(name, reason string) *InvalidArgumentError {
 	return &invalid
 }
 
-func (e InvalidArgumentError) IsClientError() bool {
+func (e *InvalidArgumentError) IsClientError() bool {
 	return true
 }
 
@@ -113,8 +113,8 @@ func (e *InvalidArgumentError) Appendf(name, reasonFmt string, args ...interface
 
 // WithStatus returns an error that combines the InvalidArgumentError
 // with a custom status code.
-func (e InvalidArgumentError) WithStatus(code int) error {
-	return &invalidArgWithStatusError{e, code}
+func (e *InvalidArgumentError) WithStatus(code int) error {
+	return &invalidArgWithStatusError{*e, code}
 }
 
 func (e *InvalidArgumentError) HasErrors() bool {
@@ -134,7 +134,7 @@ func (e *InvalidArgumentError) Error() string {
 	}
 }
 
-func (e InvalidArgumentError) Invalid() []map[string]string {
+func (e *InvalidArgumentError) Invalid() []map[string]string {
 	var invalid []map[string]string
 	for _, i := range e.Errors {
 		invalid = append(invalid, map[string]string{"name": i.name, "reason": i.reason})

--- a/server/mdm/apple/profile_matcher.go
+++ b/server/mdm/apple/profile_matcher.go
@@ -59,7 +59,7 @@ func (p *profileMatcher) PreassignProfile(ctx context.Context, payload fleet.MDM
 		}
 	}
 	if invArg.HasErrors() {
-		return ctxerr.Wrap(ctx, invArg)
+		return ctxerr.Wrap(ctx, &invArg)
 	}
 
 	md5Hash := payload.HexMD5Hash()


### PR DESCRIPTION
Attempting to fix race conditions for this test:

Go tests result: failure
https://github.com/fleetdm/fleet/actions/runs/22561475775
Summary:FAIL: TestIntegrationsEnterpriseGitops (352.91s)
FAIL: TestIntegrationsEnterpriseGitops/TestFleetDesktopSettingsBrowserAlternativeHost (6.64s)
FAIL: TestIntegrationsEnterpriseGitops/TestFleetDesktopSettingsBrowserAlternativeHost/invalid_value (0.31s)

And maybe also:

Go tests result: failure
https://github.com/fleetdm/fleet/actions/runs/22561475775
Summary:FAIL: TestIntegrationsEnterprise (273.17s)
FAIL: TestIntegrationsEnterprise/TestAllSoftwareTitles (2.07s)
FAIL: TestIntegrationsEnterprise/TestAppConfigOktaConditionalAccess (0.89s)
FAIL: TestIntegrationsEnterprise/TestFleetDesktopSettingsAlternativeBrowserHostURL (0.24s)
FAIL: TestIntegrationsEnterprise/TestGitOpsModeConfig (0.28s)

Go tests result: failure
https://github.com/fleetdm/fleet/actions/runs/22561475775
Summary:FAIL: TestIntegrationsMDM (506.39s)
FAIL: TestIntegrationsMDM/TestAppConfigMDMCustomSettings (0.54s)
FAIL: TestIntegrationsMDM/TestAppConfigMDMMacOSMigration (0.45s)
FAIL: TestIntegrationsMDM/TestAppConfigWindowsMDM (2.29s)
FAIL: TestIntegrationsMDM/TestAppleConfigSecretVariablesUpload (0.46s)

Per GPT:

```
Root cause                                                           
                                                                       
  Within a single test (e.g.                                           
  TestFleetDesktopSettingsAlternativeBrowserHostURL), the test makes an
   API request that returns an InvalidArgumentError. When encoding the 
  error response, EncodeError() does two things in sequence            
  (server/platform/endpointer/transport_error.go:78-88):               

  1. Calls ctxerr.Handle() which sends the error object to the error
  store's background goroutine via a channel
  2. Calls UUID() on the same error object, which lazily writes the
  uuid field (server/platform/http/errors.go:55)

  Meanwhile, the error store background goroutine (started once during
  SetupSuite) picks up that same error object from the channel and
  calls MarshalJSON() → InvalidArgumentError.Error()
  (server/contexts/ctxerr/ctxerr.go:244). Since Error() was a value
  receiver, Go copies the entire struct to call it, inadvertently
  reading the uuid field while step 2 is writing it.

  Two goroutines, same error object, no synchronization — that's the
  race.

  Fix

  - Changed InvalidArgumentError.Error() from value receiver to pointer
   receiver — eliminates the struct copy, so the uuid field is never
  read concurrently with the write
  - Changed InvalidArgumentError.WithStatus() to return a pointer to
  invalidArgWithStatusError, since it embeds InvalidArgumentError and
  needs a pointer to satisfy the error interface
  - Changed profile_matcher.go to pass &invArg instead of invArg to
  ctxerr.Wrap() — the only place in the codebase where
  InvalidArgumentError was used as a value rather than a pointer
```