### PR TITLE
Implement `webhooks_and_tickets_enabled` flag for policies in GitOps

### DIFF
--- a/changes/40627-add-webhooks-and-tickets-enabled-flag
+++ b/changes/40627-add-webhooks-and-tickets-enabled-flag
@@ -1,0 +1,1 @@
+- Implemented webhooks_and_tickets_enabled flag for policies in GitOps

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -749,19 +749,19 @@ func generateProfileFilename(profile *fleet.MDMConfigProfilePayload, profileCont
 
 func (cmd *GenerateGitopsCommand) generateOrgSettings() (orgSettings map[string]interface{}, err error) {
 	t := reflect.TypeOf(fleet.EnrichedAppConfig{})
+
+	webhookSettings, err := webhookSettingsWithoutPolicyIDs(cmd.AppConfig.WebhookSettings)
+	if err != nil {
+		return nil, err
+	}
+
 	orgSettings = map[string]interface{}{
 		jsonFieldName(t, "Features"):           cmd.AppConfig.Features,
 		jsonFieldName(t, "FleetDesktop"):       cmd.AppConfig.FleetDesktop,
 		jsonFieldName(t, "HostExpirySettings"): cmd.AppConfig.HostExpirySettings,
 		jsonFieldName(t, "OrgInfo"):            cmd.AppConfig.OrgInfo,
 		jsonFieldName(t, "ServerSettings"):     cmd.AppConfig.ServerSettings,
-		jsonFieldName(t, "WebhookSettings"): map[string]any{
-			"activities_webhook":       cmd.AppConfig.WebhookSettings.ActivitiesWebhook,
-			"host_status_webhook":      cmd.AppConfig.WebhookSettings.HostStatusWebhook,
-			"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(cmd.AppConfig.WebhookSettings.FailingPoliciesWebhook),
-			"vulnerabilities_webhook":  cmd.AppConfig.WebhookSettings.VulnerabilitiesWebhook,
-			"interval":                 cmd.AppConfig.WebhookSettings.Interval,
-		},
+		jsonFieldName(t, "WebhookSettings"):    webhookSettings,
 	}
 
 	integrations, err := cmd.generateIntegrations("default.yml", &GlobalOrTeamIntegrations{GlobalIntegrations: &cmd.AppConfig.Integrations})
@@ -1110,21 +1110,23 @@ func (cmd *GenerateGitopsCommand) generateTeamSettings(filePath string, team *fl
 	// For "No Team" (team ID 0), only include webhook settings
 	// Note: Jira/Zendesk integrations are not supported at the team level (including No Team)
 	// See https://github.com/fleetdm/fleet/issues/20287
+	webhookSettings, err := webhookSettingsWithoutPolicyIDs(team.Config.WebhookSettings)
+	if err != nil {
+		return nil, err
+	}
+
 	if team.ID == 0 {
-		webhookSettings := map[string]any{
-			"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(team.Config.WebhookSettings.FailingPoliciesWebhook),
-		}
+		// Only include failing_policies_webhook for "No Team".
+		fpw := webhookSettings["failing_policies_webhook"]
 		teamSettings = map[string]any{
-			jsonFieldName(t, "WebhookSettings"): webhookSettings,
+			jsonFieldName(t, "WebhookSettings"): map[string]any{
+				"failing_policies_webhook": fpw,
+			},
 		}
 		return teamSettings, nil
 	}
 
 	// For regular teams, include all settings
-	webhookSettings := map[string]any{
-		"host_status_webhook":      team.Config.WebhookSettings.HostStatusWebhook,
-		"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(team.Config.WebhookSettings.FailingPoliciesWebhook),
-	}
 	teamSettings = map[string]interface{}{
 		jsonFieldName(t, "Features"):           team.Config.Features,
 		jsonFieldName(t, "HostExpirySettings"): team.Config.HostExpirySettings,
@@ -1456,8 +1458,11 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			jsonFieldName(t, "CalendarEventsEnabled"):    policy.CalendarEventsEnabled,
 			jsonFieldName(t, "ConditionalAccessEnabled"): policy.ConditionalAccessEnabled,
 		}
+		// This is derived from the failing_policies_webhook.policy_ids field, which is being deprecated.
 		if failingPolicyIDs[policy.ID] {
 			policySpec["webhooks_and_tickets_enabled"] = true
+		} else {
+			policySpec["webhooks_and_tickets_enabled"] = false
 		}
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
@@ -1511,15 +1516,24 @@ func policyIDSliceToSet(ids []uint) map[uint]bool {
 	return m
 }
 
-// failingPoliciesWebhookWithoutPolicyIDs returns a map representation of the
-// webhook settings with the policy_ids field omitted (since those are now
-// represented as webhooks_and_tickets_enabled on individual policies).
-func failingPoliciesWebhookWithoutPolicyIDs(fpw fleet.FailingPoliciesWebhookSettings) map[string]any {
-	return map[string]any{
-		"enable_failing_policies_webhook": fpw.Enable,
-		"destination_url":                 fpw.DestinationURL,
-		"host_batch_size":                 fpw.HostBatchSize,
+// webhookSettingsWithoutPolicyIDs serializes the given webhook settings struct
+// to a map and removes the failing_policies_webhook.policy_ids key (since
+// those are now represented as webhooks_and_tickets_enabled on individual
+// policies).
+// TODO - remove this in Fleet 5 when we remove support for policy_ids under failing_policies_webhook.
+func webhookSettingsWithoutPolicyIDs(webhookSettings any) (map[string]any, error) {
+	b, err := json.Marshal(webhookSettings)
+	if err != nil {
+		return nil, fmt.Errorf("marshal webhook settings: %w", err)
 	}
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		return nil, fmt.Errorf("unmarshal webhook settings: %w", err)
+	}
+	if fpw, ok := m["failing_policies_webhook"].(map[string]any); ok {
+		delete(fpw, "policy_ids")
+	}
+	return m, nil
 }
 
 func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]interface{}, error) {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1459,11 +1459,7 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			jsonFieldName(t, "ConditionalAccessEnabled"): policy.ConditionalAccessEnabled,
 		}
 		// This is derived from the failing_policies_webhook.policy_ids field, which is being deprecated.
-		if failingPolicyIDs[policy.ID] {
-			policySpec["webhooks_and_tickets_enabled"] = true
-		} else {
-			policySpec["webhooks_and_tickets_enabled"] = false
-		}
+		policySpec["webhooks_and_tickets_enabled"] = failingPolicyIDs[policy.ID]
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
 			if software, ok := cmd.SoftwareList[policy.InstallSoftware.SoftwareTitleID]; ok {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -756,11 +756,11 @@ func (cmd *GenerateGitopsCommand) generateOrgSettings() (orgSettings map[string]
 		jsonFieldName(t, "OrgInfo"):            cmd.AppConfig.OrgInfo,
 		jsonFieldName(t, "ServerSettings"):     cmd.AppConfig.ServerSettings,
 		jsonFieldName(t, "WebhookSettings"): map[string]any{
-			"activities_webhook":      cmd.AppConfig.WebhookSettings.ActivitiesWebhook,
-			"host_status_webhook":     cmd.AppConfig.WebhookSettings.HostStatusWebhook,
+			"activities_webhook":       cmd.AppConfig.WebhookSettings.ActivitiesWebhook,
+			"host_status_webhook":      cmd.AppConfig.WebhookSettings.HostStatusWebhook,
 			"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(cmd.AppConfig.WebhookSettings.FailingPoliciesWebhook),
-			"vulnerabilities_webhook": cmd.AppConfig.WebhookSettings.VulnerabilitiesWebhook,
-			"interval":               cmd.AppConfig.WebhookSettings.Interval,
+			"vulnerabilities_webhook":  cmd.AppConfig.WebhookSettings.VulnerabilitiesWebhook,
+			"interval":                 cmd.AppConfig.WebhookSettings.Interval,
 		},
 	}
 
@@ -1122,7 +1122,7 @@ func (cmd *GenerateGitopsCommand) generateTeamSettings(filePath string, team *fl
 
 	// For regular teams, include all settings
 	webhookSettings := map[string]any{
-		"host_status_webhook":    team.Config.WebhookSettings.HostStatusWebhook,
+		"host_status_webhook":      team.Config.WebhookSettings.HostStatusWebhook,
 		"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(team.Config.WebhookSettings.FailingPoliciesWebhook),
 	}
 	teamSettings = map[string]interface{}{

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -449,6 +449,15 @@ func (cmd *GenerateGitopsCommand) Run() error {
 			MacOSSetup:                 cmd.AppConfig.MDM.MacOSSetup,
 		}
 
+		// Collect failing policy IDs from webhook settings so we can output
+		// webhooks_and_tickets_enabled per-policy instead of policy_ids in settings.
+		var failingPolicyIDs map[uint]bool
+		if team == nil {
+			failingPolicyIDs = policyIDSliceToSet(cmd.AppConfig.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
+		} else {
+			failingPolicyIDs = policyIDSliceToSet(team.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
+		}
+
 		if team == nil {
 			// Generate org settings, agent options and labels for the global config.
 			orgSettings, err := cmd.generateOrgSettings()
@@ -520,7 +529,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 		}
 
 		// Generate policies.
-		policies, err := cmd.generatePolicies(teamToProcess.ID, teamFileName)
+		policies, err := cmd.generatePolicies(teamToProcess.ID, teamFileName, failingPolicyIDs)
 		if err != nil {
 			teamName := "global"
 			if team != nil {
@@ -746,7 +755,13 @@ func (cmd *GenerateGitopsCommand) generateOrgSettings() (orgSettings map[string]
 		jsonFieldName(t, "HostExpirySettings"): cmd.AppConfig.HostExpirySettings,
 		jsonFieldName(t, "OrgInfo"):            cmd.AppConfig.OrgInfo,
 		jsonFieldName(t, "ServerSettings"):     cmd.AppConfig.ServerSettings,
-		jsonFieldName(t, "WebhookSettings"):    cmd.AppConfig.WebhookSettings,
+		jsonFieldName(t, "WebhookSettings"): map[string]any{
+			"activities_webhook":      cmd.AppConfig.WebhookSettings.ActivitiesWebhook,
+			"host_status_webhook":     cmd.AppConfig.WebhookSettings.HostStatusWebhook,
+			"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(cmd.AppConfig.WebhookSettings.FailingPoliciesWebhook),
+			"vulnerabilities_webhook": cmd.AppConfig.WebhookSettings.VulnerabilitiesWebhook,
+			"interval":               cmd.AppConfig.WebhookSettings.Interval,
+		},
 	}
 
 	integrations, err := cmd.generateIntegrations("default.yml", &GlobalOrTeamIntegrations{GlobalIntegrations: &cmd.AppConfig.Integrations})
@@ -1097,7 +1112,7 @@ func (cmd *GenerateGitopsCommand) generateTeamSettings(filePath string, team *fl
 	// See https://github.com/fleetdm/fleet/issues/20287
 	if team.ID == 0 {
 		webhookSettings := map[string]any{
-			"failing_policies_webhook": team.Config.WebhookSettings.FailingPoliciesWebhook,
+			"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(team.Config.WebhookSettings.FailingPoliciesWebhook),
 		}
 		teamSettings = map[string]any{
 			jsonFieldName(t, "WebhookSettings"): webhookSettings,
@@ -1106,10 +1121,14 @@ func (cmd *GenerateGitopsCommand) generateTeamSettings(filePath string, team *fl
 	}
 
 	// For regular teams, include all settings
+	webhookSettings := map[string]any{
+		"host_status_webhook":    team.Config.WebhookSettings.HostStatusWebhook,
+		"failing_policies_webhook": failingPoliciesWebhookWithoutPolicyIDs(team.Config.WebhookSettings.FailingPoliciesWebhook),
+	}
 	teamSettings = map[string]interface{}{
 		jsonFieldName(t, "Features"):           team.Config.Features,
 		jsonFieldName(t, "HostExpirySettings"): team.Config.HostExpirySettings,
-		jsonFieldName(t, "WebhookSettings"):    team.Config.WebhookSettings,
+		jsonFieldName(t, "WebhookSettings"):    webhookSettings,
 	}
 	integrations, err := cmd.generateIntegrations(filePath, &GlobalOrTeamIntegrations{TeamIntegrations: &team.Config.Integrations})
 	if err != nil {
@@ -1415,7 +1434,7 @@ func (cmd *GenerateGitopsCommand) generateScripts(teamId *uint, teamName string)
 	return scriptSlice, nil
 }
 
-func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string) ([]map[string]interface{}, error) {
+func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string, failingPolicyIDs map[uint]bool) ([]map[string]interface{}, error) {
 	policies, err := cmd.Client.GetPolicies(teamId)
 	if err != nil {
 		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting policies: %s\n", err)
@@ -1436,6 +1455,9 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			jsonFieldName(t, "Critical"):                 policy.Critical,
 			jsonFieldName(t, "CalendarEventsEnabled"):    policy.CalendarEventsEnabled,
 			jsonFieldName(t, "ConditionalAccessEnabled"): policy.ConditionalAccessEnabled,
+		}
+		if failingPolicyIDs[policy.ID] {
+			policySpec["webhooks_and_tickets_enabled"] = true
 		}
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
@@ -1479,6 +1501,25 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 		result[i] = policySpec
 	}
 	return result, nil
+}
+
+func policyIDSliceToSet(ids []uint) map[uint]bool {
+	m := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m
+}
+
+// failingPoliciesWebhookWithoutPolicyIDs returns a map representation of the
+// webhook settings with the policy_ids field omitted (since those are now
+// represented as webhooks_and_tickets_enabled on individual policies).
+func failingPoliciesWebhookWithoutPolicyIDs(fpw fleet.FailingPoliciesWebhookSettings) map[string]any {
+	return map[string]any{
+		"enable_failing_policies_webhook": fpw.Enable,
+		"destination_url":                 fpw.DestinationURL,
+		"host_batch_size":                 fpw.HostBatchSize,
+	}
 }
 
 func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]interface{}, error) {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1436,7 +1436,7 @@ func (cmd *GenerateGitopsCommand) generateScripts(teamId *uint, teamName string)
 	return scriptSlice, nil
 }
 
-func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string, failingPolicyIDs map[uint]bool) ([]map[string]interface{}, error) {
+func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string, failingPolicyIDs map[uint]bool) ([]map[string]any, error) {
 	policies, err := cmd.Client.GetPolicies(teamId)
 	if err != nil {
 		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting policies: %s\n", err)

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1723,7 +1723,7 @@ func TestGeneratePolicies(t *testing.T) {
 		},
 	}
 
-	policiesRaw, err := cmd.generatePolicies(nil, "default.yml")
+	policiesRaw, err := cmd.generatePolicies(nil, "default.yml", nil)
 	require.NoError(t, err)
 	require.NotNil(t, policiesRaw)
 	var policies []map[string]interface{}
@@ -1746,7 +1746,7 @@ func TestGeneratePolicies(t *testing.T) {
 	// Generate policies for a team.
 	// Note that nested keys here may be strings,
 	// so we'll JSON marshal and unmarshal to a map for comparison.
-	policiesRaw, err = cmd.generatePolicies(ptr.Uint(1), "some_team")
+	policiesRaw, err = cmd.generatePolicies(ptr.Uint(1), "some_team", nil)
 	require.NoError(t, err)
 	require.NotNil(t, policiesRaw)
 	b, err = yaml.Marshal(policiesRaw)

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3216,24 +3216,20 @@ func TestGitOpsGlobalWebhooksAndTicketsEnabled(t *testing.T) {
 	ds, appConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 
 	// Track applied policies and return them with IDs.
-	var appliedPolicies []*fleet.PolicySpec
+	var appliedPolicies []*fleet.Policy
 	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
-		appliedPolicies = append(appliedPolicies, specs...)
+		for i, spec := range specs {
+			appliedPolicies = append(appliedPolicies, &fleet.Policy{
+				PolicyData: fleet.PolicyData{
+					ID:   uint(i + 1),
+					Name: spec.Name,
+				},
+			})
+		}
 		return nil
 	}
 	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
-		var result []*fleet.Policy
-		for i, spec := range appliedPolicies {
-			if spec.Team == "" {
-				result = append(result, &fleet.Policy{
-					PolicyData: fleet.PolicyData{
-						ID:   uint(i + 1),
-						Name: spec.Name,
-					},
-				})
-			}
-		}
-		return result, nil
+		return appliedPolicies, nil
 	}
 
 	cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -3273,7 +3269,19 @@ software:
 
 	require.True(t, (*appConfig).WebhookSettings.FailingPoliciesWebhook.Enable)
 	require.Equal(t, "http://example.com/global-webhook", (*appConfig).WebhookSettings.FailingPoliciesWebhook.DestinationURL)
-	require.Len(t, (*appConfig).WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
+
+	// Get the IDs of the policies with webhooks_and_tickets_enabled.
+	policiesWithWebhooksEnabled := []string{"Global Webhook Policy 1", "Global Webhook Policy 2"}
+	expectedIDs := make([]uint, 0)
+	for _, p := range appliedPolicies {
+		if slices.Contains(policiesWithWebhooksEnabled, p.Name) {
+			expectedIDs = append(expectedIDs, uint(p.ID))
+		}
+	}
+
+	// Policies are assigned IDs 1, 2, 3 sequentially. Only the first two have
+	// webhooks_and_tickets_enabled, so only their IDs should be in the list.
+	require.ElementsMatch(t, expectedIDs, (*appConfig).WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 }
 
 func TestGitOpsFleetFailingPoliciesWebhookPolicyIDs(t *testing.T) {
@@ -3314,6 +3322,7 @@ agent_options:
 	require.NoError(t, err)
 	require.True(t, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
 	require.Equal(t, "http://example.com/webhook", savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	// Note -- this codepath doesn't actually verify that the policy's with the specified IDs exist, it just saves the IDs from the config.
 	require.Equal(t, []uint{1, 2}, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 }
 
@@ -3328,9 +3337,16 @@ func TestGitOpsFleetWebhooksAndTicketsEnabled(t *testing.T) {
 	require.Contains(t, savedFleets, fleetName)
 
 	// Override ApplyPolicySpecs to track applied policies and assign IDs.
-	var appliedPolicies []*fleet.PolicySpec
+	var appliedPolicies []*fleet.Policy
 	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
-		appliedPolicies = append(appliedPolicies, specs...)
+		for i, spec := range specs {
+			appliedPolicies = append(appliedPolicies, &fleet.Policy{
+				PolicyData: fleet.PolicyData{
+					ID:   uint(i + 1),
+					Name: spec.Name,
+				},
+			})
+		}
 		return nil
 	}
 
@@ -3338,18 +3354,7 @@ func TestGitOpsFleetWebhooksAndTicketsEnabled(t *testing.T) {
 	ds.ListTeamPoliciesFunc = func(
 		ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions,
 	) (fleetPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
-		var result []*fleet.Policy
-		for i, spec := range appliedPolicies {
-			if spec.Team == fleetName {
-				result = append(result, &fleet.Policy{
-					PolicyData: fleet.PolicyData{
-						ID:   uint(i + 1),
-						Name: spec.Name,
-					},
-				})
-			}
-		}
-		return result, nil, nil
+		return appliedPolicies, nil, nil
 	}
 
 	t.Run("conflict with policy_ids", func(t *testing.T) {
@@ -3418,7 +3423,19 @@ agent_options:
 		savedFleet, err := ds.TeamByName(context.Background(), fleetName)
 		require.NoError(t, err)
 		require.Equal(t, "http://example.com/webhook", savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
-		require.Len(t, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
+
+		// Get the IDs of the policies with webhooks_and_tickets_enabled.
+		policiesWithWebhooksEnabled := []string{"Webhook Policy 1", "Webhook Policy 2"}
+		expectedIDs := make([]uint, 0)
+		for _, p := range appliedPolicies {
+			if slices.Contains(policiesWithWebhooksEnabled, p.Name) {
+				expectedIDs = append(expectedIDs, uint(p.ID))
+			}
+		}
+
+		// Policies are assigned IDs 1, 2, 3 sequentially. Only the first two have
+		// webhooks_and_tickets_enabled, so only their IDs should be in the list.
+		require.ElementsMatch(t, expectedIDs, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 	})
 }
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1503,7 +1503,8 @@ policies:
 agent_options:
 name: ${TEST_TEAM_NAME}
 team_settings:
-  secrets: [{"secret":"${TEST_SECRET}"}]
+  secrets:
+   - secret: ${TEST_SECRET}
 software:
 `,
 	)
@@ -1811,7 +1812,8 @@ org_settings:
     - location: Foobar
       teams:
       - "${TEST_TEAM_NAME}"
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 software:
 `,
 	)
@@ -1828,7 +1830,8 @@ policies:
 agent_options:
 name: ${TEST_TEAM_NAME}
 team_settings:
-  secrets: [{"secret":"${TEST_SECRET}"}]
+  secrets:
+    - secret: ${TEST_SECRET}
 software:
   app_store_apps:
     - app_store_id: '1'
@@ -1846,7 +1849,9 @@ policies:
 agent_options:
 name: ${TEST_TEAM_NAME}
 team_settings:
-  secrets: [{"secret":"${TEST_SECRET}"},{"secret":"globalSecret"}]
+  secrets:
+    - secret: ${TEST_SECRET}
+    - secret: globalSecret
 software:
 `,
 	)
@@ -2171,7 +2176,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: %s
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 software:
   packages:
     - url: https://example.com
@@ -2344,7 +2350,8 @@ policies:
 agent_options:
 name: %s
 team_settings:
-  secrets: [{"secret":"%s"}]
+  secrets:
+    - secret: %s
 software:
 `, teamName, secret),
 	)
@@ -2369,7 +2376,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: %s
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 software:
 `, fleetServerURL, orgName),
 	)
@@ -2393,7 +2401,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: %s
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 `, fleetServerURL, orgName),
 	)
 	require.NoError(t, err)
@@ -2420,7 +2429,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: %s
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 software:
 `, fleetServerURL, orgName),
 	)
@@ -3255,7 +3265,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: GitOps Test
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
   webhook_settings:
     failing_policies_webhook:
       enable_failing_policies_webhook: true
@@ -3319,7 +3330,7 @@ agent_options:
 	require.NoError(t, err)
 	require.True(t, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
 	require.Equal(t, "http://example.com/webhook", savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
-	// Note -- this codepath doesn't actually verify that the policy's with the specified IDs exist, it just saves the IDs from the config.
+	// Note -- this codepath doesn't actually verify that the policies with the specified IDs exist, it just saves the IDs from the config.
 	require.Equal(t, []uint{1, 2}, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 }
 
@@ -3472,7 +3483,8 @@ org_settings:
     org_logo_url: ""
     org_logo_url_light_background: ""
     org_name: %s
-  secrets: [{"secret":"globalSecret"}]
+  secrets:
+    - secret: globalSecret
 software:
 `, fleetServerURL, orgName),
 	)

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3212,6 +3212,112 @@ func TestGitOpsTeamWebhooks(t *testing.T) {
 	require.Equal(t, "http://coolwebhook.biz", team.Config.WebhookSettings.HostStatusWebhook.DestinationURL)
 }
 
+func TestGitOpsWebhooksAndTicketsEnabled(t *testing.T) {
+	teamName := "TestWebhooksAndTicketsEnabled"
+
+	ds, _, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	// Create a team.
+	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: teamName})
+	require.NoError(t, err)
+	require.NotNil(t, *savedTeams[teamName])
+
+	// Override ApplyPolicySpecs to track applied policies and assign IDs.
+	var appliedPolicies []*fleet.PolicySpec
+	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+		appliedPolicies = append(appliedPolicies, specs...)
+		return nil
+	}
+
+	// Override ListTeamPolicies to return the applied policies with IDs.
+	ds.ListTeamPoliciesFunc = func(
+		ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions,
+	) (teamPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
+		var result []*fleet.Policy
+		for i, spec := range appliedPolicies {
+			if spec.Team == teamName {
+				result = append(result, &fleet.Policy{
+					PolicyData: fleet.PolicyData{
+						ID:   uint(i + 1),
+						Name: spec.Name,
+					},
+				})
+			}
+		}
+		return result, nil, nil
+	}
+
+	t.Run("conflict with policy_ids", func(t *testing.T) {
+		appliedPolicies = nil
+
+		cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+		require.NoError(t, err)
+		_, err = cfgFile.WriteString(fmt.Sprintf(`
+name: %s
+team_settings:
+  secrets:
+    - secret: "testSecret"
+  webhook_settings:
+    failing_policies_webhook:
+      enable_failing_policies_webhook: true
+      destination_url: http://example.com/webhook
+      policy_ids:
+        - 999
+software:
+queries:
+policies:
+  - name: Test Policy
+    query: "SELECT 1"
+    webhooks_and_tickets_enabled: true
+agent_options:
+`, teamName))
+		require.NoError(t, err)
+
+		_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "cannot use both 'webhooks_and_tickets_enabled' on policies and 'policy_ids'")
+	})
+
+	t.Run("sets policy_ids from webhooks_and_tickets_enabled", func(t *testing.T) {
+		appliedPolicies = nil
+
+		cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+		require.NoError(t, err)
+		_, err = cfgFile.WriteString(fmt.Sprintf(`
+name: %s
+team_settings:
+  secrets:
+    - secret: "testSecret"
+  webhook_settings:
+    failing_policies_webhook:
+      destination_url: http://example.com/webhook
+software:
+queries:
+policies:
+  - name: Webhook Policy 1
+    query: "SELECT 1"
+    webhooks_and_tickets_enabled: true
+  - name: Webhook Policy 2
+    query: "SELECT 2"
+    webhooks_and_tickets_enabled: true
+  - name: No Webhook Policy
+    query: "SELECT 3"
+agent_options:
+`, teamName))
+		require.NoError(t, err)
+
+		_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
+		require.NoError(t, err)
+
+		// Verify the team's webhook settings were updated with the correct policy IDs.
+		team, err := ds.TeamByName(context.Background(), teamName)
+		require.NoError(t, err)
+		require.True(t, team.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
+		require.Equal(t, "http://example.com/webhook", team.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+		require.Len(t, team.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
+	})
+}
+
 func TestGitOpsFeatures(t *testing.T) {
 	globalFileBasic := createGlobalFileBasic(t, fleetServerURL, orgName)
 	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3278,9 +3278,6 @@ software:
 			expectedIDs = append(expectedIDs, uint(p.ID))
 		}
 	}
-
-	// Policies are assigned IDs 1, 2, 3 sequentially. Only the first two have
-	// webhooks_and_tickets_enabled, so only their IDs should be in the list.
 	require.ElementsMatch(t, expectedIDs, (*appConfig).WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 }
 
@@ -3432,9 +3429,6 @@ agent_options:
 				expectedIDs = append(expectedIDs, uint(p.ID))
 			}
 		}
-
-		// Policies are assigned IDs 1, 2, 3 sequentially. Only the first two have
-		// webhooks_and_tickets_enabled, so only their IDs should be in the list.
 		require.ElementsMatch(t, expectedIDs, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 	})
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3312,7 +3312,6 @@ agent_options:
 		// Verify the team's webhook settings were updated with the correct policy IDs.
 		team, err := ds.TeamByName(context.Background(), teamName)
 		require.NoError(t, err)
-		require.True(t, team.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
 		require.Equal(t, "http://example.com/webhook", team.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
 		require.Len(t, team.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
 	})

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3442,6 +3442,58 @@ agent_options:
 		}
 		require.ElementsMatch(t, expectedIDs, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
 	})
+
+	t.Run("does not re-fetch policies when all already exist", func(t *testing.T) {
+		// Pre-populate appliedPolicies to simulate policies that already exist.
+		appliedPolicies = []*fleet.Policy{
+			{PolicyData: fleet.PolicyData{ID: 10, Name: "Existing Policy 1"}},
+			{PolicyData: fleet.PolicyData{ID: 20, Name: "Existing Policy 2"}},
+		}
+
+		// Track how many times ListTeamPolicies is called.
+		listTeamPoliciesCalls := 0
+		ds.ListTeamPoliciesFunc = func(
+			ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions,
+		) ([]*fleet.Policy, []*fleet.Policy, error) {
+			listTeamPoliciesCalls++
+			return appliedPolicies, nil, nil
+		}
+
+		cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+		require.NoError(t, err)
+		_, err = cfgFile.WriteString(fmt.Sprintf(`
+name: %s
+settings:
+  secrets:
+    - secret: "testSecret"
+  webhook_settings:
+    failing_policies_webhook:
+      destination_url: http://example.com/webhook
+software:
+queries:
+policies:
+  - name: Existing Policy 1
+    query: "SELECT 1"
+    webhooks_and_tickets_enabled: true
+  - name: Existing Policy 2
+    query: "SELECT 2"
+    webhooks_and_tickets_enabled: true
+agent_options:
+`, fleetName))
+		require.NoError(t, err)
+
+		_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
+		require.NoError(t, err)
+
+		// GetPolicies should only be called once (the initial fetch to diff
+		// existing vs. desired policies), not a second time to resolve IDs,
+		// since all policies already existed.
+		require.Equal(t, 1, listTeamPoliciesCalls)
+
+		savedFleet, err := ds.TeamByName(context.Background(), fleetName)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []uint{10, 20}, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
+	})
 }
 
 func TestGitOpsFeatures(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3275,7 +3275,7 @@ software:
 	expectedIDs := make([]uint, 0)
 	for _, p := range appliedPolicies {
 		if slices.Contains(policiesWithWebhooksEnabled, p.Name) {
-			expectedIDs = append(expectedIDs, uint(p.ID))
+			expectedIDs = append(expectedIDs, p.ID)
 		}
 	}
 	require.ElementsMatch(t, expectedIDs, (*appConfig).WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
@@ -3426,7 +3426,7 @@ agent_options:
 		expectedIDs := make([]uint, 0)
 		for _, p := range appliedPolicies {
 			if slices.Contains(policiesWithWebhooksEnabled, p.Name) {
-				expectedIDs = append(expectedIDs, uint(p.ID))
+				expectedIDs = append(expectedIDs, p.ID)
 			}
 		}
 		require.ElementsMatch(t, expectedIDs, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3212,15 +3212,120 @@ func TestGitOpsTeamWebhooks(t *testing.T) {
 	require.Equal(t, "http://coolwebhook.biz", team.Config.WebhookSettings.HostStatusWebhook.DestinationURL)
 }
 
-func TestGitOpsWebhooksAndTicketsEnabled(t *testing.T) {
-	teamName := "TestWebhooksAndTicketsEnabled"
+func TestGitOpsGlobalWebhooksAndTicketsEnabled(t *testing.T) {
+	ds, appConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 
-	ds, _, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+	// Track applied policies and return them with IDs.
+	var appliedPolicies []*fleet.PolicySpec
+	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+		appliedPolicies = append(appliedPolicies, specs...)
+		return nil
+	}
+	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+		var result []*fleet.Policy
+		for i, spec := range appliedPolicies {
+			if spec.Team == "" {
+				result = append(result, &fleet.Policy{
+					PolicyData: fleet.PolicyData{
+						ID:   uint(i + 1),
+						Name: spec.Name,
+					},
+				})
+			}
+		}
+		return result, nil
+	}
 
-	// Create a team.
-	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: teamName})
+	cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
-	require.NotNil(t, *savedTeams[teamName])
+	_, err = cfgFile.WriteString(fmt.Sprintf(`
+controls:
+queries:
+policies:
+  - name: Global Webhook Policy 1
+    query: "SELECT 1"
+    webhooks_and_tickets_enabled: true
+  - name: Global Webhook Policy 2
+    query: "SELECT 2"
+    webhooks_and_tickets_enabled: true
+  - name: Global No Webhook Policy
+    query: "SELECT 3"
+agent_options:
+org_settings:
+  server_settings:
+    server_url: %s
+  org_info:
+    contact_url: https://example.com/contact
+    org_logo_url: ""
+    org_logo_url_light_background: ""
+    org_name: GitOps Test
+  secrets: [{"secret":"globalSecret"}]
+  webhook_settings:
+    failing_policies_webhook:
+      enable_failing_policies_webhook: true
+      destination_url: http://example.com/global-webhook
+software:
+`, fleetServerURL))
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
+	require.NoError(t, err)
+
+	require.True(t, (*appConfig).WebhookSettings.FailingPoliciesWebhook.Enable)
+	require.Equal(t, "http://example.com/global-webhook", (*appConfig).WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	require.Len(t, (*appConfig).WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
+}
+
+func TestGitOpsFleetFailingPoliciesWebhookPolicyIDs(t *testing.T) {
+	fleetName := "TestFailingPoliciesPolicyIDs"
+
+	ds, _, savedFleets := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	// Create a fleet.
+	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fleetName})
+	require.NoError(t, err)
+	require.NotNil(t, *savedFleets[fleetName])
+
+	cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = cfgFile.WriteString(fmt.Sprintf(`
+name: %s
+settings:
+  secrets:
+    - secret: "testSecret"
+  webhook_settings:
+    failing_policies_webhook:
+      enable_failing_policies_webhook: true
+      destination_url: http://example.com/webhook
+      policy_ids:
+        - 1
+        - 2
+software:
+queries:
+policies:
+agent_options:
+`, fleetName))
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
+	require.NoError(t, err)
+
+	savedFleet, err := ds.TeamByName(context.Background(), fleetName)
+	require.NoError(t, err)
+	require.True(t, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.Enable)
+	require.Equal(t, "http://example.com/webhook", savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+	require.Equal(t, []uint{1, 2}, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs)
+}
+
+func TestGitOpsFleetWebhooksAndTicketsEnabled(t *testing.T) {
+	fleetName := "TestWebhooksAndTicketsEnabled"
+
+	ds, _, savedFleets := testing_utils.SetupFullGitOpsPremiumServer(t)
+
+	// Create a fleet.
+	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fleetName})
+	require.NoError(t, err)
+	require.NotNil(t, *savedFleets[fleetName])
 
 	// Override ApplyPolicySpecs to track applied policies and assign IDs.
 	var appliedPolicies []*fleet.PolicySpec
@@ -3232,10 +3337,10 @@ func TestGitOpsWebhooksAndTicketsEnabled(t *testing.T) {
 	// Override ListTeamPolicies to return the applied policies with IDs.
 	ds.ListTeamPoliciesFunc = func(
 		ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions,
-	) (teamPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
+	) (fleetPolicies []*fleet.Policy, inheritedPolicies []*fleet.Policy, err error) {
 		var result []*fleet.Policy
 		for i, spec := range appliedPolicies {
-			if spec.Team == teamName {
+			if spec.Team == fleetName {
 				result = append(result, &fleet.Policy{
 					PolicyData: fleet.PolicyData{
 						ID:   uint(i + 1),
@@ -3254,7 +3359,7 @@ func TestGitOpsWebhooksAndTicketsEnabled(t *testing.T) {
 		require.NoError(t, err)
 		_, err = cfgFile.WriteString(fmt.Sprintf(`
 name: %s
-team_settings:
+settings:
   secrets:
     - secret: "testSecret"
   webhook_settings:
@@ -3270,7 +3375,7 @@ policies:
     query: "SELECT 1"
     webhooks_and_tickets_enabled: true
 agent_options:
-`, teamName))
+`, fleetName))
 		require.NoError(t, err)
 
 		_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
@@ -3285,7 +3390,7 @@ agent_options:
 		require.NoError(t, err)
 		_, err = cfgFile.WriteString(fmt.Sprintf(`
 name: %s
-team_settings:
+settings:
   secrets:
     - secret: "testSecret"
   webhook_settings:
@@ -3303,17 +3408,17 @@ policies:
   - name: No Webhook Policy
     query: "SELECT 3"
 agent_options:
-`, teamName))
+`, fleetName))
 		require.NoError(t, err)
 
 		_, err = RunAppNoChecks([]string{"gitops", "-f", cfgFile.Name()})
 		require.NoError(t, err)
 
-		// Verify the team's webhook settings were updated with the correct policy IDs.
-		team, err := ds.TeamByName(context.Background(), teamName)
+		// Verify the fleet's webhook settings were updated with the correct policy IDs.
+		savedFleet, err := ds.TeamByName(context.Background(), fleetName)
 		require.NoError(t, err)
-		require.Equal(t, "http://example.com/webhook", team.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
-		require.Len(t, team.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
+		require.Equal(t, "http://example.com/webhook", savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.DestinationURL)
+		require.Len(t, savedFleet.Config.WebhookSettings.FailingPoliciesWebhook.PolicyIDs, 2)
 	})
 }
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3284,7 +3284,7 @@ func TestGitOpsFleetFailingPoliciesWebhookPolicyIDs(t *testing.T) {
 	// Create a fleet.
 	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fleetName})
 	require.NoError(t, err)
-	require.NotNil(t, *savedFleets[fleetName])
+	require.Contains(t, savedFleets, fleetName)
 
 	cfgFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
@@ -3325,7 +3325,7 @@ func TestGitOpsFleetWebhooksAndTicketsEnabled(t *testing.T) {
 	// Create a fleet.
 	_, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fleetName})
 	require.NoError(t, err)
-	require.NotNil(t, *savedFleets[fleetName])
+	require.Contains(t, savedFleets, fleetName)
 
 	// Override ApplyPolicySpecs to track applied policies and assign IDs.
 	var appliedPolicies []*fleet.PolicySpec

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedGlobalPolicies.yaml
@@ -11,3 +11,4 @@
   platform: darwin
   query: SELECT * FROM global_policy WHERE id = 1
   resolution: Do a global thing
+  webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings-insecure.yaml
@@ -128,7 +128,6 @@ webhook_settings:
     destination_url: https://some-failing-policies-webhook-url.com
     enable_failing_policies_webhook: true
     host_batch_size: 2
-    policy_ids: []
   host_status_webhook:
     days_count: 5
     destination_url: https://some-host-status-webhook-url.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedOrgSettings.yaml
@@ -126,7 +126,6 @@ webhook_settings:
     destination_url: https://some-failing-policies-webhook-url.com
     enable_failing_policies_webhook: true
     host_batch_size: 2
-    policy_ids: []
   host_status_webhook:
     days_count: 5
     destination_url: https://some-host-status-webhook-url.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -7,3 +7,4 @@
   resolution: Do a team thing
   run_script:
     path: /path/to/script1.sh
+  webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSettings-insecure.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSettings-insecure.yaml
@@ -16,10 +16,6 @@ webhook_settings:
     destination_url: https://some-team-failing_policies-webhook.com
     enable_failing_policies_webhook: false
     host_batch_size: 4
-    policy_ids:
-    - 1
-    - 2
-    - 3
   host_status_webhook:
     days_count: 3
     destination_url: https://some-team-host-status-webhook.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSettings.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSettings.yaml
@@ -16,10 +16,6 @@ webhook_settings:
     destination_url: https://some-team-failing_policies-webhook.com
     enable_failing_policies_webhook: false
     host_batch_size: 4
-    policy_ids:
-    - 1
-    - 2
-    - 3
   host_status_webhook:
     days_count: 3
     destination_url: https://some-team-host-status-webhook.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -189,6 +189,7 @@ policies:
   platform: darwin
   query: SELECT * FROM global_policy WHERE id = 1
   resolution: Do a global thing
+  webhooks_and_tickets_enabled: false
 reports:
 - automations_enabled: true
   description: This is a global query

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -164,7 +164,6 @@ org_settings:
       destination_url: https://some-failing-policies-webhook-url.com
       enable_failing_policies_webhook: true
       host_batch_size: 2
-      policy_ids:
     host_status_webhook:
       days_count: 5
       destination_url: https://some-host-status-webhook-url.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -160,7 +160,6 @@ org_settings:
       destination_url: https://some-failing-policies-webhook-url.com
       enable_failing_policies_webhook: true
       host_batch_size: 2
-      policy_ids:
     host_status_webhook:
       days_count: 5
       destination_url: https://some-host-status-webhook-url.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/default.yml
@@ -185,6 +185,7 @@ policies:
   platform: darwin
   query: SELECT * FROM global_policy WHERE id = 1
   resolution: Do a global thing
+  webhooks_and_tickets_enabled: false
 reports:
 - automations_enabled: true
   description: This is a global query

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -58,6 +58,7 @@ policies:
   platform: linux,windows
   query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing
+  webhooks_and_tickets_enabled: true
 reports:
 - automations_enabled: true
   description: This is a team query
@@ -88,10 +89,6 @@ settings:
       destination_url: https://some-team-failing_policies-webhook.com
       enable_failing_policies_webhook: false
       host_batch_size: 4
-      policy_ids:
-      - 1
-      - 2
-      - 3
     host_status_webhook:
       days_count: 3
       destination_url: https://some-team-host-status-webhook.com

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -41,14 +41,11 @@ policies:
   platform: linux,windows
   query: SELECT * FROM team_policy WHERE id = 1
   resolution: Do a team thing
+  webhooks_and_tickets_enabled: true
 settings:
   webhook_settings:
     failing_policies_webhook:
       destination_url: https://example.com/no-team-webhook
       enable_failing_policies_webhook: true
       host_batch_size: 100
-      policy_ids:
-      - 1
-      - 2
-      - 3
 software:

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -1194,7 +1194,7 @@ settings:
 	// Test dry-run first
 	output := fleetctl.RunAppForTest(t,
 		[]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "-f", noTeamFilePath, "--dry-run"})
-	s.assertDryRunOutput(t, output)
+	s.assertDryRunOutputWithDeprecation(t, output, true)
 
 	// Check that webhook settings are mentioned in the output
 	require.Contains(t, output, "would've applied webhook settings for unassigned hosts")
@@ -1202,7 +1202,7 @@ settings:
 	// Apply the configuration (non-dry-run)
 	output = fleetctl.RunAppForTest(t,
 		[]string{"gitops", "--config", fleetctlConfig.Name(), "-f", globalFile.Name(), "-f", noTeamFilePath})
-	s.assertRealRunOutput(t, output)
+	s.assertRealRunOutputWithDeprecation(t, output, true)
 
 	// Verify the output mentions webhook settings were applied
 	require.Contains(t, output, "applying webhook settings for unassigned hosts")

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -215,6 +215,10 @@ type GitOpsPolicySpec struct {
 	// RunScriptName is populated after confirming the script exists on both the file system
 	// and in the controls scripts list for the same team
 	RunScriptName *string `json:"-"`
+	// WebhooksAndTicketsEnabled indicates whether failing policy webhooks/tickets
+	// should be enabled for this policy. This is a gitops-only convenience that
+	// translates to adding the policy's ID to the failing_policies_webhook.policy_ids list.
+	WebhooksAndTicketsEnabled bool `json:"webhooks_and_tickets_enabled"`
 }
 
 type PolicyRunScript struct {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2978,7 +2978,6 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 
 			// Extract the existing webhook config and set the resolved policy IDs.
 			fpw := extractFailingPoliciesWebhookFromConfig(config)
-			fpw.Enable = true
 			fpw.PolicyIDs = resolvedIDs
 
 			// Re-apply the webhook settings with the resolved policy IDs.

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2746,6 +2746,23 @@ func (c *Client) doGitOpsLabels(
 }
 
 func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []fleet.SoftwarePackageResponse, teamVPPApps []fleet.VPPAppResponse, teamScripts []fleet.ScriptResponse, logFn func(format string, args ...interface{}), dryRun bool) error {
+	// Collect policy names that have webhooks_and_tickets_enabled set.
+	var policyNamesWithWebhooks []string
+	for _, p := range config.Policies {
+		if p.WebhooksAndTicketsEnabled {
+			policyNamesWithWebhooks = append(policyNamesWithWebhooks, p.Name)
+		}
+	}
+
+	// If any policies use webhooks_and_tickets_enabled, check for conflict with policy_ids in webhook settings.
+	if len(policyNamesWithWebhooks) > 0 {
+		if fpw := extractFailingPoliciesWebhookFromConfig(config); len(fpw.PolicyIDs) > 0 {
+			return errors.New(
+				"cannot use both 'webhooks_and_tickets_enabled' on policies and 'policy_ids' in failing_policies_webhook settings; please use one or the other",
+			)
+		}
+	}
+
 	var teamID *uint // Global policies (nil)
 	switch {
 	case config.TeamID != nil: // Team policies
@@ -2935,7 +2952,82 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			}
 		}
 	}
+
+	// If any policies have webhooks_and_tickets_enabled, resolve their IDs
+	// and update the failing policies webhook settings with the policy_ids list.
+	if len(policyNamesWithWebhooks) > 0 {
+		if dryRun {
+			logFn("[+] would've enabled webhooks/tickets for %s\n",
+				numberWithPluralization(len(policyNamesWithWebhooks), "policy", "policies"))
+		} else {
+			// Re-fetch policies to get IDs (policies were just applied above).
+			allPolicies, err := c.GetPolicies(teamID)
+			if err != nil {
+				return fmt.Errorf("error getting policies to resolve webhooks_and_tickets_enabled: %w", err)
+			}
+			policyNameSet := make(map[string]bool, len(policyNamesWithWebhooks))
+			for _, name := range policyNamesWithWebhooks {
+				policyNameSet[name] = true
+			}
+			var resolvedIDs []uint
+			for _, p := range allPolicies {
+				if policyNameSet[p.Name] {
+					resolvedIDs = append(resolvedIDs, p.ID)
+				}
+			}
+
+			// Extract the existing webhook config and set the resolved policy IDs.
+			fpw := extractFailingPoliciesWebhookFromConfig(config)
+			fpw.Enable = true
+			fpw.PolicyIDs = resolvedIDs
+
+			// Re-apply the webhook settings with the resolved policy IDs.
+			if config.TeamName == nil {
+				if err := c.ApplyAppConfig(map[string]any{
+					"webhook_settings": map[string]any{"failing_policies_webhook": fpw},
+				}, fleet.ApplySpecOptions{}); err != nil {
+					return fmt.Errorf("error updating failing policies webhook: %w", err)
+				}
+			} else {
+				var patchTeamID uint
+				if config.IsNoTeam() {
+					patchTeamID = 0
+				} else if config.TeamID != nil {
+					patchTeamID = *config.TeamID
+				}
+				var resp interface{}
+				if err := c.authenticatedRequest(
+					fleet.TeamPayload{WebhookSettings: &fleet.TeamWebhookSettings{FailingPoliciesWebhook: fpw}},
+					"PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", patchTeamID), &resp,
+				); err != nil {
+					return fmt.Errorf("error updating failing policies webhook: %w", err)
+				}
+			}
+			logFn("[+] enabled webhooks/tickets for %s\n",
+				numberWithPluralization(len(resolvedIDs), "policy", "policies"))
+		}
+	}
+
 	return nil
+}
+
+// extractFailingPoliciesWebhookFromConfig extracts the FailingPoliciesWebhookSettings
+// from the gitops config's settings (org or team).
+func extractFailingPoliciesWebhookFromConfig(config *spec.GitOps) fleet.FailingPoliciesWebhookSettings {
+	var settings map[string]any
+	if config.TeamName == nil {
+		settings = config.OrgSettings
+	} else {
+		settings = config.TeamSettings
+	}
+	if settings == nil {
+		return fleet.FailingPoliciesWebhookSettings{}
+	}
+	webhookSettings, ok := settings["webhook_settings"]
+	if !ok || webhookSettings == nil {
+		return fleet.FailingPoliciesWebhookSettings{}
+	}
+	return extractFailingPoliciesWebhook(webhookSettings)
 }
 
 func (c *Client) doGitOpsQueries(config *spec.GitOps, logFn func(format string, args ...interface{}), dryRun bool) error {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2991,7 +2991,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				var patchTeamID uint
 				if config.IsNoTeam() {
 					patchTeamID = 0
-				} else if config.TeamID != nil {
+				} else {
 					patchTeamID = *config.TeamID
 				}
 				var resp any

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2760,10 +2760,9 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			return errors.New(
 				"cannot use both 'webhooks_and_tickets_enabled' on policies and 'policy_ids' in failing_policies_webhook settings; please use one or the other",
 			)
-		} else {
-			// Log a deprecation warning.
-			logFn("[!] WARNING: using 'policy_ids' in failing_policies_webhook settings is deprecated; please use 'webhooks_and_tickets_enabled: true' on individual policies instead\n")
 		}
+		// Log a deprecation warning.
+		logFn("[!] WARNING: using 'policy_ids' in failing_policies_webhook settings is deprecated; please use 'webhooks_and_tickets_enabled: true' on individual policies instead\n")
 	}
 
 	var teamID *uint // Global policies (nil)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2687,9 +2687,7 @@ func (c *Client) doGitOpsNoTeamWebhookSettings(
 
 	if !dryRun {
 		logFn("[+] applying webhook settings for unassigned hosts\n")
-		// Apply the webhook settings to team ID 0 using the PATCH endpoint
-		var teamResp interface{}
-		err := c.authenticatedRequest(teamPayload, "PATCH", "/api/latest/fleet/teams/0", &teamResp)
+		err := c.PatchTeam(0, teamPayload)
 		if err != nil {
 			return fmt.Errorf("applying webhook settings for unassigned hosts: %w", err)
 		}
@@ -2754,12 +2752,17 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 		}
 	}
 
-	// If any policies use webhooks_and_tickets_enabled, check for conflict with policy_ids in webhook settings.
-	if len(policyNamesWithWebhooks) > 0 {
-		if fpw := extractFailingPoliciesWebhookFromConfig(config); len(fpw.PolicyIDs) > 0 {
+	// Get failing policies webhook settings to check for conflicts with policies that have webhooks_and_tickets_enabled.
+	fpw := extractFailingPoliciesWebhookFromConfig(config)
+
+	if len(fpw.PolicyIDs) > 0 {
+		if len(policyNamesWithWebhooks) > 0 {
 			return errors.New(
 				"cannot use both 'webhooks_and_tickets_enabled' on policies and 'policy_ids' in failing_policies_webhook settings; please use one or the other",
 			)
+		} else {
+			// Log a deprecation warning.
+			logFn("[!] WARNING: using 'policy_ids' in failing_policies_webhook settings is deprecated; please use 'webhooks_and_tickets_enabled: true' on individual policies instead\n")
 		}
 	}
 
@@ -2990,7 +2993,6 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			}
 
 			// Extract the existing webhook config and set the resolved policy IDs.
-			fpw := extractFailingPoliciesWebhookFromConfig(config)
 			fpw.PolicyIDs = resolvedIDs
 
 			// Re-apply the webhook settings with the resolved policy IDs.
@@ -3007,11 +3009,9 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				} else {
 					patchTeamID = *config.TeamID
 				}
-				var resp any
-				if err := c.authenticatedRequest(
-					fleet.TeamPayload{WebhookSettings: &fleet.TeamWebhookSettings{FailingPoliciesWebhook: fpw}},
-					"PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", patchTeamID), &resp,
-				); err != nil {
+				if err := c.PatchTeam(patchTeamID, fleet.TeamPayload{
+					WebhookSettings: &fleet.TeamWebhookSettings{FailingPoliciesWebhook: fpw},
+				}); err != nil {
 					return fmt.Errorf("error updating failing policies webhook: %w", err)
 				}
 			}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2687,7 +2687,7 @@ func (c *Client) doGitOpsNoTeamWebhookSettings(
 
 	if !dryRun {
 		logFn("[+] applying webhook settings for unassigned hosts\n")
-		err := c.PatchTeam(0, teamPayload)
+		err := c.PatchFleet(0, teamPayload)
 		if err != nil {
 			return fmt.Errorf("applying webhook settings for unassigned hosts: %w", err)
 		}
@@ -3009,7 +3009,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				} else {
 					patchTeamID = *config.TeamID
 				}
-				if err := c.PatchTeam(patchTeamID, fleet.TeamPayload{
+				if err := c.PatchFleet(patchTeamID, fleet.TeamPayload{
 					WebhookSettings: &fleet.TeamWebhookSettings{FailingPoliciesWebhook: fpw},
 				}); err != nil {
 					return fmt.Errorf("error updating failing policies webhook: %w", err)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2960,19 +2960,32 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 			logFn("[+] would've enabled failed policy reporting for %s\n",
 				numberWithPluralization(len(policyNamesWithWebhooks), "policy", "policies"))
 		} else {
-			// Re-fetch policies to get IDs (policies were just applied above).
-			allPolicies, err := c.GetPolicies(teamID)
-			if err != nil {
-				return fmt.Errorf("error getting policies to resolve webhooks_and_tickets_enabled: %w", err)
-			}
+			// Resolve policy names to IDs. First try using the policies we already
+			// fetched earlier; only re-fetch if some names are missing (i.e.,
+			// newly created policies whose IDs we don't have yet).
 			policyNameSet := make(map[string]bool, len(policyNamesWithWebhooks))
 			for _, name := range policyNamesWithWebhooks {
 				policyNameSet[name] = true
 			}
 			var resolvedIDs []uint
-			for _, p := range allPolicies {
+			for _, p := range policies {
 				if policyNameSet[p.Name] {
 					resolvedIDs = append(resolvedIDs, p.ID)
+					delete(policyNameSet, p.Name)
+				}
+			}
+			// If we have names left that couldn't resolve, re-fetch all the policies
+			// to get the IDs for the newly created ones.
+			if len(policyNameSet) > 0 {
+				// Some policies were newly created; re-fetch to get their IDs.
+				allPolicies, err := c.GetPolicies(teamID)
+				if err != nil {
+					return fmt.Errorf("error getting policies to resolve webhooks_and_tickets_enabled: %w", err)
+				}
+				for _, p := range allPolicies {
+					if policyNameSet[p.Name] {
+						resolvedIDs = append(resolvedIDs, p.ID)
+					}
 				}
 			}
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2957,7 +2957,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 	// and update the failing policies webhook settings with the policy_ids list.
 	if len(policyNamesWithWebhooks) > 0 {
 		if dryRun {
-			logFn("[+] would've enabled webhooks/tickets for %s\n",
+			logFn("[+] would've enabled failed policy reporting for %s\n",
 				numberWithPluralization(len(policyNamesWithWebhooks), "policy", "policies"))
 		} else {
 			// Re-fetch policies to get IDs (policies were just applied above).
@@ -3002,7 +3002,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 					return fmt.Errorf("error updating failing policies webhook: %w", err)
 				}
 			}
-			logFn("[+] enabled webhooks/tickets for %s\n",
+			logFn("[+] enabled failed policy reporting for %s\n",
 				numberWithPluralization(len(resolvedIDs), "policy", "policies"))
 		}
 	}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2994,7 +2994,7 @@ func (c *Client) doGitOpsPolicies(config *spec.GitOps, teamSoftwareInstallers []
 				} else if config.TeamID != nil {
 					patchTeamID = *config.TeamID
 				}
-				var resp interface{}
+				var resp any
 				if err := c.authenticatedRequest(
 					fleet.TeamPayload{WebhookSettings: &fleet.TeamWebhookSettings{FailingPoliciesWebhook: fpw}},
 					"PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", patchTeamID), &resp,

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -66,8 +66,8 @@ func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplyTeamSpecOpt
 	return responseBody.TeamIDsByName, nil
 }
 
-// PatchTeam sends a partial update to the specified team.
-func (c *Client) PatchTeam(teamID uint, payload fleet.TeamPayload) error {
+// PatchFleet sends a partial update to the specified team.
+func (c *Client) PatchFleet(teamID uint, payload fleet.TeamPayload) error {
 	verb, path := "PATCH", "/api/latest/fleet/teams/"+strconv.FormatUint(uint64(teamID), 10)
 	var resp teamResponse
 	return c.authenticatedRequest(payload, verb, path, &resp)

--- a/server/service/client_teams.go
+++ b/server/service/client_teams.go
@@ -66,6 +66,13 @@ func (c *Client) ApplyTeams(specs []json.RawMessage, opts fleet.ApplyTeamSpecOpt
 	return responseBody.TeamIDsByName, nil
 }
 
+// PatchTeam sends a partial update to the specified team.
+func (c *Client) PatchTeam(teamID uint, payload fleet.TeamPayload) error {
+	verb, path := "PATCH", "/api/latest/fleet/teams/"+strconv.FormatUint(uint64(teamID), 10)
+	var resp teamResponse
+	return c.authenticatedRequest(payload, verb, path, &resp)
+}
+
 // ApplyTeamProfiles sends the list of profiles to be applied for the specified
 // team.
 func (c *Client) ApplyTeamProfiles(tmName string, profiles []fleet.MDMProfileBatchPayload, opts fleet.ApplyTeamSpecOptions) error {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40627 

# Details

This PR updates the way we enable failed policy reporting (via webhook or ticket integration) for individual policies in GitOps.  The existing method is to declare a `policy_ids` key underneath `failing_policies_webhook:` in either the global or a fleet .yml file, and specify a list of policy IDs to enable the automation for.  This PR maintains this feature for backwards compatibility, and adds a new feature where you can set `webhook_and_tickets_enabled: true` key in the policy declaration itself.  If _both_ these methods are used, the GitOps run will fail.

**Implementation note:**

Because we're keeping the old way of doing this until Fleet 5, I took the easy route and just translated the new way into the old way; that is, we gather up the list of policies with `webhook_and_tickets_enabled: true`, get their IDs and send that list to the server under the same config we did previously.  This works fine and there's nothing _wrong_ with it but ideally this flag would work the same as other per-policy flags like `calendar_events_enabled` that are stored on the policy record. That requires a migration and more new code that we'd have to maintain alongside the existing code (or translate the old strategy to the new one). I'm taking the lower-touch path here.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
    - [x] Verified that `generate-gitops` outputs the new `webhooks_and_tickets_enabled` flag instead of outputting `policy_ids` under `failing_policies_webhook`
    - [X] Verified that using the new flag in a fleet .yml file results in the specified policies being enabled in the "other" automations for policies (whether the webhook automation is enabled or not) 
    - [X] Verified the same for a global .default.yml file
    - [X] Verified that using the old `failing_policies_webhook.policy_ids` a fleet .yml file results in the specified policies being enabled in the "other" automations for policies (whether the webhook automation is enabled or not) 
    - [X] Verified the same for a global .default.yml file
    - [X] Verified that trying to use both `webhooks_and_tickets_enabled` and `failing_policies_webhook.policy_ids` at the same time results in an error.

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [x] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
  see https://github.com/fleetdm/fleet/issues/40627#issuecomment-4024988552
- [x] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [x] Verified that any relevant UI is disabled when GitOps mode is enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configuration flag to enable webhooks and tickets for policies in GitOps settings.
  * System automatically resolves and assigns policy IDs when using the new flag.

* **Tests**
  * Added comprehensive test coverage for webhook and ticket enablement in GitOps workflows, including conflict detection and policy ID assignment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->