### PR TITLE
Allow `secrets:` key to be optional in GitOps

### DIFF
--- a/changes/40900-allow-omitting-secrets-key-in-gitops
+++ b/changes/40900-allow-omitting-secrets-key-in-gitops
@@ -1,0 +1,1 @@
+- Added ability to omit `secrets:` in GitOps files to retain existing enroll secrets on server.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -645,8 +645,8 @@ func parseSecrets(result *GitOps, multiError *multierror.Error) *multierror.Erro
 		rawSecrets, ok = result.TeamSettings["secrets"]
 	}
 	if !ok {
-		// If the secrets key is not present, we leave it unset so that any
-		// existing secrets on the server are preserved (no-op).
+		// Allow omitting secrets key, resulting in a no-op for secrets.
+		// Any secrets present on the server will be retained.
 		return multiError
 	}
 	// When secrets slice is empty, all secrets are removed.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -641,14 +641,13 @@ func parseSecrets(result *GitOps, multiError *multierror.Error) *multierror.Erro
 	var ok bool
 	if result.TeamName == nil {
 		rawSecrets, ok = result.OrgSettings["secrets"]
-		if !ok {
-			return multierror.Append(multiError, errors.New("'org_settings.secrets' is required"))
-		}
 	} else {
 		rawSecrets, ok = result.TeamSettings["secrets"]
-		if !ok {
-			return multierror.Append(multiError, errors.New("'settings.secrets' is required"))
-		}
+	}
+	if !ok {
+		// If the secrets key is not present, we leave it unset so that any
+		// existing secrets on the server are preserved (no-op).
+		return multiError
 	}
 	// When secrets slice is empty, all secrets are removed.
 	enrollSecrets := make([]*fleet.EnrollSecret, 0)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -723,11 +723,13 @@ func TestInvalidGitOpsYaml(t *testing.T) {
 					_, err = GitOpsFromFile(unassignedPath5, unassignedBasePath5, nil, nopLogf)
 					assert.ErrorContains(t, err, "unsupported settings option 'features' in unassigned.yml")
 
-					// Missing secrets
+					// Missing secrets -- should be a no-op (existing secrets preserved)
 					config = getConfig([]string{"settings"})
 					config += "settings:\n"
-					_, err = gitOpsFromString(t, config)
-					assert.ErrorContains(t, err, "'settings.secrets' is required")
+					result, err := gitOpsFromString(t, config)
+					assert.NoError(t, err)
+					_, hasSecrets := result.TeamSettings["secrets"]
+					assert.False(t, hasSecrets, "secrets should not be set when omitted from config")
 				} else {
 					// 'software' is not allowed in global config
 					config := getConfig(nil)
@@ -768,11 +770,25 @@ func TestInvalidGitOpsYaml(t *testing.T) {
 					_, err = gitOpsFromString(t, config)
 					assert.ErrorContains(t, err, "must have a 'secret' key")
 
-					// Missing secrets
+					// Invalid secrets 3 (using wrong type in one key)
+					config = getConfig([]string{"org_settings"})
+					config += "org_settings:\n  secrets: \n    - secret: some secret\n    - secret: 123\n"
+					_, err = gitOpsFromString(t, config)
+					assert.ErrorContains(t, err, "each item in 'secrets' must have a 'secret' key")
+
+					// Missing secrets -- should be a no-op (existing secrets preserved)
 					config = getConfig([]string{"org_settings"})
 					config += "org_settings:\n"
+					result, err := gitOpsFromString(t, config)
+					assert.NoError(t, err)
+					_, hasSecrets := result.OrgSettings["secrets"]
+					assert.False(t, hasSecrets, "secrets should not be set when omitted from config")
+
+					// Empty secrets (valid, will remove all secrets)
+					config = getConfig([]string{"org_settings"})
+					config += "org_settings:\n  secrets: \n"
 					_, err = gitOpsFromString(t, config)
-					assert.ErrorContains(t, err, "'org_settings.secrets' is required")
+					assert.NoError(t, err)
 
 					// Bad label spec (float instead of string in hosts)
 					config = getConfig([]string{"labels"})

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1875,8 +1875,10 @@ func (c *Client) DoGitOps(
 
 		// Enroll secrets are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
-		group.EnrollSecret = &fleet.EnrollSecretSpec{Secrets: incoming.OrgSettings["secrets"].([]*fleet.EnrollSecret)}
-		delete(incoming.OrgSettings, "secrets")
+		if orgSecrets, ok := incoming.OrgSettings["secrets"]; ok {
+			group.EnrollSecret = &fleet.EnrollSecretSpec{Secrets: orgSecrets.([]*fleet.EnrollSecret)}
+			delete(incoming.OrgSettings, "secrets")
+		}
 
 		// Certificate authorities are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
@@ -2101,7 +2103,9 @@ func (c *Client) DoGitOps(
 		team["software"].(map[string]any)["app_store_apps"] = incoming.Software.AppStoreApps
 		team["software"].(map[string]any)["packages"] = incoming.Software.Packages
 		team["software"].(map[string]any)["fleet_maintained_apps"] = incoming.Software.FleetMaintainedApps
-		team["secrets"] = incoming.TeamSettings["secrets"]
+		if teamSecrets, ok := incoming.TeamSettings["secrets"]; ok {
+			team["secrets"] = teamSecrets
+		}
 
 		// Ensure webhooks settings exists
 		webhookSettings, ok := incoming.TeamSettings["webhook_settings"]


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40900

# Details

This PR makes the `secrets:` key under the top-level `org_settings` (for default.yml) or `settings:` (for fleet .yml files) optional. Omitting the key causes any enroll secrets present on the server to be retained.

There is more to the parent story that will require more design, but I am getting this one out early because:
1. Our updated it-and-security files will not have `secrets:` and
2. This is not a breaking change, since currently omitting this key results in a fatal error, _not_ the removal of all secrets (that requires specifying an empty `secrets:` key)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
   - [x] Using `secrets:` with correct syntax in `defaults.yml` updated global secrets 
   - [x] Using `secrets:` with no value in `defaults.yml` removed all global secrets 
   - [x] Omitting `secrets:` in `defaults.yml` retained all global secrets 
   - [x] Using `secrets:` with correct syntax in a fleet .yml file updated that fleet's secrets 
   - [x] Using `secrets:` with no value in in a fleet .yml file removed that fleet's secrets 
   - [x] Omitting `secrets:` in in a fleet .yml file retained that fleet's secrets 