### PR TITLE
Recovery password: restrict manual mdm commands

### DIFF
--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -155,6 +155,9 @@ func RunServerWithMockedDS(t *testing.T, opts ...*service.TestServerOpts) (*http
 	ds.GetEnterpriseFunc = func(ctx context.Context) (*android.Enterprise, error) {
 		return nil, nil
 	}
+	ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+		return &fleet.TeamMDM{}, nil
+	}
 	var cachedDS fleet.Datastore
 	if len(opts) > 0 && opts[0].NoCacheDatastore {
 		cachedDS = ds

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1692,6 +1692,11 @@ func (svc *Service) EnqueueMDMAppleCommand(
 		return nil, ctxerr.Wrap(ctx, err, "decode base64 command")
 	}
 
+	// Validate the command before enqueueing
+	if err := svc.validateAppleMDMCommand(ctx, rawXMLCmd, hosts); err != nil {
+		return nil, err
+	}
+
 	return svc.enqueueAppleMDMCommand(ctx, rawXMLCmd, deviceIDs)
 }
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -580,6 +580,12 @@ func (svc *Service) RunMDMCommand(ctx context.Context, rawBase64Cmd string, host
 		return nil, ctxerr.Wrap(ctx, err, "decode base64 command")
 	}
 
+	if commandPlatform == "darwin" {
+		if err := svc.validateAppleMDMCommand(ctx, rawXMLCmd, hosts); err != nil {
+			return nil, err
+		}
+	}
+
 	// the rest is platform-specific (validation of command payload, enqueueing, etc.)
 	switch commandPlatform {
 	case "windows":
@@ -587,6 +593,54 @@ func (svc *Service) RunMDMCommand(ctx context.Context, rawBase64Cmd string, host
 	default:
 		return svc.enqueueAppleMDMCommand(ctx, rawXMLCmd, hostUUIDs)
 	}
+}
+
+// validateAppleMDMCommand validates an Apple MDM command before it is enqueued.
+// It checks for restrictions based on the command type and host/team configuration.
+func (svc *Service) validateAppleMDMCommand(ctx context.Context, rawXMLCmd []byte, hosts []*fleet.Host) error {
+	cmd, err := nanomdm.DecodeCommand(rawXMLCmd)
+	if err != nil {
+		// Don't return an error here - let enqueueAppleMDMCommand handle the decode error
+		// with proper error formatting
+		return nil
+	}
+
+	// Check if this is a SetRecoveryLock command and if any host's team (or the
+	// global config for hosts with no team) has recovery lock password enabled
+	// (which means Fleet manages the password).
+	if strings.TrimSpace(cmd.Command.RequestType) == "SetRecoveryLock" {
+		// Get app config once for hosts with no team
+		var appConfig *fleet.AppConfig
+		for _, h := range hosts {
+			var recoveryLockEnabled bool
+			if h.TeamID != nil {
+				teamMDMConfig, err := svc.ds.TeamMDMConfig(ctx, *h.TeamID)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "get team MDM config")
+				}
+				recoveryLockEnabled = teamMDMConfig != nil && teamMDMConfig.EnableRecoveryLockPassword
+			} else {
+				// Host has no team, check global config
+				if appConfig == nil {
+					appConfig, err = svc.ds.AppConfig(ctx)
+					if err != nil {
+						return ctxerr.Wrap(ctx, err, "get app config")
+					}
+				}
+				recoveryLockEnabled = appConfig.MDM.EnableRecoveryLockPassword.Value
+			}
+
+			if recoveryLockEnabled {
+				err := fleet.NewInvalidArgumentError(
+					"command",
+					"Could not run command. Recovery Lock password is already set for one or more hosts. To set a custom password, disable Recovery Lock passwords for those hosts' teams. To rotate the password, learn how: https://fleetdm.com/learn-more-about/recovery-lock-passwords",
+				).WithStatus(http.StatusConflict)
+				return ctxerr.Wrap(ctx, err, "SetRecoveryLock blocked by team config")
+			}
+		}
+	}
+
+	return nil
 }
 
 var appleMDMPremiumCommands = map[string]bool{

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -681,10 +681,10 @@ func TestRunMDMCommandSetRecoveryLockBlocked(t *testing.T) {
 
 	// Test cases where the command should be blocked
 	cases := []struct {
-		desc                        string
-		hosts                       []*fleet.Host
-		teamMDMConfig               map[uint]*fleet.TeamMDM
-		globalRecoveryLockEnabled   bool
+		desc                      string
+		hosts                     []*fleet.Host
+		teamMDMConfig             map[uint]*fleet.TeamMDM
+		globalRecoveryLockEnabled bool
 	}{
 		{
 			desc:  "SetRecoveryLock blocked when team has recovery lock enabled",

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"database/sql"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -641,6 +642,110 @@ func TestRunMDMCommandValidations(t *testing.T) {
 			_, err := svc.RunMDMCommand(ctx, "!@#", []string{"unused for this test"})
 			require.Error(t, err)
 			require.ErrorContains(t, err, c.wantErr)
+		})
+	}
+}
+
+func TestRunMDMCommandSetRecoveryLockBlocked(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	macosSingleHost := []*fleet.Host{{ID: 1, TeamID: ptr.Uint(1), UUID: "a", Platform: "darwin"}}
+	macosNoTeamHost := []*fleet.Host{{ID: 2, TeamID: nil, UUID: "b", Platform: "darwin"}}
+	macosTeam2Host := []*fleet.Host{{ID: 3, TeamID: ptr.Uint(2), UUID: "c", Platform: "darwin"}}
+
+	ds.AreHostsConnectedToFleetMDMFunc = func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {
+		res := make(map[string]bool, len(hosts))
+		for _, h := range hosts {
+			res[h.UUID] = true
+		}
+		return res, nil
+	}
+
+	// Create a SetRecoveryLock command payload
+	setRecoveryLockCmd := base64.RawStdEncoding.EncodeToString([]byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Command</key>
+    <dict>
+        <key>RequestType</key>
+        <string>SetRecoveryLock</string>
+        <key>NewPassword</key>
+        <string>MyCustomPassword</string>
+    </dict>
+    <key>CommandUUID</key>
+    <string>test-uuid</string>
+</dict>
+</plist>`))
+
+	// Test cases where the command should be blocked
+	cases := []struct {
+		desc                        string
+		hosts                       []*fleet.Host
+		teamMDMConfig               map[uint]*fleet.TeamMDM
+		globalRecoveryLockEnabled   bool
+	}{
+		{
+			desc:  "SetRecoveryLock blocked when team has recovery lock enabled",
+			hosts: macosSingleHost,
+			teamMDMConfig: map[uint]*fleet.TeamMDM{
+				1: {EnableRecoveryLockPassword: true},
+			},
+			globalRecoveryLockEnabled: false,
+		},
+		{
+			desc:  "SetRecoveryLock blocked when any host's team has recovery lock enabled",
+			hosts: []*fleet.Host{macosSingleHost[0], macosTeam2Host[0]},
+			teamMDMConfig: map[uint]*fleet.TeamMDM{
+				1: {EnableRecoveryLockPassword: false},
+				2: {EnableRecoveryLockPassword: true},
+			},
+			globalRecoveryLockEnabled: false,
+		},
+		{
+			desc:                      "SetRecoveryLock blocked for no-team host when global config has recovery lock enabled",
+			hosts:                     macosNoTeamHost,
+			teamMDMConfig:             map[uint]*fleet.TeamMDM{},
+			globalRecoveryLockEnabled: true,
+		},
+		{
+			desc:  "SetRecoveryLock blocked when no-team host in mixed group has global recovery lock enabled",
+			hosts: []*fleet.Host{macosSingleHost[0], macosNoTeamHost[0]},
+			teamMDMConfig: map[uint]*fleet.TeamMDM{
+				1: {EnableRecoveryLockPassword: false},
+			},
+			globalRecoveryLockEnabled: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			ds.ListHostsLiteByUUIDsFunc = func(ctx context.Context, filter fleet.TeamFilter, uuids []string) ([]*fleet.Host, error) {
+				return c.hosts, nil
+			}
+
+			ds.TeamMDMConfigFunc = func(ctx context.Context, teamID uint) (*fleet.TeamMDM, error) {
+				if cfg, ok := c.teamMDMConfig[teamID]; ok {
+					return cfg, nil
+				}
+				return &fleet.TeamMDM{}, nil
+			}
+
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						EnabledAndConfigured:       true,
+						EnableRecoveryLockPassword: optjson.SetBool(c.globalRecoveryLockEnabled),
+					},
+				}, nil
+			}
+
+			ctx = test.UserContext(ctx, test.UserAdmin)
+			_, err := svc.RunMDMCommand(ctx, setRecoveryLockCmd, []string{"unused"})
+
+			require.Error(t, err)
+			require.ErrorContains(t, err, "Could not run command. Recovery Lock password is already set for one or more hosts.")
 		})
 	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40670 

Restrict mdm run command API from running SetRecoveryLockPassword command if it's already enabled on a host's team.

- [X] Added/updated automated tests

- [X] QA'd all new/changed functionality manually