### PR TITLE
Fix rc minor 4.82 bypass

### DIFF
--- a/server/datastore/mysql/conditional_access_bypass.go
+++ b/server/datastore/mysql/conditional_access_bypass.go
@@ -21,6 +21,7 @@ func (ds *Datastore) ConditionalAccessBypassDevice(ctx context.Context, hostID u
 		policies p ON pm.policy_id = p.id
 	WHERE
 		pm.host_id = ?
+		AND p.conditional_access_enabled = 1
 		AND p.conditional_access_bypass_enabled = 0
 		AND pm.passes = 0
 	`

--- a/server/datastore/mysql/conditional_access_bypass_test.go
+++ b/server/datastore/mysql/conditional_access_bypass_test.go
@@ -299,7 +299,7 @@ func testConditionalAccessBypassDeviceWithBlockingPolicy(t *testing.T, ds *Datas
 
 	// Set conditional_access_bypass_enabled = 0 to make it non-bypassable
 	ExecAdhocSQL(t, ds, func(db sqlx.ExtContext) error {
-		_, err := db.ExecContext(ctx, `UPDATE policies SET conditional_access_bypass_enabled = 0 WHERE id = ?`, policy.ID)
+		_, err := db.ExecContext(ctx, `UPDATE policies SET conditional_access_bypass_enabled = 0, conditional_access_enabled = 1 WHERE id = ?`, policy.ID)
 		return err
 	})
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -24494,7 +24494,7 @@ FqU+KJOed6qlzj7qy+u5l6CQeajLGdjUxFlFyw==
 
 		// Make the policy non-bypassable
 		mysql.ExecAdhocSQL(t, s.ds, func(db sqlx.ExtContext) error {
-			_, innerErr := db.ExecContext(ctx, `UPDATE policies SET conditional_access_bypass_enabled = 0 WHERE id = ?`, policy.ID)
+			_, innerErr := db.ExecContext(ctx, `UPDATE policies SET conditional_access_bypass_enabled = 0, conditional_access_enabled = 1 WHERE id = ?`, policy.ID)
 			return innerErr
 		})
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40736

Fixes an issue identified during QA where a failing bypass-disabled policy that's not part of conditional access would prevent snoozing


- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed