### PR TITLE
Configure software_installers defaults in Loadtest terraform

### DIFF
--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -142,9 +142,6 @@ module "loadtest" {
       bucket_prefix                      = "${terraform.workspace}-sw-inst-"
       create_kms_key                     = true
       kms_alias                          = "${local.customer}-software-installers"
-      enable_bucket_versioning           = true
-      expire_noncurrent_versions         = true
-      noncurrent_version_expiration_days = 30
     }
     volumes = [
       {

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -139,7 +139,7 @@ module "loadtest" {
     )
     private_key_secret_name = "${local.customer}-fleet-server-private-key"
     software_installers = {
-      bucket_prefix                      = "${terraform.workspace}-software-installers-"
+      bucket_prefix                      = "${terraform.workspace}-sw-inst-"
       create_kms_key                     = true
       kms_alias                          = "${local.customer}-software-installers"
       enable_bucket_versioning           = true

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -138,6 +138,17 @@ module "loadtest" {
       local.extra_secrets
     )
     private_key_secret_name = "${local.customer}-fleet-server-private-key"
+    software_installers = {
+      bucket_prefix                      = "${terraform.workspace}-software-installers-"
+      create_kms_key                     = true
+      kms_alias                          = "${local.customer}-software-installers"
+      enable_bucket_versioning           = true
+      expire_noncurrent_versions         = true
+      noncurrent_version_expiration_days = 30
+      tags = {
+        backup = "true"
+      }
+    }
     volumes = [
       {
         name = "rds-tls-certs"

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -139,9 +139,10 @@ module "loadtest" {
     )
     private_key_secret_name = "${local.customer}-fleet-server-private-key"
     software_installers = {
-      bucket_prefix                      = "${terraform.workspace}-sw-inst-"
-      create_kms_key                     = true
-      kms_alias                          = "${local.customer}-software-installers"
+      # bucket_prefix shortened to allow for terraform.workspace values with longer names
+      bucket_prefix  = "${terraform.workspace}-sw-inst-"
+      create_kms_key = true
+      kms_alias      = "${terraform.workspace}-software-installers"
     }
     volumes = [
       {

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -145,9 +145,6 @@ module "loadtest" {
       enable_bucket_versioning           = true
       expire_noncurrent_versions         = true
       noncurrent_version_expiration_days = 30
-      tags = {
-        backup = "true"
-      }
     }
     volumes = [
       {

--- a/infrastructure/loadtesting/terraform/infra/template/cloudfront.tf.disabled
+++ b/infrastructure/loadtesting/terraform/infra/template/cloudfront.tf.disabled
@@ -1,10 +1,10 @@
 module "cloudfront-software-installers" {
-  source            = "github.com/fleetdm/fleet-terraform/addons/cloudfront-software-installers?ref=tf-mod-addon-cloudfront-software-installers-v1.0.1"
+  source            = "github.com/fleetdm/fleet-terraform/addons/cloudfront-software-installers?ref=tf-mod-addon-cloudfront-software-installers-v1.2.0"
   customer          = terraform.workspace
   s3_bucket         = module.loadtest.byo-db.byo-ecs.fleet_s3_software_installers_config.bucket_name
   s3_kms_key_id     = module.loadtest.byo-db.byo-ecs.fleet_s3_software_installers_config.kms_key_id
   public_key        = tls_private_key.cloudfront_key.public_key_pem
-  private_key       = tls_private_key.cloudfront_key.private_key_pem
+  private_key       = tls_private_key.cloudfront_key.private_key_pem_pkcs8
   enable_logging    = true
   logging_s3_bucket = module.logging_alb.log_s3_bucket_id
 }


### PR DESCRIPTION
- Adds software_installers {} configuration to loadtest terraform
- Modifies template/cloudfront.tf.disabled to use pkcs#8 format for the private key