### PR TITLE
Fix tone tweaks reverted as part of The Great Rename

### DIFF
--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -270,7 +270,7 @@ const EditQueryPage = ({
             host_id: hostId,
           })
         );
-        renderFlash("success", "Report created!");
+        renderFlash("success", "Report created.");
         setBackendValidators({});
       } catch (createError: any) {
         if (getErrorReason(createError).includes("already exists")) {
@@ -316,7 +316,7 @@ const EditQueryPage = ({
 
     try {
       await queryAPI.update(queryId, updatedQuery);
-      renderFlash("success", "Report updated!");
+      renderFlash("success", "Report updated.");
       refetchStoredQuery(); // Required to compare recently saved query to a subsequent save to the query
     } catch (updateError: any) {
       console.error(updateError);


### PR DESCRIPTION
For #39676.

Work is mine. Diagnosis was courtesy Zed + Sonnet 4.6, which caught this as I was iterating with it on building a test plan. Ran the prompt below to catch any other issues:

> Find any cases where `!` as ending punctuation was added to copy since `bf5d342`.

Will test this along with the QA for the parent issue once it's cherry-picked.