### PR TITLE
Add glob support to more labels, policies and reports

### DIFF
--- a/changes/41006-support-more-globs
+++ b/changes/41006-support-more-globs
@@ -1,0 +1,1 @@
+- Added support for `paths:` key under `reports:`, `labels:` and `policies:` in GitOps .yml files.

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1280,8 +1280,7 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			}
 			result.Policies = append(result.Policies, &item.GitOpsPolicySpec)
 		} else {
-			filePath := resolveApplyRelativePath(baseDir, *item.Path)
-			fileBytes, err := os.ReadFile(filePath)
+			fileBytes, err := os.ReadFile(*item.Path)
 			if err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to read policies file %s: %v", *item.Path, err))
 				continue
@@ -1306,11 +1305,11 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 								multiError, fmt.Errorf("nested paths are not supported: %s in %s", *pp.Path, *item.Path),
 							)
 						} else {
-							if err := parsePolicyInstallSoftware(filepath.Dir(filePath), result.TeamName, pp, result.Software.Packages, result.Software.AppStoreApps); err != nil {
+							if err := parsePolicyInstallSoftware(filepath.Dir(*item.Path), result.TeamName, pp, result.Software.Packages, result.Software.AppStoreApps); err != nil {
 								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy install_software %q: %v", pp.Name, err))
 								continue
 							}
-							if err := parsePolicyRunScript(filepath.Dir(filePath), parentFilePath, result.TeamName, pp, result.Controls.Scripts); err != nil {
+							if err := parsePolicyRunScript(filepath.Dir(*item.Path), parentFilePath, result.TeamName, pp, result.Controls.Scripts); err != nil {
 								multiError = multierror.Append(multiError, fmt.Errorf("failed to parse policy run_script %q: %v", pp.Name, err))
 								continue
 							}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -221,6 +221,22 @@ type SoftwarePackage struct {
 	fleet.SoftwarePackageSpec
 }
 
+// SupportsFileInclude is implemented by types that embed BaseItem and can
+// reference external files via path/paths fields.
+type SupportsFileInclude interface {
+	FileInclude(v ...BaseItem) BaseItem
+}
+
+// FileInclude gets or sets the BaseItem. Called with no arguments it returns
+// the current value; called with one argument it sets the value first.
+// Types that embed BaseItem inherit this method via promotion.
+func (b *BaseItem) FileInclude(v ...BaseItem) BaseItem {
+	if len(v) > 0 {
+		*b = v[0]
+	}
+	return *b
+}
+
 func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePackageSpec) (fleet.SoftwarePackageSpec, error) {
 	if spec.Icon.Path != "" || spec.InstallScript.Path != "" || spec.UninstallScript.Path != "" ||
 		spec.PostInstallScript.Path != "" || spec.URL != "" || spec.SHA256 != "" || spec.PreInstallQuery.Path != "" {
@@ -981,6 +997,9 @@ type GlobExpandOptions struct {
 	// RequireUniqueBasenames, if true, returns an error when two items resolve to the
 	// same filename (filepath.Base).
 	RequireUniqueBasenames bool
+	// RequireFileReference, if true, returns an error when an item has neither
+	// "path" nor "paths" set. When false, such items are passed through unchanged.
+	RequireFileReference bool
 	// Optional function to log warnings (e.g. about files skipped due to extension mismatch).
 	LogFn Logf
 }
@@ -1029,58 +1048,69 @@ func expandGlobPattern(pattern string, baseDir string, entityType string, opts G
 	return result, nil
 }
 
-// flattenBaseItems validates path/paths fields on each item, expands glob
-// patterns in "paths" entries, and returns a flat list where every item has only
-// Path set (resolved to an absolute path). Errors are collected rather than
-// returned early, so callers get all problems in one pass.
-func flattenBaseItems(input []BaseItem, baseDir string, entityType string, opts GlobExpandOptions) ([]BaseItem, []error) {
+// expandBaseItems validates path/paths fields on each item, expands glob
+// patterns in "paths" entries, and returns a flat list where every item with
+// a file reference has only Path set (resolved to an absolute path). Items
+// without path/paths are passed through unchanged unless
+// opts.RequireFileReference is set, in which case an error is returned.
+// Errors are collected rather than returned early, so callers get all
+// problems in one pass.
+func expandBaseItems[T any, PT interface {
+	*T
+	SupportsFileInclude
+}](input []T, baseDir string, entityType string, opts GlobExpandOptions) ([]T, []error) {
 	opts.setDefaults()
-	var result []BaseItem
+	var result []T
 	var errs []error
 	seenBasenames := make(map[string]string) // basename -> source (path or pattern)
 
 	for _, item := range input {
-		hasPath := item.Path != nil
-		hasPaths := item.Paths != nil
+		baseItem := PT(&item).FileInclude()
+		hasPath := baseItem.Path != nil
+		hasPaths := baseItem.Paths != nil
 
 		switch {
 		case hasPath && hasPaths:
 			errs = append(errs, fmt.Errorf(`%s entry cannot have both "path" and "paths" fields`, entityType))
 			continue
-		// Inline item (no file reference) — pass through unchanged.
+		// Inline item (no file reference).
 		case !hasPath && !hasPaths:
-			errs = append(errs, fmt.Errorf(`%s entry has no "path" or "paths" field; check for a stray "-" in the list`, entityType))
-			continue
-		// Single path -- resolve to absolute path and add to result.
-		case hasPath:
-			if containsGlobMeta(*item.Path) {
-				errs = append(errs, fmt.Errorf(`%s "path" %q contains glob characters; use "paths" for glob patterns`, entityType, *item.Path))
+			if opts.RequireFileReference {
+				errs = append(errs, fmt.Errorf(`%s entry has no "path" or "paths" field; check for a stray "-" in the list`, entityType))
 				continue
 			}
-			resolved := resolveApplyRelativePath(baseDir, *item.Path)
+			result = append(result, item)
+		// Single path -- resolve to absolute path and add to result.
+		case hasPath:
+			if containsGlobMeta(*baseItem.Path) {
+				errs = append(errs, fmt.Errorf(`%s "path" %q contains glob characters; use "paths" for glob patterns`, entityType, *baseItem.Path))
+				continue
+			}
+			resolved := resolveApplyRelativePath(baseDir, *baseItem.Path)
 			// Check for duplicate filenames if requested.
 			if opts.RequireUniqueBasenames {
 				base := filepath.Base(resolved)
 				if existing, ok := seenBasenames[base]; ok {
-					errs = append(errs, fmt.Errorf("duplicate %s basename %q (from %q and %q)", entityType, base, existing, *item.Path))
+					errs = append(errs, fmt.Errorf("duplicate %s basename %q (from %q and %q)", entityType, base, existing, *baseItem.Path))
 					continue
 				}
-				seenBasenames[base] = *item.Path
+				seenBasenames[base] = *baseItem.Path
 			}
-			result = append(result, BaseItem{Path: &resolved})
+			PT(&item).FileInclude(BaseItem{Path: &resolved})
+			result = append(result, item)
 		// Glob -- expand and add files to result.
 		case hasPaths:
-			if !containsGlobMeta(*item.Paths) {
-				errs = append(errs, fmt.Errorf(`%s "paths" %q does not contain glob characters; use "path" for a specific file`, entityType, *item.Paths))
+			if !containsGlobMeta(*baseItem.Paths) {
+				errs = append(errs, fmt.Errorf(`%s "paths" %q does not contain glob characters; use "path" for a specific file`, entityType, *baseItem.Paths))
 				continue
 			}
-			expanded, err := expandGlobPattern(*item.Paths, baseDir, entityType, opts)
+			expanded, err := expandGlobPattern(*baseItem.Paths, baseDir, entityType, opts)
 			if err != nil {
 				errs = append(errs, err)
 				continue
 			}
 			if len(expanded) == 0 {
-				opts.LogFn("[!] glob pattern %q matched no %s files\n", *item.Paths, entityType)
+				opts.LogFn("[!] glob pattern %q matched no %s files\n", *baseItem.Paths, entityType)
 				continue
 			}
 			for _, p := range expanded {
@@ -1088,12 +1118,14 @@ func flattenBaseItems(input []BaseItem, baseDir string, entityType string, opts 
 				if opts.RequireUniqueBasenames {
 					base := filepath.Base(p)
 					if existing, ok := seenBasenames[base]; ok {
-						errs = append(errs, fmt.Errorf("duplicate %s basename %q (from %q and %q)", entityType, base, existing, *item.Paths))
+						errs = append(errs, fmt.Errorf("duplicate %s basename %q (from %q and %q)", entityType, base, existing, *baseItem.Paths))
 						continue
 					}
-					seenBasenames[base] = *item.Paths
+					seenBasenames[base] = *baseItem.Paths
 				}
-				result = append(result, BaseItem{Path: &p})
+				var newItem T
+				PT(&newItem).FileInclude(BaseItem{Path: &p})
+				result = append(result, newItem)
 			}
 		}
 	}
@@ -1102,9 +1134,10 @@ func flattenBaseItems(input []BaseItem, baseDir string, entityType string, opts 
 }
 
 func resolveScriptPaths(input []BaseItem, baseDir string, logFn Logf) ([]BaseItem, []error) {
-	return flattenBaseItems(input, baseDir, "script", GlobExpandOptions{
+	return expandBaseItems(input, baseDir, "script", GlobExpandOptions{
 		AllowedExtensions:      allowedScriptExtensions,
 		RequireUniqueBasenames: true,
+		RequireFileReference:   true,
 		LogFn:                  logFn,
 	})
 }

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -245,17 +245,20 @@ type SoftwarePackage struct {
 // SupportsFileInclude is implemented by types that embed BaseItem and can
 // reference external files via path/paths fields.
 type SupportsFileInclude interface {
-	FileInclude(v ...BaseItem) BaseItem
+	GetBaseItem() BaseItem
+	SetBaseItem(v BaseItem)
 }
 
-// FileInclude gets or sets the BaseItem. Called with no arguments it returns
-// the current value; called with one argument it sets the value first.
+// GetBaseItem returns the current BaseItem value.
 // Types that embed BaseItem inherit this method via promotion.
-func (b *BaseItem) FileInclude(v ...BaseItem) BaseItem {
-	if len(v) > 0 {
-		*b = v[0]
-	}
+func (b *BaseItem) GetBaseItem() BaseItem {
 	return *b
+}
+
+// SetBaseItem sets the BaseItem value.
+// Types that embed BaseItem inherit this method via promotion.
+func (b *BaseItem) SetBaseItem(v BaseItem) {
+	*b = v
 }
 
 func (spec SoftwarePackage) HydrateToPackageLevel(packageLevel fleet.SoftwarePackageSpec) (fleet.SoftwarePackageSpec, error) {
@@ -1115,7 +1118,7 @@ func expandBaseItems[T any, PT interface {
 	seenBasenames := make(map[string]string) // basename -> source (path or pattern)
 
 	for _, entity := range inputEntities {
-		baseItem := PT(&entity).FileInclude()
+		baseItem := PT(&entity).GetBaseItem()
 		hasPath := baseItem.Path != nil
 		hasPaths := baseItem.Paths != nil
 
@@ -1146,7 +1149,7 @@ func expandBaseItems[T any, PT interface {
 				}
 				seenBasenames[base] = *baseItem.Path
 			}
-			PT(&entity).FileInclude(BaseItem{Path: &resolved})
+			PT(&entity).SetBaseItem(BaseItem{Path: &resolved})
 			result = append(result, entity)
 		// Glob -- expand and add files to result.
 		case hasPaths:
@@ -1174,7 +1177,7 @@ func expandBaseItems[T any, PT interface {
 					seenBasenames[base] = *baseItem.Paths
 				}
 				var newItem T
-				PT(&newItem).FileInclude(BaseItem{Path: &p})
+				PT(&newItem).SetBaseItem(BaseItem{Path: &p})
 				result = append(result, newItem)
 			}
 		}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1048,9 +1048,9 @@ func expandGlobPattern(pattern string, baseDir string, entityType string, opts G
 	return result, nil
 }
 
-// expandBaseItems validates path/paths fields on each item, expands glob
-// patterns in "paths" entries, and returns a flat list where every item with
-// a file reference has only Path set (resolved to an absolute path). Items
+// expandBaseItems validates path/paths fields on each entity (e.g. Label), expands glob
+// patterns in "paths" entries, and returns a flat list where every entity with
+// a file reference has only Path set (resolved to an absolute path). Entities
 // without path/paths are passed through unchanged unless
 // opts.RequireFileReference is set, in which case an error is returned.
 // Errors are collected rather than returned early, so callers get all
@@ -1058,7 +1058,7 @@ func expandGlobPattern(pattern string, baseDir string, entityType string, opts G
 func expandBaseItems[T any, PT interface {
 	*T
 	SupportsFileInclude
-}](input []T, baseDir string, entityType string, o ...GlobExpandOptions) ([]T, []error) {
+}](inputEntities []T, baseDir string, entityType string, o ...GlobExpandOptions) ([]T, []error) {
 	var opts GlobExpandOptions
 	if len(o) > 1 {
 		panic("too many GlobExpandOptions arguments")
@@ -1073,8 +1073,8 @@ func expandBaseItems[T any, PT interface {
 	var errs []error
 	seenBasenames := make(map[string]string) // basename -> source (path or pattern)
 
-	for _, item := range input {
-		baseItem := PT(&item).FileInclude()
+	for _, entity := range inputEntities {
+		baseItem := PT(&entity).FileInclude()
 		hasPath := baseItem.Path != nil
 		hasPaths := baseItem.Paths != nil
 
@@ -1082,13 +1082,13 @@ func expandBaseItems[T any, PT interface {
 		case hasPath && hasPaths:
 			errs = append(errs, fmt.Errorf(`%s entry cannot have both "path" and "paths" fields`, entityType))
 			continue
-		// Inline item (no file reference).
+		// Inline entity (no file reference).
 		case !hasPath && !hasPaths:
 			if opts.RequireFileReference {
 				errs = append(errs, fmt.Errorf(`%s entry has no "path" or "paths" field; check for a stray "-" in the list`, entityType))
 				continue
 			}
-			result = append(result, item)
+			result = append(result, entity)
 		// Single path -- resolve to absolute path and add to result.
 		case hasPath:
 			if containsGlobMeta(*baseItem.Path) {
@@ -1105,8 +1105,8 @@ func expandBaseItems[T any, PT interface {
 				}
 				seenBasenames[base] = *baseItem.Path
 			}
-			PT(&item).FileInclude(BaseItem{Path: &resolved})
-			result = append(result, item)
+			PT(&entity).FileInclude(BaseItem{Path: &resolved})
+			result = append(result, entity)
 		// Glob -- expand and add files to result.
 		case hasPaths:
 			if !containsGlobMeta(*baseItem.Paths) {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1102,16 +1102,7 @@ func expandGlobPattern(pattern string, baseDir string, entityType string, opts G
 func expandBaseItems[T any, PT interface {
 	*T
 	SupportsFileInclude
-}](inputEntities []T, baseDir string, entityType string, o ...GlobExpandOptions) ([]T, []error) {
-	var opts GlobExpandOptions
-	if len(o) > 1 {
-		panic("too many GlobExpandOptions arguments")
-	}
-	if len(o) == 1 {
-		opts = o[0]
-	} else {
-		opts = GlobExpandOptions{}
-	}
+}](inputEntities []T, baseDir string, entityType string, opts GlobExpandOptions) ([]T, []error) {
 	opts.setDefaults()
 	var result []T
 	var errs []error

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -389,10 +389,10 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	if _, ok := top["labels"]; !ok {
 		result.Labels = make([]*fleet.LabelSpec, 0)
 	} else {
-		multiError = parseLabels(top, result, baseDir, filePath, multiError)
+		multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 	}
 	// Get other top-level entities.
-	multiError = parseControls(top, result, multiError, filePath, logFn)
+	multiError = parseControls(top, result, logFn, filePath, multiError)
 	multiError = parseAgentOptions(top, result, baseDir, logFn, filePath, multiError)
 	multiError = parseReports(top, result, baseDir, logFn, filePath, multiError)
 
@@ -401,7 +401,7 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	}
 
 	// Policies can reference software installers and scripts, thus we parse them after parseSoftware and parseControls.
-	multiError = parsePolicies(top, result, baseDir, filePath, multiError)
+	multiError = parsePolicies(top, result, baseDir, logFn, filePath, multiError)
 
 	return result, multiError.ErrorOrNil()
 }
@@ -756,7 +756,7 @@ func parseAgentOptions(top map[string]json.RawMessage, result *GitOps, baseDir s
 	return multiError
 }
 
-func parseControls(top map[string]json.RawMessage, result *GitOps, multiError *multierror.Error, yamlFilename string, logFn Logf) *multierror.Error {
+func parseControls(top map[string]json.RawMessage, result *GitOps, logFn Logf, yamlFilename string, multiError *multierror.Error) *multierror.Error {
 	controlsRaw, ok := top["controls"]
 	if !ok {
 		// Nothing to do, return.
@@ -1058,7 +1058,16 @@ func expandGlobPattern(pattern string, baseDir string, entityType string, opts G
 func expandBaseItems[T any, PT interface {
 	*T
 	SupportsFileInclude
-}](input []T, baseDir string, entityType string, opts GlobExpandOptions) ([]T, []error) {
+}](input []T, baseDir string, entityType string, o ...GlobExpandOptions) ([]T, []error) {
+	var opts GlobExpandOptions
+	if len(o) > 1 {
+		panic("too many GlobExpandOptions arguments")
+	}
+	if len(o) == 1 {
+		opts = o[0]
+	} else {
+		opts = GlobExpandOptions{}
+	}
 	opts.setDefaults()
 	var result []T
 	var errs []error
@@ -1142,7 +1151,7 @@ func resolveScriptPaths(input []BaseItem, baseDir string, logFn Logf) ([]BaseIte
 	})
 }
 
-func parseLabels(top map[string]json.RawMessage, result *GitOps, baseDir string, filePath string, multiError *multierror.Error) *multierror.Error {
+func parseLabels(top map[string]json.RawMessage, result *GitOps, baseDir string, logFn Logf, filePath string, multiError *multierror.Error) *multierror.Error {
 	labelsRaw, ok := top["labels"]
 
 	// This shouldn't happen as we check for the property earlier,
@@ -1155,11 +1164,17 @@ func parseLabels(top map[string]json.RawMessage, result *GitOps, baseDir string,
 	if err := json.Unmarshal(labelsRaw, &labels); err != nil {
 		return multierror.Append(multiError, MaybeParseTypeError(filePath, []string{"labels"}, err))
 	}
+	var errs []error
+	if labels, errs = expandBaseItems(labels, baseDir, "label", GlobExpandOptions{
+		LogFn: logFn,
+	}); len(errs) > 0 {
+		multiError = multierror.Append(multiError, errs...)
+	}
 	for _, item := range labels {
 		if item.Path == nil {
 			result.Labels = append(result.Labels, &item.LabelSpec)
 		} else {
-			fileBytes, err := os.ReadFile(resolveApplyRelativePath(baseDir, *item.Path))
+			fileBytes, err := os.ReadFile(*item.Path)
 			if err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to read labels file %s: %v", *item.Path, err))
 				continue
@@ -1236,7 +1251,7 @@ func parseLabels(top map[string]json.RawMessage, result *GitOps, baseDir string,
 	return multiError
 }
 
-func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir string, filePath string, multiError *multierror.Error) *multierror.Error {
+func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir string, logFn Logf, filePath string, multiError *multierror.Error) *multierror.Error {
 	parentFilePath := filePath
 	policiesRaw, ok := top["policies"]
 	if !ok {
@@ -1246,6 +1261,13 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 	if err := json.Unmarshal(policiesRaw, &policies); err != nil {
 		return multierror.Append(multiError, MaybeParseTypeError(filePath, []string{"policies"}, err))
 	}
+	var errs []error
+	if policies, errs = expandBaseItems(policies, baseDir, "policy", GlobExpandOptions{
+		LogFn: logFn,
+	}); len(errs) > 0 {
+		multiError = multierror.Append(multiError, errs...)
+	}
+
 	for _, item := range policies {
 		if item.Path == nil {
 			if err := parsePolicyInstallSoftware(baseDir, result.TeamName, &item, result.Software.Packages, result.Software.AppStoreApps); err != nil {
@@ -1468,6 +1490,13 @@ func parseReports(top map[string]json.RawMessage, result *GitOps, baseDir string
 	if err := json.Unmarshal(reportsRaw, &queries); err != nil {
 		return multierror.Append(multiError, MaybeParseTypeError(filePath, []string{"reports"}, err))
 	}
+	var errs []error
+	if queries, errs = expandBaseItems(queries, baseDir, "report", GlobExpandOptions{
+		LogFn: logFn,
+	}); len(errs) > 0 {
+		multiError = multierror.Append(multiError, errs...)
+	}
+
 	for i, item := range queries {
 		if item.Path == nil {
 			if err := validateReport(&item.QuerySpec, filePath, fmt.Sprintf("reports[%d]", i)); err != nil {
@@ -1477,7 +1506,7 @@ func parseReports(top map[string]json.RawMessage, result *GitOps, baseDir string
 			item.QuerySpec.TeamName = ptr.ValOrZero(result.TeamName)
 			result.Queries = append(result.Queries, &item.QuerySpec)
 		} else {
-			fileBytes, err := os.ReadFile(resolveApplyRelativePath(baseDir, *item.Path))
+			fileBytes, err := os.ReadFile(*item.Path)
 			if err != nil {
 				multiError = multierror.Append(multiError, fmt.Errorf("failed to read reports file %s: %v", *item.Path, err))
 				continue

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1347,14 +1347,13 @@ func parsePolicies(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				// Validate unknown keys in path-referenced policies file.
 				multiError = multierror.Append(multiError, validateYAMLKeys(fileBytes, reflect.TypeFor[[]Policy](), *item.Path, []string{"policies"})...)
 				for _, pp := range pathPolicies {
-					pp := pp
 					if pp != nil {
 						if pp.Path != nil {
 							multiError = multierror.Append(
 								multiError, fmt.Errorf("nested paths are not supported: %s in %s", *pp.Path, *item.Path),
 							)
 						} else {
-							if err := parsePolicyInstallSoftware(filepath.Dir(*item.Path), result.TeamName, pp, result.Software.Packages, result.Software.AppStoreApps); err != nil {
+							if errs := parsePolicyInstallSoftware(filepath.Dir(*item.Path), result.TeamName, pp, result.Software.Packages, result.Software.AppStoreApps); errs != nil {
 								multiError = multierror.Append(multiError, errs...)
 								continue
 							}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1735,7 +1735,7 @@ func TestExpandBaseItems(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt"), []byte(""), 0o644))
 
 		items := []BaseItem{{Paths: ptr.String("*.yml")}}
-		result, errs := expandBaseItems(items, dir, "test")
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{})
 		require.Empty(t, errs)
 		require.Len(t, result, 2)
 		assert.Equal(t, filepath.Join(dir, "a.yml"), *result[0].Path)
@@ -1753,7 +1753,7 @@ func TestExpandBaseItems(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(subdir, "nested.yml"), []byte(""), 0o644))
 
 		items := []BaseItem{{Paths: ptr.String("**/*.yml")}}
-		result, errs := expandBaseItems(items, dir, "test")
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{})
 		require.Empty(t, errs)
 		require.Len(t, result, 2)
 		assert.Equal(t, filepath.Join(subdir, "nested.yml"), *result[0].Path)
@@ -1771,7 +1771,7 @@ func TestExpandBaseItems(t *testing.T) {
 			{Path: ptr.String("single.yml")},
 			{Paths: ptr.String("*.yaml")},
 		}
-		result, errs := expandBaseItems(items, dir, "test")
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{})
 		require.Empty(t, errs)
 		require.Len(t, result, 3)
 		assert.Equal(t, filepath.Join(dir, "single.yml"), *result[0].Path)
@@ -1782,28 +1782,28 @@ func TestExpandBaseItems(t *testing.T) {
 	t.Run("paths_without_glob_error", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{Paths: ptr.String("foo.yml")}}
-		_, errs := expandBaseItems(items, "/tmp", "test")
+		_, errs := expandBaseItems(items, "/tmp", "test", GlobExpandOptions{})
 		requireErrorContains(t, errs, `does not contain glob characters`)
 	})
 
 	t.Run("path_with_glob_error", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{Path: ptr.String("*.yml")}}
-		_, errs := expandBaseItems(items, "/tmp", "test")
+		_, errs := expandBaseItems(items, "/tmp", "test", GlobExpandOptions{})
 		requireErrorContains(t, errs, `contains glob characters`)
 	})
 
 	t.Run("both_path_and_paths_error", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{Path: ptr.String("foo.yml"), Paths: ptr.String("*.yml")}}
-		_, errs := expandBaseItems(items, "/tmp", "test")
+		_, errs := expandBaseItems(items, "/tmp", "test", GlobExpandOptions{})
 		requireErrorContains(t, errs, `cannot have both "path" and "paths"`)
 	})
 
 	t.Run("inline_items_passed_through", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{}}
-		result, errs := expandBaseItems(items, "/tmp", "test")
+		result, errs := expandBaseItems(items, "/tmp", "test", GlobExpandOptions{})
 		require.Empty(t, errs)
 		require.Len(t, result, 1)
 		assert.Nil(t, result[0].Path)
@@ -1901,7 +1901,7 @@ func TestExpandBaseItems(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "m.yml"), []byte(""), 0o644))
 
 		items := []BaseItem{{Paths: ptr.String("*.yml")}}
-		result, errs := expandBaseItems(items, dir, "test")
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{})
 		require.Empty(t, errs)
 		require.Len(t, result, 3)
 		assert.Equal(t, filepath.Join(dir, "a.yml"), *result[0].Path)
@@ -1912,7 +1912,7 @@ func TestExpandBaseItems(t *testing.T) {
 	t.Run("multiple_errors_collected", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{Path: ptr.String("*.yml")}, {Paths: ptr.String("noglob.yml")}}
-		_, errs := expandBaseItems(items, "", "test")
+		_, errs := expandBaseItems(items, "", "test", GlobExpandOptions{})
 		require.Len(t, errs, 2)
 		assert.Contains(t, errs[0].Error(), `contains glob characters`)
 		assert.Contains(t, errs[1].Error(), `does not contain glob characters`)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -12,9 +12,20 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/file"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/ghodss/yaml"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// yamlToRawJSON converts a YAML string into the map[string]json.RawMessage that parse functions expect.
+func yamlToRawJSON(t *testing.T, yamlStr string) map[string]json.RawMessage {
+	t.Helper()
+	j, err := yaml.YAMLToJSON([]byte(yamlStr))
+	require.NoError(t, err)
+	var top map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(j, &top))
+	return top
+}
 
 var topLevelOptions = map[string]string{
 	"controls":      "controls:",
@@ -1967,9 +1978,12 @@ func TestParseLabelsGlob(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(labelFile), 0o755))
 		require.NoError(t, os.WriteFile(labelFile, []byte("- name: FileLabel\n  label_membership_type: manual\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"labels": json.RawMessage(`[{"name": "InlineLabel", "label_membership_type": "manual"}, {"path": "labels/from-file.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+labels:
+  - name: InlineLabel
+    label_membership_type: manual
+  - path: labels/from-file.yml
+`)
 		result := &GitOps{}
 		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
 		require.Nil(t, multiErr.ErrorOrNil())
@@ -1987,9 +2001,10 @@ func TestParseLabelsGlob(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(labelsDir, "a.yml"), []byte("- name: LabelA\n  label_membership_type: manual\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(labelsDir, "b.yml"), []byte("- name: LabelB\n  label_membership_type: manual\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"labels": json.RawMessage(`[{"paths": "labels/*.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+labels:
+  - paths: "labels/*.yml"
+`)
 		result := &GitOps{}
 		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
 		require.Nil(t, multiErr.ErrorOrNil())
@@ -2010,9 +2025,12 @@ func TestParsePoliciesGlob(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(policyFile), 0o755))
 		require.NoError(t, os.WriteFile(policyFile, []byte("- name: FilePolicy\n  query: SELECT 1;\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"policies": json.RawMessage(`[{"name": "InlinePolicy", "query": "SELECT 1;"}, {"path": "policies/from-file.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+policies:
+  - name: InlinePolicy
+    query: SELECT 1;
+  - path: policies/from-file.yml
+`)
 		result := &GitOps{}
 		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
 		require.Nil(t, multiErr.ErrorOrNil())
@@ -2030,9 +2048,10 @@ func TestParsePoliciesGlob(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(policiesDir, "a.yml"), []byte("- name: PolicyA\n  query: SELECT 1;\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(policiesDir, "b.yml"), []byte("- name: PolicyB\n  query: SELECT 1;\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"policies": json.RawMessage(`[{"paths": "policies/*.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+policies:
+  - paths: "policies/*.yml"
+`)
 		result := &GitOps{}
 		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
 		require.Nil(t, multiErr.ErrorOrNil())
@@ -2053,9 +2072,12 @@ func TestParseReportsGlob(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Dir(reportFile), 0o755))
 		require.NoError(t, os.WriteFile(reportFile, []byte("- name: FileReport\n  query: SELECT 1;\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"reports": json.RawMessage(`[{"name": "InlineReport", "query": "SELECT 1;"}, {"path": "reports/from-file.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+reports:
+  - name: InlineReport
+    query: SELECT 1;
+  - path: reports/from-file.yml
+`)
 		teamName := "TestTeam"
 		result := &GitOps{TeamName: &teamName}
 		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)
@@ -2074,9 +2096,10 @@ func TestParseReportsGlob(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(reportsDir, "a.yml"), []byte("- name: ReportA\n  query: SELECT 1;\n"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(reportsDir, "b.yml"), []byte("- name: ReportB\n  query: SELECT 1;\n"), 0o644))
 
-		top := map[string]json.RawMessage{
-			"reports": json.RawMessage(`[{"paths": "reports/*.yml"}]`),
-		}
+		top := yamlToRawJSON(t, `
+reports:
+  - paths: "reports/*.yml"
+`)
 		teamName := "TestTeam"
 		result := &GitOps{TeamName: &teamName}
 		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1971,7 +1971,7 @@ func TestParseLabelsGlob(t *testing.T) {
 		}
 		result := &GitOps{}
 		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Labels, 2)
 		assert.Equal(t, "InlineLabel", result.Labels[0].Name)
 		assert.Equal(t, "FileLabel", result.Labels[1].Name)
@@ -1991,7 +1991,7 @@ func TestParseLabelsGlob(t *testing.T) {
 		}
 		result := &GitOps{}
 		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Labels, 2)
 		assert.Equal(t, "LabelA", result.Labels[0].Name)
 		assert.Equal(t, "LabelB", result.Labels[1].Name)
@@ -2014,7 +2014,7 @@ func TestParsePoliciesGlob(t *testing.T) {
 		}
 		result := &GitOps{}
 		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Policies, 2)
 		assert.Equal(t, "InlinePolicy", result.Policies[0].Name)
 		assert.Equal(t, "FilePolicy", result.Policies[1].Name)
@@ -2034,7 +2034,7 @@ func TestParsePoliciesGlob(t *testing.T) {
 		}
 		result := &GitOps{}
 		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Policies, 2)
 		assert.Equal(t, "PolicyA", result.Policies[0].Name)
 		assert.Equal(t, "PolicyB", result.Policies[1].Name)
@@ -2058,7 +2058,7 @@ func TestParseReportsGlob(t *testing.T) {
 		teamName := "TestTeam"
 		result := &GitOps{TeamName: &teamName}
 		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Queries, 2)
 		assert.Equal(t, "InlineReport", result.Queries[0].Name)
 		assert.Equal(t, "FileReport", result.Queries[1].Name)
@@ -2079,7 +2079,7 @@ func TestParseReportsGlob(t *testing.T) {
 		teamName := "TestTeam"
 		result := &GitOps{TeamName: &teamName}
 		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)
-		require.Nil(t, multiErr)
+		require.Nil(t, multiErr.ErrorOrNil())
 		require.Len(t, result.Queries, 2)
 		assert.Equal(t, "ReportA", result.Queries[0].Name)
 		assert.Equal(t, "ReportB", result.Queries[1].Name)

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1866,7 +1866,8 @@ func TestExpandBaseItems(t *testing.T) {
 		_, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{
 			RequireUniqueBasenames: true,
 		})
-		requireErrorContains(t, errs, "duplicate test basename")
+		requireErrorContains(t, errs, `duplicate test basename "item.yml"`)
+		requireErrorContains(t, errs, `sub/*.yml`)
 	})
 
 	t.Run("allowed_extensions_filter", func(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -1,6 +1,7 @@
 package spec
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1703,7 +1704,7 @@ func TestContainsGlobMeta(t *testing.T) {
 	}
 }
 
-func TestResolveScriptPathsGlob(t *testing.T) {
+func TestExpandBaseItems(t *testing.T) {
 	t.Parallel()
 
 	// requireErrorContains is a helper that asserts at least one error contains substr.
@@ -1723,17 +1724,16 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 	t.Run("basic_glob", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "c.ps1"), []byte("# powershell"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "c.txt"), []byte(""), 0o644))
 
-		items := []BaseItem{{Paths: ptr.String("*.sh")}}
-		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		items := []BaseItem{{Paths: ptr.String("*.yml")}}
+		result, errs := expandBaseItems(items, dir, "test")
 		require.Empty(t, errs)
 		require.Len(t, result, 2)
-		assert.Equal(t, filepath.Join(dir, "a.sh"), *result[0].Path)
-		assert.Equal(t, filepath.Join(dir, "b.sh"), *result[1].Path)
-		// Paths field should not be set on expanded items
+		assert.Equal(t, filepath.Join(dir, "a.yml"), *result[0].Path)
+		assert.Equal(t, filepath.Join(dir, "b.yml"), *result[1].Path)
 		assert.Nil(t, result[0].Paths)
 		assert.Nil(t, result[1].Paths)
 	})
@@ -1743,62 +1743,73 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 		dir := t.TempDir()
 		subdir := filepath.Join(dir, "sub")
 		require.NoError(t, os.MkdirAll(subdir, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "top.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(subdir, "nested.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "top.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(subdir, "nested.yml"), []byte(""), 0o644))
 
-		items := []BaseItem{{Paths: ptr.String("**/*.sh")}}
-		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		items := []BaseItem{{Paths: ptr.String("**/*.yml")}}
+		result, errs := expandBaseItems(items, dir, "test")
 		require.Empty(t, errs)
 		require.Len(t, result, 2)
-		// Results are sorted
-		assert.Equal(t, filepath.Join(subdir, "nested.sh"), *result[0].Path)
-		assert.Equal(t, filepath.Join(dir, "top.sh"), *result[1].Path)
+		assert.Equal(t, filepath.Join(subdir, "nested.yml"), *result[0].Path)
+		assert.Equal(t, filepath.Join(dir, "top.yml"), *result[1].Path)
 	})
 
 	t.Run("mixed_path_and_paths", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "single.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "glob1.ps1"), []byte("# ps1"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "glob2.ps1"), []byte("# ps1"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "single.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "glob1.yaml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "glob2.yaml"), []byte(""), 0o644))
 
 		items := []BaseItem{
-			{Path: ptr.String("single.sh")},
-			{Paths: ptr.String("*.ps1")},
+			{Path: ptr.String("single.yml")},
+			{Paths: ptr.String("*.yaml")},
 		}
-		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		result, errs := expandBaseItems(items, dir, "test")
 		require.Empty(t, errs)
 		require.Len(t, result, 3)
-		assert.Equal(t, filepath.Join(dir, "single.sh"), *result[0].Path)
-		assert.Equal(t, filepath.Join(dir, "glob1.ps1"), *result[1].Path)
-		assert.Equal(t, filepath.Join(dir, "glob2.ps1"), *result[2].Path)
+		assert.Equal(t, filepath.Join(dir, "single.yml"), *result[0].Path)
+		assert.Equal(t, filepath.Join(dir, "glob1.yaml"), *result[1].Path)
+		assert.Equal(t, filepath.Join(dir, "glob2.yaml"), *result[2].Path)
 	})
 
 	t.Run("paths_without_glob_error", func(t *testing.T) {
 		t.Parallel()
-		items := []BaseItem{{Paths: ptr.String("scripts/foo.sh")}}
-		_, errs := resolveScriptPaths(items, "/tmp", nopLogf)
+		items := []BaseItem{{Paths: ptr.String("foo.yml")}}
+		_, errs := expandBaseItems(items, "/tmp", "test")
 		requireErrorContains(t, errs, `does not contain glob characters`)
 	})
 
 	t.Run("path_with_glob_error", func(t *testing.T) {
 		t.Parallel()
-		items := []BaseItem{{Path: ptr.String("scripts/*.sh")}}
-		_, errs := resolveScriptPaths(items, "/tmp", nopLogf)
+		items := []BaseItem{{Path: ptr.String("*.yml")}}
+		_, errs := expandBaseItems(items, "/tmp", "test")
 		requireErrorContains(t, errs, `contains glob characters`)
 	})
 
 	t.Run("both_path_and_paths_error", func(t *testing.T) {
 		t.Parallel()
-		items := []BaseItem{{Path: ptr.String("foo.sh"), Paths: ptr.String("*.sh")}}
-		_, errs := resolveScriptPaths(items, "/tmp", nopLogf)
+		items := []BaseItem{{Path: ptr.String("foo.yml"), Paths: ptr.String("*.yml")}}
+		_, errs := expandBaseItems(items, "/tmp", "test")
 		requireErrorContains(t, errs, `cannot have both "path" and "paths"`)
 	})
 
-	t.Run("neither_path_nor_paths_error", func(t *testing.T) {
+	t.Run("inline_items_passed_through", func(t *testing.T) {
 		t.Parallel()
 		items := []BaseItem{{}}
-		_, errs := resolveScriptPaths(items, "/tmp", nopLogf)
+		result, errs := expandBaseItems(items, "/tmp", "test")
+		require.Empty(t, errs)
+		require.Len(t, result, 1)
+		assert.Nil(t, result[0].Path)
+		assert.Nil(t, result[0].Paths)
+	})
+
+	t.Run("require_file_reference_error", func(t *testing.T) {
+		t.Parallel()
+		items := []BaseItem{{}}
+		_, errs := expandBaseItems(items, "/tmp", "test", GlobExpandOptions{
+			RequireFileReference: true,
+		})
 		requireErrorContains(t, errs, `no "path" or "paths" field`)
 	})
 
@@ -1809,12 +1820,12 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 		logFn := func(format string, args ...any) {
 			warnings = append(warnings, fmt.Sprintf(format, args...))
 		}
-		items := []BaseItem{{Paths: ptr.String("*.sh")}}
-		result, errs := resolveScriptPaths(items, dir, logFn)
+		items := []BaseItem{{Paths: ptr.String("*.yml")}}
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{LogFn: logFn})
 		require.Empty(t, errs)
 		assert.Empty(t, result)
 		require.Len(t, warnings, 1)
-		assert.Contains(t, warnings[0], "matched no script")
+		assert.Contains(t, warnings[0], "matched no test")
 	})
 
 	t.Run("duplicate_basenames_error", func(t *testing.T) {
@@ -1824,12 +1835,14 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 		sub2 := filepath.Join(dir, "sub2")
 		require.NoError(t, os.MkdirAll(sub1, 0o755))
 		require.NoError(t, os.MkdirAll(sub2, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(sub1, "dup.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(sub2, "dup.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sub1, "dup.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sub2, "dup.yml"), []byte(""), 0o644))
 
-		items := []BaseItem{{Paths: ptr.String("**/*.sh")}}
-		_, errs := resolveScriptPaths(items, dir, nopLogf)
-		requireErrorContains(t, errs, "duplicate script basename")
+		items := []BaseItem{{Paths: ptr.String("**/*.yml")}}
+		_, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{
+			RequireUniqueBasenames: true,
+		})
+		requireErrorContains(t, errs, "duplicate test basename")
 	})
 
 	t.Run("duplicate_basenames_across_items_error", func(t *testing.T) {
@@ -1837,18 +1850,20 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 		dir := t.TempDir()
 		sub := filepath.Join(dir, "sub")
 		require.NoError(t, os.MkdirAll(sub, 0o755))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "script.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(sub, "script.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "item.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(sub, "item.yml"), []byte(""), 0o644))
 
 		items := []BaseItem{
-			{Path: ptr.String("script.sh")},
-			{Paths: ptr.String("sub/*.sh")},
+			{Path: ptr.String("item.yml")},
+			{Paths: ptr.String("sub/*.yml")},
 		}
-		_, errs := resolveScriptPaths(items, dir, nopLogf)
-		requireErrorContains(t, errs, "duplicate script basename")
+		_, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{
+			RequireUniqueBasenames: true,
+		})
+		requireErrorContains(t, errs, "duplicate test basename")
 	})
 
-	t.Run("non_script_files_skipped_with_warning", func(t *testing.T) {
+	t.Run("allowed_extensions_filter", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "good.sh"), []byte("#!/bin/bash"), 0o644))
@@ -1861,39 +1876,207 @@ func TestResolveScriptPathsGlob(t *testing.T) {
 		}
 
 		items := []BaseItem{{Paths: ptr.String("*")}}
-		result, errs := resolveScriptPaths(items, dir, logFn)
+		result, errs := expandBaseItems(items, dir, "test", GlobExpandOptions{
+			AllowedExtensions: map[string]bool{".sh": true},
+			LogFn:             logFn,
+		})
 		require.Empty(t, errs)
 		require.Len(t, result, 1)
 		assert.Equal(t, filepath.Join(dir, "good.sh"), *result[0].Path)
 		assert.Len(t, warnings, 2)
 	})
 
-	// Results are only sorted for the sake of tests,
-	// but having an explicit test protects against regression.
 	t.Run("results_sorted", func(t *testing.T) {
 		t.Parallel()
 		dir := t.TempDir()
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "z.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
-		require.NoError(t, os.WriteFile(filepath.Join(dir, "m.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "z.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.yml"), []byte(""), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "m.yml"), []byte(""), 0o644))
 
-		items := []BaseItem{{Paths: ptr.String("*.sh")}}
-		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		items := []BaseItem{{Paths: ptr.String("*.yml")}}
+		result, errs := expandBaseItems(items, dir, "test")
 		require.Empty(t, errs)
 		require.Len(t, result, 3)
-		assert.Equal(t, filepath.Join(dir, "a.sh"), *result[0].Path)
-		assert.Equal(t, filepath.Join(dir, "m.sh"), *result[1].Path)
-		assert.Equal(t, filepath.Join(dir, "z.sh"), *result[2].Path)
+		assert.Equal(t, filepath.Join(dir, "a.yml"), *result[0].Path)
+		assert.Equal(t, filepath.Join(dir, "m.yml"), *result[1].Path)
+		assert.Equal(t, filepath.Join(dir, "z.yml"), *result[2].Path)
 	})
 
 	t.Run("multiple_errors_collected", func(t *testing.T) {
 		t.Parallel()
-		items := []BaseItem{{}, {Path: ptr.String("scripts/*.sh")}, {Paths: ptr.String("noglob.sh")}}
-		_, errs := resolveScriptPaths(items, "", nil)
-		require.Len(t, errs, 3)
-		assert.Contains(t, errs[0].Error(), `no "path" or "paths"`)
-		assert.Contains(t, errs[1].Error(), `contains glob characters`)
-		assert.Contains(t, errs[2].Error(), `does not contain glob characters`)
+		items := []BaseItem{{Path: ptr.String("*.yml")}, {Paths: ptr.String("noglob.yml")}}
+		_, errs := expandBaseItems(items, "", "test")
+		require.Len(t, errs, 2)
+		assert.Contains(t, errs[0].Error(), `contains glob characters`)
+		assert.Contains(t, errs[1].Error(), `does not contain glob characters`)
+	})
+}
+
+func TestResolveScriptPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("path_resolves", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "script.sh"), []byte("#!/bin/bash"), 0o644))
+
+		items := []BaseItem{{Path: ptr.String("script.sh")}}
+		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		require.Empty(t, errs)
+		require.Len(t, result, 1)
+		assert.Equal(t, filepath.Join(dir, "script.sh"), *result[0].Path)
+	})
+
+	t.Run("glob_expands", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.sh"), []byte("#!/bin/bash"), 0o644))
+
+		items := []BaseItem{{Paths: ptr.String("*.sh")}}
+		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		require.Empty(t, errs)
+		require.Len(t, result, 2)
+	})
+
+	t.Run("inline_not_allowed", func(t *testing.T) {
+		t.Parallel()
+		items := []BaseItem{{}}
+		_, errs := resolveScriptPaths(items, "/tmp", nopLogf)
+		require.NotEmpty(t, errs)
+		assert.Contains(t, errs[0].Error(), `no "path" or "paths" field`)
+	})
+}
+
+func TestParseLabelsGlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline_and_path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		// Write a label file referenced by path.
+		labelFile := filepath.Join(dir, "labels", "from-file.yml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(labelFile), 0o755))
+		require.NoError(t, os.WriteFile(labelFile, []byte("- name: FileLabel\n  label_membership_type: manual\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"labels": json.RawMessage(`[{"name": "InlineLabel", "label_membership_type": "manual"}, {"path": "labels/from-file.yml"}]`),
+		}
+		result := &GitOps{}
+		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Labels, 2)
+		assert.Equal(t, "InlineLabel", result.Labels[0].Name)
+		assert.Equal(t, "FileLabel", result.Labels[1].Name)
+	})
+
+	t.Run("glob_expands", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		labelsDir := filepath.Join(dir, "labels")
+		require.NoError(t, os.MkdirAll(labelsDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(labelsDir, "a.yml"), []byte("- name: LabelA\n  label_membership_type: manual\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(labelsDir, "b.yml"), []byte("- name: LabelB\n  label_membership_type: manual\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"labels": json.RawMessage(`[{"paths": "labels/*.yml"}]`),
+		}
+		result := &GitOps{}
+		multiErr := parseLabels(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Labels, 2)
+		assert.Equal(t, "LabelA", result.Labels[0].Name)
+		assert.Equal(t, "LabelB", result.Labels[1].Name)
+	})
+}
+
+func TestParsePoliciesGlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline_and_path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		policyFile := filepath.Join(dir, "policies", "from-file.yml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(policyFile), 0o755))
+		require.NoError(t, os.WriteFile(policyFile, []byte("- name: FilePolicy\n  query: SELECT 1;\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"policies": json.RawMessage(`[{"name": "InlinePolicy", "query": "SELECT 1;"}, {"path": "policies/from-file.yml"}]`),
+		}
+		result := &GitOps{}
+		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Policies, 2)
+		assert.Equal(t, "InlinePolicy", result.Policies[0].Name)
+		assert.Equal(t, "FilePolicy", result.Policies[1].Name)
+	})
+
+	t.Run("glob_expands", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		policiesDir := filepath.Join(dir, "policies")
+		require.NoError(t, os.MkdirAll(policiesDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(policiesDir, "a.yml"), []byte("- name: PolicyA\n  query: SELECT 1;\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(policiesDir, "b.yml"), []byte("- name: PolicyB\n  query: SELECT 1;\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"policies": json.RawMessage(`[{"paths": "policies/*.yml"}]`),
+		}
+		result := &GitOps{}
+		multiErr := parsePolicies(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Policies, 2)
+		assert.Equal(t, "PolicyA", result.Policies[0].Name)
+		assert.Equal(t, "PolicyB", result.Policies[1].Name)
+	})
+}
+
+func TestParseReportsGlob(t *testing.T) {
+	t.Parallel()
+
+	t.Run("inline_and_path", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		reportFile := filepath.Join(dir, "reports", "from-file.yml")
+		require.NoError(t, os.MkdirAll(filepath.Dir(reportFile), 0o755))
+		require.NoError(t, os.WriteFile(reportFile, []byte("- name: FileReport\n  query: SELECT 1;\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"reports": json.RawMessage(`[{"name": "InlineReport", "query": "SELECT 1;"}, {"path": "reports/from-file.yml"}]`),
+		}
+		teamName := "TestTeam"
+		result := &GitOps{TeamName: &teamName}
+		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Queries, 2)
+		assert.Equal(t, "InlineReport", result.Queries[0].Name)
+		assert.Equal(t, "FileReport", result.Queries[1].Name)
+	})
+
+	t.Run("glob_expands", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+
+		reportsDir := filepath.Join(dir, "reports")
+		require.NoError(t, os.MkdirAll(reportsDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(reportsDir, "a.yml"), []byte("- name: ReportA\n  query: SELECT 1;\n"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(reportsDir, "b.yml"), []byte("- name: ReportB\n  query: SELECT 1;\n"), 0o644))
+
+		top := map[string]json.RawMessage{
+			"reports": json.RawMessage(`[{"paths": "reports/*.yml"}]`),
+		}
+		teamName := "TestTeam"
+		result := &GitOps{TeamName: &teamName}
+		multiErr := parseReports(top, result, dir, nopLogf, "test.yml", nil)
+		require.Nil(t, multiErr)
+		require.Len(t, result.Queries, 2)
+		assert.Equal(t, "ReportA", result.Queries[0].Name)
+		assert.Equal(t, "ReportB", result.Queries[1].Name)
 	})
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41006

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
Added tests for using path, paths and inline declaration for reports, policies and labels.
- [X] QA'd all new/changed functionality manually
   - [x] tested that `path:` works for policies
   - [x] tested that `paths:` works for policies
   - [x] tested that incline declaration works for policies
   - [x] tested that `path:` works for reports
   - [x] tested that `paths:` works for reports
   - [x] tested that incline declaration works for reports
   - [x] tested that `path:` works for labels
   - [x] tested that `paths:` works for labels
   - [x] tested that incline declaration works for labels



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for glob patterns in path specifications within reports, labels, and policies configuration sections.
  * Enhanced validation and error handling for external file references.
  * Improved logging and error messages during configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->