### PR TITLE
40314 patch policy autoupdate

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -465,6 +465,13 @@ func (svc *Service) UpdateSoftwareInstaller(ctx context.Context, payload *fleet.
 			payloadForNewInstallerFile = nil
 			payload.InstallerFile = nil
 		}
+
+		if existingInstaller.FleetMaintainedAppID != nil {
+			return nil, &fleet.BadRequestError{
+				Message:     "Couldn't update. The package can't be changed for Fleet-maintained apps.",
+				InternalErr: ctxerr.Wrap(ctx, err, "installer file changed for fleet maintained app installer"),
+			}
+		}
 	}
 
 	if payload.InstallerFile == nil { // fill in existing existingInstaller data to payload

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1034,16 +1034,12 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 		args.Type = fleet.PolicyTypeDynamic
 	}
 	if args.Type == fleet.PolicyTypePatch {
-		installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, *args.PatchSoftwareTitleID, false)
+		generated, err := ds.generatePatchPolicy(ctx, teamID, *args.PatchSoftwareTitleID)
 		if err != nil {
-			return nil, err
+			return nil, ctxerr.Wrap(ctx, err, "generating patch policy fields")
 		}
-		if installer.FleetMaintainedAppID == nil {
-			return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
-				Message: fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID %d", *args.PatchSoftwareTitleID, teamID),
-			})
-		}
-		generated := generatePatchPolicy(installer)
+
+		// TODO(JK): how to extract this part when it can be either PolicyPayload or PolicySpec
 		if args.Name == "" {
 			args.Name = generated.Name
 		}
@@ -1444,19 +1440,12 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 
 				// PATCH POLICIES!!!!!
 				// we need to generate a new query for the patch policy
-				// TODO(JK): since this is kinda duplicated can i make this nicer.
-				// Actually maybe we can have a patch_policy interface to do this! Since its split between policySpec and policyPayload
 				if spec.Type == fleet.PolicyTypePatch {
-					installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, teamID, *fmaTitleID, false)
+					// TODO(JK): not sure about this ValOrZero, can teamID be null here?
+					patch, err := ds.generatePatchPolicy(ctx, ptr.ValOrZero(teamID), *fmaTitleID)
 					if err != nil {
-						return ctxerr.Wrap(ctx, err, "getting patch policy software installer")
+						return ctxerr.Wrap(ctx, err, "generating patch policy fields")
 					}
-					if installer.FleetMaintainedAppID == nil {
-						return ctxerr.Wrap(ctx, &fleet.BadRequestError{
-							Message: fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID %d", *fmaTitleID, teamID),
-						})
-					}
-					patch := generatePatchPolicy(installer)
 					if spec.Name == "" {
 						spec.Name = patch.Name
 					}
@@ -2539,7 +2528,17 @@ type patchPolicy struct {
 	Resolution  string
 }
 
-func generatePatchPolicy(installer *fleet.SoftwareInstaller) *patchPolicy {
+func (ds *Datastore) generatePatchPolicy(ctx context.Context, teamID, titleID uint) (*patchPolicy, error) {
+	installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, titleID, false)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting software installer")
+	}
+	if installer.FleetMaintainedAppID == nil {
+		return nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{
+			Message: fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID %d", titleID, teamID),
+		})
+	}
+
 	var policy patchPolicy
 	switch {
 	case installer.Platform == string(fleet.MacOSPlatform):
@@ -2564,7 +2563,7 @@ func generatePatchPolicy(installer *fleet.SoftwareInstaller) *patchPolicy {
 	policy.Description = "Outdated software might introduce security vulnerabilities or compatibility issues."
 	policy.Resolution = "Install the latest version from self-service."
 
-	return &policy
+	return &policy, nil
 }
 
 func (ds *Datastore) deletePatchPolicy(ctx context.Context, teamID, titleID uint) error {

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2528,7 +2528,7 @@ type patchPolicy struct {
 	Resolution  string
 }
 
-func (ds *Datastore) generatePatchPolicy(ctx context.Context, teamID, titleID uint) (*patchPolicy, error) {
+func (ds *Datastore) generatePatchPolicy(ctx context.Context, teamID uint, titleID uint) (*patchPolicy, error) {
 	installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, &teamID, titleID, false)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting software installer")
@@ -2566,12 +2566,17 @@ func (ds *Datastore) generatePatchPolicy(ctx context.Context, teamID, titleID ui
 	return &policy, nil
 }
 
-func (ds *Datastore) deletePatchPolicy(ctx context.Context, teamID, titleID uint) error {
-	var policyID uint
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyID, `SELECT id FROM policies WHERE team_id = ? AND patch_software_title_id = ?`, teamID, titleID)
+func (ds *Datastore) GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error) {
+	query := `SELECT id, name FROM policies WHERE team_id = ? AND patch_software_title_id = ?`
+	var policy fleet.PatchPolicyData
+
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &policy, query, ptr.ValOrZero(teamID), titleID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get patch policy for title id")
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ctxerr.Wrap(ctx, notFound("PatchPolicy"), "get patch policy")
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get patch policy")
 	}
-	ds.DeleteTeamPolicies(ctx, teamID, []uint{policyID})
-	return nil
+
+	return &policy, nil
 }

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1039,7 +1039,6 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 			return nil, ctxerr.Wrap(ctx, err, "generating patch policy fields")
 		}
 
-		// TODO(JK): how to extract this part when it can be either PolicyPayload or PolicySpec
 		if args.Name == "" {
 			args.Name = generated.Name
 		}
@@ -1438,10 +1437,8 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 
 				fmaTitleID := fmaTitleIDs[teamNameToID[spec.Team]][spec.FleetMaintainedAppSlug]
 
-				// PATCH POLICIES!!!!!
-				// we need to generate a new query for the patch policy
+				// generate new up-to-date query and other fields for patch policy
 				if spec.Type == fleet.PolicyTypePatch {
-					// TODO(JK): not sure about this ValOrZero, can teamID be null here?
 					patch, err := ds.generatePatchPolicy(ctx, ptr.ValOrZero(teamID), *fmaTitleID)
 					if err != nil {
 						return ctxerr.Wrap(ctx, err, "generating patch policy fields")

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1420,12 +1420,6 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					}
 				}
 
-				if err := spec.Verify(); err != nil {
-					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
-						Message: fmt.Sprintf("policy spec payload verification: %s", err),
-					})
-				}
-
 				scriptID := spec.ScriptID
 				if spec.ScriptID != nil && *spec.ScriptID == 0 {
 					scriptID = nil
@@ -2485,7 +2479,8 @@ func (ds *Datastore) getPoliciesBySoftwareTitleIDs(
 	SELECT
 		p.id AS id,
 		p.name AS name,
-		COALESCE(si.title_id, va.title_id) AS software_title_id
+		COALESCE(si.title_id, va.title_id) AS software_title_id,
+		p.type AS type
 	FROM policies p
 	LEFT JOIN software_installers si ON p.software_installer_id = si.id
 	LEFT JOIN vpp_apps_teams vat ON p.vpp_apps_teams_id = vat.id

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2500,3 +2500,13 @@ func generatePatchPolicy(installer *fleet.SoftwareInstaller) *patchPolicy {
 
 	return &policy
 }
+
+func (ds *Datastore) deletePatchPolicy(ctx context.Context, teamID, titleID uint) error {
+	var policyID uint
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyID, `SELECT id FROM policies WHERE team_id = ? AND patch_software_title_id = ?`, teamID, titleID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get patch policy for title id")
+	}
+	ds.DeleteTeamPolicies(ctx, teamID, []uint{policyID})
+	return nil
+}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -1044,11 +1044,17 @@ func (ds *Datastore) NewTeamPolicy(ctx context.Context, teamID uint, authorID *u
 			})
 		}
 		generated := generatePatchPolicy(installer)
-		args.Name = generated.Name
-		args.Query = generated.Query
+		if args.Name == "" {
+			args.Name = generated.Name
+		}
+		if args.Description == "" {
+			args.Description = generated.Description
+		}
+		if args.Resolution == "" {
+			args.Resolution = generated.Resolution
+		}
 		args.Platform = generated.Platform
-		args.Description = generated.Description
-		args.Resolution = generated.Resolution
+		args.Query = generated.Query
 	}
 
 	if err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
@@ -1419,6 +1425,12 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 					}
 				}
 
+				if err := spec.Verify(); err != nil {
+					return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+						Message: fmt.Sprintf("policy spec payload verification: %s", err),
+					})
+				}
+
 				scriptID := spec.ScriptID
 				if spec.ScriptID != nil && *spec.ScriptID == 0 {
 					scriptID = nil
@@ -1429,6 +1441,34 @@ func (ds *Datastore) ApplyPolicySpecs(ctx context.Context, authorID uint, specs 
 				}
 
 				fmaTitleID := fmaTitleIDs[teamNameToID[spec.Team]][spec.FleetMaintainedAppSlug]
+
+				// PATCH POLICIES!!!!!
+				// we need to generate a new query for the patch policy
+				// TODO(JK): since this is kinda duplicated can i make this nicer.
+				// Actually maybe we can have a patch_policy interface to do this! Since its split between policySpec and policyPayload
+				if spec.Type == fleet.PolicyTypePatch {
+					installer, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, teamID, *fmaTitleID, false)
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "getting patch policy software installer")
+					}
+					if installer.FleetMaintainedAppID == nil {
+						return ctxerr.Wrap(ctx, &fleet.BadRequestError{
+							Message: fmt.Sprintf("Software installer for Fleet maintained app with title ID %d does not exist for team ID %d", *fmaTitleID, teamID),
+						})
+					}
+					patch := generatePatchPolicy(installer)
+					if spec.Name == "" {
+						spec.Name = patch.Name
+					}
+					if spec.Description == "" {
+						spec.Description = patch.Description
+					}
+					if spec.Resolution == "" {
+						spec.Resolution = patch.Resolution
+					}
+					spec.Platform = patch.Platform
+					spec.Query = patch.Query
+				}
 
 				res, err := tx.ExecContext(
 					ctx,

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -7250,4 +7250,6 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 		Platform: "darwin",
 	})
 	require.NoError(t, err)
+
+	// TODO(JK):: test name/description/resolution arent overwritten
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -7200,7 +7200,7 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 		PostInstallScript: "world",
 		StorageID:         "storage1",
 		Filename:          "maintained1",
-		Title:             "maintained1",
+		Title:             "Maintained1",
 		Version:           "1.0",
 		Source:            "apps",
 		Platform:          "darwin",
@@ -7251,5 +7251,56 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// TODO(JK):: test name/description/resolution arent overwritten
+	_, err = ds.DeleteTeamPolicies(ctx, team1.ID, []uint{p1.ID})
+	require.NoError(t, err)
+
+	// everything automatically generated
+	p3, err := ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
+		Type:                 fleet.PolicyTypePatch,
+		PatchSoftwareTitleID: &titleID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "macOS - Maintained1 up to date", p3.Name)
+	require.Equal(t, "Outdated software might introduce security vulnerabilities or compatibility issues.", p3.Description)
+	require.Equal(t, "Install the latest version from self-service.", *p3.Resolution)
+	require.Equal(t, "darwin", p3.Platform)
+	require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'fleet.maintained1' AND version_compare(bundle_short_version, '1.0') >= 0;", p3.Query)
+
+	_, err = ds.DeleteTeamPolicies(ctx, team1.ID, []uint{p3.ID})
+	require.NoError(t, err)
+
+	// some fields should not be overwritten
+	p4, err := ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
+		Name:                 "name",
+		Description:          "description",
+		Resolution:           "resolution",
+		Type:                 fleet.PolicyTypePatch,
+		PatchSoftwareTitleID: &titleID,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "name", p4.Name)
+	require.Equal(t, "description", p4.Description)
+	require.Equal(t, "resolution", *p4.Resolution)
+	require.Equal(t, "darwin", p4.Platform)
+	require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'fleet.maintained1' AND version_compare(bundle_short_version, '1.0') >= 0;", p4.Query)
+
+	// test GetPatchPolicy
+
+	data, err := ds.GetPatchPolicy(ctx, &team1.ID, titleID)
+	require.NoError(t, err)
+	require.Equal(t, p4.ID, data.ID)
+	require.Equal(t, p4.Name, data.Name)
+
+	payload2 := &fleet.UploadSoftwareInstallerPayload{
+		Filename:        "bar",
+		Title:           "bar",
+		UserID:          user1.ID,
+		TeamID:          &team1.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	}
+	_, titleID2, err := ds.MatchOrCreateSoftwareInstaller(context.Background(), payload2)
+	require.NoError(t, err)
+
+	_, err = ds.GetPatchPolicy(ctx, &team1.ID, titleID2)
+	require.True(t, fleet.IsNotFound(err))
 }

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -6063,8 +6063,8 @@ func testPoliciesBySoftwareTitleID(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Len(t, policies, 2)
 	expected := map[uint]fleet.AutomaticInstallPolicy{
-		policy3.ID: {ID: policy3.ID, Name: policy3.Name, TitleID: *installer3.TitleID},
-		policy4.ID: {ID: policy4.ID, Name: policy4.Name, TitleID: *installer4.TitleID},
+		policy3.ID: {ID: policy3.ID, Name: policy3.Name, TitleID: *installer3.TitleID, Type: fleet.PolicyTypeDynamic},
+		policy4.ID: {ID: policy4.ID, Name: policy4.Name, TitleID: *installer4.TitleID, Type: fleet.PolicyTypeDynamic},
 	}
 
 	for _, got := range policies {

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -7285,7 +7285,6 @@ func testTeamPatchPolicy(t *testing.T, ds *Datastore) {
 	require.Equal(t, "SELECT 1 FROM apps WHERE bundle_identifier = 'fleet.maintained1' AND version_compare(bundle_short_version, '1.0') >= 0;", p4.Query)
 
 	// test GetPatchPolicy
-
 	data, err := ds.GetPatchPolicy(ctx, &team1.ID, titleID)
 	require.NoError(t, err)
 	require.Equal(t, p4.ID, data.ID)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1112,14 +1112,26 @@ WHERE
 }
 
 var (
-	errDeleteInstallerWithAssociatedPolicy = &fleet.ConflictError{Message: "Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again."}
-	errDeleteInstallerInstalledDuringSetup = &fleet.ConflictError{Message: "Couldn't delete. This software is installed during new host setup. Please remove software in Controls > Setup experience and try again."}
+	errDeleteInstallerWithAssociatedInstallPolicy = &fleet.ConflictError{Message: "Couldn't delete. Policy automation uses this software. Please disable policy automation for this software and try again."}
+	errDeleteInstallerInstalledDuringSetup        = &fleet.ConflictError{Message: "Couldn't delete. This software is installed during new host setup. Please remove software in Controls > Setup experience and try again."}
+	errDeleteInstallerWithAssociatedPatchPolicy   = &fleet.ConflictError{Message: "Couldn’t delete. This software has a patch policy. Please remove the patch policy and try again."}
 )
 
 func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error {
 	var activateAffectedHostIDs []uint
 
-	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+	// check if there is a patch policy that uses this title
+	policyStmt := `SELECT 1 FROM policies p JOIN software_installers si ON si.title_id = p.patch_software_title_id WHERE si.id = ?`
+	var policyExists bool
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyExists, policyStmt, id)
+	if err != nil && err != sql.ErrNoRows {
+		return ctxerr.Wrap(ctx, err, "checking if patch policy exists for software installer")
+	}
+	if policyExists {
+		return errDeleteInstallerWithAssociatedPatchPolicy
+	}
+
+	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "clean up related installs and uninstalls")
@@ -1136,7 +1148,7 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 					return ctxerr.Wrapf(ctx, err, "getting reference from policies")
 				}
 				if count > 0 {
-					return errDeleteInstallerWithAssociatedPolicy
+					return errDeleteInstallerWithAssociatedInstallPolicy
 				}
 			}
 			return ctxerr.Wrap(ctx, err, "delete software installer")

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -682,9 +682,12 @@ func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.Up
 
 	var touchUploaded string
 	var clearFleetMaintainedAppID string // FMA becomes custom package when uploading a new installer file
+	var clearPatchPolicy bool            // Delete patch policy
 	if payload.InstallerFile != nil {
 		touchUploaded = ", uploaded_at = NOW()"
 		clearFleetMaintainedAppID = ", fleet_maintained_app_id = NULL"
+		// we need to remove the associated patch policy
+		clearPatchPolicy = true
 	}
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
@@ -746,6 +749,13 @@ func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.Up
 		// When an installer is modified reset attempt numbers for policy automations
 		if err := ds.resetInstallerPolicyAutomationAttempts(ctx, tx, payload.InstallerID); err != nil {
 			return ctxerr.Wrap(ctx, err, "resetting policy automation attempts for installer")
+		}
+
+		// TODO(JK): remove patch policy
+		if clearPatchPolicy {
+			if err := ds.deletePatchPolicy(ctx, ptr.ValOrZero(payload.TeamID), payload.TitleID); err != nil {
+				return ctxerr.Wrap(ctx, err, "update software title display name")
+			}
 		}
 
 		return nil

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -681,13 +681,9 @@ func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.Up
 	}
 
 	var touchUploaded string
-	var clearFleetMaintainedAppID string // FMA becomes custom package when uploading a new installer file
-	var clearPatchPolicy bool            // Delete patch policy
 	if payload.InstallerFile != nil {
+		// installer cannot be changed when associated with an FMA
 		touchUploaded = ", uploaded_at = NOW()"
-		clearFleetMaintainedAppID = ", fleet_maintained_app_id = NULL"
-		// we need to remove the associated patch policy
-		clearPatchPolicy = true
 	}
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
@@ -704,8 +700,8 @@ func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.Up
 			upgrade_code = ?,
 			user_id = ?,
 			user_name = (SELECT name FROM users WHERE id = ?),
-			user_email = (SELECT email FROM users WHERE id = ?)%s%s
-			WHERE id = ?`, touchUploaded, clearFleetMaintainedAppID)
+			user_email = (SELECT email FROM users WHERE id = ?)%s
+			WHERE id = ?`, touchUploaded)
 
 		args := []interface{}{
 			payload.StorageID,
@@ -749,13 +745,6 @@ func (ds *Datastore) SaveInstallerUpdates(ctx context.Context, payload *fleet.Up
 		// When an installer is modified reset attempt numbers for policy automations
 		if err := ds.resetInstallerPolicyAutomationAttempts(ctx, tx, payload.InstallerID); err != nil {
 			return ctxerr.Wrap(ctx, err, "resetting policy automation attempts for installer")
-		}
-
-		// TODO(JK): remove patch policy
-		if clearPatchPolicy {
-			if err := ds.deletePatchPolicy(ctx, ptr.ValOrZero(payload.TeamID), payload.TitleID); err != nil {
-				return ctxerr.Wrap(ctx, err, "update software title display name")
-			}
 		}
 
 		return nil
@@ -1131,7 +1120,7 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 	var activateAffectedHostIDs []uint
 
 	// check if there is a patch policy that uses this title
-	policyStmt := `SELECT 1 FROM policies p JOIN software_installers si ON si.title_id = p.patch_software_title_id WHERE si.id = ?`
+	policyStmt := `SELECT 1 FROM policies p JOIN software_installers si ON si.title_id = p.patch_software_title_id AND si.global_or_team_id = p.team_id WHERE si.id = ?`
 	var policyExists bool
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyExists, policyStmt, id)
 	if err != nil && err != sql.ErrNoRows {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1120,10 +1120,13 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 	var activateAffectedHostIDs []uint
 
 	// check if there is a patch policy that uses this title
-	policyStmt := `SELECT 1 FROM policies p JOIN software_installers si ON si.title_id = p.patch_software_title_id AND si.global_or_team_id = p.team_id WHERE si.id = ?`
 	var policyExists bool
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyExists, policyStmt, id)
-	if err != nil && err != sql.ErrNoRows {
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &policyExists, `SELECT EXISTS (
+		SELECT 1 FROM policies p
+		JOIN software_installers si ON si.title_id = p.patch_software_title_id AND si.global_or_team_id = p.team_id
+		WHERE si.id = ?
+	)`, id)
+	if err != nil {
 		return ctxerr.Wrap(ctx, err, "checking if patch policy exists for software installer")
 	}
 	if policyExists {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -2183,7 +2183,7 @@ func testDeleteSoftwareInstallers(t *testing.T, ds *Datastore) {
 
 	err = ds.DeleteSoftwareInstaller(ctx, softwareInstallerID)
 	require.Error(t, err)
-	require.ErrorIs(t, err, errDeleteInstallerWithAssociatedPolicy)
+	require.ErrorIs(t, err, errDeleteInstallerWithAssociatedInstallPolicy)
 
 	_, err = ds.DeleteTeamPolicies(ctx, team1.ID, []uint{p1.ID})
 	require.NoError(t, err)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -53,7 +53,6 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"BatchSetSoftwareInstallersSetupExperienceSideEffects", testBatchSetSoftwareInstallersSetupExperienceSideEffects},
 		{"EditDeleteSoftwareInstallersActivateNextActivity", testEditDeleteSoftwareInstallersActivateNextActivity},
 		{"BatchSetSoftwareInstallersActivateNextActivity", testBatchSetSoftwareInstallersActivateNextActivity},
-		{"SaveInstallerUpdatesClearsFleetMaintainedAppID", testSaveInstallerUpdatesClearsFleetMaintainedAppID},
 		{"SoftwareInstallerReplicaLag", testSoftwareInstallerReplicaLag},
 		{"SoftwareTitleDisplayName", testSoftwareTitleDisplayName},
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
@@ -3750,67 +3749,6 @@ func testBatchSetSoftwareInstallersActivateNextActivity(t *testing.T, ds *Datast
 	checkUpcomingActivities(t, ds, host1, host1Script.ExecutionID)
 	checkUpcomingActivities(t, ds, host2, host2Script.ExecutionID)
 	checkUpcomingActivities(t, ds, host3)
-}
-
-func testSaveInstallerUpdatesClearsFleetMaintainedAppID(t *testing.T, ds *Datastore) {
-	ctx := context.Background()
-	user := test.NewUser(t, ds, "Test User", "test@example.com", true)
-	tfr, err := fleet.NewTempFileReader(strings.NewReader("file contents"), t.TempDir)
-	require.NoError(t, err)
-
-	// Create a maintained app
-	maintainedApp, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
-		Name:             "Maintained1",
-		Slug:             "maintained1",
-		Platform:         "darwin",
-		UniqueIdentifier: "fleet.maintained1",
-	})
-	require.NoError(t, err)
-
-	// Create an installer with a non-NULL fleet_maintained_app_id
-	installerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
-		Title:                "testpkg",
-		Source:               "apps",
-		InstallScript:        "echo install",
-		PreInstallQuery:      "SELECT 1",
-		UninstallScript:      "echo uninstall",
-		InstallerFile:        tfr,
-		StorageID:            "storageid1",
-		Filename:             "test.pkg",
-		Version:              "1.0",
-		UserID:               user.ID,
-		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: ptr.Uint(maintainedApp.ID),
-	})
-	require.NoError(t, err)
-
-	// Prepare update payload with a new installer file (should clear FMA id)
-	installScript := "echo install updated"
-	uninstallScript := "echo uninstall updated"
-	preInstallQuery := "SELECT 2"
-	selfService := true
-	payload := &fleet.UpdateSoftwareInstallerPayload{
-		TitleID:         titleID,
-		InstallerID:     installerID,
-		StorageID:       "storageid2", // different storage id
-		Filename:        "test2.pkg",
-		Version:         "2.0",
-		PackageIDs:      []string{"com.test.pkg"},
-		InstallScript:   &installScript,
-		UninstallScript: &uninstallScript,
-		PreInstallQuery: &preInstallQuery,
-		SelfService:     &selfService,
-		InstallerFile:   tfr, // triggers clearing
-		UserID:          user.ID,
-	}
-
-	require.NoError(t, ds.SaveInstallerUpdates(ctx, payload))
-
-	// Assert that fleet_maintained_app_id is now NULL
-	var fmaID *uint
-	err = sqlx.GetContext(ctx, ds.reader(ctx), &fmaID, `SELECT fleet_maintained_app_id FROM software_installers WHERE id = ?`, installerID)
-	require.NoError(t, err)
-	assert.Nil(t, fmaID, "fleet_maintained_app_id should be NULL after update")
 }
 
 func testSoftwareInstallerReplicaLag(t *testing.T, _ *Datastore) {

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -4760,10 +4760,12 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 		{
 			ID:   policy1.ID,
 			Name: policy1.Name,
+			Type: fleet.PolicyTypeDynamic,
 		},
 		{
 			ID:   policy2.ID,
 			Name: policy2.Name,
+			Type: fleet.PolicyTypeDynamic,
 		},
 	}
 	compareResults(expectedWithPolicies, sw, true)
@@ -4948,10 +4950,12 @@ func testListHostSoftware(t *testing.T, ds *Datastore) {
 					{
 						ID:   policy3.ID,
 						Name: policy3.Name,
+						Type: fleet.PolicyTypeDynamic,
 					},
 					{
 						ID:   policy4.ID,
 						Name: policy4.Name,
+						Type: fleet.PolicyTypeDynamic,
 					},
 				},
 			},

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -909,7 +909,7 @@ func (ds *Datastore) DeleteVPPAppFromTeam(ctx context.Context, teamID *uint, app
 				return ctxerr.Wrapf(ctx, err, "getting reference from policies")
 			}
 			if count > 0 {
-				return errDeleteInstallerWithAssociatedPolicy
+				return errDeleteInstallerWithAssociatedInstallPolicy
 			}
 
 		}

--- a/server/datastore/mysql/vpp_test.go
+++ b/server/datastore/mysql/vpp_test.go
@@ -1765,7 +1765,7 @@ func testDeleteVPPAssignedToPolicy(t *testing.T, ds *Datastore) {
 
 	err = ds.DeleteVPPAppFromTeam(ctx, ptr.Uint(0), va1.VPPAppID)
 	require.Error(t, err)
-	require.ErrorIs(t, err, errDeleteInstallerWithAssociatedPolicy)
+	require.ErrorIs(t, err, errDeleteInstallerWithAssociatedInstallPolicy)
 
 	_, err = ds.DeleteTeamPolicies(ctx, fleet.PolicyNoTeamID, []uint{p1.ID})
 	require.NoError(t, err)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -849,6 +849,8 @@ type Datastore interface {
 	GetCalendarPolicies(ctx context.Context, teamID uint) ([]PolicyCalendarData, error)
 	// GetPoliciesForConditionalAccess returns the team policies that are configured for "Conditional access".
 	GetPoliciesForConditionalAccess(ctx context.Context, teamID uint) ([]uint, error)
+	// GetPatchPolicy returns the patch policy associated with the title id
+	GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*PatchPolicyData, error) // TODO(JK): why do we always return pointers to things?
 
 	// ConditionalAccessBypassDevice lets the host skip the conditional access check next time it fails
 	ConditionalAccessBypassDevice(ctx context.Context, hostID uint) error

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -850,7 +850,7 @@ type Datastore interface {
 	// GetPoliciesForConditionalAccess returns the team policies that are configured for "Conditional access".
 	GetPoliciesForConditionalAccess(ctx context.Context, teamID uint) ([]uint, error)
 	// GetPatchPolicy returns the patch policy associated with the title id
-	GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*PatchPolicyData, error) // TODO(JK): why do we always return pointers to things?
+	GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*PatchPolicyData, error)
 
 	// ConditionalAccessBypassDevice lets the host skip the conditional access check next time it fails
 	ConditionalAccessBypassDevice(ctx context.Context, hostID uint) error

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -141,9 +141,6 @@ func (p PolicyPayload) Verify() error {
 		if p.QueryID != nil {
 			return errPolicyPatchAndQuerySet
 		}
-		if err := verifyPolicyName(p.Name); err != nil {
-			return err
-		}
 		if !emptyString(p.Query) {
 			return errPolicyPatchAndQuerySet
 		}

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -729,6 +729,7 @@ type AutomaticInstallPolicy struct {
 	ID      uint   `json:"id" db:"id"`
 	Name    string `json:"name" db:"name"`
 	TitleID uint   `json:"-" db:"software_title_id"`
+	Type    string `json:"type" db:"type"`
 }
 
 type PatchPolicyData struct {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -133,6 +133,9 @@ type SoftwareInstaller struct {
 
 	// DisplayName is an end-user friendly name.
 	DisplayName string `json:"display_name"`
+
+	// PatchPolicy is present for Fleet maintained apps with an associated patch policy
+	PatchPolicy *PatchPolicyData `json:"patch_policy"`
 }
 
 // SoftwarePackageResponse is the response type used when applying software by batch.
@@ -726,6 +729,11 @@ type AutomaticInstallPolicy struct {
 	ID      uint   `json:"id" db:"id"`
 	Name    string `json:"name" db:"name"`
 	TitleID uint   `json:"-" db:"software_title_id"`
+}
+
+type PatchPolicyData struct {
+	ID   uint   `json:"id" db:"id"`
+	Name string `json:"name" db:"name"`
 }
 
 // SoftwarePackageOrApp provides information about a software installer

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -643,6 +643,8 @@ type GetCalendarPoliciesFunc func(ctx context.Context, teamID uint) ([]fleet.Pol
 
 type GetPoliciesForConditionalAccessFunc func(ctx context.Context, teamID uint) ([]uint, error)
 
+type GetPatchPolicyFunc func(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error)
+
 type ConditionalAccessBypassDeviceFunc func(ctx context.Context, hostID uint) error
 
 type ConditionalAccessConsumeBypassFunc func(ctx context.Context, hostID uint) (*time.Time, error)
@@ -2715,6 +2717,9 @@ type DataStore struct {
 
 	GetPoliciesForConditionalAccessFunc        GetPoliciesForConditionalAccessFunc
 	GetPoliciesForConditionalAccessFuncInvoked bool
+
+	GetPatchPolicyFunc        GetPatchPolicyFunc
+	GetPatchPolicyFuncInvoked bool
 
 	ConditionalAccessBypassDeviceFunc        ConditionalAccessBypassDeviceFunc
 	ConditionalAccessBypassDeviceFuncInvoked bool
@@ -6600,6 +6605,13 @@ func (s *DataStore) GetPoliciesForConditionalAccess(ctx context.Context, teamID 
 	s.GetPoliciesForConditionalAccessFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetPoliciesForConditionalAccessFunc(ctx, teamID)
+}
+
+func (s *DataStore) GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error) {
+	s.mu.Lock()
+	s.GetPatchPolicyFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetPatchPolicyFunc(ctx, teamID, titleID)
 }
 
 func (s *DataStore) ConditionalAccessBypassDevice(ctx context.Context, hostID uint) error {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26604,7 +26604,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			IDs: []uint{policyResp.Policy.ID},
 		}, http.StatusOK, &deleteGlobalPoliciesResponse{})
 
-		// Test 2: Update the fleet maintained app installer
+		// Test 2: Update the fleet maintained app installer so that its no longer a fleet maintained app
 
 		// Test 3: gitops updated existing fleet maintained app installer?
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26641,7 +26641,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		// can delete installer successfully
 		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID))) //nolint:gosec // dismiss G115
 
-		// Test 2: Update the fleet maintained app installer so that its no longer a fleet maintained app
+		// Test 2: Updating an FMA installer with a new file fails
 		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
 		updateInstallerFMAID(fmaID, teamID, titleID)
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26633,7 +26633,14 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 	})
 
 	t.Run("batch team patch policy", func(t *testing.T) {
-		startFMAServers(t, s.ds)
+		// initialize FMA server
+		states := make(map[string]*fmaTestState, 1)
+		states["/zoom/windows.json"] = &fmaTestState{
+			version:        "1.0",
+			installerBytes: []byte("xyz"),
+			installerPath:  "/zoom.msi",
+		}
+		startFMAServers(t, s.ds, states)
 
 		getActiveTitleForTeam := func(teamID uint, titleName string) fleet.SoftwareTitleListResult {
 			var resp listSoftwareTitlesResponse
@@ -26740,9 +26747,37 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Nil(t, listPolResp.Policies[0].InstallSoftware)
 		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
 		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
+		// TODO(JK): shorten this check by extracting it to a function? ^^
 
 		// FMA Version is updated (query should use new version)
 
+		// resetFMAState resets an fmaTestState to the given version and installer bytes.
+		resetFMAState := func(state *fmaTestState, version string, installerBytes []byte) {
+			state.version = version
+			state.installerBytes = installerBytes
+			state.ComputeSHA(installerBytes)
+		}
+		resetFMAState(states["/zoom/windows.json"], "1.2", []byte("abc"))
+
+		s.DoJSON("POST", "/api/latest/fleet/software/batch",
+			batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{{Slug: ptr.String("zoom/windows")}}, TeamName: team.Name},
+			http.StatusAccepted, &resp,
+			"team_name", team.Name, "team_id", fmt.Sprint(team.ID),
+		)
+		waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, resp.RequestUUID)
+
+		applyResp = applyPolicySpecsResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/spec/policies",
+			applyPolicySpecsRequest{Specs: []*fleet.PolicySpec{spec}},
+			http.StatusOK, &applyResp,
+		)
+		title = getActiveTitleForTeam(team.ID, "zoom")
+
+		listPolResp = listTeamPoliciesResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
+		require.Len(t, listPolResp.Policies, 1)
+		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.2') >= 0;`, listPolResp.Policies[0].Query)
+		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
 		// FMA Version is pinned back after update? (query should use old version)
 	})
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26435,12 +26435,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			TeamID:        nil,
 		}
 		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
-
-		var titleID uint
-		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(context.Background(), q, &titleID, `SELECT title_id FROM software_installers WHERE global_or_team_id = ? AND filename = ?`, 0, payload.Filename)
-		})
-		require.NotZero(t, titleID)
+		titleID := getSoftwareTitleID(t, s.ds, "DummyApp", "apps")
 
 		// try to add a patch policy that matches to an installer, but not an FMA
 		params = map[string]any{
@@ -26565,4 +26560,54 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Empty(t, getPolicyResp.Policy.PatchSoftware)
 		require.Empty(t, getPolicyResp.Policy.PatchSoftwareTitleID)
 	})
+
+	t.Run("no_team_patch_policy", func(t *testing.T) {
+		// Test 1: delete software installer when there is an associatd patch policy
+
+		// upload a software installer
+		payload := &fleet.UploadSoftwareInstallerPayload{
+			InstallScript: "some install script",
+			Filename:      "dummy_installer.pkg",
+			TeamID:        nil,
+		}
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+		titleID := getSoftwareTitleID(t, s.ds, "DummyApp", "apps")
+
+		// add a fleet maintained app and associate the installer with it
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			res, err := q.ExecContext(ctx, `INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
+			VALUES ('DummyApp', 'dummy/darwin', 'darwin', 'com.example.dummy')`)
+			require.NoError(t, err)
+			id, err := res.LastInsertId()
+			require.NoError(t, err)
+
+			_, err = q.ExecContext(ctx, `UPDATE software_installers SET fleet_maintained_app_id = ? WHERE title_id = ?`, id, titleID)
+			require.NoError(t, err)
+			return nil
+		})
+
+		// add a patch policy
+		policyResp := teamPolicyResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies", teamPolicyRequest{
+			Type:                 ptr.String("patch"),
+			PatchSoftwareTitleID: &titleID,
+		}, http.StatusOK, &policyResp)
+
+		// attempt to delete installer
+		res := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusConflict, "team_id", "0")
+		errMsg := extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `Couldn’t delete. This software has a patch policy. Please remove the patch policy and try again.`)
+		res.Body.Close()
+
+		// remove patch policy and delete installer
+		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies/delete", deleteGlobalPoliciesRequest{
+			IDs: []uint{policyResp.Policy.ID},
+		}, http.StatusOK, &deleteGlobalPoliciesResponse{})
+
+		// Test 2: Update the fleet maintained app installer
+
+		// Test 3: gitops updated existing fleet maintained app installer?
+
+	})
+
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26405,6 +26405,15 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 	_, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "Team 1"})
 	require.NoError(t, err)
 
+	// most logic relies on fma id being present, so no need to create manifest server
+	updateInstallerFMAID := func(fmaID, teamID, titleID uint) {
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err = q.ExecContext(ctx, `UPDATE software_installers SET fleet_maintained_app_id = ? WHERE global_or_team_id = ? AND title_id = ?`, fmaID, teamID, titleID)
+			require.NoError(t, err)
+			return nil
+		})
+	}
+
 	t.Run("no_team_patch_policy", func(t *testing.T) {
 		// add a regular "No team" policy
 		tpParams := teamPolicyRequest{
@@ -26561,53 +26570,75 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Empty(t, getPolicyResp.Policy.PatchSoftwareTitleID)
 	})
 
-	t.Run("no_team_patch_policy", func(t *testing.T) {
+	t.Run("patch_policy_lifecycle", func(t *testing.T) {
 		// Test 1: delete software installer when there is an associatd patch policy
+
+		resp := teamResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/fleets", &createTeamRequest{
+			TeamPayload: fleet.TeamPayload{Name: ptr.String("team_1")},
+		}, http.StatusOK, &resp)
+		teamID := resp.Team.ID
 
 		// upload a software installer
 		payload := &fleet.UploadSoftwareInstallerPayload{
 			InstallScript: "some install script",
 			Filename:      "dummy_installer.pkg",
-			TeamID:        nil,
+			TeamID:        &teamID,
 		}
 		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
 		titleID := getSoftwareTitleID(t, s.ds, "DummyApp", "apps")
+		fmaID := getFleetMaintainedAppID(t, s.ds, "dummy/darwin")
 
 		// add a fleet maintained app and associate the installer with it
-		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			res, err := q.ExecContext(ctx, `INSERT INTO fleet_maintained_apps (name, slug, platform, unique_identifier)
-			VALUES ('DummyApp', 'dummy/darwin', 'darwin', 'com.example.dummy')`)
-			require.NoError(t, err)
-			id, err := res.LastInsertId()
-			require.NoError(t, err)
-
-			_, err = q.ExecContext(ctx, `UPDATE software_installers SET fleet_maintained_app_id = ? WHERE title_id = ?`, id, titleID)
-			require.NoError(t, err)
-			return nil
-		})
+		updateInstallerFMAID(fmaID, teamID, titleID)
 
 		// add a patch policy
 		policyResp := teamPolicyResponse{}
-		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies", teamPolicyRequest{
+		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", teamID), teamPolicyRequest{
 			Type:                 ptr.String("patch"),
 			PatchSoftwareTitleID: &titleID,
 		}, http.StatusOK, &policyResp)
 
 		// attempt to delete installer
-		res := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusConflict, "team_id", "0")
+		res := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusConflict, "team_id", strconv.Itoa(int(teamID)))
 		errMsg := extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Couldn’t delete. This software has a patch policy. Please remove the patch policy and try again.`)
 		res.Body.Close()
 
 		// remove patch policy and delete installer
-		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies/delete", deleteGlobalPoliciesRequest{
-			IDs: []uint{policyResp.Policy.ID},
-		}, http.StatusOK, &deleteGlobalPoliciesResponse{})
+		s.DoJSON("POST", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies/delete", teamID), deleteTeamPoliciesRequest{
+			TeamID: teamID,
+			IDs:    []uint{policyResp.Policy.ID}}, http.StatusOK, &deleteTeamPoliciesResponse{})
+
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			mysql.DumpTable(t, q, "policies", "team_id", "name", "type", "patch_software_title_id")
+			return nil
+		})
+
+		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID)))
 
 		// Test 2: Update the fleet maintained app installer so that its no longer a fleet maintained app
+		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
+		updateInstallerFMAID(fmaID, teamID, titleID)
+
+		dummyBytes, err := os.ReadFile("testdata/software-installers/dummy_installer.pkg")
+		require.NoError(t, err)
+		body, headers := generateMultipartRequest(t, "software", "dummy_installer.pkg", dummyBytes, s.token, map[string][]string{"team_id": {strconv.Itoa(int(teamID))}})
+		res = s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusBadRequest, headers)
+		errMsg = extractServerErrorText(res.Body)
+		require.Contains(t, errMsg, `Couldn't update. The package can't be changed for Fleet-maintained apps.`)
+		res.Body.Close()
 
 		// Test 3: gitops updated existing fleet maintained app installer?
 
 	})
 
+}
+
+func getFleetMaintainedAppID(t *testing.T, ds *mysql.Datastore, slug string) uint {
+	var id uint
+	mysql.ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(context.Background(), q, &id, `SELECT id FROM fleet_maintained_apps WHERE slug = ?`, slug)
+	})
+	return id
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26751,7 +26751,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
 		require.Nil(t, listPolResp.Policies[0].InstallSoftware)
 
-		// FMA Version is updated (query should use new version)
+		// Test 2: FMA Version is updated (query should use new version)
 		resetFMAState(states["/zoom/windows.json"], "1.2", []byte("abc"))
 
 		s.DoJSON("POST", "/api/latest/fleet/software/batch",
@@ -26773,7 +26773,28 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Len(t, listPolResp.Policies, 1)
 		checkPolicy(listPolResp.Policies[0], spec.Name, "1.2", title.ID)
 
-		// FMA Version is pinned back after update? (query should use old version)
+		// Test 3: FMA Version is pinned back after update? (query should use old version)
+		s.DoJSON("POST", "/api/latest/fleet/software/batch",
+			batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{
+				{Slug: ptr.String("zoom/windows"), SelfService: true, RollbackVersion: "1.0"},
+			}, TeamName: team.Name},
+			http.StatusAccepted, &resp,
+			"team_name", team.Name, "team_id", fmt.Sprint(team.ID),
+		)
+		waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, team.Name, resp.RequestUUID)
+
+		applyResp = applyPolicySpecsResponse{}
+		s.DoJSON("POST", "/api/latest/fleet/spec/policies",
+			applyPolicySpecsRequest{Specs: []*fleet.PolicySpec{spec}},
+			http.StatusOK, &applyResp,
+		)
+		title = getActiveTitleForTeam(team.ID, "zoom")
+
+		listPolResp = listTeamPoliciesResponse{}
+		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
+		require.Len(t, listPolResp.Policies, 1)
+		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
+
 	})
 }
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26476,15 +26476,15 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		// add the same patch policy, but this time it belongs to an FMA
 		policyResp := teamPolicyResponse{}
 		s.DoJSON("POST", "/api/latest/fleet/fleets/0/policies", teamPolicyRequest{
-			Name:                 "test-4",
+			Name:                 "",
 			Query:                "",
-			Description:          "um",
+			Description:          "",
 			Type:                 ptr.String("patch"),
 			PatchSoftwareTitleID: &titleID,
 		}, http.StatusOK, &policyResp)
-		require.Equal(t, policyResp.Policy.Name, "macOS - DummyApp up to date")
-		require.Equal(t, policyResp.Policy.Description, "Outdated software might introduce security vulnerabilities or compatibility issues.")
-		require.Equal(t, *policyResp.Policy.Resolution, "Install the latest version from self-service.")
+		require.Equal(t, "macOS - DummyApp up to date", policyResp.Policy.Name)
+		require.Equal(t, "Outdated software might introduce security vulnerabilities or compatibility issues.", policyResp.Policy.Description)
+		require.Equal(t, "Install the latest version from self-service.", *policyResp.Policy.Resolution)
 		require.Contains(t, policyResp.Policy.Query, "SELECT 1 FROM apps WHERE bundle_identifier =")
 		require.NotNil(t, policyResp.Policy.PatchSoftware)
 		require.Equal(t, titleID, policyResp.Policy.PatchSoftware.SoftwareTitleID)
@@ -26616,6 +26616,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			return nil
 		})
 
+		// can delete installer successfully
 		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID)))
 
 		// Test 2: Update the fleet maintained app installer so that its no longer a fleet maintained app
@@ -26629,9 +26630,6 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Couldn't update. The package can't be changed for Fleet-maintained apps.`)
 		res.Body.Close()
-
-		// Test 3: gitops updated existing fleet maintained app installer?
-
 	})
 
 	t.Run("batch team patch policy", func(t *testing.T) {
@@ -26684,6 +26682,8 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.NotNil(t, listPolResp.Policies[0].PatchSoftware)
 		require.Equal(t, title.ID, listPolResp.Policies[0].PatchSoftware.SoftwareTitleID)
 		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
+		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
+		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
 
 		// now enable automation on the policy
 		spec = &fleet.PolicySpec{
@@ -26711,6 +26711,8 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
 		// This is only set if the automation is enable
 		require.Equal(t, title.ID, listPolResp.Policies[0].InstallSoftware.SoftwareTitleID)
+		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
+		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
 
 		// Now disable the automation
 		spec = &fleet.PolicySpec{
@@ -26736,6 +26738,12 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Equal(t, title.ID, listPolResp.Policies[0].PatchSoftware.SoftwareTitleID)
 		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
 		require.Nil(t, listPolResp.Policies[0].InstallSoftware)
+		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
+		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
+
+		// FMA Version is updated (query should use new version)
+
+		// FMA Version is pinned back after update? (query should use old version)
 	})
 }
 

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26430,6 +26430,18 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		require.Equal(t, name, policy.Name)
 	}
 
+	createHostPolicyResults := func(host *fleet.Host, policy *fleet.Policy) {
+		distributedResp := submitDistributedQueryResultsResponse{}
+		s.DoJSONWithoutAuth("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+			host,
+			map[uint]*bool{
+				policy.ID: ptr.Bool(false),
+			},
+		), http.StatusOK, &distributedResp)
+		err = s.ds.UpdateHostPolicyCounts(ctx)
+		require.NoError(t, err)
+	}
+
 	t.Run("no_team_patch_policy", func(t *testing.T) {
 		// add a regular "No team" policy
 		tpParams := teamPolicyRequest{
@@ -26652,6 +26664,11 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}
 		startFMAServers(t, s.ds, states)
 
+		// Add some hosts
+		teamHosts := s.createHosts(t, "windows", "windows")
+		require.NoError(t, s.ds.AddHostsToTeam(context.Background(), fleet.NewAddHostsToTeamParams(&team.ID, []uint{teamHosts[0].ID})))
+		require.NoError(t, s.ds.AddHostsToTeam(context.Background(), fleet.NewAddHostsToTeamParams(&team.ID, []uint{teamHosts[1].ID})))
+
 		getActiveTitleForTeam := func(teamID uint, titleName string) fleet.SoftwareTitleListResult {
 			var resp listSoftwareTitlesResponse
 			s.DoJSON(
@@ -26746,6 +26763,12 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
 		require.Nil(t, listPolResp.Policies[0].InstallSoftware)
 
+		// check policy membership
+		createHostPolicyResults(teamHosts[0], listPolResp.Policies[0])
+		listPolResp.Policies[0], err = s.ds.Policy(ctx, listPolResp.Policies[0].ID)
+		require.NoError(t, err)
+		require.Equal(t, uint(1), listPolResp.Policies[0].FailingHostCount)
+
 		// Test 2: FMA Version is updated (query should use new version)
 		resetFMAState(states["/zoom/windows.json"], "1.2", []byte("abc"))
 
@@ -26767,6 +26790,11 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 		require.Len(t, listPolResp.Policies, 1)
 		checkPolicy(listPolResp.Policies[0], spec.Name, "1.2", title.ID)
+
+		// check policy membership
+		listPolResp.Policies[0], err = s.ds.Policy(ctx, listPolResp.Policies[0].ID)
+		require.NoError(t, err)
+		require.Equal(t, uint(0), listPolResp.Policies[0].FailingHostCount)
 
 		// Test 3: FMA Version is pinned back after update? (query should use old version)
 		s.DoJSON("POST", "/api/latest/fleet/software/batch",

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26406,7 +26406,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 	team, err := s.ds.NewTeam(ctx, &fleet.Team{Name: "Team 1" + t.Name()})
 	require.NoError(t, err)
 
-	// most an installer being uploaded through FMA
+	// mock an installer being uploaded through FMA
 	updateInstallerFMAID := func(fmaID, teamID, titleID uint) {
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
 			_, err = q.ExecContext(ctx, `UPDATE software_installers SET fleet_maintained_app_id = ? WHERE global_or_team_id = ? AND title_id = ?`, fmaID, teamID, titleID)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26415,6 +26415,21 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		})
 	}
 
+	// resetFMAState resets an fmaTestState to the given version and installer bytes.
+	resetFMAState := func(state *fmaTestState, version string, installerBytes []byte) {
+		state.version = version
+		state.installerBytes = installerBytes
+		state.ComputeSHA(installerBytes)
+	}
+
+	checkPolicy := func(policy *fleet.Policy, name, version string, titleID uint) {
+		require.NotNil(t, policy.PatchSoftware)
+		require.Equal(t, titleID, policy.PatchSoftware.SoftwareTitleID)
+		require.Equal(t, fleet.PolicyTypePatch, policy.Type)
+		require.Equal(t, fmt.Sprintf(`SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '%s') >= 0;`, version), policy.Query)
+		require.Equal(t, name, policy.Name)
+	}
+
 	t.Run("no_team_patch_policy", func(t *testing.T) {
 		// add a regular "No team" policy
 		tpParams := teamPolicyRequest{
@@ -26686,11 +26701,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		var listPolResp = listTeamPoliciesResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 		require.Len(t, listPolResp.Policies, 1)
-		require.NotNil(t, listPolResp.Policies[0].PatchSoftware)
-		require.Equal(t, title.ID, listPolResp.Policies[0].PatchSoftware.SoftwareTitleID)
-		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
-		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
-		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
+		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
 
 		// now enable automation on the policy
 		spec = &fleet.PolicySpec{
@@ -26713,13 +26724,9 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		listPolResp = listTeamPoliciesResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 		require.Len(t, listPolResp.Policies, 1)
-		require.NotNil(t, listPolResp.Policies[0].PatchSoftware)
-		require.Equal(t, title.ID, listPolResp.Policies[0].PatchSoftware.SoftwareTitleID)
-		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
+		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
 		// This is only set if the automation is enable
 		require.Equal(t, title.ID, listPolResp.Policies[0].InstallSoftware.SoftwareTitleID)
-		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
-		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
 
 		// Now disable the automation
 		spec = &fleet.PolicySpec{
@@ -26741,22 +26748,10 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		listPolResp = listTeamPoliciesResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 		require.Len(t, listPolResp.Policies, 1)
-		require.NotNil(t, listPolResp.Policies[0].PatchSoftware)
-		require.Equal(t, title.ID, listPolResp.Policies[0].PatchSoftware.SoftwareTitleID)
-		require.Equal(t, fleet.PolicyTypePatch, listPolResp.Policies[0].Type)
+		checkPolicy(listPolResp.Policies[0], spec.Name, "1.0", title.ID)
 		require.Nil(t, listPolResp.Policies[0].InstallSoftware)
-		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.0') >= 0;`, listPolResp.Policies[0].Query)
-		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
-		// TODO(JK): shorten this check by extracting it to a function? ^^
 
 		// FMA Version is updated (query should use new version)
-
-		// resetFMAState resets an fmaTestState to the given version and installer bytes.
-		resetFMAState := func(state *fmaTestState, version string, installerBytes []byte) {
-			state.version = version
-			state.installerBytes = installerBytes
-			state.ComputeSHA(installerBytes)
-		}
 		resetFMAState(states["/zoom/windows.json"], "1.2", []byte("abc"))
 
 		s.DoJSON("POST", "/api/latest/fleet/software/batch",
@@ -26776,8 +26771,8 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		listPolResp = listTeamPoliciesResponse{}
 		s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/fleets/%d/policies", team.ID), listTeamPoliciesRequest{}, http.StatusOK, &listPolResp, "page", "0")
 		require.Len(t, listPolResp.Policies, 1)
-		require.Equal(t, `SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND version_compare(bundle_short_version, '1.2') >= 0;`, listPolResp.Policies[0].Query)
-		require.Equal(t, spec.Name, listPolResp.Policies[0].Name)
+		checkPolicy(listPolResp.Policies[0], spec.Name, "1.2", title.ID)
+
 		// FMA Version is pinned back after update? (query should use old version)
 	})
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26628,7 +26628,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 		}, http.StatusOK, &policyResp)
 
 		// attempt to delete installer
-		res := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusConflict, "team_id", strconv.Itoa(int(teamID)))
+		res := s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusConflict, "team_id", strconv.Itoa(int(teamID))) //nolint:gosec // dismiss G115
 		errMsg := extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Couldn’t delete. This software has a patch policy. Please remove the patch policy and try again.`)
 		res.Body.Close()
@@ -26639,7 +26639,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			IDs:    []uint{policyResp.Policy.ID}}, http.StatusOK, &deleteTeamPoliciesResponse{})
 
 		// can delete installer successfully
-		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID)))
+		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID))) //nolint:gosec // dismiss G115
 
 		// Test 2: Update the fleet maintained app installer so that its no longer a fleet maintained app
 		s.uploadSoftwareInstaller(t, payload, http.StatusOK, "")
@@ -26647,7 +26647,7 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 
 		dummyBytes, err := os.ReadFile("testdata/software-installers/dummy_installer.pkg")
 		require.NoError(t, err)
-		body, headers := generateMultipartRequest(t, "software", "dummy_installer.pkg", dummyBytes, s.token, map[string][]string{"team_id": {strconv.Itoa(int(teamID))}})
+		body, headers := generateMultipartRequest(t, "software", "dummy_installer.pkg", dummyBytes, s.token, map[string][]string{"team_id": {strconv.Itoa(int(teamID))}}) //nolint:gosec // dismiss G115
 		res = s.DoRawWithHeaders("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package", titleID), body.Bytes(), http.StatusBadRequest, headers)
 		errMsg = extractServerErrorText(res.Body)
 		require.Contains(t, errMsg, `Couldn't update. The package can't be changed for Fleet-maintained apps.`)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -26626,11 +26626,6 @@ func (s *integrationEnterpriseTestSuite) TestPatchPolicies() {
 			TeamID: teamID,
 			IDs:    []uint{policyResp.Policy.ID}}, http.StatusOK, &deleteTeamPoliciesResponse{})
 
-		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			mysql.DumpTable(t, q, "policies", "team_id", "name", "type", "patch_software_title_id")
-			return nil
-		})
-
 		// can delete installer successfully
 		s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/software/titles/%d/available_for_install", titleID), nil, http.StatusNoContent, "team_id", strconv.Itoa(int(teamID)))
 

--- a/server/service/software_titles.go
+++ b/server/service/software_titles.go
@@ -208,6 +208,13 @@ func (svc *Service) SoftwareTitleByID(ctx context.Context, id uint, teamID *uint
 					return nil, ctxerr.Wrap(ctx, err, "get fleet maintained versions")
 				}
 				meta.FleetMaintainedVersions = fmaVersions
+
+				// Populate PatchPolicy if there is one
+				patchPolicy, err := svc.ds.GetPatchPolicy(ctx, teamID, id)
+				if err != nil && !fleet.IsNotFound(err) {
+					return nil, ctxerr.Wrap(ctx, err, "get patch policy")
+				}
+				meta.PatchPolicy = patchPolicy
 			}
 		}
 

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -1420,43 +1420,57 @@ func messageWithAndroidIdentifiers(t *testing.T, notificationType android.Notifi
 	}
 }
 
-func startFMAServers(t *testing.T, ds fleet.Datastore) {
-	// TODO: allow for configurable FMAs
-	type fmaTestState struct {
-		version        string
-		installerBytes []byte
-		sha256         string
+type fmaTestState struct {
+	version        string
+	installerBytes []byte
+	sha256         string
+	installerPath  string
+}
+
+func (s *fmaTestState) ComputeSHA(b []byte) {
+	h := sha256.New()
+	h.Write(b)
+	s.sha256 = hex.EncodeToString(h.Sum(nil))
+}
+
+func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTestState) {
+	// DONE: allow for configurable FMAs
+
+	if len(states) == 0 {
+		states = make(map[string]*fmaTestState, 1)
+		states["/zoom/windows.json"] = &fmaTestState{
+			version:        "1.0",
+			installerBytes: []byte("xyz"),
+			installerPath:  "/zoom.msi",
+		}
 	}
 
-	computeSHA := func(b []byte) string {
-		h := sha256.New()
-		h.Write(b)
-		return hex.EncodeToString(h.Sum(nil))
+	statesByInstallerPath := make(map[string]*fmaTestState, len(states))
+	for _, state := range states {
+		state.ComputeSHA(state.installerBytes)
+		statesByInstallerPath[state.installerPath] = state
 	}
-
-	zoomState := &fmaTestState{version: "1.0", installerBytes: []byte("xyz")}
-	zoomState.sha256 = computeSHA(zoomState.installerBytes)
-
 	var downloadMu sync.Mutex
 
 	// Mock installer server — routes by path to serve per-FMA bytes.
 	installerServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		downloadMu.Lock()
 		defer downloadMu.Unlock()
-		_, _ = w.Write(zoomState.installerBytes)
 
+		state, found := statesByInstallerPath[r.URL.Path]
+		if !found {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write(state.installerBytes)
 	}))
 
 	maintained_apps.SyncApps(t, ds)
 
 	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var state *fmaTestState
-		var installerPath string
-		switch r.URL.Path {
-		case "/zoom/windows.json":
-			state = zoomState
-			installerPath = "/zoom.msi"
-		default:
+		state, found := states[r.URL.Path]
+		if !found {
 			http.NotFound(w, r)
 			return
 		}
@@ -1465,7 +1479,7 @@ func startFMAServers(t *testing.T, ds fleet.Datastore) {
 			{
 				Version:            state.version,
 				Queries:            ma.FMAQueries{Exists: "SELECT 1 FROM osquery_info;"},
-				InstallerURL:       installerServer.URL + installerPath,
+				InstallerURL:       installerServer.URL + state.installerPath,
 				InstallScriptRef:   "foobaz",
 				UninstallScriptRef: "foobaz",
 				SHA256:             state.sha256,

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -1434,8 +1434,6 @@ func (s *fmaTestState) ComputeSHA(b []byte) {
 }
 
 func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTestState) {
-	// DONE: allow for configurable FMAs
-
 	if len(states) == 0 {
 		states = make(map[string]*fmaTestState, 1)
 		states["/zoom/windows.json"] = &fmaTestState{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40314 
- New error when attempting to delete an installer that has a patch policy associated
- New error when attempting to update the file for an installer associated with an FMA
- Gitops runs will generate the patch policy every time so it matches the current installer version
  - Existing code checks if the query was changed and resets membership, which should be enough.
- Added patch_policy object to software title, but we might change that based on discussion

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed
