### PR TITLE
Website: update form label and range for two windows options in the configuration builder

### DIFF
--- a/website/assets/js/pages/configuration-builder.page.js
+++ b/website/assets/js/pages/configuration-builder.page.js
@@ -1851,9 +1851,9 @@ parasails.registerPage('configuration-builder', {
                 ],
                 formInput: {
                   type: 'number',
-                  maxValue: 9000,
+                  maxValue: 999,
                   minValue: 1,
-                  unitLabel: 'seconds'
+                  unitLabel: 'minutes'
                 },
                 formOutput: {
                   settingFormat: 'int',
@@ -1874,9 +1874,9 @@ parasails.registerPage('configuration-builder', {
                 ],
                 formInput: {
                   type: 'number',
-                  maxValue: 9000,
+                  maxValue: 999,
                   minValue: 1,
-                  unitLabel: 'seconds'
+                  unitLabel: 'minutes'
                 },
                 formOutput: {
                   settingFormat: 'int',


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/40847

Changes:
- Updated the max accepted value and form label for the "Maximum inactivity time before device locks" and "Maximum inactivity time before device locks with external display" Windows settings in the configuration profile builder