### PR TITLE
avoid double encoding $FLEET_SECRET in GitOps

### DIFF
--- a/changes/40108-avoid-double-encoding-fleet-secrets
+++ b/changes/40108-avoid-double-encoding-fleet-secrets
@@ -1,0 +1,1 @@
+* Fixed an issue where $FLEET_SECRET was being double encoded, if set via GitOps.

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3540,3 +3540,76 @@ team_settings:
 		})
 	}
 }
+
+func (s *enterpriseIntegrationGitopsTestSuite) TestConfigurationProfileEscaping() {
+	t := s.T()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	// Get the testdata mobileconfig profile
+	_, currentFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	profilePath := filepath.Join(filepath.Dir(currentFile), "testdata", "apple-profile.mobileconfig")
+	require.FileExists(t, profilePath)
+
+	const secretPasswordValue = "custom&password<tag>"
+	t.Setenv("FLEET_SECRET_PASSWORD", secretPasswordValue)
+	t.Setenv("API_KEY", "my-api-key&value")
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	gitopsConfig := fmt.Sprintf(`
+org_settings:
+  server_settings:
+    server_url: %s
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: test_secret
+agent_options:
+controls:
+  macos_settings:
+    custom_settings:
+      - path: %s
+policies:
+reports:
+`, s.Server.URL, profilePath)
+
+	configPath := filepath.Join(tempDir, "gitops.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(gitopsConfig), 0o644)) //nolint:gosec
+
+	// Run gitops
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", configPath})
+
+	// Verify the stored profile in the DB, based on my testing these vars are okay as they are not host-specific and we can avoid enrolling a host and checking the host specific payload.
+	profiles, err := s.DS.ListMDMAppleConfigProfiles(ctx, nil)
+	require.NoError(t, err)
+
+	var storedProfile *fleet.MDMAppleConfigProfile
+	for _, p := range profiles {
+		if strings.Contains(p.Identifier, "fleet.9913C522") {
+			storedProfile = p
+			break
+		}
+	}
+	require.NotNil(t, storedProfile, "should find the uploaded profile")
+	profileBody := string(storedProfile.Mobileconfig)
+
+	// $FLEET_SECRET_PASSWORD should NOT be expanded, as it will be expanded server-side
+	assert.Contains(t, profileBody, "$FLEET_SECRET_PASSWORD",
+		"stored profile should still contain the FLEET_SECRET_ placeholder")
+	// $API_KEY should be expanded and its value should have been escaped during gitops
+	assert.Contains(t, profileBody, "my-api-key&amp;value",
+		"stored profile should have the expanded $API_KEY value")
+	assert.NotContains(t, profileBody, "$API_KEY",
+		"stored profile should not contain the $API_KEY variable reference")
+
+	// Verify the secret was saved to the server unescaped, to avoid double encoding secrets.
+	secrets, err := s.DS.GetSecretVariables(ctx, []string{"PASSWORD"})
+	require.NoError(t, err)
+	require.Len(t, secrets, 1)
+	assert.Equal(t, secretPasswordValue, secrets[0].Value,
+		"secret should be stored as the raw value (not XML-escaped)")
+}

--- a/cmd/fleetctl/integrationtest/gitops/testdata/apple-profile.mobileconfig
+++ b/cmd/fleetctl/integrationtest/gitops/testdata/apple-profile.mobileconfig
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>PayloadContent</key>
+        <array>
+            <dict>
+                <key>PayloadContent</key>
+                <dict>
+                    <key>com.fleet.idp.info</key>
+                    <dict>
+                        <key>Forced</key>
+                        <array>
+                            <dict>
+                                <key>mcx_preference_settings</key>
+                                <dict>
+                                    <key>fleet secret</key>
+                                    <string>$FLEET_SECRET_PASSWORD</string>
+                                    <key>api key</key>
+                                    <string>$API_KEY</string>
+                                </dict>
+                            </dict>
+                        </array>
+                    </dict>
+                </dict>
+                <key>PayloadDisplayName</key>
+                <string>Managed Preferences Username</string>
+                <key>PayloadIdentifier</key>
+                <string>com.apple.ManagedClient.preferences.99AA78CD-F89B-41D0-850F-3CA29300E6FB</string>
+                <key>PayloadType</key>
+                <string>com.apple.ManagedClient.preferences</string>
+                <key>PayloadUUID</key>
+                <string>99AA78CD-F89B-41D0-850F-3CA29300E6FB</string>
+                <key>PayloadVersion</key>
+                <integer>1</integer>
+            </dict>
+        </array>
+        <key>PayloadDisplayName</key>
+        <string>Managed Preferences</string>
+        <key>PayloadIdentifier</key>
+        <string>fleet.9913C522-DF69-45CA-9113-B1843E6145BC</string>
+        <key>PayloadOrganization</key>
+        <string>Fleet</string>
+        <key>PayloadType</key>
+        <string>Configuration</string>
+        <key>PayloadUUID</key>
+        <string>9913C522-DF69-45CA-9113-B1843E6145BC</string>
+        <key>PayloadVersion</key>
+        <integer>1</integer>
+    </dict>
+</plist>

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -376,15 +376,15 @@ func ExpandEnvBytesIncludingSecrets(b []byte) ([]byte, error) {
 	return []byte(s), nil
 }
 
-// LookupEnvSecrets only looks up FLEET_SECRET_XXX environment variables. Escaping is limited to XML files.
-// This is used for finding secrets in scripts only. The original string is not modified.
-// A map of secret names to values is updated.
+// LookupEnvSecrets only looks up FLEET_SECRET_XXX environment variables.
+// This is used for finding secrets in profiles and scripts. The original string is not modified.
+// A map of secret names to raw (unescaped) values is updated.
+// XML escaping is intentionally NOT done here — it is handled server-side during
+// secret expansion (see expandEmbeddedSecrets in secret_variables.go).
 func LookupEnvSecrets(s string, secretsMap map[string]string) error {
 	if secretsMap == nil {
 		return errors.New("secretsMap cannot be nil")
 	}
-
-	documentIsXML := strings.HasPrefix(strings.TrimSpace(s), "<") // We need to be more aggressive here, to also escape XML in Windows profiles which does not begin with <?xml
 
 	var err *multierror.Error
 	_ = fleet.MaybeExpand(s, func(env string, startPos, endPos int) (string, bool) {
@@ -394,17 +394,6 @@ func LookupEnvSecrets(s string, secretsMap map[string]string) error {
 			if !ok {
 				err = multierror.Append(err, fmt.Errorf("environment variable %q not set", env))
 				return "", false
-			}
-
-			if documentIsXML {
-				// Escape XML special characters
-				var b strings.Builder
-				xmlErr := xml.EscapeText(&b, []byte(v))
-				if xmlErr != nil {
-					err = multierror.Append(xmlErr, fmt.Errorf("failed to XML escape fleet secret %s", env))
-					return "", false
-				}
-				v = b.String()
 			}
 
 			secretsMap[env] = v

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -233,7 +233,7 @@ func TestLookupEnvSecrets(t *testing.T) {
 			map[string]string{},
 			checkMultiErrors(t, "environment variable \"FLEET_SECRET_foo\" not set"),
 		},
-		{map[string]string{"FLEET_SECRET_foo": "test&123"}, `<Add>$FLEET_SECRET_foo</Add>`, map[string]string{"FLEET_SECRET_foo": "test&amp;123"}, nil},
+		{map[string]string{"FLEET_SECRET_foo": "test&123"}, `<Add>$FLEET_SECRET_foo</Add>`, map[string]string{"FLEET_SECRET_foo": "test&123"}, nil},
 	} {
 		// save the current env before clearing it.
 		testutils.SaveEnv(t)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40108 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed double encoding of secret environment variables when configured through GitOps, ensuring secrets are stored with proper escaping.

* **Tests**
  * Added test coverage for configuration profile escaping to verify proper handling of secret variables and API keys during GitOps operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->