### PR TITLE
fix(software): restore disabled auto-install tooltip for script packages

### DIFF
--- a/changes/41312-missing-auto-install-tooltip
+++ b/changes/41312-missing-auto-install-tooltip
@@ -1,0 +1,1 @@
+- Fleet UI: Restore automatic-install tooltip hover copy when the slider is disabled for script packages in Add software.

--- a/frontend/components/forms/fields/Slider/_styles.scss
+++ b/frontend/components/forms/fields/Slider/_styles.scss
@@ -26,7 +26,9 @@
     align-items: center;
     height: 24px; // Noticeable with help text below slider
     &--disabled {
-      @include disabled;
+      // Keep hover/pointer events enabled so nested tooltip triggers still work
+      // when the slider is disabled.
+      @include disabled(true);
     }
   }
 

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, fireEvent } from "@testing-library/react";
+import { screen, fireEvent, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 
 import SoftwareOptionsSelector from "./SoftwareOptionsSelector";
@@ -154,5 +154,26 @@ describe("SoftwareOptionsSelector", () => {
     renderComponent({ isEditingSoftware: true });
 
     expect(screen.queryByText("Automatic install")).not.toBeInTheDocument();
+  });
+
+  it("shows automatic install tooltip copy for disabled script packages", async () => {
+    const { user } = renderComponent({ isScriptPackage: true });
+
+    const tooltipAnchor = document.querySelector(
+      ".software-options-selector__automatic-install-slider .component__tooltip-wrapper__element"
+    ) as HTMLElement;
+
+    await user.hover(tooltipAnchor);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Fleet can't create a policy to detect existing installations of", {
+          exact: false,
+        })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("script-only packages.", { exact: false })
+      ).toBeInTheDocument();
+    });
   });
 });


### PR DESCRIPTION
**Related issue:** Resolves #41312

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

### What changed
- Keep pointer events enabled for disabled slider wrappers so tooltip triggers still fire.
- Add a unit test that verifies tooltip copy appears for disabled automatic-install on script packages.
- Add a changes entry for this UI fix.

### Validation
- Attempted: `pnpm test SoftwareOptionsSelector.tests.tsx -- --runInBand` (blocked: repo is yarn-configured)
- Attempted: `yarn test SoftwareOptionsSelector.tests.tsx --runInBand` (blocked by local Node engine mismatch: expected `^24.10.0`, current `22.22.0`)
- Because of the environment engine mismatch, tests could not be executed locally in this run.
