### PR TITLE
Fleet UI: Update disabled sliders to show tooltip

### DIFF
--- a/frontend/components/forms/fields/Slider/Slider.tsx
+++ b/frontend/components/forms/fields/Slider/Slider.tsx
@@ -4,12 +4,15 @@ import { pick } from "lodash";
 
 import FormField from "components/forms/FormField";
 import { IFormFieldProps } from "components/forms/FormField/FormField";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface ISliderProps {
   onChange: () => void;
   value: boolean;
   inactiveText: JSX.Element | string;
   activeText: JSX.Element | string;
+  /** Use to display slider label tooltip, compatible with disabled state */
+  labelTooltip?: JSX.Element | string;
   className?: string;
   helpText?: JSX.Element | string;
   autoFocus?: boolean;
@@ -24,6 +27,7 @@ const Slider = (props: ISliderProps): JSX.Element => {
     value,
     inactiveText,
     activeText,
+    labelTooltip,
     autoFocus,
     disabled,
   } = props;
@@ -63,6 +67,8 @@ const Slider = (props: ISliderProps): JSX.Element => {
   const wrapperClassNames = classnames(`${baseClass}__wrapper`, {
     [`${baseClass}__wrapper--disabled`]: disabled,
   });
+
+  const text = value ? activeText : inactiveText;
   return (
     <FormField {...formFieldProps} type="slider">
       <div className={wrapperClassNames}>
@@ -76,13 +82,26 @@ const Slider = (props: ISliderProps): JSX.Element => {
         >
           <div className={sliderDotClass} />
         </button>
-        <span
-          className={`${baseClass}__label ${baseClass}__label--${
-            value ? "active" : "inactive"
-          }`}
-        >
-          {value ? activeText : inactiveText}
-        </span>
+        {labelTooltip ? (
+          <TooltipWrapper tipContent={labelTooltip}>
+            {" "}
+            <span
+              className={`${baseClass}__label ${baseClass}__label--${
+                value ? "active" : "inactive"
+              }`}
+            >
+              {text}
+            </span>
+          </TooltipWrapper>
+        ) : (
+          <span
+            className={`${baseClass}__label ${baseClass}__label--${
+              value ? "active" : "inactive"
+            }`}
+          >
+            {text}
+          </span>
+        )}
       </div>
     </FormField>
   );

--- a/frontend/components/forms/fields/Slider/_styles.scss
+++ b/frontend/components/forms/fields/Slider/_styles.scss
@@ -23,10 +23,19 @@
 
   &__wrapper {
     display: flex;
+    gap: $pad-small;
     align-items: center;
     height: 24px; // Noticeable with help text below slider
+
     &--disabled {
-      @include disabled;
+      .fleet-slider {
+        @include disabled;
+      }
+
+      .fleet-slider__label {
+        @include disabled;
+        pointer-events: initial; // Allow label interaction when slider is disabled to view tooltip
+      }
     }
   }
 
@@ -49,7 +58,6 @@
     font-size: $x-small;
     font-weight: $regular;
     text-align: left;
-    margin-left: $pad-small;
   }
 
   &__help-text {

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -183,30 +183,13 @@ const SoftwareOptionsSelector = ({
     ) : null;
   };
 
-  const selfServiceLabel = () => {
-    return !isSelfServiceDisabled ? (
-      <TooltipWrapper
-        tipContent={getSelfServiceTooltip(
-          isPlatformIosOrIpados,
-          isPlatformAndroid
-        )}
-      >
-        <span>Self-service</span>
-      </TooltipWrapper>
-    ) : (
-      "Self-service"
-    );
-  };
+  const selfServiceLabelTooltip = !isSelfServiceDisabled
+    ? getSelfServiceTooltip(isPlatformIosOrIpados, isPlatformAndroid)
+    : undefined;
 
-  const automaticInstallLabel = () => {
-    return showAutomaticInstallTooltip ? (
-      <TooltipWrapper tipContent={getAutomaticInstallTooltip()}>
-        <span>Automatic install</span>
-      </TooltipWrapper>
-    ) : (
-      "Automatic install"
-    );
-  };
+  const automaticInstallLabelTooltip = showAutomaticInstallTooltip
+    ? getAutomaticInstallTooltip()
+    : undefined;
 
   return (
     <div className={`form-field ${classNames}`}>
@@ -216,8 +199,9 @@ const SoftwareOptionsSelector = ({
         <Slider
           value={formData.selfService}
           onChange={onToggleSelfService}
-          inactiveText={selfServiceLabel()}
-          activeText={selfServiceLabel()}
+          inactiveText="Self-service"
+          activeText="Self-service"
+          labelTooltip={selfServiceLabelTooltip}
           className={`${baseClass}__self-service-slider`}
           disabled={isSelfServiceDisabled}
         />
@@ -234,9 +218,10 @@ const SoftwareOptionsSelector = ({
         <Slider
           value={formData.automaticInstall}
           onChange={onToggleAutomaticInstall}
-          activeText={automaticInstallLabel()}
-          inactiveText={automaticInstallLabel()}
+          activeText="Automatic install"
+          inactiveText="Automatic install"
           className={`${baseClass}__automatic-install-slider`}
+          labelTooltip={automaticInstallLabelTooltip}
           disabled={isAutomaticInstallDisabled}
         />
       )}


### PR DESCRIPTION
## Issue
Closes #41312

## Description
- Problem: Switching from checkbox to slider no longer showed tooltip on disabled state
- Sleeper bug: Slider hid pointer events on disabled state, undo on label only so we could see the tooltip on hover
- Sleeper bug: Tooltip was greyed out (filter grayscale opacity 0.5) like all other disabled states, undo on tooltip only so it's the correct color
- Fix: Include CSS plus refactoring Slider to properly render tooltip
- Ensured no other instance of a disabled slider includes a tooltip that may be hidden/greyed

This is for the RC branch first as we removed this component in 4.83, but it will be put back in 4.83 this week ([slack thread](https://fleetdm.slack.com/archives/C086V2QK76X/p1773083828308019?thread_ts=1772729531.506039&cid=C086V2QK76X)). I will ensure parity!

## Screen recording of fix

https://github.com/user-attachments/assets/d04c1ed6-58a2-4379-ad1f-f2fa619c9e61

