### PR TITLE
Update workstations configuration

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -5,9 +5,7 @@ team_settings:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL
       enable_failing_policies_webhook: true
       host_batch_size: 0
-      policy_ids:
-        - 14946
-        - 15329
+      policy_ids: []
   features:
     enable_host_users: true
     enable_software_inventory: true


### PR DESCRIPTION
This pull request makes a small change to the `it-and-security/teams/workstations.yml` configuration file by clearing the list of policy IDs for failing policies webhooks. No other settings are modified.

- Set `policy_ids` to an empty list in the `team_settings` section, removing the previous policy associations.