### PR TITLE
Bump supported MySQL versions

### DIFF
--- a/.github/workflows/config/randokiller.json
+++ b/.github/workflows/config/randokiller.json
@@ -1,6 +1,6 @@
 {
   "mysql_matrix": [
-    "mysql:8.0.36"
+    "mysql:8.0.44"
   ],
   "pkg_to_test": "server/service",
   "tests_to_run": "^TestIntegrationsMDM\\$$",

--- a/.github/workflows/fleet-and-orbit.yml
+++ b/.github/workflows/fleet-and-orbit.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        mysql: ["mysql:8.0.36"]
+        mysql: ["mysql:8.0.44"]
     runs-on: ubuntu-latest
     needs: gen
     steps:

--- a/.github/workflows/test-go-activity.yaml
+++ b/.github/workflows/test-go-activity.yaml
@@ -50,7 +50,7 @@ jobs:
   test-go-activity:
     strategy:
       matrix:
-        mysql: ["mysql:8.0.44", "mysql:9.6.0"]
+        mysql: ["mysql:8.0.44", "mysql:9.5.0"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: activity

--- a/.github/workflows/test-go-activity.yaml
+++ b/.github/workflows/test-go-activity.yaml
@@ -50,7 +50,7 @@ jobs:
   test-go-activity:
     strategy:
       matrix:
-        mysql: ["mysql:8.0.36", "mysql:9.5.0"]
+        mysql: ["mysql:8.0.44", "mysql:9.6.0"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: activity
@@ -68,7 +68,7 @@ jobs:
     if: github.event_name == 'schedule'
     strategy:
       matrix:
-        mysql: ["mysql:8.0.32", "mysql:8.4.7"]
+        mysql: ["mysql:8.0.39", "mysql:8.4.8"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: activity
@@ -124,10 +124,10 @@ jobs:
         run: |
           failed_tests=""
           status_count=0
-          # Find all status files (they are in directories like 'activity-mysql8.0.36-status/status')
+          # Find all status files (they are in directories like 'activity-mysql8.0.44-status/status')
           for status_file in $(find ./ -type f -name 'status'); do
             status_count=$((status_count + 1))
-            # Extract test name from parent directory (e.g., 'activity-mysql8.0.36-status')
+            # Extract test name from parent directory (e.g., 'activity-mysql8.0.44-status')
             test_dir=$(basename $(dirname "$status_file"))
             # Remove '-status' suffix to get the test name
             test_name="${test_dir%-status}"

--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -10,7 +10,7 @@ on:
         required: true
         type: string
       mysql:
-        description: 'MySQL Docker image (e.g., "mysql:8.0.36"). Leave empty for suites that do not need MySQL.'
+        description: 'MySQL Docker image (e.g., "mysql:8.0.44"). Leave empty for suites that do not need MySQL.'
         required: false
         type: string
         default: ''

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
-        mysql: ["mysql:8.0.44", "mysql:9.6.0"]
+        mysql: ["mysql:8.0.44", "mysql:9.5.0"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: ${{ matrix.suite }}

--- a/.github/workflows/test-go.yaml
+++ b/.github/workflows/test-go.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       matrix:
         suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
-        mysql: ["mysql:8.0.36", "mysql:9.5.0"]
+        mysql: ["mysql:8.0.44", "mysql:9.6.0"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: ${{ matrix.suite }}
@@ -87,7 +87,7 @@ jobs:
     strategy:
       matrix:
         suite: ["integration-core", "integration-enterprise", "integration-mdm", "fleetctl", "main", "mysql", "service", "vuln"]
-        mysql: ["mysql:8.0.32", "mysql:8.4.7"]
+        mysql: ["mysql:8.0.39", "mysql:8.4.8"]
     uses: ./.github/workflows/test-go-suite.yaml
     with:
       suite: ${{ matrix.suite }}
@@ -100,7 +100,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     services:
       mysql:
-        image: mysql:8.0.36
+        image: mysql:8.0.44
         env:
           MYSQL_RANDOM_ROOT_PASSWORD: yes
           MYSQL_DATABASE: testdb
@@ -244,10 +244,10 @@ jobs:
         run: |
           failed_tests=""
           status_count=0
-          # Find all status files (they are in directories like 'fleetctl-mysql8.0.36-status/status')
+          # Find all status files (they are in directories like 'fleetctl-mysql8.0.44-status/status')
           for status_file in $(find ./ -type f -name 'status'); do
             status_count=$((status_count + 1))
-            # Extract test name from parent directory (e.g., 'fleetctl-mysql8.0.36-status')
+            # Extract test name from parent directory (e.g., 'fleetctl-mysql8.0.44-status')
             test_dir=$(basename $(dirname "$status_file"))
             # Remove '-status' suffix to get the test name
             test_name="${test_dir%-status}"

--- a/articles/deploy-fleet-on-hetzner-cloud.md
+++ b/articles/deploy-fleet-on-hetzner-cloud.md
@@ -69,14 +69,12 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docke
 apt update
 apt install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
-docker pull mysql@sha256:134e2d1c7c517d05e5328a77aa5a165a314dc4c4116503e7e089494f4e398ab1 # mysql:8.0.36 as of 2024/07/04
-
 ######################
 # MySQL (dockerized) #
 ######################
 
-# mysql:8.0.36 as of 2024/07/04
-docker pull mysql@sha256:134e2d1c7c517d05e5328a77aa5a165a314dc4c4116503e7e089494f4e398ab1
+# mysql:8.0.44 as of 2026/03/03
+docker pull mysql@sha256:9c3380eac945af0736031b200027f581925927c81e010056214a4bd6b6693714
 
 # Create the Fleet MySQL data folder
 mkdir -p /etc/fleet
@@ -435,7 +433,7 @@ To run MySQL, we’ll have to do the following:
 We can pull the [official MySQL docker image](https://hub.docker.com/_/mysql) like so:
 
 ```sh
-$ docker pull mysql@sha256:134e2d1c7c517d05e5328a77aa5a165a314dc4c4116503e7e089494f4e398ab1 # mysql:8.0.36 as of 2024/07/04
+$ docker pull mysql@sha256:9c3380eac945af0736031b200027f581925927c81e010056214a4bd6b6693714 # mysql:8.0.44 as of 2026/03/03
 ```
 
 ### Create & enable a systemd unit for MySQL

--- a/changes/bump-mysql
+++ b/changes/bump-mysql
@@ -1,1 +1,1 @@
-* Revised which versions Fleet tests MySQL against to 8.0.39, 8.0.44, 8.4.8, and 9.6.0.
+* Revised which versions Fleet tests MySQL against to 9.5.0 (unchanged), 8.4.8, 8.0.44, and 8.0.39, 8.0.44.

--- a/changes/bump-mysql
+++ b/changes/bump-mysql
@@ -1,0 +1,1 @@
+* Revised which versions Fleet tests MySQL against to 8.0.39, 8.0.44, 8.4.8, and 9.6.0.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   # officially supported).
   # To run in macOS M1, set FLEET_MYSQL_IMAGE=arm64v8/mysql:oracle FLEET_MYSQL_PLATFORM=linux/arm64/v8
   mysql:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     volumes:
       - mysql-persistent-volume:/tmp
@@ -29,7 +29,7 @@ services:
       - "3306:3306"
 
   mysql_test:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: [
@@ -55,7 +55,7 @@ services:
       - /tmpfs
 
   mysql_replica_test:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: [

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -33,7 +33,7 @@ Fleet currently has three infrastructure dependencies: MySQL, Redis, and a TLS c
 Fleet uses MySQL extensively as its main database. Many cloud providers (such as [AWS](https://aws.amazon.com/rds/mysql/) and [GCP](https://cloud.google.com/sql/)) host reliable MySQL services which you may consider for this purpose. A well-supported MySQL [Docker image](https://hub.docker.com/_/mysql/) also exists if you would rather run MySQL in a container. 
 For more information on how to configure the `fleet` binary to use the correct MySQL instance, see the [MySQL configuration](https://fleetdm.com/docs/configuration/fleet-server-configuration#mysql) documentation.
 
-Fleet requires at least MySQL version 8.0.36, and is tested using the InnoDB storage engine [with versions 8.0.36, 8.4.7, and 9.5.0](https://github.com/fleetdm/fleet/blob/main/.github/workflows/test-go.yaml#L51).
+Fleet requires at least MySQL version 8.0.44, and is tested using the InnoDB storage engine [with versions 8.0.44, 8.4.8, and 9.6.0](https://github.com/fleetdm/fleet/blob/main/.github/workflows/test-go.yaml#L73-L90).
 
 There are many "drop-in replacements" for MySQL available. If you'd like to experiment with some bleeding-edge technology and use Fleet with one of these alternative database servers, we think that's awesome! Please be aware they are not officially supported and that it is very important to set up a dev environment to thoroughly test new releases.
 

--- a/docs/Deploy/Reference-Architectures.md
+++ b/docs/Deploy/Reference-Architectures.md
@@ -33,7 +33,7 @@ Fleet currently has three infrastructure dependencies: MySQL, Redis, and a TLS c
 Fleet uses MySQL extensively as its main database. Many cloud providers (such as [AWS](https://aws.amazon.com/rds/mysql/) and [GCP](https://cloud.google.com/sql/)) host reliable MySQL services which you may consider for this purpose. A well-supported MySQL [Docker image](https://hub.docker.com/_/mysql/) also exists if you would rather run MySQL in a container. 
 For more information on how to configure the `fleet` binary to use the correct MySQL instance, see the [MySQL configuration](https://fleetdm.com/docs/configuration/fleet-server-configuration#mysql) documentation.
 
-Fleet requires at least MySQL version 8.0.44, and is tested using the InnoDB storage engine [with versions 8.0.44, 8.4.8, and 9.6.0](https://github.com/fleetdm/fleet/blob/main/.github/workflows/test-go.yaml#L73-L90).
+Fleet requires at least MySQL version 8.0.44, and is tested using the InnoDB storage engine [with versions 8.0.44, 8.4.8, and 9.5.0](https://github.com/fleetdm/fleet/blob/main/.github/workflows/test-go.yaml#L73-L90). MySQL 9.6.0 is currently incompatible.
 
 There are many "drop-in replacements" for MySQL available. If you'd like to experiment with some bleeding-edge technology and use Fleet with one of these alternative database servers, we think that's awesome! Please be aware they are not officially supported and that it is very important to set up a dev environment to thoroughly test new releases.
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -152,7 +152,7 @@ See the ["How to uninstall fleetd" guide](https://fleetdm.com/guides/how-to-unin
 
 ### What MySQL versions are supported?
 
-Fleet is tested with MySQL 8.0.34, 8.4.8, and 9.6.0. Newer versions of MySQL 8 typically work well. AWS Aurora requires at least version 3.08.2. Please avoid using MariaDB or other MySQL variants that are not officially supported. Compatibility issues have been identified with MySQL variants, and these may not be addressed in future Fleet releases.
+Fleet is tested with MySQL 8.0.34, 8.4.8, and 9.5.0 (9.6.0 is currently incompatible). Newer versions of MySQL 8 typically work well. AWS Aurora requires at least version 3.08.2. Please avoid using MariaDB or other MySQL variants that are not officially supported. Compatibility issues have been identified with MySQL variants, and these may not be addressed in future Fleet releases.
 
 ### What version of the Mac Admins osquery extension is supported?
 

--- a/docs/Get started/FAQ.md
+++ b/docs/Get started/FAQ.md
@@ -152,7 +152,7 @@ See the ["How to uninstall fleetd" guide](https://fleetdm.com/guides/how-to-unin
 
 ### What MySQL versions are supported?
 
-Fleet is tested with MySQL 8.0.36, 8.4.7, and 9.5.0. Newer versions of MySQL 8 typically work well. AWS Aurora requires at least version 3.07.0. Please avoid using MariaDB or other MySQL variants that are not officially supported. Compatibility issues have been identified with MySQL variants, and these may not be addressed in future Fleet releases.
+Fleet is tested with MySQL 8.0.34, 8.4.8, and 9.6.0. Newer versions of MySQL 8 typically work well. AWS Aurora requires at least version 3.08.2. Please avoid using MariaDB or other MySQL variants that are not officially supported. Compatibility issues have been identified with MySQL variants, and these may not be addressed in future Fleet releases.
 
 ### What version of the Mac Admins osquery extension is supported?
 

--- a/server/mdm/nanomdm/docker-compose.yml
+++ b/server/mdm/nanomdm/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   # To run in macOS M1, set FLEET_MYSQL_PLATFORM=linux/arm64/v8
   mysql_nanomdm_test:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     # innodb-file-per-table=OFF gives ~20% speedup for test runs.
     command: [

--- a/test/upgrade/docker-compose.yml
+++ b/test/upgrade/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   mysql:
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
-    image: mysql:8.0.36
+    image: mysql:8.0.44
     environment:
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet

--- a/tools/backup_db/backup.sh
+++ b/tools/backup_db/backup.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BACKUP_NAME="${1:-backup.sql.gz}"
-docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c "mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 --add-drop-database --databases fleet | gzip -" > "$BACKUP_NAME"
+docker run --rm --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.44} bash -c "mysqldump -hmysql -uroot -ptoor --default-character-set=utf8mb4 --add-drop-database --databases fleet | gzip -" > "$BACKUP_NAME"

--- a/tools/backup_db/restore.sh
+++ b/tools/backup_db/restore.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 BACKUP_NAME="${1:-backup.sql.gz}"
-docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.36} bash -c 'gzip -dc - | MYSQL_PWD=toor mysql -hmysql -uroot fleet' < "${BACKUP_NAME}"
+docker run --rm -i --network fleet_default ${FLEET_MYSQL_IMAGE:-mysql:8.0.44} bash -c 'gzip -dc - | MYSQL_PWD=toor mysql -hmysql -uroot fleet' < "${BACKUP_NAME}"

--- a/tools/backup_db/restore_e2e_software_test.sh
+++ b/tools/backup_db/restore_e2e_software_test.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker run --rm -i --network fleet_default mysql:8.0.36 bash -c 'gzip -kdc - | mysql -hmysql_test -uroot -ptoor e2e'  < tools/testdata/e2e_software_test.sql.gz
+docker run --rm -i --network fleet_default mysql:8.0.44 bash -c 'gzip -kdc - | mysql -hmysql_test -uroot -ptoor e2e'  < tools/testdata/e2e_software_test.sql.gz

--- a/tools/mysql-replica-testing/docker-compose.yml
+++ b/tools/mysql-replica-testing/docker-compose.yml
@@ -2,7 +2,7 @@
 version: "2"
 services:
   mysql_main:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     volumes:
       - mysql-persistent-volume-replica-main:/tmp
@@ -27,7 +27,7 @@ services:
       - "3308:3306"
 
   mysql_read_replica:
-    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.36}
+    image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
     platform: ${FLEET_MYSQL_PLATFORM:-linux/x86_64}
     volumes:
       - mysql-persistent-volume-replica-read:/tmp

--- a/tools/osquery/in-a-box/docker-compose.yml
+++ b/tools/osquery/in-a-box/docker-compose.yml
@@ -9,7 +9,7 @@ networks:
 
 services:
   mysql01:
-    image: mysql:8.0.36
+    image: mysql:8.0.44
     platform: linux/x86_64
     volumes:
       - .:/data

--- a/tools/percona/test/upgrade.sh
+++ b/tools/percona/test/upgrade.sh
@@ -12,7 +12,7 @@ docker volume rm fleet_mysql-persistent-volume
 
 # Start dependencies using Percona XtraDB as MySQL server.
 # NOTE: To troubleshoot, remove `>/dev/null`.
-FLEET_MYSQL_IMAGE=percona/percona-xtradb-cluster:8.0.36 docker compose up >/dev/null 2>&1 &
+FLEET_MYSQL_IMAGE=percona/percona-xtradb-cluster:8.0.44 docker compose up >/dev/null 2>&1 &
 
 export MYSQL_PWD=toor
 


### PR DESCRIPTION
Fixes #40975.

8.0.32 (was running in Aurora managed cloud at the time) -> 8.0.39 (what we're running now) 8.0.36 -> 8.0.44 (latest 8.0.x version supported by Aurora; holding off on 8.0.45 until Aurora supports it) 8.4.7 -> 8.4.8
9.5.0 -> 9.6.0

Also bumped the supported Aurora version from 3.07.0 to 3.08.2 to match what we're running in managed cloud right now

Fleet might work on older patch versions but we'll no longer dev/test on them. MySQL 9.x not testing previous minor versions matches with our previous approach for that version.

Since these are all patch/minor bumps (and the overnight build cases are patch bumps/are covered by AWS envs) automated testing should be sufficient here.