### PR TITLE
Flakey test - increase retry tolerance

### DIFF
--- a/pkg/retry/retry_test.go
+++ b/pkg/retry/retry_test.go
@@ -42,17 +42,18 @@ func TestRetryDo(t *testing.T) {
 	t.Run("with backoff", func(t *testing.T) {
 		count := 0
 		maxAttempts := 4
+		tolerance := 50 * time.Millisecond // Use a generous tolerance for CI environments where scheduling jitter can occur
 		start := time.Now()
 		err := Do(func() error {
 			switch count {
 			case 0:
-				require.WithinDuration(t, start, time.Now(), 1*time.Millisecond)
+				require.WithinDuration(t, start, time.Now(), tolerance)
 			case 1:
-				require.WithinDuration(t, start.Add(50*time.Millisecond), time.Now(), 10*time.Millisecond)
+				require.WithinDuration(t, start.Add(50*time.Millisecond), time.Now(), tolerance)
 			case 2:
-				require.WithinDuration(t, start.Add((50+100)*time.Millisecond), time.Now(), 10*time.Millisecond)
+				require.WithinDuration(t, start.Add((50+100)*time.Millisecond), time.Now(), tolerance)
 			case 3:
-				require.WithinDuration(t, start.Add((50+100+200)*time.Millisecond), time.Now(), 10*time.Millisecond)
+				require.WithinDuration(t, start.Add((50+100+200)*time.Millisecond), time.Now(), tolerance)
 			}
 			count++
 			if count != maxAttempts {


### PR DESCRIPTION
Increase tolerance for flakey test:

```
  === Failed
  === FAIL: pkg/retry TestRetryDo/with_backoff (0.36s)
  retry_test.go:55:
  Error Trace:    /home/runner/work/fleet/fleet/pkg/retry/retry_test.go:55
  /home/runner/work/fleet/fleet/pkg/retry/retry.go:91
  /home/runner/work/fleet/fleet/pkg/retry/retry_test.go:46
  Error:          Max difference between 2026-03-11 03:31:19.600298628 +0000 UTC m=+0.366404429 and 2026-03-11 03:31:19.612075587 +0000 UTC m=+0.378181379 allowed is 10ms, but difference was
  -11.77695ms
  Test:           TestRetryDo/with_backoff
  --- FAIL: TestRetryDo/with_backoff (0.36s)

  === FAIL: pkg/retry TestRetryDo (0.58s)
```

