### PR TITLE
Update Workstations configuration

### DIFF
--- a/it-and-security/teams/workstations.yml
+++ b/it-and-security/teams/workstations.yml
@@ -5,7 +5,10 @@ team_settings:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL
       enable_failing_policies_webhook: true
       host_batch_size: 0
-      policy_ids: []
+      policy_ids:
+        - 38244 # Linux - Sufficient disk space available
+        - 38230 # macOS - Sufficient disk space available
+        - 38239 # Windows - Sufficient disk space available
   features:
     enable_host_users: true
     enable_software_inventory: true


### PR DESCRIPTION
This pull request updates the workstation team settings to ensure that disk space policies are enforced across all major operating systems. The most important change is the addition of specific policy IDs for monitoring disk space on Linux, macOS, and Windows.

**Policy enforcement improvements:**

* Added `policy_ids` for disk space monitoring on Linux (`38244`), macOS (`38230`), and Windows (`38239`) in the `team_settings` section of `it-and-security/teams/workstations.yml`.