### PR TITLE
Cherry-Pick: Bump tar from 7.5.8 to 7.5.10 in /tools/fleetctl-npm

### DIFF
--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "axios": "1.13.5",
     "rimraf": "6.1.2",
-    "tar": "7.5.8"
+    "tar": "7.5.10"
   },
   "keywords": [
     "osquery",

--- a/tools/fleetctl-npm/yarn.lock
+++ b/tools/fleetctl-npm/yarn.lock
@@ -241,10 +241,10 @@ rimraf@6.1.2:
     glob "^13.0.0"
     package-json-from-dist "^1.0.1"
 
-tar@7.5.8:
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.8.tgz#6bbdfdb487914803d401bab6a2abb100aaa253d5"
-  integrity sha512-SYkBtK99u0yXa+IWL0JRzzcl7RxNpvX/U08Z+8DKnysfno7M+uExnTZH8K+VGgShf2qFPKtbNr9QBl8n7WBP6Q==
+tar@7.5.10:
+  version "7.5.10"
+  resolved "https://registry.yarnpkg.com/tar/-/tar-7.5.10.tgz#2281541123f5507db38bc6eb22619f4bbaef73ad"
+  integrity sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==
   dependencies:
     "@isaacs/fs-minipass" "^4.0.0"
     chownr "^3.0.0"


### PR DESCRIPTION
Merged into `main` in #41034.