### PR TITLE
Update mdm enroll copy

### DIFF
--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -61,14 +61,14 @@
       p {
         font-size: 14px;
       }
-    
+
       a {
         color: #515774;
         text-decoration: none;
         font-weight: 600;
         border-bottom: 1px solid #e2e4ea;
       }
-      
+
       ol {
         display: flex;
         flex-direction: column;
@@ -234,9 +234,27 @@
                   href="https://support.google.com/android/answer/6088915?hl=en"
                 >
                   factory reset it
-                  <svg width="9" height="9" viewBox="0 0 9 9" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <rect x="0.5" y="0.5" width="8" height="8" rx="2" stroke="#515774"/>
-                    <path d="M3.49992 2.83325H6.16659M6.16659 2.83325V5.49992M6.16659 2.83325L2.83325 6.16659" stroke="#515774" stroke-linecap="round" stroke-linejoin="round"/>
+                  <svg
+                    width="9"
+                    height="9"
+                    viewBox="0 0 9 9"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect
+                      x="0.5"
+                      y="0.5"
+                      width="8"
+                      height="8"
+                      rx="2"
+                      stroke="#515774"
+                    />
+                    <path
+                      d="M3.49992 2.83325H6.16659M6.16659 2.83325V5.49992M6.16659 2.83325L2.83325 6.16659"
+                      stroke="#515774"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    />
                   </svg>
                 </a>
               </span>
@@ -340,8 +358,8 @@
               <p>
                 <span>1.</span>
                 <span>
-                  Tap the button below to download the Fleet profile. Double
-                  click on it. You'll see a warning, which is expected.
+                  Tap the button below to download the Fleet profile. Open it.
+                  You'll see a warning.
                 </span>
               </p>
               <a class="download-link" href="{{.EnrollURL}}">Download</a>

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -359,7 +359,7 @@
                 <span>1.</span>
                 <span>
                   Tap the button below to download the Fleet profile. Open it.
-                  You'll see a warning.
+                  You'll see a warning, which is expected.
                 </span>
               </p>
               <a class="download-link" href="{{.EnrollURL}}">Download</a>


### PR DESCRIPTION
- Many users will be single-clicking the downloaded Profile from the expanded dock - "open" is the right level of specificity.
<img width="199" height="240" alt="Screenshot 2026-03-05 at 10 35 28 AM" src="https://github.com/user-attachments/assets/5c782753-f479-425c-9492-61e9b13fef86" />

- The fact that we call out that there will be a warning communicates that it is expected, redundant to say so. Also, it looks cleaner.
<img width="829" height="413" alt="Screenshot 2026-03-05 at 10 32 59 AM" src="https://github.com/user-attachments/assets/f4e1fff2-4391-4971-ba99-32edbf2e25f4" />
