### PR TITLE
Skip uninstall validation if productCode empty

### DIFF
--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -377,6 +377,9 @@ func buildUpgradeCodeBasedUninstallScript(upgradeCode string) (string, error) {
 }
 
 func preProcessUninstallScript(uninstallScript, productCode string) (string, error) {
+	if productCode == "" {
+		return uninstallScript, nil
+	}
 	if err := file.ValidatePackageIdentifiers([]string{productCode}, ""); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Add an early return in preProcessUninstallScript to return the original uninstallScript when productCode is empty. This prevents calling file.ValidatePackageIdentifiers with an empty product code and avoids unnecessary validation errors.
