### PR TITLE
Update error message when clearing End Users settings while EUA is enabled

### DIFF
--- a/changes/40790-fix-clear-idp-error-message
+++ b/changes/40790-fix-clear-idp-error-message
@@ -1,0 +1,1 @@
+* Fixed inaccurate error message when clearing identity provider settings while end user authentication is enabled.

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3457,6 +3457,10 @@ func TestGitOpsMDMAuthSettings(t *testing.T) {
 		return nil
 	}
 
+	ds.TeamIDsWithSetupExperienceIdPEnabledFunc = func(ctx context.Context) ([]uint, error) {
+		return nil, nil
+	}
+
 	// Do a GitOps run with no mdm end user auth settings.
 	_, err := RunAppNoChecks([]string{"gitops", "-f", globalFileBasic.Name()})
 	require.NoError(t, err)

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1523,12 +1523,22 @@ func (svc *Service) validateMDM(
 
 	// MacOSSetup validation
 	if mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty() {
-		// IdP is being cleared: block if any team has EUA enabled.
+		// IdP is being cleared: block if global EUA will still be enabled after this update
+		// (mdm.MacOSSetup.EnableEndUserAuthentication reflects the incoming request's value),
+		// or if any team has EUA enabled. We only look at non-zero team IDs since global (id=0)
+		// is covered by the incoming request value.
 		teamIDs, err := svc.ds.TeamIDsWithSetupExperienceIdPEnabled(ctx)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "checking teams with EUA enabled")
 		}
-		if len(teamIDs) > 0 {
+		anyTeamEUAEnabled := false
+		for _, id := range teamIDs {
+			if id != 0 {
+				anyTeamEUAEnabled = true
+				break
+			}
+		}
+		if anyTeamEUAEnabled || mdm.MacOSSetup.EnableEndUserAuthentication {
 			invalid.Append("end_user_authentication",
 				`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)
 		}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1524,10 +1524,16 @@ func (svc *Service) validateMDM(
 	// MacOSSetup validation
 	if mdm.MacOSSetup.EnableEndUserAuthentication {
 		if mdm.EndUserAuthentication.IsEmpty() {
-			// TODO: update this error message to include steps to resolve the issue once docs for IdP
-			// config are available
-			invalid.Append("macos_setup.enable_end_user_authentication",
-				`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
+			if !oldMdm.EndUserAuthentication.IsEmpty() {
+				// IdP is being cleared while EUA is still enabled.
+				invalid.Append("end_user_authentication",
+					`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)
+			} else {
+				// TODO: update this error message to include steps to resolve the issue once docs for IdP
+				// config are available
+				invalid.Append("macos_setup.enable_end_user_authentication",
+					`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
+			}
 		}
 	}
 

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1522,19 +1522,21 @@ func (svc *Service) validateMDM(
 	}
 
 	// MacOSSetup validation
-	if mdm.MacOSSetup.EnableEndUserAuthentication {
-		if mdm.EndUserAuthentication.IsEmpty() {
-			if !oldMdm.EndUserAuthentication.IsEmpty() {
-				// IdP is being cleared while EUA is still enabled.
-				invalid.Append("end_user_authentication",
-					`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)
-			} else {
-				// TODO: update this error message to include steps to resolve the issue once docs for IdP
-				// config are available
-				invalid.Append("macos_setup.enable_end_user_authentication",
-					`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
-			}
+	if mdm.EndUserAuthentication.IsEmpty() && !oldMdm.EndUserAuthentication.IsEmpty() {
+		// IdP is being cleared: block if any team has EUA enabled.
+		teamIDs, err := svc.ds.TeamIDsWithSetupExperienceIdPEnabled(ctx)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "checking teams with EUA enabled")
 		}
+		if len(teamIDs) > 0 {
+			invalid.Append("end_user_authentication",
+				`End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again`)
+		}
+	} else if mdm.MacOSSetup.EnableEndUserAuthentication && mdm.EndUserAuthentication.IsEmpty() {
+		// TODO: update this error message to include steps to resolve the issue once docs for IdP
+		// config are available
+		invalid.Append("macos_setup.enable_end_user_authentication",
+			`Couldn't enable macos_setup.enable_end_user_authentication because no IdP is configured for MDM features.`)
 	}
 
 	if mdm.MacOSSetup.LockEndUserInfo.Value && !mdm.MacOSSetup.EnableEndUserAuthentication {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5193,6 +5193,8 @@ func (s *integrationMDMTestSuite) TestMDMMacOSSetup() {
 	t.Run("ValidateEnableEndUserAuthentication", func(t *testing.T) {
 		// ensure the test is setup correctly
 		var acResp appConfigResponse
+		var errResp validationErrResp
+		var teamResp teamResponse
 		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 			"mdm": {
 				"end_user_authentication": {
@@ -5207,8 +5209,8 @@ func (s *integrationMDMTestSuite) TestMDMMacOSSetup() {
 		}`), http.StatusOK, &acResp)
 		require.NotEmpty(t, acResp.MDM.EndUserAuthentication)
 
-		// can't clear IdP settings while end user authentication is enabled
-		acResp = appConfigResponse{}
+		// can't clear IdP settings while end user authentication is enabled (global)
+		errResp = validationErrResp{}
 		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 			"mdm": {
 				"end_user_authentication": {
@@ -5217,23 +5219,91 @@ func (s *integrationMDMTestSuite) TestMDMMacOSSetup() {
 					"metadata_url": ""
 				}
 			}
-		}`), http.StatusUnprocessableEntity, &acResp)
+		}`), http.StatusUnprocessableEntity, &errResp)
+		require.Len(t, errResp.Errors, 1)
+		require.Equal(t, errResp.Errors[0].Reason, "End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again")
 
-		// ok to disable end user authentication without a configured IdP
+		//  disable end user authentication before clearing IdP settings
 		acResp = appConfigResponse{}
 		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 			"mdm": {
-				"end_user_authentication": {
-					"entity_id": "",
-					"idp_name": "",
-					"metadata_url": ""
-				},
 				"macos_setup": {
 					"enable_end_user_authentication": false
 				}
 			}
 		}`), http.StatusOK, &acResp)
 		require.Equal(t, acResp.MDM.MacOSSetup.EnableEndUserAuthentication, false)
+		acResp = appConfigResponse{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"mdm": {
+				"end_user_authentication": {
+					"entity_id": "",
+					"idp_name": "",
+					"metadata_url": ""
+				}
+			}
+		}`), http.StatusOK, &acResp)
+		require.True(t, acResp.MDM.EndUserAuthentication.IsEmpty())
+
+		// can't clear IdP settings while end user authentication is enabled on a team
+		// 1. configure IdP globally
+		acResp = appConfigResponse{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"mdm": {
+				"end_user_authentication": {
+					"entity_id": "https://localhost:8080",
+					"idp_name": "SimpleSAML",
+					"metadata_url": "http://localhost:9080/simplesaml/saml2/idp/metadata.php"
+				}
+			}
+		}`), http.StatusOK, &acResp)
+		require.NotEmpty(t, acResp.MDM.EndUserAuthentication)
+		require.False(t, acResp.MDM.MacOSSetup.EnableEndUserAuthentication)
+
+		// 2. enable EUA on a team
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(fmt.Sprintf(`{
+			"name": %q,
+			"mdm": {
+				"macos_setup": {
+					"enable_end_user_authentication": true
+				}
+			}
+		}`, tm.Name)), http.StatusOK, &teamResp)
+		require.True(t, teamResp.Team.Config.MDM.MacOSSetup.EnableEndUserAuthentication)
+
+		// 3. clearing IdP while team EUA is enabled should fail
+		errResp = validationErrResp{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"mdm": {
+				"end_user_authentication": {
+					"entity_id": "",
+					"idp_name": "",
+					"metadata_url": ""
+				}
+			}
+		}`), http.StatusUnprocessableEntity, &errResp)
+		require.Len(t, errResp.Errors, 1)
+		require.Equal(t, errResp.Errors[0].Reason, "End user authentication is enabled. Please disable end user authentication in Controls > Setup experience and try again")
+
+		// 4. disable team EUA, then clear IdP
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(fmt.Sprintf(`{
+			"name": %q,
+			"mdm": {
+				"macos_setup": {
+					"enable_end_user_authentication": false
+				}
+			}
+		}`, tm.Name)), http.StatusOK, &teamResp)
+		acResp = appConfigResponse{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"mdm": {
+				"end_user_authentication": {
+					"entity_id": "",
+					"idp_name": "",
+					"metadata_url": ""
+				}
+			}
+		}`), http.StatusOK, &acResp)
 		require.True(t, acResp.MDM.EndUserAuthentication.IsEmpty())
 
 		// can't enable end user authentication without a configured IdP
@@ -5255,7 +5325,6 @@ func (s *integrationMDMTestSuite) TestMDMMacOSSetup() {
 			fleet.MDMAppleSetupPayload{TeamID: ptr.Uint(0), EnableEndUserAuthentication: ptr.Bool(true)}, http.StatusUnprocessableEntity)
 
 		// can't enable end user authentication on team config without a configured IdP already on app config
-		var teamResp teamResponse
 		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(fmt.Sprintf(`{
 			"name": %q,
 			"mdm": {

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -5207,6 +5207,18 @@ func (s *integrationMDMTestSuite) TestMDMMacOSSetup() {
 		}`), http.StatusOK, &acResp)
 		require.NotEmpty(t, acResp.MDM.EndUserAuthentication)
 
+		// can't clear IdP settings while end user authentication is enabled
+		acResp = appConfigResponse{}
+		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+			"mdm": {
+				"end_user_authentication": {
+					"entity_id": "",
+					"idp_name": "",
+					"metadata_url": ""
+				}
+			}
+		}`), http.StatusUnprocessableEntity, &acResp)
+
 		// ok to disable end user authentication without a configured IdP
 		acResp = appConfigResponse{}
 		s.DoJSON("PATCH", "/api/latest/fleet/config", json.RawMessage(`{


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40790

Updating error message returned when EUA is still enabled in at least one team, and user attempts to clear out End users settings in Settings > Integrations > SSO.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/492fed92-019e-4c2a-ab09-98841bb45da4


