### PR TITLE
Crypto package for db encryption

### DIFF
--- a/server/crypto/aes.go
+++ b/server/crypto/aes.go
@@ -13,6 +13,10 @@ import (
 // The key must be 32 bytes for AES-256.
 // Returns [nonce || ciphertext].
 func EncryptAESGCM(plainText []byte, key string) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("invalid key size: got %d bytes, AES-256 requires exactly 32 bytes", len(key))
+	}
+
 	block, err := aes.NewCipher([]byte(key))
 	if err != nil {
 		return nil, fmt.Errorf("create cipher: %w", err)
@@ -34,6 +38,10 @@ func EncryptAESGCM(plainText []byte, key string) ([]byte, error) {
 // DecryptAESGCM decrypts ciphertext that was encrypted with EncryptAESGCM.
 // The key must be the same 32-byte key used for encryption.
 func DecryptAESGCM(encrypted []byte, key string) ([]byte, error) {
+	if len(key) != 32 {
+		return nil, fmt.Errorf("invalid key size: got %d bytes, AES-256 requires exactly 32 bytes", len(key))
+	}
+
 	block, err := aes.NewCipher([]byte(key))
 	if err != nil {
 		return nil, fmt.Errorf("create cipher: %w", err)

--- a/server/crypto/aes.go
+++ b/server/crypto/aes.go
@@ -1,0 +1,54 @@
+// Package crypto provides cryptographic utilities for Fleet.
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// EncryptAESGCM encrypts plaintext using AES-256-GCM with the given key.
+// The key must be 32 bytes for AES-256.
+// Returns [nonce || ciphertext].
+func EncryptAESGCM(plainText []byte, key string) ([]byte, error) {
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create gcm: %w", err)
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	return aesGCM.Seal(nonce, nonce, plainText, nil), nil
+}
+
+// DecryptAESGCM decrypts ciphertext that was encrypted with EncryptAESGCM.
+// The key must be the same 32-byte key used for encryption.
+func DecryptAESGCM(encrypted []byte, key string) ([]byte, error) {
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return nil, fmt.Errorf("create cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create gcm: %w", err)
+	}
+
+	nonceSize := aesGCM.NonceSize()
+	if len(encrypted) < nonceSize+1 {
+		return nil, fmt.Errorf("malformed ciphertext: length %d is less than minimum required %d", len(encrypted), nonceSize+1)
+	}
+
+	nonce, ciphertext := encrypted[:nonceSize], encrypted[nonceSize:]
+	return aesGCM.Open(nil, nonce, ciphertext, nil)
+}

--- a/server/crypto/aes_test.go
+++ b/server/crypto/aes_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEncryptDecryptAESGCM(t *testing.T) {
@@ -23,23 +26,15 @@ func TestEncryptDecryptAESGCM(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			encrypted, err := EncryptAESGCM(tt.plaintext, key)
-			if err != nil {
-				t.Fatalf("EncryptAESGCM() error = %v", err)
-			}
+			require.NoError(t, err, "EncryptAESGCM()")
 
 			// Encrypted should be longer than plaintext (nonce + auth tag)
-			if len(encrypted) <= len(tt.plaintext) {
-				t.Errorf("encrypted length %d should be > plaintext length %d", len(encrypted), len(tt.plaintext))
-			}
+			assert.Greater(t, len(encrypted), len(tt.plaintext), "encrypted length should be > plaintext length")
 
 			decrypted, err := DecryptAESGCM(encrypted, key)
-			if err != nil {
-				t.Fatalf("DecryptAESGCM() error = %v", err)
-			}
+			require.NoError(t, err, "DecryptAESGCM()")
 
-			if !bytes.Equal(decrypted, tt.plaintext) {
-				t.Errorf("DecryptAESGCM() = %v, want %v", decrypted, tt.plaintext)
-			}
+			assert.True(t, bytes.Equal(decrypted, tt.plaintext), "DecryptAESGCM() result mismatch")
 		})
 	}
 }
@@ -50,14 +45,10 @@ func TestDecryptAESGCM_InvalidKey(t *testing.T) {
 
 	plaintext := []byte("secret message")
 	encrypted, err := EncryptAESGCM(plaintext, key)
-	if err != nil {
-		t.Fatalf("EncryptAESGCM() error = %v", err)
-	}
+	require.NoError(t, err, "EncryptAESGCM()")
 
 	_, err = DecryptAESGCM(encrypted, wrongKey)
-	if err == nil {
-		t.Error("DecryptAESGCM() with wrong key should fail")
-	}
+	assert.Error(t, err, "DecryptAESGCM() with wrong key should fail")
 }
 
 func TestDecryptAESGCM_MalformedCiphertext(t *testing.T) {
@@ -76,9 +67,7 @@ func TestDecryptAESGCM_MalformedCiphertext(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := DecryptAESGCM(tt.ciphertext, key)
-			if err == nil {
-				t.Errorf("DecryptAESGCM() with %s ciphertext should fail", tt.name)
-			}
+			assert.Error(t, err, "DecryptAESGCM() with %s ciphertext should fail", tt.name)
 		})
 	}
 }
@@ -102,8 +91,10 @@ func TestEncryptAESGCM_InvalidKeyLength(t *testing.T) {
 			key := strings.Repeat("a", tt.keyLen)
 
 			_, err := EncryptAESGCM([]byte("test"), key)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("EncryptAESGCM() error = %v, wantErr %v", err, tt.wantErr)
+			if tt.wantErr {
+				assert.Error(t, err, "EncryptAESGCM() should fail")
+			} else {
+				assert.NoError(t, err, "EncryptAESGCM() should succeed")
 			}
 		})
 	}
@@ -113,9 +104,7 @@ func TestDecryptAESGCM_InvalidKeyLength(t *testing.T) {
 	// First encrypt with valid key
 	validKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	encrypted, err := EncryptAESGCM([]byte("test"), validKey)
-	if err != nil {
-		t.Fatalf("EncryptAESGCM() error = %v", err)
-	}
+	require.NoError(t, err, "EncryptAESGCM()")
 
 	tests := []struct {
 		name   string
@@ -133,9 +122,7 @@ func TestDecryptAESGCM_InvalidKeyLength(t *testing.T) {
 			key := strings.Repeat("b", tt.keyLen)
 
 			_, err := DecryptAESGCM(encrypted, key)
-			if err == nil {
-				t.Errorf("DecryptAESGCM() with %d-byte key should fail", tt.keyLen)
-			}
+			assert.Error(t, err, "DecryptAESGCM() with %d-byte key should fail", tt.keyLen)
 		})
 	}
 }
@@ -145,16 +132,11 @@ func TestEncryptAESGCM_UniqueNonces(t *testing.T) {
 	plaintext := []byte("same message")
 
 	encrypted1, err := EncryptAESGCM(plaintext, key)
-	if err != nil {
-		t.Fatalf("first EncryptAESGCM() error = %v", err)
-	}
+	require.NoError(t, err, "first EncryptAESGCM()")
+
 	encrypted2, err := EncryptAESGCM(plaintext, key)
-	if err != nil {
-		t.Fatalf("second EncryptAESGCM() error = %v", err)
-	}
+	require.NoError(t, err, "second EncryptAESGCM()")
 
 	// Same plaintext should produce different ciphertext due to random nonce
-	if bytes.Equal(encrypted1, encrypted2) {
-		t.Error("encrypting same plaintext twice should produce different ciphertext")
-	}
+	assert.NotEqual(t, encrypted1, encrypted2, "encrypting same plaintext twice should produce different ciphertext")
 }

--- a/server/crypto/aes_test.go
+++ b/server/crypto/aes_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -62,18 +63,80 @@ func TestDecryptAESGCM_InvalidKey(t *testing.T) {
 func TestDecryptAESGCM_MalformedCiphertext(t *testing.T) {
 	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-	// Too short to contain nonce
-	_, err := DecryptAESGCM([]byte("short"), key)
-	if err == nil {
-		t.Error("DecryptAESGCM() with short ciphertext should fail")
+	tests := []struct {
+		name       string
+		ciphertext []byte
+	}{
+		{"empty", []byte{}},
+		{"one byte", []byte{0x01}},
+		{"too short for nonce", []byte("short")},
+		{"exactly nonce size", make([]byte, 12)}, // GCM nonce is 12 bytes, but no ciphertext
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := DecryptAESGCM(tt.ciphertext, key)
+			if err == nil {
+				t.Errorf("DecryptAESGCM() with %s ciphertext should fail", tt.name)
+			}
+		})
 	}
 }
 
 func TestEncryptAESGCM_InvalidKeyLength(t *testing.T) {
-	// AES requires 16, 24, or 32 byte keys
-	_, err := EncryptAESGCM([]byte("test"), "short")
-	if err == nil {
-		t.Error("EncryptAESGCM() with invalid key length should fail")
+	tests := []struct {
+		name    string
+		keyLen  int
+		wantErr bool
+	}{
+		{"empty key", 0, true},
+		{"too short", 5, true},
+		{"AES-128 rejected", 16, true},
+		{"AES-192 rejected", 24, true},
+		{"AES-256 accepted", 32, false},
+		{"too long", 64, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := strings.Repeat("a", tt.keyLen)
+
+			_, err := EncryptAESGCM([]byte("test"), key)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("EncryptAESGCM() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDecryptAESGCM_InvalidKeyLength(t *testing.T) {
+	// First encrypt with valid key
+	validKey := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	encrypted, err := EncryptAESGCM([]byte("test"), validKey)
+	if err != nil {
+		t.Fatalf("EncryptAESGCM() error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		keyLen int
+	}{
+		{"empty key", 0},
+		{"too short", 5},
+		{"AES-128 rejected", 16},
+		{"AES-192 rejected", 24},
+		{"too long", 64},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			key := strings.Repeat("b", tt.keyLen)
+
+			_, err := DecryptAESGCM(encrypted, key)
+			if err == nil {
+				t.Errorf("DecryptAESGCM() with %d-byte key should fail", tt.keyLen)
+			}
+		})
 	}
 }
 

--- a/server/crypto/aes_test.go
+++ b/server/crypto/aes_test.go
@@ -1,0 +1,91 @@
+package crypto
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncryptDecryptAESGCM(t *testing.T) {
+	// 32-byte key for AES-256 (simple test key to avoid false positive secret scanning warnings)
+	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	tests := []struct {
+		name      string
+		plaintext []byte
+	}{
+		{"empty", []byte{}},
+		{"short", []byte("hello")},
+		{"medium", []byte("this is a longer test message for encryption")},
+		{"with special chars", []byte("hello\x00world\ntest\ttab")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			encrypted, err := EncryptAESGCM(tt.plaintext, key)
+			if err != nil {
+				t.Fatalf("EncryptAESGCM() error = %v", err)
+			}
+
+			// Encrypted should be longer than plaintext (nonce + auth tag)
+			if len(encrypted) <= len(tt.plaintext) {
+				t.Errorf("encrypted length %d should be > plaintext length %d", len(encrypted), len(tt.plaintext))
+			}
+
+			decrypted, err := DecryptAESGCM(encrypted, key)
+			if err != nil {
+				t.Fatalf("DecryptAESGCM() error = %v", err)
+			}
+
+			if !bytes.Equal(decrypted, tt.plaintext) {
+				t.Errorf("DecryptAESGCM() = %v, want %v", decrypted, tt.plaintext)
+			}
+		})
+	}
+}
+
+func TestDecryptAESGCM_InvalidKey(t *testing.T) {
+	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	wrongKey := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+
+	plaintext := []byte("secret message")
+	encrypted, err := EncryptAESGCM(plaintext, key)
+	if err != nil {
+		t.Fatalf("EncryptAESGCM() error = %v", err)
+	}
+
+	_, err = DecryptAESGCM(encrypted, wrongKey)
+	if err == nil {
+		t.Error("DecryptAESGCM() with wrong key should fail")
+	}
+}
+
+func TestDecryptAESGCM_MalformedCiphertext(t *testing.T) {
+	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+	// Too short to contain nonce
+	_, err := DecryptAESGCM([]byte("short"), key)
+	if err == nil {
+		t.Error("DecryptAESGCM() with short ciphertext should fail")
+	}
+}
+
+func TestEncryptAESGCM_InvalidKeyLength(t *testing.T) {
+	// AES requires 16, 24, or 32 byte keys
+	_, err := EncryptAESGCM([]byte("test"), "short")
+	if err == nil {
+		t.Error("EncryptAESGCM() with invalid key length should fail")
+	}
+}
+
+func TestEncryptAESGCM_UniqueNonces(t *testing.T) {
+	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	plaintext := []byte("same message")
+
+	encrypted1, _ := EncryptAESGCM(plaintext, key)
+	encrypted2, _ := EncryptAESGCM(plaintext, key)
+
+	// Same plaintext should produce different ciphertext due to random nonce
+	if bytes.Equal(encrypted1, encrypted2) {
+		t.Error("encrypting same plaintext twice should produce different ciphertext")
+	}
+}

--- a/server/crypto/aes_test.go
+++ b/server/crypto/aes_test.go
@@ -144,8 +144,14 @@ func TestEncryptAESGCM_UniqueNonces(t *testing.T) {
 	key := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	plaintext := []byte("same message")
 
-	encrypted1, _ := EncryptAESGCM(plaintext, key)
-	encrypted2, _ := EncryptAESGCM(plaintext, key)
+	encrypted1, err := EncryptAESGCM(plaintext, key)
+	if err != nil {
+		t.Fatalf("first EncryptAESGCM() error = %v", err)
+	}
+	encrypted2, err := EncryptAESGCM(plaintext, key)
+	if err != nil {
+		t.Fatalf("second EncryptAESGCM() error = %v", err)
+	}
 
 	// Same plaintext should produce different ciphertext due to random nonce
 	if bytes.Equal(encrypted1, encrypted2) {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6078,9 +6078,9 @@ func decrypt(encrypted []byte, privateKey string) ([]byte, error) {
 	// Get the nonce size
 	nonceSize := aesGCM.NonceSize()
 
-	// Validate that encrypted data is long enough to contain at least the nonce
-	if len(encrypted) < nonceSize {
-		return nil, fmt.Errorf("encrypted data too short: got %d bytes, need at least %d", len(encrypted), nonceSize)
+	// Validate that encrypted data is long enough to contain nonce + at least 1 byte of ciphertext
+	if len(encrypted) <= nonceSize {
+		return nil, fmt.Errorf("encrypted data too short: got %d bytes, need at least %d", len(encrypted), nonceSize+1)
 	}
 
 	// Extract the nonce from the encrypted data

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6078,11 +6078,6 @@ func decrypt(encrypted []byte, privateKey string) ([]byte, error) {
 	// Get the nonce size
 	nonceSize := aesGCM.NonceSize()
 
-	// Validate that encrypted data is long enough to contain nonce + at least 1 byte of ciphertext
-	if len(encrypted) <= nonceSize {
-		return nil, fmt.Errorf("encrypted data too short: got %d bytes, need at least %d", len(encrypted), nonceSize+1)
-	}
-
 	// Extract the nonce from the encrypted data
 	nonce, ciphertext := encrypted[:nonceSize], encrypted[nonceSize:]
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6078,6 +6078,11 @@ func decrypt(encrypted []byte, privateKey string) ([]byte, error) {
 	// Get the nonce size
 	nonceSize := aesGCM.NonceSize()
 
+	// Validate that encrypted data is long enough to contain at least the nonce
+	if len(encrypted) < nonceSize {
+		return nil, fmt.Errorf("encrypted data too short: got %d bytes, need at least %d", len(encrypted), nonceSize)
+	}
+
 	// Extract the nonce from the encrypted data
 	nonce, ciphertext := encrypted[:nonceSize], encrypted[nonceSize:]
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41140 

 - Extracts duplicated AES-256-GCM encryption logic into a shared server/crypto package
  - Code pulled from existing implementations in server/datastore/mysql/apple_mdm.go and server/mdm/mdm.go

Intentionally not integrated into existing call sites in this PR to minimize risk and testing scope. Existing code continues to work unchanged. Future PRs can migrate callers incrementally.


- [X] Added/updated automated tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AES-256-GCM encryption/decryption support for securing sensitive data.

* **Bug Fixes**
  * Improved validation to detect malformed ciphertext and prevent invalid decryption attempts.

* **Tests**
  * Added comprehensive unit tests covering round-trip encryption, wrong/invalid keys, malformed input, invalid key lengths, and nonce uniqueness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->