### PR TITLE
gkarr cp 81.1 fixes

### DIFF
--- a/changes/40476-fix-query-results-cleanup-placeholder-limit
+++ b/changes/40476-fix-query-results-cleanup-placeholder-limit
@@ -1,0 +1,1 @@
+* Fixed query results cleanup cron failing with "too many placeholders" error by filtering to only saved queries and batching the SQL IN clause.

--- a/changes/40725-fix-macos-setup
+++ b/changes/40725-fix-macos-setup
@@ -1,0 +1,1 @@
+* Fixed a bug where macOS systems previous enrolled in fleet wouldn't always go through setup experience after a wipe

--- a/changes/fix-query-results-cleanup-placeholder-limit
+++ b/changes/fix-query-results-cleanup-placeholder-limit
@@ -1,0 +1,1 @@
+* Fixed query results cleanup cron failing with "too many placeholders" error by filtering to only saved queries and batching the SQL IN clause.

--- a/server/datastore/mysql/query_results.go
+++ b/server/datastore/mysql/query_results.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -155,12 +156,14 @@ func (ds *Datastore) CleanupExcessQueryResultRows(ctx context.Context, maxQueryR
 		batchSize = opts[0].BatchSize
 	}
 
-	// Get all distinct query_ids that have results and are scheduled queries with discard_data = false
+	// Get all saved query IDs that could have query results to clean up.
+	// Only saved queries (scheduled reports) store rows in query_results;
+	// live queries do not, so there's nothing to clean up for them.
 	var queryIDs []uint
 	selectStmt := `
 		SELECT id
 		FROM queries
-		WHERE discard_data = false AND logging_type = 'snapshot'
+		WHERE saved = 1 AND discard_data = false AND logging_type = 'snapshot'
 	`
 	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &queryIDs, selectStmt); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "selecting query IDs for cleanup")
@@ -188,12 +191,18 @@ func (ds *Datastore) CleanupExcessQueryResultRows(ctx context.Context, maxQueryR
         ) cutoff
         WHERE rn = ?
     `
-	query, args, err := sqlx.In(cutoffStmt, queryIDs, maxQueryReportRows)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "building cutoff query")
-	}
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &queryCutoffs, ds.reader(ctx).Rebind(query), args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "selecting cutoffs")
+	// Batch the IN clause to avoid MySQL's 65,535 placeholder limit.
+	const queryIDBatchSize = 50000
+	for batch := range slices.Chunk(queryIDs, queryIDBatchSize) {
+		var batchCutoffs []cutoffRow
+		query, args, err := sqlx.In(cutoffStmt, batch, maxQueryReportRows)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building cutoff query")
+		}
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &batchCutoffs, ds.reader(ctx).Rebind(query), args...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "selecting cutoffs")
+		}
+		queryCutoffs = append(queryCutoffs, batchCutoffs...)
 	}
 
 	// Delete excess rows from each query, in batches.
@@ -230,12 +239,16 @@ func (ds *Datastore) CleanupExcessQueryResultRows(ctx context.Context, maxQueryR
         WHERE query_id IN (?) AND data IS NOT NULL
         GROUP BY query_id
     `
-	query, args, err = sqlx.In(countStmt, queryIDs)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "building count query")
-	}
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &counts, ds.reader(ctx).Rebind(query), args...); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "selecting counts")
+	for batch := range slices.Chunk(queryIDs, queryIDBatchSize) {
+		var batchCounts []countRow
+		query, args, err := sqlx.In(countStmt, batch)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "building count query")
+		}
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &batchCounts, ds.reader(ctx).Rebind(query), args...); err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "selecting counts")
+		}
+		counts = append(counts, batchCounts...)
 	}
 
 	queryCounts := make(map[uint]int)

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -24,32 +24,34 @@ func (ds *Datastore) ResetSetupExperienceItemsAfterFailure(ctx context.Context, 
 }
 
 func (ds *Datastore) enqueueSetupExperienceItems(ctx context.Context, hostPlatformLike string, hostUUID string, teamID uint, resetFailedSetupSteps bool) (bool, error) {
-	// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
-	// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
-	// Orbit version that didn't support setup experience to one that does.
-	// See https://github.com/fleetdm/fleet/issues/35717
-	stmtHost := `
-	SELECT
-		last_enrolled_at
-	FROM
-		hosts
-	WHERE uuid = ? AND platform = ?
-	`
-	var lastEnrolledAt sql.NullTime
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			// This shouldn't happen but we don't check for it elsewhere,
-			// so we'll log a warning and continue.
-			level.Warn(ds.logger).Log("msg", "Host not found while enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike)
-		} else {
-			return false, ctxerr.Wrap(ctx, err, "finding host for enqueueing setup experience items")
+	if hostPlatformLike != "darwin" && hostPlatformLike != "ios" && hostPlatformLike != "ipados" {
+		// Find the host with the given UUID and platform. If it's already been enrolled for > the cutoff,
+		// don't enqueue any items. This handles the edge case where an enrolled host upgrades from an
+		// Orbit version that didn't support setup experience to one that does.
+		// See https://github.com/fleetdm/fleet/issues/35717
+		stmtHost := `
+		SELECT
+			last_enrolled_at
+		FROM
+			hosts
+		WHERE uuid = ? AND platform = ?
+		`
+		var lastEnrolledAt sql.NullTime
+		if err := sqlx.GetContext(ctx, ds.reader(ctx), &lastEnrolledAt, stmtHost, hostUUID, hostPlatformLike); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				// This shouldn't happen but we don't check for it elsewhere,
+				// so we'll log a warning and continue.
+				level.Warn(ds.logger).Log("msg", "Host not found while enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike)
+			} else {
+				return false, ctxerr.Wrap(ctx, err, "finding host for enqueueing setup experience items")
+			}
 		}
-	}
-	// If the host was enrolled more than 24 hours ago, don't enqueue any items.
-	// Note: if the last enroll date is our "zero date" (1/1/2000), treat it as if it's never enrolled.
-	if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) && lastEnrolledAt.Time.After(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)) {
-		level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
-		return false, nil
+		// If the host was enrolled more than 24 hours ago, don't enqueue any items.
+		// Note: if the last enroll date is our "zero date" (1/1/2000), treat it as if it's never enrolled.
+		if lastEnrolledAt.Valid && lastEnrolledAt.Time.Before(time.Now().Add(-24*time.Hour)) && lastEnrolledAt.Time.After(time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC)) {
+			level.Debug(ds.logger).Log("msg", "Host enrolled more than 24 hours ago, skipping enqueueing setup experience items", "host_uuid", hostUUID, "platform_like", hostPlatformLike, "last_enrolled_at", lastEnrolledAt.Time)
+			return false, nil
+		}
 	}
 
 	// NOTE: currently, the Android platform does not use the "enqueue setup experience items" flow as it


### PR DESCRIPTION
- **Batch select query in CleanupExcessQueryResultRows (#40491)**
- **Cherry-pick: Remove "do not enqueue setup experience items >24 hours after enrollment" logic for macOS hosts (#40739) (#40748)**
