### PR TITLE
Update urls to use "fleets" and "reports" instead of "teams" and "queries"

### DIFF
--- a/frontend/components/top_nav/SiteTopNav/navItems.ts
+++ b/frontend/components/top_nav/SiteTopNav/navItems.ts
@@ -86,7 +86,7 @@ export default (
       name: "Reports",
       location: {
         regex: new RegExp(`^${URL_PREFIX}/queries/`),
-        pathname: PATHS.MANAGE_QUERIES,
+        pathname: PATHS.MANAGE_REPORTS,
       },
       withParams: { type: "query", names: ["fleet_id"] },
     },

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -168,7 +168,7 @@ const UserMenu = ({
           );
           renderFlash("warning-filled", msg);
         }
-        onUserMenuItemClick(PATHS.TEAM_DETAILS_USERS(targetTeam.value));
+        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
       };
     }
 

--- a/frontend/pages/admin/AdminWrapper.tsx
+++ b/frontend/pages/admin/AdminWrapper.tsx
@@ -50,7 +50,7 @@ const AdminWrapper = ({
     },
     {
       name: "Fleets",
-      pathname: PATHS.ADMIN_TEAMS,
+      pathname: PATHS.ADMIN_FLEETS,
       exclude: !isPremiumTier,
     },
   ];

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -35,7 +35,7 @@ const Agents = ({
 }: IAppConfigFormProps): JSX.Element => {
   const gitOpsModeEnabled = appConfig.gitops.gitops_mode_enabled;
 
-  const { ADMIN_FLEETS: ADMIN_TEAMS } = paths;
+  const { ADMIN_FLEETS } = paths;
 
   const [formData, setFormData] = useState<IAgentOptionsFormData>({
     agentOptions: agentOptionsToYaml(appConfig.agent_options),
@@ -103,7 +103,7 @@ const Agents = ({
             <div>
               These options are not applied to hosts in a fleet. To update agent
               options for hosts in a fleet, head to the&nbsp;
-              <CustomLink url={ADMIN_TEAMS} text="Fleets page" />.
+              <CustomLink url={ADMIN_FLEETS} text="Fleets page" />.
             </div>
           </InfoBanner>
         ) : (

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -35,7 +35,7 @@ const Agents = ({
 }: IAppConfigFormProps): JSX.Element => {
   const gitOpsModeEnabled = appConfig.gitops.gitops_mode_enabled;
 
-  const { ADMIN_TEAMS } = paths;
+  const { ADMIN_FLEETS: ADMIN_TEAMS } = paths;
 
   const [formData, setFormData] = useState<IAgentOptionsFormData>({
     agentOptions: agentOptionsToYaml(appConfig.agent_options),

--- a/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamDetailsWrapper/TeamDetailsWrapper.tsx
@@ -47,15 +47,15 @@ interface ITeamDetailsSubNavItem {
 const teamDetailsSubNav: ITeamDetailsSubNavItem[] = [
   {
     name: "Users",
-    getPathname: PATHS.TEAM_DETAILS_USERS,
+    getPathname: PATHS.FLEET_DETAILS_USERS,
   },
   {
     name: "Agent options",
-    getPathname: PATHS.TEAM_DETAILS_OPTIONS,
+    getPathname: PATHS.FLEET_DETAILS_OPTIONS,
   },
   {
     name: "Settings",
-    getPathname: PATHS.TEAM_DETAILS_SETTINGS,
+    getPathname: PATHS.FLEET_DETAILS_SETTINGS,
   },
 ];
 
@@ -301,7 +301,7 @@ const TeamDetailsWrapper = ({
 
     try {
       await teamsAPI.destroy(teamIdForApi);
-      router.push(PATHS.ADMIN_TEAMS);
+      router.push(PATHS.ADMIN_FLEETS);
       renderFlash("success", "Fleet removed");
     } catch (response) {
       renderFlash("error", "Something went wrong removing the fleet");
@@ -393,7 +393,7 @@ const TeamDetailsWrapper = ({
       <>
         {isGlobalAdmin ? (
           <div className={`${baseClass}__header-links`}>
-            <BackButton text="Back to fleets" path={PATHS.ADMIN_TEAMS} />
+            <BackButton text="Back to fleets" path={PATHS.ADMIN_FLEETS} />
           </div>
         ) : (
           <></>

--- a/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamTableConfig.tsx
@@ -64,7 +64,7 @@ const generateTableHeaders = (
       Cell: (cellProps: ICellProps) => (
         <LinkCell
           value={cellProps.cell.value}
-          path={PATHS.TEAM_DETAILS_USERS(cellProps.row.original.id)}
+          path={PATHS.FLEET_DETAILS_USERS(cellProps.row.original.id)}
         />
       ),
     },

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -392,7 +392,7 @@ const UserForm = ({
           catches up or&nbsp;
           <Link
             className={`${baseClass}__create-team-link`}
-            to={PATHS.ADMIN_TEAMS}
+            to={PATHS.ADMIN_FLEETS}
           >
             create a fleet
           </Link>

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tsx
@@ -92,7 +92,7 @@ const TransferHostModal = ({
             <p>
               Fleet not here?{" "}
               <Link
-                to={PATHS.ADMIN_TEAMS}
+                to={PATHS.ADMIN_FLEETS}
                 className={`${baseClass}__team-link`}
               >
                 Create a fleet

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -961,7 +961,7 @@ const HostDetailsPage = ({
 
   const onClickAddQuery = () => {
     router.push(
-      getPathWithQueryParams(PATHS.NEW_QUERY, {
+      getPathWithQueryParams(PATHS.NEW_REPORT, {
         fleet_id: currentTeam?.id || location.query.fleet_id,
         host_id: hostIdFromURL,
       })

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/SelectQueryModal/SelectQueryModal.tsx
@@ -74,7 +74,7 @@ const SelectQueryModal = ({
   const onQueryHostCustom = () => {
     setSelectedQueryTargetsByType(DEFAULT_TARGETS_BY_TYPE);
     router.push(
-      getPathWithQueryParams(PATHS.NEW_QUERY, {
+      getPathWithQueryParams(PATHS.NEW_REPORT, {
         host_id: hostId,
         fleet_id: currentTeamId,
       })
@@ -84,7 +84,7 @@ const SelectQueryModal = ({
   const onQueryHostSaved = (selectedQuery: ISchedulableQuery) => {
     setSelectedQueryTargetsByType(DEFAULT_TARGETS_BY_TYPE);
     router.push(
-      getPathWithQueryParams(PATHS.EDIT_QUERY(selectedQuery.id), {
+      getPathWithQueryParams(PATHS.EDIT_REPORT(selectedQuery.id), {
         host_id: hostId,
         fleet_id: currentTeamId,
       })

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -39,7 +39,7 @@ const HostQueryReport = ({
   const queryId = Number(query_id);
 
   if (globalReportsDisabled) {
-    router.push(PATHS.HOST_QUERIES(hostId));
+    router.push(PATHS.HOST_REPORTS(hostId));
   }
 
   const [showQuery, setShowQuery] = useState(false);
@@ -97,7 +97,7 @@ const HostQueryReport = ({
 
   // previous reroute can be done before API call, not this one, hence 2
   if (queryDiscardData) {
-    router.push(PATHS.HOST_QUERIES(hostId));
+    router.push(PATHS.HOST_REPORTS(hostId));
   }
 
   // Updates title that shows up on browser tabs
@@ -111,7 +111,7 @@ const HostQueryReport = ({
 
   const HQRHeader = useCallback(() => {
     const fullReportPath = getPathWithQueryParams(
-      PATHS.QUERY_DETAILS(queryId),
+      PATHS.REPORT_DETAILS(queryId),
       { fleet_id: currentTeam?.id }
     );
     return (

--- a/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/HostQueries.tsx
@@ -89,7 +89,7 @@ const HostQueries = ({
       if (!hostId || !queryId || !should_link_to_hqr || queryReportsDisabled) {
         return;
       }
-      router.push(`${PATHS.HOST_QUERY_REPORT(hostId, queryId)}`);
+      router.push(`${PATHS.HOST_REPORT_RESULTS(hostId, queryId)}`);
     },
     [hostId, queryReportsDisabled, router]
   );

--- a/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
+++ b/frontend/pages/hosts/details/cards/Queries/ReportUpdatedCell/ReportUpdatedCell.tsx
@@ -118,7 +118,7 @@ const ReportUpdatedCell = ({
   const onClick = () => {
     hostId &&
       queryId &&
-      browserHistory.push(PATHS.HOST_QUERY_REPORT(hostId, queryId));
+      browserHistory.push(PATHS.HOST_REPORT_RESULTS(hostId, queryId));
   };
 
   return (

--- a/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/ManageQueriesPage.tsx
@@ -194,7 +194,7 @@ const ManageQueriesPage = ({
   const onCreateQueryClick = useCallback(() => {
     setLastEditedQueryBody(DEFAULT_QUERY.query);
     router.push(
-      getPathWithQueryParams(PATHS.NEW_QUERY, { fleet_id: currentTeamId })
+      getPathWithQueryParams(PATHS.NEW_REPORT, { fleet_id: currentTeamId })
     );
   }, [currentTeamId, router, setLastEditedQueryBody]);
 

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTable.tsx
@@ -155,7 +155,7 @@ const QueriesTable = ({
       newQueryParams.fleet_id = queryParams?.fleet_id;
 
       const locationPath = getNextLocationPath({
-        pathPrefix: PATHS.MANAGE_QUERIES,
+        pathPrefix: PATHS.MANAGE_REPORTS,
         queryParams: { ...queryParams, ...newQueryParams },
       });
 
@@ -209,7 +209,7 @@ const QueriesTable = ({
     (selectedTargetedPlatform: SingleValue<CustomOptionType>) => {
       router?.push(
         getNextLocationPath({
-          pathPrefix: PATHS.MANAGE_QUERIES,
+          pathPrefix: PATHS.MANAGE_REPORTS,
           queryParams: {
             ...queryParams,
             page: 0,
@@ -229,7 +229,7 @@ const QueriesTable = ({
   const handleRowSelect = (row: IRowProps) => {
     if (row.original.id) {
       router?.push(
-        getPathWithQueryParams(PATHS.QUERY_DETAILS(row.original.id), {
+        getPathWithQueryParams(PATHS.REPORT_DETAILS(row.original.id), {
           fleet_id: currentTeamId,
         })
       );

--- a/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
+++ b/frontend/pages/queries/ManageQueriesPage/components/QueriesTable/QueriesTableConfig.tsx
@@ -175,7 +175,7 @@ const generateColumnConfigs = ({
                   )}
               </>
             }
-            path={getPathWithQueryParams(PATHS.QUERY_DETAILS(id), {
+            path={getPathWithQueryParams(PATHS.REPORT_DETAILS(id), {
               fleet_id: team_id ?? currentTeamId,
             })}
           />

--- a/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
+++ b/frontend/pages/queries/details/QueryDetailsPage/QueryDetailsPage.tsx
@@ -70,7 +70,7 @@ const QueryDetailsPage = ({
 }: IQueryDetailsPageProps): JSX.Element => {
   const queryId = parseInt(paramsQueryId, 10);
   if (isNaN(queryId)) {
-    router.push(PATHS.MANAGE_QUERIES);
+    router.push(PATHS.MANAGE_REPORTS);
   }
   const queryParams = location.query;
 
@@ -262,7 +262,7 @@ const QueryDetailsPage = ({
           PATHS.HOST_DETAILS(hostId, currentTeamId)
         );
 
-      return getPathWithQueryParams(PATHS.MANAGE_QUERIES, {
+      return getPathWithQueryParams(PATHS.MANAGE_REPORTS, {
         fleet_id: currentTeamId,
       });
     };
@@ -308,7 +308,7 @@ const QueryDetailsPage = ({
                           queryId &&
                             router.push(
                               getPathWithQueryParams(
-                                PATHS.LIVE_QUERY(queryId),
+                                PATHS.LIVE_REPORT(queryId),
                                 {
                                   host_id: hostId,
                                   fleet_id: currentTeamId,
@@ -338,7 +338,7 @@ const QueryDetailsPage = ({
                     onClick={() => {
                       queryId &&
                         router.push(
-                          getPathWithQueryParams(PATHS.EDIT_QUERY(queryId), {
+                          getPathWithQueryParams(PATHS.EDIT_REPORT(queryId), {
                             fleet_id: currentTeamId,
                             host_id: hostId,
                           })

--- a/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
+++ b/frontend/pages/queries/details/components/QueryReport/QueryReportTableConfig.tsx
@@ -80,7 +80,7 @@ const generateReportColumnConfigsFromResults = (
           return (
             <LinkCell
               value={cellProps.cell.value}
-              path={PATHS.HOST_QUERY_REPORT(hostID, queryId)}
+              path={PATHS.HOST_REPORT_RESULTS(hostID, queryId)}
             />
           );
         }

--- a/frontend/pages/queries/edit/EditQueryPage.tsx
+++ b/frontend/pages/queries/edit/EditQueryPage.tsx
@@ -214,7 +214,7 @@ const EditQueryPage = ({
     ) {
       // Reroute to query report page still maintains query params for live query purposes
       router.push(
-        getPathWithQueryParams(PATHS.QUERY_DETAILS(queryId), {
+        getPathWithQueryParams(PATHS.REPORT_DETAILS(queryId), {
           host_id: location.query.host_id,
           fleet_id: location.query.fleet_id,
         })
@@ -265,7 +265,7 @@ const EditQueryPage = ({
       try {
         const { query } = await queryAPI.create(formData);
         router.push(
-          getPathWithQueryParams(PATHS.QUERY_DETAILS(query.id), {
+          getPathWithQueryParams(PATHS.REPORT_DETAILS(query.id), {
             fleet_id: query.team_id,
             host_id: hostId,
           })
@@ -374,7 +374,7 @@ const EditQueryPage = ({
   // Returns to queries details page, manage queries page with filters, or default manage queries page
   const backPath = () => {
     if (queryId) {
-      return getPathWithQueryParams(PATHS.QUERY_DETAILS(queryId), {
+      return getPathWithQueryParams(PATHS.REPORT_DETAILS(queryId), {
         fleet_id: currentTeamId,
         host_id: hostId,
       });
@@ -386,7 +386,7 @@ const EditQueryPage = ({
 
     if (filteredQueriesPath) return filteredQueriesPath;
 
-    return getPathWithQueryParams(PATHS.MANAGE_QUERIES, {
+    return getPathWithQueryParams(PATHS.MANAGE_REPORTS, {
       fleet_id: currentTeamId,
     });
   };

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -637,7 +637,7 @@ const EditQueryForm = ({
             <Button
               onClick={() => {
                 router.push(
-                  getPathWithQueryParams(PATHS.LIVE_QUERY(queryIdForEdit), {
+                  getPathWithQueryParams(PATHS.LIVE_REPORT(queryIdForEdit), {
                     host_id: hostId,
                     fleet_id: apiTeamIdForQuery,
                   })
@@ -932,7 +932,7 @@ const EditQueryForm = ({
                     setEditingExistingQuery(true); // Persists edited query data through live query flow
                   }
                   router.push(
-                    getPathWithQueryParams(PATHS.LIVE_QUERY(queryIdForEdit), {
+                    getPathWithQueryParams(PATHS.LIVE_REPORT(queryIdForEdit), {
                       host_id: hostId,
                       fleet_id: currentTeamId,
                     })

--- a/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
@@ -162,7 +162,7 @@ const SaveAsNewQueryModal = ({
       setIsSaving(false);
       renderFlash("success", `Successfully added report ${newQuery.name}.`);
       router.push(
-        getPathWithQueryParams(PATHS.QUERY_DETAILS(newQuery.id), {
+        getPathWithQueryParams(PATHS.REPORT_DETAILS(newQuery.id), {
           fleet_id: newQuery.team_id,
           host_id: hostId,
         })

--- a/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
+++ b/frontend/pages/queries/live/LiveQueryPage/LiveQueryPage.tsx
@@ -86,7 +86,7 @@ const RunQueryPage = ({
 
   // Reroute users out of live flow when live queries are globally disabled
   if (disabledLiveQuery) {
-    const path = queryId ? PATHS.QUERY_DETAILS(queryId) : PATHS.NEW_QUERY;
+    const path = queryId ? PATHS.REPORT_DETAILS(queryId) : PATHS.NEW_REPORT;
 
     router.push(
       getPathWithQueryParams(path, {
@@ -161,7 +161,7 @@ const RunQueryPage = ({
   }, [location.pathname, storedQuery?.name]);
 
   const goToQueryEditor = useCallback(() => {
-    const path = queryId ? PATHS.EDIT_QUERY(queryId) : PATHS.NEW_QUERY;
+    const path = queryId ? PATHS.EDIT_REPORT(queryId) : PATHS.NEW_REPORT;
 
     router.push(getPathWithQueryParams(path, { fleet_id: currentTeamId }));
   }, []);

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -212,7 +212,8 @@ const routes = (
                   <Route path="users" component={AdminUserManagementPage} />
                 </Route>
                 <Route component={PremiumRoutes}>
-                  <Route path="teams" component={AdminTeamManagementPage} />
+                  <Redirect from="teams" to="fleets" />
+                  <Route path="fleets" component={AdminTeamManagementPage} />
                 </Route>
               </Route>
             </Route>
@@ -236,7 +237,11 @@ const routes = (
             <Redirect from="integrations/vpp/setup" to="integrations/mdm/vpp" />
             <Route path="integrations/mdm/vpp" component={VppPage} />
 
-            <Route path="teams" component={TeamDetailsWrapper}>
+            <Redirect from="teams" to="fleets" />
+            <Redirect from="teams/users" to="fleets/users" />
+            <Redirect from="teams/options" to="fleets/options" />
+            <Redirect from="teams/settings" to="fleets/settings" />
+            <Route path="fleets" component={TeamDetailsWrapper}>
               <Redirect from="members" to="users" />
               <Route path="users" component={UsersPage} />
               <Route path="options" component={AgentOptionsPage} />
@@ -271,7 +276,7 @@ const routes = (
             />
             <Route path=":host_id" component={HostDetailsPage}>
               <IndexRedirect to="details" />
-              <Redirect from="schedule" to="queries" />
+              <Redirect from="schedule" to="reports" />
               <Route path="details" component={HostDetailsPage} />
               <Route path="scripts" component={HostDetailsPage} />
               <Route path="software" component={HostDetailsPage}>
@@ -282,9 +287,13 @@ const routes = (
               <Route path="policies" component={HostDetailsPage} />
             </Route>
 
+            <Redirect
+              from=":host_id/queries/:query_id"
+              to=":host_id/reports/:query_id"
+            />
             <Route
               // outside of '/hosts' nested routes to avoid react-tabs-specific routing issues
-              path=":host_id/queries/:query_id"
+              path=":host_id/reports/:query_id"
               component={HostQueryReport}
             />
           </Route>
@@ -370,7 +379,9 @@ const routes = (
               </Route>
             </Route>
           </Route>
-          <Route path="queries">
+          <Redirect from="queries" to="reports" />
+          <Redirect from="queries/:id" to="reports/:id" />
+          <Route path="reports">
             <IndexRedirect to="manage" />
             <Route path="manage" component={ManageQueriesPage} />
             <Route component={AuthAnyMaintainerAdminObserverPlusRoutes}>

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -247,9 +247,9 @@ const routes = (
               <Route path="options" component={AgentOptionsPage} />
               <Route path="settings" component={TeamSettings} />
             </Route>
-            <Redirect from="teams/:team_id" to="teams" />
-            <Redirect from="teams/:team_id/users" to="teams" />
-            <Redirect from="teams/:team_id/options" to="teams" />
+            <Redirect from="teams/:team_id" to="fleets" />
+            <Redirect from="teams/:team_id/users" to="fleets" />
+            <Redirect from="teams/:team_id/options" to="fleets" />
           </Route>
           <Route path="labels">
             <IndexRedirect to="manage" />
@@ -380,7 +380,12 @@ const routes = (
             </Route>
           </Route>
           <Redirect from="queries" to="reports" />
+          <Redirect from="queries/manage" to="reports/manage" />
+          <Redirect from="queries/new" to="reports/new" />
+          <Redirect from="queries/new/live" to="reports/new/live" />
           <Redirect from="queries/:id" to="reports/:id" />
+          <Redirect from="queries/:id/edit" to="reports/:id/edit" />
+          <Redirect from="queries/:id/live" to="reports/:id/live" />
           <Route path="reports">
             <IndexRedirect to="manage" />
             <Route path="manage" component={ManageQueriesPage} />

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -276,7 +276,6 @@ const routes = (
             />
             <Route path=":host_id" component={HostDetailsPage}>
               <IndexRedirect to="details" />
-              <Redirect from="schedule" to="reports" />
               <Route path="details" component={HostDetailsPage} />
               <Route path="scripts" component={HostDetailsPage} />
               <Route path="software" component={HostDetailsPage}>

--- a/frontend/router/page_titles.ts
+++ b/frontend/router/page_titles.ts
@@ -16,10 +16,10 @@ export default [
     title: `Software | ${DOCUMENT_TITLE_SUFFIX}`,
   },
   {
-    path: PATHS.MANAGE_QUERIES,
+    path: PATHS.MANAGE_REPORTS,
     title: `Reports | ${DOCUMENT_TITLE_SUFFIX}`,
   },
-  { path: PATHS.NEW_QUERY, title: `New report | ${DOCUMENT_TITLE_SUFFIX}` },
+  { path: PATHS.NEW_REPORT, title: `New report | ${DOCUMENT_TITLE_SUFFIX}` },
   {
     path: PATHS.MANAGE_POLICIES,
     title: `Policies | ${DOCUMENT_TITLE_SUFFIX}`,

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -68,7 +68,7 @@ export default {
   ADMIN_INTEGRATIONS_SSO_END_USERS: `${INTEGRATIONS_PREFIX}/sso/end-users`,
   ADMIN_INTEGRATIONS_HOST_STATUS_WEBHOOK: `${INTEGRATIONS_PREFIX}/host-status-webhook`,
 
-  ADMIN_TEAMS: `${URL_PREFIX}/settings/teams`,
+  ADMIN_FLEETS: `${URL_PREFIX}/settings/fleets`,
   ADMIN_ORGANIZATION: `${URL_PREFIX}/settings/organization`,
   ADMIN_ORGANIZATION_INFO: `${URL_PREFIX}/settings/organization/info`,
   ADMIN_ORGANIZATION_WEBADDRESS: `${URL_PREFIX}/settings/organization/webaddress`,
@@ -117,12 +117,12 @@ export default {
   },
   PACK: (packId: number): string => `${URL_PREFIX}/packs/${packId}`,
   EDIT_LABEL: (labelId: number): string => `${URL_PREFIX}/labels/${labelId}`,
-  EDIT_QUERY: (queryId: number): string =>
-    `${URL_PREFIX}/queries/${queryId}/edit`,
-  LIVE_QUERY: (queryId: number | null): string =>
-    `${URL_PREFIX}/queries/${queryId || "new"}/live`,
-  QUERY_DETAILS: (queryId: number): string =>
-    `${URL_PREFIX}/queries/${queryId}`,
+  EDIT_REPORT: (queryId: number): string =>
+    `${URL_PREFIX}/reports/${queryId}/edit`,
+  LIVE_REPORT: (queryId: number | null): string =>
+    `${URL_PREFIX}/reports/${queryId || "new"}/live`,
+  REPORT_DETAILS: (queryId: number): string =>
+    `${URL_PREFIX}/reports/${queryId}`,
   EDIT_POLICY: (policyId: number): string =>
     `${URL_PREFIX}/policies/${policyId}`,
   FORGOT_PASSWORD: `${URL_PREFIX}/login/forgot`,
@@ -159,14 +159,14 @@ export default {
   HOST_LIBRARY: (id: number): string => {
     return `${URL_PREFIX}/hosts/${id}/software/library`;
   },
-  HOST_QUERIES: (id: number): string => {
-    return `${URL_PREFIX}/hosts/${id}/queries`;
+  HOST_REPORTS: (id: number): string => {
+    return `${URL_PREFIX}/hosts/${id}/reports`;
   },
   HOST_POLICIES: (id: number): string => {
     return `${URL_PREFIX}/hosts/${id}/policies`;
   },
-  HOST_QUERY_REPORT: (hostId: number, queryId: number): string =>
-    `${URL_PREFIX}/hosts/${hostId}/queries/${queryId}`,
+  HOST_REPORT_RESULTS: (hostId: number, queryId: number): string =>
+    `${URL_PREFIX}/hosts/${hostId}/reports/${queryId}`,
   DEVICE_USER_DETAILS: (deviceAuthToken: string): string => {
     return `${URL_PREFIX}/device/${deviceAuthToken}`;
   },
@@ -183,31 +183,31 @@ export default {
     return `${URL_PREFIX}/api/v1/fleet/device/${deviceAuthToken}/transparency`;
   },
 
-  TEAM_DETAILS_USERS: (teamId?: number): string => {
+  FLEET_DETAILS_USERS: (teamId?: number): string => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/users?fleet_id=${teamId}`;
+      return `${URL_PREFIX}/settings/fleets/users?fleet_id=${teamId}`;
     }
-    return `${URL_PREFIX}/settings/teams`;
+    return `${URL_PREFIX}/settings/fleets`;
   },
-  TEAM_DETAILS_OPTIONS: (teamId?: number): string => {
+  FLEET_DETAILS_OPTIONS: (teamId?: number): string => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/options?fleet_id=${teamId}`;
+      return `${URL_PREFIX}/settings/fleets/options?fleet_id=${teamId}`;
     }
-    return `${URL_PREFIX}/settings/teams`;
+    return `${URL_PREFIX}/settings/fleets`;
   },
-  TEAM_DETAILS_SETTINGS: (teamId?: number) => {
+  FLEET_DETAILS_SETTINGS: (teamId?: number) => {
     if (teamId !== undefined && teamId > 0) {
-      return `${URL_PREFIX}/settings/teams/settings?fleet_id=${teamId}`;
+      return `${URL_PREFIX}/settings/fleets/settings?fleet_id=${teamId}`;
     }
-    return `${URL_PREFIX}/settings/teams`;
+    return `${URL_PREFIX}/settings/fleets`;
   },
   MANAGE_PACKS: `${URL_PREFIX}/packs/manage`,
   NEW_PACK: `${URL_PREFIX}/packs/new`,
-  MANAGE_QUERIES: `${URL_PREFIX}/queries/manage`,
+  MANAGE_REPORTS: `${URL_PREFIX}/reports/manage`,
   MANAGE_SCHEDULE: `${URL_PREFIX}/schedule/manage`,
   MANAGE_POLICIES: `${URL_PREFIX}/policies/manage`,
   NEW_POLICY: `${URL_PREFIX}/policies/new`,
-  NEW_QUERY: `${URL_PREFIX}/queries/new`,
+  NEW_REPORT: `${URL_PREFIX}/reports/new`,
   RESET_PASSWORD: `${URL_PREFIX}/login/reset`,
   SETUP: `${URL_PREFIX}/setup`,
   ACCOUNT: `${URL_PREFIX}/account`,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #41030

# Details

This PR updates front-end routes and redirects the old routes to the new ones. 

While I typically have shied away from renaming vars and constants in this phase of the renaming work, I chose to rename the path constants here because they're a lot less useful when they have names that don't correspond to the paths they're representing. I did the renames using VSCode's "Rename Symbol" feature which automatically finds and fixes any references. I then asked Claude to verify the changes and it didn't find any dangling references (also the code would fail to compile unless all the new names collided with old ones).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a

## Testing

- [ ] Added/updated automated tests
no relevant tests exist
- [X] QA'd all new/changed functionality manually

## Reports (formerly Queries)

**New routes:**
- [x] /reports/manage — Reports list page
- [x] /reports/new — New report editor
- [x] /reports/new/live — New report live query
- [x] /reports/:id — Report details
- [x] /reports/:id/edit — Edit report
- [x] /reports/:id/live — Live report run

**Redirects from old routes:**
- [x] /queries → /reports
- [x] /queries/manage → /reports/manage
- [x] /queries/new → /reports/new
- [x] /queries/new/live → /reports/new/live
- [x] /queries/:id → /reports/:id
- [x] /queries/:id/edit → /reports/:id/edit
- [x] /queries/:id/live → /reports/:id/live

## Host Reports (formerly Host Queries)

**New routes:**
- [x] /hosts/:host_id/reports/:query_id — Host report results

**Redirects from old routes:**
- [ ] ~/hosts/:host_id/schedule → /hosts/:host_id/reports~ <- this is not a real URL; removed current broken redirect
- [x] /hosts/:host_id/queries/:query_id → /hosts/:host_id/reports/:query_id

## Fleets (formerly Teams)

**New routes:**
- [x] /settings/fleets — Fleets list page
- [x] /settings/fleets/users?fleet_id=:id — Fleet users
- [x] /settings/fleets/options?fleet_id=:id — Fleet agent options
- [x] /settings/fleets/settings?fleet_id=:id — Fleet settings

**Redirects from old routes:**
- [x] /settings/teams → /settings/fleets
- [x] /settings/teams/users → /settings/fleets/users
- [x] /settings/teams/options → /settings/fleets/options
- [x] /settings/teams/settings → /settings/fleets/settings
- [x] /settings/teams/:team_id → /settings/fleets
- [x] /settings/teams/:team_id/users → /settings/fleets
- [x] /settings/teams/:team_id/options → /settings/fleets

**Navigation & Links**

- [x] Top nav "Reports" link goes to /reports/manage
- [x] User menu team switcher navigates to /settings/fleets/users?fleet_id=:id
- [x] Admin sidebar "Fleets" tab goes to /settings/fleets
- [x] "Create a fleet" links (user form, transfer host modal) go to /settings/fleets
- [x] "Back to fleets" button on fleet details goes to /settings/fleets
- [x] Fleet table name links go to /settings/fleets/users?fleet_id=:id
- [x] Host details "Add query" button goes to /reports/new
- [x] Select query modal links go to /reports/new and /reports/:id/edit
- [x] Query report "full report" link goes to /reports/:id
- [x] Browser tab titles show correct names for report pages

**Query params preserved through redirects**

- [x] /queries/:id?fleet_id=1 → /reports/:id?fleet_id=1
- [x] /settings/teams/users?fleet_id=1 → /settings/fleets/users?fleet_id=1

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
