### PR TITLE
Add fleet_id / fleet_name columns to CSV hosts export

### DIFF
--- a/changes/41074-add-fleet-columns-to-csv
+++ b/changes/41074-add-fleet-columns-to-csv
@@ -1,0 +1,1 @@
+- Added `fleet_name` and `fleet_id` columns to hosts CSV export where needed

--- a/server/fleet/hostresponse.go
+++ b/server/fleet/hostresponse.go
@@ -10,6 +10,9 @@ import (
 // rendering in the UI.
 type HostResponse struct {
 	*Host
+	// Add alias fields for team name and ID for use in CSV reports.
+	FleetID          *uint        `json:"-" csv:"fleet_id"`
+	FleetName        *string      `json:"-" csv:"fleet_name"`
 	Status           HostStatus   `json:"status" csv:"status"`
 	DisplayText      string       `json:"display_text" csv:"display_text"`
 	DisplayName      string       `json:"display_name" csv:"display_name"`

--- a/server/fleet/hostresponse.go
+++ b/server/fleet/hostresponse.go
@@ -11,6 +11,7 @@ import (
 type HostResponse struct {
 	*Host
 	// Add alias fields for team name and ID for use in CSV reports.
+	// TODO: clean up in Fleet 5.
 	FleetID          *uint        `json:"-" csv:"fleet_id"`
 	FleetName        *string      `json:"-" csv:"fleet_name"`
 	Status           HostStatus   `json:"status" csv:"status"`

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2498,6 +2498,9 @@ func (r hostsReportResponse) HijackRender(ctx context.Context, w http.ResponseWr
 				sb.WriteString(dm.Email)
 			}
 			h.CSVDeviceMapping = sb.String()
+			// Add the aliased fields for team_id and team_name.
+			h.FleetID = h.TeamID
+			h.FleetName = h.TeamName
 		}
 	}
 
@@ -2589,6 +2592,13 @@ func hostsReportEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 			cols = append(cols, rawCol)
 			if rawCol == "device_mapping" {
 				req.Opts.DeviceMapping = true
+			}
+			// If team_id / team_name are requested, also include their aliases.
+			if rawCol == "team_id" {
+				cols = append(cols, "fleet_id")
+			}
+			if rawCol == "team_name" {
+				cols = append(cols, "fleet_name")
 			}
 		}
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -2594,6 +2594,7 @@ func hostsReportEndpoint(ctx context.Context, request interface{}, svc fleet.Ser
 				req.Opts.DeviceMapping = true
 			}
 			// If team_id / team_name are requested, also include their aliases.
+			// TODO: clean up in Fleet 5.
 			if rawCol == "team_id" {
 				cols = append(cols, "fleet_id")
 			}

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -10089,7 +10089,12 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Len(t, rows, len(hosts)+1) // all hosts + header row
-	assert.Len(t, rows[0], 55)         // total number of cols
+	assert.Len(t, rows[0], 57)         // total number of cols
+	// Validate that both team_id and fleet_id columns are present.
+	assert.Contains(t, rows[0], "team_id")
+	assert.Contains(t, rows[0], "fleet_id")
+	assert.Contains(t, rows[0], "team_name")
+	assert.Contains(t, rows[0], "fleet_name")
 
 	const (
 		idCol        = 3
@@ -10114,13 +10119,17 @@ func (s *integrationTestSuite) TestHostsReportDownload() {
 	// valid format, some columns
 	res = s.DoRaw(
 		"GET", "/api/latest/fleet/hosts/report", nil, http.StatusOK, "format", "csv",
-		"columns", "hostname,gigs_disk_space_available,percent_disk_space_available,gigs_total_disk_space",
+		"columns", "hostname,gigs_disk_space_available,percent_disk_space_available,gigs_total_disk_space,team_id,team_name",
 	)
 	rows, err = csv.NewReader(res.Body).ReadAll()
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Len(t, rows, len(hosts)+1)
 	require.Contains(t, rows[0], "hostname") // first row contains headers
+	assert.Contains(t, rows[0], "team_id")
+	assert.Contains(t, rows[0], "fleet_id")
+	assert.Contains(t, rows[0], "team_name")
+	assert.Contains(t, rows[0], "fleet_name")
 	require.Contains(t, res.Header, "Content-Disposition")
 	require.Contains(t, res.Header, "Content-Type")
 	require.Contains(t, res.Header, "X-Content-Type-Options")

--- a/server/service/integration_core_test.go
+++ b/server/service/integration_core_test.go
@@ -12486,7 +12486,7 @@ func (s *integrationTestSuite) TestHostsReportWithPolicyResults() {
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Len(t, rows1, len(hosts)+1) // all hosts + header row
-	assert.Len(t, rows1[0], 55)         // total number of cols
+	assert.Len(t, rows1[0], 57)         // total number of cols
 
 	var (
 		idIdx     int
@@ -12516,7 +12516,7 @@ func (s *integrationTestSuite) TestHostsReportWithPolicyResults() {
 	res.Body.Close()
 	require.NoError(t, err)
 	require.Len(t, rows2, len(hosts)+1) // all hosts + header row
-	assert.Len(t, rows2[0], 55)         // total number of cols
+	assert.Len(t, rows2[0], 57)         // total number of cols
 
 	// Check that all hosts have 0 issues and that they match the previous call to `/hosts/report`.
 	for i := 1; i < len(hosts)+1; i++ {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41074 

# Details

Fixes an issue where CSV export still has `team_name` and `team_id` columns, but not `fleet_name` or `fleet_id`.

Unlike the API param and other renames, I took a manual approach here since it's just the two fields and isn't likely to expand.  I added cleaning them up to my Fleet 5 punchlist.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [X] QA'd all new/changed functionality manually
    - [X] exported report from UI, saw both team_name and fleet_name
    - [X] exported report via API with no columns requested (so all columns returned), saw team_id, team_name, fleet_id and fleet_name

