### PR TITLE
Added support for NDES CA for Windows hosts

### DIFF
--- a/changes/33421-ndes-windows
+++ b/changes/33421-ndes-windows
@@ -1,0 +1,1 @@
+* Added support for NDES CA for Windows hosts.

--- a/server/mdm/microsoft/profile_variables.go
+++ b/server/mdm/microsoft/profile_variables.go
@@ -166,17 +166,10 @@ func preprocessWindowsProfileContents(deps ProfilePreprocessDependencies, params
 					message: fmt.Sprintf("NDES is not configured. Fleet couldn't populate %s.", fleet.FleetVarNDESSCEPChallenge.WithPrefix()),
 				}
 			}
-			if deps.GetNDESSCEPChallenge == nil {
-				return profileContents, ctxerr.New(deps.Context, "NDES challenge retrieval function not configured")
-			}
 			deps.Logger.DebugContext(deps.Context, "fetching NDES challenge", "host_uuid", params.HostUUID, "profile_uuid", params.ProfileUUID)
 			challenge, err := deps.GetNDESSCEPChallenge(deps.Context, *deps.NDESConfig)
 			if err != nil {
-				detail := fmt.Sprintf("Fleet couldn't populate %s. %s", fleet.FleetVarNDESSCEPChallenge.WithPrefix(), err.Error())
-				if deps.NDESChallengeErrorToDetail != nil {
-					detail = deps.NDESChallengeErrorToDetail(err)
-				}
-				return profileContents, &MicrosoftProfileProcessingError{message: detail}
+				return profileContents, &MicrosoftProfileProcessingError{message: deps.NDESChallengeErrorToDetail(err)}
 			}
 			payload := &fleet.MDMManagedCertificate{
 				HostUUID:             params.HostUUID,

--- a/server/mdm/microsoft/profile_variables.go
+++ b/server/mdm/microsoft/profile_variables.go
@@ -4,14 +4,12 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"net/url"
 	"slices"
 	"strings"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/profiles"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/variables"
@@ -182,9 +180,7 @@ func preprocessWindowsProfileContents(deps ProfilePreprocessDependencies, params
 			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPChallengeRegexp, result, challenge)
 
 		case fleetVar == string(fleet.FleetVarNDESSCEPProxyURL):
-			proxyURL := fmt.Sprintf("%s%s%s", deps.AppConfig.MDMUrl(), apple_mdm.SCEPProxyPath,
-				url.PathEscape(fmt.Sprintf("%s,%s,NDES", params.HostUUID, params.ProfileUUID)))
-			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPProxyURLRegexp, result, proxyURL)
+			result = profiles.ReplaceNDESSCEPProxyURLVariable(deps.AppConfig.MDMUrl(), params.HostUUID, params.ProfileUUID, result)
 		}
 	}
 

--- a/server/mdm/microsoft/profile_variables.go
+++ b/server/mdm/microsoft/profile_variables.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"net/url"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/profiles"
+	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/variables"
 )
 
@@ -37,6 +41,9 @@ type ProfilePreprocessDependencies struct {
 	AppConfig                  *fleet.AppConfig
 	CustomSCEPCAs              map[string]*fleet.CustomSCEPProxyCA
 	ManagedCertificatePayloads *[]*fleet.MDMManagedCertificate
+	NDESConfig                 *fleet.NDESSCEPProxyCA
+	GetNDESSCEPChallenge       func(ctx context.Context, proxy fleet.NDESSCEPProxyCA) (string, error)
+	NDESChallengeErrorToDetail func(err error) string
 }
 
 type ProfilePreprocessParams struct {
@@ -56,6 +63,8 @@ type ProfilePreprocessParams struct {
 //   - $FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID or ${FLEET_VAR_SCEP_WINDOWS_CERTIFICATE_ID}: Replaced with the profile UUID for SCEP certificate
 //   - $FLEET_VAR_CUSTOM_SCEP_CHALLENGE_<CA_NAME> or ${FLEET_VAR_CUSTOM_SCEP_CHALLENGE_<CA_NAME>}: Replaced with the challenge for the specified custom SCEP CA
 //   - $FLEET_VAR_CUSTOM_SCEP_PROXY_URL_<CA_NAME> or ${FLEET_VAR_CUSTOM_SCEP_PROXY_URL_<CA_NAME>}: Replaced with the proxy URL for the specified custom SCEP CA
+//   - $FLEET_VAR_NDES_SCEP_CHALLENGE or ${FLEET_VAR_NDES_SCEP_CHALLENGE}: Replaced with the one-time NDES challenge password
+//   - $FLEET_VAR_NDES_SCEP_PROXY_URL or ${FLEET_VAR_NDES_SCEP_PROXY_URL}: Replaced with the Fleet SCEP proxy URL for NDES
 //
 // Why we don't use Go templates here:
 //  1. Error handling: Go templates don't provide fine-grained error handling for individual variable
@@ -150,9 +159,40 @@ func preprocessWindowsProfileContents(deps ProfilePreprocessDependencies, params
 			result = replacedContents
 
 			*deps.ManagedCertificatePayloads = append(*deps.ManagedCertificatePayloads, managedCertificate)
-		}
 
-		// Add other Fleet variables here as they are implemented, identify if it can be skipped for verification.
+		case fleetVar == string(fleet.FleetVarNDESSCEPChallenge):
+			if deps.NDESConfig == nil {
+				return profileContents, &MicrosoftProfileProcessingError{
+					message: fmt.Sprintf("NDES is not configured. Fleet couldn't populate %s.", fleet.FleetVarNDESSCEPChallenge.WithPrefix()),
+				}
+			}
+			if deps.GetNDESSCEPChallenge == nil {
+				return profileContents, ctxerr.New(deps.Context, "NDES challenge retrieval function not configured")
+			}
+			deps.Logger.DebugContext(deps.Context, "fetching NDES challenge", "host_uuid", params.HostUUID, "profile_uuid", params.ProfileUUID)
+			challenge, err := deps.GetNDESSCEPChallenge(deps.Context, *deps.NDESConfig)
+			if err != nil {
+				detail := fmt.Sprintf("Fleet couldn't populate %s. %s", fleet.FleetVarNDESSCEPChallenge.WithPrefix(), err.Error())
+				if deps.NDESChallengeErrorToDetail != nil {
+					detail = deps.NDESChallengeErrorToDetail(err)
+				}
+				return profileContents, &MicrosoftProfileProcessingError{message: detail}
+			}
+			payload := &fleet.MDMManagedCertificate{
+				HostUUID:             params.HostUUID,
+				ProfileUUID:          params.ProfileUUID,
+				ChallengeRetrievedAt: ptr.Time(time.Now()),
+				Type:                 fleet.CAConfigNDES,
+				CAName:               "NDES",
+			}
+			*deps.ManagedCertificatePayloads = append(*deps.ManagedCertificatePayloads, payload)
+			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPChallengeRegexp, result, challenge)
+
+		case fleetVar == string(fleet.FleetVarNDESSCEPProxyURL):
+			proxyURL := fmt.Sprintf("%s%s%s", deps.AppConfig.MDMUrl(), apple_mdm.SCEPProxyPath,
+				url.PathEscape(fmt.Sprintf("%s,%s,NDES", params.HostUUID, params.ProfileUUID)))
+			result = profiles.ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPProxyURLRegexp, result, proxyURL)
+		}
 	}
 
 	return result, nil

--- a/server/mdm/microsoft/profile_variables_test.go
+++ b/server/mdm/microsoft/profile_variables_test.go
@@ -87,19 +87,23 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 	getNDESChallengeFail := func(_ context.Context, _ fleet.NDESSCEPProxyCA) (string, error) {
 		return "", fmt.Errorf("ndes server error")
 	}
+	defaultNDESErrorToDetail := func(err error) string {
+		return fmt.Sprintf("Fleet couldn't populate %s. %s", fleet.FleetVarNDESSCEPChallenge.WithPrefix(), err.Error())
+	}
 
 	tests := []struct {
-		name                 string
-		hostUUID             string
-		profileContents      string
-		expectedContents     string
-		expectError          bool
-		processingError      string                                                          // if set then we expect the error to be of type MicrosoftProfileProcessingError with this message
-		setup                func()                                                          // Used for setting up datastore mocks.
-		expect               func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) // Add more params as they need validation.
-		freeTier             bool
-		withNDESConfig       *fleet.NDESSCEPProxyCA
-		getNDESChallengeFunc func(ctx context.Context, proxy fleet.NDESSCEPProxyCA) (string, error)
+		name                       string
+		hostUUID                   string
+		profileContents            string
+		expectedContents           string
+		expectError                bool
+		processingError            string                                                          // if set then we expect the error to be of type MicrosoftProfileProcessingError with this message
+		setup                      func()                                                          // Used for setting up datastore mocks.
+		expect                     func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) // Add more params as they need validation.
+		freeTier                   bool
+		withNDESConfig             *fleet.NDESSCEPProxyCA
+		getNDESChallengeFunc       func(ctx context.Context, proxy fleet.NDESSCEPProxyCA) (string, error)
+		ndesChallengeErrorToDetail func(err error) string
 	}{
 		{
 			name:             "no fleet variables",
@@ -302,10 +306,11 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 			},
 		},
 		{
-			name:                 "ndes challenge and proxy url replaced",
-			hostUUID:             "ndes-host-uuid",
-			withNDESConfig:       ndesConfig,
-			getNDESChallengeFunc: getNDESChallengeSuccess,
+			name:                       "ndes challenge and proxy url replaced",
+			hostUUID:                   "ndes-host-uuid",
+			withNDESConfig:             ndesConfig,
+			getNDESChallengeFunc:       getNDESChallengeSuccess,
+			ndesChallengeErrorToDetail: defaultNDESErrorToDetail,
 			profileContents: `<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
 				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>` +
 				`<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/ServerURL</LocURI></Target>` +
@@ -333,10 +338,45 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 			},
 		},
 		{
-			name:                 "ndes challenge fetch fails",
-			hostUUID:             "ndes-fail-host",
-			withNDESConfig:       ndesConfig,
-			getNDESChallengeFunc: getNDESChallengeFail,
+			name:                       "ndes challenge and proxy url replaced in atomic profile",
+			hostUUID:                   "ndes-atomic-host",
+			withNDESConfig:             ndesConfig,
+			getNDESChallengeFunc:       getNDESChallengeSuccess,
+			ndesChallengeErrorToDetail: defaultNDESErrorToDetail,
+			profileContents: `<Atomic>` +
+				`<Add><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>` +
+				`<Add><CmdID>2</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/ServerURL</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_PROXY_URL</Data></Item></Add>` +
+				`</Atomic>`,
+			expectedContents: `<Atomic>` +
+				`<Add><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
+				`<Data>ndes-test-challenge</Data></Item></Add>` +
+				`<Add><CmdID>2</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/ServerURL</LocURI></Target>` +
+				`<Data>https://test-fleet.com/mdm/scep/proxy/ndes-atomic-host%2C` + profileUUID + `%2CNDES</Data></Item></Add>` +
+				`</Atomic>`,
+			setup: func() {
+				ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+					return &fleet.AppConfig{
+						ServerSettings: fleet.ServerSettings{
+							ServerURL: "https://test-fleet.com",
+						},
+					}, nil
+				}
+			},
+			expect: func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) {
+				require.Len(t, managedCerts, 1)
+				require.Equal(t, "NDES", managedCerts[0].CAName)
+				require.Equal(t, fleet.CAConfigNDES, managedCerts[0].Type)
+				require.Equal(t, "ndes-atomic-host", managedCerts[0].HostUUID)
+			},
+		},
+		{
+			name:                       "ndes challenge fetch fails",
+			hostUUID:                   "ndes-fail-host",
+			withNDESConfig:             ndesConfig,
+			getNDESChallengeFunc:       getNDESChallengeFail,
+			ndesChallengeErrorToDetail: defaultNDESErrorToDetail,
 			profileContents: `<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
 				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>`,
 			expectError:     true,
@@ -392,6 +432,7 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 				ManagedCertificatePayloads: managedCertificates,
 				NDESConfig:                 tt.withNDESConfig,
 				GetNDESSCEPChallenge:       tt.getNDESChallengeFunc,
+				NDESChallengeErrorToDetail: tt.ndesChallengeErrorToDetail,
 			}
 
 			result, err := PreprocessWindowsProfileContentsForDeployment(deps, ProfilePreprocessParams{

--- a/server/mdm/microsoft/profile_variables_test.go
+++ b/server/mdm/microsoft/profile_variables_test.go
@@ -2,6 +2,7 @@ package microsoft_mdm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"testing"
@@ -85,7 +86,7 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 		return "ndes-test-challenge", nil
 	}
 	getNDESChallengeFail := func(_ context.Context, _ fleet.NDESSCEPProxyCA) (string, error) {
-		return "", fmt.Errorf("ndes server error")
+		return "", errors.New("ndes server error")
 	}
 	defaultNDESErrorToDetail := func(err error) string {
 		return fmt.Sprintf("Fleet couldn't populate %s. %s", fleet.FleetVarNDESSCEPChallenge.WithPrefix(), err.Error())

--- a/server/mdm/microsoft/profile_variables_test.go
+++ b/server/mdm/microsoft/profile_variables_test.go
@@ -75,16 +75,31 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 	// use the same uuid for all profile UUID actions
 	profileUUID := uuid.NewString()
 
+	ndesConfig := &fleet.NDESSCEPProxyCA{
+		URL:      "https://ndes.example.com/certsrv/mscep/mscep.dll",
+		AdminURL: "https://ndes.example.com/certsrv/mscep_admin/",
+		Username: "admin",
+		Password: "password",
+	}
+	getNDESChallengeSuccess := func(_ context.Context, _ fleet.NDESSCEPProxyCA) (string, error) {
+		return "ndes-test-challenge", nil
+	}
+	getNDESChallengeFail := func(_ context.Context, _ fleet.NDESSCEPProxyCA) (string, error) {
+		return "", fmt.Errorf("ndes server error")
+	}
+
 	tests := []struct {
-		name             string
-		hostUUID         string
-		profileContents  string
-		expectedContents string
-		expectError      bool
-		processingError  string                                                          // if set then we expect the error to be of type MicrosoftProfileProcessingError with this message
-		setup            func()                                                          // Used for setting up datastore mocks.
-		expect           func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) // Add more params as they need validation.
-		freeTier         bool
+		name                 string
+		hostUUID             string
+		profileContents      string
+		expectedContents     string
+		expectError          bool
+		processingError      string                                                          // if set then we expect the error to be of type MicrosoftProfileProcessingError with this message
+		setup                func()                                                          // Used for setting up datastore mocks.
+		expect               func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) // Add more params as they need validation.
+		freeTier             bool
+		withNDESConfig       *fleet.NDESSCEPProxyCA
+		getNDESChallengeFunc func(ctx context.Context, proxy fleet.NDESSCEPProxyCA) (string, error)
 	}{
 		{
 			name:             "no fleet variables",
@@ -286,6 +301,54 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:                 "ndes challenge and proxy url replaced",
+			hostUUID:             "ndes-host-uuid",
+			withNDESConfig:       ndesConfig,
+			getNDESChallengeFunc: getNDESChallengeSuccess,
+			profileContents: `<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>` +
+				`<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/ServerURL</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_PROXY_URL</Data></Item></Add>`,
+			expectedContents: `<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
+				`<Data>ndes-test-challenge</Data></Item></Add>` +
+				`<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/ServerURL</LocURI></Target>` +
+				`<Data>https://test-fleet.com/mdm/scep/proxy/ndes-host-uuid%2C` + profileUUID + `%2CNDES</Data></Item></Add>`,
+			setup: func() {
+				ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+					return &fleet.AppConfig{
+						ServerSettings: fleet.ServerSettings{
+							ServerURL: "https://test-fleet.com",
+						},
+					}, nil
+				}
+			},
+			expect: func(t *testing.T, managedCerts []*fleet.MDMManagedCertificate) {
+				require.Len(t, managedCerts, 1)
+				require.Equal(t, "NDES", managedCerts[0].CAName)
+				require.Equal(t, fleet.CAConfigNDES, managedCerts[0].Type)
+				require.Equal(t, "ndes-host-uuid", managedCerts[0].HostUUID)
+				require.Equal(t, profileUUID, managedCerts[0].ProfileUUID)
+				require.NotNil(t, managedCerts[0].ChallengeRetrievedAt)
+			},
+		},
+		{
+			name:                 "ndes challenge fetch fails",
+			hostUUID:             "ndes-fail-host",
+			withNDESConfig:       ndesConfig,
+			getNDESChallengeFunc: getNDESChallengeFail,
+			profileContents: `<Add><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/test/Install/Challenge</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>`,
+			expectError:     true,
+			processingError: "Fleet couldn't populate $FLEET_VAR_NDES_SCEP_CHALLENGE. ndes server error",
+		},
+		{
+			name:            "ndes not configured",
+			hostUUID:        "ndes-noconfig-host",
+			profileContents: `<Add><Item><Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>`,
+			expectError:     true,
+			processingError: "NDES is not configured. Fleet couldn't populate $FLEET_VAR_NDES_SCEP_CHALLENGE.",
+		},
 	}
 
 	hostIDForUUIDCache := make(map[string]uint)
@@ -327,6 +390,8 @@ func TestPreprocessWindowsProfileContentsForDeployment(t *testing.T) {
 				AppConfig:                  appConfig,
 				CustomSCEPCAs:              customSCEPCAs,
 				ManagedCertificatePayloads: managedCertificates,
+				NDESConfig:                 tt.withNDESConfig,
+				GetNDESSCEPChallenge:       tt.getNDESChallengeFunc,
 			}
 
 			result, err := PreprocessWindowsProfileContentsForDeployment(deps, ProfilePreprocessParams{

--- a/server/mdm/profiles/profile_variables.go
+++ b/server/mdm/profiles/profile_variables.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 )
 
@@ -62,7 +61,7 @@ func ReplaceCustomSCEPProxyURLVariable(ctx context.Context, logger *slog.Logger,
 		return "", nil, false, ctxerr.Wrap(ctx, err, "generating SCEP challenge")
 	}
 	// Insert the SCEP URL into the profile contents
-	proxyURL := fmt.Sprintf("%s%s%s", appConfig.MDMUrl(), apple_mdm.SCEPProxyPath,
+	proxyURL := fmt.Sprintf("%s%s%s", appConfig.MDMUrl(), SCEPProxyPath,
 		url.PathEscape(fmt.Sprintf("%s,%s,%s,%s", hostUUID, profUUID, caName, challenge)))
 	contents, err = ReplaceExactFleetPrefixVariableInXML(string(fleet.FleetVarCustomSCEPProxyURLPrefix), ca.Name, profileContents, proxyURL)
 	if err != nil {
@@ -224,6 +223,21 @@ func IsCustomSCEPConfigured(ctx context.Context,
 	}
 
 	return nil
+}
+
+// SCEPProxyPath is the HTTP path that serves the SCEP proxy service. The path is followed by an identifier.
+const SCEPProxyPath = "/mdm/scep/proxy/"
+
+// BuildNDESSCEPProxyURL constructs the NDES SCEP proxy URL for a given host and profile.
+func BuildNDESSCEPProxyURL(mdmURL string, hostUUID string, profileUUID string) string {
+	return fmt.Sprintf("%s%s%s", mdmURL, SCEPProxyPath,
+		url.PathEscape(fmt.Sprintf("%s,%s,NDES", hostUUID, profileUUID)))
+}
+
+// ReplaceNDESSCEPProxyURLVariable replaces the NDES SCEP proxy URL variable in profile contents.
+func ReplaceNDESSCEPProxyURLVariable(mdmURL string, hostUUID string, profileUUID string, profileContents string) string {
+	proxyURL := BuildNDESSCEPProxyURL(mdmURL, hostUUID, profileUUID)
+	return ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPProxyURLRegexp, profileContents, proxyURL)
 }
 
 func HydrateHost(ctx context.Context, ds fleet.Datastore, hostLite fleet.Host, onHostCountMismatch func(int) error) (fleet.Host, bool, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -71,8 +71,6 @@ const (
 
 var (
 	fleetVarHostEndUserEmailIDPRegexp = regexp.MustCompile(fmt.Sprintf(`(\$FLEET_VAR_%s)|(\${FLEET_VAR_%[1]s})`, fleet.FleetVarHostEndUserEmailIDP))
-	fleetVarNDESSCEPChallengeRegexp   = regexp.MustCompile(fmt.Sprintf(`(\$FLEET_VAR_%s)|(\${FLEET_VAR_%[1]s})`, fleet.FleetVarNDESSCEPChallenge))
-	fleetVarNDESSCEPProxyURLRegexp    = regexp.MustCompile(fmt.Sprintf(`(\$FLEET_VAR_%s)|(\${FLEET_VAR_%[1]s})`, fleet.FleetVarNDESSCEPProxyURL))
 	fleetVarSCEPRenewalIDRegexp       = regexp.MustCompile(fmt.Sprintf(`(\$FLEET_VAR_%s)|(\${FLEET_VAR_%[1]s})`, fleet.FleetVarSCEPRenewalID))
 	fleetVarHostUUIDRegexp            = regexp.MustCompile(fmt.Sprintf(`(\$FLEET_VAR_%s)|(\${FLEET_VAR_%[1]s})`, fleet.FleetVarHostUUID))
 
@@ -5583,13 +5581,11 @@ func preprocessProfileContents(
 					}
 					managedCertificatePayloads = append(managedCertificatePayloads, payload)
 
-					hostContents = profiles.ReplaceFleetVariableInXML(fleetVarNDESSCEPChallengeRegexp, hostContents, challenge)
+					hostContents = profiles.ReplaceFleetVariableInXML(fleet.FleetVarNDESSCEPChallengeRegexp, hostContents, challenge)
 
 				case fleetVar == string(fleet.FleetVarNDESSCEPProxyURL):
 					// Insert the SCEP URL into the profile contents
-					proxyURL := fmt.Sprintf("%s%s%s", appConfig.MDMUrl(), apple_mdm.SCEPProxyPath,
-						url.PathEscape(fmt.Sprintf("%s,%s,NDES", hostUUID, profUUID)))
-					hostContents = profiles.ReplaceFleetVariableInXML(fleetVarNDESSCEPProxyURLRegexp, hostContents, proxyURL)
+					hostContents = profiles.ReplaceNDESSCEPProxyURLVariable(appConfig.MDMUrl(), hostUUID, profUUID, hostContents)
 
 				case fleetVar == string(fleet.FleetVarSCEPRenewalID):
 					// Insert the SCEP renewal ID into the SCEP Payload CN or OU

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5559,26 +5559,7 @@ func preprocessProfileContents(
 					// Insert the SCEP challenge into the profile contents
 					challenge, err := scepConfig.GetNDESSCEPChallenge(ctx, *ndesConfig)
 					if err != nil {
-						detail := ""
-						switch {
-						case errors.As(err, &eeservice.NDESInvalidError{}):
-							detail = fmt.Sprintf("Invalid NDES admin credentials. "+
-								"Fleet couldn't populate $FLEET_VAR_%s. "+
-								"Please update credentials in Settings > Integrations > Mobile Device Management > Simple Certificate Enrollment Protocol.",
-								fleet.FleetVarNDESSCEPChallenge)
-						case errors.As(err, &eeservice.NDESPasswordCacheFullError{}):
-							detail = fmt.Sprintf("The NDES password cache is full. "+
-								"Fleet couldn't populate $FLEET_VAR_%s. "+
-								"Please increase the number of cached passwords in NDES and try again.",
-								fleet.FleetVarNDESSCEPChallenge)
-						case errors.As(err, &eeservice.NDESInsufficientPermissionsError{}):
-							detail = fmt.Sprintf("This account does not have sufficient permissions to enroll with SCEP. "+
-								"Fleet couldn't populate $FLEET_VAR_%s. "+
-								"Please update the account with NDES SCEP enroll permissions and try again.",
-								fleet.FleetVarNDESSCEPChallenge)
-						default:
-							detail = fmt.Sprintf("Fleet couldn't populate $FLEET_VAR_%s. %s", fleet.FleetVarNDESSCEPChallenge, err.Error())
-						}
+						detail := ndesChallengeErrorToDetail(err)
 						err := ds.UpdateOrDeleteHostMDMAppleProfile(ctx, &fleet.HostMDMAppleProfile{
 							CommandUUID:        target.cmdUUID,
 							HostUUID:           hostUUID,

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2523,6 +2523,8 @@ func (svc *Service) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *ui
 	return ps, nil
 }
 
+// ndesChallengeErrorToDetail translates NDES-specific error types into user-friendly messages
+// for profile failure details. Used by both Apple and Windows NDES profile processing.
 func ndesChallengeErrorToDetail(err error) string {
 	varName := fleet.FleetVarNDESSCEPChallenge.WithPrefix()
 	switch {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	eeservice "github.com/fleetdm/fleet/v4/ee/server/service"
 	"github.com/fleetdm/fleet/v4/pkg/fleetdbase"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -2522,6 +2523,23 @@ func (svc *Service) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *ui
 	return ps, nil
 }
 
+func ndesChallengeErrorToDetail(err error) string {
+	varName := fleet.FleetVarNDESSCEPChallenge.WithPrefix()
+	switch {
+	case errors.As(err, &eeservice.NDESInvalidError{}):
+		return fmt.Sprintf("Invalid NDES admin credentials. Fleet couldn't populate %s. "+
+			"Please update credentials in Settings > Integrations > Mobile Device Management > Simple Certificate Enrollment Protocol.", varName)
+	case errors.As(err, &eeservice.NDESPasswordCacheFullError{}):
+		return fmt.Sprintf("The NDES password cache is full. Fleet couldn't populate %s. "+
+			"Please increase the number of cached passwords in NDES and try again.", varName)
+	case errors.As(err, &eeservice.NDESInsufficientPermissionsError{}):
+		return fmt.Sprintf("This account does not have sufficient permissions to enroll with SCEP. Fleet couldn't populate %s. "+
+			"Please update the account with NDES SCEP enroll permissions and try again.", varName)
+	default:
+		return fmt.Sprintf("Fleet couldn't populate %s. %s", varName, err.Error())
+	}
+}
+
 func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error {
 	appConfig, err := ds.AppConfig(ctx)
 	if err != nil {
@@ -2608,6 +2626,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		return ctxerr.Wrap(ctx, err, "getting grouped certificate authorities")
 	}
 
+	scepConfigSvc := eeservice.NewSCEPConfigService(logger, nil)
 	managedCertificatePayloads := &[]*fleet.MDMManagedCertificate{}
 	deps := microsoft_mdm.ProfilePreprocessDependencies{
 		Context:                    ctx,
@@ -2617,6 +2636,9 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		AppConfig:                  appConfig,
 		CustomSCEPCAs:              groupedCAs.ToCustomSCEPProxyCAMap(),
 		ManagedCertificatePayloads: managedCertificatePayloads,
+		NDESConfig:                 groupedCAs.NDESSCEP,
+		GetNDESSCEPChallenge:       scepConfigSvc.GetNDESSCEPChallenge,
+		NDESChallengeErrorToDetail: ndesChallengeErrorToDetail,
 	}
 
 	for profUUID, target := range installTargets {

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -183,6 +183,22 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 	return foundVars, nil
 }
 
+// collectAllSyncMLItems returns all CmdItems from a SyncMLCmd, including items from nested
+// commands within Atomic blocks (ReplaceCommands, AddCommands, ExecCommands).
+func collectAllSyncMLItems(cmd *fleet.SyncMLCmd) []fleet.CmdItem {
+	items := cmd.Items
+	for _, nested := range cmd.ReplaceCommands {
+		items = append(items, nested.Items...)
+	}
+	for _, nested := range cmd.AddCommands {
+		items = append(items, nested.Items...)
+	}
+	for _, nested := range cmd.ExecCommands {
+		items = append(items, nested.Items...)
+	}
+	return items
+}
+
 func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESVarsFound) error {
 	if ndesVars == nil {
 		return nil
@@ -201,7 +217,7 @@ func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESV
 			break
 		}
 
-		for _, cmd := range cmdMsg.Items {
+		for _, cmd := range collectAllSyncMLItems(cmdMsg) {
 			if cmd.Target == nil || cmd.Data == nil {
 				continue
 			}
@@ -230,7 +246,9 @@ func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESV
 				renewalVar := fleet.FleetVarSCEPRenewalID.WithPrefix()
 				renewalVarBraces := fleet.FleetVarSCEPRenewalID.WithBraces()
 				if !strings.Contains(cmd.Data.Content, "OU="+renewalVar) && !strings.Contains(cmd.Data.Content, "OU="+renewalVarBraces) {
-					return fmt.Errorf("SubjectName item must contain the %s variable in the OU field", renewalVar)
+					return &fleet.BadRequestError{
+						Message: fmt.Sprintf("SubjectName item must contain the %s variable in the OU field", renewalVar),
+					}
 				}
 			}
 		}
@@ -257,9 +275,7 @@ func additionalCustomSCEPValidationForWindowsProfiles(contents string, customSCE
 			break
 		}
 
-		// cmdMsg represents a top-level command (<Replace>...</Replace>)
-		// so we look through all items, often there is only one item per command.
-		for _, cmd := range cmdMsg.Items {
+		for _, cmd := range collectAllSyncMLItems(cmdMsg) {
 			if cmd.Target == nil {
 				continue
 			}

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -199,6 +199,16 @@ func collectAllSyncMLItems(cmd *fleet.SyncMLCmd) []fleet.CmdItem {
 	return items
 }
 
+// containsFleetVar checks if s contains the given Fleet variable in either $FLEET_VAR_ or ${FLEET_VAR_} form.
+func containsFleetVar(s string, v fleet.FleetVarName) bool {
+	return strings.Contains(s, v.WithPrefix()) || strings.Contains(s, v.WithBraces())
+}
+
+// isFleetVar checks if s is exactly the given Fleet variable in either $FLEET_VAR_ or ${FLEET_VAR_} form.
+func isFleetVar(s string, v fleet.FleetVarName) bool {
+	return s == v.WithPrefix() || s == v.WithBraces()
+}
+
 func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESVarsFound) error {
 	if ndesVars == nil {
 		return nil
@@ -218,37 +228,61 @@ func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESV
 		}
 
 		for _, cmd := range collectAllSyncMLItems(cmdMsg) {
-			if cmd.Target == nil || cmd.Data == nil {
+			if cmd.Target == nil {
 				continue
 			}
 
-			if strings.HasSuffix(*cmd.Target, "/Install/Challenge") {
-				challengeVar := fleet.FleetVarNDESSCEPChallenge.WithPrefix()
-				challengeVarBraces := fleet.FleetVarNDESSCEPChallenge.WithBraces()
-				if cmd.Data.Content != challengeVar && cmd.Data.Content != challengeVarBraces {
-					return &fleet.BadRequestError{
-						Message: fmt.Sprintf("Variable %q must be in the SCEP certificate's \"Challenge\" field.", challengeVar),
-					}
+			dataContent := ""
+			if cmd.Data != nil {
+				dataContent = cmd.Data.Content
+			}
+
+			isChallenge := strings.HasSuffix(*cmd.Target, "/Install/Challenge")
+			isServerURL := strings.HasSuffix(*cmd.Target, "/Install/ServerURL")
+			isSubjectName := strings.HasSuffix(*cmd.Target, "/Install/SubjectName")
+
+			// Verify that each NDES variable appears ONLY in its expected field.
+			// This prevents the one-time challenge or proxy URL from being placed in an unexpected field
+			// where it could be exfiltrated, since variable replacement is a global string substitution.
+			if !isChallenge && containsFleetVar(dataContent, fleet.FleetVarNDESSCEPChallenge) {
+				return &fleet.BadRequestError{
+					Message: fmt.Sprintf(
+						"Variable %q must only be in the SCEP certificate's \"Challenge\" field.", fleet.FleetVarNDESSCEPChallenge.WithPrefix()),
+				}
+			}
+			if !isServerURL && containsFleetVar(dataContent, fleet.FleetVarNDESSCEPProxyURL) {
+				return &fleet.BadRequestError{
+					Message: fmt.Sprintf(
+						"Variable %q must only be in the SCEP certificate's \"ServerURL\" field.", fleet.FleetVarNDESSCEPProxyURL.WithPrefix()),
 				}
 			}
 
-			if strings.HasSuffix(*cmd.Target, "/Install/ServerURL") {
-				urlVar := fleet.FleetVarNDESSCEPProxyURL.WithPrefix()
-				urlVarBraces := fleet.FleetVarNDESSCEPProxyURL.WithBraces()
-				if cmd.Data.Content != urlVar && cmd.Data.Content != urlVarBraces {
-					return &fleet.BadRequestError{
-						Message: fmt.Sprintf("Variable %q must be in the SCEP certificate's \"ServerURL\" field.", urlVar),
-					}
+			// Variables must not appear in LocURI target paths.
+			if containsFleetVar(*cmd.Target, fleet.FleetVarNDESSCEPChallenge) ||
+				containsFleetVar(*cmd.Target, fleet.FleetVarNDESSCEPProxyURL) {
+				return &fleet.BadRequestError{
+					Message: "NDES Fleet variables must not appear in LocURI target paths.",
 				}
 			}
 
-			if strings.HasSuffix(*cmd.Target, "/Install/SubjectName") {
-				renewalVar := fleet.FleetVarSCEPRenewalID.WithPrefix()
-				renewalVarBraces := fleet.FleetVarSCEPRenewalID.WithBraces()
-				if !strings.Contains(cmd.Data.Content, "OU="+renewalVar) && !strings.Contains(cmd.Data.Content, "OU="+renewalVarBraces) {
-					return &fleet.BadRequestError{
-						Message: fmt.Sprintf("SubjectName item must contain the %s variable in the OU field", renewalVar),
-					}
+			// Verify the expected fields contain the correct variables.
+			if isChallenge && !isFleetVar(dataContent, fleet.FleetVarNDESSCEPChallenge) {
+				return &fleet.BadRequestError{
+					Message: fmt.Sprintf(
+						"Variable %q must be in the SCEP certificate's \"Challenge\" field.", fleet.FleetVarNDESSCEPChallenge.WithPrefix()),
+				}
+			}
+			if isServerURL && !isFleetVar(dataContent, fleet.FleetVarNDESSCEPProxyURL) {
+				return &fleet.BadRequestError{
+					Message: fmt.Sprintf(
+						"Variable %q must be in the SCEP certificate's \"ServerURL\" field.", fleet.FleetVarNDESSCEPProxyURL.WithPrefix()),
+				}
+			}
+			if isSubjectName &&
+				!strings.Contains(dataContent, "OU="+fleet.FleetVarSCEPRenewalID.WithPrefix()) &&
+				!strings.Contains(dataContent, "OU="+fleet.FleetVarSCEPRenewalID.WithBraces()) {
+				return &fleet.BadRequestError{
+					Message: fmt.Sprintf("SubjectName item must contain the %s variable in the OU field", fleet.FleetVarSCEPRenewalID.WithPrefix()),
 				}
 			}
 		}

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -149,6 +149,8 @@ var fleetVarsSupportedInWindowsProfiles = []fleet.FleetVarName{
 	fleet.FleetVarHostEndUserIDPDepartment,
 	fleet.FleetVarHostEndUserIDPGroups,
 	fleet.FleetVarHostPlatform,
+	fleet.FleetVarNDESSCEPChallenge,
+	fleet.FleetVarNDESSCEPProxyURL,
 }
 
 func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInfo, groupedCAs *fleet.GroupedCertificateAuthorities) ([]string, error) {
@@ -171,7 +173,7 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 		}
 	}
 
-	err := validateProfileCertificateAuthorityVariables(contents, lic, groupedCAs, nil, additionalCustomSCEPValidationForWindowsProfiles, nil, nil)
+	err := validateProfileCertificateAuthorityVariables(contents, lic, groupedCAs, nil, additionalCustomSCEPValidationForWindowsProfiles, additionalNDESValidationForWindowsProfiles, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -179,6 +181,62 @@ func validateWindowsProfileFleetVariables(contents string, lic *fleet.LicenseInf
 	// Do additional validation that both custom SCEP URL and challenge vars are provided and not using different CA names etc.
 
 	return foundVars, nil
+}
+
+func additionalNDESValidationForWindowsProfiles(contents string, ndesVars *NDESVarsFound) error {
+	if ndesVars == nil {
+		return nil
+	}
+
+	var cmdMsg *fleet.SyncMLCmd
+	dec := xml.NewDecoder(bytes.NewReader(bytes.TrimSpace([]byte(contents))))
+	for {
+		if err := dec.Decode(&cmdMsg); err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("The payload isn't valid XML: %w", err)
+		}
+		if cmdMsg == nil {
+			break
+		}
+
+		for _, cmd := range cmdMsg.Items {
+			if cmd.Target == nil || cmd.Data == nil {
+				continue
+			}
+
+			if strings.HasSuffix(*cmd.Target, "/Install/Challenge") {
+				challengeVar := fleet.FleetVarNDESSCEPChallenge.WithPrefix()
+				challengeVarBraces := fleet.FleetVarNDESSCEPChallenge.WithBraces()
+				if cmd.Data.Content != challengeVar && cmd.Data.Content != challengeVarBraces {
+					return &fleet.BadRequestError{
+						Message: fmt.Sprintf("Variable %q must be in the SCEP certificate's \"Challenge\" field.", challengeVar),
+					}
+				}
+			}
+
+			if strings.HasSuffix(*cmd.Target, "/Install/ServerURL") {
+				urlVar := fleet.FleetVarNDESSCEPProxyURL.WithPrefix()
+				urlVarBraces := fleet.FleetVarNDESSCEPProxyURL.WithBraces()
+				if cmd.Data.Content != urlVar && cmd.Data.Content != urlVarBraces {
+					return &fleet.BadRequestError{
+						Message: fmt.Sprintf("Variable %q must be in the SCEP certificate's \"ServerURL\" field.", urlVar),
+					}
+				}
+			}
+
+			if strings.HasSuffix(*cmd.Target, "/Install/SubjectName") {
+				renewalVar := fleet.FleetVarSCEPRenewalID.WithPrefix()
+				renewalVarBraces := fleet.FleetVarSCEPRenewalID.WithBraces()
+				if !strings.Contains(cmd.Data.Content, "OU="+renewalVar) && !strings.Contains(cmd.Data.Content, "OU="+renewalVarBraces) {
+					return fmt.Errorf("SubjectName item must contain the %s variable in the OU field", renewalVar)
+				}
+			}
+		}
+	}
+
+	return nil
 }
 
 func additionalCustomSCEPValidationForWindowsProfiles(contents string, customSCEPVars *CustomSCEPVarsFound) error {

--- a/server/service/windows_mdm_profiles_test.go
+++ b/server/service/windows_mdm_profiles_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
@@ -149,6 +150,144 @@ func TestValidateWindowsProfileFleetVariables(t *testing.T) {
 				if tt.errContains != "" {
 					require.Contains(t, err.Error(), tt.errContains)
 				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAdditionalNDESValidationForWindowsProfiles(t *testing.T) {
+	ndesVars := &NDESVarsFound{}
+	ndesVars, _ = ndesVars.SetChallenge()
+	ndesVars, _ = ndesVars.SetURL()
+
+	// Helper to build a SyncML Add item with a LocURI target and Data content.
+	addItem := func(locURI, data string) string {
+		return fmt.Sprintf(
+			`<Add><Item><Target><LocURI>%s</LocURI></Target><Data>%s</Data></Item></Add>`,
+			locURI, data,
+		)
+	}
+
+	// A valid NDES profile with all required fields.
+	validProfile := addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_CHALLENGE") +
+		addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_PROXY_URL") +
+		addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/SubjectName", "CN=test,OU=$FLEET_VAR_SCEP_RENEWAL_ID")
+
+	tests := []struct {
+		name        string
+		contents    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "valid NDES profile",
+			contents: validProfile,
+		},
+		{
+			name: "valid NDES profile with braces syntax",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "${FLEET_VAR_NDES_SCEP_CHALLENGE}") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "${FLEET_VAR_NDES_SCEP_PROXY_URL}") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/SubjectName", "CN=test,OU=${FLEET_VAR_SCEP_RENEWAL_ID}"),
+		},
+		{
+			name: "valid NDES profile wrapped in atomic",
+			contents: `<Atomic>` +
+				`<Add><CmdID>1</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_CHALLENGE</Data></Item></Add>` +
+				`<Add><CmdID>2</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL</LocURI></Target>` +
+				`<Data>$FLEET_VAR_NDES_SCEP_PROXY_URL</Data></Item></Add>` +
+				`<Add><CmdID>3</CmdID><Item><Target><LocURI>./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/SubjectName</LocURI></Target>` +
+				`<Data>CN=test,OU=$FLEET_VAR_SCEP_RENEWAL_ID</Data></Item></Add>` +
+				`</Atomic>`,
+		},
+		{
+			name: "challenge var in wrong field",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_CHALLENGE") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_CHALLENGE"),
+			wantErr:     true,
+			errContains: `must only be in the SCEP certificate's "Challenge" field`,
+		},
+		{
+			name: "challenge var in arbitrary data field",
+			contents: addItem("./Device/Vendor/MSFT/Something/Else", "$FLEET_VAR_NDES_SCEP_CHALLENGE") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_CHALLENGE"),
+			wantErr:     true,
+			errContains: `must only be in the SCEP certificate's "Challenge" field`,
+		},
+		{
+			name: "proxy url var in wrong field",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_PROXY_URL") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_PROXY_URL"),
+			wantErr:     true,
+			errContains: `must only be in the SCEP certificate's "ServerURL" field`,
+		},
+		{
+			name: "proxy url var in arbitrary data field",
+			contents: addItem("./Device/Vendor/MSFT/Something/Else", "$FLEET_VAR_NDES_SCEP_PROXY_URL") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_PROXY_URL"),
+			wantErr:     true,
+			errContains: `must only be in the SCEP certificate's "ServerURL" field`,
+		},
+		{
+			name: "challenge var in LocURI target",
+			contents: addItem(
+				"./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/$FLEET_VAR_NDES_SCEP_CHALLENGE/Install/Challenge",
+				"$FLEET_VAR_NDES_SCEP_CHALLENGE",
+			),
+			wantErr:     true,
+			errContains: "must not appear in LocURI target paths",
+		},
+		{
+			name: "proxy url var in LocURI target",
+			contents: addItem(
+				"./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/$FLEET_VAR_NDES_SCEP_PROXY_URL/Install/ServerURL",
+				"$FLEET_VAR_NDES_SCEP_PROXY_URL",
+			),
+			wantErr:     true,
+			errContains: "must not appear in LocURI target paths",
+		},
+		{
+			name: "challenge field has wrong value",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "hardcoded-password") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_PROXY_URL"),
+			wantErr:     true,
+			errContains: `must be in the SCEP certificate's "Challenge" field`,
+		},
+		{
+			name: "server url field has wrong value",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_CHALLENGE") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "https://hardcoded.example.com"),
+			wantErr:     true,
+			errContains: `must be in the SCEP certificate's "ServerURL" field`,
+		},
+		{
+			name: "subject name missing renewal id",
+			contents: addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/Challenge", "$FLEET_VAR_NDES_SCEP_CHALLENGE") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/ServerURL", "$FLEET_VAR_NDES_SCEP_PROXY_URL") +
+				addItem("./Device/Vendor/MSFT/ClientCertificateInstall/SCEP/cert1/Install/SubjectName", "CN=test"),
+			wantErr:     true,
+			errContains: "SubjectName item must contain the $FLEET_VAR_SCEP_RENEWAL_ID variable in the OU field",
+		},
+		{
+			name:     "nil ndes vars returns nil",
+			contents: validProfile,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vars := ndesVars
+			if tt.name == "nil ndes vars returns nil" {
+				vars = nil
+			}
+			err := additionalNDESValidationForWindowsProfiles(tt.contents, vars)
+			if tt.wantErr {
+				require.Error(t, err)
+				var badReqErr *fleet.BadRequestError
+				require.ErrorAs(t, err, &badReqErr, "expected BadRequestError for: %s", tt.name)
+				require.Contains(t, err.Error(), tt.errContains)
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33421 

Video: https://www.youtube.com/watch?v=-mpW8o4vqu0 
Docs: https://github.com/fleetdm/fleet/pull/41496/changes

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for NDES (Network Device Enrollment Service) Certificate Authority for Windows devices, enabling secure device enrollment through NDES proxy integration.
  * New profile variables (NDESSCEPChallenge and NDESSCEPProxyURL) enable NDES configuration in Windows profiles.
  * Enhanced validation ensures proper NDES configuration requirements are met in Windows MDM profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->