### PR TITLE
jve test merge

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1431,7 +1431,10 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			jsonFieldName(t, "CalendarEventsEnabled"):          policy.CalendarEventsEnabled,
 			jsonFieldName(t, "ConditionalAccessEnabled"):       policy.ConditionalAccessEnabled,
 			jsonFieldName(t, "ConditionalAccessBypassEnabled"): policy.ConditionalAccessBypassEnabled,
+			jsonFieldName(t, "Type"):                           policy.Type,
+			jsonFieldName(t, "FleetMaintainedAppSlug"):         policy.FleetMaintainedAppSlug,
 		}
+		fmt.Printf("policy.FleetMaintainedAppSlug: %v\n", policy.FleetMaintainedAppSlug)
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
 			if software, ok := cmd.SoftwareList[policy.InstallSoftware.SoftwareTitleID]; ok {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1435,8 +1435,8 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 		if policy.FleetMaintainedAppSlug != "" {
 			policySpec["fleet_maintained_app_slug"] = policy.FleetMaintainedAppSlug
 		}
-		if policy.Type != "" {
-			policySpec["type"] = policy.Type
+		if v := ptr.ValOrZero(policy.Type); v != "" {
+			policySpec["type"] = v
 		}
 		// Handle software automation.
 		if policy.InstallSoftware != nil {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1431,10 +1431,13 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			jsonFieldName(t, "CalendarEventsEnabled"):          policy.CalendarEventsEnabled,
 			jsonFieldName(t, "ConditionalAccessEnabled"):       policy.ConditionalAccessEnabled,
 			jsonFieldName(t, "ConditionalAccessBypassEnabled"): policy.ConditionalAccessBypassEnabled,
-			jsonFieldName(t, "Type"):                           policy.Type,
-			jsonFieldName(t, "FleetMaintainedAppSlug"):         policy.FleetMaintainedAppSlug,
 		}
-		fmt.Printf("policy.FleetMaintainedAppSlug: %v\n", policy.FleetMaintainedAppSlug)
+		if policy.FleetMaintainedAppSlug != "" {
+			policySpec["fleet_maintained_app_slug"] = policy.FleetMaintainedAppSlug
+		}
+		if policy.Type != "" {
+			policySpec["type"] = policy.Type
+		}
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
 			if software, ok := cmd.SoftwareList[policy.InstallSoftware.SoftwareTitleID]; ok {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -337,6 +337,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 					}},
 					ConditionalAccessEnabled:       true,
 					ConditionalAccessBypassEnabled: ptr.Bool(true),
+					Type:                           fleet.PolicyTypeDynamic,
 				},
 				InstallSoftware: &fleet.PolicySoftwareTitle{
 					SoftwareTitleID: 1,
@@ -355,9 +356,25 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				Platform:                       "linux,windows",
 				ConditionalAccessEnabled:       true,
 				ConditionalAccessBypassEnabled: ptr.Bool(true),
+				Type:                           fleet.PolicyTypeDynamic,
 			},
 			RunScript: &fleet.PolicyScript{
 				ID: 1,
+			},
+		},
+
+		{
+			PolicyData: fleet.PolicyData{
+				ID:                             2,
+				Name:                           "Team patch policy",
+				Query:                          "SELECT * FROM team_policy WHERE id = 1",
+				Resolution:                     ptr.String("Do a team thing"),
+				Description:                    "This is a team patch policy",
+				Platform:                       "linux,windows",
+				ConditionalAccessEnabled:       true,
+				ConditionalAccessBypassEnabled: ptr.Bool(false),
+				FleetMaintainedAppSlug:         "foo/darwin",
+				Type:                           fleet.PolicyTypePatch,
 			},
 		},
 	}, nil
@@ -1727,43 +1744,46 @@ func TestGeneratePolicies(t *testing.T) {
 	policiesRaw, err := cmd.generatePolicies(nil, "default.yml")
 	require.NoError(t, err)
 	require.NotNil(t, policiesRaw)
-	var policies []map[string]interface{}
+	var generatedPolicies []map[string]any
 	b, err := yaml.Marshal(policiesRaw)
 	require.NoError(t, err)
-	fmt.Println("policies raw:\n", string(b)) // Debugging line
-	err = yaml.Unmarshal(b, &policies)
+	fmt.Println("generated global policies raw:\n", string(b)) // Debugging line
+	err = yaml.Unmarshal(b, &generatedPolicies)
 	require.NoError(t, err)
 
 	// Get the expected org settings YAML.
 	b, err = os.ReadFile("./testdata/generateGitops/expectedGlobalPolicies.yaml")
 	require.NoError(t, err)
-	var expectedPolicies []map[string]interface{}
+	var expectedPolicies []map[string]any
 	err = yaml.Unmarshal(b, &expectedPolicies)
 	require.NoError(t, err)
 
 	// Compare.
-	require.Equal(t, expectedPolicies, policies)
+	require.Equal(t, expectedPolicies, generatedPolicies)
 
 	// Generate policies for a team.
 	// Note that nested keys here may be strings,
 	// so we'll JSON marshal and unmarshal to a map for comparison.
+
+	var expectedTeamPolicies []map[string]any
+	var generatedTeamPolicies []map[string]any
 	policiesRaw, err = cmd.generatePolicies(ptr.Uint(1), "some_team")
 	require.NoError(t, err)
 	require.NotNil(t, policiesRaw)
 	b, err = yaml.Marshal(policiesRaw)
 	require.NoError(t, err)
-	fmt.Println("policies raw:\n", string(b)) // Debugging line
-	err = yaml.Unmarshal(b, &policies)
+	fmt.Println("generated team policies raw:\n", string(b)) // Debugging line
+	err = yaml.Unmarshal(b, &generatedTeamPolicies)
 	require.NoError(t, err)
 
 	// Get the expected org settings YAML.
 	b, err = os.ReadFile("./testdata/generateGitops/expectedTeamPolicies.yaml")
 	require.NoError(t, err)
-	err = yaml.Unmarshal(b, &expectedPolicies)
+	err = yaml.Unmarshal(b, &expectedTeamPolicies)
 	require.NoError(t, err)
 
 	// Compare.
-	require.Equal(t, expectedPolicies, policies)
+	require.Equal(t, expectedPolicies, generatedPolicies)
 }
 
 func TestGenerateQueries(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1728,7 +1728,7 @@ func TestGeneratePolicies(t *testing.T) {
 		Client:       fleetClient,
 		CLI:          cli.NewContext(cli.NewApp(), nil, nil),
 		Messages:     Messages{},
-		FilesToWrite: make(map[string]interface{}),
+		FilesToWrite: make(map[string]any),
 		AppConfig:    appConfig,
 		SoftwareList: map[uint]Software{
 			1: {

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -337,7 +337,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 					}},
 					ConditionalAccessEnabled:       true,
 					ConditionalAccessBypassEnabled: ptr.Bool(true),
-					Type:                           fleet.PolicyTypeDynamic,
+					Type:                           ptr.String(fleet.PolicyTypeDynamic),
 				},
 				InstallSoftware: &fleet.PolicySoftwareTitle{
 					SoftwareTitleID: 1,
@@ -356,7 +356,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				Platform:                       "linux,windows",
 				ConditionalAccessEnabled:       true,
 				ConditionalAccessBypassEnabled: ptr.Bool(true),
-				Type:                           fleet.PolicyTypeDynamic,
+				Type:                           ptr.String(fleet.PolicyTypeDynamic),
 			},
 			RunScript: &fleet.PolicyScript{
 				ID: 1,
@@ -374,7 +374,7 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				ConditionalAccessEnabled:       true,
 				ConditionalAccessBypassEnabled: ptr.Bool(false),
 				FleetMaintainedAppSlug:         "foo/darwin",
-				Type:                           fleet.PolicyTypePatch,
+				Type:                           ptr.String(fleet.PolicyTypePatch),
 			},
 		},
 	}, nil

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
@@ -12,3 +12,4 @@
   platform: darwin
   query: SELECT * FROM global_policy WHERE id = 1
   resolution: Do a global thing
+  type: dynamic

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -7,3 +7,17 @@
   resolution: Do a team thing
   run_script:
     path: /path/to/script1.sh
+  type: dynamic
+  conditional_access_enabled: true
+  conditional_access_bypass_enabled: true
+- calendar_events_enabled: false
+  critical: false
+  description: This is a team patch policy
+  name: Team patch policy
+  platform: linux,windows
+  query: SELECT * FROM team_policy WHERE id = 1
+  resolution: Do a team thing
+  fleet_maintained_app_slug: "foo/darwin"
+  type: patch
+  conditional_access_enabled: true
+  conditional_access_bypass_enabled: false

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1121,8 +1121,6 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 		if item.Type == "" {
 			item.Type = fleet.PolicyTypeDynamic
 		}
-		// TODO: cross-reference with software and ensure that the slug exists if it's a patch policy
-		fmt.Printf("item.FleetMaintainedAppSlug: %v\n", item.FleetMaintainedAppSlug)
 		if item.Query == "" && item.Type != fleet.PolicyTypePatch {
 			multiError = multierror.Append(multiError, errors.New("policy query is required for each policy"))
 		}

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -3613,7 +3613,7 @@ func (ds *Datastore) ListPoliciesForHost(ctx context.Context, host *fleet.Host) 
 		// We log to help troubleshooting in case this happens.
 		ds.logger.ErrorContext(ctx, "unrecognized platform", "hostID", host.ID, "platform", host.Platform)
 	}
-	query := `SELECT p.id, p.team_id, p.resolution, p.name, p.query, p.description, p.author_id, p.platforms, p.critical, p.created_at, p.updated_at, p.conditional_access_enabled, p.conditional_access_bypass_enabled,
+	query := `SELECT p.id, p.team_id, p.resolution, p.name, p.query, p.description, p.author_id, p.platforms, p.critical, p.created_at, p.updated_at, p.conditional_access_enabled, p.conditional_access_bypass_enabled, p.type,
 		COALESCE(u.name, '<deleted>') AS author_name,
 		COALESCE(u.email, '') AS author_email,
 		CASE

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -37,7 +37,8 @@ const policyCols = `
 	p.id, p.team_id, p.resolution, p.name, p.query, p.description,
 	p.author_id, p.platforms, p.created_at, p.updated_at, p.critical,
 	p.calendar_events_enabled, p.software_installer_id, p.script_id,
-	p.vpp_apps_teams_id, p.conditional_access_enabled, p.conditional_access_bypass_enabled
+	p.vpp_apps_teams_id, p.conditional_access_enabled, p.conditional_access_bypass_enabled,
+	p.type, p.patch_software_title_id
 `
 
 const (

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1080,13 +1080,14 @@ func newTeamPolicy(ctx context.Context, db sqlx.ExtContext, teamID uint, authorI
 			`INSERT INTO policies (
 				name, query, description, team_id, resolution, author_id,
 				platforms, critical, calendar_events_enabled, software_installer_id,
-				script_id, vpp_apps_teams_id, conditional_access_enabled, conditional_access_bypass_enabled, checksum
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s)`,
+				script_id, vpp_apps_teams_id, conditional_access_enabled, conditional_access_bypass_enabled, checksum,
+				type, patch_software_title_id
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?)`,
 			policiesChecksumComputedColumn(),
 		),
 		nameUnicode, args.Query, args.Description, teamID, args.Resolution, authorID, args.Platform, args.Critical,
 		args.CalendarEventsEnabled, args.SoftwareInstallerID, args.ScriptID, args.VPPAppsTeamsID,
-		args.ConditionalAccessEnabled, args.ConditionalAccessBypassEnabled,
+		args.ConditionalAccessEnabled, args.ConditionalAccessBypassEnabled, args.Type, args.PatchSoftwareTitleID,
 	)
 	switch {
 	case err == nil:

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1029,6 +1029,19 @@ func (ds *Datastore) PolicyQueriesForHost(ctx context.Context, host *fleet.Host)
 func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *uint, args fleet.PolicyPayload) (policy *fleet.Policy, err error) {
 	var newPolicy *fleet.Policy
 	if err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		if args.Type == "patch" {
+			installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, *args.PatchSoftwareTitleID, false)
+			if err != nil {
+				return err
+			}
+			if installer.FleetMaintainedAppID == nil {
+				return ctxerr.Wrap(ctx, nil, "TODO(JK): correct error message")
+			}
+			if installer.Platform == string(fleet.MacOSPlatform) {
+				args.Query = fmt.Sprintf("TODO(JK)... version = %s", installer.Version)
+			}
+		}
+
 		p, err := newTeamPolicy(ctx, tx, teamID, authorID, args)
 		if err != nil {
 			return err

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1030,7 +1030,7 @@ func (ds *Datastore) PolicyQueriesForHost(ctx context.Context, host *fleet.Host)
 func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *uint, args fleet.PolicyPayload) (policy *fleet.Policy, err error) {
 	var newPolicy *fleet.Policy
 	if err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		if args.Type == "patch" {
+		if args.Type == fleet.PolicyTypePatch {
 			installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, *args.PatchSoftwareTitleID, false)
 			if err != nil {
 				return err

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1029,6 +1029,10 @@ func (ds *Datastore) PolicyQueriesForHost(ctx context.Context, host *fleet.Host)
 
 func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *uint, args fleet.PolicyPayload) (policy *fleet.Policy, err error) {
 	var newPolicy *fleet.Policy
+	if args.Type != fleet.PolicyTypePatch {
+		// type should already be set to dynamic when called from the service layer
+		args.Type = fleet.PolicyTypeDynamic
+	}
 	if err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		if args.Type == fleet.PolicyTypePatch {
 			installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, *args.PatchSoftwareTitleID, false)

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -302,6 +302,10 @@ func policyDB(ctx context.Context, q sqlx.QueryerContext, id uint, teamID *uint)
 		return nil, ctxerr.Wrap(ctx, err, "laoding policy labels")
 	}
 
+	if policy.TeamID == nil {
+		policy.Type = nil
+	}
+
 	return &policy, nil
 }
 

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1122,6 +1122,10 @@ func newTeamPolicy(ctx context.Context, db sqlx.ExtContext, teamID uint, authorI
 	switch {
 	case err == nil:
 		// OK
+	case IsDuplicate(err) && args.Type == fleet.PolicyTypePatch:
+		return nil, &fleet.ConflictError{
+			Message: "Couldn't add. Specified \"patch_software_title_id\" already has a policy with \"type\" set to \"patch\".",
+		}
 	case IsDuplicate(err):
 		return nil, ctxerr.Wrap(ctx, alreadyExists("Policy", nameUnicode))
 	default:

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1038,19 +1038,17 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 			if installer.FleetMaintainedAppID == nil {
 				return ctxerr.Wrap(ctx, &fleet.BadRequestError{
 					// TODO(JK): improve error message
-					// Maybe we could also move this earlier in the code if we get the installer sooner
 					Message: fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID %d", *args.PatchSoftwareTitleID, teamID),
 				})
 			}
 			if installer.Platform == string(fleet.MacOSPlatform) {
-				// TODO(JK): can we use version_compare? What about older osquery versions
 				args.Query = fmt.Sprintf(
 					"SELECT 1 FROM apps WHERE bundle_identifier = '%s' AND version_compare(bundle_short_version, '%s') >= 0;",
 					installer.BundleIdentifier,
 					installer.Version,
 				)
 			} else if installer.Platform == "windows" {
-				// TODO(JK): could we use upgrade code here? maybe leave as TODO for the future
+				// TODO: use upgrade code if possible?
 				args.Query = fmt.Sprintf(
 					"SELECT 1 FROM programs WHERE name = '%s' AND version_compare(bundle_short_version, '%s') >= 0;",
 					installer.SoftwareTitle,

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1047,6 +1047,7 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 					installer.BundleIdentifier,
 					installer.Version,
 				)
+				args.Platform = string(fleet.MacOSPlatform)
 			} else if installer.Platform == "windows" {
 				// TODO: use upgrade code if possible?
 				args.Query = fmt.Sprintf(
@@ -1054,6 +1055,7 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 					installer.SoftwareTitle,
 					installer.Version,
 				)
+				args.Platform = "windows"
 			}
 		}
 

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1120,19 +1120,20 @@ func newTeamPolicy(ctx context.Context, db sqlx.ExtContext, teamID uint, authorI
 	if args.ConditionalAccessBypassEnabled == nil {
 		args.ConditionalAccessBypassEnabled = ptr.Bool(true)
 	}
+	fmt.Printf("[DEBUG %s] %s newTeamPolicy\n", time.Now().Format(time.RFC3339Nano), func() string { _, f, l, _ := runtime.Caller(0); return fmt.Sprintf("%s:%d", f, l) }())
 
 	res, err := db.ExecContext(ctx,
 		fmt.Sprintf(
 			`INSERT INTO policies (
 				name, query, description, team_id, resolution, author_id,
 				platforms, critical, calendar_events_enabled, software_installer_id,
-				script_id, vpp_apps_teams_id, conditional_access_enabled, conditional_access_bypass_enabled, checksum
-			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s)`,
+				script_id, vpp_apps_teams_id, conditional_access_enabled, conditional_access_bypass_enabled, checksum, type, patch_software_title_id
+			) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?)`,
 			policiesChecksumComputedColumn(),
 		),
 		nameUnicode, args.Query, args.Description, teamID, args.Resolution, authorID, args.Platform, args.Critical,
 		args.CalendarEventsEnabled, args.SoftwareInstallerID, args.ScriptID, args.VPPAppsTeamsID,
-		args.ConditionalAccessEnabled, args.ConditionalAccessBypassEnabled,
+		args.ConditionalAccessEnabled, args.ConditionalAccessBypassEnabled, args.Type, args.PatchSoftwareTitleID,
 	)
 	switch {
 	case err == nil:
@@ -1257,6 +1258,7 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 	teamIDToPolicies := make(map[*uint][]*fleet.PolicySpec, 1)
 	softwareInstallerIDs := make(map[*uint]map[uint]*uint) // teamID -> titleID -> softwareInstallerID
 	vppAppsTeamsIDs := make(map[*uint]map[uint]*uint)      // teamID -> titleID -> vppAppsTeamsID
+	fmaTitleIDs := make(map[*uint]map[string]*uint)        // teamID -> FMA slug -> titleID
 	vppTitleIDs := make(map[uint]struct{})                 // set when a title is a VPP app rather than a software installer
 
 	// Get the team IDs
@@ -1288,6 +1290,25 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 
 	// Get software installer ids + VPP apps teams IDs from software title IDs.
 	for _, spec := range specs {
+
+		if spec.FleetMaintainedAppSlug != "" {
+			var fmaTitleID *uint
+			err := sqlx.GetContext(ctx, queryerContext, &fmaTitleID, `
+			SELECT si.title_id FROM software_installers si
+						JOIN fleet_maintained_apps fma ON si.fleet_maintained_app_id = fma.id
+						WHERE fma.slug = ?
+						AND si.global_or_team_id = ?
+			`, spec.FleetMaintainedAppSlug, teamNameToID[spec.Team])
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "get fma title id")
+			}
+			if len(fmaTitleIDs[teamNameToID[spec.Team]]) == 0 {
+				fmaTitleIDs[teamNameToID[spec.Team]] = make(map[string]*uint)
+			}
+			fmaTitleIDs[teamNameToID[spec.Team]][spec.FleetMaintainedAppSlug] = fmaTitleID
+
+		}
+
 		if spec.SoftwareTitleID == nil || *spec.SoftwareTitleID == 0 {
 			continue
 		}
@@ -1366,6 +1387,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 		}
 	}
 
+	fmt.Printf("[JVE %s] %s hmm\n", time.Now().Format(time.RFC3339Nano), func() string { _, f, l, _ := runtime.Caller(0); return fmt.Sprintf("%s:%d", f, l) }())
+
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 		query := fmt.Sprintf(
 			`
@@ -1384,8 +1407,10 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 		    script_id,
 			conditional_access_enabled,
 			conditional_access_bypass_enabled,
-			checksum
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s)
+			checksum,
+			type,
+			patch_software_title_id
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, %s, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			query = VALUES(query),
 			description = VALUES(description),
@@ -1398,7 +1423,9 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 			vpp_apps_teams_id = VALUES(vpp_apps_teams_id),
 			script_id = VALUES(script_id),
 			conditional_access_enabled = VALUES(conditional_access_enabled),
-			conditional_access_bypass_enabled = VALUES(conditional_access_bypass_enabled)
+			conditional_access_bypass_enabled = VALUES(conditional_access_bypass_enabled),
+			type = VALUES(type),
+			patch_software_title_id = VALUES(patch_software_title_id)
 		`, policiesChecksumComputedColumn(),
 		)
 		for teamID, teamPolicySpecs := range teamIDToPolicies {
@@ -1422,12 +1449,18 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					spec.ConditionalAccessBypassEnabled = ptr.Bool(true)
 				}
 
+				fmaTitleID := fmaTitleIDs[teamNameToID[spec.Team]][spec.FleetMaintainedAppSlug]
+
+				fmt.Printf("[JVE %s] %s fmaTitleID: %v\n", time.Now().Format(time.RFC3339Nano), func() string { _, f, l, _ := runtime.Caller(0); return fmt.Sprintf("%s:%d", f, l) }(), ptr.ValOrZero(fmaTitleID))
+				fmt.Printf("spec.Name: %v\n", spec.Name)
+				fmt.Printf("spec.FleetMaintainedAppSlug: %v\n", spec.FleetMaintainedAppSlug)
+
 				res, err := tx.ExecContext(
 					ctx,
 					query,
 					spec.Name, spec.Query, spec.Description, authorID, spec.Resolution, teamID, spec.Platform, spec.Critical,
 					spec.CalendarEventsEnabled, softwareInstallerID, vppAppsTeamsID, scriptID, spec.ConditionalAccessEnabled,
-					spec.ConditionalAccessBypassEnabled,
+					spec.ConditionalAccessBypassEnabled, spec.Type, fmaTitleID,
 				)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "exec ApplyPolicySpecs insert")

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -7066,10 +7066,10 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'fleet.maintained1' AND version_compare(bundle_short_version, '1.0') >= 0;", p1.Query)
 
-	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
-		DumpTable(t, tx, "software_titles")
-		DumpTable(t, tx, "software_installers")
-		DumpTable(t, tx, "policies")
-		return nil
+	_, err = ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
+		Name:     "p2",
+		Query:    "SELECT 1;",
+		Platform: "darwin",
 	})
+	require.NoError(t, err)
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -7015,6 +7015,7 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 	user1 := test.NewUser(t, ds, "Alice", "alice@example.com", true)
 	team1, err := ds.NewTeam(ctx, &fleet.Team{Name: "team1"})
+	require.NoError(t, err)
 
 	payload := &fleet.UploadSoftwareInstallerPayload{
 		InstallScript:     "hello",

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -1738,6 +1738,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Team:             "",
 			Platform:         "",
 			LabelsIncludeAny: []string{fooLabel.Name},
+			Type:             fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:                           "query2",
@@ -1749,6 +1750,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			CalendarEventsEnabled:          true,
 			LabelsExcludeAny:               []string{barLabel.Name},
 			ConditionalAccessBypassEnabled: ptr.Bool(false),
+			Type:                           fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:        "query3",
@@ -1757,6 +1759,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Resolution:  "some other good resolution",
 			Team:        "team1",
 			Platform:    "windows,linux",
+			Type:        fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:        "query4",
@@ -1765,6 +1768,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Resolution:  "some other good resolution 2",
 			Team:        "No team",
 			Platform:    "",
+			Type:        fleet.PolicyTypeDynamic,
 		},
 	}))
 
@@ -1784,6 +1788,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 		LabelName: fooLabel.Name,
 		LabelID:   fooLabel.ID,
 	}}, policies[0].LabelsIncludeAny)
+	assert.Equal(t, policies[0].Type, fleet.PolicyTypeDynamic)
 
 	teamPolicies, _, err := ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{})
 	require.NoError(t, err)
@@ -1840,6 +1845,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Team:             "",
 			Platform:         "",
 			LabelsIncludeAny: []string{fooLabel.Name},
+			Type:             fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:                           "query2",
@@ -1851,6 +1857,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			CalendarEventsEnabled:          true,
 			LabelsExcludeAny:               []string{barLabel.Name},
 			ConditionalAccessBypassEnabled: ptr.Bool(false),
+			Type:                           fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:        "query3",
@@ -1859,6 +1866,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Resolution:  "some other good resolution",
 			Team:        "team1",
 			Platform:    "windows,linux",
+			Type:        fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:        "query4",
@@ -1867,6 +1875,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Resolution:  "some other good resolution 2",
 			Team:        "No team",
 			Platform:    "",
+			Type:        fleet.PolicyTypeDynamic,
 		},
 	}))
 
@@ -1890,6 +1899,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Team:             "", // No error, team did not change
 			Platform:         "",
 			LabelsExcludeAny: []string{fooLabel.Name, barLabel.Name},
+			Type:             fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:                  "query2",
@@ -1899,6 +1909,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 			Team:                  "team1", // No error, team did not change
 			Platform:              "windows",
 			CalendarEventsEnabled: false,
+			Type:                  fleet.PolicyTypeDynamic,
 		},
 	}))
 	policies, err = ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
@@ -1950,6 +1961,7 @@ func testApplyPolicySpec(t *testing.T, ds *Datastore) {
 					Resolution:  "some resolution updated again",
 					Team:        "team1",
 					Platform:    "",
+					Type:        fleet.PolicyTypeDynamic,
 				},
 			}))
 }
@@ -2026,36 +2038,42 @@ func testApplyPolicySpecWithQueryPlatformChanges(t *testing.T, ds *Datastore) {
 					Query:    "select 1;",
 					Team:     "",
 					Platform: "",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     globalNames[1],
 					Query:    "select 2;",
 					Team:     "",
 					Platform: "darwin",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     globalNames[2],
 					Query:    "select 3;",
 					Team:     "",
 					Platform: "darwin,linux",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     teamNames[0],
 					Query:    "select 1;",
 					Team:     "team1" + unicode,
 					Platform: "",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     teamNames[1],
 					Query:    "select 2;",
 					Team:     "team1" + unicode,
 					Platform: "darwin",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     teamNames[2],
 					Query:    "select 3;",
 					Team:     "team1" + unicodeEq,
 					Platform: "darwin,linux",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 			},
 		),
@@ -2192,30 +2210,35 @@ func testApplyPolicySpecWithQueryPlatformChanges(t *testing.T, ds *Datastore) {
 					Team:        "",
 					Platform:    "",
 					Description: "updated", // update description
+					Type:        fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     globalNames[1],
 					Query:    "select 2 updated;", // update query
 					Team:     "",
 					Platform: "darwin",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     globalNames[2],
 					Query:    "select 3;",
 					Team:     "",
 					Platform: "darwin", // update platform
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     "new global query",
 					Query:    "select 4;",
 					Team:     "",
 					Platform: "",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     teamNames[0],
 					Query:    "select 1;",
 					Team:     "team1" + unicode,
 					Platform: "linux", // update platform
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:                  teamNames[1],
@@ -2223,18 +2246,21 @@ func testApplyPolicySpecWithQueryPlatformChanges(t *testing.T, ds *Datastore) {
 					Team:                  "team1" + unicode,
 					Platform:              "darwin",
 					CalendarEventsEnabled: true, // update calendar events
+					Type:                  fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     teamNames[2],
 					Query:    "select 3 updated;", // update query
 					Team:     "team1" + unicodeEq,
 					Platform: "darwin,linux",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 				{
 					Name:     "new team query",
 					Query:    "select 4;",
 					Team:     "team1" + unicode,
 					Platform: "",
+					Type:     fleet.PolicyTypeDynamic,
 				},
 			},
 		),
@@ -4914,6 +4940,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: installer1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "Team policy 2",
@@ -4923,6 +4950,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team2",
 			Platform:        "linux",
 			SoftwareTitleID: installer2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "No team policy 3",
@@ -4932,6 +4960,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "No team",
 			Platform:        "linux",
 			SoftwareTitleID: installer3.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 1",
@@ -4941,6 +4970,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: &va1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 2",
@@ -4950,6 +4980,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team2",
 			Platform:        "linux",
 			SoftwareTitleID: &va2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP No team policy 3",
@@ -4959,6 +4990,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "No team",
 			Platform:        "linux",
 			SoftwareTitleID: &va1NoTeam.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)
@@ -5014,6 +5046,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: nil,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 1",
@@ -5023,6 +5056,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: nil,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)
@@ -5045,6 +5079,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: installer2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5061,6 +5096,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: &va2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5076,6 +5112,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "No team",
 			Platform:        "darwin",
 			SoftwareTitleID: installer2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5091,6 +5128,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "No team",
 			Platform:        "darwin",
 			SoftwareTitleID: &va2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5106,6 +5144,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: ptr.Uint(999_999),
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5121,6 +5160,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "No team",
 			Platform:        "darwin",
 			SoftwareTitleID: ptr.Uint(999_999),
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.Error(t, err)
@@ -5136,6 +5176,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team2",
 			Platform:        "linux",
 			SoftwareTitleID: ptr.Uint(0),
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)
@@ -5181,6 +5222,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: installer1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "Team policy 2",
@@ -5190,6 +5232,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team2",
 			Platform:        "linux",
 			SoftwareTitleID: installer4.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 1",
@@ -5199,6 +5242,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: &va1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 2",
@@ -5208,6 +5252,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team2",
 			Platform:        "linux",
 			SoftwareTitleID: &va4Team2.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)
@@ -5258,6 +5303,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: installer1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 1",
@@ -5267,6 +5313,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: &va1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)
@@ -5310,6 +5357,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: installer5.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 		{
 			Name:            "VPP Team policy 1",
@@ -5319,6 +5367,7 @@ func testApplyPolicySpecWithInstallers(t *testing.T, ds *Datastore) {
 			Team:            "team1",
 			Platform:        "darwin",
 			SoftwareTitleID: &va4Team1.TitleID,
+			Type:            fleet.PolicyTypeDynamic,
 		},
 	})
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1002,7 +1002,8 @@ SELECT
   si.uploaded_at,
   si.self_service,
   si.url,
-  COALESCE(st.name, '') AS software_title
+  COALESCE(st.name, '') AS software_title,
+  COALESCE(st.bundle_identifier, '') AS bundle_identifier
   %s
 FROM
   software_installers si

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -484,6 +484,7 @@ func (ds *Datastore) createAutomaticPolicy(ctx context.Context, tx sqlx.ExtConte
 		Description:         policyData.Description,
 		SoftwareInstallerID: softwareInstallerID,
 		VPPAppsTeamsID:      vppAppsTeamsID,
+		Type:                fleet.PolicyTypeDynamic,
 	})
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "create automatic policy query")

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -143,8 +143,10 @@ func (p PolicyPayload) Verify() error {
 		if err := verifyPolicyName(p.Name); err != nil {
 			return err
 		}
-		if err := verifyPolicyQuery(p.Query); err != nil {
-			return err
+		if p.Type != "patch" {
+			if err := verifyPolicyQuery(p.Query); err != nil {
+				return err
+			}
 		}
 	}
 	if err := verifyPolicyPlatforms(p.Platform); err != nil {
@@ -154,6 +156,9 @@ func (p PolicyPayload) Verify() error {
 		return errPolicyConflictingLabels
 	}
 	if p.Type == "patch" {
+		if p.QueryID != nil {
+			return errPolicyPatchAndQuerySet
+		}
 		if err := verifyPatchPolicy(p.PatchSoftwareTitleID, p.Query); err != nil {
 			return err
 		}
@@ -320,6 +325,9 @@ type PolicyData struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" db:"conditional_access_bypass_enabled"`
 
+	Type                 string `json:"type"` // TODO(JK): db?
+	PatchSoftwareTitleID *uint  `json:"-"`
+
 	UpdateCreateTimestamps
 }
 
@@ -347,6 +355,9 @@ type Policy struct {
 	//
 	// This field is populated from PolicyData.ScriptID
 	RunScript *PolicyScript `json:"run_script,omitempty"`
+
+	// TODO(JK): comment
+	PatchSoftware *PolicySoftwareTitle `json:patch_software,omitempty"`
 }
 
 type PolicyCalendarData struct {

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -137,7 +137,7 @@ func (p PolicyPayload) Verify() error {
 		if err := verifyPolicyName(p.Name); err != nil {
 			return err
 		}
-		if err := verifyPolicyQuery(p.Query); err != nil {
+		if err := verifyPolicyQuery(p.Query, p.Type); err != nil {
 			return err
 		}
 	}
@@ -161,8 +161,8 @@ func emptyString(s string) bool {
 	return len(strings.TrimSpace(s)) == 0
 }
 
-func verifyPolicyQuery(query string) error {
-	if emptyString(query) {
+func verifyPolicyQuery(query string, typ string) error {
+	if emptyString(query) && typ != PolicyTypePatch {
 		return errPolicyEmptyQuery
 	}
 	return nil
@@ -235,7 +235,7 @@ func (p ModifyPolicyPayload) Verify() error {
 		}
 	}
 	if p.Query != nil {
-		if err := verifyPolicyQuery(*p.Query); err != nil {
+		if err := verifyPolicyQuery(*p.Query, PolicyTypeDynamic); err != nil {
 			return err
 		}
 	}
@@ -301,6 +301,10 @@ type PolicyData struct {
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" db:"conditional_access_bypass_enabled"`
 
 	UpdateCreateTimestamps
+
+	Type                   string `json:"type" db:"type"`
+	PatchSoftwareTitleID   *uint  `json:"-" db:"patch_software_title_id"`
+	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
 }
 
 // Policy is a fleet's policy query.
@@ -421,6 +425,9 @@ type PolicySpec struct {
 	//
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled"`
+
+	Type                   string `json:"type"`
+	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
 }
 
 // PolicySoftwareTitle contains software title data for policies.
@@ -446,7 +453,7 @@ func (p PolicySpec) Verify() error {
 	if err := verifyPolicyName(p.Name); err != nil {
 		return err
 	}
-	if err := verifyPolicyQuery(p.Query); err != nil {
+	if err := verifyPolicyQuery(p.Query, p.Type); err != nil {
 		return err
 	}
 	if err := verifyPolicyPlatforms(p.Platform); err != nil {
@@ -500,3 +507,6 @@ type PolicyMembershipResult struct {
 	PolicyID uint
 	Passes   *bool
 }
+
+const PolicyTypePatch = "patch"
+const PolicyTypeDynamic = "dynamic"

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -325,8 +325,8 @@ type PolicyData struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" db:"conditional_access_bypass_enabled"`
 
-	Type                 string `json:"type"` // TODO(JK): db?
-	PatchSoftwareTitleID *uint  `json:"-"`
+	Type                 string `json:"type" db:"type"`
+	PatchSoftwareTitleID *uint  `json:"-" db:"patch_software_title_id"`
 
 	UpdateCreateTimestamps
 }
@@ -357,7 +357,7 @@ type Policy struct {
 	RunScript *PolicyScript `json:"run_script,omitempty"`
 
 	// TODO(JK): comment
-	PatchSoftware *PolicySoftwareTitle `json:patch_software,omitempty"`
+	PatchSoftware *PolicySoftwareTitle `json:"patch_software,omitempty"`
 }
 
 type PolicyCalendarData struct {

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -143,7 +143,7 @@ func (p PolicyPayload) Verify() error {
 		if err := verifyPolicyName(p.Name); err != nil {
 			return err
 		}
-		if p.Type != "patch" {
+		if p.Type != PolicyTypePatch {
 			if err := verifyPolicyQuery(p.Query); err != nil {
 				return err
 			}
@@ -155,7 +155,7 @@ func (p PolicyPayload) Verify() error {
 	if len(p.LabelsIncludeAny) > 0 && len(p.LabelsExcludeAny) > 0 {
 		return errPolicyConflictingLabels
 	}
-	if p.Type == "patch" {
+	if p.Type == PolicyTypePatch {
 		if p.QueryID != nil {
 			return errPolicyPatchAndQuerySet
 		}
@@ -531,3 +531,8 @@ type PolicyMembershipResult struct {
 	PolicyID uint
 	Passes   *bool
 }
+
+const (
+	PolicyTypeDynamic = "dynamic"
+	PolicyTypePatch   = "patch"
+)

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -254,7 +254,7 @@ type ModifyPolicyPayload struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" premium:"true"`
 
-	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
+	// Type is the policy type. It is 'dynamic' by default and 'patch' for patch policies.
 	Type string `json:"-"`
 }
 

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -62,10 +62,9 @@ type PolicyPayload struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool
 
-	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
+	// Type is the policy type. It is 'dynamic' by default and 'patch' for patch policies.
 	Type string
-	// PatchSoftwareTitleID is the title id of the Fleet maintained app
-	// that will be updated in a patch policy.
+	// PatchSoftwareTitleID is the title id of the Fleet maintained app chcked by a patch policy.
 	//
 	// Only applies to team policies with the patch type.
 	PatchSoftwareTitleID *uint
@@ -111,9 +110,9 @@ type NewTeamPolicyPayload struct {
 	// bypassed by the end user
 	ConditionalAccessBypassEnabled *bool
 
-	// TODO(JK): comments
-	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
-	Type                 *string
+	// Type is the policy type. It is 'dynamic' by default and 'patch' for patch policies.
+	Type *string
+	// PatchSoftwareTitleID is the title id of the Fleet maintained app checked by a patch policy.
 	PatchSoftwareTitleID *uint
 }
 
@@ -347,8 +346,12 @@ type PolicyData struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" db:"conditional_access_bypass_enabled"`
 
-	Type                 string `json:"type" db:"type"`
-	PatchSoftwareTitleID *uint  `json:"-" db:"patch_software_title_id"`
+	// Type is the policy type. It is 'dynamic' by default and 'patch' for patch policies.
+	Type string `json:"type" db:"type"`
+	// PatchSoftwareTitleID is the title id of the Fleet maintained app chcked by a patch policy.
+	//
+	// Only applies to team policies with the patch type.
+	PatchSoftwareTitleID *uint `json:"-" db:"patch_software_title_id"`
 
 	UpdateCreateTimestamps
 }
@@ -378,7 +381,12 @@ type Policy struct {
 	// This field is populated from PolicyData.ScriptID
 	RunScript *PolicyScript `json:"run_script,omitempty"`
 
-	// TODO(JK): comment
+	// PatchSoftware is used to check the installed version of a Fleet
+	// maintaind app.
+	//
+	// Only applies to team policies with the patch type.
+	//
+	// This field is populated from PolicyData.PatchSoftwareTitleID
 	PatchSoftware *PolicySoftwareTitle `json:"patch_software,omitempty"`
 }
 

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -260,21 +260,6 @@ type ModifyPolicyPayload struct {
 
 // Verify verifies the policy payload is valid.
 func (p ModifyPolicyPayload) Verify() error {
-	if p.Type == PolicyTypePatch {
-		if p.Name != nil {
-			if err := verifyPolicyName(*p.Name); err != nil {
-				return err
-			}
-		}
-		if p.Query != nil && !emptyString(*p.Query) {
-			return errPolicyPatchAndQuerySet
-		}
-		if p.Platform != nil && !emptyString(*p.Platform) {
-			return errPolicyPatchAndPlatformSet
-		}
-		return nil
-	}
-
 	if p.Name != nil {
 		if err := verifyPolicyName(*p.Name); err != nil {
 			return err

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -349,7 +349,7 @@ type PolicyData struct {
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" db:"conditional_access_bypass_enabled"`
 
 	// Type is the policy type. It is 'dynamic' by default and 'patch' for patch policies.
-	Type string `json:"type" db:"type"`
+	Type *string `json:"type,omitempty" db:"type"`
 	// PatchSoftwareTitleID is the title id of the Fleet maintained app chcked by a patch policy.
 	//
 	// Only applies to team policies with the patch type.

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -118,13 +118,14 @@ type NewTeamPolicyPayload struct {
 }
 
 var (
-	errPolicyEmptyName         = errors.New("policy name cannot be empty")
-	errPolicyEmptyQuery        = errors.New("policy query cannot be empty")
-	errPolicyIDAndQuerySet     = errors.New("both fields \"queryID\" and \"query\" cannot be set")
-	errPolicyInvalidPlatform   = errors.New("invalid policy platform")
-	errPolicyConflictingLabels = errors.New("policy cannot include both labels_include_any and labels_exclude_any")
-	errPolicyPatchAndQuerySet  = errors.New("The policy where the \"type\" is \"patch\" doesn't support the \"query\" field.")
-	errPolicyPatchNoTitleID    = errors.New("patch_software_title_id is required if \"type\" is \"patch\".") // TODO(JK): what message
+	errPolicyEmptyName           = errors.New("policy name cannot be empty")
+	errPolicyEmptyQuery          = errors.New("policy query cannot be empty")
+	errPolicyIDAndQuerySet       = errors.New("both fields \"queryID\" and \"query\" cannot be set")
+	errPolicyInvalidPlatform     = errors.New("invalid policy platform")
+	errPolicyConflictingLabels   = errors.New("policy cannot include both labels_include_any and labels_exclude_any")
+	errPolicyPatchAndQuerySet    = errors.New("If the \"type\" is \"patch\", the \"query\" field is not supported.")
+	errPolicyPatchAndPlatformSet = errors.New("If the \"type\" is \"patch\", the \"platform\" field is not supported.")
+	errPolicyPatchNoTitleID      = errors.New("If the \"type\" is \"patch\", the \"patch_software_title_id\" field is required.")
 )
 
 // PolicyNoTeamID is the team ID of "No team" policies.
@@ -161,6 +162,9 @@ func (p PolicyPayload) Verify() error {
 		}
 		if err := verifyPatchPolicy(p.PatchSoftwareTitleID, p.Query); err != nil {
 			return err
+		}
+		if p.Platform != "" {
+			return errPolicyPatchAndPlatformSet
 		}
 	}
 	return nil

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -62,7 +62,6 @@ type PolicyPayload struct {
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool
 
-	// TODO(JK): what other structs need these fields added?
 	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
 	Type string
 	// PatchSoftwareTitleID is the title id of the Fleet maintained app
@@ -113,6 +112,7 @@ type NewTeamPolicyPayload struct {
 	ConditionalAccessBypassEnabled *bool
 
 	// TODO(JK): comments
+	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
 	Type                 *string
 	PatchSoftwareTitleID *uint
 }
@@ -136,6 +136,28 @@ const MaxPolicyAutomationRetries = 3
 
 // Verify verifies the policy payload is valid.
 func (p PolicyPayload) Verify() error {
+	if p.Type == PolicyTypePatch {
+		if p.QueryID != nil {
+			return errPolicyPatchAndQuerySet
+		}
+		if err := verifyPolicyName(p.Name); err != nil {
+			return err
+		}
+		if !emptyString(p.Query) {
+			return errPolicyPatchAndQuerySet
+		}
+		if p.PatchSoftwareTitleID == nil {
+			return errPolicyPatchNoTitleID
+		}
+		if !emptyString(p.Platform) {
+			return errPolicyPatchAndPlatformSet
+		}
+		if len(p.LabelsIncludeAny) > 0 && len(p.LabelsExcludeAny) > 0 {
+			return errPolicyConflictingLabels
+		}
+		return nil
+	}
+
 	if p.QueryID != nil {
 		if p.Query != "" {
 			return errPolicyIDAndQuerySet
@@ -144,10 +166,8 @@ func (p PolicyPayload) Verify() error {
 		if err := verifyPolicyName(p.Name); err != nil {
 			return err
 		}
-		if p.Type != PolicyTypePatch {
-			if err := verifyPolicyQuery(p.Query); err != nil {
-				return err
-			}
+		if err := verifyPolicyQuery(p.Query); err != nil {
+			return err
 		}
 	}
 	if err := verifyPolicyPlatforms(p.Platform); err != nil {
@@ -155,17 +175,6 @@ func (p PolicyPayload) Verify() error {
 	}
 	if len(p.LabelsIncludeAny) > 0 && len(p.LabelsExcludeAny) > 0 {
 		return errPolicyConflictingLabels
-	}
-	if p.Type == PolicyTypePatch {
-		if p.QueryID != nil {
-			return errPolicyPatchAndQuerySet
-		}
-		if err := verifyPatchPolicy(p.PatchSoftwareTitleID, p.Query); err != nil {
-			return err
-		}
-		if p.Platform != "" {
-			return errPolicyPatchAndPlatformSet
-		}
 	}
 	return nil
 }
@@ -199,15 +208,6 @@ func verifyPolicyPlatforms(platforms string) error {
 		default:
 			return errPolicyInvalidPlatform
 		}
-	}
-	return nil
-}
-func verifyPatchPolicy(patchPolicyTitleID *uint, query string) error {
-	if query != "" {
-		return errPolicyPatchAndQuerySet
-	}
-	if patchPolicyTitleID == nil {
-		return errPolicyPatchNoTitleID
 	}
 	return nil
 }
@@ -254,10 +254,28 @@ type ModifyPolicyPayload struct {
 	//
 	// Only applies to team policies.
 	ConditionalAccessBypassEnabled *bool `json:"conditional_access_bypass_enabled" premium:"true"`
+
+	// Type is either dynamic (classic, editable) or patch (tied to Fleet maintained app).
+	Type string `json:"-"`
 }
 
 // Verify verifies the policy payload is valid.
 func (p ModifyPolicyPayload) Verify() error {
+	if p.Type == PolicyTypePatch {
+		if p.Name != nil {
+			if err := verifyPolicyName(*p.Name); err != nil {
+				return err
+			}
+		}
+		if p.Query != nil && !emptyString(*p.Query) {
+			return errPolicyPatchAndQuerySet
+		}
+		if p.Platform != nil && !emptyString(*p.Platform) {
+			return errPolicyPatchAndPlatformSet
+		}
+		return nil
+	}
+
 	if p.Name != nil {
 		if err := verifyPolicyName(*p.Name); err != nil {
 			return err

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -125,6 +125,8 @@ var (
 	errPolicyPatchAndQuerySet    = errors.New("If the \"type\" is \"patch\", the \"query\" field is not supported.")
 	errPolicyPatchAndPlatformSet = errors.New("If the \"type\" is \"patch\", the \"platform\" field is not supported.")
 	errPolicyPatchNoTitleID      = errors.New("If the \"type\" is \"patch\", the \"patch_software_title_id\" field is required.")
+	errPolicyQueryUpdated        = errors.New("\"query\" can't be updated")
+	errPolicyPlatformUpdated     = errors.New("\"platform\" can't be updated")
 )
 
 // PolicyNoTeamID is the team ID of "No team" policies.
@@ -260,6 +262,21 @@ type ModifyPolicyPayload struct {
 
 // Verify verifies the policy payload is valid.
 func (p ModifyPolicyPayload) Verify() error {
+	if p.Type == PolicyTypePatch {
+		if p.Name != nil {
+			if err := verifyPolicyName(*p.Name); err != nil {
+				return err
+			}
+		}
+		if p.Query != nil {
+			return errPolicyQueryUpdated
+		}
+		if p.Platform != nil {
+			return errPolicyPlatformUpdated
+		}
+		return nil
+	}
+
 	if p.Name != nil {
 		if err := verifyPolicyName(*p.Name); err != nil {
 			return err

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -302,9 +302,9 @@ type PolicyData struct {
 
 	UpdateCreateTimestamps
 
-	Type                   string `json:"type" db:"type"`
+	Type                   string `json:"type,omitempty" db:"type"`
 	PatchSoftwareTitleID   *uint  `json:"-" db:"patch_software_title_id"`
-	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug"`
+	FleetMaintainedAppSlug string `json:"fleet_maintained_app_slug,omitempty"`
 }
 
 // Policy is a fleet's policy query.

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -563,6 +563,8 @@ func (svc *Service) ApplyPolicySpecs(ctx context.Context, policies []*fleet.Poli
 
 	// After the authorization check, check the policy fields.
 	for _, policy := range policies {
+		fmt.Printf("policy.Type: %v\n", policy.Type)
+		fmt.Printf("policy.FleetMaintainedAppSlug: %v\n", policy.FleetMaintainedAppSlug)
 		if err := policy.Verify(); err != nil {
 			return ctxerr.Wrap(ctx, &fleet.BadRequestError{
 				Message: fmt.Sprintf("policy spec payload verification: %s", err),

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -55,6 +55,7 @@ func globalPolicyEndpoint(ctx context.Context, request interface{}, svc fleet.Se
 		Critical:         req.Critical,
 		LabelsIncludeAny: req.LabelsIncludeAny,
 		LabelsExcludeAny: req.LabelsExcludeAny,
+		Type:             fleet.PolicyTypeDynamic,
 	})
 	if err != nil {
 		return globalPolicyResponse{Err: err}, nil
@@ -73,6 +74,12 @@ func (svc Service) NewGlobalPolicy(ctx context.Context, p fleet.PolicyPayload) (
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("policy payload verification: %s", err),
+		})
+	}
+	if p.Type == fleet.PolicyTypePatch {
+		// patch type is only allowed for team policies
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: "patch policy is supported for teams only",
 		})
 	}
 

--- a/server/service/global_policies.go
+++ b/server/service/global_policies.go
@@ -76,12 +76,6 @@ func (svc Service) NewGlobalPolicy(ctx context.Context, p fleet.PolicyPayload) (
 			Message: fmt.Sprintf("policy payload verification: %s", err),
 		})
 	}
-	if p.Type == fleet.PolicyTypePatch {
-		// patch type is only allowed for team policies
-		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-			Message: "patch policy is supported for teams only",
-		})
-	}
 
 	if err := verifyLabelsToAssociate(ctx, svc.ds, nil, append(p.LabelsIncludeAny, p.LabelsExcludeAny...), vc.User); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "verify labels to associate")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -3357,6 +3357,7 @@ func (s *integrationTestSuite) TestHostDetailsPolicies() {
 	policies := *hd.Policies
 	require.Len(t, policies, 2)
 	// Policies that did not run are listed before passing policies
+	// TODO(JVE): verify that this passes once JK merges his code
 	require.True(t, reflect.DeepEqual(tpResp.Policy.PolicyData, policies[0].PolicyData))
 	require.Equal(t, policies[0].Response, "") // policy didn't "run"
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26524,7 +26524,8 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res.Body.Close()
 
 		policyResp := globalPolicyResponse{}
-		json.Unmarshal(resBody, &policyResp)
+		err = json.Unmarshal(resBody, &policyResp)
+		require.NoError(t, err)
 		policyID := policyResp.Policy.ID
 
 		getPolicyResp := getPolicyByIDResponse{}

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26374,12 +26374,6 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 	_, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "Team 1"})
 	require.NoError(t, err)
 
-	// Add a policy with type "badtype"
-	// Add a patch policy with no title id
-	// Add a patch policy with a title id that doesn't match an FMA
-	// Add a patch policy with a good title id
-	// Add that same policy again with a different name
-
 	t.Run("no_team_patch_policy", func(t *testing.T) {
 		// add a regular "No team" policy
 		tpParams := teamPolicyRequest{
@@ -26453,7 +26447,6 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			PatchSoftwareTitleID: &titleID,
 		}, http.StatusOK, &policyResp)
 		policyID := policyResp.Policy.ID
-		policyQuery := policyResp.Policy.Query
 
 		// attempt to add the same policy again
 		params = map[string]any{
@@ -26474,7 +26467,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, `patch policy query cannot be modified`)
+		require.Contains(t, errMsg, `"query" can't be updated`)
 		res.Body.Close()
 
 		// attempt to update patch policy with platform
@@ -26483,16 +26476,16 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, `patch policy platform cannot be modified`)
+		require.Contains(t, errMsg, `"platform" can't be updated`)
 		res.Body.Close()
 
 		// update the patch policy successfully
-		modifyPolicyResp := modifyTeamPolicyResponse{}
-		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), teamPolicyRequest{
-			Name:     "test-6-new-name",
-			Query:    policyQuery,
-			Platform: "darwin",
-		}, http.StatusOK, &modifyPolicyResp)
+		params = map[string]any{
+			"name":        "test-6-new-name",
+			"description": "new description",
+		}
+		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusOK)
+		res.Body.Close()
 
 		// list policies
 		var listPolResp listTeamPoliciesResponse

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26381,25 +26381,71 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 	// Add that same policy again with a different name
 
 	t.Run("no_team_patch_policy", func(t *testing.T) {
-		// Create a "No team" policy.
+		// add a regular "No team" policy
 		tpParams := teamPolicyRequest{
 			Name:  "noTeamPolicy1",
 			Query: "SELECT 1;",
 		}
 		r := teamPolicyResponse{}
-		s.DoJSON("POST", "/api/latest/fleet/teams/0/policies", tpParams, http.StatusOK, &r)
+		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies", tpParams, http.StatusOK, &r)
 		require.NotNil(t, r.Policy.TeamID)
 
+		// try to add a patch policy with a query, should fail
 		params := map[string]interface{}{
-			"name":                    "test2",
+			"name":                    "test-2",
 			"query":                   "SELECT 1 FROM;",
 			"description":             "um",
 			"type":                    "patch",
 			"patch_software_title_id": 4484,
 		}
-		res := s.Do("POST", "/api/latest/fleet/teams/9/policies", params, http.StatusBadRequest)
+		res := s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
 		errMsg := extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `The policy where the "type" is "patch" doesn't support the "query" field.`)
 		fmt.Println(errMsg)
-		defer res.Body.Close()
+		// defer res.Body.Close()
+
+		// Upload some software installer (not fma)
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallScript: "some install script",
+			Filename:      "dummy_installer.pkg",
+			TeamID:        nil,
+		}
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+
+		var titleID uint
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(context.Background(), q, &titleID, `SELECT title_id FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, 0, payload.Filename)
+		})
+		require.NotZero(t, titleID)
+
+		// try to add a patch policy that matches to an installer, but not an FMA
+		params = map[string]interface{}{
+			"name":                    "test-3",
+			"query":                   "",
+			"description":             "um",
+			"type":                    "patch",
+			"patch_software_title_id": titleID,
+		}
+		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID 0", titleID))
+		fmt.Println(errMsg)
+
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			res, err := q.ExecContext(ctx, `INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
+			VALUES ('DummyApp', 'dummy/darwin', 'darwin', 'com.example.dummy')`)
+			require.NoError(t, err)
+			id, err := res.LastInsertId()
+			require.NoError(t, err)
+
+			_, err = q.ExecContext(ctx, `UPDATE software_installers SET fleet_maintained_app_id = ? WHERE title_id = ?`, id, titleID)
+			require.NoError(t, err)
+			return nil
+		})
+
+		// add the same patch policy, but this time it belongs to an FMA
+		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusOK)
+
+		// TODO(JK): list policies, update policy
 	})
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26453,6 +26453,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			PatchSoftwareTitleID: &titleID,
 		}, http.StatusOK, &policyResp)
 		policyID := policyResp.Policy.ID
+		policyQuery := policyResp.Policy.Query
 
 		// attempt to add the same policy again
 		params = map[string]any{
@@ -26473,7 +26474,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, `If the "type" is "patch", the "query" field is not supported.`)
+		require.Contains(t, errMsg, `patch policy query cannot be modified`)
 		res.Body.Close()
 
 		// attempt to update patch policy with platform
@@ -26482,13 +26483,15 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, `If the "type" is "patch", the "platform" field is not supported.`)
+		require.Contains(t, errMsg, `patch policy platform cannot be modified`)
 		res.Body.Close()
 
 		// update the patch policy successfully
 		modifyPolicyResp := modifyTeamPolicyResponse{}
 		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), teamPolicyRequest{
-			Name: "test-6-new-name",
+			Name:     "test-6-new-name",
+			Query:    policyQuery,
+			Platform: "darwin",
 		}, http.StatusOK, &modifyPolicyResp)
 
 		// list policies

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26391,7 +26391,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.NotNil(t, r.Policy.TeamID)
 
 		// try to add a patch policy with a query, should fail
-		params := map[string]interface{}{
+		params := map[string]any{
 			"name":                    "test-2",
 			"query":                   "SELECT 1 FROM;",
 			"description":             "um",
@@ -26400,8 +26400,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		res := s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
 		errMsg := extractServerErrorText(res.Body)
-		require.Contains(t, errMsg, `The policy where the "type" is "patch" doesn't support the "query" field.`)
-		fmt.Println(errMsg)
+		require.Contains(t, errMsg, `If the "type" is "patch", the "query" field is not supported.`)
 		// defer res.Body.Close()
 
 		// Upload some software installer (not fma)
@@ -26419,7 +26418,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.NotZero(t, titleID)
 
 		// try to add a patch policy that matches to an installer, but not an FMA
-		params = map[string]interface{}{
+		params = map[string]any{
 			"name":                    "test-3",
 			"query":                   "",
 			"description":             "um",
@@ -26429,8 +26428,8 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID 0", titleID))
-		fmt.Println(errMsg)
 
+		// add a fleet maintained app and associate the installer with it
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 			res, err := q.ExecContext(ctx, `INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
 			VALUES ('DummyApp', 'dummy/darwin', 'darwin', 'com.example.dummy')`)
@@ -26444,8 +26443,61 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		})
 
 		// add the same patch policy, but this time it belongs to an FMA
-		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusOK)
+		policyResp := teamPolicyResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies", teamPolicyRequest{
+			Name:                 "test-4",
+			Query:                "",
+			Description:          "um",
+			Type:                 ptr.String("patch"),
+			PatchSoftwareTitleID: &titleID,
+		}, http.StatusOK, &policyResp)
+		policyID := policyResp.Policy.ID
 
-		// TODO(JK): list policies, update policy
+		// attempt to add the same policy again
+		params = map[string]any{
+			"name":                    "test-5",
+			"query":                   "",
+			"description":             "um",
+			"type":                    "patch",
+			"patch_software_title_id": titleID,
+		}
+		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusConflict)
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `Couldn't add. Specified "patch_software_title_id" already has a policy with "type" set to "patch".`)
+
+		// attempt to update patch policy with query
+		params = map[string]any{
+			"query": "blablabla",
+		}
+		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `If the "type" is "patch", the "query" field is not supported.`)
+
+		// attempt to update patch policy with platform
+		params = map[string]any{
+			"platform": "windows,linux",
+		}
+		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `If the "type" is "patch", the "platform" field is not supported.`)
+
+		// update the patch policy successfully
+		modifyPolicyResp := modifyTeamPolicyResponse{}
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), teamPolicyRequest{
+			Name: "test-6-new-name",
+		}, http.StatusOK, &modifyPolicyResp)
+
+		// list policies
+		var listPolResp listTeamPoliciesResponse
+		s.DoJSON("GET", "/api/latest/fleet/fleets/0/policies", listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
+		require.Len(t, listPolResp.Policies, 2)
+		require.NotNil(t, listPolResp.Policies[1].PatchSoftware)
+		require.Equal(t, titleID, listPolResp.Policies[1].PatchSoftware.SoftwareTitleID)
+
+		// get policy by id
+		getPolicyResp := getTeamPolicyByIDResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), nil, http.StatusOK, &getPolicyResp)
+		require.NotNil(t, getPolicyResp.Policy.PatchSoftware)
+		require.Equal(t, titleID, getPolicyResp.Policy.PatchSoftware.SoftwareTitleID)
 	})
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26524,7 +26524,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		getPolicyResp := getPolicyByIDResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", policyID), nil, http.StatusOK, &getPolicyResp)
 		require.NotNil(t, getPolicyResp.Policy)
-		require.Equal(t, "dynamic", getPolicyResp.Policy.Type)
+		require.Nil(t, getPolicyResp.Policy.Type)
 		require.Empty(t, getPolicyResp.Policy.PatchSoftware)
 		require.Empty(t, getPolicyResp.Policy.PatchSoftwareTitleID)
 	})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26401,7 +26401,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res := s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
 		errMsg := extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `If the "type" is "patch", the "query" field is not supported.`)
-		// defer res.Body.Close()
+		res.Body.Close()
 
 		// Upload some software installer (not fma)
 		payload := &fleet.UploadSoftwareInstallerPayload{
@@ -26428,6 +26428,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID 0", titleID))
+		res.Body.Close()
 
 		// add a fleet maintained app and associate the installer with it
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
@@ -26464,6 +26465,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res = s.Do("POST", "/api/latest/fleet/fleets/0/policies", params, http.StatusConflict)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Couldn't add. Specified "patch_software_title_id" already has a policy with "type" set to "patch".`)
+		res.Body.Close()
 
 		// attempt to update patch policy with query
 		params = map[string]any{
@@ -26472,6 +26474,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `If the "type" is "patch", the "query" field is not supported.`)
+		res.Body.Close()
 
 		// attempt to update patch policy with platform
 		params = map[string]any{
@@ -26480,6 +26483,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), params, http.StatusBadRequest)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `If the "type" is "patch", the "platform" field is not supported.`)
+		res.Body.Close()
 
 		// update the patch policy successfully
 		modifyPolicyResp := modifyTeamPolicyResponse{}
@@ -26499,5 +26503,32 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/0/policies/%d", policyID), nil, http.StatusOK, &getPolicyResp)
 		require.NotNil(t, getPolicyResp.Policy.PatchSoftware)
 		require.Equal(t, titleID, getPolicyResp.Policy.PatchSoftware.SoftwareTitleID)
+	})
+
+	t.Run("global_patch_policy", func(t *testing.T) {
+		// attempt to add a global patch policy
+		params := map[string]any{
+			"name":                    "global-policy",
+			"query":                   "UNAFFECTED;",
+			"description":             "patch policies only work for teams",
+			"type":                    "patch",
+			"patch_software_title_id": "1", // should not matter
+		}
+		res := s.Do("POST", "/api/latest/fleet/policies", params, http.StatusOK)
+
+		resBody, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		res.Body.Close()
+
+		policyResp := globalPolicyResponse{}
+		json.Unmarshal(resBody, &policyResp)
+		policyID := policyResp.Policy.ID
+
+		getPolicyResp := getPolicyByIDResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/policies/%d", policyID), nil, http.StatusOK, &getPolicyResp)
+		require.NotNil(t, getPolicyResp.Policy)
+		require.Equal(t, "dynamic", getPolicyResp.Policy.Type)
+		require.Empty(t, getPolicyResp.Policy.PatchSoftware)
+		require.Empty(t, getPolicyResp.Policy.PatchSoftwareTitleID)
 	})
 }

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -96,7 +96,6 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 			Message: fmt.Sprintf("policy payload verification: %s", err),
 		})
 	}
-
 	// TODO(JK): automatically set platform. should verify?
 
 	if err := verifyLabelsToAssociate(ctx, svc.ds, &teamID, append(tp.LabelsIncludeAny, tp.LabelsExcludeAny...), vc.User); err != nil {
@@ -208,7 +207,7 @@ func (svc *Service) populatePolicyPatchSoftware(ctx context.Context, p *fleet.Po
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "get software installer metadata by title id")
 		}
-		p.InstallSoftware = &fleet.PolicySoftwareTitle{
+		p.PatchSoftware = &fleet.PolicySoftwareTitle{
 			SoftwareTitleID: *installerMetadata.TitleID,
 			Name:            installerMetadata.SoftwareTitle,
 			DisplayName:     installerMetadata.DisplayName,

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -97,6 +97,8 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		})
 	}
 
+	// TODO(JK): automatically set platform. should verify?
+
 	if err := verifyLabelsToAssociate(ctx, svc.ds, &teamID, append(tp.LabelsIncludeAny, tp.LabelsExcludeAny...), vc.User); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "verify labels to associate")
 	}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -218,10 +218,10 @@ func (svc *Service) populatePolicyPatchSoftware(ctx context.Context, p *fleet.Po
 }
 
 func (svc *Service) newTeamPolicyPayloadToPolicyPayload(ctx context.Context, teamID uint, p fleet.NewTeamPolicyPayload) (fleet.PolicyPayload, error) {
-	policyType := "dynamic"
+	policyType := fleet.PolicyTypeDynamic
 
-	if p.Type != nil && *p.Type == "patch" {
-		policyType = "patch"
+	if p.Type != nil && *p.Type == fleet.PolicyTypePatch {
+		policyType = fleet.PolicyTypePatch
 	}
 
 	softwareInstallerID, vppAppsTeamsID, err := svc.getInstallerOrVPPAppForTitle(ctx, &teamID, p.SoftwareTitleID)

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -646,6 +646,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 
 			if p.Type == fleet.PolicyTypePatch {
 				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					// TODO(JK): error message?
 					Message: "patch policy query cannot be modified",
 				})
 			}
@@ -661,6 +662,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 
 			if p.Type == fleet.PolicyTypePatch {
 				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					// TODO(JK): error message?
 					Message: "patch policy platform cannot be modified",
 				})
 			}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -618,7 +618,9 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		})
 	}
 
-	p.Type = policy.Type
+	if policy.Type != nil {
+		p.Type = *policy.Type
+	}
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("policy payload verification: %s", err),

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -618,6 +618,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		})
 	}
 
+	p.Type = policy.Type
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("policy payload verification: %s", err),
@@ -640,13 +641,6 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		if policy.Query != *p.Query {
 			removeAllMemberships = true
 			removeStats = true
-
-			if policy.Type == fleet.PolicyTypePatch {
-				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-					// TODO(JK): error message?
-					Message: "patch policy query cannot be modified",
-				})
-			}
 		}
 		policy.Query = *p.Query
 	}
@@ -656,13 +650,6 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.Platform != nil {
 		if policy.Platform != *p.Platform {
 			removeStats = true
-
-			if policy.Type == fleet.PolicyTypePatch {
-				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-					// TODO(JK): error message?
-					Message: "patch policy platform cannot be modified",
-				})
-			}
 		}
 		policy.Platform = *p.Platform
 	}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -96,7 +96,6 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 			Message: fmt.Sprintf("policy payload verification: %s", err),
 		})
 	}
-	// TODO(JK): automatically set platform. should verify?
 
 	if err := verifyLabelsToAssociate(ctx, svc.ds, &teamID, append(tp.LabelsIncludeAny, tp.LabelsExcludeAny...), vc.User); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "verify labels to associate")

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -618,9 +618,6 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		})
 	}
 
-	// fill in policy type for verification
-	p.Type = policy.Type
-
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("policy payload verification: %s", err),
@@ -644,7 +641,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 			removeAllMemberships = true
 			removeStats = true
 
-			if p.Type == fleet.PolicyTypePatch {
+			if policy.Type == fleet.PolicyTypePatch {
 				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 					// TODO(JK): error message?
 					Message: "patch policy query cannot be modified",
@@ -660,7 +657,7 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		if policy.Platform != *p.Platform {
 			removeStats = true
 
-			if p.Type == fleet.PolicyTypePatch {
+			if policy.Type == fleet.PolicyTypePatch {
 				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 					// TODO(JK): error message?
 					Message: "patch policy platform cannot be modified",

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -112,7 +112,6 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
 	}
-	// TODO(JK): populate patch policy "patch_software: object (same software title struct type)
 	if err := svc.populatePolicyPatchSoftware(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
 	}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -643,10 +643,12 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		if policy.Query != *p.Query {
 			removeAllMemberships = true
 			removeStats = true
-			// if p.Type == fleet.PolicyTypePatch {
-			// 	// fail
-			// 	return nil, ctxerr.Wrap(ctx, err, "patch policy query cannot be modified")
-			// }
+
+			if p.Type == fleet.PolicyTypePatch {
+				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					Message: "patch policy query cannot be modified",
+				})
+			}
 		}
 		policy.Query = *p.Query
 	}
@@ -656,10 +658,12 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.Platform != nil {
 		if policy.Platform != *p.Platform {
 			removeStats = true
-			// if p.Type == fleet.PolicyTypePatch {
-			// 	// fail
-			// 	return nil, ctxerr.Wrap(ctx, err, "patch policy platform cannot be modified")
-			// }
+
+			if p.Type == fleet.PolicyTypePatch {
+				return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+					Message: "patch policy platform cannot be modified",
+				})
+			}
 		}
 		policy.Platform = *p.Platform
 	}
@@ -722,8 +726,6 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 			policy.LabelsExcludeAny = append(policy.LabelsExcludeAny, fleet.LabelIdent{LabelName: label})
 		}
 	}
-
-	// todo(jk): alternative: check that query, platforms, have not changed
 
 	logging.WithExtras(ctx, "name", policy.Name, "sql", policy.Query)
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -86,7 +86,7 @@ func (svc Service) NewTeamPolicy(ctx context.Context, teamID uint, tp fleet.NewT
 		return nil, errors.New("user must be authenticated to create team policies")
 	}
 
-	p, err := svc.newTeamPolicyPayloadToPolicyPayload(ctx, teamID, tp) // TODO(JK): update
+	p, err := svc.newTeamPolicyPayloadToPolicyPayload(ctx, teamID, tp)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +198,6 @@ func (svc *Service) populatePolicyRunScript(ctx context.Context, p *fleet.Policy
 	return nil
 }
 
-// TODO(JK): how can we deduplicate all the calls to this? maybe by modifying getInstallerOrVPPAppForTitle?
 func (svc *Service) populatePolicyPatchSoftware(ctx context.Context, p *fleet.Policy) error {
 	if p.PatchSoftwareTitleID != nil {
 		installerMetadata, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, p.TeamID, *p.PatchSoftwareTitleID, false)
@@ -327,7 +326,6 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 		if err := svc.populatePolicyRunScript(ctx, teamPolicies[i]); err != nil {
 			return nil, nil, ctxerr.Wrapf(ctx, err, "populate run_script for policy_id: %d", teamPolicies[i].ID)
 		}
-		// TODO(JK): mergeInherited(global) shouldnt support patch software right?
 		if err := svc.populatePolicyPatchSoftware(ctx, teamPolicies[i]); err != nil {
 			return nil, nil, ctxerr.Wrapf(ctx, err, "populate patch_software for policy_id: %d", teamPolicies[i].ID)
 		}
@@ -716,6 +714,8 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 			policy.LabelsExcludeAny = append(policy.LabelsExcludeAny, fleet.LabelIdent{LabelName: label})
 		}
 	}
+
+	// todo(jk): alternative: check that query, platforms, have not changed
 
 	logging.WithExtras(ctx, "name", policy.Name, "sql", policy.Query)
 

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -643,6 +643,10 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		if policy.Query != *p.Query {
 			removeAllMemberships = true
 			removeStats = true
+			// if p.Type == fleet.PolicyTypePatch {
+			// 	// fail
+			// 	return nil, ctxerr.Wrap(ctx, err, "patch policy query cannot be modified")
+			// }
 		}
 		policy.Query = *p.Query
 	}
@@ -652,6 +656,10 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	if p.Platform != nil {
 		if policy.Platform != *p.Platform {
 			removeStats = true
+			// if p.Type == fleet.PolicyTypePatch {
+			// 	// fail
+			// 	return nil, ctxerr.Wrap(ctx, err, "patch policy platform cannot be modified")
+			// }
 		}
 		policy.Platform = *p.Platform
 	}

--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -328,6 +328,10 @@ func (svc *Service) ListTeamPolicies(ctx context.Context, teamID uint, opts flee
 		if err := svc.populatePolicyRunScript(ctx, teamPolicies[i]); err != nil {
 			return nil, nil, ctxerr.Wrapf(ctx, err, "populate run_script for policy_id: %d", teamPolicies[i].ID)
 		}
+		// TODO(JK): mergeInherited(global) shouldnt support patch software right?
+		if err := svc.populatePolicyPatchSoftware(ctx, teamPolicies[i]); err != nil {
+			return nil, nil, ctxerr.Wrapf(ctx, err, "populate patch_software for policy_id: %d", teamPolicies[i].ID)
+		}
 	}
 
 	return teamPolicies, inheritedPolicies, nil
@@ -438,6 +442,9 @@ func (svc Service) GetTeamPolicyByIDQueries(ctx context.Context, teamID uint, po
 	}
 	if err := svc.populatePolicyRunScript(ctx, teamPolicy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
+	}
+	if err := svc.populatePolicyPatchSoftware(ctx, teamPolicy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
 	}
 
 	return teamPolicy, nil
@@ -614,6 +621,9 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 		})
 	}
 
+	// fill in policy type for verification
+	p.Type = policy.Type
+
 	if err := p.Verify(); err != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
 			Message: fmt.Sprintf("policy payload verification: %s", err),
@@ -720,6 +730,9 @@ func (svc *Service) modifyPolicy(ctx context.Context, teamID *uint, id uint, p f
 	}
 	if err := svc.populatePolicyRunScript(ctx, policy); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "populate run_script")
+	}
+	if err := svc.populatePolicyPatchSoftware(ctx, policy); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "populate patch_software")
 	}
 
 	if teamID == nil {

--- a/server/webhooks/failing_policies_test.go
+++ b/server/webhooks/failing_policies_test.go
@@ -200,6 +200,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 				Platform:                       "darwin",
 				CalendarEventsEnabled:          true,
 				ConditionalAccessBypassEnabled: ptr.Bool(true),
+				Type:                           ptr.String("dynamic"),
 			},
 		},
 		2: {
@@ -215,6 +216,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 				Resolution:                     ptr.String("policy2 resolution"),
 				Platform:                       "darwin",
 				ConditionalAccessBypassEnabled: ptr.Bool(true),
+				Type:                           ptr.String("dynamic"),
 			},
 		},
 		3: {
@@ -230,6 +232,7 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 				Resolution:                     ptr.String("policy3 resolution"),
 				Platform:                       "darwin",
 				ConditionalAccessBypassEnabled: ptr.Bool(true),
+				Type:                           ptr.String("dynamic"),
 			},
 		},
 	}
@@ -322,7 +325,8 @@ func TestTriggerFailingPoliciesWebhookTeam(t *testing.T) {
 		"critical": false,
 		"calendar_events_enabled": true,
 		"conditional_access_enabled": false,
-		"conditional_access_bypass_enabled": true
+		"conditional_access_bypass_enabled": true,
+		"type": "dynamic"
     },
     "hosts": [
         {


### PR DESCRIPTION
- **initial commit: new team policy**
- **new team patch policy**
- **create version compare query**
- **fix patch_software object**
- **use const for policy type**
- **ds unit test**
- **gitops support**
- **started integration test**
- **integration test**
- **error messages**
- **verify modify policy**
- **fix test**
- **modify, list, get**
- **fix test**
- **update some comments**
- **make global policies always dynamic**
- **check if query/platform changed in modify policy**
- **remove unnecessary check**
- **remove unnecessary check**
- **save data on batch endpoint**
- **set type to dynamic by default in ds.NewTeamPolicy instead of passing empty string**
- **add p.type to ListPoliciesForHost query**
- **fix unchekced errors**
- **dont allow query/platform fields**
- **Return nil for type when policy is global**
- **fix TestTriggerFailingPoliciesWebhookTeam**
- **fix tests**

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
