### PR TITLE
Pass along android fully_managed flag through SSO callback (#41120)

### DIFF
--- a/server/service/frontend.go
+++ b/server/service/frontend.go
@@ -224,7 +224,13 @@ func renderEnrollPage(w io.Writer, appCfg *fleet.AppConfig, urlPrefix, enrollSec
 }
 
 func initiateOTAEnrollSSO(svc fleet.Service, w http.ResponseWriter, r *http.Request, enrollSecret string) error {
-	ssnID, ssnDurationSecs, idpURL, err := svc.InitiateMDMSSO(r.Context(), "ota_enroll", "/enroll?enroll_secret="+url.QueryEscape(enrollSecret), "")
+	requestURL := "/enroll?enroll_secret=" + url.QueryEscape(enrollSecret)
+	// pass the fully_managed parameter for Android enrollments so that it is returned after the callback, else the
+	// user won't get the android fully managed page
+	if r.URL.Query().Get("fully_managed") == "true" {
+		requestURL += "&fully_managed=true"
+	}
+	ssnID, ssnDurationSecs, idpURL, err := svc.InitiateMDMSSO(r.Context(), "ota_enroll", requestURL, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41088
CHerrypicking this PR: https://github.com/fleetdm/fleet/pull/41120

Fixes an unreleased bug where the Android fully managed enroll page wouldn't be shown if end user auth was enabled. Passes along the flag to the SSO callback code. There doesn't seem to be any tests that cover this enroll page so I didn't add/update any however the change is simple and manually tested to verify the device enrolls and the EUA user link gets set

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
