### PR TITLE
Guide: Remove duplicate key from usage statistics example

### DIFF
--- a/articles/fleet-usage-statistics.md
+++ b/articles/fleet-usage-statistics.md
@@ -19,7 +19,6 @@ Below is the JSON payload that is sent to Fleet Device Management Inc:
   "numTeams": 999,
   "numQueries": 999,
   "numPolicies": 999,
-  "numQueries": 999,
   "numLabels": 999,
   "softwareInventoryEnabled": true,
   "vulnDetectionEnabled": true,


### PR DESCRIPTION
Remove duplicate `numQueries` key