### PR TITLE
Dismiss gosec G602 and G115 in test code

### DIFF
--- a/server/activity/internal/testutils/testutils.go
+++ b/server/activity/internal/testutils/testutils.go
@@ -64,7 +64,7 @@ func (tdb *TestDB) InsertUser(t *testing.T, name, email string) uint {
 
 	id, err := result.LastInsertId()
 	require.NoError(t, err)
-	return uint(id)
+	return uint(id) //nolint:gosec // dismiss G115
 }
 
 // InsertActivity creates an activity in the database and returns the activity ID.
@@ -104,7 +104,7 @@ func (tdb *TestDB) InsertActivityWithTime(t *testing.T, userID *uint, activityTy
 
 	id, err := result.LastInsertId()
 	require.NoError(t, err)
-	return uint(id)
+	return uint(id) //nolint:gosec // dismiss G115
 }
 
 // InsertHost creates a host in the database and returns the host ID.
@@ -120,7 +120,7 @@ func (tdb *TestDB) InsertHost(t *testing.T, hostname string, teamID *uint) uint 
 
 	id, err := result.LastInsertId()
 	require.NoError(t, err)
-	return uint(id)
+	return uint(id) //nolint:gosec // dismiss G115
 }
 
 // InsertHostActivity creates a link between a host and an activity in the host_activities junction table.

--- a/server/datastore/mysql/labels_test.go
+++ b/server/datastore/mysql/labels_test.go
@@ -805,7 +805,7 @@ func setupLabelSpecsTest(t *testing.T, ds fleet.Datastore) []*fleet.LabelSpec {
 	err := ds.ApplyLabelSpecs(context.Background(), expectedSpecs)
 	require.Nil(t, err)
 
-	expectedSpecs[4].Hosts = []string{"1", "2", "3", "4"}
+	expectedSpecs[4].Hosts = []string{"1", "2", "3", "4"} //nolint:gosec // dismiss G602
 	return expectedSpecs
 }
 

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -2461,13 +2461,13 @@ func testBulkSetPendingMDMHostProfiles(t *testing.T, ds *Datastore) {
 	// it got deleted and re-inserted from the team's profiles, so this is reflected in
 	// the host's profiles list.
 	newTm1DarwinProfiles = []*fleet.MDMAppleConfigProfile{
-		tm1DarwinProfiles[0],
+		tm1DarwinProfiles[0], //nolint:gosec // dismiss G602
 		configProfileForTest(t, "T1.2a", "T1.2a", "e"),
 		configProfileForTest(t, "T1.3a", "T1.3a", "f"),
 	}
 	newTm1WindowsProfiles = []*fleet.MDMWindowsConfigProfile{
 		windowsConfigProfileForTest(t, "T1.1w", "T1.1"),
-		tm1WindowsProfiles[1],
+		tm1WindowsProfiles[1], //nolint:gosec // dismiss G602
 		windowsConfigProfileForTest(t, "T1.3w", "T1.3"),
 	}
 

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -6937,7 +6937,7 @@ func testPolicyModificationResetsAttemptNumber(t *testing.T, ds *Datastore) {
 	script, err := ds.NewScript(ctx, &fleet.Script{
 		Name:            "test.sh",
 		TeamID:          &team.ID,
-		ScriptContentID: uint(scriptContentID),
+		ScriptContentID: uint(scriptContentID), //nolint:gosec // dismiss G115
 		ScriptContents:  "echo 'test'",
 	})
 	require.NoError(t, err)

--- a/server/datastore/mysql/scripts_test.go
+++ b/server/datastore/mysql/scripts_test.go
@@ -3163,7 +3163,7 @@ func testScriptModificationResetsAttemptNumber(t *testing.T, ds *Datastore) {
 	script, err := ds.NewScript(ctx, &fleet.Script{
 		Name:            "test.sh",
 		TeamID:          &team.ID,
-		ScriptContentID: uint(scriptContentID),
+		ScriptContentID: uint(scriptContentID), //nolint:gosec // dismiss G115
 		ScriptContents:  "echo 'v1'",
 	})
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_titles_test.go
+++ b/server/datastore/mysql/software_titles_test.go
@@ -2074,7 +2074,7 @@ func testSoftwareTitleHostCount(t *testing.T, ds *Datastore) {
 		tm, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team " + strconv.Itoa(i)})
 		require.NoError(t, err)
 
-		installers[i], _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		installers[i], _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{ //nolint:gosec // dismiss G602
 			Title:            "foo",
 			Source:           "apps",
 			Version:          "1.0",
@@ -2087,14 +2087,14 @@ func testSoftwareTitleHostCount(t *testing.T, ds *Datastore) {
 			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
 		})
 		require.NoError(t, err)
-		require.NotZero(t, installers[i])
+		require.NotZero(t, installers[i]) //nolint:gosec // dismiss G602
 	}
 
 	// install software on host
 	updateSw, err := fleet.SoftwareFromOsqueryRow("foo", "1.0", "apps", "", "", "", "", "com.foo.installer", "", "", "", "")
 	require.NoError(t, err)
 
-	hostInstall1, err := ds.InsertSoftwareInstallRequest(ctx, host1.ID, installers[0], fleet.HostSoftwareInstallOptions{})
+	hostInstall1, err := ds.InsertSoftwareInstallRequest(ctx, host1.ID, installers[0], fleet.HostSoftwareInstallOptions{}) //nolint:gosec // dismiss G602
 	require.NoError(t, err)
 
 	_, err = ds.SetHostSoftwareInstallResult(ctx, &fleet.HostSoftwareInstallResultPayload{

--- a/server/datastore/mysql/software_upgrade_code_test.go
+++ b/server/datastore/mysql/software_upgrade_code_test.go
@@ -251,7 +251,7 @@ func testUpgradeCodeDuplicateEntryError(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, softwareEntries, 1)
 	require.NotNil(t, softwareEntries[0].TitleID)
-	assert.Equal(t, uint(titleAID), *softwareEntries[0].TitleID,
+	assert.Equal(t, uint(titleAID), *softwareEntries[0].TitleID, //nolint:gosec // dismiss G115
 		"Software should be linked to Title A (the one with matching upgrade_code)")
 }
 
@@ -308,7 +308,7 @@ func testUpgradeCodeCaseSensitivityWithExistingUpgradeCode(t *testing.T, ds *Dat
 
 	// Software should be linked to the existing title despite case difference
 	require.NotNil(t, softwareEntries[0].TitleID, "Software should have title_id set")
-	assert.Equal(t, uint(titleID), *softwareEntries[0].TitleID,
+	assert.Equal(t, uint(titleID), *softwareEntries[0].TitleID, //nolint:gosec // dismiss G115
 		"Software should be linked to existing title")
 }
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -1061,7 +1061,7 @@ func (s *integrationMDMTestSuite) TestWindowsProfileRetries() {
 			expectedProfileStatuses["N1"] = fleet.MDMDeliveryPending
 			expectedProfileStatuses["N2"] = fleet.MDMDeliveryVerified
 			checkProfilesStatus(t)
-			expectedRetryCounts["N1"] = uint(i + 1)
+			expectedRetryCounts["N1"] = uint(i + 1) //nolint:gosec // dismiss G115
 			checkRetryCounts(t)
 		}
 

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -4247,7 +4247,7 @@ func (s *integrationMDMTestSuite) TestBootstrapPackageStatus() {
 	var summaryResp getMDMAppleBootstrapPackageSummaryResponse
 	s.DoJSON("GET", "/api/latest/fleet/bootstrap/summary", nil, http.StatusOK, &summaryResp)
 	// We don't count the "skipped" device as it is pending migration and will not install the bootstrap package
-	require.Equal(t, fleet.MDMAppleBootstrapPackageSummary{Pending: uint(len(noTeamDevices) - 1)}, summaryResp.MDMAppleBootstrapPackageSummary)
+	require.Equal(t, fleet.MDMAppleBootstrapPackageSummary{Pending: uint(len(noTeamDevices) - 1)}, summaryResp.MDMAppleBootstrapPackageSummary) //nolint:gosec // dismiss G115
 
 	var lhr listHostsResponse
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &lhr, "team_id", "0", "bootstrap_package", "pending")
@@ -4279,7 +4279,7 @@ func (s *integrationMDMTestSuite) TestBootstrapPackageStatus() {
 
 	summaryResp = getMDMAppleBootstrapPackageSummaryResponse{}
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/bootstrap/summary?team_id=%d", team.ID), nil, http.StatusOK, &summaryResp)
-	require.Equal(t, fleet.MDMAppleBootstrapPackageSummary{Pending: uint(len(teamDevices) - 1)}, summaryResp.MDMAppleBootstrapPackageSummary)
+	require.Equal(t, fleet.MDMAppleBootstrapPackageSummary{Pending: uint(len(teamDevices) - 1)}, summaryResp.MDMAppleBootstrapPackageSummary) //nolint:gosec // dismiss G115
 
 	mockErrorChain := []mdm.ErrorChain{
 		{ErrorCode: 12021, ErrorDomain: "MCMDMErrorDomain", LocalizedDescription: "Unknown command", USEnglishDescription: "Unknown command"},

--- a/server/worker/automation_failer_test.go
+++ b/server/worker/automation_failer_test.go
@@ -72,7 +72,7 @@ func TestJiraFailer(t *testing.T) {
 	var failedIndices []int
 	cves := []string{"CVE-2018-1234", "CVE-2019-1234", "CVE-2020-1234", "CVE-2021-1234"}
 	for i := 0; i < 10; i++ {
-		cve := cves[i%len(cves)]
+		cve := cves[i%len(cves)] //nolint:gosec // dismiss G602
 		err := jira.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), json.RawMessage(fmt.Sprintf(`{"vulnerability":{"cve":%q}}`, cve)))
 		if err != nil {
 			failedIndices = append(failedIndices, i)
@@ -131,7 +131,7 @@ func TestZendeskFailer(t *testing.T) {
 	var failedIndices []int
 	cves := []string{"CVE-2018-1234", "CVE-2019-1234", "CVE-2020-1234", "CVE-2021-1234"}
 	for i := 0; i < 10; i++ {
-		cve := cves[i%len(cves)]
+		cve := cves[i%len(cves)] //nolint:gosec // dismiss G602
 		err := zendesk.Run(license.NewContext(context.Background(), &fleet.LicenseInfo{Tier: fleet.TierFree}), json.RawMessage(fmt.Sprintf(`{"vulnerability":{"cve":%q}}`, cve)))
 		if err != nil {
 			failedIndices = append(failedIndices, i)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #
Dismisses some gosec rules in test code where they do not apply, since they show up when running `golangci-lint run` locally and make it harder to spot newly introduced errors.

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually
