### PR TITLE
Cherry-pick #41071: Add missing deprecation warning for `--policies-team`

### DIFF
--- a/cmd/fleetctl/fleetctl/apply.go
+++ b/cmd/fleetctl/fleetctl/apply.go
@@ -54,6 +54,10 @@ func applyCommand() *cli.Command {
 			enableLogTopicsFlag(),
 			disableLogTopicsFlag(),
 		},
+		Before: func(c *cli.Context) error {
+			logDeprecatedFlagName(c, "policies-team", "policies-fleet")
+			return nil
+		},
 		Action: func(c *cli.Context) error {
 			// Disable field deprecation warnings for now.
 			// TODO - remove this in future release to unleash warnings.


### PR DESCRIPTION
Cherry-pick of #41071 into `rc-minor-fleet-v4.82.0`.