### PR TITLE
Fixed CPE matching failing for software names that sanitize to FTS5 reserved keywords (AND, OR, NOT)

### DIFF
--- a/changes/41225-cpe-matching-reserved-keywords
+++ b/changes/41225-cpe-matching-reserved-keywords
@@ -1,0 +1,1 @@
+* Fixed CPE matching failing for software names that sanitize to FTS5 reserved keywords (AND, OR, NOT).

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -55,6 +55,25 @@ func TestCPEFromSoftware(t *testing.T) {
 	_, err = CPEFromSoftware(t.Context(), slog.New(slog.DiscardHandler), db, &fleet.Software{Name: "[", Version: "1.2.3", BundleIdentifier: "vendor", Source: "apps"}, nil,
 		reCache)
 	require.NoError(t, err)
+
+	// Does not error on names that sanitize to FTS5 reserved keywords (AND, OR, NOT).
+	// These names are composed of special characters surrounding a keyword, so after
+	// sanitizeMatch strips non-alphanumeric chars, only the keyword remains.
+	ftsKeywordNames := []string{
+		"_OR_",       // sanitizes to " OR "
+		"(AND)",      // sanitizes to " AND "
+		"[NOT]",      // sanitizes to " NOT "
+		"--OR--",     // sanitizes to " OR "
+		"OR - Debug", // sanitizes to "OR Debug" (OR at start)
+		"foo - OR",   // sanitizes to "foo OR" (OR at end)
+	}
+	for _, name := range ftsKeywordNames {
+		_, err = CPEFromSoftware(
+			t.Context(), slog.New(slog.DiscardHandler), db,
+			&fleet.Software{Name: name, Version: "1.0", Source: "programs"}, nil, reCache,
+		)
+		require.NoError(t, err, "software name %q should not cause FTS5 syntax error", name)
+	}
 }
 
 func TestCPETranslations(t *testing.T) {

--- a/server/vulnerabilities/nvd/cpe_test.go
+++ b/server/vulnerabilities/nvd/cpe_test.go
@@ -58,14 +58,15 @@ func TestCPEFromSoftware(t *testing.T) {
 
 	// Does not error on names that sanitize to FTS5 reserved keywords (AND, OR, NOT).
 	// These names are composed of special characters surrounding a keyword, so after
-	// sanitizeMatch strips non-alphanumeric chars, only the keyword remains.
+	// sanitizeMatch strips non-alphanumeric chars and quotes each token, the keyword
+	// becomes a quoted literal instead of an FTS5 operator.
 	ftsKeywordNames := []string{
-		"_OR_",       // sanitizes to " OR "
-		"(AND)",      // sanitizes to " AND "
-		"[NOT]",      // sanitizes to " NOT "
-		"--OR--",     // sanitizes to " OR "
-		"OR - Debug", // sanitizes to "OR Debug" (OR at start)
-		"foo - OR",   // sanitizes to "foo OR" (OR at end)
+		"_OR_",       // sanitizes to `"OR"`
+		"(AND)",      // sanitizes to `"AND"`
+		"[NOT]",      // sanitizes to `"NOT"`
+		"--OR--",     // sanitizes to `"OR"`
+		"OR - Debug", // sanitizes to `"OR" "Debug"`
+		"foo - OR",   // sanitizes to `"foo" "OR"`
 	}
 	for _, name := range ftsKeywordNames {
 		_, err = CPEFromSoftware(

--- a/server/vulnerabilities/nvd/sanitize.go
+++ b/server/vulnerabilities/nvd/sanitize.go
@@ -204,11 +204,16 @@ func vendorVariations(s *fleet.Software) []string {
 	return r
 }
 
-// sanitizeMatch sanitizes the search string for sqlite fts queries. Replaces all non alpha numeric characters with spaces.
+// sanitizeMatch sanitizes the search string for sqlite fts queries. Replaces all non alpha numeric characters with spaces
+// and quotes each token to prevent FTS5 reserved keywords (AND, OR, NOT) from being interpreted as operators.
 func sanitizeMatch(s string) string {
 	s = strings.TrimSuffix(s, ".app")
 	s = nonAlphaNumeric.ReplaceAllString(s, " ")
-	return s
+	tokens := strings.Fields(s)
+	for i, t := range tokens {
+		tokens[i] = `"` + t + `"`
+	}
+	return strings.Join(tokens, " ")
 }
 
 // sanitizeVersion attempts to sanitize versions and attempt to make it dot separated.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41225

Most diffs are from regenerating software.sql, where we added this:
```
('_OR_ (FTS5 keyword test)', '1.0.0', 'apps', 'com.test.or', 'Test Vendor', '', '', '', '', NULL, NULL),
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CPE matching failures when software names contain reserved keywords (AND, OR, NOT), ensuring accurate matching in all scenarios.

* **Tests**
  * Added test coverage for CPE matching with reserved keyword names to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->