### PR TITLE
fix(software): keep automatic-install tooltip visible when disabled

### DIFF
--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -69,6 +69,15 @@ describe("SoftwareOptionsSelector", () => {
     expect(automaticInstallSwitch.disabled).toBe(true);
   });
 
+  it("shows tooltip affordance for disabled automatic install on iOS", () => {
+    renderComponent({ platform: "ios" });
+
+    const automaticInstallLabel = screen.getByText("Automatic install");
+    expect(
+      automaticInstallLabel.closest(".component__tooltip-wrapper")
+    ).toBeInTheDocument();
+  });
+
   it("enables self-service and disables automatic install sliders for iPadOS", () => {
     renderComponent({ platform: "ipados" });
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -121,13 +121,18 @@ const SoftwareOptionsSelector = ({
     isTarballPackage ||
     isScriptPackage;
 
-  /** Tooltip only shows when enabled or for exe/tar.gz/sh/ps1 packages */
-  const showAutomaticInstallTooltip =
-    !isAutomaticInstallDisabled ||
-    isExePackage ||
-    isTarballPackage ||
-    isScriptPackage;
+  /** Tooltip should also show when disabled so users can understand why. */
+  const showAutomaticInstallTooltip = true;
   const getAutomaticInstallTooltip = (): JSX.Element => {
+    if (isPlatformIosOrIpados) {
+      return (
+        <>
+          Automatic install for iOS and iPadOS is coming soon. Today, you can
+          manually install from the <b>Host details</b> page for each host.
+        </>
+      );
+    }
+
     if (isExePackage || isTarballPackage) {
       return (
         <>


### PR DESCRIPTION
**Related issue:** Resolves #41312

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation
- [ ] QA'd all new/changed functionality manually

## Summary

- Keep the **Automatic install** tooltip available even when the slider is disabled.
- Add iOS/iPadOS-specific tooltip copy so users understand why automatic install is unavailable.
- Add a unit test that verifies tooltip affordance is present for disabled automatic install on iOS.

## Validation

- Attempted: `npm test -- SoftwareOptionsSelector.tests.tsx --runInBand`
- Not runnable in this environment because `jest` is not executable/available from the repo checkout (`sh: 1: jest: Permission denied` and no local `node_modules/jest` to invoke directly).
- Added/updated test coverage in `SoftwareOptionsSelector.tests.tsx` for the tooltip affordance behavior.
