### PR TITLE
Remove stale [] for link in certificate guide

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -853,8 +853,6 @@ Custom SCEP proxy:
 
 An example CAThumprint looks like this: `2133EC6A3CFB8418837BB395188D1A62CA2B96A6`
 
-Steps to get CAThumbrint from your SCEP server:
-
 1. In your browser, open the following URL to download a certificate: https://<your-scep-server-url>/scep?operation=GetCACert
 2. Run the following command to get the SHA1 Thumbprint:
     1. **Terminal (macOS)** -> `openssl x509 -inform DER -in /path/to/downloaded-cert.cer -noout -fingerprint -sha1 | sed 's/sha1 Fingerprint=//; s/://g`

--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -554,7 +554,7 @@ How does this work? Fleet installs the "Fleet" Android app on each host. Every 1
 <details>
 <summary>Windows configuration profile</summary>
 
-All options in the example profile are required. To get the [CAThumbprint of your SCEP server] follow [these steps](#how-to-get-the-cathumbprint-for-windows-scep-profiles).
+All options in the example profile are required. To get the CAThumbprint of your SCEP server follow [these steps](#how-to-get-the-cathumbprint-for-windows-scep-profiles).
 
 You can add any other options listed under Device/SCEP in the [Microsoft documentation](https://learn.microsoft.com/en-us/windows/client-management/mdm/clientcertificateinstall-csp).
 


### PR DESCRIPTION
Removed unnecessary brackets from the CAThumbprint reference.