### PR TITLE
fix(fleetctl): avoid truncated controls validation error

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -298,12 +298,13 @@ func gitopsCommand() *cli.Command {
 				isGlobalConfig := configFile.IsGlobalConfig
 
 				if isGlobalConfig {
+					controlsNoTeamFilename := controlsSourceFilename(noTeamFilename)
 					if noTeamControls.Set() && config.Controls.Set() {
-						return fmt.Errorf("'controls' cannot be set on both global config and on %s", noTeamFilename)
+						return fmt.Errorf("'controls' cannot be set on both global config and on %s", controlsNoTeamFilename)
 					}
 					if !noTeamControls.Defined && !config.Controls.Defined {
 						if appConfig.License.IsPremium() {
-							return fmt.Errorf("'controls' must be set on global config or %s", noTeamFilename)
+							return fmt.Errorf("'controls' must be set on global config or %s", controlsNoTeamFilename)
 						}
 						return errors.New("'controls' must be set on global config")
 					}
@@ -837,6 +838,13 @@ func getCustomSettings(osSettings interface{}) ([]fleet.MDMProfileSpec, bool) {
 		return settingsMap.GetMDMProfileSpecs(), true
 	}
 	return nil, false
+}
+
+func controlsSourceFilename(noTeamFilename string) string {
+	if noTeamFilename == "" {
+		return "unassigned.yml"
+	}
+	return noTeamFilename
 }
 
 func extractControlsForNoTeam(flFilenames cli.StringSlice, appConfig *fleet.EnrichedAppConfig, gitOpsOpts spec.GitOpsOptions) (spec.GitOpsControls, bool, string, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4840,6 +4840,17 @@ software:
 	})
 }
 
+func TestControlsSourceFilename(t *testing.T) {
+	t.Run("defaults to unassigned when no no-team file is provided", func(t *testing.T) {
+		require.Equal(t, "unassigned.yml", controlsSourceFilename(""))
+	})
+
+	t.Run("keeps explicit no-team/unassigned filename", func(t *testing.T) {
+		require.Equal(t, "no-team.yml", controlsSourceFilename("no-team.yml"))
+		require.Equal(t, "unassigned.yml", controlsSourceFilename("unassigned.yml"))
+	})
+}
+
 func TestComputeLabelChanges(t *testing.T) {
 	testCases := []struct {
 		name            string


### PR DESCRIPTION
**Related issue:** Resolves #41307

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

## Summary

- avoid interpolating an empty no-team filename in premium controls validation errors
- add `controlsSourceFilename` helper so errors consistently reference `unassigned.yml` when no `no-team.yml`/`unassigned.yml` file is provided
- keep existing behavior unchanged when `no-team.yml` or `unassigned.yml` is explicitly present

## Validation

- added unit test `TestControlsSourceFilename` for both fallback and explicit filename paths
- full `go test ./cmd/fleetctl/fleetctl -run TestControlsSourceFilename` could not be executed in this sparse checkout because dependent module packages are not present locally
