### PR TITLE
Website: add script to report Render trial usage

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -70,6 +70,17 @@ module.exports = {
     marketingAttributionCookie: {
       type: {},
       description: 'The contents of the marketingAttribution cookie set in the requesting user\'s browser',
+    },
+
+    trialInstanceUsageDetails: {
+      type: {
+        status: 'string',
+        lastUpdatedOn: 'string',
+        trialStartedOn: 'string',
+        trialEndsOn: 'string',
+        numUsers: 'number',
+        numHostsEnrolled: 'number',
+      }
     }
 
   },
@@ -90,7 +101,7 @@ module.exports = {
 
   },
 
-  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, jobTitle, primaryBuyingSituation, psychologicalStage, psychologicalStageChangeReason, contactSource, description, getStartedResponses, intentSignal, marketingAttributionCookie}) {
+  fn: async function ({emailAddress, linkedinUrl, firstName, lastName, organization, jobTitle, primaryBuyingSituation, psychologicalStage, psychologicalStageChangeReason, contactSource, description, getStartedResponses, intentSignal, marketingAttributionCookie, trialInstanceUsageDetails}) {
 
     // Return undefined if we're not running in a production environment.
     if(sails.config.environment !== 'production') {
@@ -151,6 +162,16 @@ module.exports = {
     }
     if(jobTitle) {
       valuesToSet.Title = jobTitle;
+    }
+
+
+    if(trialInstanceUsageDetails) {
+      valuesToSet.Trial_status__c = trialInstanceUsageDetails.status;// eslint-disable-line camelcase
+      valuesToSet.Last_trial_sync__c = trialInstanceUsageDetails.lastUpdatedOn;// eslint-disable-line camelcase
+      valuesToSet.Trial_start_date__c = trialInstanceUsageDetails.trialStartedOn;// eslint-disable-line camelcase
+      valuesToSet.Trial_end_date__c = trialInstanceUsageDetails.trialEndsOn;// eslint-disable-line camelcase
+      valuesToSet.Trial_user_count__c = trialInstanceUsageDetails.numUsers;// eslint-disable-line camelcase
+      valuesToSet.Trial_hosts_enrolled__c = trialInstanceUsageDetails.numHostsEnrolled;// eslint-disable-line camelcase
     }
 
     //  ╔═╗╦═╗╔═╗╔═╗╔═╗╔═╗╔═╗╔═╗  ╔╦╗╔═╗╦═╗╦╔═╔═╗╔╦╗╦╔╗╔╔═╗  ╔═╗╔╦╗╔╦╗╦═╗╦╔╗ ╦ ╦╔╦╗╦╔═╗╔╗╔

--- a/website/scripts/send-trial-usage-information-to-crm.js
+++ b/website/scripts/send-trial-usage-information-to-crm.js
@@ -1,0 +1,99 @@
+module.exports = {
+
+
+  friendlyName: 'Send trial usage information to CRM',
+
+
+  description: 'Reports recent usage information about Render trial instances.',
+
+  inputs: {
+    reportAllHistoricalData: {
+      type: 'boolean',
+      description: 'Whether or not to report details for all past render trial instnaces or not.',
+      extendedDescription: 'This is meant to be used once when the script is first created. Without this flag enabled, this script will only report analytics for active and recently expired Render trial instances.'
+    }
+  },
+
+  fn: async function ({reportAllHistoricalData}) {
+
+    sails.log('Running custom shell script... (`sails run send-trial-usage-information-to-crm`)');
+
+    let nowAt = Date.now();
+    let oneDayAgoAt = nowAt - (1000 * 60 * 60 * 24);
+
+
+    let renderTrialInstancesToSendAnalyticsFor;
+    if(reportAllHistoricalData) {
+      // Find all active and expired render instance details.
+      renderTrialInstancesToSendAnalyticsFor = await RenderProofOfValue.find({status: {'!=': 'record created'}});
+    } else {
+      // Find render instance details for active Render trials, and trials that have expired in the past 24 hours.
+      let thirtyDaysFromNowAt = nowAt + (1000 * 60 * 60 * 24 * 30);
+      renderTrialInstancesToSendAnalyticsFor = await RenderProofOfValue.find({
+        renderTrialEndsAt: { '>=': oneDayAgoAt, '<=':  thirtyDaysFromNowAt }
+      });
+    }
+
+
+    sails.log(`Reporting Render trial usage information for ${renderTrialInstancesToSendAnalyticsFor.length} trial instances`);
+
+    for(let renderTrial of renderTrialInstancesToSendAnalyticsFor) {
+      let lastReportedStatisticsForThisTrial = await HistoricalUsageSnapshot.find({
+        organization: 'Render-trial-'+renderTrial.slug,
+      }).sort('createdAt DESC').limit(1);
+      // If no records were found, then search for one that is not prefixed with 'Render-trial-'
+      if(lastReportedStatisticsForThisTrial.length < 1) {
+        sails.log(`No analytics found for prefixed organization, searching for ${renderTrial.slug}`);
+        lastReportedStatisticsForThisTrial = await HistoricalUsageSnapshot.find({
+          organization: renderTrial.slug,
+        }).sort('createdAt DESC').limit(1);
+      }
+      if(lastReportedStatisticsForThisTrial.length < 1) {
+        // If we didn't find usage statistics reported by a Render trial instance, log a warning and continue.
+        sails.log.warn(`When reporting usage details for Render trial instances to Salesforce, no usage analytics were found reported by a Render trial (slug: ${renderTrial.slug})`);
+        continue;
+      }
+      let thisRenderTrialsUser = await User.findOne({id: renderTrial.user});
+      if(!thisRenderTrialsUser) {
+        // If the user record associated with this Render trial is missing, (e.g., if this person requested that we delete their account) log a warning and continue.
+        sails.log.warn(`When reporting usage details for Render trial instances to Salesforce, no user could be found that was associated with a Render trial (slug: ${renderTrial.slug})`);
+        continue;
+      }
+      // Create a formatted timestamp of when this Render trial was started (When this user signed up)
+      let renderTrialStartedOn = new Date(thisRenderTrialsUser.createdAt);
+      let formattedTimestampOfWhenThisRenderTrialStarted = renderTrialStartedOn.toISOString().replace('Z', '+0000');
+      // Create a formatted timestamp of when this Render trial ends.
+      let renderTrialEndsOn = new Date(thisRenderTrialsUser.fleetPremiumTrialLicenseKeyExpiresAt);
+      let formattedTimestampOfWhenThisRenderTrialends = renderTrialEndsOn.toISOString().replace('Z', '+0000');
+      // Create a formatted timestamp of when this Render trial last reported usage statistics.
+      let trialReportedAnalyticsOn = new Date(lastReportedStatisticsForThisTrial[0].createdAt);
+      let formattedTimestampOfWhenThisInstanceReportedAnalytics = trialReportedAnalyticsOn.toISOString().replace('Z', '+0000');
+
+      // Build a trialInstanceUsageDetails to send to CRM helper.
+      let trialInstanceUsageDetails = {
+        status: renderTrial.status,
+        lastUpdatedOn: formattedTimestampOfWhenThisInstanceReportedAnalytics,
+        trialStartedOn: formattedTimestampOfWhenThisRenderTrialStarted,
+        trialEndsOn: formattedTimestampOfWhenThisRenderTrialends,
+        numUsers: lastReportedStatisticsForThisTrial[0].numUsers,
+        numHostsEnrolled: lastReportedStatisticsForThisTrial[0].numHostsEnrolled
+      };
+
+      // Update the contact record that was created for this user when they signed up.
+      await sails.helpers.salesforce.updateOrCreateContactAndAccount.with({
+        emailAddress: thisRenderTrialsUser.emailAddress,
+        firstName: thisRenderTrialsUser.firstName,
+        lastName: thisRenderTrialsUser.lastName,
+        contactSource: 'Website - Sign up',
+        trialInstanceUsageDetails: trialInstanceUsageDetails
+      });
+
+
+    }// After each Render trial Instance
+
+
+  }
+
+
+};
+


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/13687

Changes:
- Added a new script: `send-trial-usage-information-to-crm`, A script that reports the latest usage information for Render trial Fleet instances created and assigned to users by the website.
- Updated the updateOrCreateContactAndAccount helper to accept a `trialInstanceUsageDetails` input and set provided values on contact records.