### PR TITLE
add option to lock end user info during setup experience to UI

### DIFF
--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -35,6 +35,7 @@ const DEFAULT_CONFIG_MDM_MOCK: IMdmConfig = {
     macos_setup_assistant: null,
     enable_release_device_manually: false,
     require_all_software_macos: false,
+    lock_end_user_info: false,
   },
   macos_migration: {
     enable: false,

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -80,6 +80,7 @@ export interface IMdmConfig {
     enable_release_device_manually: boolean | null;
     manual_agent_install: boolean | null;
     require_all_software_macos: boolean | null;
+    lock_end_user_info: boolean | null;
   };
   macos_migration: IMacOsMigrationSettings;
   windows_updates: {

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -64,6 +64,7 @@ export interface ITeam extends ITeamSummary {
       enable_release_device_manually: boolean | null;
       manual_agent_install: boolean | null;
       require_all_software_macos: boolean | null;
+      lock_end_user_info: boolean | null;
     };
     windows_updates: {
       deadline_days: number | null;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
@@ -38,6 +38,23 @@ const getEnabledEndUserAuth = (
   return teamConfig?.mdm?.macos_setup.enable_end_user_authentication ?? false;
 };
 
+const getLockEndUserInfo = (
+  currentTeamId: number,
+  globalConfig?: IConfig,
+  teamConfig?: ITeamConfig
+) => {
+  if (globalConfig === undefined && teamConfig === undefined) {
+    return false;
+  }
+
+  // team is "No team" when currentTeamId === 0
+  if (currentTeamId === 0) {
+    return globalConfig?.mdm?.macos_setup.lock_end_user_info ?? false;
+  }
+
+  return teamConfig?.mdm?.macos_setup.lock_end_user_info ?? false;
+};
+
 const isIdPConfigured = ({
   end_user_authentication: idp,
 }: Pick<IMdmConfig, "end_user_authentication">) => {
@@ -75,6 +92,12 @@ const EndUserAuthentication = ({
     teamConfig
   );
 
+  const defaultLockEndUserInfo = getLockEndUserInfo(
+    currentTeamId,
+    globalConfig,
+    teamConfig
+  );
+
   const renderContent = () => {
     if (!globalConfig || isLoadingGlobalConfig || isLoadingTeamConfig) {
       return <Spinner />;
@@ -94,9 +117,7 @@ const EndUserAuthentication = ({
           <EndUserAuthForm
             currentTeamId={currentTeamId}
             defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
-            defaultLockEndUserInfo={
-              globalConfig.mdm.macos_setup.lock_end_user_info ?? false
-            }
+            defaultLockEndUserInfo={defaultLockEndUserInfo}
           />
         )}
       </SetupExperienceContentContainer>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/EndUserAuthentication.tsx
@@ -94,6 +94,9 @@ const EndUserAuthentication = ({
           <EndUserAuthForm
             currentTeamId={currentTeamId}
             defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
+            defaultLockEndUserInfo={
+              globalConfig.mdm.macos_setup.lock_end_user_info ?? false
+            }
           />
         )}
       </SetupExperienceContentContainer>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/EndUserAuthentication/components/EndUserAuthForm/EndUserAuthForm.tsx
@@ -1,16 +1,17 @@
 import React, { useContext, useState } from "react";
+import classnames from "classnames";
 
 import PATHS from "router/paths";
 import mdmAPI from "services/entities/mdm";
-import classnames from "classnames";
+import { NotificationContext } from "context/notification";
+import { AppContext } from "context/app";
 
 import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import CustomLink from "components/CustomLink";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
-import { NotificationContext } from "context/notification";
-import { AppContext } from "context/app";
 import TooltipWrapper from "components/TooltipWrapper";
+import RevealButton from "components/buttons/RevealButton";
 
 const baseClass = "end-user-auth-form";
 
@@ -26,11 +27,13 @@ const getTooltipCopy = (android = false) => {
 interface IEndUserAuthFormProps {
   currentTeamId: number;
   defaultIsEndUserAuthEnabled: boolean;
+  defaultLockEndUserInfo: boolean;
 }
 
 const EndUserAuthForm = ({
   currentTeamId,
   defaultIsEndUserAuthEnabled,
+  defaultLockEndUserInfo,
 }: IEndUserAuthFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const gitOpsModeEnabled = useContext(AppContext).config?.gitops
@@ -39,24 +42,35 @@ const EndUserAuthForm = ({
   const [isEndUserAuthEnabled, setEndUserAuthEnabled] = useState(
     defaultIsEndUserAuthEnabled
   );
+  const [lockEndUserInfo, setLockEndUserInfo] = useState(
+    defaultLockEndUserInfo
+  );
   const [isUpdating, setIsUpdating] = useState(false);
+  const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
 
   const onToggleEndUserAuth = (newCheckVal: boolean) => {
     setEndUserAuthEnabled(newCheckVal);
   };
 
+  const onChangeLockEndUserInfo = (newCheckVal: boolean) => {
+    setLockEndUserInfo(newCheckVal);
+  };
+
   const onClickSave = async () => {
     setIsUpdating(true);
+    const canLockEndUserInfo = isEndUserAuthEnabled && lockEndUserInfo;
     try {
       await mdmAPI.updateEndUserAuthentication(
         currentTeamId,
-        isEndUserAuthEnabled
+        isEndUserAuthEnabled,
+        canLockEndUserInfo
       );
       renderFlash("success", "Successfully updated.");
     } catch {
       renderFlash("error", "Couldn’t update. Please try again.");
     } finally {
       setIsUpdating(false);
+      setLockEndUserInfo(canLockEndUserInfo);
     }
   };
 
@@ -86,6 +100,37 @@ const EndUserAuthForm = ({
         >
           Turn on
         </Checkbox>
+        <RevealButton
+          isShowing={showAdvancedOptions}
+          showText="Advanced options"
+          hideText="Advanced options"
+          caretPosition="after"
+          onClick={() => setShowAdvancedOptions(!showAdvancedOptions)}
+        />
+        {showAdvancedOptions && (
+          <Checkbox
+            disabled={!isEndUserAuthEnabled}
+            onChange={onChangeLockEndUserInfo}
+            value={lockEndUserInfo}
+          >
+            <TooltipWrapper
+              tipContent={
+                <span>
+                  End user can&apos;t edit the local account&apos;s{" "}
+                  <b>Account Name</b> and
+                  <br />
+                  <b>Full Name</b> in macOS Setup Assistant. These fields will
+                  be
+                  <br />
+                  locked to values from your IdP.
+                </span>
+              }
+            >
+              Lock end user info
+            </TooltipWrapper>
+          </Checkbox>
+        )}
+
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
             <Button

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -254,11 +254,16 @@ const mdmService = {
     return sendRequest("GET", MDM_EULA(token));
   },
 
-  updateEndUserAuthentication: (teamId: number, isEnabled: boolean) => {
+  updateEndUserAuthentication: (
+    teamId: number,
+    isEnabled: boolean,
+    canLockEndUserInfo: boolean
+  ) => {
     const { MDM_SETUP } = endpoints;
     return sendRequest("PATCH", MDM_SETUP, {
       team_id: teamId,
       enable_end_user_authentication: isEnabled,
+      lock_end_user_info: canLockEndUserInfo,
     });
   },
 


### PR DESCRIPTION
**Related issue:** Resolves #38669

Added the ability to lock end user info on the end use auth section of the setup experience page

<img width="468" height="372" alt="image" src="https://github.com/user-attachments/assets/a5f4e21b-3a1e-4631-b0d4-e3d833a4484c" />

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
