### PR TITLE
check for DEP capable migration before showing automatic preview

### DIFF
--- a/orbit/changes/39252-manual-migration-if-not-dep-capable
+++ b/orbit/changes/39252-manual-migration-if-not-dep-capable
@@ -1,0 +1,1 @@
+* Fixed an issue where the automatic migration preview would show, if not MDM enrolled and device is not enrolled via DEP.

--- a/orbit/changes/39252-manual-migration-if-not-dep-capable
+++ b/orbit/changes/39252-manual-migration-if-not-dep-capable
@@ -1,1 +1,1 @@
-* Fixed an issue where the automatic migration preview would show, if not MDM enrolled and device is not enrolled via DEP.
+* Fixed an issue where the automatic migration preview would show when the device was not MDM-enrolled and not enrolled via DEP.

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -147,7 +147,7 @@ func ParseMDMEnrollmentStatus() (enrolledViaDEP bool, err error) {
 	// If the host is not enrolled into an MDM, the last line is omitted,
 	// so we need to check that:
 	//
-	// 1. We've got three rows
+	// 1. We've got two rows
 	// 2. The first row contains "Yes" or "No"
 	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
 	if len(lines) < 2 {

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -158,6 +158,45 @@ func IsManuallyEnrolledInMDM() (bool, error) {
 	return true, nil
 }
 
+// IsDEPCapable runs the `profiles` command to check if the device is DEP capable.
+// Which is determined by the output and looking at the `Enrolled via DEP` field.
+// If true, even if not MDM enrolled currently this method returns true.
+func IsDEPCapable() (bool, error) {
+	out, err := getMDMInfoFromProfilesCmd()
+	if err != nil {
+		return false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
+	}
+
+	// The output of the command is in the form:
+	//
+	// ```
+	// Enrolled via DEP: No
+	// MDM enrollment: Yes (User Approved)
+	// MDM server: https://test.example.com/mdm/apple/mdm
+	// ```
+	// OR
+	// ```
+	// Enrolled via DEP: No
+	// MDM enrollment: No
+	// ```
+	//
+	// If the host is not enrolled into an MDM, the last line is ommitted,
+	// so we need to check that:
+	//
+	// 1. We've got at least two rows
+	// 2. Whether the first line contains "Yes" or "No"
+	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
+	if len(lines) < 2 {
+		return false, fmt.Errorf("Got %d lines of output, when expected at least 2 or more", len(lines))
+	}
+
+	if strings.Contains(string(lines[0]), "Yes") {
+		return true, nil
+	}
+
+	return false, nil
+}
+
 // getMDMInfoFromProfilesCmd is declared as a variable so it can be overwritten by tests.
 var getMDMInfoFromProfilesCmd = func() ([]byte, error) {
 	cmd := exec.Command("/usr/bin/profiles", "status", "-type", "enrollment")

--- a/orbit/pkg/profiles/profiles_darwin.go
+++ b/orbit/pkg/profiles/profiles_darwin.go
@@ -127,7 +127,10 @@ func IsEnrolledInMDM() (bool, string, error) {
 	return true, enrollmentURL, nil
 }
 
-func IsManuallyEnrolledInMDM() (bool, error) {
+// ParseMDMEnrollmentStatus runs the `profiles` command to get the current MDM
+// enrollment information and reports if the host is enrolled via DEP or not.
+// Which is used to check for manual enrollment or not.
+func ParseMDMEnrollmentStatus() (enrolledViaDEP bool, err error) {
 	out, err := getMDMInfoFromProfilesCmd()
 	if err != nil {
 		return false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
@@ -141,50 +144,11 @@ func IsManuallyEnrolledInMDM() (bool, error) {
 	// MDM server: https://test.example.com/mdm/apple/mdm
 	// ```
 	//
-	// If the host is not enrolled into an MDM, the last line is ommitted,
+	// If the host is not enrolled into an MDM, the last line is omitted,
 	// so we need to check that:
 	//
 	// 1. We've got three rows
-	// 2. Whether the first line contains "Yes" or "No"
-	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
-	if len(lines) < 3 {
-		return false, nil
-	}
-
-	if strings.Contains(string(lines[0]), "Yes") {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// IsDEPCapable runs the `profiles` command to check if the device is DEP capable.
-// Which is determined by the output and looking at the `Enrolled via DEP` field.
-// If true, even if not MDM enrolled currently this method returns true.
-func IsDEPCapable() (bool, error) {
-	out, err := getMDMInfoFromProfilesCmd()
-	if err != nil {
-		return false, fmt.Errorf("calling /usr/bin/profiles: %w", err)
-	}
-
-	// The output of the command is in the form:
-	//
-	// ```
-	// Enrolled via DEP: No
-	// MDM enrollment: Yes (User Approved)
-	// MDM server: https://test.example.com/mdm/apple/mdm
-	// ```
-	// OR
-	// ```
-	// Enrolled via DEP: No
-	// MDM enrollment: No
-	// ```
-	//
-	// If the host is not enrolled into an MDM, the last line is ommitted,
-	// so we need to check that:
-	//
-	// 1. We've got at least two rows
-	// 2. Whether the first line contains "Yes" or "No"
+	// 2. The first row contains "Yes" or "No"
 	lines := bytes.Split(bytes.TrimSpace(out), []byte("\n"))
 	if len(lines) < 2 {
 		return false, fmt.Errorf("Got %d lines of output, when expected at least 2 or more", len(lines))

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -327,6 +327,43 @@ MDM server: https://valid.com/mdm/apple/mdm
 	}
 }
 
+func TestIsDEPCapable(t *testing.T) {
+	cases := []struct {
+		cmdOut  *string
+		cmdErr  error
+		want    bool
+		wantErr bool
+	}{
+		{nil, errors.New("test error"), false, true},
+		{ptr.String(""), nil, false, true},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: No"), nil, false, false},
+		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: No"), nil, true, false},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)"), nil, false, false},
+	}
+
+	origCmd := getMDMInfoFromProfilesCmd
+	t.Cleanup(func() { getMDMInfoFromProfilesCmd = origCmd })
+	for _, c := range cases {
+		getMDMInfoFromProfilesCmd = func() ([]byte, error) {
+			if c.cmdOut == nil {
+				return nil, c.cmdErr
+			}
+
+			var buf bytes.Buffer
+			buf.WriteString(*c.cmdOut)
+			return []byte(*c.cmdOut), nil
+		}
+
+		got, err := IsDEPCapable()
+		if c.wantErr {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+		require.Equal(t, c.want, got)
+	}
+}
+
 func TestCheckAssignedEnrollmentProfile(t *testing.T) {
 	fleetURL := "https://valid.com"
 	cases := []struct {

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -327,7 +327,7 @@ MDM server: https://valid.com/mdm/apple/mdm
 	}
 }
 
-func TestIsDEPCapable(t *testing.T) {
+func TestParseMDMEnrollmentStatus(t *testing.T) {
 	cases := []struct {
 		cmdOut  *string
 		cmdErr  error
@@ -354,7 +354,7 @@ func TestIsDEPCapable(t *testing.T) {
 			return []byte(*c.cmdOut), nil
 		}
 
-		got, err := IsDEPCapable()
+		got, err := ParseMDMEnrollmentStatus()
 		if c.wantErr {
 			require.Error(t, err)
 		} else {

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -339,6 +339,8 @@ func TestParseMDMEnrollmentStatus(t *testing.T) {
 		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: No"), nil, false, false},
 		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: No"), nil, true, false},
 		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)"), nil, false, false},
+		{ptr.String("Enrolled via DEP: No\nMDM Enrollment: Yes (User Approved)\nMDM Server: https://mdm.example.com"), nil, false, false},
+		{ptr.String("Enrolled via DEP: Yes\nMDM Enrollment: Yes\nMDM Server: https://mdm.example.com"), nil, true, false},
 	}
 
 	origCmd := getMDMInfoFromProfilesCmd

--- a/orbit/pkg/profiles/profiles_darwin_test.go
+++ b/orbit/pkg/profiles/profiles_darwin_test.go
@@ -351,7 +351,7 @@ func TestParseMDMEnrollmentStatus(t *testing.T) {
 
 			var buf bytes.Buffer
 			buf.WriteString(*c.cmdOut)
-			return []byte(*c.cmdOut), nil
+			return buf.Bytes(), nil
 		}
 
 		got, err := ParseMDMEnrollmentStatus()

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -406,14 +406,9 @@ func (m *swiftDialogMDMMigrator) waitForUnenrollment(isADEMigration bool) error 
 
 func (m *swiftDialogMDMMigrator) renderMigration() error {
 	log.Debug().Msg("checking current enrollment status")
-	isCurrentlyManuallyEnrolled, err := profiles.IsManuallyEnrolledInMDM()
+	enrolledViaDEP, err := profiles.ParseMDMEnrollmentStatus()
 	if err != nil {
 		return err
-	}
-
-	isDEPCapable, err := profiles.IsDEPCapable()
-	if err != nil {
-		return fmt.Errorf("checking if device is DEP capable: %w", err)
 	}
 
 	// Check what kind of migration was in progress, if any.
@@ -423,10 +418,10 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 		return fmt.Errorf("getting migration type: %w", err)
 	}
 
-	isManualMigration := isCurrentlyManuallyEnrolled || previousMigrationType == constant.MDMMigrationTypeManual || !isDEPCapable
+	isManualMigration := !enrolledViaDEP || previousMigrationType == constant.MDMMigrationTypeManual
 	isADEMigration := previousMigrationType == constant.MDMMigrationTypeADE
 
-	log.Debug().Bool("isManualMigration", isManualMigration).Bool("isADEMigration", isADEMigration).Bool("isCurrentlyManuallyEnrolled", isCurrentlyManuallyEnrolled).Bool("isDEPCapable", isDEPCapable).Str("previousMigrationType", previousMigrationType).Msg("props after assigning")
+	log.Debug().Bool("isManualMigration", isManualMigration).Bool("isADEMigration", isADEMigration).Bool("enrolledViaDEP", enrolledViaDEP).Str("previousMigrationType", previousMigrationType).Msg("props after assigning")
 
 	vers, err := m.getMacOSMajorVersion()
 	if err != nil {

--- a/orbit/pkg/useraction/mdm_migration_darwin.go
+++ b/orbit/pkg/useraction/mdm_migration_darwin.go
@@ -411,6 +411,11 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 		return err
 	}
 
+	isDEPCapable, err := profiles.IsDEPCapable()
+	if err != nil {
+		return fmt.Errorf("checking if device is DEP capable: %w", err)
+	}
+
 	// Check what kind of migration was in progress, if any.
 	previousMigrationType, err := m.mrw.GetMigrationType()
 	if err != nil {
@@ -418,10 +423,10 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 		return fmt.Errorf("getting migration type: %w", err)
 	}
 
-	isManualMigration := isCurrentlyManuallyEnrolled || previousMigrationType == constant.MDMMigrationTypeManual
+	isManualMigration := isCurrentlyManuallyEnrolled || previousMigrationType == constant.MDMMigrationTypeManual || !isDEPCapable
 	isADEMigration := previousMigrationType == constant.MDMMigrationTypeADE
 
-	log.Debug().Bool("isManualMigration", isManualMigration).Bool("isADEMigration", isADEMigration).Bool("isCurrentlyManuallyEnrolled", isCurrentlyManuallyEnrolled).Str("previousMigrationType", previousMigrationType).Msg("props after assigning")
+	log.Debug().Bool("isManualMigration", isManualMigration).Bool("isADEMigration", isADEMigration).Bool("isCurrentlyManuallyEnrolled", isCurrentlyManuallyEnrolled).Bool("isDEPCapable", isDEPCapable).Str("previousMigrationType", previousMigrationType).Msg("props after assigning")
 
 	vers, err := m.getMacOSMajorVersion()
 	if err != nil {
@@ -465,7 +470,7 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 
 		if !m.props.IsUnmanaged {
 			// show the loading spinner
-			m.renderLoadingSpinner(isPreSonoma, isCurrentlyManuallyEnrolled)
+			m.renderLoadingSpinner(isPreSonoma, isManualMigration)
 
 			// send the API call
 			if notifyErr := m.handler.NotifyRemote(); notifyErr != nil {
@@ -498,7 +503,7 @@ func (m *swiftDialogMDMMigrator) renderMigration() error {
 			switch {
 			case isPreSonoma:
 				if err := m.mrw.SetMigrationFile(constant.MDMMigrationTypePreSonoma); err != nil {
-					log.Error().Str("migration_type", constant.MDMMigrationTypeADE).Err(err).Msg("set migration file")
+					log.Error().Str("migration_type", constant.MDMMigrationTypePreSonoma).Err(err).Msg("set migration file")
 				}
 
 				log.Info().Msg("showing instructions after pre-sonoma unenrollment")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39252

I couldn't find any other code path that would resolve to automatic other than the device not being MDM enrolled, and we naively assumed 3 lines for manual migration, so I added the new IsDEPCapable method which checks if the first line returned by profiles status is No or Yes, to check if the device was enrolled via ABM/DEP, if not and not MDM enrolled then show the manual.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
