### PR TITLE
fix(software): paginate host software pages by distinct title IDs

### DIFF
--- a/server/datastore/mysql/software.go
+++ b/server/datastore/mysql/software.go
@@ -5684,10 +5684,52 @@ func (ds *Datastore) ListHostSoftware(ctx context.Context, host *fleet.Host, opt
 			`)
 		}
 		stmt = fmt.Sprintf(stmt, replacements...)
-		stmt = fmt.Sprintf("SELECT * FROM (%s) AS combined_results", stmt)
-		stmt, _ = appendListOptionsToSQL(stmt, &opts.ListOptions)
 
-		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostSoftwareList, stmt, args...); err != nil {
+		type hostSoftwareTitleIDRow struct {
+			ID uint `db:"id"`
+		}
+		idStmt := fmt.Sprintf("SELECT DISTINCT id, name FROM (%s) AS combined_results", countStmt)
+		idListOptions := opts.ListOptions
+		idListOptions.IncludeMetadata = false
+		idStmt, _ = appendListOptionsToSQL(idStmt, &idListOptions)
+
+		var pagedTitleIDRows []hostSoftwareTitleIDRow
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &pagedTitleIDRows, idStmt, args...); err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "list paged host software title ids")
+		}
+		if len(pagedTitleIDRows) == 0 {
+			var metaData *fleet.PaginationMetadata
+			if opts.ListOptions.IncludeMetadata {
+				metaData = &fleet.PaginationMetadata{
+					HasPreviousResults: opts.ListOptions.Page > 0,
+					TotalResults:       titleCount,
+					HasNextResults:     false,
+				}
+			}
+			return []*fleet.HostSoftwareWithInstaller{}, metaData, nil
+		}
+
+		pagedTitleIDs := make([]uint, 0, len(pagedTitleIDRows))
+		for _, row := range pagedTitleIDRows {
+			pagedTitleIDs = append(pagedTitleIDs, row.ID)
+		}
+
+		stmt = fmt.Sprintf("SELECT * FROM (%s) AS combined_results WHERE id IN (?)", stmt)
+		stmt, titleIDArgs, err := sqlx.In(stmt, pagedTitleIDs)
+		if err != nil {
+			return nil, nil, ctxerr.Wrap(ctx, err, "expand IN query for paged host software title ids")
+		}
+		allArgs := append([]any{}, args...)
+		allArgs = append(allArgs, titleIDArgs...)
+
+		fieldPlaceholders := strings.TrimSuffix(strings.Repeat("?,", len(pagedTitleIDs)), ",")
+		stmt += fmt.Sprintf(" ORDER BY FIELD(id, %s)", fieldPlaceholders)
+		for _, id := range pagedTitleIDs {
+			allArgs = append(allArgs, id)
+		}
+
+		stmt = ds.reader(ctx).Rebind(stmt)
+		if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostSoftwareList, stmt, allArgs...); err != nil {
 			return nil, nil, ctxerr.Wrap(ctx, err, "list host software")
 		}
 

--- a/server/datastore/mysql/software_test.go
+++ b/server/datastore/mysql/software_test.go
@@ -11646,6 +11646,25 @@ func testListHostSoftwarePaginationWithMultipleInstallers(t *testing.T, ds *Data
 	assert.Equal(t, uint(totalTitles), meta.TotalResults, "total results should reflect unique titles, not duplicated rows")
 	assert.True(t, meta.HasNextResults, "page 0 of %d items with perPage=%d should have next results", totalTitles, perPage)
 	assert.False(t, meta.HasPreviousResults)
+
+	page0IDs := make(map[uint]struct{}, len(sw))
+	for _, s := range sw {
+		page0IDs[s.ID] = struct{}{}
+	}
+
+	// Page 1: should also contain perPage unique titles with no overlap from page 0.
+	opts.ListOptions.Page = 1
+	sw, meta, err = ds.ListHostSoftware(ctx, host, opts)
+	require.NoError(t, err)
+	require.Len(t, sw, perPage, "page 1 should have %d items", perPage)
+	require.NotNil(t, meta)
+	assert.Equal(t, uint(totalTitles), meta.TotalResults)
+	assert.False(t, meta.HasNextResults)
+	assert.True(t, meta.HasPreviousResults)
+	for _, s := range sw {
+		_, overlapped := page0IDs[s.ID]
+		require.False(t, overlapped, "title %d appeared in both page 0 and page 1", s.ID)
+	}
 }
 
 // TestUniqueSoftwareTitleStrNormalization tests that UniqueSoftwareTitleStr


### PR DESCRIPTION
**Related issue:** Resolves #41277

## Summary
- paginate `ListHostSoftware` using a distinct title-id query first, then fetch/hydrate rows only for that page of title IDs
- preserve page ordering by applying `ORDER BY FIELD(id, ...)` when loading detailed rows for dedup/hydration
- extend `testListHostSoftwarePaginationWithMultipleInstallers` to verify page 1 contains a full page with no overlap against page 0

## Testing
- [x] Added/updated automated tests
- [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation
- [ ] QA'd all new/changed functionality manually

Validation run in this environment:
- `go test ./server/datastore/mysql -run TestDatastoreReplica -count=1`

Note: the `ListHostSoftwarePaginationWithMultipleInstallers` integration-style datastore test was updated but not executable in this runtime because the required datastore integration harness (seeded MySQL test setup) is not active in this isolated run.
