### PR TITLE
Draft: Batch up reconciler pushes

### DIFF
--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -8997,7 +8997,7 @@ func testDeleteMDMProfilesCancelsInstalls(t *testing.T, ds *Datastore) {
 	forceSetAppleHostProfileStatus(t, ds, host2.UUID, test.ToMDMAppleConfigProfile(profNameToProf["A2"]), fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying)
 	// enqueue the corresponding command for the installed profile
 	cmdUUID := uuid.New().String()
-	err = commander.InstallProfile(ctx, []string{host2.UUID}, appleProfs[1].Mobileconfig, cmdUUID)
+	err = commander.InstallProfile(ctx, []string{host2.UUID}, appleProfs[1].Mobileconfig, cmdUUID, true)
 	require.NoError(t, err)
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx, `UPDATE host_mdm_apple_profiles SET command_uuid = ? WHERE host_uuid = ? AND profile_uuid = ?`, cmdUUID, host2.UUID, profNameToProf["A2"].ProfileUUID)
@@ -9028,7 +9028,7 @@ func testDeleteMDMProfilesCancelsInstalls(t *testing.T, ds *Datastore) {
 	forceSetAppleHostProfileStatus(t, ds, host1.UUID, test.ToMDMAppleConfigProfile(profNameToProf["A3"]), fleet.MDMOperationTypeInstall, fleet.MDMDeliveryPending)
 	// enqueue the corresponding command for the installed profile
 	cmdUUID = uuid.New().String()
-	err = commander.InstallProfile(ctx, []string{host1.UUID}, appleProfs[2].Mobileconfig, cmdUUID)
+	err = commander.InstallProfile(ctx, []string{host1.UUID}, appleProfs[2].Mobileconfig, cmdUUID, true)
 	require.NoError(t, err)
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		_, err := q.ExecContext(ctx, `UPDATE host_mdm_apple_profiles SET command_uuid = ? WHERE host_uuid = ? AND profile_uuid = ?`, cmdUUID, host1.UUID, profNameToProf["A3"].ProfileUUID)

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -19,8 +19,8 @@ import (
 )
 
 type MDMAppleCommandIssuer interface {
-	InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error
-	RemoveProfile(ctx context.Context, hostUUIDs []string, identifier string, uuid string) error
+	InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string, notify bool) error
+	RemoveProfile(ctx context.Context, hostUUIDs []string, identifier string, uuid string, notify bool) error
 	DeviceLock(ctx context.Context, host *Host, uuid string) (unlockPIN string, err error)
 	EnableLostMode(ctx context.Context, host *Host, commandUUID string, orgName string) error
 	DisableLostMode(ctx context.Context, host *Host, commandUUID string) error

--- a/server/mdm/apple/commander.go
+++ b/server/mdm/apple/commander.go
@@ -45,12 +45,16 @@ func NewMDMAppleCommander(mdmStorage fleet.MDMAppleStore, mdmPushService nanomdm
 
 // InstallProfile sends the homonymous MDM command to the given hosts, it also
 // takes care of the base64 encoding of the provided profile bytes.
-func (svc *MDMAppleCommander) InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string) error {
+func (svc *MDMAppleCommander) InstallProfile(ctx context.Context, hostUUIDs []string, profile mobileconfig.Mobileconfig, uuid string, notify bool) error {
 	raw, err := svc.SignAndEncodeInstallProfile(ctx, profile, uuid)
 	if err != nil {
 		return err
 	}
-	err = svc.EnqueueCommand(ctx, hostUUIDs, raw)
+	if notify {
+		err = svc.EnqueueCommand(ctx, hostUUIDs, raw)
+	} else {
+		err = svc.EnqueueCommandWithoutNotification(ctx, hostUUIDs, raw)
+	}
 	return ctxerr.Wrap(ctx, err, "commander install profile")
 }
 
@@ -80,7 +84,7 @@ func (svc *MDMAppleCommander) SignAndEncodeInstallProfile(ctx context.Context, p
 }
 
 // RemoveProfile sends the homonymous MDM command to the given hosts.
-func (svc *MDMAppleCommander) RemoveProfile(ctx context.Context, hostUUIDs []string, profileIdentifier string, uuid string) error {
+func (svc *MDMAppleCommander) RemoveProfile(ctx context.Context, hostUUIDs []string, profileIdentifier string, uuid string, notify bool) error {
 	raw := fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -96,7 +100,12 @@ func (svc *MDMAppleCommander) RemoveProfile(ctx context.Context, hostUUIDs []str
 	</dict>
 </dict>
 </plist>`, uuid, profileIdentifier)
-	err := svc.EnqueueCommand(ctx, hostUUIDs, raw)
+	var err error
+	if notify {
+		err = svc.EnqueueCommand(ctx, hostUUIDs, raw)
+	} else {
+		err = svc.EnqueueCommandWithoutNotification(ctx, hostUUIDs, raw)
+	}
 	return ctxerr.Wrap(ctx, err, "commander remove profile")
 }
 
@@ -507,6 +516,26 @@ func (svc *MDMAppleCommander) EnqueueCommand(ctx context.Context, hostUUIDs []st
 	return svc.enqueueAndNotify(ctx, hostUUIDs, cmd, mdm.CommandSubtypeNone)
 }
 
+func (svc *MDMAppleCommander) EnqueueCommandWithoutNotification(ctx context.Context, hostUUIDs []string, rawCommand string) error {
+	cmd, err := mdm.DecodeCommand([]byte(rawCommand))
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "decoding command")
+	}
+
+	return svc.enqueue(ctx, hostUUIDs, cmd, mdm.CommandSubtypeNone)
+}
+
+func (svc *MDMAppleCommander) enqueue(ctx context.Context, hostUUIDs []string, cmd *mdm.Command,
+	subtype mdm.CommandSubtype,
+) error {
+	if _, err := svc.storage.EnqueueCommand(ctx, hostUUIDs,
+		&mdm.CommandWithSubtype{Command: *cmd, Subtype: subtype}); err != nil {
+		return ctxerr.Wrap(ctx, err, "enqueuing command")
+	}
+
+	return nil
+}
+
 func (svc *MDMAppleCommander) enqueueAndNotify(ctx context.Context, hostUUIDs []string, cmd *mdm.Command,
 	subtype mdm.CommandSubtype,
 ) error {
@@ -524,7 +553,7 @@ func (svc *MDMAppleCommander) enqueueAndNotify(ctx context.Context, hostUUIDs []
 // EnqueueCommandInstallProfileWithSecrets is a special case of EnqueueCommand that does not expand secret variables.
 // Secret variables are expanded when the command is sent to the device, and secrets are never stored in the database unencrypted.
 func (svc *MDMAppleCommander) EnqueueCommandInstallProfileWithSecrets(ctx context.Context, hostUUIDs []string,
-	rawCommand mobileconfig.Mobileconfig, commandUUID string,
+	rawCommand mobileconfig.Mobileconfig, commandUUID string, notify bool,
 ) error {
 	cmd := &mdm.Command{
 		CommandUUID: commandUUID,
@@ -532,7 +561,11 @@ func (svc *MDMAppleCommander) EnqueueCommandInstallProfileWithSecrets(ctx contex
 	}
 	cmd.Command.RequestType = "InstallProfile"
 
-	return svc.enqueueAndNotify(ctx, hostUUIDs, cmd, mdm.CommandSubtypeProfileWithSecrets)
+	if notify {
+		return svc.enqueueAndNotify(ctx, hostUUIDs, cmd, mdm.CommandSubtypeProfileWithSecrets)
+	}
+
+	return svc.enqueue(ctx, hostUUIDs, cmd, mdm.CommandSubtypeProfileWithSecrets)
 }
 
 func (svc *MDMAppleCommander) SendNotifications(ctx context.Context, hostUUIDs []string) error {

--- a/server/mdm/apple/commander_test.go
+++ b/server/mdm/apple/commander_test.go
@@ -104,7 +104,7 @@ func TestMDMAppleCommander(t *testing.T) {
 	}
 
 	cmdUUID := uuid.New().String()
-	err := cmdr.InstallProfile(ctx, hostUUIDs, mc, cmdUUID)
+	err := cmdr.InstallProfile(ctx, hostUUIDs, mc, cmdUUID, true)
 	require.NoError(t, err)
 	require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
 	mdmStorage.EnqueueCommandFuncInvoked = false
@@ -118,7 +118,7 @@ func TestMDMAppleCommander(t *testing.T) {
 		return nil, nil
 	}
 	cmdUUID = uuid.New().String()
-	err = cmdr.RemoveProfile(ctx, hostUUIDs, payloadIdentifier, cmdUUID)
+	err = cmdr.RemoveProfile(ctx, hostUUIDs, payloadIdentifier, cmdUUID, true)
 	require.True(t, mdmStorage.EnqueueCommandFuncInvoked)
 	mdmStorage.EnqueueCommandFuncInvoked = false
 	require.True(t, mdmStorage.RetrievePushInfoFuncInvoked)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5383,7 +5383,10 @@ func ReconcileAppleProfiles(
 
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles sending notifications", "enrollment_id_count", len(enrollmentIDs))
 	if len(enrollmentIDs) > 0 {
-		commander.SendNotifications(ctx, enrollmentIDs)
+		err = commander.SendNotifications(ctx, enrollmentIDs)
+		if err != nil {
+			level.Info(logger).Log("msg", "failed to send APNs notification to some hosts after reconciling profiles, but commands were enqueued successfully", "error", err)
+		}
 	}
 
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4841,6 +4841,7 @@ func ReconcileAppleDeclarations(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4855,12 +4856,15 @@ func ReconcileAppleDeclarations(
 		return ctxerr.Wrap(ctx, err, "updating host declaration state")
 	}
 
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations fetched changed hosts")
+
 	// Find any hosts that requested a resync. This is used to cover special cases where we're not
 	// 100% certain of the declarations on the device.
 	resyncHosts, err := ds.MDMAppleHostDeclarationsGetAndClearResync(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting and clearing resync hosts")
 	}
+	level.Info(logger).Log("msg", "ReconcileAppleDeclarations fetched resync hosts", "resync_host_count", len(resyncHosts))
 	if len(resyncHosts) > 0 {
 		changedHosts = append(changedHosts, resyncHosts...)
 		// Deduplicate changedHosts
@@ -4911,7 +4915,7 @@ func ReconcileAppleProfiles(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
-	logger.Log("msg", "ReconcileAppleProfiles starting")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4935,20 +4939,20 @@ func ReconcileAppleProfiles(
 	if block == nil || block.Type != "CERTIFICATE" {
 		return ctxerr.Wrap(ctx, err, "failed to decode PEM block from SCEP certificate")
 	}
-	logger.Log("msg", "ReconcileAppleProfiles loaded assets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles loaded assets")
 
 	if err := ensureFleetProfiles(ctx, ds, logger, block.Bytes); err != nil {
 		logger.Log("err", "unable to ensure a fleetd configuration profiles are in place", "details", err)
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
 
 	// retrieve the profiles to install/remove.
 	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting profiles to install and remove")
 	}
-	logger.Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
 
 	// Exclude macOS only profiles from iPhones/iPads.
 	toInstall = fleet.FilterMacOSOnlyProfilesFromIOSIPadOS(toInstall)
@@ -5135,7 +5139,7 @@ func ReconcileAppleProfiles(
 		hostProfilesToInstallMap[hostProfileUUID{HostUUID: p.HostUUID, ProfileUUID: p.ProfileUUID}] = hostProfile
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles processed install targets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles processed install targets")
 
 	for _, p := range toRemove {
 		// Exclude profiles that are also marked for installation.
@@ -5199,7 +5203,7 @@ func ReconcileAppleProfiles(
 		})
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles processed remove targets")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles processed remove targets")
 
 	// delete all profiles that have a matching identifier to be installed.
 	// This is to prevent sending both a `RemoveProfile` and an
@@ -5225,7 +5229,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "deleting profiles that didn't change")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles cleaned up profiles")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles cleaned up profiles")
 
 	// FIXME: How does this impact variable profiles? This happens before pre-processing, doesn't
 	// this potentially race with the command uuid and variable substitution?
@@ -5240,7 +5244,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "updating host profiles")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles upserted host profiles")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles upserted host profiles")
 
 	// Grab the contents of all the profiles we need to install
 	profileUUIDs := make([]string, 0, len(toGetContents))
@@ -5257,7 +5261,7 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
 
 	// Insert variables into profile contents of install targets. Variables may be host-specific.
 	err = preprocessProfileContents(ctx, appConfig, ds,
@@ -5268,14 +5272,14 @@ func ReconcileAppleProfiles(
 		return err
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
 
 	// Find the profiles containing secret variables.
 	profilesWithSecrets, err := findProfilesWithSecrets(logger, installTargets, profileContents)
 	if err != nil {
 		return err
 	}
-	logger.Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
 
 	type remoteResult struct {
 		Err     error
@@ -5310,7 +5314,7 @@ func ReconcileAppleProfiles(
 			ch <- remoteResult{err, target.cmdUUID}
 		}
 	}
-	logger.Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeInstall)
@@ -5319,7 +5323,7 @@ func ReconcileAppleProfiles(
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeRemove)
 	}
-	logger.Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 
 	// index the host profiles by cmdUUID, for ease of error processing in the
 	// consumer goroutine below.
@@ -5351,18 +5355,18 @@ func ReconcileAppleProfiles(
 		}
 	}()
 
-	logger.Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
 	wgProd.Wait()
-	logger.Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
 	close(ch) // done sending at this point, this triggers end of for loop in consumer
 	wgCons.Wait()
-	logger.Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
 
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, failed); err != nil {
 		return ctxerr.Wrap(ctx, err, "reverting status of failed profiles")
 	}
 
-	logger.Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
 
 	return nil
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5295,6 +5295,7 @@ func ReconcileAppleProfiles(
 
 	execCmd := func(profUUID string, target *cmdTarget, op fleet.MDMOperationType) {
 		defer wgProd.Done()
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles execcmd starting", "operation", op, "profile_uuid", profUUID, "command_uuid", target.cmdUUID, "enrollment_id_count", len(target.enrollmentIDs))
 
 		var err error
 		switch op {
@@ -5316,6 +5317,7 @@ func ReconcileAppleProfiles(
 			level.Error(logger).Log("err", fmt.Sprintf("enqueue command to %s profiles", op), "details", err)
 			ch <- remoteResult{err, target.cmdUUID}
 		}
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles execcmd completing", "profile_uuid", profUUID, "command_uuid", target.cmdUUID, "enrollment_id_count", len(target.enrollmentIDs))
 	}
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4911,6 +4911,7 @@ func ReconcileAppleProfiles(
 	commander *apple_mdm.MDMAppleCommander,
 	logger kitlog.Logger,
 ) error {
+	logger.Log("msg", "ReconcileAppleProfiles starting")
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("reading app config: %w", err)
@@ -4934,16 +4935,20 @@ func ReconcileAppleProfiles(
 	if block == nil || block.Type != "CERTIFICATE" {
 		return ctxerr.Wrap(ctx, err, "failed to decode PEM block from SCEP certificate")
 	}
+	logger.Log("msg", "ReconcileAppleProfiles loaded assets")
 
 	if err := ensureFleetProfiles(ctx, ds, logger, block.Bytes); err != nil {
 		logger.Log("err", "unable to ensure a fleetd configuration profiles are in place", "details", err)
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles ensured fleet profiles exist for all teams")
 
 	// retrieve the profiles to install/remove.
 	toInstall, toRemove, err := ds.ListMDMAppleProfilesToInstallAndRemove(ctx)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "getting profiles to install and remove")
 	}
+	logger.Log("msg", "ReconcileAppleProfiles retrieved profiles to install and remove", "to_install_count", len(toInstall), "to_remove_count", len(toRemove))
 
 	// Exclude macOS only profiles from iPhones/iPads.
 	toInstall = fleet.FilterMacOSOnlyProfilesFromIOSIPadOS(toInstall)
@@ -5130,6 +5135,8 @@ func ReconcileAppleProfiles(
 		hostProfilesToInstallMap[hostProfileUUID{HostUUID: p.HostUUID, ProfileUUID: p.ProfileUUID}] = hostProfile
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles processed install targets")
+
 	for _, p := range toRemove {
 		// Exclude profiles that are also marked for installation.
 		if _, ok := profileIntersection.GetMatchingProfileInDesiredState(p); ok {
@@ -5192,6 +5199,8 @@ func ReconcileAppleProfiles(
 		})
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles processed remove targets")
+
 	// delete all profiles that have a matching identifier to be installed.
 	// This is to prevent sending both a `RemoveProfile` and an
 	// `InstallProfile` for the same identifier, which can cause race
@@ -5216,6 +5225,8 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "deleting profiles that didn't change")
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles cleaned up profiles")
+
 	// FIXME: How does this impact variable profiles? This happens before pre-processing, doesn't
 	// this potentially race with the command uuid and variable substitution?
 	//
@@ -5228,6 +5239,8 @@ func ReconcileAppleProfiles(
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, hostProfiles); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating host profiles")
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles upserted host profiles")
 
 	// Grab the contents of all the profiles we need to install
 	profileUUIDs := make([]string, 0, len(toGetContents))
@@ -5244,6 +5257,8 @@ func ReconcileAppleProfiles(
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles fetched profile contents and grouped CAs")
+
 	// Insert variables into profile contents of install targets. Variables may be host-specific.
 	err = preprocessProfileContents(ctx, appConfig, ds,
 		eeservice.NewSCEPConfigService(logger, nil),
@@ -5253,11 +5268,14 @@ func ReconcileAppleProfiles(
 		return err
 	}
 
+	logger.Log("msg", "ReconcileAppleProfiles preprocessed profile contents")
+
 	// Find the profiles containing secret variables.
 	profilesWithSecrets, err := findProfilesWithSecrets(logger, installTargets, profileContents)
 	if err != nil {
 		return err
 	}
+	logger.Log("msg", "ReconcileAppleProfiles found profiles with secrets", "count", len(profilesWithSecrets))
 
 	type remoteResult struct {
 		Err     error
@@ -5292,6 +5310,7 @@ func ReconcileAppleProfiles(
 			ch <- remoteResult{err, target.cmdUUID}
 		}
 	}
+	logger.Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 	for profUUID, target := range installTargets {
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeInstall)
@@ -5300,6 +5319,7 @@ func ReconcileAppleProfiles(
 		wgProd.Add(1)
 		go execCmd(profUUID, target, fleet.MDMOperationTypeRemove)
 	}
+	logger.Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
 
 	// index the host profiles by cmdUUID, for ease of error processing in the
 	// consumer goroutine below.
@@ -5331,13 +5351,18 @@ func ReconcileAppleProfiles(
 		}
 	}()
 
+	logger.Log("msg", "ReconcileAppleProfiles launched consumer goroutine")
 	wgProd.Wait()
+	logger.Log("msg", "ReconcileAppleProfiles all producer goroutines finished")
 	close(ch) // done sending at this point, this triggers end of for loop in consumer
 	wgCons.Wait()
+	logger.Log("msg", "ReconcileAppleProfiles consumer goroutine finished")
 
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, failed); err != nil {
 		return ctxerr.Wrap(ctx, err, "reverting status of failed profiles")
 	}
+
+	logger.Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
 
 	return nil
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5221,6 +5221,7 @@ func ReconcileAppleProfiles(
 	}
 	// We need to delete commands from the nano queue so they don't get sent to device.
 	if len(commandUUIDToHostIDsCleanupMap) > 0 {
+		level.Info(logger).Log("msg", "ReconcileAppleProfiles cleaning up nano commands without results", "count", len(commandUUIDToHostIDsCleanupMap))
 		if err := commander.BulkDeleteHostUserCommandsWithoutResults(ctx, commandUUIDToHostIDsCleanupMap); err != nil {
 			return ctxerr.Wrap(ctx, err, "deleting nano commands without results")
 		}
@@ -5253,6 +5254,8 @@ func ReconcileAppleProfiles(
 	}
 	profileContents, err := ds.GetMDMAppleProfilesContents(ctx, profileUUIDs)
 	if err != nil {
+		level.Error(logger).Log("err", "ReconcileAppleProfiles error fetching profile contents", "details", err)
+
 		return ctxerr.Wrap(ctx, err, "get profile contents")
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/url"
@@ -2217,7 +2218,7 @@ func (svc *Service) enqueueMDMAppleCommandRemoveEnrollmentProfile(ctx context.Co
 	}
 
 	cmdUUID := uuid.New().String()
-	err = svc.mdmAppleCommander.RemoveProfile(ctx, []string{nanoEnroll.ID}, apple_mdm.FleetPayloadIdentifier, cmdUUID)
+	err = svc.mdmAppleCommander.RemoveProfile(ctx, []string{nanoEnroll.ID}, apple_mdm.FleetPayloadIdentifier, cmdUUID, true)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "enqueuing mdm apple remove profile command")
 	}
@@ -5301,12 +5302,12 @@ func ReconcileAppleProfiles(
 		switch op {
 		case fleet.MDMOperationTypeInstall:
 			if _, ok := profilesWithSecrets[profUUID]; ok {
-				err = commander.EnqueueCommandInstallProfileWithSecrets(ctx, target.enrollmentIDs, profileContents[profUUID], target.cmdUUID)
+				err = commander.EnqueueCommandInstallProfileWithSecrets(ctx, target.enrollmentIDs, profileContents[profUUID], target.cmdUUID, false)
 			} else {
-				err = commander.InstallProfile(ctx, target.enrollmentIDs, profileContents[profUUID], target.cmdUUID)
+				err = commander.InstallProfile(ctx, target.enrollmentIDs, profileContents[profUUID], target.cmdUUID, false)
 			}
 		case fleet.MDMOperationTypeRemove:
-			err = commander.RemoveProfile(ctx, target.enrollmentIDs, target.profIdent, target.cmdUUID)
+			err = commander.RemoveProfile(ctx, target.enrollmentIDs, target.profIdent, target.cmdUUID, false)
 		}
 
 		var e *apple_mdm.APNSDeliveryError
@@ -5320,12 +5321,19 @@ func ReconcileAppleProfiles(
 		level.Info(logger).Log("msg", "ReconcileAppleProfiles execcmd completing", "profile_uuid", profUUID, "command_uuid", target.cmdUUID, "enrollment_id_count", len(target.enrollmentIDs))
 	}
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles launching goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
+	enrollmentIDsForNotifications := make(map[string]bool)
 	for profUUID, target := range installTargets {
 		wgProd.Add(1)
+		for _, enrollmentID := range target.enrollmentIDs {
+			enrollmentIDsForNotifications[enrollmentID] = true
+		}
 		go execCmd(profUUID, target, fleet.MDMOperationTypeInstall)
 	}
 	for profUUID, target := range removeTargets {
 		wgProd.Add(1)
+		for _, enrollmentID := range target.enrollmentIDs {
+			enrollmentIDsForNotifications[enrollmentID] = true
+		}
 		go execCmd(profUUID, target, fleet.MDMOperationTypeRemove)
 	}
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles launched goroutines to send commands", "install_target_count", len(installTargets), "remove_target_count", len(removeTargets))
@@ -5369,6 +5377,13 @@ func ReconcileAppleProfiles(
 
 	if err := ds.BulkUpsertMDMAppleHostProfiles(ctx, failed); err != nil {
 		return ctxerr.Wrap(ctx, err, "reverting status of failed profiles")
+	}
+
+	enrollmentIDs := slices.Collect(maps.Keys(enrollmentIDsForNotifications))
+
+	level.Info(logger).Log("msg", "ReconcileAppleProfiles sending notifications", "enrollment_id_count", len(enrollmentIDs))
+	if len(enrollmentIDs) > 0 {
+		commander.SendNotifications(ctx, enrollmentIDs)
 	}
 
 	level.Info(logger).Log("msg", "ReconcileAppleProfiles reverted status of failed profiles", "failed_count", len(failed))
@@ -6355,7 +6370,7 @@ func renewSCEPWithProfile(
 		uuids = append(uuids, assoc.HostUUID)
 	}
 
-	if err := commander.InstallProfile(ctx, uuids, profile, cmdUUID); err != nil {
+	if err := commander.InstallProfile(ctx, uuids, profile, cmdUUID, true); err != nil {
 		return ctxerr.Wrapf(ctx, err, "sending InstallProfile command for hosts %s", uuids)
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
