### PR TITLE
Remove body size limitations around osquery/log end-point

### DIFF
--- a/changes/40813-apiosquerylog-content-length-exceeded
+++ b/changes/40813-apiosquerylog-content-length-exceeded
@@ -1,0 +1,2 @@
+* Removed the body size limit for `osquery/log` end-point by implementing a custom submitLogsRequest.DecodeRequest method that streams the `node_key` and uses that to authenticate the host before reading the potentially huge rest of the payload.
+* Fixed false positive PayloadTooLargeError errors.

--- a/server/contexts/nodeauth/nodeauth.go
+++ b/server/contexts/nodeauth/nodeauth.go
@@ -1,0 +1,25 @@
+// Package nodeauth provides a context key for storing a host node-key
+// authenticator so that request decoders can authenticate before reading
+// potentially large request bodies.
+package nodeauth
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+type key int
+
+const nodeAuthKey key = 0
+
+// NewContext stores a fleet.HostAuthenticator in ctx.
+func NewContext(ctx context.Context, svc fleet.HostAuthenticator) context.Context {
+	return context.WithValue(ctx, nodeAuthKey, svc)
+}
+
+// FromContext retrieves the fleet.HostAuthenticator from ctx, or nil if not set.
+func FromContext(ctx context.Context) fleet.HostAuthenticator {
+	svc, _ := ctx.Value(nodeAuthKey).(fleet.HostAuthenticator)
+	return svc
+}

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -43,6 +43,14 @@ type EnterpriseOverrides struct {
 	InstallVPPAppPostValidation       func(ctx context.Context, host *Host, vppApp *VPPApp, token string, opts HostSoftwareInstallOptions) (string, error)
 }
 
+// HostAuthenticator is a subset of OsqueryService used to authenticate an
+// osquery host by its node key. It is stored in the request context so that
+// DecodeRequest implementations can authenticate before reading a potentially
+// large request body (see submitLogsRequest.DecodeRequest).
+type HostAuthenticator interface {
+	AuthenticateHost(ctx context.Context, nodeKey string) (host *Host, debug bool, err error)
+}
+
 type OsqueryService interface {
 	EnrollOsquery(
 		ctx context.Context, enrollSecret, hostIdentifier string, hostDetails map[string](map[string]string),

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -518,8 +518,9 @@ func MakeDecoder(
 	}
 	if rd, ok := iface.(RequestDecoder); ok {
 		return func(ctx context.Context, r *http.Request) (interface{}, error) {
+			var limitedReader *io.LimitedReader
 			if maxRequestBodySize != -1 {
-				limitedReader := io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
+				limitedReader = io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
 
 				r.Body = &LimitedReadCloser{
 					LimitedReader: limitedReader,
@@ -527,7 +528,7 @@ func MakeDecoder(
 				}
 			}
 			ret, err := rd.DecodeRequest(ctx, r)
-			if err != nil && errors.Is(err, io.ErrUnexpectedEOF) {
+			if err != nil && errors.Is(err, io.ErrUnexpectedEOF) && limitedReader != nil && limitedReader.N == 0 {
 				return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
 			}
 			return ret, err
@@ -543,9 +544,10 @@ func MakeDecoder(
 		v := reflect.New(t)
 		nilBody := false
 		var rewriter *JSONKeyRewriteReader
+		var limitedReader *io.LimitedReader
 
 		if maxRequestBodySize != -1 {
-			limitedReader := io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
+			limitedReader = io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
 
 			r.Body = &LimitedReadCloser{
 				LimitedReader: limitedReader,
@@ -590,7 +592,7 @@ func MakeDecoder(
 						}
 					}
 
-					if errors.Is(err, io.ErrUnexpectedEOF) {
+					if errors.Is(err, io.ErrUnexpectedEOF) && limitedReader != nil && limitedReader.N == 0 {
 						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
 					}
 
@@ -680,7 +682,7 @@ func MakeDecoder(
 					}
 				}
 
-				if errors.Is(err, io.ErrUnexpectedEOF) {
+				if errors.Is(err, io.ErrUnexpectedEOF) && limitedReader != nil && limitedReader.N == 0 {
 					return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
 				}
 				return nil, err

--- a/server/service/carves.go
+++ b/server/service/carves.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strconv"
-	"strings"
 	"time"
 
 	carvestorectx "github.com/fleetdm/fleet/v4/server/contexts/carvestore"
@@ -284,26 +283,6 @@ func (r carveBlockRequest) DecodeRequest(ctx context.Context, req *http.Request)
 		return ctxerr.Wrap(ctx, fleet.NewAuthFailedError(err.Error()), "authentication error")
 	}
 
-	readUntil := func(maxToRead int, endChar byte) (string, error) {
-		var s strings.Builder
-		endCharFound := false
-		for i := 0; i <= maxToRead; i++ {
-			character := make([]byte, 1)
-			if _, err := req.Body.Read(character); err != nil {
-				return "", fmt.Errorf("failed to read character: %w", err)
-			}
-			if character[0] == endChar {
-				endCharFound = true
-				break
-			}
-			s.Write(character)
-		}
-		if !endCharFound {
-			return "", fmt.Errorf(`end character not found: %q`, s.String())
-		}
-		return s.String(), nil
-	}
-
 	// 1. Must start with {
 	delimiter := make([]byte, 1)
 	if _, err := req.Body.Read(delimiter); err != nil {
@@ -322,7 +301,7 @@ func (r carveBlockRequest) DecodeRequest(ctx context.Context, req *http.Request)
 	}
 	// 3. Must continue with a number.
 	const maxNumberOfDigits = 19
-	blockIDStr, err := readUntil(maxNumberOfDigits, ',')
+	blockIDStr, err := readUntil(req.Body, maxNumberOfDigits, ',')
 	if err != nil {
 		return nil, newAuthRequiredError(fmt.Errorf(`invalid "block_id" field: %w`, err))
 	}
@@ -340,7 +319,7 @@ func (r carveBlockRequest) DecodeRequest(ctx context.Context, req *http.Request)
 	}
 	// 5. Must continue with a string (up to 255 chars).
 	const maxSizeSessionID = 255 // defined in DB
-	sessionID, err := readUntil(maxSizeSessionID, '"')
+	sessionID, err := readUntil(req.Body, maxSizeSessionID, '"')
 	if err != nil {
 		return nil, newAuthRequiredError(fmt.Errorf(`invalid "session_id" field: %w`, err))
 	}
@@ -357,7 +336,7 @@ func (r carveBlockRequest) DecodeRequest(ctx context.Context, req *http.Request)
 	}
 	// 7. Must continue with a string (up to 64 chars).
 	const maxSizeRequestID = 64 // defined in DB.
-	requestID, err := readUntil(maxSizeRequestID, '"')
+	requestID, err := readUntil(req.Body, maxSizeRequestID, '"')
 	if err != nil {
 		return nil, newAuthRequiredError(fmt.Errorf(`invalid "request_id" field: %w`, err))
 	}

--- a/server/service/endpoint_utils_test.go
+++ b/server/service/endpoint_utils_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"mime/multipart"
@@ -265,6 +266,7 @@ func TestUniversalDecoderSizeLimit(t *testing.T) {
 	}
 	decoder := makeDecoder(universalStruct{}, platform_http.MaxRequestBodySize)
 
+	// Body larger than the limit should return PayloadTooLargeError.
 	largeBody := `{"key": "` + strings.Repeat("A", int(platform_http.MaxRequestBodySize)+1) + `"}`
 	req := httptest.NewRequest("POST", "/target?per_page=77&page=4", strings.NewReader(largeBody))
 	req = mux.SetURLVars(req, map[string]string{"some-id": "123"})
@@ -273,6 +275,18 @@ func TestUniversalDecoderSizeLimit(t *testing.T) {
 	require.Error(t, err)
 	require.IsType(t, platform_http.PayloadTooLargeError{}, err)
 
+	// Body within the limit but with broken JSON
+	incompleteBody := `{"key": "` + strings.Repeat("A", 100) // missing closing "}
+	req = httptest.NewRequest("POST", "/target?per_page=77&page=4", strings.NewReader(incompleteBody))
+	req = mux.SetURLVars(req, map[string]string{"some-id": "123"})
+
+	_, err = decoder(context.Background(), req)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, io.ErrUnexpectedEOF), "expected io.ErrUnexpectedEOF, got %T: %v", err, err)
+	_, isPayloadTooLarge := err.(platform_http.PayloadTooLargeError)
+	require.False(t, isPayloadTooLarge, "incomplete body within size limit must not produce PayloadTooLargeError, got %T: %v", err, err)
+
+	// Body within the limit and complete ... OK
 	largeBody = `{"key": "` + strings.Repeat("A", int(platform_http.MaxRequestBodySize)-11) + `"}` // -11 to account for the wrapping JSON
 	req = httptest.NewRequest("POST", "/target?per_page=77&page=4", strings.NewReader(largeBody))
 	req = mux.SetURLVars(req, map[string]string{"some-id": "123"})

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -15,6 +15,7 @@ import (
 	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/server/config"
 	carvestorectx "github.com/fleetdm/fleet/v4/server/contexts/carvestore"
+	nodeauthctx "github.com/fleetdm/fleet/v4/server/contexts/nodeauth"
 	"github.com/fleetdm/fleet/v4/server/contexts/publicip"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -98,6 +99,12 @@ func setCarveStoreInRequestContext(carveStore fleet.CarveStore) kithttp.RequestF
 	}
 }
 
+func setHostAuthenticatorInRequestContext(svc fleet.Service) kithttp.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		return nodeauthctx.NewContext(ctx, svc)
+	}
+}
+
 // MakeHandler creates an HTTP handler for the Fleet server endpoints.
 func MakeHandler(
 	svc fleet.Service,
@@ -126,6 +133,7 @@ func MakeHandler(
 			auth.SetRequestsContexts(svc),
 			endpointer.LogDeprecatedPathAlias, // log deprecation warning for deprecated URL path aliases
 			setCarveStoreInRequestContext(carveStore),
+			setHostAuthenticatorInRequestContext(svc),
 		),
 		kithttp.ServerErrorHandler(&endpointer.ErrorHandler{Logger: logger}),
 		kithttp.ServerErrorEncoder(fleetErrorEncoder),
@@ -924,8 +932,6 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 		POST("/api/osquery/distributed/write", submitDistributedQueryResultsEndpoint, submitDistributedQueryResultsRequestShim{})
 	he.WithAltPaths("/api/v1/osquery/carve/begin").
 		POST("/api/osquery/carve/begin", carveBeginEndpoint, carveBeginRequest{})
-	he.WithAltPaths("/api/v1/osquery/log").
-		POST("/api/osquery/log", submitLogsEndpoint, submitLogsRequest{})
 	he.WithAltPaths("/api/v1/osquery/yara/{name}").
 		POST("/api/osquery/yara/{name}", getYaraEndpoint, getYaraRequest{})
 
@@ -968,6 +974,10 @@ func attachFleetAPIRoutes(r *mux.Router, svc fleet.Service, config config.FleetC
 	ne := newNoAuthEndpointer(svc, opts, r, apiVersions...)
 	ne.WithAltPaths("/api/v1/osquery/enroll").
 		POST("/api/osquery/enroll", enrollAgentEndpoint, contract.EnrollOsqueryAgentRequest{})
+
+	// The log endpoint authenticates the host inside DecodeRequest
+	ne.SkipRequestBodySizeLimit().WithAltPaths("/api/v1/osquery/log").
+		POST("/api/osquery/log", submitLogsEndpoint, submitLogsRequest{})
 
 	// These endpoint are token authenticated.
 	// NOTE: remember to update

--- a/server/service/integration_logger_test.go
+++ b/server/service/integration_logger_test.go
@@ -285,22 +285,46 @@ func (s *integrationLoggerTestSuite) TestSubmitLog() {
 	assert.Contains(t, errRes["error"], "unknown log type")
 	s.handler.Clear()
 
-	// submit gzip-encoded request
+	// submit gzip-encoded request (compact JSON required by the streaming parser)
 	var body bytes.Buffer
 	gw := gzip.NewWriter(&body)
-	_, err = fmt.Fprintf(gw, `{
-		"node_key": %q,
-		"log_type": "status",
-		"data":     null
-	}`, *h.NodeKey)
-	require.NoError(t, err)
+	enc := json.NewEncoder(gw)
+	enc.SetEscapeHTML(false)
+	require.NoError(t, enc.Encode(submitLogsRequest{NodeKey: *h.NodeKey, LogType: "status"}))
 	require.NoError(t, gw.Close())
 
 	s.DoRawWithHeaders("POST", "/api/osquery/log", body.Bytes(), http.StatusOK, map[string]string{"Content-Encoding": "gzip"})
 	assertIPAddrLogged(s.handler.Records())
 
-	// submit same payload without specifying gzip encoding fails
+	// submit same gzip payload without specifying gzip encoding fails (gzip bytes are not valid JSON)
 	s.DoRawWithHeaders("POST", "/api/osquery/log", body.Bytes(), http.StatusBadRequest, nil)
+
+	// submit large gzip-compressed log payload whose compressed size is under the old 1 MiB
+	// limit but whose decompressed size is several MiB; verifies the log endpoint has no
+	// body size limit and that gzip decoding works correctly in DecodeRequest.
+	s.handler.Clear()
+	entry := `{"name":"test","action":"added","hostIdentifier":"host1","calendarTime":"Mon Dec  2 23:26:48 2019 UTC","unixTime":1575330408,"columns":{"name":"test"}}`
+	manyEntries := make([]string, 0, 5000)
+	for range 5000 {
+		manyEntries = append(manyEntries, entry)
+	}
+	var largeBuf bytes.Buffer
+	lgw := gzip.NewWriter(&largeBuf)
+	lenc := json.NewEncoder(lgw)
+	require.NoError(t, lenc.Encode(submitLogsRequest{
+		NodeKey: *h.NodeKey,
+		LogType: "status",
+		Data: func() []json.RawMessage {
+			msgs := make([]json.RawMessage, len(manyEntries))
+			for i, e := range manyEntries {
+				msgs[i] = json.RawMessage(e)
+			}
+			return msgs
+		}(),
+	}))
+	require.NoError(t, lgw.Close())
+	s.DoRawWithHeaders("POST", "/api/osquery/log", largeBuf.Bytes(), http.StatusOK, map[string]string{"Content-Encoding": "gzip"})
+	assertIPAddrLogged(s.handler.Records())
 }
 
 func (s *integrationLoggerTestSuite) TestEnrollOsqueryLogsErrors() {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2710,7 +2710,7 @@ type submitLogsRequest struct {
 func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request) (any, error) {
 	body := io.Reader(req.Body)
 	if req.Header.Get("content-encoding") == "gzip" {
-		gzr, err := gzip.NewReader(req.Body)
+		gzr, err := gzip.NewReader(body)
 		if err != nil {
 			return nil, newOsqueryError("gzip decoder error: " + err.Error())
 		}
@@ -2798,6 +2798,15 @@ func (r submitLogsResponse) Error() error { return r.Err }
 func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*submitLogsRequest)
 
+	// Replicate the side-effects that authenticatedHost middleware normally applies
+	// for endpoints on the he (host-authenticated) endpointer.
+	// SetChecked must be called before the nil-host guard below so that the
+	// authzcheck middleware does not swallow the error response.
+	if ac, ok := authz_ctx.FromContext(ctx); ok {
+		ac.SetAuthnMethod(authz_ctx.AuthnHostToken)
+		ac.SetChecked()
+	}
+
 	// DecodeRequest must have authenticated the host before returning. A nil host
 	// here means a programming error (DecodeRequest returned without error and without
 	// a host), not a normal runtime condition.
@@ -2805,16 +2814,10 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		return submitLogsResponse{Err: newOsqueryError("internal: missing host after authentication")}, nil
 	}
 
-	// Replicate the side-effects that authenticatedHost middleware normally applies
-	// for endpoints on the he (host-authenticated) endpointer.
 	ctx = hostctx.NewContext(ctx, req.host)
 	hostProvider := &hostctx.HostAttributeProvider{Host: req.host}
 	ctx = ctxerr.AddErrorContextProvider(ctx, hostProvider)
 	instrumentHostLogger(ctx, req.host.ID)
-	if ac, ok := authz_ctx.FromContext(ctx); ok {
-		ac.SetAuthnMethod(authz_ctx.AuthnHostToken)
-		ac.SetChecked()
-	}
 
 	var hlogger *slog.Logger
 	if req.debug {

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -2705,8 +2705,8 @@ type submitLogsRequest struct {
 
 // DecodeRequest implements the endpointer.RequestDecoder interface.
 // The log endpoint can receive very large payloads.
-// To prevent DoS, we authenticate the host by reading only the "node_key" portion of the payload
-// and "log_type" fields before reading the (potentially large) "data" field.
+// To prevent DoS, we authenticate the host by reading only the "node_key" field via streaming
+// before decoding the rest of the (potentially large) body with a standard JSON decoder.
 func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request) (any, error) {
 	body := io.Reader(req.Body)
 	if req.Header.Get("content-encoding") == "gzip" {
@@ -2724,7 +2724,10 @@ func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request)
 		return osqErr
 	}
 
-	// 1. Must start with {
+	// Stream just the node_key field so we can authenticate before reading the
+	// (potentially large) remainder of the body.
+
+	// Must start with {
 	delimiter := make([]byte, 1)
 	if _, err := body.Read(delimiter); err != nil {
 		return nil, newInvalidRequestError(fmt.Errorf("failed to read object start: %w", err))
@@ -2732,39 +2735,22 @@ func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request)
 	if string(delimiter) != "{" {
 		return nil, newInvalidRequestError(fmt.Errorf("expected '{', got %q", string(delimiter)))
 	}
-	// 2. Must continue with "node_key":".
+	// Must continue with "node_key":".
 	nodeKeyLabel := make([]byte, 12)
-	if _, err := body.Read(nodeKeyLabel); err != nil {
+	if _, err := io.ReadFull(body, nodeKeyLabel); err != nil {
 		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "node_key" key: %w`, err))
 	}
 	if string(nodeKeyLabel) != `"node_key":"` {
 		return nil, newInvalidRequestError(fmt.Errorf(`expected "node_key":", got %q`, string(nodeKeyLabel)))
 	}
-	// 3. Must continue with a string (node key value).
+	// Must continue with a string (node key value).
 	const maxNodeKeySize = 255
 	nodeKey, err := readUntil(body, maxNodeKeySize, '"')
 	if err != nil {
 		return nil, newInvalidRequestError(fmt.Errorf(`invalid "node_key" field: %w`, err))
 	}
-	// 4. Must continue with ,"log_type":".
-	logTypeLabel := make([]byte, 13)
-	if _, err := body.Read(logTypeLabel); err != nil {
-		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "log_type" key: %w`, err))
-	}
-	if string(logTypeLabel) != `,"log_type":"` {
-		return nil, newInvalidRequestError(fmt.Errorf(`expected ,"log_type":", got %q`, string(logTypeLabel)))
-	}
-	// 5. Must continue with a string (log type value).
-	const maxLogTypeSize = 64
-	logType, err := readUntil(body, maxLogTypeSize, '"')
-	if err != nil {
-		return nil, newInvalidRequestError(fmt.Errorf(`invalid "log_type" field: %w`, err))
-	}
 
-	//
-	// 6. Authenticate the host before reading the (potentially large) "data" field.
-	//
-
+	// Authenticate the host before reading the rest of the body.
 	authenticator := nodeauthctx.FromContext(ctx)
 	if authenticator == nil {
 		return nil, newOsqueryError("internal: missing host authenticator in context")
@@ -2775,22 +2761,16 @@ func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request)
 		return nil, err
 	}
 
-	//
-	// 7. Authentication successful. Now read the "data" field.
-	//
+	// Reconstruct the full JSON by prepending the already-consumed prefix so that
+	// the standard JSON decoder sees a complete, valid object.
+	consumed := `{"node_key":"` + nodeKey + `"`
+	fullReader := io.MultiReader(strings.NewReader(consumed), body)
 
-	// Must continue with ,"data":
-	dataLabel := make([]byte, 8)
-	if _, err := body.Read(dataLabel); err != nil {
-		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "data" key: %w`, err))
+	var logReq struct {
+		LogType string            `json:"log_type"`
+		Data    []json.RawMessage `json:"data"`
 	}
-	if string(dataLabel) != `,"data":` {
-		return nil, newInvalidRequestError(fmt.Errorf(`expected ,"data":, got %q`, string(dataLabel)))
-	}
-
-	// Decode the data array (or null).
-	var data []json.RawMessage
-	if err := json.NewDecoder(body).Decode(&data); err != nil {
+	if err := json.NewDecoder(fullReader).Decode(&logReq); err != nil {
 		var netErr net.Error
 		if errors.Is(err, os.ErrDeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
 			osqErr := NewOsqueryError("request body read error: "+err.Error(), false)
@@ -2802,8 +2782,8 @@ func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request)
 
 	return &submitLogsRequest{
 		NodeKey: nodeKey,
-		LogType: logType,
-		Data:    data,
+		LogType: logReq.LogType,
+		Data:    logReq.Data,
 		host:    host,
 		debug:   debug,
 	}, nil

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/x509"
 	"encoding/json"
@@ -8,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -21,10 +23,12 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
 	"github.com/fleetdm/fleet/v4/server"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
+	nodeauthctx "github.com/fleetdm/fleet/v4/server/contexts/nodeauth"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
@@ -2691,10 +2695,117 @@ type submitLogsRequest struct {
 	NodeKey string            `json:"node_key"`
 	LogType string            `json:"log_type"`
 	Data    []json.RawMessage `json:"data"`
+
+	// host and debug are populated by DecodeRequest after authenticating the node key.
+	// They are not part of the JSON body.
+	host  *fleet.Host
+	debug bool
 }
 
-func (r *submitLogsRequest) hostNodeKey() string {
-	return r.NodeKey
+// DecodeRequest implements the endpointer.RequestDecoder interface.
+// The log endpoint can receive very large payloads.
+// To prevent DoS, we authenticate the host by reading only the "node_key" portion of the payload
+// and "log_type" fields before reading the (potentially large) "data" field.
+func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request) (any, error) {
+	body := io.Reader(req.Body)
+	if req.Header.Get("content-encoding") == "gzip" {
+		gzr, err := gzip.NewReader(req.Body)
+		if err != nil {
+			return nil, newOsqueryError("gzip decoder error: " + err.Error())
+		}
+		defer gzr.Close()
+		body = gzr
+	}
+
+	newInvalidRequestError := func(err error) error {
+		osqErr := newOsqueryError("invalid log request: " + err.Error())
+		osqErr.StatusCode = http.StatusBadRequest
+		return osqErr
+	}
+
+	// 1. Must start with {
+	delimiter := make([]byte, 1)
+	if _, err := body.Read(delimiter); err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf("failed to read object start: %w", err))
+	}
+	if string(delimiter) != "{" {
+		return nil, newInvalidRequestError(fmt.Errorf("expected '{', got %q", string(delimiter)))
+	}
+	// 2. Must continue with "node_key":".
+	nodeKeyLabel := make([]byte, 12)
+	if _, err := body.Read(nodeKeyLabel); err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "node_key" key: %w`, err))
+	}
+	if string(nodeKeyLabel) != `"node_key":"` {
+		return nil, newInvalidRequestError(fmt.Errorf(`expected "node_key":", got %q`, string(nodeKeyLabel)))
+	}
+	// 3. Must continue with a string (node key value).
+	const maxNodeKeySize = 255
+	nodeKey, err := readUntil(body, maxNodeKeySize, '"')
+	if err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf(`invalid "node_key" field: %w`, err))
+	}
+	// 4. Must continue with ,"log_type":".
+	logTypeLabel := make([]byte, 13)
+	if _, err := body.Read(logTypeLabel); err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "log_type" key: %w`, err))
+	}
+	if string(logTypeLabel) != `,"log_type":"` {
+		return nil, newInvalidRequestError(fmt.Errorf(`expected ,"log_type":", got %q`, string(logTypeLabel)))
+	}
+	// 5. Must continue with a string (log type value).
+	const maxLogTypeSize = 64
+	logType, err := readUntil(body, maxLogTypeSize, '"')
+	if err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf(`invalid "log_type" field: %w`, err))
+	}
+
+	//
+	// 6. Authenticate the host before reading the (potentially large) "data" field.
+	//
+
+	authenticator := nodeauthctx.FromContext(ctx)
+	if authenticator == nil {
+		return nil, newOsqueryError("internal: missing host authenticator in context")
+	}
+	host, debug, err := authenticator.AuthenticateHost(ctx, nodeKey)
+	if err != nil {
+		logging.WithErr(ctx, err)
+		return nil, err
+	}
+
+	//
+	// 7. Authentication successful. Now read the "data" field.
+	//
+
+	// Must continue with ,"data":
+	dataLabel := make([]byte, 8)
+	if _, err := body.Read(dataLabel); err != nil {
+		return nil, newInvalidRequestError(fmt.Errorf(`failed to read "data" key: %w`, err))
+	}
+	if string(dataLabel) != `,"data":` {
+		return nil, newInvalidRequestError(fmt.Errorf(`expected ,"data":, got %q`, string(dataLabel)))
+	}
+
+	// Decode the data array (or null).
+	var data []json.RawMessage
+	if err := json.NewDecoder(body).Decode(&data); err != nil {
+		var netErr net.Error
+		if errors.Is(err, os.ErrDeadlineExceeded) || (errors.As(err, &netErr) && netErr.Timeout()) {
+			osqErr := NewOsqueryError("request body read error: "+err.Error(), false)
+			osqErr.StatusCode = http.StatusRequestTimeout
+			return nil, osqErr
+		}
+		return nil, err
+	}
+
+	return &submitLogsRequest{
+		NodeKey: nodeKey,
+		LogType: logType,
+		Data:    data,
+		host:    host,
+		debug:   debug,
+	}, nil
 }
 
 type submitLogsResponse struct {
@@ -2705,6 +2816,31 @@ func (r submitLogsResponse) Error() error { return r.Err }
 
 func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*submitLogsRequest)
+
+	// DecodeRequest must have authenticated the host before returning. A nil host
+	// here means a programming error (DecodeRequest returned without error and without
+	// a host), not a normal runtime condition.
+	if req.host == nil {
+		return submitLogsResponse{Err: newOsqueryError("internal: missing host after authentication")}, nil
+	}
+
+	// Replicate the side-effects that authenticatedHost middleware normally applies
+	// for endpoints on the he (host-authenticated) endpointer.
+	ctx = hostctx.NewContext(ctx, req.host)
+	hostProvider := &hostctx.HostAttributeProvider{Host: req.host}
+	ctx = ctxerr.AddErrorContextProvider(ctx, hostProvider)
+	instrumentHostLogger(ctx, req.host.ID)
+	if ac, ok := authz_ctx.FromContext(ctx); ok {
+		ac.SetAuthnMethod(authz_ctx.AuthnHostToken)
+	}
+
+	var hlogger *slog.Logger
+	if req.debug {
+		if s, ok := svc.(*Service); ok {
+			hlogger = s.logger.With("host_id", req.host.ID)
+			logJSON(ctx, hlogger, req, "request")
+		}
+	}
 
 	var err error
 	switch req.LogType {
@@ -2727,7 +2863,11 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 		err = newOsqueryError("unknown log type: " + req.LogType)
 	}
 
-	return submitLogsResponse{Err: err}, nil
+	resp := submitLogsResponse{Err: err}
+	if hlogger != nil {
+		logJSON(ctx, hlogger, resp, "response")
+	}
+	return resp, nil
 }
 
 // preProcessOsqueryResults will attempt to unmarshal `osqueryResults` and will return:

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	nodeauthctx "github.com/fleetdm/fleet/v4/server/contexts/nodeauth"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
@@ -2796,7 +2797,7 @@ func (r submitLogsRequest) DecodeRequest(ctx context.Context, req *http.Request)
 			osqErr.StatusCode = http.StatusRequestTimeout
 			return nil, osqErr
 		}
-		return nil, err
+		return nil, endpointer.BadRequestErr("json decoder error", err)
 	}
 
 	return &submitLogsRequest{
@@ -2832,6 +2833,7 @@ func submitLogsEndpoint(ctx context.Context, request interface{}, svc fleet.Serv
 	instrumentHostLogger(ctx, req.host.ID)
 	if ac, ok := authz_ctx.FromContext(ctx); ok {
 		ac.SetAuthnMethod(authz_ctx.AuthnHostToken)
+		ac.SetChecked()
 	}
 
 	var hlogger *slog.Logger

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"database/sql"
 	"encoding/json"
@@ -11,6 +12,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"reflect"
 	"sort"
@@ -25,6 +27,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	fleetLogging "github.com/fleetdm/fleet/v4/server/contexts/logging"
+	nodeauthctx "github.com/fleetdm/fleet/v4/server/contexts/nodeauth"
 	"github.com/fleetdm/fleet/v4/server/contexts/viewer"
 	"github.com/fleetdm/fleet/v4/server/datastore/mysqlredis"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
@@ -4741,6 +4744,132 @@ func TestUpdateFleetdVersion(t *testing.T) {
 		updateFleetdVersion("windows", results)
 		require.Equal(t, originalResults, results)
 	})
+}
+
+// mockHostAuth is a fleet.HostAuthenticator that delegates to a function.
+type mockHostAuth struct {
+	fn func(ctx context.Context, nodeKey string) (*fleet.Host, bool, error)
+}
+
+func (m *mockHostAuth) AuthenticateHost(ctx context.Context, nodeKey string) (*fleet.Host, bool, error) {
+	return m.fn(ctx, nodeKey)
+}
+
+func TestSubmitLogsDecodeRequest(t *testing.T) {
+	validNodeKey := "valid-node-key-1234"
+	validHost := &fleet.Host{ID: 42, NodeKey: &validNodeKey}
+
+	// Returns a context with an authenticator that accepts only validNodeKey.
+	ctxWithAuth := nodeauthctx.NewContext(context.Background(), &mockHostAuth{
+		fn: func(_ context.Context, nodeKey string) (*fleet.Host, bool, error) {
+			if nodeKey == validNodeKey {
+				return validHost, false, nil
+			}
+			return nil, false, fleet.NewAuthFailedError("invalid node key")
+		},
+	})
+
+	makeBody := func(s string) *http.Request {
+		return httptest.NewRequest("POST", "/api/osquery/log", strings.NewReader(s))
+	}
+
+	makeGzipBody := func(v any) *http.Request {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		enc := json.NewEncoder(gw)
+		enc.SetEscapeHTML(false)
+		require.NoError(t, enc.Encode(v))
+		require.NoError(t, gw.Close())
+		req := httptest.NewRequest("POST", "/api/osquery/log", &buf)
+		req.Header.Set("Content-Encoding", "gzip")
+		return req
+	}
+
+	tests := []struct {
+		name        string
+		req         *http.Request
+		ctx         context.Context
+		wantErr     bool
+		wantErrMsg  string
+		wantNodeKey string
+		wantLogType string
+	}{
+		{
+			name:        "valid JSON request",
+			req:         makeBody(`{"node_key":"valid-node-key-1234","log_type":"status","data":null}`),
+			ctx:         ctxWithAuth,
+			wantNodeKey: validNodeKey,
+			wantLogType: "status",
+		},
+		{
+			name:        "valid gzip-encoded request",
+			req:         makeGzipBody(submitLogsRequest{NodeKey: validNodeKey, LogType: "result"}),
+			ctx:         ctxWithAuth,
+			wantNodeKey: validNodeKey,
+			wantLogType: "result",
+		},
+		{
+			name:       "invalid node key is rejected with auth error",
+			req:        makeBody(`{"node_key":"bad-key","log_type":"status","data":null}`),
+			ctx:        ctxWithAuth,
+			wantErr:    true,
+			wantErrMsg: "Authentication failed",
+		},
+		{
+			name:       "body does not start with {",
+			req:        makeBody(`["node_key","bad"]`),
+			ctx:        ctxWithAuth,
+			wantErr:    true,
+			wantErrMsg: "expected '{'",
+		},
+		{
+			name:       "node_key is not the first field",
+			req:        makeBody(`{"log_type":"status","node_key":"valid-node-key-1234","data":null}`),
+			ctx:        ctxWithAuth,
+			wantErr:    true,
+			wantErrMsg: `expected "node_key":`,
+		},
+		{
+			name:       "node_key exceeds 255 bytes",
+			req:        makeBody(`{"node_key":"` + strings.Repeat("A", 256) + `","log_type":"status","data":null}`),
+			ctx:        ctxWithAuth,
+			wantErr:    true,
+			wantErrMsg: "end character not found",
+		},
+		{
+			name:       "empty body",
+			req:        makeBody(``),
+			ctx:        ctxWithAuth,
+			wantErr:    true,
+			wantErrMsg: "failed to read object start",
+		},
+		{
+			name:       "missing authenticator in context",
+			req:        makeBody(`{"node_key":"valid-node-key-1234","log_type":"status","data":null}`),
+			ctx:        context.Background(), // no authenticator
+			wantErr:    true,
+			wantErrMsg: "missing host authenticator in context",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := (submitLogsRequest{}).DecodeRequest(tt.ctx, tt.req)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrMsg != "" {
+					require.Contains(t, err.Error(), tt.wantErrMsg)
+				}
+				return
+			}
+			require.NoError(t, err)
+			got, ok := result.(*submitLogsRequest)
+			require.True(t, ok)
+			require.Equal(t, tt.wantNodeKey, got.NodeKey)
+			require.Equal(t, tt.wantLogType, got.LogType)
+			require.Equal(t, validHost, got.host)
+		})
+	}
 }
 
 // makeLiveQueryStore creates a mock live query store that returns `countToReturn` from the

--- a/server/service/osquery_test.go
+++ b/server/service/osquery_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/types"
 	"github.com/fleetdm/fleet/v4/server/authz"
 	"github.com/fleetdm/fleet/v4/server/config"
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	hostctx "github.com/fleetdm/fleet/v4/server/contexts/host"
 	fleetLogging "github.com/fleetdm/fleet/v4/server/contexts/logging"
 	nodeauthctx "github.com/fleetdm/fleet/v4/server/contexts/nodeauth"
@@ -4870,6 +4871,22 @@ func TestSubmitLogsDecodeRequest(t *testing.T) {
 			require.Equal(t, validHost, got.host)
 		})
 	}
+}
+
+// TestSubmitLogsEndpointNilHost verifies that the nil-host guard in submitLogsEndpoint
+// returns the correct error.
+func TestSubmitLogsEndpointNilHost(t *testing.T) {
+	authzCtx := &authz_ctx.AuthorizationContext{}
+	ctx := authz_ctx.NewContext(context.Background(), authzCtx)
+
+	resp, err := submitLogsEndpoint(ctx, &submitLogsRequest{host: nil}, nil)
+
+	require.NoError(t, err)
+	require.True(t, authzCtx.Checked())
+	slResp, ok := resp.(submitLogsResponse)
+	require.True(t, ok)
+	require.Error(t, slResp.Err)
+	require.Contains(t, slResp.Err.Error(), "internal: missing host after authentication")
 }
 
 // makeLiveQueryStore creates a mock live query store that returns `countToReturn` from the

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strconv"
 	"strings"
@@ -633,4 +634,32 @@ func userListOptionsFromRequest(r *http.Request) (fleet.UserListOptions, error) 
 
 type getGenericSpecRequest struct {
 	Name string `url:"name"`
+}
+
+// readUntil reads up to maxToRead bytes of content from r one byte at a time,
+// consuming the endChar terminator when found within that range.
+// It returns the content bytes (not including endChar).
+// The loop runs at most maxToRead+1 times: up to maxToRead content bytes, then one
+// terminator byte. An error is returned if endChar is not found within maxToRead content bytes.
+// It is used by DecodeRequest implementations that parse the request body field-by-field
+// to authenticate before reading a potentially large payload (see carveBlockRequest and
+// submitLogsRequest).
+func readUntil(r io.Reader, maxToRead int, endChar byte) (string, error) {
+	var s strings.Builder
+	endCharFound := false
+	var b [1]byte
+	for i := 0; i <= maxToRead; i++ {
+		if _, err := r.Read(b[:]); err != nil {
+			return "", fmt.Errorf("failed to read character: %w", err)
+		}
+		if b[0] == endChar {
+			endCharFound = true
+			break
+		}
+		s.Write(b[:])
+	}
+	if !endCharFound {
+		return "", fmt.Errorf(`end character not found: %q`, s.String())
+	}
+	return s.String(), nil
 }

--- a/server/service/transport.go
+++ b/server/service/transport.go
@@ -659,7 +659,7 @@ func readUntil(r io.Reader, maxToRead int, endChar byte) (string, error) {
 		s.Write(b[:])
 	}
 	if !endCharFound {
-		return "", fmt.Errorf(`end character not found: %q`, s.String())
+		return "", fmt.Errorf("end character not found within %d bytes", maxToRead)
 	}
 	return s.String(), nil
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40813 

* Implemented a custom submitLogsRequest.DecodeRequest method that streams the `node_key` and uses that to authenticate the host before reading the potentially huge rest of the payload.
* Removed the body size limit for `osquery/log` end-point.
* Fixed false positive PayloadTooLargeError errors.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for gzip-compressed log submissions.
  * Improved handling of large request payloads with better error detection.

* **Bug Fixes**
  * Enhanced request body size validation to correctly identify and reject oversized payloads.

* **Refactor**
  * Reorganized log endpoint authentication to occur before reading large request bodies, improving performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->