### PR TITLE
fix(activity): show success icon when app is already installed

### DIFF
--- a/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/SoftwareIpaInstallDetailsModal/SoftwareIpaInstallDetailsModal.tsx
@@ -292,7 +292,13 @@ export const SoftwareIpaInstallDetailsModal = ({
 
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
-  const iconName = INSTALL_DETAILS_STATUS_ICONS[displayStatus];
+  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
+  const effectiveDisplayStatus =
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus)
+      ? "installed"
+      : displayStatus;
+  const iconName = INSTALL_DETAILS_STATUS_ICONS[effectiveDisplayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
   // as some cases have command results not available for pending_installs
@@ -313,8 +319,6 @@ export const SoftwareIpaInstallDetailsModal = ({
   const excludeVersions = ["pending_install", "pending"].includes(
     swInstallResult?.status || ""
   );
-
-  const hasInstalledVersions = !!hostSoftware?.installed_versions?.length;
 
   // Hide failed details if host shows installed versions (4.82 #31663)
   // Note: Currently no uninstall IPA but added for symmetry with SoftwareInstallDetailsModal

--- a/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
+++ b/frontend/components/ActivityDetails/InstallDetails/VppInstallDetailsModal/VppInstallDetailsModal.tsx
@@ -338,7 +338,15 @@ export const VppInstallDetailsModal = ({
 
   // Fallback to "installed" if no status is provided
   const displayStatus = fleetInstallStatus ?? "installed";
-  const iconName = INSTALL_DETAILS_STATUS_ICONS[displayStatus];
+  const hasInstalledVersions =
+    (vppCommandResult?.results_metadata?.software_installed as boolean) ??
+    !!hostSoftware?.installed_versions?.length;
+  const effectiveDisplayStatus =
+    hasInstalledVersions &&
+    ["failed_install", "failed_uninstall"].includes(displayStatus)
+      ? "installed"
+      : displayStatus;
+  const iconName = INSTALL_DETAILS_STATUS_ICONS[effectiveDisplayStatus];
 
   // Handles "pending" value prior to 4.57 AND never shows error state on pending_install
   // as some cases have command results not available for pending_installs
@@ -372,9 +380,7 @@ export const VppInstallDetailsModal = ({
     hostDisplayName,
     commandUpdatedAt: vppCommandResult?.updated_at || "",
     platform: hostSoftware?.app_store_app?.platform || detailsPlatform,
-    hasInstalledVersions:
-      (vppCommandResult?.results_metadata?.software_installed as boolean) ??
-      !!hostSoftware?.installed_versions?.length,
+    hasInstalledVersions,
   });
 
   const renderInventoryVersionsSection = () => {
@@ -416,10 +422,6 @@ export const VppInstallDetailsModal = ({
       </>
     );
   };
-
-  const hasInstalledVersions =
-    (vppCommandResult?.results_metadata?.software_installed as boolean) ??
-    !!hostSoftware?.installed_versions?.length;
 
   // Hide failed details if host shows installed versions (4.82 #31663)
   // NOTE: Currently no uninstall VPP but added for symmetry with SoftwareInstallDetailsModal


### PR DESCRIPTION
**Related issue:** Resolves #39983

# Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

## Summary

- normalize failed install/uninstall statuses to `installed` for icon selection when installed versions are present
- apply this status normalization in both VPP and IPA install details modals
- keep existing status copy behavior while aligning icon rendering with the installed outcome

## Validation

- Attempted: `npm test -- VppInstallDetailsModal.tests.tsx SoftwareIpaInstallDetailsModal.tests.tsx --runInBand`
- Not runnable in this checkout because the `jest` executable is unavailable (`sh: 1: jest: Permission denied`).
- Manual verification not run in this environment.
