### PR TITLE
Revert "last updated on" from #36924

### DIFF
--- a/website/views/pages/articles/basic-article.ejs
+++ b/website/views/pages/articles/basic-article.ejs
@@ -34,7 +34,7 @@
         </div>
         <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
           <div purpose="article-details" class="d-flex align-items-sm-center">
-            <span>Last updated on <js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+            <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
             <span  purpose="divider" class="px-2">|</span>
             <% if(articleCategorySlug !== 'customers') { %>
               <div purpose="article-author" class="d-flex flex-row align-items-center">
@@ -114,7 +114,7 @@
           </div>
           <div class="d-flex flex-sm-row flex-column justify-content-between align-items-sm-center">
             <div purpose="article-details" class="d-flex flex-row align-items-center">
-              <span>Last updated on <js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
+              <span><js-timestamp format="billing" :at="thisPage.meta.publishedOn"></js-timestamp></span>
               <% if(articleCategorySlug !== 'customers') { %>
                 <span class="px-2">|</span>
                 <img style="height: 28px; width: 28px; border-radius: 100%;" alt="The author's GitHub profile picture" :src="'https://github.com/'+thisPage.meta.authorGitHubUsername+'.png?size=200'">


### PR DESCRIPTION
Only adding the text "Last updated on" was a misinterpretation of #35379.
We're currently calling the publish date the last updated date on the website, but the publish date usually isn't updated when a change is made to an article. Until we can automatically update this date field based on when the file itself was last updated, we should revert to the original behavior.