### PR TITLE
Website: Add note about using req.body in android proxy endpoints

### DIFF
--- a/website/api/controllers/android-proxy/create-android-enrollment-token.js
+++ b/website/api/controllers/android-proxy/create-android-enrollment-token.js
@@ -72,6 +72,7 @@ module.exports = {
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Enrollmenttokens.html#create
       let enrollmentTokenCreateResponse = await androidmanagement.enterprises.enrollmentTokens.create({
         parent: `enterprises/${androidEnterpriseId}`,
+        // Note: Typically, we use defined inputs instead of accessing req.body directly. This behavior should not be repeated in future Android proxy endpoints.
         requestBody: this.req.body,
       });
       return enrollmentTokenCreateResponse.data;

--- a/website/api/controllers/android-proxy/modify-android-device.js
+++ b/website/api/controllers/android-proxy/modify-android-device.js
@@ -80,6 +80,8 @@ module.exports = {
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Devices.html#patch
       let patchDeviceResponse = await androidmanagement.enterprises.devices.patch({
         name: `enterprises/${androidEnterpriseId}/devices/${deviceId}`,
+        // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.
+        // This behavior should not be repeated in future Android proxy endpoints.
         requestBody: this.req.body,
       });
       return patchDeviceResponse.data;

--- a/website/api/controllers/android-proxy/modify-android-policies.js
+++ b/website/api/controllers/android-proxy/modify-android-policies.js
@@ -80,6 +80,8 @@ module.exports = {
       // [?]: https://googleapis.dev/nodejs/googleapis/latest/androidmanagement/classes/Resource$Enterprises$Policies.html#patch
       let patchPoliciesResponse = await androidmanagement.enterprises.policies.patch({
         name: `enterprises/${androidEnterpriseId}/policies/${policyId}`,
+        // Note: Typically, we use defined inputs instead of accessing req.body directly. We forward req.body here to prevent previously set values from being overwritten by undefined values.
+        // This behavior should not be repeated in future Android proxy endpoints.
         requestBody: this.req.body,
         updateMask: this.req.param('updateMask') // Pass the update mask to avoid overwriting applications
       });


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/39688

Changes:
- Added a note to android proxy endpoints that forward `req.body` to the Android management API.