### PR TITLE
Rename for dogfood

### DIFF
--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -27,7 +27,7 @@ controls:
     enable_end_user_authentication: true
   scripts:
 policies:
-queries:
+reports:
 software:
   app_store_apps:
     # iOS apps

--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -1,5 +1,5 @@
 name: 📱🏢 Employee-issued mobile devices
-team_settings:
+settings:
   features:
   host_expiry_settings:
     host_expiry_enabled: false
@@ -18,12 +18,12 @@ controls:
     deadline: "2025-06-01"
     minimum_version: "18.5"
   macos_settings:
-    custom_settings:
+    configuration_profiles:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/declaration-profiles/Software Update settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  macos_setup:
+  setup_experience:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -18,12 +18,12 @@ controls:
     deadline: "2025-06-01"
     minimum_version: "18.5"
   macos_settings:
-    configuration_profiles:
+    custom_settings:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/declaration-profiles/Software Update settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  setup_experience:
+  macos_setup:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -25,7 +25,7 @@ controls:
     enable_end_user_authentication: true
   scripts:
 policies:
-queries:
+reports:
 software:
   app_store_apps:
     # iOS apps

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -1,5 +1,5 @@
 name: 📱🔐 Personal mobile devices
-team_settings:
+settings:
   features:
   host_expiry_settings:
     host_expiry_enabled: false
@@ -18,10 +18,10 @@ controls:
     deadline: "2025-06-01"
     minimum_version: "18.5"
   macos_settings:
-    custom_settings:
+    configuration_profiles:
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  macos_setup:
+  setup_experience:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -18,10 +18,10 @@ controls:
     deadline: "2025-06-01"
     minimum_version: "18.5"
   macos_settings:
-    configuration_profiles:
+    custom_settings:
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  setup_experience:
+  macos_setup:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/servers.yml
+++ b/it-and-security/fleets/servers.yml
@@ -1,5 +1,5 @@
 name: "☁️ IT servers"
-team_settings:
+settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
@@ -13,11 +13,11 @@ agent_options:
 controls:
   enable_disk_encryption: false
   macos_settings:
-    custom_settings:
-  macos_setup:
+    configuration_profiles:
+  setup_experience:
     bootstrap_package: null
     enable_end_user_authentication: false
-    macos_setup_assistant: null
+    apple_setup_assistant: null
   macos_updates:
     deadline: null
     minimum_version: null

--- a/it-and-security/fleets/servers.yml
+++ b/it-and-security/fleets/servers.yml
@@ -28,5 +28,5 @@ controls:
     grace_period_days: null
   scripts:
 policies:
-queries:
+reports:
 software:

--- a/it-and-security/fleets/servers.yml
+++ b/it-and-security/fleets/servers.yml
@@ -13,11 +13,11 @@ agent_options:
 controls:
   enable_disk_encryption: false
   macos_settings:
-    configuration_profiles:
-  setup_experience:
+    custom_settings:
+  macos_setup:
     bootstrap_package: null
     enable_end_user_authentication: false
-    apple_setup_assistant: null
+    macos_setup_assistant: null
   macos_updates:
     deadline: null
     minimum_version: null

--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -27,10 +27,10 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
-  setup_experience:
+  macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: true
-    apple_setup_assistant: 
+    macos_setup_assistant: 
   macos_updates:
     deadline:
     minimum_version:

--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -1,5 +1,5 @@
 name: "🧪 Testing & QA"
-team_settings:
+settings:
   features:
     enable_host_users: true
     enable_software_inventory: true
@@ -27,10 +27,10 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
-  macos_setup:
+  setup_experience:
     bootstrap_package: ""
     enable_end_user_authentication: true
-    macos_setup_assistant: 
+    apple_setup_assistant: 
   macos_updates:
     deadline:
     minimum_version:

--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -48,7 +48,7 @@ policies:
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   # Linux policies
   - path: ../lib/linux/policies/check-fleet-desktop-extension-enabled.yml
-queries:
+reports:
 software:
   packages:
     # Linux apps

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -1,5 +1,5 @@
 name: $DOGFOOD_APPLE_BM_DEFAULT_TEAM
-team_settings:
+settings:
   webhook_settings:
     failing_policies_webhook:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL
@@ -42,8 +42,8 @@ agent_options:
     desktop: stable
 controls:
   enable_disk_encryption: true
-  macos_settings:
-    custom_settings:
+  apple_settings:
+    configuration_profiles:
       - path: ../lib/macos/configuration-profiles/date-time.mobileconfig
       - path: ../lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
       - path: ../lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
@@ -87,10 +87,10 @@ controls:
       - path: ../lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
         labels_include_any:
           - "Microsoft AutoUpdate installed"
-  macos_setup:
+  setup_experience:
     bootstrap_package: ""
     enable_end_user_authentication: true
-    macos_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
+    apple_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
   macos_updates:
     deadline:
     minimum_version:

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -151,7 +151,7 @@ policies:
   - path: ../lib/linux/policies/disk-encryption-check.yml
   - path: ../lib/linux/policies/disk-space-check.yml
   - path: ../lib/linux/policies/check-fleet-desktop-extension-enabled.yml
-queries:
+reports:
   - path: ../lib/macos/queries/detect-apple-intelligence.yml
   - path: ../lib/macos/queries/collect-santa-denied-logs.yml
   - path: ../lib/all/queries/dex-queries.yml

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -42,8 +42,8 @@ agent_options:
     desktop: stable
 controls:
   enable_disk_encryption: true
-  apple_settings:
-    configuration_profiles:
+  macos_settings:
+    custom_settings:
       - path: ../lib/macos/configuration-profiles/date-time.mobileconfig
       - path: ../lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
       - path: ../lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
@@ -87,10 +87,10 @@ controls:
       - path: ../lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
         labels_include_any:
           - "Microsoft AutoUpdate installed"
-  setup_experience:
+  macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: true
-    apple_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
+    macos_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
   macos_updates:
     deadline:
     minimum_version:

--- a/it-and-security/teams/no-team.yml
+++ b/it-and-security/teams/no-team.yml
@@ -1,5 +1,0 @@
-name: No team
-policies:
-software:
-controls:
-  macos_settings:

--- a/website/generators/gitops/templates/fleets/personal-mobile-devices.yml.template
+++ b/website/generators/gitops/templates/fleets/personal-mobile-devices.yml.template
@@ -18,7 +18,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 name: "📱🔐 Personal mobile devices"
 controls:
-  apple_setup:
+  setup_experience:
     ###########################################################
     # Uncomment to use single-sign on (SSO) to authenticate 
     # end users enrolling their personal device.
@@ -42,12 +42,12 @@ controls:
   #   • https://fleetdm.com/docs/configuration/yaml-files#android-settings
   ###########################################################
   apple_settings:
-    profiles:
+    configuration_profiles:
       # … e.g.
       # - path: ../lib/ios/declaration-profiles/Passcode settings.json
       # - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
   android_settings:
-    profiles:
+    configuration_profiles:
     certificates:
 
   ###########################################################

--- a/website/generators/gitops/templates/fleets/personal-mobile-devices.yml.template
+++ b/website/generators/gitops/templates/fleets/personal-mobile-devices.yml.template
@@ -18,7 +18,7 @@
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 name: "📱🔐 Personal mobile devices"
 controls:
-  setup_experience:
+  apple_setup:
     ###########################################################
     # Uncomment to use single-sign on (SSO) to authenticate 
     # end users enrolling their personal device.
@@ -42,12 +42,12 @@ controls:
   #   • https://fleetdm.com/docs/configuration/yaml-files#android-settings
   ###########################################################
   apple_settings:
-    configuration_profiles:
+    profiles:
       # … e.g.
       # - path: ../lib/ios/declaration-profiles/Passcode settings.json
       # - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
   android_settings:
-    configuration_profiles:
+    profiles:
     certificates:
 
   ###########################################################


### PR DESCRIPTION
UPDATE: @noahtalerman: Use this PR instead: https://github.com/fleetdm/fleet/pull/40726

---

- `teams/` => `fleets/`
- `queries` => `reports`
- Remove `no-team.yml` (now `unassigned.yml`) because we don't use it and it's not required
- Other key renames coming in 4.83: https://github.com/fleetdm/fleet/issues/40488
