### PR TITLE
Cherry-Pick: Bump dompurify from 3.2.4 to 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "core-js": "3.25.1",
     "date-fns": "3.6.0",
     "date-fns-tz": "3.1.3",
-    "dompurify": "3.2.4",
+    "dompurify": "3.3.2",
     "es6-object-assign": "1.1.0",
     "es6-promise": "4.2.8",
     "file-saver": "1.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5122,10 +5122,10 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   dependencies:
     domelementtype "^2.2.0"
 
-dompurify@3.2.4:
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.2.4.tgz#af5a5a11407524431456cf18836c55d13441cd8e"
-  integrity sha512-ysFSFEDVduQpyhzAob/kkuJjf5zWkZD8/A9ywSp1byueyuCfHamrCBa14/Oc2iiB0e51B+NpxSl5gmzn+Ms/mg==
+dompurify@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.3.2.tgz#58c515d0f8508b8749452a028aa589ad80b36325"
+  integrity sha512-6obghkliLdmKa56xdbLOpUZ43pAR6xFy1uOrxBaIDjT+yaRuuybLjGS9eVBoSR/UPU5fq3OXClEHLJNGvbxKpQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 


### PR DESCRIPTION
Merged into `main` in #41068.