### PR TITLE
Allow read-only API tokens for gitops dry-run

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1993,7 +1993,7 @@ func (svc *Service) BatchSetSoftwareInstallers(
 		teamID = &tm.ID
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, dryRun); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 
@@ -2746,8 +2746,8 @@ func (svc *Service) GetBatchSetSoftwareInstallersResult(ctx context.Context, tmN
 	// but adding it here so we don't need to worry about a special case endpoint.
 	//
 	// We use fleet.ActionWrite because this method is the counterpart of the POST
-	// /api/latest/fleet/software/batch.
-	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: ptrTeamID}, fleet.ActionWrite); err != nil {
+	// /api/latest/fleet/software/batch. For dry runs, we fall back to ActionRead.
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: ptrTeamID}, dryRun); err != nil {
 		return "", "", nil, ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -1993,7 +1993,11 @@ func (svc *Service) BatchSetSoftwareInstallers(
 		teamID = &tm.ID
 	}
 
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, action); err != nil {
 		return "", ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 
@@ -2746,8 +2750,12 @@ func (svc *Service) GetBatchSetSoftwareInstallersResult(ctx context.Context, tmN
 	// but adding it here so we don't need to worry about a special case endpoint.
 	//
 	// We use fleet.ActionWrite because this method is the counterpart of the POST
-	// /api/latest/fleet/software/batch. For dry runs, we fall back to ActionRead.
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: ptrTeamID}, dryRun); err != nil {
+	// /api/latest/fleet/software/batch. For dry runs, we use ActionValidate.
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: ptrTeamID}, action); err != nil {
 		return "", "", nil, ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -993,7 +993,7 @@ func setAuthCheckedOnPreAuthErr(ctx context.Context) {
 	}
 }
 
-func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fleet.TeamSpec) error {
+func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fleet.TeamSpec, dryRun bool) error {
 	for _, spec := range specs {
 		var team *fleet.Team
 		var err error
@@ -1010,7 +1010,7 @@ func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fle
 			if err != nil {
 				if fleet.IsNotFound(err) {
 					// Can the user create a new team?
-					if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionWrite); err != nil {
+					if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.Team{}, dryRun); err != nil {
 						return err
 					}
 					continue
@@ -1023,7 +1023,7 @@ func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fle
 		}
 
 		// can the user modify each team it's trying to modify
-		if err := svc.authz.Authorize(ctx, team, fleet.ActionWrite); err != nil {
+		if err := svc.authz.AuthorizeForDryRun(ctx, team, dryRun); err != nil {
 			return err
 		}
 	}
@@ -1039,7 +1039,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		return map[string]uint{}, nil
 	}
 
-	if err := svc.checkAuthorizationForTeams(ctx, specs); err != nil {
+	if err := svc.checkAuthorizationForTeams(ctx, specs, applyOpts.DryRun); err != nil {
 		return nil, err
 	}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -994,6 +994,10 @@ func setAuthCheckedOnPreAuthErr(ctx context.Context) {
 }
 
 func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fleet.TeamSpec, dryRun bool) error {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
 	for _, spec := range specs {
 		var team *fleet.Team
 		var err error
@@ -1010,7 +1014,7 @@ func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fle
 			if err != nil {
 				if fleet.IsNotFound(err) {
 					// Can the user create a new team?
-					if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.Team{}, dryRun); err != nil {
+					if err := svc.authz.Authorize(ctx, &fleet.Team{}, action); err != nil {
 						return err
 					}
 					continue
@@ -1023,7 +1027,7 @@ func (svc *Service) checkAuthorizationForTeams(ctx context.Context, specs []*fle
 		}
 
 		// can the user modify each team it's trying to modify
-		if err := svc.authz.AuthorizeForDryRun(ctx, team, dryRun); err != nil {
+		if err := svc.authz.Authorize(ctx, team, action); err != nil {
 			return err
 		}
 	}

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -79,7 +79,11 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 		manualAgentInstall = ac.MDM.MacOSSetup.ManualAgentInstall.Value
 	}
 
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, action); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 

--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -79,7 +79,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 		manualAgentInstall = ac.MDM.MacOSSetup.ManualAgentInstall.Value
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SoftwareInstaller{TeamID: teamID}, dryRun); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "validating authorization")
 	}
 

--- a/server/authz/authz.go
+++ b/server/authz/authz.go
@@ -132,28 +132,6 @@ func (a *Authorizer) Authorize(ctx context.Context, object, action interface{}) 
 	return nil
 }
 
-// AuthorizeForDryRun attempts ActionWrite authorization first. If dryRun is true
-// and the write check fails, it falls back to ActionRead. This allows both
-// write-capable users (e.g. gitops, which has write-only permissions on many
-// resources) and read-capable users to perform dry-run operations, while still
-// requiring write permission for real applies.
-func (a *Authorizer) AuthorizeForDryRun(ctx context.Context, object interface{}, dryRun bool) error {
-	err := a.Authorize(ctx, object, fleet.ActionWrite)
-	if err == nil {
-		return nil
-	}
-	if !dryRun {
-		return err
-	}
-	// During dry run, also accept read-only access.
-	readErr := a.Authorize(ctx, object, fleet.ActionRead)
-	if readErr == nil {
-		return nil
-	}
-	// Return the original write error for better error messages.
-	return err
-}
-
 // ExtraAuthzer is the interface to implement extra fields for the policy.
 type ExtraAuthzer interface {
 	// ExtraAuthz returns the extra key/value pairs for the type.

--- a/server/authz/authz.go
+++ b/server/authz/authz.go
@@ -132,6 +132,28 @@ func (a *Authorizer) Authorize(ctx context.Context, object, action interface{}) 
 	return nil
 }
 
+// AuthorizeForDryRun attempts ActionWrite authorization first. If dryRun is true
+// and the write check fails, it falls back to ActionRead. This allows both
+// write-capable users (e.g. gitops, which has write-only permissions on many
+// resources) and read-capable users to perform dry-run operations, while still
+// requiring write permission for real applies.
+func (a *Authorizer) AuthorizeForDryRun(ctx context.Context, object interface{}, dryRun bool) error {
+	err := a.Authorize(ctx, object, fleet.ActionWrite)
+	if err == nil {
+		return nil
+	}
+	if !dryRun {
+		return err
+	}
+	// During dry run, also accept read-only access.
+	readErr := a.Authorize(ctx, object, fleet.ActionRead)
+	if readErr == nil {
+		return nil
+	}
+	// Return the original write error for better error messages.
+	return err
+}
+
 // ExtraAuthzer is the interface to implement extra fields for the policy.
 type ExtraAuthzer interface {
 	// ExtraAuthz returns the extra key/value pairs for the type.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -38,7 +38,11 @@ maintainer := "maintainer"
 observer := "observer"
 observer_plus := "observer_plus"
 gitops := "gitops"
+gitops_validator := "gitops_validator"
 technician := "technician"
+
+# Dry-run validation action
+validate := "validate"
 
 # Default deny
 default allow = false
@@ -1280,4 +1284,114 @@ allow {
   object.type == "certificate_template"
   team_role(subject, object.team_id) == [admin, maintainer, gitops][_]
   action == [read, write][_]
+}
+
+##
+# Dry-run validation (validate action)
+#
+# These rules grant the "validate" action to roles that can perform dry-run
+# gitops operations. Both gitops and gitops_validator roles are granted
+# validate on all gitops-relevant resources.
+##
+
+# Global admins, gitops and gitops_validator can validate global config.
+allow {
+  object.type == "app_config"
+  subject.global_role == [admin, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, gitops and gitops_validator can validate teams.
+allow {
+  object.type == "team"
+  subject.global_role == [admin, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Team admins, gitops and gitops_validator can validate their teams.
+allow {
+  object.type == "team"
+  team_role(subject, object.id) == [admin, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, gitops and gitops_validator can validate global enroll secrets.
+allow {
+  object.type == "enroll_secret"
+  object.is_global_secret
+  subject.global_role == [admin, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins and maintainers can validate enroll secrets.
+allow {
+  object.type == "enroll_secret"
+  subject.global_role == [admin, maintainer][_]
+  action == validate
+}
+
+# Team admins and maintainers can validate enroll secrets for appropriate teams.
+allow {
+  object.type == "enroll_secret"
+  team_role(subject, object.team_id) == [admin, maintainer][_]
+  action == validate
+}
+
+# Global admins, gitops and gitops_validator can validate certificate authorities.
+allow {
+  object.type == "certificate_authority"
+  subject.global_role == [admin, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, maintainers, gitops and gitops_validator can validate MDM config profiles.
+allow {
+  object.type == "mdm_config_profile"
+  subject.global_role == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Team admins, maintainers, gitops and gitops_validator can validate MDM config profiles on their teams.
+allow {
+  object.type == "mdm_config_profile"
+  object.team_id != 0
+  team_role(subject, object.team_id) == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, maintainers, gitops and gitops_validator can validate scripts.
+allow {
+  object.type == "script"
+  subject.global_role == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Team admins, maintainers, gitops and gitops_validator can validate scripts for their teams.
+allow {
+  object.type == "script"
+  not is_null(object.team_id)
+  team_role(subject, object.team_id) == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, maintainers, gitops and gitops_validator can validate software.
+allow {
+  object.type == "installable_entity"
+  subject.global_role == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Team admins, maintainers, gitops and gitops_validator can validate software in their teams.
+allow {
+  not is_null(object.team_id)
+  object.type == "installable_entity"
+  team_role(subject, object.team_id) == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
+}
+
+# Global admins, maintainers, gitops and gitops_validator can validate secret variables.
+allow {
+  object.type == "secret_variable"
+  subject.global_role == [admin, maintainer, gitops, gitops_validator][_]
+  action == validate
 }

--- a/server/fleet/authz.go
+++ b/server/fleet/authz.go
@@ -50,4 +50,7 @@ const (
 	ActionSelectiveRead = "selective_read"
 	// ActionSelectiveList allows targeted list access of an entity.
 	ActionSelectiveList = "selective_list"
+
+	// ActionValidate permits dry-run validation of gitops configurations without mutation.
+	ActionValidate = "validate"
 )

--- a/server/fleet/teams.go
+++ b/server/fleet/teams.go
@@ -13,14 +13,15 @@ import (
 )
 
 const (
-	RoleAdmin        = "admin"
-	RoleMaintainer   = "maintainer"
-	RoleObserver     = "observer"
-	RoleObserverPlus = "observer_plus"
-	RoleGitOps       = "gitops"
-	RoleTechnician   = "technician"
-	TeamNameNoTeam   = "No team"
-	TeamNameAllTeams = "All teams"
+	RoleAdmin           = "admin"
+	RoleMaintainer      = "maintainer"
+	RoleObserver        = "observer"
+	RoleObserverPlus    = "observer_plus"
+	RoleGitOps          = "gitops"
+	RoleGitOpsValidator = "gitops_validator"
+	RoleTechnician      = "technician"
+	TeamNameNoTeam      = "No team"
+	TeamNameAllTeams    = "All teams"
 )
 
 const (
@@ -492,18 +493,20 @@ type TeamUser struct {
 }
 
 var teamRoles = map[string]struct{}{
-	RoleAdmin:        {},
-	RoleObserver:     {},
-	RoleMaintainer:   {},
-	RoleTechnician:   {},
-	RoleObserverPlus: {},
-	RoleGitOps:       {},
+	RoleAdmin:           {},
+	RoleObserver:        {},
+	RoleMaintainer:      {},
+	RoleTechnician:      {},
+	RoleObserverPlus:    {},
+	RoleGitOps:          {},
+	RoleGitOpsValidator: {},
 }
 
 var premiumTeamRoles = map[string]struct{}{
-	RoleTechnician:   {},
-	RoleObserverPlus: {},
-	RoleGitOps:       {},
+	RoleTechnician:      {},
+	RoleObserverPlus:    {},
+	RoleGitOps:          {},
+	RoleGitOpsValidator: {},
 }
 
 // ValidTeamRole returns whether the role provided is valid for a team user.
@@ -513,18 +516,20 @@ func ValidTeamRole(role string) bool {
 }
 
 var globalRoles = map[string]struct{}{
-	RoleObserver:     {},
-	RoleMaintainer:   {},
-	RoleAdmin:        {},
-	RoleTechnician:   {},
-	RoleObserverPlus: {},
-	RoleGitOps:       {},
+	RoleObserver:        {},
+	RoleMaintainer:      {},
+	RoleAdmin:           {},
+	RoleTechnician:      {},
+	RoleObserverPlus:    {},
+	RoleGitOps:          {},
+	RoleGitOpsValidator: {},
 }
 
 var premiumGlobalRoles = map[string]struct{}{
-	RoleTechnician:   {},
-	RoleObserverPlus: {},
-	RoleGitOps:       {},
+	RoleTechnician:      {},
+	RoleObserverPlus:    {},
+	RoleGitOps:          {},
+	RoleGitOpsValidator: {},
 }
 
 // ValidGlobalRole returns whether the role provided is valid for a global user.
@@ -589,7 +594,7 @@ func ValidateUserRoles(createNew bool, payload UserPayload, license LicenseInfo)
 	premiumRolesPresent := false
 	gitOpsRolePresent := false
 	if payload.GlobalRole != nil {
-		if *payload.GlobalRole == RoleGitOps {
+		if *payload.GlobalRole == RoleGitOps || *payload.GlobalRole == RoleGitOpsValidator {
 			gitOpsRolePresent = true
 		}
 		if _, ok := premiumGlobalRoles[*payload.GlobalRole]; ok {
@@ -597,7 +602,7 @@ func ValidateUserRoles(createNew bool, payload UserPayload, license LicenseInfo)
 		}
 	}
 	for _, teamUser := range teamUsers_ {
-		if teamUser.Role == RoleGitOps {
+		if teamUser.Role == RoleGitOps || teamUser.Role == RoleGitOpsValidator {
 			gitOpsRolePresent = true
 		}
 		if _, ok := premiumTeamRoles[teamUser.Role]; ok {
@@ -612,7 +617,7 @@ func ValidateUserRoles(createNew bool, payload UserPayload, license LicenseInfo)
 		((createNew && (payload.APIOnly == nil || !*payload.APIOnly)) ||
 			// Removing API only status from existing user.
 			(!createNew && payload.APIOnly != nil && !*payload.APIOnly)) {
-		return NewErrorf(ErrAPIOnlyRole, "role GitOps can only be set for API only users")
+		return NewErrorf(ErrAPIOnlyRole, "role GitOps/GitOps Validator can only be set for API only users")
 	}
 
 	return nil

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -311,7 +311,11 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 }
 
 func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fleet.ApplySpecOptions) (*fleet.AppConfig, error) {
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.AppConfig{}, applyOpts.DryRun); err != nil {
+	action := fleet.ActionWrite
+	if applyOpts.DryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, action); err != nil {
 		return nil, err
 	}
 
@@ -1871,7 +1875,11 @@ func applyEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc
 }
 
 func (svc *Service) ApplyEnrollSecretSpec(ctx context.Context, spec *fleet.EnrollSecretSpec, applyOpts fleet.ApplySpecOptions) error {
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.EnrollSecret{}, applyOpts.DryRun); err != nil {
+	action := fleet.ActionWrite
+	if applyOpts.DryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.EnrollSecret{}, action); err != nil {
 		return err
 	}
 	if len(spec.Secrets) > fleet.MaxEnrollSecretsCount {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -311,7 +311,7 @@ func modifyAppConfigEndpoint(ctx context.Context, request interface{}, svc fleet
 }
 
 func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fleet.ApplySpecOptions) (*fleet.AppConfig, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.AppConfig{}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.AppConfig{}, applyOpts.DryRun); err != nil {
 		return nil, err
 	}
 
@@ -1871,7 +1871,7 @@ func applyEnrollSecretSpecEndpoint(ctx context.Context, request interface{}, svc
 }
 
 func (svc *Service) ApplyEnrollSecretSpec(ctx context.Context, spec *fleet.EnrollSecretSpec, applyOpts fleet.ApplySpecOptions) error {
-	if err := svc.authz.Authorize(ctx, &fleet.EnrollSecret{}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.EnrollSecret{}, applyOpts.DryRun); err != nil {
 		return err
 	}
 	if len(spec.Secrets) > fleet.MaxEnrollSecretsCount {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2490,7 +2490,7 @@ func batchSetMDMAppleProfilesEndpoint(ctx context.Context, request interface{}, 
 
 func (svc *Service) BatchSetMDMAppleProfiles(ctx context.Context, tmID *uint, tmName *string, profiles [][]byte, dryRun, skipBulkPending bool) error {
 	var err error
-	tmID, tmName, err = svc.authorizeBatchProfiles(ctx, tmID, tmName)
+	tmID, tmName, err = svc.authorizeBatchProfiles(ctx, tmID, tmName, dryRun)
 	if err != nil {
 		return err
 	}

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -199,7 +199,11 @@ func batchApplyCertificateAuthoritiesEndpoint(ctx context.Context, request inter
 }
 
 func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error {
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.CertificateAuthority{}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, action); err != nil {
 		return err
 	}
 

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -199,7 +199,7 @@ func batchApplyCertificateAuthoritiesEndpoint(ctx context.Context, request inter
 }
 
 func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error {
-	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.CertificateAuthority{}, dryRun); err != nil {
 		return err
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2329,7 +2329,11 @@ func (svc *Service) authorizeBatchProfiles(ctx context.Context, tmID *uint, tmNa
 		}
 	}
 
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.MDMConfigProfileAuthz{TeamID: tmID}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: tmID}, action); err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err)
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1992,7 +1992,7 @@ func (svc *Service) BatchSetMDMProfiles(
 	noCache bool,
 ) error {
 	var err error
-	if tmID, tmName, err = svc.authorizeBatchProfiles(ctx, tmID, tmName); err != nil {
+	if tmID, tmName, err = svc.authorizeBatchProfiles(ctx, tmID, tmName, dryRun); err != nil {
 		return err
 	}
 
@@ -2297,7 +2297,7 @@ func fmtDuplicateNameErrMsg(name string) string {
 	return fmt.Sprintf(SameProfileNameErrorMsg, name)
 }
 
-func (svc *Service) authorizeBatchProfiles(ctx context.Context, tmID *uint, tmName *string) (*uint, *string, error) {
+func (svc *Service) authorizeBatchProfiles(ctx context.Context, tmID *uint, tmName *string, dryRun bool) (*uint, *string, error) {
 	if tmID != nil && tmName != nil {
 		svc.authz.SkipAuthorization(ctx) // so that the error message is not replaced by "forbidden"
 		return nil, nil, ctxerr.Wrap(ctx, fleet.NewInvalidArgumentError("team_name", "cannot specify both team_id and team_name"))
@@ -2329,7 +2329,7 @@ func (svc *Service) authorizeBatchProfiles(ctx context.Context, tmID *uint, tmNa
 		}
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: tmID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.MDMConfigProfileAuthz{TeamID: tmID}, dryRun); err != nil {
 		return nil, nil, ctxerr.Wrap(ctx, err)
 	}
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -1042,7 +1042,7 @@ func (svc *Service) BatchSetScripts(ctx context.Context, maybeTmID *uint, maybeT
 		teamName = &team.Name
 	}
 
-	if err := svc.authz.Authorize(ctx, &fleet.Script{TeamID: teamID}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.Script{TeamID: teamID}, dryRun); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
 

--- a/server/service/scripts.go
+++ b/server/service/scripts.go
@@ -1042,7 +1042,11 @@ func (svc *Service) BatchSetScripts(ctx context.Context, maybeTmID *uint, maybeT
 		teamName = &team.Name
 	}
 
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.Script{TeamID: teamID}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.Script{TeamID: teamID}, action); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
 

--- a/server/service/secret_variables.go
+++ b/server/service/secret_variables.go
@@ -38,7 +38,11 @@ func createSecretVariablesEndpoint(ctx context.Context, request interface{}, svc
 
 func (svc *Service) CreateSecretVariables(ctx context.Context, secretVariables []fleet.SecretVariable, dryRun bool) error {
 	// Do authorization check first so that we don't have to worry about it later in the flow.
-	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SecretVariable{}, dryRun); err != nil {
+	action := fleet.ActionWrite
+	if dryRun {
+		action = fleet.ActionValidate
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.SecretVariable{}, action); err != nil {
 		return err
 	}
 

--- a/server/service/secret_variables.go
+++ b/server/service/secret_variables.go
@@ -38,7 +38,7 @@ func createSecretVariablesEndpoint(ctx context.Context, request interface{}, svc
 
 func (svc *Service) CreateSecretVariables(ctx context.Context, secretVariables []fleet.SecretVariable, dryRun bool) error {
 	// Do authorization check first so that we don't have to worry about it later in the flow.
-	if err := svc.authz.Authorize(ctx, &fleet.SecretVariable{}, fleet.ActionWrite); err != nil {
+	if err := svc.authz.AuthorizeForDryRun(ctx, &fleet.SecretVariable{}, dryRun); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Introduces a new `gitops_validator` role and `ActionValidate` authorization action
- When `fleetctl gitops --dry-run` is used, server-side authorization checks require `ActionValidate` instead of `ActionWrite`
- The existing `gitops` role is granted both `write` and `validate`, so there is no change for current users
- The new `gitops_validator` role is granted `validate` only — it can dry-run but cannot apply changes
- This enables organizations to use a lower-privilege API token for PR validation workflows while reserving write-access tokens for actual applies

## Motivation

Currently, `fleetctl gitops --dry-run` requires the same write-access API token as a real apply. This means CI pipelines that validate configs on PRs must use a token with full write permissions. With this change, organizations can create a `gitops_validator` API user for PR checks and a `gitops` user for applies on merge, following the principle of least privilege.

| Token Role | `--dry-run` | Real apply |
|---|---|---|
| `gitops` | Works | Works |
| `gitops_validator` | Works | 403 Forbidden |

## Changes

**New authorization action** (`server/fleet/authz.go`):
- `ActionValidate` — permits dry-run validation but not mutation

**New role** (`server/fleet/role.go`):
- `gitops_validator` — can validate configs via dry-run but cannot apply them

**OPA policy updates** (`server/authz/policy.rego`):
- ~15 new rules granting `validate` action to both `gitops` and `gitops_validator` roles on all gitops-relevant resource types

**Handler updates** (9 service files):
- When `dry_run=true`, require `ActionValidate` instead of `ActionWrite`

## Test plan

- [ ] Verify `fleetctl gitops --dry-run` succeeds with a `gitops` role token (no regression)
- [ ] Verify `fleetctl gitops --dry-run` succeeds with a `gitops_validator` role token
- [ ] Verify `fleetctl gitops` (without `--dry-run`) succeeds with a `gitops` role token
- [ ] Verify `fleetctl gitops` (without `--dry-run`) returns 403 with a `gitops_validator` role token
- [ ] Verify existing integration tests pass
- [ ] Verify `gitops_validator` role can be assigned when creating an API-only user