### PR TITLE
Fix select-all header checkbox not selecting rows in a specific case

### DIFF
--- a/changes/40789-fix-select-all-header-checkbox
+++ b/changes/40789-fix-select-all-header-checkbox
@@ -1,1 +1,1 @@
-* Fixed select-all header checkbox not selecting rows on partial pages.
+* Fixed select-all header checkbox not selecting rows on partial pages where not all rows are selectable.

--- a/changes/40789-fix-select-all-header-checkbox
+++ b/changes/40789-fix-select-all-header-checkbox
@@ -1,1 +1,1 @@
-* Fixed table header "select all" checkbox not selecting rows when the page has fewer than 20 rows.
+* Fixed select-all header checkbox not selecting rows on partial pages.

--- a/changes/40789-fix-select-all-header-checkbox
+++ b/changes/40789-fix-select-all-header-checkbox
@@ -1,0 +1,1 @@
+* Fixed table header "select all" checkbox not selecting rows when the page has fewer than 20 rows.

--- a/frontend/components/TableContainer/utilities/config_utils.ts
+++ b/frontend/components/TableContainer/utilities/config_utils.ts
@@ -33,7 +33,7 @@ export const getConditionalSelectHeaderCheckboxProps = ({
       });
     } else {
       // Otherwise select every selectable row on the page
-      headerProps.page.forEach((row) => {
+      headerProps.rows.forEach((row) => {
         const rowChecked = checkIfRowIsSelectable(row);
         headerProps.toggleRowSelected(row.id, rowChecked);
       });


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40789

Seems like on specific pages of server-side paginated tables, the select-all header checkbox does not work. This happens when:
- the page has less than 20 rows (I think this is the default page size)
- AND not all the rows are selectable

`headerProps.rows` always contains all rows currently visible in the table. Using rows also keeps the select logic consistent with the deselect and "all selected" checks, which already used rows.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

### Before

Clicking on the table header checkbox doesn't perform any selection


https://github.com/user-attachments/assets/d5b1f2fc-1400-4f3e-a2b4-2ae6a3da65af

### After


https://github.com/user-attachments/assets/54a67707-7978-40ec-ba50-c146a67795b2


