### PR TITLE
[Guide] Windows device-scoped profiles verification without osquery

### DIFF
--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -83,15 +83,13 @@ Currently, when editing a profile using Fleet's GitOps workflow, it can take 30 
 
 ### Verified
 
-> For some Windows configuration profiles, [verification doesn't work](https://github.com/fleetdm/fleet/issues/38833). Fleet will [remove verification](https://github.com/fleetdm/fleet/issues/31921) for Windows profiles in 4.83 (coming soon).
-
-Hosts that applied all OS settings. 
+Hosts that applied all OS settings.
 
 For macOS configuration profiles and device-scoped Windows profiles, Fleet verified by running an osquery query. It can take up to 1 hour ([configurable](https://fleetdm.com/docs/configuration/fleet-server-configuration#osquery-detail-update-interval)) for these profiles to move from "Verifying" to "Verified".
 
 macOS declarations profiles are verified with a [DDM StatusReport](https://developer.apple.com/documentation/devicemanagement/statusreport).
 
-User-scoped Windows profiles are "Verified" after Fleet gets a [200 response](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes) from the Windows MDM protocol.
+User-scoped Windows profiles are "Verified" after Fleet gets a [200 response](https://learn.microsoft.com/en-us/windows/client-management/oma-dm-protocol-support#syncml-response-status-codes) from the Windows MDM protocol. _Note: Windows profiles are not verified by osquery._
 
 iOS and iPadOS hosts are "Verified" after they acknowledge all MDM commands to apply OS settings. Android hosts are "Verified" after Fleet verifies that the settings is applied in the next [status report](https://developers.google.com/android/management/reference/rest/v1/enterprises.devices).
 

--- a/articles/custom-os-settings.md
+++ b/articles/custom-os-settings.md
@@ -113,26 +113,6 @@ macOS, iOS, or iPadOS hosts may display OS settings as "Failed" even when MDM is
 
 To resolve this issue, turn MDM back on, then select **Actions > Turn off MDM** while the host is online.
 
-### Special Windows behavior
-
-For Windows configuration profiles with the [Win32 and Desktop Bridge app ADMX policies](https://learn.microsoft.com/en-us/windows/client-management/win32-and-centennial-app-policy-configuration), Fleet only verifies that the host returned a success status code in response to the MDM command to install the configuration profile. You can query the registry keys defined by the ADMX policy. For instance, if an ADMX file defines the following policy:
-```
-      <policy name="Subteam" class="Machine" displayName="Subteam" key="Software\Policies\employee\Attributes" explainText="Subteam" presentation="String">
-         <parentCategory ref="DefaultCategory" />
-         <supportedOn ref="SUPPORTED_WIN10" />
-         <elements>
-            <text id="Subteam" valueName="Subteam" />
-         </elements>
-      </policy>
-```
-
-To verify that the OS setting is applied, run the following osquery query:
-```
-SELECT data FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Policies\employee\Attributes\Subteam';
-```
-
-> If your Windows profile fails with the following error: "The MDM protocol returned a success but the result couldn’t be verified by osquery", and the profile includes `[!CDATA []]` sections, [escape the XML](https://www.freeformatter.com/xml-escape.html) instead of using CDATA. For example, `[!CDATA[<enabled/>]]>` should be changed to `&lt;enabled/&gt;`.
-
 ### Special Android behvaior
 
 On Android, if some settings from the profile fail (e.g. incompatible device), other settings from the profile will still be applied. Failed settings will be surfaced on **Host > OS settings**.


### PR DESCRIPTION
Removed the section on special Windows behavior from the custom OS settings documentation.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #31921 