### PR TITLE
[Guide] Apple OS updates: Only update new macOS hosts below the minimum version & better error messages

### DIFF
--- a/articles/enforce-os-updates.md
+++ b/articles/enforce-os-updates.md
@@ -48,7 +48,9 @@ If you set a past date (ex. yesterday) as the deadline, the end user will immedi
 
 You can require hosts that automatically enroll via ADE to update to the latest version before they enroll to Fleet (during Setup Assistant).
 
-For macOS hosts, in Fleet, head to **Controls > OS updates** and check the **Update new hosts to latest** checkbox.
+For macOS hosts, in Fleet, head to **Controls > OS updates** and check the **Update new hosts to latest** checkbox. 
+
+If **Update new hosts to latest** is checked, hosts below the minimum version are updated to the latest version during Setup Assistant. If a minimum version isn’t set, all hosts get updated.
 
 For iOS/iPadOS hosts, set a minimum version and deadline. New iOS/iPadOS hosts will always update to the latest version (not the minimum version specified). On already enrolled hosts, updates are only enforced if the host is [below the minimum version](#apple-macos-ios-and-ipados-end-user-experience).
 


### PR DESCRIPTION
Clarify the behavior of the 'Update new hosts to latest' feature for macOS hosts in Fleet, including conditions for updates during Setup Assistant.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39713 
