### PR TITLE
Invalidate vppSoftware and fleet-maintained-apps cache entries after adding software

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreVpp/SoftwareAppStoreVpp.tsx
@@ -186,6 +186,9 @@ const SoftwareAppStoreVpp = ({
       queryClient.invalidateQueries({
         queryKey: [{ scope: "software-titles" }],
       });
+      queryClient.invalidateQueries({
+        queryKey: ["vppSoftware", currentTeamId],
+      });
 
       router.push(
         getPathWithQueryParams(

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -1,6 +1,6 @@
 import React, { useContext, useEffect, useState } from "react";
 import { InjectedRouter } from "react-router";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 
 import PATHS from "router/paths";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
@@ -42,6 +42,7 @@ const SoftwareCustomPackage = ({
 }: ISoftwarePackageProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { isPremiumTier, config } = useContext(AppContext);
+  const queryClient = useQueryClient();
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -143,6 +144,10 @@ const SoftwareCustomPackage = ({
           </>
         );
       }
+
+      queryClient.invalidateQueries({
+        queryKey: [{ scope: "software-titles" }],
+      });
 
       const newQueryParams: QueryParams = {
         fleet_id: currentTeamId,

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -229,6 +229,9 @@ const FleetMaintainedAppDetailsPage = ({
       queryClient.invalidateQueries({
         queryKey: [{ scope: "software-titles" }],
       });
+      queryClient.invalidateQueries({
+        queryKey: [{ scope: "fleet-maintained-apps" }],
+      });
 
       router.push(
         getPathWithQueryParams(


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41290 (follow-up of https://github.com/fleetdm/fleet/pull/41331 - missed invalidating the App store and FMA lists). Also added a change to refetch all software titles after a Custom Package is added.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

(Already added as part of the first PR).

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/6b6d5410-0cd8-4c60-98e0-9b1b4a86be40


https://github.com/user-attachments/assets/815b85e7-98ac-4178-95cb-8b5f61e8edf7

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed


