### PR TITLE
Update default Apple automatic enrollment profile

### DIFF
--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -102,7 +102,7 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		AutoAdvanceSetup: false,
 		IsMultiUser:      false,
 		IsMandatory:      false,
-		IsMDMRemovable:   false,
+		IsMDMRemovable:   true,
 		Language:         "en",
 		OrgMagic:         "1",
 		SkipSetupItems: []string{

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -103,7 +103,7 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		IsSupervised:     false,
 		IsMultiUser:      false,
 		IsMandatory:      false,
-		IsMDMRemovable:   true,
+		IsMDMRemovable:   false,
 		Language:         "en",
 		OrgMagic:         "1",
 		Region:           "US",

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -100,7 +100,7 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		ProfileName:      "Fleet default enrollment profile",
 		AllowPairing:     true,
 		AutoAdvanceSetup: false,
-		IsSupervised:     false,
+		IsSupervised:     true,
 		IsMultiUser:      false,
 		IsMandatory:      false,
 		IsMDMRemovable:   false,

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -108,7 +108,6 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		OrgMagic:         "1",
 		Region:           "US",
 		SkipSetupItems: []string{
-			"Accessibility",
 			"Appearance",
 			"AppleID",
 			"AppStore",
@@ -117,15 +116,20 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 			"FileVault",
 			"iCloudDiagnostics",
 			"iCloudStorage",
+			"Intelligence",
 			"Location",
+			"OSShowcase",
 			"Payment",
 			"Privacy",
 			"Restore",
 			"ScreenTime",
 			"Siri",
+			"SoftwareUpdate",
 			"TermsOfAddress",
 			"TOS",
 			"UnlockWithWatch",
+			"UpdateCompleted",
+			"Welcome",
 		},
 	}
 }

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -100,7 +100,6 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		ProfileName:      "Fleet default enrollment profile",
 		AllowPairing:     true,
 		AutoAdvanceSetup: false,
-		IsSupervised:     true,
 		IsMultiUser:      false,
 		IsMandatory:      false,
 		IsMDMRemovable:   false,

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -106,7 +106,6 @@ func (d *DEPService) getDefaultProfile() *godep.Profile {
 		IsMDMRemovable:   false,
 		Language:         "en",
 		OrgMagic:         "1",
-		Region:           "US",
 		SkipSetupItems: []string{
 			"Appearance",
 			"AppleID",


### PR DESCRIPTION
- We should never skip the Accessibility screen on macOS. Some end users cannot use a computer without these features.
- Added some keys that were released after this list was last updated.
- Removed `Region`, since we have customers in more than the US now.
- Removed `IsSupervised`, as devices are [automatically supervised now](https://support.apple.com/guide/deployment/about-device-supervision-dep1d89f0bff/web#:~:text=The%20following%20devices%20are%20supervised%20automatically%20when%20they%E2%80%99re%20enrolled%20using%20Automated%20Device%20Enrollment).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refined the default Apple Device Enrollment Program configuration to streamline the device setup experience by adjusting which setup assistant steps are presented during enrollment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->