### PR TITLE
add tls skip-verify to MDM assets tool to allow connecting to TLS required DB's

### DIFF
--- a/tools/mdm/assets/main.go
+++ b/tools/mdm/assets/main.go
@@ -65,7 +65,7 @@ func setupSharedFlags() {
 func setupDS(privateKey, userName, password, address, name string) *mysql.Datastore {
 	db, err := sql.Open(
 		"mysql",
-		fmt.Sprintf("%s:%s@tcp(%s)/?multiStatements=true", testUsername, testPassword, testAddress),
+		fmt.Sprintf("%s:%s@tcp(%s)/?multiStatements=true&tls=skip-verify", testUsername, testPassword, testAddress),
 	)
 	if err != nil {
 		log.Fatal("opening MySQL connection:", err)
@@ -73,10 +73,11 @@ func setupDS(privateKey, userName, password, address, name string) *mysql.Datast
 	defer db.Close()
 
 	mysqlCfg := config.MysqlConfig{
-		Username: userName,
-		Password: password,
-		Address:  address,
-		Database: name,
+		Username:  userName,
+		Password:  password,
+		Address:   address,
+		Database:  name,
+		TLSConfig: "skip-verify",
 	}
 	ds, err := mysql.New(
 		mysqlCfg,


### PR DESCRIPTION
Small change to allow extracting MDM assets with the new change to cloud DB's
https://fleetdm.slack.com/archives/C051QJU3D0V/p1772813030600689

No need for configured value, skip-verify works locally and for cloud.