### PR TITLE
Linux orbit-side SCEP enrollment for Okta conditional access (Phase 1)

### DIFF
--- a/ee/orbit/pkg/condaccess/condaccess.go
+++ b/ee/orbit/pkg/condaccess/condaccess.go
@@ -1,0 +1,160 @@
+// Package condaccess handles SCEP enrollment for Fleet's Okta conditional access feature on Linux.
+// It generates an ECC key, fetches a client certificate from Fleet's SCEP endpoint, and persists
+// both to disk so the certificate can be presented during mTLS at Fleet's SAML SSO endpoint.
+package condaccess
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+
+	orbitscep "github.com/fleetdm/fleet/v4/ee/orbit/pkg/scep"
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/rs/zerolog"
+)
+
+const (
+	// commonName is the CN used in the SCEP certificate request, matching the macOS MDM profile.
+	commonName = "Fleet conditional access for Okta"
+	// sanURIPrefix is the SAN URI prefix used to identify the device UUID in the certificate.
+	sanURIPrefix = "urn:device:fleet:uuid:"
+	// renewalThreshold is how far from expiry we trigger re-enrollment.
+	renewalThreshold = 30 * 24 * time.Hour
+)
+
+// scepSigningKey wraps *ecdsa.PrivateKey to satisfy orbitscep.SigningKey.
+type scepSigningKey struct {
+	key *ecdsa.PrivateKey
+}
+
+// Signer returns the underlying ECDSA key as a crypto.Signer.
+func (s *scepSigningKey) Signer() (crypto.Signer, error) {
+	return s.key, nil
+}
+
+// Enroll ensures a valid conditional access certificate exists in metadataDir.
+// If no certificate exists or the existing one is expiring within 30 days, it
+// generates a new ECC P-256 key, enrolls via SCEP, and saves the cert and key.
+// Returns the certificate (existing or newly issued).
+func Enroll(
+	ctx context.Context,
+	metadataDir string,
+	scepURL string,
+	scepChallenge string,
+	hardwareUUID string,
+	rootCA string,
+	insecure bool,
+	logger zerolog.Logger,
+) (*x509.Certificate, error) {
+	cert, err := loadCert(metadataDir)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("load existing cert: %w", err)
+	}
+
+	if cert != nil && !certNeedsRenewal(cert, renewalThreshold) {
+		logger.Debug().Str("serial", cert.SerialNumber.String()).Msg("conditional access cert valid, skipping enrollment")
+		return cert, nil
+	}
+
+	logger.Info().Msg("enrolling conditional access SCEP certificate")
+
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, fmt.Errorf("generate ECC key: %w", err)
+	}
+
+	if err := saveKey(metadataDir, privKey); err != nil {
+		return nil, fmt.Errorf("save private key: %w", err)
+	}
+
+	sanURI, err := url.Parse(sanURIPrefix + hardwareUUID)
+	if err != nil {
+		return nil, fmt.Errorf("parse SAN URI: %w", err)
+	}
+
+	opts := []orbitscep.Option{
+		orbitscep.WithSigningKey(&scepSigningKey{key: privKey}),
+		orbitscep.WithURL(scepURL),
+		orbitscep.WithChallenge(scepChallenge),
+		orbitscep.WithCommonName(commonName),
+		orbitscep.WithURIs([]*url.URL{sanURI}),
+		orbitscep.WithRootCA(rootCA),
+		orbitscep.WithLogger(logger),
+	}
+	if insecure {
+		opts = append(opts, orbitscep.Insecure())
+	}
+
+	scepClient, err := orbitscep.NewClient(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create SCEP client: %w", err)
+	}
+
+	newCert, err := scepClient.FetchCert(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("SCEP enrollment: %w", err)
+	}
+
+	if err := saveCert(metadataDir, newCert); err != nil {
+		return nil, fmt.Errorf("save cert: %w", err)
+	}
+
+	logger.Info().Str("serial", newCert.SerialNumber.String()).Msg("conditional access SCEP enrollment complete")
+	return newCert, nil
+}
+
+// loadCert reads the conditional access certificate from metadataDir.
+// Returns os.ErrNotExist if the file doesn't exist.
+func loadCert(metadataDir string) (*x509.Certificate, error) {
+	certPath := filepath.Join(metadataDir, constant.ConditionalAccessCertFileName)
+	pemBytes, err := os.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil || block.Type != "CERTIFICATE" {
+		return nil, errors.New("failed to decode PEM certificate block")
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+// saveCert writes the certificate as PEM to metadataDir (world-readable).
+func saveCert(metadataDir string, cert *x509.Certificate) error {
+	certPath := filepath.Join(metadataDir, constant.ConditionalAccessCertFileName)
+	f, err := os.OpenFile(certPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, constant.DefaultWorldReadableFileMode)
+	if err != nil {
+		return fmt.Errorf("open cert file: %w", err)
+	}
+	defer f.Close()
+	return pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+// saveKey encodes privKey as PKCS#8 PEM and writes it to metadataDir with mode 0600.
+func saveKey(metadataDir string, privKey *ecdsa.PrivateKey) error {
+	keyPath := filepath.Join(metadataDir, constant.ConditionalAccessKeyFileName)
+	derBytes, err := x509.MarshalPKCS8PrivateKey(privKey)
+	if err != nil {
+		return fmt.Errorf("marshal private key: %w", err)
+	}
+	f, err := os.OpenFile(keyPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, constant.DefaultFileMode)
+	if err != nil {
+		return fmt.Errorf("open key file: %w", err)
+	}
+	defer f.Close()
+	return pem.Encode(f, &pem.Block{Type: "PRIVATE KEY", Bytes: derBytes})
+}
+
+// certNeedsRenewal returns true if the certificate expires within threshold.
+func certNeedsRenewal(cert *x509.Certificate, threshold time.Duration) bool {
+	return time.Until(cert.NotAfter) < threshold
+}

--- a/ee/orbit/pkg/condaccess/condaccess_test.go
+++ b/ee/orbit/pkg/condaccess/condaccess_test.go
@@ -1,0 +1,146 @@
+package condaccess
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeSelfSignedCert creates a minimal self-signed cert for testing, expiring at notAfter.
+func makeSelfSignedCert(t *testing.T, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// writeCertToDisk writes a DER-encoded cert as PEM to the given directory.
+func writeCertToDisk(t *testing.T, dir string, cert *x509.Certificate) {
+	t.Helper()
+	certPath := filepath.Join(dir, constant.ConditionalAccessCertFileName)
+	f, err := os.OpenFile(certPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	require.NoError(t, err)
+	defer f.Close()
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))
+}
+
+func TestEnroll_ValidCertExists(t *testing.T) {
+	// A valid cert that is not near expiry — SCEP should never be called.
+	dir := t.TempDir()
+	cert := makeSelfSignedCert(t, time.Now().Add(90*24*time.Hour))
+	writeCertToDisk(t, dir, cert)
+
+	scepCalled := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		scepCalled = true
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	got, err := Enroll(context.Background(), dir, srv.URL, "challenge", "uuid-1234", "", true, zerolog.Nop())
+	require.NoError(t, err)
+	assert.Equal(t, cert.SerialNumber, got.SerialNumber)
+	assert.False(t, scepCalled, "SCEP server must not be contacted for a valid cert")
+}
+
+func TestEnroll_ExpiringCert(t *testing.T) {
+	// Cert expiring in 10 days — within the 30-day renewal threshold.
+	dir := t.TempDir()
+	oldCert := makeSelfSignedCert(t, time.Now().Add(10*24*time.Hour))
+	writeCertToDisk(t, dir, oldCert)
+
+	// We just verify that SCEP is contacted (it will fail with a non-SCEP response,
+	// and that error surfaces). The important assertion is that a new enrollment was attempted.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), dir, srv.URL, "challenge", "uuid-1234", "", true, zerolog.Nop())
+	require.Error(t, err, "expected enrollment to fail when SCEP stub returns error")
+	assert.Contains(t, err.Error(), "SCEP enrollment")
+}
+
+func TestEnroll_SCEPError(t *testing.T) {
+	// No existing cert, SCEP fails — no partial cert file should be created.
+	dir := t.TempDir()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), dir, srv.URL, "challenge", "uuid-1234", "", true, zerolog.Nop())
+	require.Error(t, err)
+
+	// cert file must not exist (key file may exist since it's written before SCEP call)
+	_, statErr := os.Stat(filepath.Join(dir, constant.ConditionalAccessCertFileName))
+	assert.True(t, os.IsNotExist(statErr), "cert file must not be written on SCEP failure")
+}
+
+func TestEnroll_NoExistingCert_SavesKeyAndCert(t *testing.T) {
+	// Without an httptest SCEP stub that speaks full SCEP protocol we can only verify
+	// that Enroll attempts enrollment and that the key file is created before the SCEP call.
+	dir := t.TempDir()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	_, err := Enroll(context.Background(), dir, srv.URL, "challenge", "uuid-1234", "", true, zerolog.Nop())
+	require.Error(t, err, "expected error from stub SCEP server")
+
+	// The key must have been written before the SCEP call.
+	keyPath := filepath.Join(dir, constant.ConditionalAccessKeyFileName)
+	keyInfo, statErr := os.Stat(keyPath)
+	require.NoError(t, statErr, "key file must be created before SCEP call")
+	assert.Equal(t, os.FileMode(constant.DefaultFileMode), keyInfo.Mode().Perm(), "key file must be mode 0600")
+}
+
+func TestCertNeedsRenewal(t *testing.T) {
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	makeExpiry := func(d time.Duration) *x509.Certificate {
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			NotBefore:    time.Now().Add(-time.Hour),
+			NotAfter:     time.Now().Add(d),
+		}
+		der, err := x509.CreateCertificate(rand.Reader, template, template, &priv.PublicKey, priv)
+		require.NoError(t, err)
+		cert, err := x509.ParseCertificate(der)
+		require.NoError(t, err)
+		return cert
+	}
+
+	assert.True(t, certNeedsRenewal(makeExpiry(10*24*time.Hour), renewalThreshold), "10 days should need renewal")
+	assert.False(t, certNeedsRenewal(makeExpiry(90*24*time.Hour), renewalThreshold), "90 days should not need renewal")
+}

--- a/ee/orbit/pkg/condaccess/condaccess_test.go
+++ b/ee/orbit/pkg/condaccess/condaccess_test.go
@@ -44,7 +44,7 @@ func makeSelfSignedCert(t *testing.T, notAfter time.Time) *x509.Certificate {
 func writeCertToDisk(t *testing.T, dir string, cert *x509.Certificate) {
 	t.Helper()
 	certPath := filepath.Join(dir, constant.ConditionalAccessCertFileName)
-	f, err := os.OpenFile(certPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	f, err := os.OpenFile(certPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o600)
 	require.NoError(t, err)
 	defer f.Close()
 	require.NoError(t, pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}))

--- a/ee/orbit/pkg/scep/scep.go
+++ b/ee/orbit/pkg/scep/scep.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"slices"
 	"time"
 
@@ -48,6 +49,8 @@ type Client struct {
 
 	// extraExtensions allows adding custom extensions to the CSR
 	extraExtensions []pkix.Extension
+	// uris sets the Subject Alternative Name URI fields on the CSR
+	uris []*url.URL
 }
 
 // Option is a functional option for configuring a SCEP Client
@@ -114,6 +117,13 @@ func Insecure() Option {
 func WithExtraExtensions(extensions []pkix.Extension) Option {
 	return func(c *Client) {
 		c.extraExtensions = extensions
+	}
+}
+
+// WithURIs sets Subject Alternative Name URI fields on the CSR.
+func WithURIs(uris []*url.URL) Option {
+	return func(c *Client) {
+		c.uris = uris
 	}
 }
 
@@ -194,6 +204,7 @@ func (c *Client) FetchCert(ctx context.Context) (*x509.Certificate, error) {
 			// Currently, signer.Public() will always be of type *ecdsa.PublicKey.
 			SignatureAlgorithm: x509.ECDSAWithSHA256,
 			ExtraExtensions:    c.extraExtensions,
+			URIs:               c.uris,
 		},
 		ChallengePassword: c.scepChallenge,
 	}

--- a/ee/server/service/condaccess/depot/depot.go
+++ b/ee/server/service/condaccess/depot/depot.go
@@ -175,8 +175,8 @@ func extractUUIDFromCert(crt *x509.Certificate) string {
 	for _, uri := range crt.URIs {
 		uriStr := uri.String()
 		for _, prefix := range knownURIPrefixes {
-			if strings.HasPrefix(uriStr, prefix) {
-				return strings.TrimPrefix(uriStr, prefix)
+			if after, ok := strings.CutPrefix(uriStr, prefix); ok {
+				return after
 			}
 		}
 	}

--- a/ee/server/service/condaccess/depot/depot.go
+++ b/ee/server/service/condaccess/depot/depot.go
@@ -161,16 +161,23 @@ func (d *ConditionalAccessSCEPDepot) Put(name string, crt *x509.Certificate) err
 	return nil
 }
 
+// knownURIPrefixes are the SAN URI prefixes used by Fleet-enrolled device certificates.
+// Apple MDM profiles use the "apple" prefix; Linux orbit enrollment uses the "fleet" prefix.
+var knownURIPrefixes = []string{
+	"urn:device:apple:uuid:",
+	"urn:device:fleet:uuid:",
+}
+
 // extractUUIDFromCert extracts the device UUID from the SAN URI field.
-// Expected format: urn:device:apple:uuid:<uuid>
+// Supports both urn:device:apple:uuid:<uuid> (macOS) and urn:device:fleet:uuid:<uuid> (Linux).
 // Returns the UUID portion or empty string if not found.
 func extractUUIDFromCert(crt *x509.Certificate) string {
-	const prefix = "urn:device:apple:uuid:"
 	for _, uri := range crt.URIs {
-		// Check if this is a device URI (urn:device:apple:uuid:...)
 		uriStr := uri.String()
-		if strings.HasPrefix(uriStr, prefix) {
-			return strings.TrimPrefix(uriStr, prefix)
+		for _, prefix := range knownURIPrefixes {
+			if strings.HasPrefix(uriStr, prefix) {
+				return strings.TrimPrefix(uriStr, prefix)
+			}
 		}
 	}
 	return ""

--- a/ee/server/service/condaccess/depot/depot_test.go
+++ b/ee/server/service/condaccess/depot/depot_test.go
@@ -1,0 +1,45 @@
+package depot
+
+import (
+	"crypto/x509"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func mustParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestExtractUUIDFromCert_AppleFormat(t *testing.T) {
+	const wantUUID = "AABBCCDD-1122-3344-5566-778899AABBCC"
+	crt := &x509.Certificate{
+		URIs: []*url.URL{mustParseURL("urn:device:apple:uuid:" + wantUUID)},
+	}
+	assert.Equal(t, wantUUID, extractUUIDFromCert(crt))
+}
+
+func TestExtractUUIDFromCert_FleetFormat(t *testing.T) {
+	const wantUUID = "DEADBEEF-CAFE-BABE-F00D-BAADDEADBEEF"
+	crt := &x509.Certificate{
+		URIs: []*url.URL{mustParseURL("urn:device:fleet:uuid:" + wantUUID)},
+	}
+	assert.Equal(t, wantUUID, extractUUIDFromCert(crt))
+}
+
+func TestExtractUUIDFromCert_NoURI(t *testing.T) {
+	crt := &x509.Certificate{}
+	assert.Equal(t, "", extractUUIDFromCert(crt))
+}
+
+func TestExtractUUIDFromCert_UnknownPrefix(t *testing.T) {
+	crt := &x509.Certificate{
+		URIs: []*url.URL{mustParseURL("urn:device:windows:uuid:SOME-UUID")},
+	}
+	assert.Equal(t, "", extractUUIDFromCert(crt))
+}

--- a/orbit/cmd/orbit/orbit.go
+++ b/orbit/cmd/orbit/orbit.go
@@ -1229,6 +1229,15 @@ func main() {
 				windowsMDMBitlockerCommandFrequency, orbitClient, comWorker))
 		case "linux":
 			orbitClient.RegisterConfigReceiver(luks.New(orbitClient))
+			orbitClient.RegisterConfigReceiver(update.NewConditionalAccessRunner(
+				c.String("root-dir"),
+				fleetURL,
+				enrollSecret,
+				orbitHostInfo.HardwareUUID,
+				c.String("fleet-certificate"),
+				c.Bool("insecure"),
+				log.Logger,
+			))
 		}
 
 		flagUpdateReceiver := update.NewFlagReceiver(orbitClient.TriggerOrbitRestart, update.FlagUpdateOptions{

--- a/orbit/pkg/constant/constant.go
+++ b/orbit/pkg/constant/constant.go
@@ -86,4 +86,9 @@ const (
 	FleetHTTPSignatureTPMKeyFileName = "host_identity_tpm.pem"
 	// FleetHTTPSignatureTPMKeyBackupFileName is the filename for the backup of the TPM key during renewal
 	FleetHTTPSignatureTPMKeyBackupFileName = "host_identity_tpm.old.pem"
+
+	// ConditionalAccessCertFileName is the filename for the conditional access client certificate.
+	ConditionalAccessCertFileName = "conditional_access.crt"
+	// ConditionalAccessKeyFileName is the filename for the conditional access private key.
+	ConditionalAccessKeyFileName = "conditional_access.key"
 )

--- a/orbit/pkg/update/conditional_access_linux.go
+++ b/orbit/pkg/update/conditional_access_linux.go
@@ -1,0 +1,85 @@
+//go:build linux
+
+package update
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/fleetdm/fleet/v4/ee/orbit/pkg/condaccess"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// ConditionalAccessRunner reacts to the RunConditionalAccessEnrollment orbit
+// notification by enrolling or renewing the SCEP client certificate used for
+// Okta conditional access mTLS on Linux.
+type ConditionalAccessRunner struct {
+	isRunning    atomic.Bool
+	metadataDir  string
+	scepURL      string
+	enrollSecret string
+	hardwareUUID string
+	rootCA       string
+	insecure     bool
+	logger       zerolog.Logger
+
+	// enrollFn is the enrollment function, overridable in tests.
+	enrollFn func(ctx context.Context, metadataDir, scepURL, challenge, uuid, rootCA string, insecure bool, logger zerolog.Logger) error
+}
+
+// NewConditionalAccessRunner creates a runner for Linux conditional access SCEP enrollment.
+func NewConditionalAccessRunner(
+	metadataDir string,
+	fleetURL string,
+	enrollSecret string,
+	hardwareUUID string,
+	rootCA string,
+	insecure bool,
+	logger zerolog.Logger,
+) *ConditionalAccessRunner {
+	r := &ConditionalAccessRunner{
+		metadataDir:  metadataDir,
+		scepURL:      fleetURL + "/api/fleet/conditional_access/scep",
+		enrollSecret: enrollSecret,
+		hardwareUUID: hardwareUUID,
+		rootCA:       rootCA,
+		insecure:     insecure,
+		logger:       logger,
+	}
+	r.enrollFn = func(ctx context.Context, metadataDir, scepURL, challenge, uuid, rootCA string, insecure bool, logger zerolog.Logger) error {
+		_, err := condaccess.Enroll(ctx, metadataDir, scepURL, challenge, uuid, rootCA, insecure, logger)
+		return err
+	}
+	return r
+}
+
+// Run implements fleet.OrbitConfigReceiver. It launches a goroutine to perform
+// SCEP enrollment when the server notification is set. Concurrent calls while
+// a goroutine is already running are silently ignored (idempotent).
+func (r *ConditionalAccessRunner) Run(cfg *fleet.OrbitConfig) error {
+	if !cfg.Notifications.RunConditionalAccessEnrollment {
+		return nil
+	}
+	if r.isRunning.Swap(true) {
+		// already running, skip
+		return nil
+	}
+	go func() {
+		defer r.isRunning.Store(false)
+		if err := r.enrollFn(
+			context.Background(),
+			r.metadataDir,
+			r.scepURL,
+			r.enrollSecret,
+			r.hardwareUUID,
+			r.rootCA,
+			r.insecure,
+			r.logger,
+		); err != nil {
+			log.Error().Err(err).Msg("conditional access SCEP enrollment failed")
+		}
+	}()
+	return nil
+}

--- a/orbit/pkg/update/conditional_access_linux_test.go
+++ b/orbit/pkg/update/conditional_access_linux_test.go
@@ -1,0 +1,105 @@
+//go:build linux
+
+package update
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestRunner() (*ConditionalAccessRunner, *int, *sync.Mutex) {
+	r := NewConditionalAccessRunner("dir", "https://fleet.example.com", "secret", "uuid", "", false, zerolog.Nop())
+	count := 0
+	mu := &sync.Mutex{}
+	r.enrollFn = func(ctx context.Context, metadataDir, scepURL, challenge, uuid, rootCA string, insecure bool, logger zerolog.Logger) error {
+		mu.Lock()
+		count++
+		mu.Unlock()
+		return nil
+	}
+	return r, &count, mu
+}
+
+func TestConditionalAccessRunner_NotificationFalse(t *testing.T) {
+	r, count, mu := newTestRunner()
+
+	cfg := &fleet.OrbitConfig{}
+	cfg.Notifications.RunConditionalAccessEnrollment = false
+	require.NoError(t, r.Run(cfg))
+
+	// Give any goroutine a moment to run (there should be none).
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 0, *count, "enrollFn must not be called when notification is false")
+}
+
+func TestConditionalAccessRunner_NotificationTrue(t *testing.T) {
+	r, count, mu := newTestRunner()
+
+	// Add a brief sleep so we can detect the goroutine finishing.
+	done := make(chan struct{})
+	r.enrollFn = func(ctx context.Context, metadataDir, scepURL, challenge, uuid, rootCA string, insecure bool, logger zerolog.Logger) error {
+		mu.Lock()
+		*count++
+		mu.Unlock()
+		close(done)
+		return nil
+	}
+
+	cfg := &fleet.OrbitConfig{}
+	cfg.Notifications.RunConditionalAccessEnrollment = true
+	require.NoError(t, r.Run(cfg))
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("enrollFn was not called within 2s")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, *count)
+}
+
+func TestConditionalAccessRunner_IdempotentWhileRunning(t *testing.T) {
+	r, count, mu := newTestRunner()
+
+	started := make(chan struct{})
+	unblock := make(chan struct{})
+	r.enrollFn = func(ctx context.Context, metadataDir, scepURL, challenge, uuid, rootCA string, insecure bool, logger zerolog.Logger) error {
+		mu.Lock()
+		*count++
+		mu.Unlock()
+		close(started)
+		<-unblock
+		return nil
+	}
+
+	cfg := &fleet.OrbitConfig{}
+	cfg.Notifications.RunConditionalAccessEnrollment = true
+
+	// First call starts the goroutine.
+	require.NoError(t, r.Run(cfg))
+	<-started // wait until goroutine is inside enrollFn
+
+	// Second call while goroutine is running — should be no-op.
+	require.NoError(t, r.Run(cfg))
+
+	close(unblock) // let goroutine finish
+
+	// Brief pause to let goroutine exit.
+	time.Sleep(50 * time.Millisecond)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 1, *count, "enrollFn must only be called once despite two Run() calls")
+}

--- a/orbit/pkg/update/conditional_access_other.go
+++ b/orbit/pkg/update/conditional_access_other.go
@@ -1,0 +1,29 @@
+//go:build !linux
+
+package update
+
+import (
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/rs/zerolog"
+)
+
+// ConditionalAccessRunner is a no-op placeholder on non-Linux platforms.
+type ConditionalAccessRunner struct{}
+
+// NewConditionalAccessRunner returns a no-op runner on non-Linux platforms.
+func NewConditionalAccessRunner(
+	metadataDir string,
+	fleetURL string,
+	enrollSecret string,
+	hardwareUUID string,
+	rootCA string,
+	insecure bool,
+	logger zerolog.Logger,
+) *ConditionalAccessRunner {
+	return &ConditionalAccessRunner{}
+}
+
+// Run is a no-op on non-Linux platforms.
+func (r *ConditionalAccessRunner) Run(_ *fleet.OrbitConfig) error {
+	return nil
+}

--- a/server/fleet/orbit.go
+++ b/server/fleet/orbit.go
@@ -55,6 +55,11 @@ type OrbitConfigNotifications struct {
 	// see EnforceBitLockerEncryption for Windows and RotateDiskEncryptionKey
 	// for macOS.
 	RunDiskEncryptionEscrow bool `json:"run_disk_encryption_escrow,omitempty"`
+
+	// RunConditionalAccessEnrollment tells orbit to ensure a conditional access
+	// SCEP certificate is enrolled. Only set for Linux hosts when Okta conditional
+	// access is configured globally.
+	RunConditionalAccessEnrollment bool `json:"run_conditional_access_enrollment,omitempty"`
 }
 
 type OrbitConfig struct {

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -421,6 +421,10 @@ func (svc *Service) GetOrbitConfig(ctx context.Context) (fleet.OrbitConfig, erro
 		*host.DiskEncryptionEnabled &&
 		svc.ds.IsHostPendingEscrow(ctx, host.ID)
 
+	notifs.RunConditionalAccessEnrollment = fleet.IsLinux(host.Platform) &&
+		appConfig.ConditionalAccess != nil &&
+		appConfig.ConditionalAccess.OktaConfigured()
+
 	// load the (active, ready to execute) pending software install executions for that host
 	pendingInstalls, err := svc.ds.ListReadyToExecuteSoftwareInstalls(ctx, host.ID)
 	if err != nil {

--- a/server/service/orbit_test.go
+++ b/server/service/orbit_test.go
@@ -989,3 +989,85 @@ func TestSoftwareInstallReplicaLag(t *testing.T) {
 	})
 	require.Equal(t, 1, retryCount, "should have scheduled a retry in upcoming_activities")
 }
+
+// newOrbitConfigContext sets up a minimal mock context for GetOrbitConfig tests.
+func newOrbitConfigContext(t *testing.T, host *fleet.Host, appCfg *fleet.AppConfig) (*mock.Store, fleet.Service, context.Context) {
+	t.Helper()
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil, &TestServerOpts{License: &fleet.LicenseInfo{Tier: fleet.TierPremium}, SkipCreateTestUsers: true})
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) { return appCfg, nil }
+	ds.ListReadyToExecuteScriptsForHostFunc = func(ctx context.Context, hostID uint, onlyShowInternal bool) ([]*fleet.HostScriptResult, error) {
+		return nil, nil
+	}
+	ds.ListReadyToExecuteSoftwareInstallsFunc = func(ctx context.Context, hostID uint) ([]string, error) {
+		return nil, nil
+	}
+	ds.IsHostConnectedToFleetMDMFunc = func(ctx context.Context, host *fleet.Host) (bool, error) {
+		return false, nil
+	}
+	ds.GetHostMDMFunc = func(ctx context.Context, hostID uint) (*fleet.HostMDM, error) {
+		return nil, nil
+	}
+	ds.GetHostAwaitingConfigurationFunc = func(ctx context.Context, hostUUID string) (bool, error) {
+		return false, nil
+	}
+	ctx = test.HostContext(ctx, host)
+	return ds, svc, ctx
+}
+
+func TestGetOrbitConfigLinuxConditionalAccessNotification(t *testing.T) {
+	linuxHost := &fleet.Host{
+		OsqueryHostID: ptr.String("linux-test"),
+		ID:            1,
+		Platform:      "ubuntu",
+	}
+	macHost := &fleet.Host{
+		OsqueryHostID: ptr.String("mac-test"),
+		ID:            2,
+		Platform:      "darwin",
+	}
+
+	fullyConfiguredOkta := &fleet.ConditionalAccessSettings{
+		OktaIDPID:                       optjson.SetString("idp-id"),
+		OktaAssertionConsumerServiceURL: optjson.SetString("https://example.okta.com/sso"),
+		OktaAudienceURI:                 optjson.SetString("https://fleet.example.com"),
+		OktaCertificate:                 optjson.SetString("-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----"),
+	}
+
+	t.Run("linux with Okta configured gets notification=true", func(t *testing.T) {
+		appCfg := &fleet.AppConfig{ConditionalAccess: fullyConfiguredOkta}
+		_, svc, ctx := newOrbitConfigContext(t, linuxHost, appCfg)
+		cfg, err := svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.True(t, cfg.Notifications.RunConditionalAccessEnrollment)
+	})
+
+	t.Run("linux without Okta configured gets notification=false", func(t *testing.T) {
+		appCfg := &fleet.AppConfig{} // nil ConditionalAccess
+		_, svc, ctx := newOrbitConfigContext(t, linuxHost, appCfg)
+		cfg, err := svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.False(t, cfg.Notifications.RunConditionalAccessEnrollment)
+	})
+
+	t.Run("linux with partially configured Okta gets notification=false", func(t *testing.T) {
+		partial := &fleet.ConditionalAccessSettings{
+			OktaIDPID: optjson.SetString("only-idp-set"),
+			// other fields empty
+		}
+		appCfg := &fleet.AppConfig{ConditionalAccess: partial}
+		_, svc, ctx := newOrbitConfigContext(t, linuxHost, appCfg)
+		cfg, err := svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.False(t, cfg.Notifications.RunConditionalAccessEnrollment)
+	})
+
+	t.Run("macOS with Okta configured gets notification=false", func(t *testing.T) {
+		appCfg := &fleet.AppConfig{ConditionalAccess: fullyConfiguredOkta}
+		_, svc, ctx := newOrbitConfigContext(t, macHost, appCfg)
+		cfg, err := svc.GetOrbitConfig(ctx)
+		require.NoError(t, err)
+		require.False(t, cfg.Notifications.RunConditionalAccessEnrollment)
+	})
+}


### PR DESCRIPTION
## Summary

Phase 1 of bringing Fleet's Okta conditional access feature to Linux. macOS gets a client certificate automatically via MDM `.mobileconfig`; Linux has no MDM, so orbit handles SCEP enrollment directly.

- **`RunConditionalAccessEnrollment` notification** — server sets this `true` for Linux hosts when all four Okta conditional access fields are configured globally; orbit acts on it
- **`ee/orbit/pkg/condaccess.Enroll()`** — idempotent enrollment: loads existing cert, skips if valid with >30 days remaining, otherwise generates a fresh ECC P-256 key, enrolls via SCEP with a `urn:device:fleet:uuid:<uuid>` SAN URI, and persists cert + key to root-dir
- **SCEP client `WithURIs` option** — new functional option sets `URIs []*url.URL` on the embedded `x509.CertificateRequest` so the SAN URI is included in the CSR
- **Depot UUID extraction** — `extractUUIDFromCert` now accepts both `urn:device:apple:uuid:` (macOS MDM) and `urn:device:fleet:uuid:` (Linux orbit) so the IdP can look up Linux hosts by cert serial
- **`ConditionalAccessRunner`** — `//go:build linux` runner registered in `orbit.go`'s `case "linux":` block; atomic bool prevents concurrent enrollment goroutines

## What this does NOT include (Phase 2+)
- NSS cert store installation (`certutil` / `pk12util`)
- Chrome / Firefox policy files for auto cert selection
- TPM-backed key storage
- Windows support

## Test plan

- [ ] `go test ./server/fleet/...` passes
- [ ] `go test ./server/service/... -run TestGetOrbitConfigLinuxConditionalAccessNotification` — 4 subtests pass (linux+configured=true, linux+unconfigured=false, linux+partial=false, macOS+configured=false)
- [ ] `go test ./ee/orbit/pkg/condaccess/...` — 5 unit tests pass
- [ ] `go test ./ee/server/service/condaccess/depot/...` — 4 unit tests pass (apple format, fleet format, no URI, unknown prefix)
- [ ] `GOOS=linux go vet ./orbit/pkg/update/` — clean
- [ ] `GOOS=linux go build -o /dev/null ./orbit/cmd/orbit/...` — clean
- [ ] Manual: deploy to a Linux host with Okta CA configured → check logs for "conditional access SCEP enrollment complete" and presence of `conditional_access.crt` / `conditional_access.key` in root-dir