### PR TITLE
Add secret to dogfood-gitops configuration

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -82,6 +82,7 @@ jobs:
           DOGFOOD_END_USER_SSO_METADATA: ${{ secrets.DOGFOOD_END_USER_SSO_METADATA }}
           DOGFOOD_TESTING_AND_QA_ENROLL_SECRET: ${{ secrets.DOGFOOD_TESTING_AND_QA_ENROLL_SECRET }}
           DOGFOOD_OKTA_CA_CERTIFICATE: ${{ secrets.DOGFOOD_OKTA_CA_CERTIFICATE }}
+          DOGFOOD_OKTA_VERIFY_WINDOWS_URL: ${{ secrets.DOGFOOD_OKTA_VERIFY_WINDOWS_URL }}
 
       - name: Notify on Gitops failure
         if: failure() && github.ref_name == 'main'


### PR DESCRIPTION
This pull request makes a small change to the GitHub Actions workflow configuration by adding a new secret environment variable for use in the dogfood environment.

- Added the `DOGFOOD_OKTA_VERIFY_WINDOWS_URL` secret to the environment variables in the `.github/workflows/dogfood-gitops.yml` workflow file.