### PR TITLE
Fleet UI: Fix refresh preserve toggle, fix border radius

### DIFF
--- a/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.tsx
+++ b/frontend/components/AuthenticationFormWrapper/AuthenticationFormWrapper.tsx
@@ -44,7 +44,11 @@ const AuthenticationFormWrapper = ({
       </nav>
       {breadcrumbs}
       <div className={classNames}>
-        <Card className={`${baseClass}__card`} paddingSize="xlarge">
+        <Card
+          className={`${baseClass}__card`}
+          borderRadiusSize="xxlarge"
+          paddingSize="xlarge"
+        >
           {(header || headerCta) && (
             <div className={`${baseClass}__header-container`}>
               {header && <CardHeader header={header} />}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -17,7 +17,10 @@ import TabText from "components/TabText";
 import SidePanelContent from "components/SidePanelContent";
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
 
-import { FmaPlatformValue } from "./SoftwareFleetMaintained/FleetMaintainedAppsTable/FmaFilters/FmaFilters";
+import {
+  FmaPlatformValue,
+  FmaStatusValue,
+} from "./SoftwareFleetMaintained/FleetMaintainedAppsTable/FmaFilters/FmaFilters";
 
 const baseClass = "software-add-page";
 
@@ -55,6 +58,7 @@ export interface ISoftwareAddPageQueryParams {
   order_key?: string;
   order_direction?: "asc" | "desc";
   platform: FmaPlatformValue;
+  status: FmaStatusValue;
 }
 
 interface ISoftwareAddPageProps {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppsTable/FleetMaintainedAppsTable.tsx
@@ -82,6 +82,7 @@ interface IFleetMaintainedAppsTableProps {
   orderDirection: "asc" | "desc";
   orderKey: string;
   platformParam?: FmaPlatformValue;
+  statusParam?: FmaStatusValue;
   currentPage: number;
   router: InjectedRouter;
   data?: ISoftwareFleetMaintainedAppsResponse;
@@ -100,10 +101,11 @@ const FleetMaintainedAppsTable = ({
   perPage,
   orderDirection,
   platformParam,
+  statusParam,
   orderKey,
   currentPage,
 }: IFleetMaintainedAppsTableProps) => {
-  const [status, setStatus] = useState<FmaStatusValue>("all");
+  const [status, setStatus] = useState<FmaStatusValue>(statusParam || "all");
   const [platform, setPlatform] = useState<FmaPlatformValue>(
     platformParam || "all"
   );
@@ -122,13 +124,15 @@ const FleetMaintainedAppsTable = ({
             return val !== currentPage;
           case "platform":
             return val !== platformParam;
+          case "status":
+            return val !== statusParam;
           default:
             return false;
         }
       });
       return changedEntry?.[0] ?? "";
     },
-    [currentPage, orderDirection, orderKey, query, platformParam]
+    [currentPage, orderDirection, orderKey, query, platformParam, statusParam]
   );
 
   const generateNewQueryParams = useCallback(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/SoftwareFleetMaintained.tsx
@@ -61,6 +61,7 @@ const SoftwareFleetMaintained = ({
     query = "",
     page,
     platform,
+    status,
   } = location.query;
   const currentPage = page ? parseInt(page, 10) : DEFAULT_PAGE;
 
@@ -117,6 +118,7 @@ const SoftwareFleetMaintained = ({
         perPage={DEFAULT_PAGE_SIZE}
         currentPage={currentPage}
         platformParam={platform}
+        statusParam={status}
       />
     </div>
   );


### PR DESCRIPTION
## Issue
Post- 4.82 QA

## Description
- Refresh should preserve toggle
- Authentication pages should have a card border radius of 16px

## Screenshot of fixes

https://github.com/user-attachments/assets/0567a397-f747-474c-83e9-2ef6b6ed6606


https://github.com/user-attachments/assets/0a158d38-c686-46c8-944d-262b4bfcb940



## Testing

- [x] QA'd all new/changed functionality manually
