### PR TITLE
Website: Add support for new usage statistics

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -45,6 +45,8 @@ module.exports = {
     numHostsFleetDesktopEnabled: {type: 'number', defaultsTo: 0 },
     numQueries: {type: 'number', defaultsTo: 0 },
     numHostsABMPending: {type: 'number', defaultsTo: 0 },
+    fleetMaintainedAppsWindows: {type: ['string'], defaultsTo: [] },
+    fleetMaintainedAppsMacOS: {type: ['string'], defaultsTo: [] },
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -49,6 +49,8 @@ module.exports = {
     numHostsFleetDesktopEnabled: {required: true, type: 'number'},
     numQueries: {required: true, type: 'number' },
     numHostsABMPending: {required: true, type: 'number' },
+    fleetMaintainedAppsMacOS: {required: true, type: 'json'},
+    fleetMaintainedAppsWindows: {required: true, type: 'json'},
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/39836

Changes:
- Added `fleetMaintainedAppsWindows` and `fleetMaintainedAppsMacOS` attributes to the HistoricalUsageSnapshot model
- Added `fleetMaintainedAppsWindows` and `fleetMaintainedAppsMacOS` as inputs to the receive-usage-analytics webhook


Note: This pull request requires database migrations and should only be merged after the website's database is updated while it is in maintenance mode.