### PR TITLE
Update Firefox configuration in update-firefox.yml

### DIFF
--- a/it-and-security/lib/macos/policies/update-firefox.yml
+++ b/it-and-security/lib/macos/policies/update-firefox.yml
@@ -3,6 +3,4 @@
   critical: false
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: Download the latest version from self-service or check for updates using Firefox's built-in update functionality. You can also delete Firefox if you are no longer using it.
-  install_software:
-    package_path: ../software/mozilla-firefox.yml
   platform: darwin


### PR DESCRIPTION
This pull request makes a minor update to the Firefox update policy for macOS by removing the explicit `install_software` directive. The policy now simply describes the issue and resolution steps without referencing the installation package.