### PR TITLE
Fleet UI: Hide native input, don't remove edit from non-FMA flow

### DIFF
--- a/frontend/components/FileUploader/FileUploader.tsx
+++ b/frontend/components/FileUploader/FileUploader.tsx
@@ -244,9 +244,9 @@ export const FileUploader = ({
 
   const renderFileUploader = () => {
     return (
-      <div className="content-wrapper">
-        <div className="outer">
-          <div className="inner">
+      <div className={`${baseClass}__content-wrapper`}>
+        <div className={`${baseClass}__outer`}>
+          <div className={`${baseClass}__inner`}>
             <div className={`${baseClass}__graphics`}>{renderGraphics()}</div>
             {renderTitle()}
             <p className={`${baseClass}__message`}>{message}</p>
@@ -265,6 +265,7 @@ export const FileUploader = ({
               id="upload-file"
               type="file"
               onChange={onFileSelect}
+              className="file-input-visually-hidden"
             />
           )}
         </div>

--- a/frontend/components/FileUploader/_styles.scss
+++ b/frontend/components/FileUploader/_styles.scss
@@ -8,8 +8,18 @@
   padding: $pad-xlarge $pad-large;
   font-size: $x-small;
 
+  &__outer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $pad-large;
+  }
+
   &__inner {
-    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: $pad-small;
 
     input {
       display: none;
@@ -19,10 +29,6 @@
   // Cannot hide all input as preview may include dropdown input that needs to be shown
   .file-input-visually-hidden {
     display: none;
-  }
-
-  &__content-wrapper {
-    @include content-wrapper();
   }
 
   &__error {
@@ -44,9 +50,11 @@
     justify-content: center;
     gap: $pad-medium;
   }
+
   &__message {
     margin: 0;
     color: $ui-fleet-black-75;
+    text-align: center;
   }
 
   &__additional-info {

--- a/frontend/components/FileUploader/_styles.scss
+++ b/frontend/components/FileUploader/_styles.scss
@@ -8,16 +8,20 @@
   padding: $pad-xlarge $pad-large;
   font-size: $x-small;
 
-  &:not(.file-uploader__file-preview) {
+  &__inner {
     text-align: center;
 
-    // Preview may include dropdown input that needs to be shown
     input {
       display: none;
     }
   }
 
-  .content-wrapper {
+  // Cannot hide all input as preview may include dropdown input that needs to be shown
+  .file-input-visually-hidden {
+    display: none;
+  }
+
+  &__content-wrapper {
     @include content-wrapper();
   }
 

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -406,10 +406,6 @@ const PackageForm = ({
   );
 
   const renderCustomEditor = () => {
-    if (isEditingSoftware && !isFleetMaintainedApp) {
-      return null;
-    }
-
     const fmaVersionsSortedByLatestFirst = sortByVersionLatestFirst<ISoftwareVersion>(
       defaultSoftware.fleet_maintained_versions || []
     );
@@ -442,7 +438,7 @@ const PackageForm = ({
       <form className={`${baseClass}__form`} onSubmit={onFormSubmit}>
         <FileUploader
           canEdit={canEditFile}
-          customEditor={renderCustomEditor}
+          customEditor={isFleetMaintainedApp ? renderCustomEditor : undefined}
           graphicName={getGraphicName(ext || "")}
           accept={ACCEPTED_EXTENSIONS}
           message={renderFileTypeMessage()}

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -556,18 +556,3 @@ $max-width: 2560px;
   background-repeat: no-repeat;
   background-color: #fff; // area below gradient will just be white
 }
-
-@mixin content-wrapper {
-  .outer {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: $pad-large;
-  }
-  .inner {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: $pad-small;
-  }
-}


### PR DESCRIPTION
## Issue
Closes #40602
Closes #40823 

## Description
- changes to CSS of `input` caused native `input` to show when it wasn't suppose to - FIXED
- not gating rendering customEditor when FMA only shows no editor - FIXED

## Screenrecording of fixes


https://github.com/user-attachments/assets/3dcedfab-c6c8-40b8-816c-97bc18f046b8


https://github.com/user-attachments/assets/df5b906f-db31-41c0-86b5-c93cb8bf1820



## Testing

- [x] QA'd all new/changed functionality manually
