### PR TITLE
Enhance Okta verification with issued certificates check

### DIFF
--- a/articles/enable-okta-verify-on-windows-using-a-scep-configuration-profile.md
+++ b/articles/enable-okta-verify-on-windows-using-a-scep-configuration-profile.md
@@ -108,7 +108,7 @@ Get-WinEvent -LogName Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-
 1. Log in to Okta Admin Console
 2. Navigate to **Reports** > **System Log**
 3. Filter for certificate issued events (`eventType eq "pki.cert.issue"`)
-4. Confirm the certificates were issued successfully (The certificate `CN` should match the devices serial number)
+4. Confirm the certificates were issued successfully (The certificate `CN` should match the hosts serial number)
 
 ## Troubleshooting
 

--- a/articles/enable-okta-verify-on-windows-using-a-scep-configuration-profile.md
+++ b/articles/enable-okta-verify-on-windows-using-a-scep-configuration-profile.md
@@ -107,8 +107,8 @@ Get-WinEvent -LogName Microsoft-Windows-DeviceManagement-Enterprise-Diagnostics-
 
 1. Log in to Okta Admin Console
 2. Navigate to **Reports** > **System Log**
-3. Filter for device attestation events
-4. Confirm the device appears as managed
+3. Filter for certificate issued events (`eventType eq "pki.cert.issue"`)
+4. Confirm the certificates were issued successfully (The certificate `CN` should match the devices serial number)
 
 ## Troubleshooting
 


### PR DESCRIPTION
Performing a minor update on the [Enable Okta Verify on Windows](https://fleetdm.com/guides/enable-okta-verify-on-windows-using-a-scep-configuration-profile) article that documents the option of checking if the certificates are being successfully issued by Okta or not.

This seems to be a better indicator of success than checking if the devices show up as managed, since this might happen for multiple other reasons, namely:
* The user not selecting the FastPass authenticator
* Another Okta Verify method (Push, TOTP, etc.) was used
* Browser incompatibility issues / lack of permissions to read local network access data that allow Verify to sync the metrics