### PR TITLE
show apns expiration banner in UI for free tier

### DIFF
--- a/changes/issue-39184-apns-banner-fix
+++ b/changes/issue-39184-apns-banner-fix
@@ -1,0 +1,1 @@
+- show apns expiry banner in the UI for fleet free tier

--- a/changes/issue-39184-apns-banner-fix
+++ b/changes/issue-39184-apns-banner-fix
@@ -1,1 +1,1 @@
-- show apns expiry banner in the UI for fleet free tier
+- Added APNs expiry banner in the UI for fleet free tier.

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -72,7 +72,7 @@ const MainContent = ({
         banner = <LicenseExpirationBanner />;
       }
     } else if (isApplePnsExpired || willApplePnsExpire) {
-      // APNS exipiration banner will show for either premium or free tiers
+      // APNs expiration banner will show for either premium or free tiers
       // but all other banners are only for premium tiers
       banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
     }

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -71,6 +71,10 @@ const MainContent = ({
       } else if (isFleetLicenseExpired) {
         banner = <LicenseExpirationBanner />;
       }
+    } else if (isApplePnsExpired || willApplePnsExpire) {
+      // APNS exipiration banner will show for either premium or free tiers
+      // but all other banners are only for premium tiers
+      banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
     }
 
     if (banner) {

--- a/frontend/components/MainContent/MainContent.tsx
+++ b/frontend/components/MainContent/MainContent.tsx
@@ -57,10 +57,12 @@ const MainContent = ({
 
     // the order of these checks is important. This is the priority order
     // for showing banners and only one banner is shown at a time.
-    if (isPremiumTier) {
-      if (isApplePnsExpired || willApplePnsExpire) {
-        banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
-      } else if (isAndroidEnterpriseDeleted) {
+    if (isApplePnsExpired || willApplePnsExpire) {
+      // APNs expiration banner will show for either premium or free tiers
+      // but all other banners are only for premium tiers
+      banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
+    } else if (isPremiumTier) {
+      if (isAndroidEnterpriseDeleted) {
         banner = <AndroidEnterpriseDeletedMessage />;
       } else if (isAppleBmExpired || willAppleBmExpire) {
         banner = <AppleBMRenewalMessage expired={isAppleBmExpired} />;
@@ -71,10 +73,6 @@ const MainContent = ({
       } else if (isFleetLicenseExpired) {
         banner = <LicenseExpirationBanner />;
       }
-    } else if (isApplePnsExpired || willApplePnsExpire) {
-      // APNs expiration banner will show for either premium or free tiers
-      // but all other banners are only for premium tiers
-      banner = <ApplePNCertRenewalMessage expired={isApplePnsExpired} />;
     }
 
     if (banner) {


### PR DESCRIPTION
**Related issue:** Resolves #39184

show apns expiration banner for the free tier in the UI. Before it was limited to show only for premium tier.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] QA'd all new/changed functionality manually
