### PR TITLE
Fleet UI: Show installed status icon if installed

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -109,7 +109,9 @@ describe("SoftwareInstallDetailsModal", () => {
 
       expect(screen.getByText(/CoolApp/)).toBeInTheDocument();
       expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
+      expect(screen.getByTestId("success-icon")).toBeInTheDocument();
       expect(screen.queryByText(/failed to install/i)).not.toBeInTheDocument();
+      expect(screen.queryByTestId("failed-icon")).not.toBeInTheDocument();
     });
 
     it("on host details page, renders failed install without retry", () => {

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tests.tsx
@@ -103,7 +103,7 @@ describe("SoftwareInstallDetailsModal", () => {
             status: "failed_install",
           })}
           isMyDevicePage={false}
-          hasInstalledVersions
+          canOverrideFailureWithInstalled
         />
       );
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -64,7 +64,11 @@ interface IInstallStatusMessage {
   installResult?: ISoftwareInstallResult;
   isMyDevicePage: boolean;
   contactUrl?: string;
-  hasInstalledVersions?: boolean;
+  /**  Used only for overriding failed_install/failed_uninstall -> "is installed."
+   - From Host -> Software: override based on inventory.
+   - From Activity feed: never override (always show the failure).
+   Parity with VPPInstallDetailsModal/SoftwareIpaInstallDetailsModal */
+  canOverrideFailureWithInstalled?: boolean;
 }
 
 // TODO - match VppInstallDetailsModal status to this, still accounting for MDM-specific cases
@@ -74,7 +78,7 @@ export const StatusMessage = ({
   installResult,
   isMyDevicePage,
   contactUrl,
-  hasInstalledVersions,
+  canOverrideFailureWithInstalled = false,
 }: IInstallStatusMessage) => {
   // the case when software is installed by the user and not by Fleet
   if (!installResult) {
@@ -100,13 +104,13 @@ export const StatusMessage = ({
     created_at,
   } = installResult;
 
-  // Treat failed_install/ failed_uninstall with installed versions as installed
+  // Treat failed_install/failed_uninstall with installed versions as installed
   // as the host still reports installed versions (4.82 #31663)
-  const isActuallyInstalled =
-    hasInstalledVersions &&
+  const overrideFailureWithInstalled =
+    canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(status || "");
 
-  if (isActuallyInstalled) {
+  if (overrideFailureWithInstalled) {
     return (
       <IconStatusMessage
         className={`${baseClass}__status-message`}
@@ -336,15 +340,6 @@ export const SoftwareInstallDetailsModal = ({
     swInstallResult?.status || ""
   );
 
-  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
-
-  // Hide failed details if host shows installed versions (4.82 #31663)
-  const excludeInstallDetails =
-    hasInstalledVersions &&
-    ["failed_install", "failed_uninstall"].includes(
-      swInstallResult?.status || ""
-    );
-
   const hostDisplayname =
     swInstallResult?.host_display_name || detailsFromProps.host_display_name;
 
@@ -354,6 +349,28 @@ export const SoftwareInstallDetailsModal = ({
         host_display_name: hostDisplayname,
       }
     : undefined;
+
+  // True when host inventory reports at least one installed version for this app.
+  const inventoryReportsInstalled = !!hostSoftware?.installed_versions?.length;
+
+  // This modal is opened in two contexts:
+  // - From Host -> Software: hostSoftware is defined (we trust inventory to override failures).
+  // - From the Activity feed: hostSoftware is undefined (we trust install result status).
+  const openedFromHostSoftwarePage = !!hostSoftware;
+
+  // Used only for overriding failed_install/failed_uninstall -> "is installed."
+  // - From Host -> Software: override based on inventory.
+  // - From Activity feed: never override (always show the failure).
+  const canOverrideFailureWithInstalled = openedFromHostSoftwarePage
+    ? inventoryReportsInstalled
+    : false;
+
+  // Hide failed details if host shows installed versions (4.82 #31663)
+  const excludeInstallDetails =
+    canOverrideFailureWithInstalled &&
+    ["failed_install", "failed_uninstall"].includes(
+      swInstallResult?.status || ""
+    );
 
   const renderContent = () => {
     if (isInstalledByFleet) {
@@ -413,7 +430,7 @@ export const SoftwareInstallDetailsModal = ({
           )}
           isMyDevicePage={!!deviceAuthToken}
           contactUrl={contactUrl}
-          hasInstalledVersions={!!hostSoftware?.installed_versions?.length}
+          canOverrideFailureWithInstalled={canOverrideFailureWithInstalled}
         />
 
         {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareInstallDetailsModal/SoftwareInstallDetailsModal.tsx
@@ -335,11 +335,6 @@ export const SoftwareInstallDetailsModal = ({
     );
   };
 
-  // Hide version section for pending installs only
-  const excludeVersions = ["pending_install"].includes(
-    swInstallResult?.status || ""
-  );
-
   const hostDisplayname =
     swInstallResult?.host_display_name || detailsFromProps.host_display_name;
 
@@ -365,12 +360,24 @@ export const SoftwareInstallDetailsModal = ({
     ? inventoryReportsInstalled
     : false;
 
-  // Hide failed details if host shows installed versions (4.82 #31663)
-  const excludeInstallDetails =
+  // Treat failed_install / failed_uninstall with installed versions as installed
+  const overrideFailedMessageWithInstalledMessage =
     canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(
-      swInstallResult?.status || ""
+      swInstallResult?.status || "" || ""
     );
+
+  // Hide version section from pending installs or failures that aren't overridden to installed (4.82 #31663)
+  const shouldShowInventoryVersions =
+    (!!hostSoftware &&
+      deviceAuthToken &&
+      ![
+        "pending_install",
+        "failed_install",
+        "failed_uninstall",
+        "pending",
+      ].includes(swInstallResult?.status || "")) ||
+    overrideFailedMessageWithInstalledMessage;
 
   const renderContent = () => {
     if (isInstalledByFleet) {
@@ -433,9 +440,9 @@ export const SoftwareInstallDetailsModal = ({
           canOverrideFailureWithInstalled={canOverrideFailureWithInstalled}
         />
 
-        {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
+        {shouldShowInventoryVersions && renderInventoryVersionsSection()}
         {isInstalledByFleet &&
-          !excludeInstallDetails &&
+          !overrideFailedMessageWithInstalledMessage &&
           renderInstallDetailsSection()}
       </div>
     );

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
@@ -158,10 +158,12 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     await waitFor(() => {
       expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
       expect(screen.getByText(/Current version/i)).toBeInTheDocument();
+      expect(screen.getByTestId("success-icon")).toBeInTheDocument();
     });
 
     // No failure wording when treated as installed
     expect(screen.queryByText(/failed to install/i)).not.toBeInTheDocument();
+    expect(screen.queryAllByTestId("error-icon")).toBeInTheDocument();
     expect(
       screen.queryByText(/Please re-attempt this installation/i)
     ).not.toBeInTheDocument();

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tests.tsx
@@ -99,6 +99,7 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     });
     expect(screen.getByText(/Logic Pro/i)).toBeInTheDocument();
     expect(screen.getByText(/Marko's MacBook Pro/i)).toBeInTheDocument();
+    expect(screen.getByTestId("success-icon")).toBeInTheDocument();
   });
 
   it("renders manual install message when installed not through Fleet", async () => {
@@ -114,6 +115,7 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     await waitFor(() => {
       expect(screen.getByText(/Logic Pro/i)).toBeInTheDocument();
       expect(screen.getByText(/is installed\./i)).toBeInTheDocument();
+      expect(screen.getByTestId("success-icon")).toBeInTheDocument();
     });
   });
 
@@ -130,6 +132,7 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     await waitFor(() => {
       expect(screen.getByText(/Fleet installed/i)).toBeInTheDocument();
       expect(screen.getByText(/the host/i)).toBeInTheDocument();
+      expect(screen.getByTestId("success-icon")).toBeInTheDocument();
     });
   });
 
@@ -163,7 +166,7 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
 
     // No failure wording when treated as installed
     expect(screen.queryByText(/failed to install/i)).not.toBeInTheDocument();
-    expect(screen.queryAllByTestId("error-icon")).toBeInTheDocument();
+    expect(screen.queryByTestId("error-icon")).not.toBeInTheDocument();
     expect(
       screen.queryByText(/Please re-attempt this installation/i)
     ).not.toBeInTheDocument();
@@ -192,6 +195,7 @@ describe("SoftwareIpaInstallDetailsModal component", () => {
     expect(
       screen.getByText(/Please re-attempt this installation/i)
     ).toBeInTheDocument();
+    expect(screen.getByTestId("error-icon")).toBeInTheDocument();
   });
 
   it("renders Done button by default", async () => {

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -361,6 +361,17 @@ export const SoftwareIpaInstallDetailsModal = ({
       ].includes(displayStatus)) ||
     overrideFailedMessageWithInstalledMessage;
 
+  // Hide failed details if host shows installed versions (4.82 #31663)
+  // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
+  const excludeInstallDetails =
+    canOverrideFailureWithInstalled &&
+    [
+      "failed_install_installed",
+      "failed_uninstall_installed",
+      "failed_install",
+      "failed_uninstall",
+    ].includes(displayStatus || "");
+
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
     : true; // if no hostSoftware passed in, can assume this is the activity feed, meaning this can only refer to a Fleet-handled install
@@ -455,15 +466,7 @@ export const SoftwareIpaInstallDetailsModal = ({
         {shouldShowInventoryVersions && renderInventoryVersionsSection()}
         {!isPendingInstall &&
           isInstalledByFleet &&
-          !(
-            canOverrideFailureWithInstalled &&
-            [
-              "failed_install_installed",
-              "failed_uninstall_installed",
-              "failed_install",
-              "failed_uninstall",
-            ].includes(displayStatus || "")
-          ) &&
+          !excludeInstallDetails &&
           renderInstallDetailsSection()}
       </div>
     );

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -40,13 +40,19 @@ import decodeBase64Utf8 from "../helpers";
 
 interface IGetStatusMessageProps {
   isMyDevicePage?: boolean;
-  displayStatus: SoftwareInstallUninstallStatus;
+  /** "pending" is an edge case here where IPA install activities that were added to the feed
+   * prior to v4.57 will list the status as "pending" rather than "pending_install" */
+  displayStatus: SoftwareInstallUninstallStatus | "pending";
   isMDMStatusNotNow: boolean;
   isMDMStatusAcknowledged: boolean;
   appName: string;
   hostDisplayName: string;
   commandUpdatedAt: string;
-  hasInstalledVersions?: boolean;
+  /**  Used only for overriding failed_install/failed_uninstall -> "is installed."
+   - From Host -> Software: override based on inventory.
+   - From Activity feed: never override (always show the failure).
+   Parity with VPPInstallDetailsModal/SoftwareInstallDetailsModal */
+  canOverrideFailureWithInstalled?: boolean;
 }
 
 export const getStatusMessage = ({
@@ -57,10 +63,10 @@ export const getStatusMessage = ({
   appName,
   hostDisplayName,
   commandUpdatedAt,
-  hasInstalledVersions,
+  canOverrideFailureWithInstalled = false,
 }: IGetStatusMessageProps) => {
   const formattedHost = hostDisplayName ? <b>{hostDisplayName}</b> : "the host";
-  const displayTimeStamp =
+  const displayTimestamp =
     ["failed_install", "installed"].includes(displayStatus || "") &&
     commandUpdatedAt
       ? ` (${formatDistanceToNow(new Date(commandUpdatedAt), {
@@ -69,16 +75,18 @@ export const getStatusMessage = ({
         })})`
       : null;
 
-  const isPendingInstall = displayStatus === "pending_install";
+  // Handles "pending" value prior to 4.57
+  const isPendingInstall = ["pending_install", "pending"].includes(
+    displayStatus
+  );
 
   // Treat failed_install / failed_uninstall with installed versions as installed
   // as the host still reports installed versions (4.82 #31663)
-  // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
-  const isActuallyInstalled =
-    hasInstalledVersions &&
+  const overrideFailureWithInstalled =
+    canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(displayStatus || "");
 
-  if (isActuallyInstalled) {
+  if (overrideFailureWithInstalled) {
     return (
       <>
         <b>{appName}</b> is installed.
@@ -87,8 +95,6 @@ export const getStatusMessage = ({
   }
 
   // Handles the case where software is installed manually by the user and not through Fleet
-  // This IPA software_packages modal matches app_store_app modal and software_packages modal
-  // for software installed manually shown with VppInstallDetailsModal and SoftwareInstallDetailsModal
   if (displayStatus === "installed" && !commandUpdatedAt) {
     return (
       <>
@@ -109,7 +115,7 @@ export const getStatusMessage = ({
             was running on battery power while in Power Nap
           </>
         )}
-        {displayTimeStamp && <> {displayTimeStamp}</>}. Fleet will try again.
+        {displayTimestamp && <> {displayTimestamp}</>}. Fleet will try again.
       </>
     );
   }
@@ -143,7 +149,7 @@ export const getStatusMessage = ({
       <>
         The MDM command (request) to install <b>{appName}</b>
         {!isMyDevicePage && <> on {formattedHost}</>} failed
-        {displayTimeStamp && <> {displayTimeStamp}</>}. Please re-attempt this
+        {displayTimestamp && <> {displayTimestamp}</>}. Please re-attempt this
         installation.
       </>
     );
@@ -151,18 +157,17 @@ export const getStatusMessage = ({
 
   const renderSuffix = () => {
     if (isMyDevicePage) {
-      return <> {displayTimeStamp && <> {displayTimeStamp}</>}</>;
+      return <> {displayTimestamp && <> {displayTimestamp}</>}</>;
     }
     return (
       <>
         {" "}
         on {formattedHost}
         {isPendingInstall && " when it comes online"}
-        {displayTimeStamp && <> {displayTimeStamp}</>}
+        {displayTimestamp && <> {displayTimestamp}</>}
       </>
     );
   };
-  // Create predicate and subordinate for other statuses
   return (
     <>
       Fleet {getInstallDetailsStatusPredicate(displayStatus)} <b>{appName}</b>
@@ -259,9 +264,6 @@ export const SoftwareIpaInstallDetailsModal = ({
   ) => {
     const results = response.results?.[0];
     if (!results) {
-      // FIXME: It's currently possible that the command results API response is empty for pending
-      // commands. As a temporary workaround to handle this case, we'll ignore the empty response and
-      // display some minimal pending UI. This should be removed once the API response is fixed.
       return {} as ICommandResult;
     }
     return {
@@ -290,57 +292,64 @@ export const SoftwareIpaInstallDetailsModal = ({
     }
   );
 
-  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
+  // Reconcile "installed" state from inventory vs command results.
+
+  // True when host inventory reports at least one installed version for this app.
+  const inventoryReportsInstalled = !!hostSoftware?.installed_versions?.length;
+
+  // True when the IPA command result metadata says the app is installed on the host.
+  const commandReportsInstalled =
+    (swInstallResult?.results_metadata?.software_installed as boolean) ?? false;
+
+  // This modal is opened in two contexts:
+  // - From Host -> Software: hostSoftware is defined (we trust inventory to override failures).
+  // - From the Activity feed: hostSoftware is undefined (we trust command result status).
+  const openedFromHostSoftwarePage = !!hostSoftware;
+
+  // Used only for overriding failed_install/failed_uninstall -> "is installed."
+  // - From Host -> Software: override based on inventory.
+  // - From Activity feed: never override (always show the failure).
+  const canOverrideFailureWithInstalled = openedFromHostSoftwarePage
+    ? inventoryReportsInstalled
+    : false;
+
+  const hasInstalledVersionsOnHost =
+    commandReportsInstalled || inventoryReportsInstalled;
+
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
 
   // Treat failed_install / failed_uninstall with installed versions as installed
-  const isActuallyInstalled =
-    hasInstalledVersions &&
+  const overrideFailedMessageWithInstalledMessage =
+    canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(displayStatus || "");
 
   const commandUpdatedAt = swInstallResult?.updated_at;
 
   // Handles the case where software is installed manually by the user and not through Fleet
-  const isInstalledManual = displayStatus === "installed" && !commandUpdatedAt; // using same condition as in getStatusMessage
+  const isInstalledManual = displayStatus === "installed" && !commandUpdatedAt;
 
   // Use success icon when we show “is installed”
   const iconName =
-    isActuallyInstalled || isInstalledManual
+    overrideFailedMessageWithInstalledMessage || isInstalledManual
       ? "success"
       : INSTALL_DETAILS_STATUS_ICONS[displayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
-  // as some cases have command results not available for pending_installs
-  // which we don't want to show a UI error state for
   const isPendingInstall = ["pending_install", "pending"].includes(
     displayStatus
   );
 
-  // Note: We need to reconcile status values from two different sources. From props, we
-  // get the status of the Fleet install operation (which can be "failed", "pending", or
-  // "installed"). From the command results API response, we also receive the raw status
-  // from the MDM protocol, e.g., "NotNow" or "Acknowledged". We need to display some special
-  // messaging for the "NotNow" status, which otherwise would be treated as "pending".
   const isMDMStatusNotNow = swInstallResult?.status === "NotNow";
   const isMDMStatusAcknowledged = swInstallResult?.status === "Acknowledged";
 
-  // Hide version section for pending installs only
-  const excludeVersions = ["pending_install", "pending"].includes(
-    swInstallResult?.status || ""
-  );
-
-  // Hide failed details if host shows installed versions (4.82 #31663)
-  // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
-  const excludeInstallDetails =
-    hasInstalledVersions &&
-    ["failed_install", "failed_uninstall"].includes(
-      swInstallResult?.status || ""
-    );
+  const excludeVersions =
+    !deviceAuthToken &&
+    ["pending_install", "failed_install", "pending"].includes(displayStatus);
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
-    : true; // if no hostSoftware passed in, can assume this is the activity feed, meaning this can only refer to a Fleet-handled install
+    : true;
 
   const statusMessage = getStatusMessage({
     isMyDevicePage: !!deviceAuthToken,
@@ -350,7 +359,7 @@ export const SoftwareIpaInstallDetailsModal = ({
     appName,
     hostDisplayName,
     commandUpdatedAt: commandUpdatedAt || "",
-    hasInstalledVersions,
+    canOverrideFailureWithInstalled,
   });
 
   const renderInventoryVersionsSection = () => {
@@ -361,7 +370,6 @@ export const SoftwareIpaInstallDetailsModal = ({
   };
 
   const renderInstallDetailsSection = () => {
-    // Hide section if there's no details to display
     if (!swInstallResult?.result && !swInstallResult?.payload) {
       return null;
     }
@@ -432,7 +440,15 @@ export const SoftwareIpaInstallDetailsModal = ({
         {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
         {!isPendingInstall &&
           isInstalledByFleet &&
-          !excludeInstallDetails &&
+          !(
+            canOverrideFailureWithInstalled &&
+            [
+              "failed_install_installed",
+              "failed_uninstall_installed",
+              "failed_install",
+              "failed_uninstall",
+            ].includes(displayStatus || "")
+          ) &&
           renderInstallDetailsSection()}
       </div>
     );

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -303,10 +303,6 @@ export const SoftwareIpaInstallDetailsModal = ({
   // True when host inventory reports at least one installed version for this app.
   const inventoryReportsInstalled = !!hostSoftware?.installed_versions?.length;
 
-  // True when the IPA command result metadata says the app is installed on the host.
-  const commandReportsInstalled =
-    (swInstallResult?.results_metadata?.software_installed as boolean) ?? false;
-
   // This modal is opened in two contexts:
   // - From Host -> Software: hostSoftware is defined (we trust inventory to override failures).
   // - From the Activity feed: hostSoftware is undefined (we trust command result status).

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -95,6 +95,8 @@ export const getStatusMessage = ({
   }
 
   // Handles the case where software is installed manually by the user and not through Fleet
+  // This IPA software_packages modal matches app_store_app modal and software_packages modal
+  // for software installed manually shown with VppInstallDetailsModal and SoftwareInstallDetailsModal
   if (displayStatus === "installed" && !commandUpdatedAt) {
     return (
       <>
@@ -168,6 +170,7 @@ export const getStatusMessage = ({
       </>
     );
   };
+  // Create predicate and subordinate for other statuses
   return (
     <>
       Fleet {getInstallDetailsStatusPredicate(displayStatus)} <b>{appName}</b>
@@ -264,6 +267,9 @@ export const SoftwareIpaInstallDetailsModal = ({
   ) => {
     const results = response.results?.[0];
     if (!results) {
+      // FIXME: It's currently possible that the command results API response is empty for pending
+      // commands. As a temporary workaround to handle this case, we'll ignore the empty response and
+      // display some minimal pending UI. This should be removed once the API response is fixed.
       return {} as ICommandResult;
     }
     return {
@@ -313,9 +319,6 @@ export const SoftwareIpaInstallDetailsModal = ({
     ? inventoryReportsInstalled
     : false;
 
-  const hasInstalledVersionsOnHost =
-    commandReportsInstalled || inventoryReportsInstalled;
-
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
 
@@ -336,10 +339,17 @@ export const SoftwareIpaInstallDetailsModal = ({
       : INSTALL_DETAILS_STATUS_ICONS[displayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
+  // as some cases have command results not available for pending_installs
+  // which we don't want to show a UI error state for
   const isPendingInstall = ["pending_install", "pending"].includes(
     displayStatus
   );
 
+  // Note: We need to reconcile status values from two different sources. From props, we
+  // get the status of the Fleet install operation (which can be "failed", "pending", or
+  // "installed"). From the command results API response, we also receive the raw status
+  // from the MDM protocol, e.g., "NotNow" or "Acknowledged". We need to display some special
+  // messaging for the "NotNow" status, which otherwise would be treated as "pending".
   const isMDMStatusNotNow = swInstallResult?.status === "NotNow";
   const isMDMStatusAcknowledged = swInstallResult?.status === "Acknowledged";
 
@@ -357,7 +367,7 @@ export const SoftwareIpaInstallDetailsModal = ({
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
-    : true;
+    : true; // if no hostSoftware passed in, can assume this is the activity feed, meaning this can only refer to a Fleet-handled install
 
   const statusMessage = getStatusMessage({
     isMyDevicePage: !!deviceAuthToken,
@@ -378,6 +388,7 @@ export const SoftwareIpaInstallDetailsModal = ({
   };
 
   const renderInstallDetailsSection = () => {
+    // Hide section if there's no details to display
     if (!swInstallResult?.result && !swInstallResult?.payload) {
       return null;
     }

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -343,9 +343,17 @@ export const SoftwareIpaInstallDetailsModal = ({
   const isMDMStatusNotNow = swInstallResult?.status === "NotNow";
   const isMDMStatusAcknowledged = swInstallResult?.status === "Acknowledged";
 
-  const excludeVersions =
-    !deviceAuthToken &&
-    ["pending_install", "failed_install", "pending"].includes(displayStatus);
+  // Hide version section from pending installs or failures that aren't overridden to installed (4.82 #31663)
+  const shouldShowInventoryVersions =
+    (!!hostSoftware &&
+      deviceAuthToken &&
+      ![
+        "pending_install",
+        "failed_install",
+        "failed_uninstall",
+        "pending",
+      ].includes(displayStatus)) ||
+    overrideFailedMessageWithInstalledMessage;
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
@@ -437,7 +445,7 @@ export const SoftwareIpaInstallDetailsModal = ({
           iconName={iconName}
           message={<span>{statusMessage}</span>}
         />
-        {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
+        {shouldShowInventoryVersions && renderInventoryVersionsSection()}
         {!isPendingInstall &&
           isInstalledByFleet &&
           !(

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -25,7 +25,7 @@ import InventoryVersions from "pages/hosts/details/components/InventoryVersions"
 import Modal from "components/Modal";
 import ModalFooter from "components/ModalFooter";
 import Button from "components/buttons/Button";
-import Icon from "components/Icon";
+import IconStatusMessage from "components/IconStatusMessage";
 import Textarea from "components/Textarea";
 import DataError from "components/DataError/DataError";
 import DeviceUserError from "components/DeviceUserError";
@@ -424,10 +424,11 @@ export const SoftwareIpaInstallDetailsModal = ({
     }
     return (
       <div className={`${baseClass}__modal-content`}>
-        <div className={`${baseClass}__status-message`}>
-          {!!iconName && <Icon name={iconName} />}
-          <span>{statusMessage}</span>
-        </div>
+        <IconStatusMessage
+          className={`${baseClass}__status-message`}
+          iconName={iconName}
+          message={<span>{statusMessage}</span>}
+        />
         {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
         {!isPendingInstall &&
           isInstalledByFleet &&

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -290,9 +290,25 @@ export const SoftwareIpaInstallDetailsModal = ({
     }
   );
 
+  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
-  const iconName = INSTALL_DETAILS_STATUS_ICONS[displayStatus];
+
+  // Treat failed_install / failed_uninstall with installed versions as installed
+  const isActuallyInstalled =
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus || "");
+
+  const commandUpdatedAt = swInstallResult?.updated_at;
+
+  // Handles the case where software is installed manually by the user and not through Fleet
+  const isInstalledManual = displayStatus === "installed" && !commandUpdatedAt; // using same condition as in getStatusMessage
+
+  // Use success icon when we show “is installed”
+  const iconName =
+    isActuallyInstalled || isInstalledManual
+      ? "success"
+      : INSTALL_DETAILS_STATUS_ICONS[displayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
   // as some cases have command results not available for pending_installs
@@ -314,8 +330,6 @@ export const SoftwareIpaInstallDetailsModal = ({
     swInstallResult?.status || ""
   );
 
-  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
-
   // Hide failed details if host shows installed versions (4.82 #31663)
   // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal
   const excludeInstallDetails =
@@ -335,7 +349,7 @@ export const SoftwareIpaInstallDetailsModal = ({
     isMDMStatusAcknowledged,
     appName,
     hostDisplayName,
-    commandUpdatedAt: swInstallResult?.updated_at || "",
+    commandUpdatedAt: commandUpdatedAt || "",
     hasInstalledVersions,
   });
 

--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/_styles.scss
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/_styles.scss
@@ -7,15 +7,6 @@
     gap: $pad-medium;
   }
 
-  &__status-message {
-    display: flex;
-    align-items: center;
-    gap: $pad-small;
-    margin: 0;
-    .icon {
-      align-self: flex-start;
-    }
-  }
   .data-set__horizontal {
     flex-direction: row;
   }

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tests.tsx
@@ -233,7 +233,8 @@ describe("getStatusMessage helper function", () => {
         hostDisplayName: "Marko's MacBook Pro",
         commandUpdatedAt: "2025-07-29T22:49:52Z",
         platform: "darwin",
-        hasInstalledVersions: true,
+        canOverrideFailureWithInstalled: true,
+        hasInstalledVersionsOnHost: true,
       })
     );
 
@@ -254,7 +255,8 @@ describe("getStatusMessage helper function", () => {
         hostDisplayName: "Marko's iPhone",
         commandUpdatedAt: "2025-07-29T22:49:52Z",
         platform: "ios",
-        hasInstalledVersions: true,
+        canOverrideFailureWithInstalled: true,
+        hasInstalledVersionsOnHost: true,
       })
     );
 
@@ -275,7 +277,8 @@ describe("getStatusMessage helper function", () => {
         hostDisplayName: "Marko's iPad",
         commandUpdatedAt: "2025-07-29T22:49:52Z",
         platform: "ipados",
-        hasInstalledVersions: true,
+        canOverrideFailureWithInstalled: true,
+        hasInstalledVersionsOnHost: true,
       })
     );
 
@@ -296,7 +299,8 @@ describe("getStatusMessage helper function", () => {
         hostDisplayName: "Marko's MacBook Pro",
         commandUpdatedAt: "2025-07-29T22:49:52Z",
         platform: "darwin",
-        hasInstalledVersions: true,
+        canOverrideFailureWithInstalled: true,
+        hasInstalledVersionsOnHost: true,
       })
     );
 

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -405,9 +405,17 @@ export const VppInstallDetailsModal = ({
   const isMDMStatusNotNow = vppCommandResult?.status === "NotNow";
   const isMDMStatusAcknowledged = vppCommandResult?.status === "Acknowledged";
 
-  const excludeVersions =
-    !deviceAuthToken &&
-    ["pending_install", "failed_install", "pending"].includes(displayStatus);
+  // Hide version section from pending installs or failures that aren't overridden to installed (4.82 #31663)
+  const shouldShowInventoryVersions =
+    (!!hostSoftware &&
+      deviceAuthToken &&
+      ![
+        "pending_install",
+        "failed_install",
+        "failed_uninstall",
+        "pending",
+      ].includes(displayStatus)) ||
+    overrideFailedMessageWithInstalledMessage;
 
   const isInstalledByFleet = hostSoftware
     ? !!hostSoftware.app_store_app?.last_install
@@ -513,7 +521,7 @@ export const VppInstallDetailsModal = ({
           iconName={iconName}
           message={<span>{statusMessage}</span>}
         />
-        {hostSoftware && !excludeVersions && renderInventoryVersionsSection()}
+        {shouldShowInventoryVersions && renderInventoryVersionsSection()}
         {!isPendingInstall &&
           isInstalledByFleet &&
           !excludeInstallDetails &&

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -1,6 +1,6 @@
-/** This modal is only used for VPP apps and their related installations.
- * For iOS/iPadOS packages (e.g. .ipa packages software source is ios_apps or ipados_apps)
- *  we use SoftwareIpaInstallDetailsModal with the command_uuid. */
+/** Modal for VPP app installs only.
+ * For iOS/iPadOS .ipa packages (software source: ios_apps or ipados_apps),
+ * use SoftwareIpaInstallDetailsModal with the command_uuid instead. */
 
 import React, { useState } from "react";
 import { useQuery } from "react-query";
@@ -51,7 +51,14 @@ interface IGetStatusMessageProps {
   hostDisplayName: string;
   commandUpdatedAt: string;
   platform?: string;
-  hasInstalledVersions?: boolean;
+  /**  Used only for overriding failed_install/failed_uninstall -> "is installed."
+   - From Host -> Software: override based on inventory.
+   - From Activity feed: never override (always show the failure).
+   Parity with SoftwareInstallDetailsModal/SoftwareIpaInstallDetailsModal */
+  canOverrideFailureWithInstalled?: boolean;
+  /** Used to show warning to close an app if failed to install with
+   * detected installed version on host */
+  hasInstalledVersionsOnHost?: boolean;
 }
 
 export const getStatusMessage = ({
@@ -63,10 +70,11 @@ export const getStatusMessage = ({
   hostDisplayName,
   commandUpdatedAt,
   platform,
-  hasInstalledVersions = false,
+  canOverrideFailureWithInstalled = false,
+  hasInstalledVersionsOnHost = false,
 }: IGetStatusMessageProps) => {
   const formattedHost = hostDisplayName ? <b>{hostDisplayName}</b> : "the host";
-  const displayTimeStamp =
+  const displayTimestamp =
     ["failed_install", "installed"].includes(displayStatus || "") &&
     commandUpdatedAt
       ? ` (${formatDistanceToNow(new Date(commandUpdatedAt), {
@@ -82,11 +90,11 @@ export const getStatusMessage = ({
 
   // Treat failed_install / failed_uninstall with installed versions as installed
   // as the host still reports installed versions (4.82 #31663)
-  const isActuallyInstalled =
-    hasInstalledVersions &&
+  const overrideFailureWithInstalled =
+    canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(displayStatus || "");
 
-  if (isActuallyInstalled) {
+  if (overrideFailureWithInstalled) {
     return (
       <>
         <b>{appName}</b> is installed.
@@ -116,7 +124,7 @@ export const getStatusMessage = ({
             was running on battery power while in Power Nap
           </>
         )}
-        {displayTimeStamp && <> {displayTimeStamp}</>}. Fleet will try again.
+        {displayTimestamp && <> {displayTimestamp}</>}. Fleet will try again.
       </>
     );
   }
@@ -144,7 +152,7 @@ export const getStatusMessage = ({
               {!isMyDevicePage && <> on {formattedHost}</>}, but the app failed
               to install.
             </div>
-            {platform && isMacOS(platform) && hasInstalledVersions && (
+            {platform && isMacOS(platform) && hasInstalledVersionsOnHost && (
               <div className="vpp-install-details-modal__update-tip">
                 If you&apos;re updating the app and the app is open,{" "}
                 <TooltipWrapper
@@ -183,7 +191,7 @@ export const getStatusMessage = ({
           <>
             The MDM command (request) to install <b>{appName}</b>
             {!isMyDevicePage && <> on {formattedHost}</>} failed
-            {displayTimeStamp && <> {displayTimeStamp}</>}. Please re-attempt
+            {displayTimestamp && <> {displayTimestamp}</>}. Please re-attempt
             this installation.
           </>
         )}
@@ -193,14 +201,14 @@ export const getStatusMessage = ({
 
   const renderSuffix = () => {
     if (isMyDevicePage) {
-      return <> {displayTimeStamp && <> {displayTimeStamp}</>}</>;
+      return <> {displayTimestamp && <> {displayTimestamp}</>}</>;
     }
     return (
       <>
         {" "}
         on {formattedHost}
         {isPendingInstall && " when it comes online"}
-        {displayTimeStamp && <> {displayTimeStamp}</>}
+        {displayTimestamp && <> {displayTimestamp}</>}
       </>
     );
   };
@@ -336,25 +344,49 @@ export const VppInstallDetailsModal = ({
     }
   );
 
-  const hasInstalledVersions =
+  // Reconcile "installed" state from inventory vs command results.
+
+  // True when host inventory reports at least one installed version for this app.
+  const inventoryReportsInstalled = !!hostSoftware?.installed_versions?.length;
+
+  // True when the VPP command result metadata says the app is installed on the host.
+  const commandReportsInstalled =
     (vppCommandResult?.results_metadata?.software_installed as boolean) ??
-    !!hostSoftware?.installed_versions?.length;
+    false;
+
+  // This modal is opened in two contexts:
+  // - From Host -> Software: hostSoftware is defined (we trust inventory to override failures).
+  // - From the Activity feed: hostSoftware is undefined (we trust command result status).
+  const openedFromHostSoftwarePage = !!hostSoftware;
+
+  // Used only for overriding failed_install/failed_uninstall -> "is installed."
+  // - From Host -> Software: override based on inventory.
+  // - From Activity feed: never override (always show the failure).
+  const canOverrideFailureWithInstalled = openedFromHostSoftwarePage
+    ? inventoryReportsInstalled
+    : false;
+
+  // Used to
+  const hasInstalledVersionsOnHost =
+    commandReportsInstalled || inventoryReportsInstalled;
+
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
 
   // Treat failed_install / failed_uninstall with installed versions as installed
-  const isActuallyInstalled =
-    hasInstalledVersions &&
+  const overrideFailedMessageWithInstalledMessage =
+    canOverrideFailureWithInstalled &&
     ["failed_install", "failed_uninstall"].includes(displayStatus || "");
 
   const commandUpdatedAt = vppCommandResult?.updated_at;
 
   // Handles the case where software is installed manually by the user and not through Fleet
-  const isInstalledManual = displayStatus === "installed" && !commandUpdatedAt; // using same condition as in getStatusMessage
+  const isManuallyInstalled =
+    displayStatus === "installed" && !commandUpdatedAt; // using same condition as in getStatusMessage
 
   // Use success icon when we show “is installed”
   const iconName =
-    isActuallyInstalled || isInstalledManual
+    overrideFailedMessageWithInstalledMessage || isManuallyInstalled
       ? "success"
       : INSTALL_DETAILS_STATUS_ICONS[displayStatus];
 
@@ -390,9 +422,8 @@ export const VppInstallDetailsModal = ({
     hostDisplayName,
     commandUpdatedAt: vppCommandResult?.updated_at || "",
     platform: hostSoftware?.app_store_app?.platform || detailsPlatform,
-    hasInstalledVersions:
-      (vppCommandResult?.results_metadata?.software_installed as boolean) ??
-      !!hostSoftware?.installed_versions?.length,
+    canOverrideFailureWithInstalled,
+    hasInstalledVersionsOnHost,
   });
 
   const renderInventoryVersionsSection = () => {
@@ -438,7 +469,7 @@ export const VppInstallDetailsModal = ({
   // Hide failed details if host shows installed versions (4.82 #31663)
   // NOTE: Currently no uninstall VPP but added for symmetry with SoftwareInstallDetailsModal
   const excludeInstallDetails =
-    hasInstalledVersions &&
+    canOverrideFailureWithInstalled &&
     [
       "failed_install_installed",
       "failed_uninstall_installed",

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -336,9 +336,27 @@ export const VppInstallDetailsModal = ({
     }
   );
 
+  const hasInstalledVersions =
+    (vppCommandResult?.results_metadata?.software_installed as boolean) ??
+    !!hostSoftware?.installed_versions?.length;
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
-  const iconName = INSTALL_DETAILS_STATUS_ICONS[displayStatus];
+
+  // Treat failed_install / failed_uninstall with installed versions as installed
+  const isActuallyInstalled =
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus || "");
+
+  const commandUpdatedAt = vppCommandResult?.updated_at;
+
+  // Handles the case where software is installed manually by the user and not through Fleet
+  const isInstalledManual = displayStatus === "installed" && !commandUpdatedAt; // using same condition as in getStatusMessage
+
+  // Use success icon when we show “is installed”
+  const iconName =
+    isActuallyInstalled || isInstalledManual
+      ? "success"
+      : INSTALL_DETAILS_STATUS_ICONS[displayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
   // as some cases have command results not available for pending_installs
@@ -416,10 +434,6 @@ export const VppInstallDetailsModal = ({
       </>
     );
   };
-
-  const hasInstalledVersions =
-    (vppCommandResult?.results_metadata?.software_installed as boolean) ??
-    !!hostSoftware?.installed_versions?.length;
 
   // Hide failed details if host shows installed versions (4.82 #31663)
   // NOTE: Currently no uninstall VPP but added for symmetry with SoftwareInstallDetailsModal


### PR DESCRIPTION
## Issue
Closes #39983 

## Description

This is so long because installation details are within 3 modals and so all 3 had to be updated:

- SoftwareInstallDetailsModal
  - Updated variables and naming for readability
  -  Added icons to tests
  - `shouldShowInventoryVersions` will show if `overrideFailedMessageWithInstalledMessage` (bug fix)
- SoftwareIpaInstallDetailsModal
  - Updated variables and naming for readability
  - Added icons to tests
  - Use reusable component `IconStatusMessage`
  -  Added pre-4.57 "pending" case just in case to match VPP
  -  Override icon to success icon if `overrideFailedMessageWithInstalledMessage || isInstalledManual` (bug fix)
  - `shouldShowInventoryVersions` will show if `overrideFailedMessageWithInstalledMessage` (bug fix)
- VPPInstallDetailsModal
  - Updated variables and naming for readability
  - TODO: Create tests to add icons to
  -  Use reusable component `IconStatusMessage`
  - Override icon to success icon if `overrideFailedMessageWithInstalledMessage || isInstalledManual` (bug fix)
  - `shouldShowInventoryVersions` will show if `overrideFailedMessageWithInstalledMessage` (bug fix)

## Screenshots

### BEFORE

https://github.com/user-attachments/assets/3472daef-47bd-4dbb-9ce9-afbf3d13302b



### AFTER

https://github.com/user-attachments/assets/c3212f58-6172-4437-9d60-76c42b98f451


## Testing

- [x] Added/updated automated tests
 Tests already exist, ensured they still passed

- [x] QA'd all new/changed functionality manually