### PR TITLE
Invalidate software-titles query cache after adding VPP or fleet-maintained app

### DIFF
--- a/changes/41290-invalidate-software-titles-cache-after-add
+++ b/changes/41290-invalidate-software-titles-cache-after-add
@@ -1,0 +1,1 @@
+* Fixed stale software titles list after adding a VPP or fleet-maintained app by invalidating the query cache on success.

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { AxiosError } from "axios";
 import PATHS from "router/paths";
 
@@ -90,6 +90,7 @@ const SoftwareAppStoreVpp = ({
 }: ISoftwareAppStoreProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { isPremiumTier } = useContext(AppContext);
+  const queryClient = useQueryClient();
 
   const [isLoading, setIsLoading] = useState(false);
   const [
@@ -181,6 +182,10 @@ const SoftwareAppStoreVpp = ({
         </>,
         { persistOnPageChange: true }
       );
+
+      queryClient.invalidateQueries({
+        queryKey: [{ scope: "software-titles" }],
+      });
 
       router.push(
         getPathWithQueryParams(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, useState } from "react";
 import { AxiosResponse } from "axios";
 import { Location } from "history";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router";
 import { useErrorHandler } from "react-error-boundary";
 
@@ -138,6 +138,7 @@ const FleetMaintainedAppDetailsPage = ({
   }
 
   const { renderFlash } = useContext(NotificationContext);
+  const queryClient = useQueryClient();
 
   const handlePageError = useErrorHandler();
   const { isPremiumTier } = useContext(AppContext);
@@ -223,6 +224,10 @@ const FleetMaintainedAppDetailsPage = ({
       } = await softwareAPI.addFleetMaintainedApp(parseInt(teamId, 10), {
         ...formData,
         appId,
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: [{ scope: "software-titles" }],
       });
 
       router.push(


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41290

Will need to be cherry-picked to 4.82 RC branch.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/60201628-eb4f-4c11-ac02-2481a7764b73


https://github.com/user-attachments/assets/4655d1de-8a0d-41fd-995c-44bc54f369d4



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed
