### PR TITLE
Update cron logging

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4841,6 +4841,7 @@ func ReconcileAppleDeclarations(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4855,12 +4856,15 @@ func ReconcileAppleDeclarations(
 		return ctxerr.Wrap(ctx, err, "updating host declaration state")
 	}
 
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations fetched changed hosts")
+
 	// Find any hosts that requested a resync. This is used to cover special cases where we're not
 	// 100% certain of the declarations on the device.
 	resyncHosts, err := ds.MDMAppleHostDeclarationsGetAndClearResync(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting and clearing resync hosts")
 	}
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations fetched resync hosts", "resync_host_count", len(resyncHosts))
 	if len(resyncHosts) > 0 {
 		changedHosts = append(changedHosts, resyncHosts...)
 		// Deduplicate changedHosts
@@ -4911,7 +4915,7 @@ func ReconcileAppleProfiles(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
-	logger.Log("msg", "ReconcileAppleProfiles starting")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4935,20 +4939,20 @@ func ReconcileAppleProfiles(
 	if block == nil || block.Type != "CERTIFICATE" {
 		return ctxerr.Wrap(ctx, err, "failed to decode PEM block from SCEP certificate")
 	}
-	logger.Log("msg", "ReconcileAppleProfiles loaded assets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles loaded assets")
 
 	if err := ensureFleetProfiles(ctx, ds, logger, block.Bytes); err != nil {
 		logger.Log("err", "unable to ensure a fleetd configuration profiles are in place", "details", err)
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
 
 	// retrieve the profiles to install/remove.
 	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting profiles to install and remove")
 	}
-	logger.Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
 
 	// Exclude macOS only profiles from iPhones/iPads.
 	toInstall = fleet.FilterMacOSOnlyProfilesFromIOSIPadOS(toInstall)
@@ -5135,7 +5139,7 @@ func ReconcileAppleProfiles(
 		hostProfilesToInstallMap[hostProfileUUID{HostUUID: p.HostUUID, ProfileUUID: p.ProfileUUID}] = hostProfile
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles processed install targets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles processed install targets")
 
 	for _, p := range toRemove {
 		// Exclude profiles that are also marked for installation.
@@ -5199,7 +5203,7 @@ func ReconcileAppleProfiles(
 		})
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles processed remove targets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles processed remove targets")
 
 	// delete all profiles that have a matching identifier to be installed.
 	// This is to prevent sending both a `RemoveProfile` and an
@@ -5225,7 +5229,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "deleting profiles that didn't change")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles cleaned up profiles")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles cleaned up profiles")
 
 	// FIXME: How does this impact variable profiles? This happens before pre-processing, doesn't
 	// this potentially race with the command uuid and variable substitution?
@@ -5240,7 +5244,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "updating host profiles")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles upserted host profiles")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles upserted host profiles")
 
 	// Grab the contents of all the profiles we need to install
 	profileUUIDs := make([]string, 0, len(toGetContents))
@@ -5257,7 +5261,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
 
 	// Insert variables into profile contents of install targets. Variables may be host-specific.
 	err = preprocessProfileContents(ctx, appConfig, ds,
@@ -5268,14 +5272,14 @@ func ReconcileAppleProfiles(
 		return err
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
 
 	// Find the profiles containing secret variables.
 	profilesWithSecrets, err := findProfilesWithSecrets(logger, installTargets, profileContents)
 	if err != nil {
 		return err
 	}
-	logger.Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
 
 	type remoteResult struct {
 		Err     error
@@ -5310,7 +5314,7 @@ func ReconcileAppleProfiles(
 			ch <- remoteResult{err, target.cmdUUID}
 		}
 	}
-	logger.Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeInstall)
@@ -5319,7 +5323,7 @@ func ReconcileAppleProfiles(
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeRemove)
 	}
-	logger.Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 
 	// index the host profiles by cmdUUID, for ease of error processing in the
 	// consumer goroutine below.
@@ -5351,18 +5355,18 @@ func ReconcileAppleProfiles(
 		}
 	}()
 
-	logger.Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
 	wgProd.Wait()
-	logger.Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
 	close(ch) // done sending at this point, this triggers end of for loop in consumer
 	wgCons.Wait()
-	logger.Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
 
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, failed); err != nil {
 		return ctxerr.Wrap(ctx, err, "reverting status of failed profiles")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
 
 	return nil
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5295,6 +5295,7 @@ func ReconcileAppleProfiles(
 
 	execCmd := func(profUUID string, target *cmdTarget, op fleet.MDMOperationType) {
 		defer wgProd.Done()
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles execcmd starting", "operation", op, "profile_uuid", profUUID, "command_uuid", target.cmdUUID, "enrollment_id_count", len(target.enrollmentIDs))
 
 		var err error
 		switch op {
@@ -5316,6 +5317,7 @@ func ReconcileAppleProfiles(
 			level.Error(logger).Log("err", fmt.Sprintf("enqueue command to %s profiles", op), "details", err)
 			ch <- remoteResult{err, target.cmdUUID}
 		}
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles execcmd completing", "profile_uuid", profUUID, "command_uuid", target.cmdUUID, "enrollment_id_count", len(target.enrollmentIDs))
 	}
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4911,6 +4911,7 @@ func ReconcileAppleProfiles(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
+	logger.Log("msg", "ReconcileAppleProfiles starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4934,16 +4935,20 @@ func ReconcileAppleProfiles(
 	if block == nil || block.Type != "CERTIFICATE" {
 		return ctxerr.Wrap(ctx, err, "failed to decode PEM block from SCEP certificate")
 	}
+	logger.Log("msg", "ReconcileAppleProfiles loaded assets")
 
 	if err := ensureFleetProfiles(ctx, ds, logger, block.Bytes); err != nil {
 		logger.Log("err", "unable to ensure a fleetd configuration profiles are in place", "details", err)
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
 
 	// retrieve the profiles to install/remove.
 	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting profiles to install and remove")
 	}
+	logger.Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
 
 	// Exclude macOS only profiles from iPhones/iPads.
 	toInstall = fleet.FilterMacOSOnlyProfilesFromIOSIPadOS(toInstall)
@@ -5130,6 +5135,8 @@ func ReconcileAppleProfiles(
 		hostProfilesToInstallMap[hostProfileUUID{HostUUID: p.HostUUID, ProfileUUID: p.ProfileUUID}] = hostProfile
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles processed install targets")
+
 	for _, p := range toRemove {
 		// Exclude profiles that are also marked for installation.
 		if _, ok := profileIntersection.GetMatchingProfileInDesiredState(p); ok {
@@ -5192,6 +5199,8 @@ func ReconcileAppleProfiles(
 		})
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles processed remove targets")
+
 	// delete all profiles that have a matching identifier to be installed.
 	// This is to prevent sending both a `RemoveProfile` and an
 	// `InstallProfile` for the same identifier, which can cause race
@@ -5216,6 +5225,8 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "deleting profiles that didn't change")
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles cleaned up profiles")
+
 	// FIXME: How does this impact variable profiles? This happens before pre-processing, doesn't
 	// this potentially race with the command uuid and variable substitution?
 	//
@@ -5228,6 +5239,8 @@ func ReconcileAppleProfiles(
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, hostProfiles); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating host profiles")
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles upserted host profiles")
 
 	// Grab the contents of all the profiles we need to install
 	profileUUIDs := make([]string, 0, len(toGetContents))
@@ -5244,6 +5257,8 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
+
 	// Insert variables into profile contents of install targets. Variables may be host-specific.
 	err = preprocessProfileContents(ctx, appConfig, ds,
 		eeservice.NewSCEPConfigService(logger, nil),
@@ -5253,11 +5268,14 @@ func ReconcileAppleProfiles(
 		return err
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
+
 	// Find the profiles containing secret variables.
 	profilesWithSecrets, err := findProfilesWithSecrets(logger, installTargets, profileContents)
 	if err != nil {
 		return err
 	}
+	logger.Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
 
 	type remoteResult struct {
 		Err     error
@@ -5292,6 +5310,7 @@ func ReconcileAppleProfiles(
 			ch <- remoteResult{err, target.cmdUUID}
 		}
 	}
+	logger.Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeInstall)
@@ -5300,6 +5319,7 @@ func ReconcileAppleProfiles(
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeRemove)
 	}
+	logger.Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 
 	// index the host profiles by cmdUUID, for ease of error processing in the
 	// consumer goroutine below.
@@ -5331,13 +5351,18 @@ func ReconcileAppleProfiles(
 		}
 	}()
 
+	logger.Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
 	wgProd.Wait()
+	logger.Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
 	close(ch) // done sending at this point, this triggers end of for loop in consumer
 	wgCons.Wait()
+	logger.Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
 
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, failed); err != nil {
 		return ctxerr.Wrap(ctx, err, "reverting status of failed profiles")
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
 
 	return nil
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5221,6 +5221,7 @@ func ReconcileAppleProfiles(
 	}
 	// We need to delete commands from the nano queue so they don't get sent to device.
 	if len(commandUUIDToHostIDsCleanupMap) > 0 {
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles cleaning up nano commands without results", "count", len(commandUUIDToHostIDsCleanupMap))
 		if err := commander.BulkDeleteHostUserCommandsWithoutResults(ctx, commandUUIDToHostIDsCleanupMap); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting nano commands without results")
 		}
@@ -5253,6 +5254,8 @@ func ReconcileAppleProfiles(
 	}
 	profileContents, err := ds.GetMDMAppleProfilesContents(ctx, profileUUIDs)
 	if err != nil {
+		level.Error(logger).Log("err", "ReconcileAppleProfiles error fetching profile contents", "details", err)
+
 		return ctxerr.Wrap(ctx, err, "get profile contents")
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
