### PR TITLE
Fleet UI: Remove all Automatic Install slider and replace with conditionally shown Deploy slider

### DIFF
--- a/frontend/components/forms/fields/Slider/Slider.tsx
+++ b/frontend/components/forms/fields/Slider/Slider.tsx
@@ -4,12 +4,15 @@ import { pick } from "lodash";
 
 import FormField from "components/forms/FormField";
 import { IFormFieldProps } from "components/forms/FormField/FormField";
+import TooltipWrapper from "components/TooltipWrapper";
 
 interface ISliderProps {
   onChange: () => void;
   value: boolean;
   inactiveText: JSX.Element | string;
   activeText: JSX.Element | string;
+  /** Use to display slider label tooltip, compatible with disabled state */
+  labelTooltip?: JSX.Element | string;
   className?: string;
   helpText?: JSX.Element | string;
   autoFocus?: boolean;
@@ -24,6 +27,7 @@ const Slider = (props: ISliderProps): JSX.Element => {
     value,
     inactiveText,
     activeText,
+    labelTooltip,
     autoFocus,
     disabled,
   } = props;
@@ -63,6 +67,8 @@ const Slider = (props: ISliderProps): JSX.Element => {
   const wrapperClassNames = classnames(`${baseClass}__wrapper`, {
     [`${baseClass}__wrapper--disabled`]: disabled,
   });
+
+  const text = value ? activeText : inactiveText;
   return (
     <FormField {...formFieldProps} type="slider">
       <div className={wrapperClassNames}>
@@ -76,13 +82,26 @@ const Slider = (props: ISliderProps): JSX.Element => {
         >
           <div className={sliderDotClass} />
         </button>
-        <span
-          className={`${baseClass}__label ${baseClass}__label--${
-            value ? "active" : "inactive"
-          }`}
-        >
-          {value ? activeText : inactiveText}
-        </span>
+        {labelTooltip ? (
+          <TooltipWrapper tipContent={labelTooltip}>
+            {" "}
+            <span
+              className={`${baseClass}__label ${baseClass}__label--${
+                value ? "active" : "inactive"
+              }`}
+            >
+              {text}
+            </span>
+          </TooltipWrapper>
+        ) : (
+          <span
+            className={`${baseClass}__label ${baseClass}__label--${
+              value ? "active" : "inactive"
+            }`}
+          >
+            {text}
+          </span>
+        )}
       </div>
     </FormField>
   );

--- a/frontend/components/forms/fields/Slider/_styles.scss
+++ b/frontend/components/forms/fields/Slider/_styles.scss
@@ -23,10 +23,19 @@
 
   &__wrapper {
     display: flex;
+    gap: $pad-small;
     align-items: center;
     height: 24px; // Noticeable with help text below slider
+
     &--disabled {
-      @include disabled;
+      .fleet-slider {
+        @include disabled;
+      }
+
+      .fleet-slider__label {
+        @include disabled;
+        pointer-events: initial; // Allow label interaction when slider is disabled to view tooltip
+      }
     }
   }
 
@@ -49,7 +58,6 @@
     font-size: $x-small;
     font-weight: $regular;
     text-align: left;
-    margin-left: $pad-small;
   }
 
   &__help-text {

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAddPage.tsx
@@ -16,6 +16,7 @@ import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import SidePanelContent from "components/SidePanelContent";
 import QuerySidePanel from "components/side_panels/QuerySidePanel";
+import PageDescription from "components/PageDescription";
 
 import { FmaPlatformValue } from "./SoftwareFleetMaintained/FleetMaintainedAppsTable/FmaFilters/FmaFilters";
 
@@ -117,6 +118,7 @@ const SoftwareAddPage = ({
             />
           </div>
           <h1>Add software</h1>
+          <PageDescription content="Add software to your library. You can add it to self-service later." />
           <TabNav>
             <Tabs
               selectedIndex={getTabIndex(location?.pathname || "")}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
@@ -3,7 +3,3 @@
     margin-top: $pad-xxxlarge;
   }
 }
-
-.info-banner {
-  margin-bottom: $pad-xlarge;
-}

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/FleetAppDetailsForm.tsx
@@ -1,6 +1,6 @@
 /** FleetAppDetailsForm is a separate component remnant of when we had advanced options on add <4.83 */
 
-import React from "react";
+import React, { useState } from "react";
 import { SoftwareCategory } from "interfaces/software";
 
 import { getPathWithQueryParams } from "utilities/url";
@@ -10,6 +10,7 @@ import Button from "components/buttons/Button";
 import TooltipWrapper from "components/TooltipWrapper";
 import CustomLink from "components/CustomLink";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import SoftwareDeploySlider from "pages/SoftwarePage/components/forms/SoftwareDeploySelector";
 
 const baseClass = "fleet-app-details-form";
 
@@ -77,7 +78,7 @@ const FleetAppDetailsForm = ({
   onSubmit,
   softwareTitleId,
 }: IFleetAppDetailsFormProps) => {
-  const formData: IFleetMaintainedAppFormData = {
+  const [formData, setFormData] = useState<IFleetMaintainedAppFormData>({
     selfService: false,
     automaticInstall: false,
     preInstallQuery: "",
@@ -88,6 +89,13 @@ const FleetAppDetailsForm = ({
     customTarget: "labelsIncludeAny",
     labelTargets: {},
     categories: categories || [],
+  });
+
+  const onToggleDeploySoftware = () => {
+    setFormData((prevData: IFleetMaintainedAppFormData) => ({
+      ...prevData,
+      automaticInstall: !prevData.automaticInstall,
+    }));
   };
 
   const onSubmitForm = (evt: React.FormEvent<HTMLFormElement>) => {
@@ -100,6 +108,10 @@ const FleetAppDetailsForm = ({
 
   return (
     <form className={baseClass} onSubmit={onSubmitForm}>
+      <SoftwareDeploySlider
+        deploySoftware={formData.automaticInstall}
+        onToggleDeploySoftware={onToggleDeploySoftware}
+      />
       <div className={`${baseClass}__action-buttons`}>
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetAppDetailsForm/_styles.scss
@@ -62,12 +62,7 @@
     gap: $pad-small;
   }
 
-  .info-banner {
-    margin-top: $pad-small;
-  }
-
   .form-fields--disabled {
     @include disabled;
   }
-  
 }

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareFleetMaintained/FleetMaintainedAppDetailsPage/FleetMaintainedAppDetailsPage.tsx
@@ -231,10 +231,7 @@ const FleetMaintainedAppDetailsPage = ({
             className={`${baseClass}__back-to-add-software`}
           />
           <h1>{fleetApp.name}</h1>
-          <PageDescription
-            content="Add software to your library. You can deploy it and select target
-            hosts later."
-          />
+          <PageDescription content="Add software to your library. You can add it to self-service later." />
           <div className={`${baseClass}__page-content`}>
             <FleetAppSummary
               name={fleetApp.name}

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
+import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import {
   getExtensionFromFileName,
   getFileDetails,
@@ -15,7 +16,6 @@ import { ILabelSummary } from "interfaces/label";
 import { ISoftwareVersion, SoftwareCategory } from "interfaces/software";
 
 import { CustomOptionType } from "components/forms/fields/DropdownWrapper/DropdownWrapper";
-
 import Button from "components/buttons/Button";
 import TooltipWrapper from "components/TooltipWrapper";
 import FileUploader from "components/FileUploader";
@@ -28,6 +28,8 @@ import {
 } from "pages/SoftwarePage/helpers";
 import TargetLabelSelector from "components/TargetLabelSelector";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
+import InfoBanner from "components/InfoBanner";
+import CustomLink from "components/CustomLink";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
 import {
@@ -72,6 +74,24 @@ const getGraphicName = (ext: string) => {
   }
   return "file-pkg";
 };
+
+const renderSoftwareDeployWarningBanner = () => (
+  <InfoBanner
+    color="yellow"
+    className={`${baseClass}__deploy-warning`}
+    cta={
+      <CustomLink
+        url={`${LEARN_MORE_ABOUT_BASE_LINK}/query-templates-for-automatic-install-software`}
+        text="Learn more"
+        newTab
+      />
+    }
+  >
+    Installing software over existing installations might cause issues.
+    Fleet&apos;s policy may not detect these existing installations. Please
+    create a test fleet in Fleet to verify a smooth installation.
+  </InfoBanner>
+);
 
 const renderFileTypeMessage = () => {
   return (
@@ -367,8 +387,10 @@ const PackageForm = ({
     formData.software && !isScriptPackage && !isIpaPackage;
 
   const showDeploySoftwareSlider =
-    !gitOpsModeEnabled &&
-    !isEditingSoftware &&
+    !!formData.software && // show after selection
+    !gitOpsModeEnabled && // hide in gitOps mode
+    !isEditingSoftware && // show only on add, not edit
+    // automatic install is not supported for ipa packages, exe, tarball, or script packages
     !isIpaPackage &&
     !isExePackage &&
     !isTarballPackage &&
@@ -377,14 +399,13 @@ const PackageForm = ({
   // 4.83+ Show deploy slider on add if the package type supports it.
   // Hide from gitOps mode
   const renderSoftwareDeploySlider = () => (
-    <SoftwareDeploySlider
-      deploySoftware={formData.automaticInstall}
-      onToggleDeploySoftware={onToggleAutomaticInstall}
-      isExePackage={false}
-      isTarballPackage={false}
-      isScriptPackage={false}
-      disableOptions={!formData.software} // Disable until app is selected
-    />
+    <>
+      <SoftwareDeploySlider
+        deploySoftware={formData.automaticInstall}
+        onToggleDeploySoftware={onToggleAutomaticInstall}
+      />
+      {formData.automaticInstall && renderSoftwareDeployWarningBanner()}
+    </>
   );
 
   // GitOps mode hides SoftwareOptionsSelector and TargetLabelSelector
@@ -394,15 +415,9 @@ const PackageForm = ({
   const renderSoftwareOptionsSelector = () => (
     <SoftwareOptionsSelector
       formData={formData}
-      onToggleAutomaticInstall={onToggleAutomaticInstall}
       onToggleSelfService={onToggleSelfService}
       onSelectCategory={onSelectCategory}
-      isCustomPackage
       isEditingSoftware={isEditingSoftware}
-      isExePackage={isExePackage}
-      isTarballPackage={isTarballPackage}
-      isScriptPackage={isScriptPackage}
-      isIpaPackage={isIpaPackage}
       onClickPreviewEndUserExperience={() =>
         onClickPreviewEndUserExperience(isIpaPackage)
       }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -27,7 +27,6 @@ import {
   getTargetType,
 } from "pages/SoftwarePage/helpers";
 import TargetLabelSelector from "components/TargetLabelSelector";
-import Card from "components/Card";
 import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 
 import PackageAdvancedOptions from "../PackageAdvancedOptions";
@@ -37,6 +36,7 @@ import {
   sortByVersionLatestFirst,
 } from "./helpers";
 import PackageVersionSelector from "../PackageVersionSelector";
+import SoftwareDeploySlider from "../SoftwareDeploySelector";
 
 export const baseClass = "package-form";
 
@@ -366,6 +366,27 @@ const PackageForm = ({
   const showAdvancedOptions =
     formData.software && !isScriptPackage && !isIpaPackage;
 
+  const showDeploySoftwareSlider =
+    !gitOpsModeEnabled &&
+    !isEditingSoftware &&
+    !isIpaPackage &&
+    !isExePackage &&
+    !isTarballPackage &&
+    !isScriptPackage;
+
+  // 4.83+ Show deploy slider on add if the package type supports it.
+  // Hide from gitOps mode
+  const renderSoftwareDeploySlider = () => (
+    <SoftwareDeploySlider
+      deploySoftware={formData.automaticInstall}
+      onToggleDeploySoftware={onToggleAutomaticInstall}
+      isExePackage={false}
+      isTarballPackage={false}
+      isScriptPackage={false}
+      disableOptions={!formData.software} // Disable until app is selected
+    />
+  );
+
   // GitOps mode hides SoftwareOptionsSelector and TargetLabelSelector
   // 4.83 Removed option/targets from Add page
   const showOptionsTargetsSelectors = !gitOpsModeEnabled && isEditingSoftware;
@@ -462,6 +483,7 @@ const PackageForm = ({
               : "form"
           }
         >
+          {showDeploySoftwareSlider && renderSoftwareDeploySlider()}
           {showOptionsTargetsSelectors && (
             <div className={`${baseClass}__form-frame`}>
               {renderSoftwareOptionsSelector()}

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/_styles.scss
@@ -1,6 +1,12 @@
 .package-form {
   container-type: inline-size;
 
+  // TODO: Refactor InfoBanner to not have default margin so we don't have to override it
+  // Flex gaps should be handling spacing around all InfoBanner
+  .info-banner {
+    margin: 0;
+  }
+
   &__form-frame {
     display: flex;
     align-items: flex-start;
@@ -57,10 +63,6 @@
 
   &__file-uploader {
     box-sizing: border-box;
-  }
-
-  .info-banner {
-    margin-top: $pad-small;
   }
 
   &__form-fields {

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
@@ -9,10 +9,8 @@ import { IInputFieldParseTarget } from "interfaces/form_field";
 
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import Card from "components/Card";
 import CustomLink from "components/CustomLink";
 import Button from "components/buttons/Button";
-import SoftwareOptionsSelector from "pages/SoftwarePage/components/forms/SoftwareOptionsSelector";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 
 import {
@@ -96,47 +94,6 @@ const SoftwareAndroidForm = ({
     const newFormData = { ...formData, [name]: value };
     setFormData(newFormData);
     setFormValidation(generateFormValidation(newFormData));
-  };
-
-  const onToggleSelfService = () => {
-    const newData = { ...formData, selfService: !formData.selfService };
-    setFormData(newData);
-  };
-
-  const onSelectCategory = ({
-    name,
-    value,
-  }: {
-    name: string;
-    value: boolean;
-  }) => {
-    let newCategories: string[];
-
-    if (value) {
-      // Add the name if not already present
-      newCategories = formData.categories.includes(name)
-        ? formData.categories
-        : [...formData.categories, name];
-    } else {
-      // Remove the name if present
-      newCategories = formData.categories.filter((cat) => cat !== name);
-    }
-
-    const newData = {
-      ...formData,
-      categories: newCategories,
-    };
-
-    setFormData(newData);
-    setFormValidation(generateFormValidation(newData));
-  };
-
-  const onToggleAutomaticInstall = () => {
-    const newData = {
-      ...formData,
-      automaticInstall: !formData.automaticInstall,
-    };
-    setFormData(newData);
   };
 
   const isSubmitDisabled = !formValidation.isValid;

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tests.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import { screen, fireEvent } from "@testing-library/react";
+import { createCustomRenderer } from "test/test-utils";
+
+import SoftwareDeploySlider from "./SoftwareDeploySlider";
+
+const defaultProps = {
+  deploySoftware: false,
+  onToggleDeploySoftware: jest.fn(),
+};
+
+const getSwitchByLabelText = (text: string) => {
+  const label = screen.getByText(text);
+  const wrapper = label.closest(".fleet-slider__wrapper");
+  if (!wrapper) throw new Error(`Wrapper not found for "${text}"`);
+  const btn = wrapper.querySelector('button[role="switch"]');
+  if (!btn) throw new Error(`Switch button not found for "${text}"`);
+  return btn as HTMLButtonElement;
+};
+
+describe("SoftwareOptionsSelector", () => {
+  const renderComponent = (props = {}) => {
+    return createCustomRenderer({ context: {} })(
+      <SoftwareDeploySlider {...defaultProps} {...props} />
+    );
+  };
+
+  it("calls onToggleDeploySoftware when the deploy software slider is toggled", () => {
+    const onToggleDeploySoftware = jest.fn();
+    renderComponent({ onToggleDeploySoftware });
+
+    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
+    fireEvent.click(deploySoftwareSwitch);
+
+    expect(onToggleDeploySoftware).toHaveBeenCalledTimes(1);
+    expect(onToggleDeploySoftware).toHaveBeenCalledWith();
+  });
+
+  it("disables deploy software slider for iOS", () => {
+    renderComponent({ platform: "ios" });
+
+    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
+
+    expect(deploySoftwareSwitch.disabled).toBe(true);
+  });
+
+  it("disables deploy software slider for iPadOS", () => {
+    renderComponent({ platform: "ipados" });
+
+    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
+
+    expect(deploySoftwareSwitch.disabled).toBe(true);
+  });
+
+  it("disables slider when disableOptions is true", () => {
+    renderComponent({ disableOptions: true });
+
+    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
+
+    expect(deploySoftwareSwitch.disabled).toBe(true);
+  });
+
+  it("renders the InfoBanner when deploySoftware is true and isCustomPackage is true", () => {
+    renderComponent({
+      formData: { deploySoftware: true },
+      isCustomPackage: true,
+    });
+
+    expect(
+      screen.getByText(
+        /Installing software over existing installations might cause issues/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does not render the InfoBanner when deploySoftware is false", () => {
+    renderComponent({
+      formData: { deploySoftware: false },
+      isCustomPackage: true,
+    });
+
+    expect(
+      screen.queryByText(
+        /Installing software over existing installations might cause issues/i
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not render the InfoBanner when isCustomPackage is false", () => {
+    renderComponent({
+      formData: { deploySoftware: true },
+      isCustomPackage: false,
+    });
+
+    expect(
+      screen.queryByText(
+        /Installing software over existing installations might cause issues/i
+      )
+    ).not.toBeInTheDocument();
+  });
+
+  it("displays platform-specific message for iOS", () => {
+    renderComponent({ platform: "ios" });
+
+    expect(
+      screen.getByText(/Deploy software for iOS and iPadOS is coming soon./i)
+    ).toBeInTheDocument();
+  });
+
+  it("displays platform-specific message for iPadOS", () => {
+    renderComponent({ platform: "ipados" });
+
+    expect(
+      screen.getByText(/Deploy software for iOS and iPadOS is coming soon./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tests.tsx
@@ -1,7 +1,5 @@
 import React from "react";
-import { screen, fireEvent } from "@testing-library/react";
-import { createCustomRenderer } from "test/test-utils";
-
+import { render, screen, fireEvent } from "@testing-library/react";
 import SoftwareDeploySlider from "./SoftwareDeploySlider";
 
 const defaultProps = {
@@ -19,99 +17,19 @@ const getSwitchByLabelText = (text: string) => {
 };
 
 describe("SoftwareOptionsSelector", () => {
-  const renderComponent = (props = {}) => {
-    return createCustomRenderer({ context: {} })(
-      <SoftwareDeploySlider {...defaultProps} {...props} />
-    );
-  };
-
   it("calls onToggleDeploySoftware when the deploy software slider is toggled", () => {
     const onToggleDeploySoftware = jest.fn();
-    renderComponent({ onToggleDeploySoftware });
+    render(
+      <SoftwareDeploySlider
+        {...defaultProps}
+        onToggleDeploySoftware={onToggleDeploySoftware}
+      />
+    );
 
     const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
     fireEvent.click(deploySoftwareSwitch);
 
     expect(onToggleDeploySoftware).toHaveBeenCalledTimes(1);
     expect(onToggleDeploySoftware).toHaveBeenCalledWith();
-  });
-
-  it("disables deploy software slider for iOS", () => {
-    renderComponent({ platform: "ios" });
-
-    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
-
-    expect(deploySoftwareSwitch.disabled).toBe(true);
-  });
-
-  it("disables deploy software slider for iPadOS", () => {
-    renderComponent({ platform: "ipados" });
-
-    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
-
-    expect(deploySoftwareSwitch.disabled).toBe(true);
-  });
-
-  it("disables slider when disableOptions is true", () => {
-    renderComponent({ disableOptions: true });
-
-    const deploySoftwareSwitch = getSwitchByLabelText("Deploy");
-
-    expect(deploySoftwareSwitch.disabled).toBe(true);
-  });
-
-  it("renders the InfoBanner when deploySoftware is true and isCustomPackage is true", () => {
-    renderComponent({
-      formData: { deploySoftware: true },
-      isCustomPackage: true,
-    });
-
-    expect(
-      screen.getByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).toBeInTheDocument();
-  });
-
-  it("does not render the InfoBanner when deploySoftware is false", () => {
-    renderComponent({
-      formData: { deploySoftware: false },
-      isCustomPackage: true,
-    });
-
-    expect(
-      screen.queryByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("does not render the InfoBanner when isCustomPackage is false", () => {
-    renderComponent({
-      formData: { deploySoftware: true },
-      isCustomPackage: false,
-    });
-
-    expect(
-      screen.queryByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("displays platform-specific message for iOS", () => {
-    renderComponent({ platform: "ios" });
-
-    expect(
-      screen.getByText(/Deploy software for iOS and iPadOS is coming soon./i)
-    ).toBeInTheDocument();
-  });
-
-  it("displays platform-specific message for iPadOS", () => {
-    renderComponent({ platform: "ipados" });
-
-    expect(
-      screen.getByText(/Deploy software for iOS and iPadOS is coming soon./i)
-    ).toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tsx
@@ -1,91 +1,34 @@
 import React from "react";
 import classnames from "classnames";
 import Slider from "components/forms/fields/Slider";
-import { isIPadOrIPhone } from "interfaces/platform";
 
 const baseClass = "software-deploy-slider";
+
+const LABEL_TOOLTIP =
+  "Automatically install only on hosts missing this software.";
 
 interface ISoftwareDeploySliderProps {
   deploySoftware: boolean;
   onToggleDeploySoftware: () => void;
-  platform?: string;
-  isExePackage?: boolean;
-  isTarballPackage?: boolean;
-  isScriptPackage?: boolean;
-  disableOptions?: boolean;
   className?: string;
 }
 
 const SoftwareDeploySlider = ({
   deploySoftware,
   onToggleDeploySoftware,
-  platform,
-  isExePackage,
-  isTarballPackage,
-  isScriptPackage,
-  disableOptions = false,
   className,
 }: ISoftwareDeploySliderProps) => {
-  // This should never happen with platform gate in parent component
-  const isPlatformIosOrIpados = isIPadOrIPhone(platform || "") || false;
-
-  const isDeploySoftwareDisabled =
-    disableOptions ||
-    isPlatformIosOrIpados ||
-    isExePackage ||
-    isTarballPackage ||
-    isScriptPackage;
-
-  /** Tooltip only shows when enabled or for exe/tar.gz/sh/ps1 packages */
-  const showDeploySoftwareTooltip =
-    !isDeploySoftwareDisabled ||
-    isExePackage ||
-    isTarballPackage ||
-    isScriptPackage;
-
-  const getDeploySoftwareLabelTooltip = (): JSX.Element => {
-    if (isExePackage || isTarballPackage) {
-      return (
-        <>
-          Fleet can&apos;t create a policy to detect existing installations for{" "}
-          {isExePackage ? ".exe packages" : ".tar.gz archives"}. To
-          automatically install{" "}
-          {isExePackage ? ".exe packages" : ".tar.gz archives"}, add a custom
-          policy and enable the install software automation on the{" "}
-          <b>Policies</b> page.
-        </>
-      );
-    }
-
-    if (isScriptPackage) {
-      return (
-        <>
-          Fleet can&apos;t create a policy to detect existing installations of
-          script-only packages. To automatically install these packages, add a
-          custom policy and enable the install software automation on the{" "}
-          <b>Policies</b> page.
-        </>
-      );
-    }
-    return <>Automatically install only on hosts missing this software.</>;
-  };
-
-  const deploySoftwareLabelTooltip = showDeploySoftwareTooltip
-    ? getDeploySoftwareLabelTooltip()
-    : undefined;
+  const sliderClassNames = classnames(`${baseClass}__container`, className);
 
   return (
-    <div
-      className={classnames(`${baseClass}__deploy-slider-container`, className)}
-    >
+    <div className={sliderClassNames}>
       <Slider
         value={deploySoftware}
         onChange={onToggleDeploySoftware}
         activeText="Deploy"
         inactiveText="Deploy"
         className={`${baseClass}__deploy-slider`}
-        labelTooltip={deploySoftwareLabelTooltip}
-        disabled={isDeploySoftwareDisabled}
+        labelTooltip={LABEL_TOOLTIP}
       />
     </div>
   );

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/SoftwareDeploySlider.tsx
@@ -1,0 +1,94 @@
+import React from "react";
+import classnames from "classnames";
+import Slider from "components/forms/fields/Slider";
+import { isIPadOrIPhone } from "interfaces/platform";
+
+const baseClass = "software-deploy-slider";
+
+interface ISoftwareDeploySliderProps {
+  deploySoftware: boolean;
+  onToggleDeploySoftware: () => void;
+  platform?: string;
+  isExePackage?: boolean;
+  isTarballPackage?: boolean;
+  isScriptPackage?: boolean;
+  disableOptions?: boolean;
+  className?: string;
+}
+
+const SoftwareDeploySlider = ({
+  deploySoftware,
+  onToggleDeploySoftware,
+  platform,
+  isExePackage,
+  isTarballPackage,
+  isScriptPackage,
+  disableOptions = false,
+  className,
+}: ISoftwareDeploySliderProps) => {
+  // This should never happen with platform gate in parent component
+  const isPlatformIosOrIpados = isIPadOrIPhone(platform || "") || false;
+
+  const isDeploySoftwareDisabled =
+    disableOptions ||
+    isPlatformIosOrIpados ||
+    isExePackage ||
+    isTarballPackage ||
+    isScriptPackage;
+
+  /** Tooltip only shows when enabled or for exe/tar.gz/sh/ps1 packages */
+  const showDeploySoftwareTooltip =
+    !isDeploySoftwareDisabled ||
+    isExePackage ||
+    isTarballPackage ||
+    isScriptPackage;
+
+  const getDeploySoftwareLabelTooltip = (): JSX.Element => {
+    if (isExePackage || isTarballPackage) {
+      return (
+        <>
+          Fleet can&apos;t create a policy to detect existing installations for{" "}
+          {isExePackage ? ".exe packages" : ".tar.gz archives"}. To
+          automatically install{" "}
+          {isExePackage ? ".exe packages" : ".tar.gz archives"}, add a custom
+          policy and enable the install software automation on the{" "}
+          <b>Policies</b> page.
+        </>
+      );
+    }
+
+    if (isScriptPackage) {
+      return (
+        <>
+          Fleet can&apos;t create a policy to detect existing installations of
+          script-only packages. To automatically install these packages, add a
+          custom policy and enable the install software automation on the{" "}
+          <b>Policies</b> page.
+        </>
+      );
+    }
+    return <>Automatically install only on hosts missing this software.</>;
+  };
+
+  const deploySoftwareLabelTooltip = showDeploySoftwareTooltip
+    ? getDeploySoftwareLabelTooltip()
+    : undefined;
+
+  return (
+    <div
+      className={classnames(`${baseClass}__deploy-slider-container`, className)}
+    >
+      <Slider
+        value={deploySoftware}
+        onChange={onToggleDeploySoftware}
+        activeText="Deploy"
+        inactiveText="Deploy"
+        className={`${baseClass}__deploy-slider`}
+        labelTooltip={deploySoftwareLabelTooltip}
+        disabled={isDeploySoftwareDisabled}
+      />
+    </div>
+  );
+};
+
+export default SoftwareDeploySlider;

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/_styles.scss
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/_styles.scss
@@ -1,0 +1,2 @@
+.software-deploy-slider {
+}

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareDeploySelector/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SoftwareDeploySlider";

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tests.tsx
@@ -48,111 +48,25 @@ describe("SoftwareOptionsSelector", () => {
     expect(onToggleSelfService).toHaveBeenCalledWith();
   });
 
-  it("calls onToggleAutomaticInstall when the automatic install slider is toggled", () => {
-    const onToggleAutomaticInstall = jest.fn();
-    renderComponent({ onToggleAutomaticInstall });
-
-    const automaticInstallSwitch = getSwitchByLabelText("Automatic install");
-    fireEvent.click(automaticInstallSwitch);
-
-    expect(onToggleAutomaticInstall).toHaveBeenCalledTimes(1);
-    expect(onToggleAutomaticInstall).toHaveBeenCalledWith();
-  });
-
-  it("enables self-service and disables automatic install sliders for iOS", () => {
+  it("enables self-service sliders for iOS", () => {
     renderComponent({ platform: "ios" });
 
     const selfServiceSwitch = getSwitchByLabelText("Self-service");
-    const automaticInstallSwitch = getSwitchByLabelText("Automatic install");
-
     expect(selfServiceSwitch.disabled).toBe(false);
-    expect(automaticInstallSwitch.disabled).toBe(true);
   });
 
-  it("enables self-service and disables automatic install sliders for iPadOS", () => {
+  it("enables self-service  for iPadOS", () => {
     renderComponent({ platform: "ipados" });
 
     const selfServiceSwitch = getSwitchByLabelText("Self-service");
-    const automaticInstallSwitch = getSwitchByLabelText("Automatic install");
-
     expect(selfServiceSwitch.disabled).toBe(false);
-    expect(automaticInstallSwitch.disabled).toBe(true);
   });
 
-  it("disables sliders when disableOptions is true", () => {
+  it("disables self-service when disableOptions is true", () => {
     renderComponent({ disableOptions: true });
 
     const selfServiceSwitch = getSwitchByLabelText("Self-service");
-    const automaticInstallSwitch = getSwitchByLabelText("Automatic install");
 
     expect(selfServiceSwitch.disabled).toBe(true);
-    expect(automaticInstallSwitch.disabled).toBe(true);
-  });
-
-  it("renders the InfoBanner when automaticInstall is true and isCustomPackage is true", () => {
-    renderComponent({
-      formData: { ...defaultProps.formData, automaticInstall: true },
-      isCustomPackage: true,
-    });
-
-    expect(
-      screen.getByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).toBeInTheDocument();
-  });
-
-  it("does not render the InfoBanner when automaticInstall is false", () => {
-    renderComponent({
-      formData: { ...defaultProps.formData, automaticInstall: false },
-      isCustomPackage: true,
-    });
-
-    expect(
-      screen.queryByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("does not render the InfoBanner when isCustomPackage is false", () => {
-    renderComponent({
-      formData: { ...defaultProps.formData, automaticInstall: true },
-      isCustomPackage: false,
-    });
-
-    expect(
-      screen.queryByText(
-        /Installing software over existing installations might cause issues/i
-      )
-    ).not.toBeInTheDocument();
-  });
-
-  it("does not render automatic install slider when isEditingSoftware is true", () => {
-    renderComponent({ isEditingSoftware: true });
-
-    expect(screen.queryByText("Automatic install")).not.toBeInTheDocument();
-  });
-
-  it("displays platform-specific message for iOS", () => {
-    renderComponent({ platform: "ios" });
-
-    expect(
-      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
-    ).toBeInTheDocument();
-  });
-
-  it("displays platform-specific message for iPadOS", () => {
-    renderComponent({ platform: "ipados" });
-
-    expect(
-      screen.getByText(/Automatic install for iOS and iPadOS is coming soon./i)
-    ).toBeInTheDocument();
-  });
-
-  it("does not render automatic install slider in edit mode", () => {
-    renderComponent({ isEditingSoftware: true });
-
-    expect(screen.queryByText("Automatic install")).not.toBeInTheDocument();
   });
 });

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -184,30 +184,13 @@ const SoftwareOptionsSelector = ({
     ) : null;
   };
 
-  const selfServiceLabel = () => {
-    return !isSelfServiceDisabled ? (
-      <TooltipWrapper
-        tipContent={getSelfServiceTooltip(
-          isPlatformIosOrIpados,
-          isPlatformAndroid
-        )}
-      >
-        <span>Self-service</span>
-      </TooltipWrapper>
-    ) : (
-      "Self-service"
-    );
-  };
+  const selfServiceLabelTooltip = !isSelfServiceDisabled
+    ? getSelfServiceTooltip(isPlatformIosOrIpados, isPlatformAndroid)
+    : undefined;
 
-  const automaticInstallLabel = () => {
-    return showAutomaticInstallTooltip ? (
-      <TooltipWrapper tipContent={getAutomaticInstallTooltip()}>
-        <span>Automatic install</span>
-      </TooltipWrapper>
-    ) : (
-      "Automatic install"
-    );
-  };
+  const automaticInstallLabelTooltip = showAutomaticInstallTooltip
+    ? getAutomaticInstallTooltip()
+    : undefined;
 
   return (
     <div className={`form-field ${classNames}`}>
@@ -217,8 +200,9 @@ const SoftwareOptionsSelector = ({
         <Slider
           value={formData.selfService}
           onChange={onToggleSelfService}
-          inactiveText={selfServiceLabel()}
-          activeText={selfServiceLabel()}
+          inactiveText="Self-service"
+          activeText="Self-service"
+          labelTooltip={selfServiceLabelTooltip}
           className={`${baseClass}__self-service-slider`}
           disabled={isSelfServiceDisabled}
         />
@@ -235,9 +219,10 @@ const SoftwareOptionsSelector = ({
         <Slider
           value={formData.automaticInstall}
           onChange={onToggleAutomaticInstall}
-          activeText={automaticInstallLabel()}
-          inactiveText={automaticInstallLabel()}
+          activeText="Automatic install"
+          inactiveText="Automatic install"
           className={`${baseClass}__automatic-install-slider`}
+          labelTooltip={automaticInstallLabelTooltip}
           disabled={isAutomaticInstallDisabled}
         />
       )}

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareOptionsSelector/SoftwareOptionsSelector.tsx
@@ -3,9 +3,7 @@ import classnames from "classnames";
 
 import Checkbox from "components/forms/fields/Checkbox";
 import Slider from "components/forms/fields/Slider";
-import InfoBanner from "components/InfoBanner";
 import CustomLink from "components/CustomLink";
-import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
 import paths from "router/paths";
 import { getSelfServiceTooltip } from "pages/SoftwarePage/helpers";
@@ -19,7 +17,6 @@ import {
 } from "pages/hosts/details/cards/Software/SelfService/helpers";
 import Button from "components/buttons/Button";
 import { isAndroid, isIPadOrIPhone } from "interfaces/platform";
-import TooltipWrapper from "components/TooltipWrapper";
 
 const baseClass = "software-options-selector";
 
@@ -84,39 +81,24 @@ interface ISoftwareOptionsSelector {
     | ISoftwareVppFormData
     | IPackageFormData
     | ISoftwareAndroidFormData;
-  /** Only used in create mode not edit mode for FMA, VPP, and custom packages */
-  onToggleAutomaticInstall: () => void;
   onToggleSelfService: () => void;
   onClickPreviewEndUserExperience: () => void;
   onSelectCategory: ({ name, value }: { name: string; value: boolean }) => void;
   platform?: string;
   className?: string;
-  isCustomPackage?: boolean;
-  /** Exe packages do not have ability to select automatic install */
-  isExePackage?: boolean;
-  /** Tarball packages do not have ability to select automatic install */
-  isTarballPackage?: boolean;
-  /** Script only packages do not have ability to select automatic install */
-  isScriptPackage?: boolean;
-  /** IPA packages do not have ability to select automatic install or self-service */
+  /** IPA packages do not have ability to select self-service */
   isIpaPackage?: boolean;
-  /** Edit mode does not have ability to change automatic install */
   isEditingSoftware?: boolean;
   disableOptions?: boolean;
 }
 
 const SoftwareOptionsSelector = ({
   formData,
-  onToggleAutomaticInstall,
   onToggleSelfService,
   onClickPreviewEndUserExperience,
   onSelectCategory,
   platform,
   className,
-  isCustomPackage,
-  isExePackage,
-  isTarballPackage,
-  isScriptPackage,
   isIpaPackage,
   isEditingSoftware,
   disableOptions = false,
@@ -127,69 +109,15 @@ const SoftwareOptionsSelector = ({
     isIPadOrIPhone(platform || "") || isIpaPackage || false;
   const isPlatformAndroid = isAndroid(platform || "");
   const isSelfServiceDisabled = disableOptions;
-  const isAutomaticInstallDisabled =
-    disableOptions ||
-    isPlatformIosOrIpados ||
-    isExePackage ||
-    isTarballPackage ||
-    isScriptPackage;
-
-  /** Tooltip only shows when enabled or for exe/tar.gz/sh/ps1 packages */
-  const showAutomaticInstallTooltip =
-    !isAutomaticInstallDisabled ||
-    isExePackage ||
-    isTarballPackage ||
-    isScriptPackage;
-  const getAutomaticInstallTooltip = (): JSX.Element => {
-    if (isExePackage || isTarballPackage) {
-      return (
-        <>
-          Fleet can&apos;t create a policy to detect existing installations for{" "}
-          {isExePackage ? ".exe packages" : ".tar.gz archives"}. To
-          automatically install{" "}
-          {isExePackage ? ".exe packages" : ".tar.gz archives"}, add a custom
-          policy and enable the install software automation on the{" "}
-          <b>Policies</b> page.
-        </>
-      );
-    }
-
-    if (isScriptPackage) {
-      return (
-        <>
-          Fleet can&apos;t create a policy to detect existing installations of
-          script-only packages. To automatically install these packages, add a
-          custom policy and enable the install software automation on the{" "}
-          <b>Policies</b> page.
-        </>
-      );
-    }
-    return <>Automatically install only on hosts missing this software.</>;
-  };
 
   // Ability to set categories when adding software is in a future ticket #28061
   const canSelectSoftwareCategories = formData.selfService && isEditingSoftware;
 
-  const renderOptionsDescription = () => {
-    if (isPlatformAndroid) {
-      return <AndroidOptionsDescription />;
-    }
-    // Render unavailable description for iOS or iPadOS add software form only
-    return isPlatformIosOrIpados && !isEditingSoftware ? (
-      <p>
-        Automatic install for iOS and iPadOS is coming soon. Today, you can
-        manually install it from the <strong>Host details</strong> page for each
-        host.
-      </p>
-    ) : null;
-  };
+  const renderOptionsDescription = () =>
+    isPlatformAndroid ? <AndroidOptionsDescription /> : null;
 
   const selfServiceLabelTooltip = !isSelfServiceDisabled
     ? getSelfServiceTooltip(isPlatformIosOrIpados, isPlatformAndroid)
-    : undefined;
-
-  const automaticInstallLabelTooltip = showAutomaticInstallTooltip
-    ? getAutomaticInstallTooltip()
     : undefined;
 
   return (
@@ -215,30 +143,6 @@ const SoftwareOptionsSelector = ({
           />
         )}
       </div>
-      {!isEditingSoftware && (
-        <Slider
-          value={formData.automaticInstall}
-          onChange={onToggleAutomaticInstall}
-          activeText="Automatic install"
-          inactiveText="Automatic install"
-          className={`${baseClass}__automatic-install-slider`}
-          labelTooltip={automaticInstallLabelTooltip}
-          disabled={isAutomaticInstallDisabled}
-        />
-      )}
-      {formData.automaticInstall && isCustomPackage && (
-        <InfoBanner color="yellow">
-          Installing software over existing installations might cause issues.
-          Fleet&apos;s policy may not detect these existing installations.
-          Please create a test fleet in Fleet to verify a smooth installation.{" "}
-          <CustomLink
-            url={`${LEARN_MORE_ABOUT_BASE_LINK}/query-templates-for-automatic-software-install`}
-            text="Learn more"
-            newTab
-            variant="banner-link"
-          />
-        </InfoBanner>
-      )}
     </div>
   );
 };

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
@@ -26,6 +26,7 @@ import {
 } from "pages/SoftwarePage/helpers";
 
 import { generateFormValidation, getUniqueAppId } from "./helpers";
+import SoftwareDeploySlider from "../SoftwareDeploySelector";
 
 const baseClass = "software-vpp-form";
 
@@ -296,6 +297,12 @@ const SoftwareVppForm = ({
       );
     }
 
+    // Hides deploy slider until app is selected
+    // Hides deploy slider for iOS/iPadOS apps
+    const showDeploySoftwareSlider =
+      !!formData.selectedApp &&
+      !isIpadOrIphoneSoftware(formData.selectedApp.platform);
+
     // Add VPP form
     // 4.83+ has no additional options to select beyond the app
     if (vppApps) {
@@ -311,6 +318,16 @@ const SoftwareVppForm = ({
             apps, head to{" "}
             <CustomLink url="https://business.apple.com" text="ABM" newTab />
           </div>
+          {showDeploySoftwareSlider && (
+            <SoftwareDeploySlider
+              deploySoftware={formData.automaticInstall}
+              onToggleDeploySoftware={onToggleAutomaticInstall}
+              platform={formData.selectedApp?.platform}
+              isExePackage={false}
+              isTarballPackage={false}
+              isScriptPackage={false}
+            />
+          )}
         </div>
       );
     }

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareVppForm/SoftwareVppForm.tsx
@@ -265,7 +265,6 @@ const SoftwareVppForm = ({
             <SoftwareOptionsSelector
               platform={softwareVppForEdit.platform}
               formData={formData}
-              onToggleAutomaticInstall={onToggleAutomaticInstall}
               onToggleSelfService={onToggleSelfService}
               onSelectCategory={onSelectCategory}
               isEditingSoftware
@@ -322,10 +321,6 @@ const SoftwareVppForm = ({
             <SoftwareDeploySlider
               deploySoftware={formData.automaticInstall}
               onToggleDeploySoftware={onToggleAutomaticInstall}
-              platform={formData.selectedApp?.platform}
-              isExePackage={false}
-              isTarballPackage={false}
-              isScriptPackage={false}
             />
           )}
         </div>


### PR DESCRIPTION
## Issue
Parent #31914 
Mid-sprint revamp of...
Closes #40402 

## Description
- Deploy slider replaces all software options on add
- Deploy slider is not shown in a variety of cases (instead of a disabled with tooltip as it was before)

> Note: Updates to Slider.tsx was merged into 4.82 RC, this includes a cherry pick of that as it's first commit https://github.com/fleetdm/fleet/pull/41448/changes/9e3e28054506dad4b7610343e4299b9634b7c6d7

## Screenrecording and screenshots
https://fleetdm.zoom.us/clips/share/YCkSX13bT5mVBSE-EaZZjA

- Added page description after the screenrecording
<img width="980" height="726" alt="Screenshot 2026-03-11 at 11 08 36 AM" src="https://github.com/user-attachments/assets/de16357a-f387-4ef6-8050-803682b5248e" />
<img width="884" height="460" alt="Screenshot 2026-03-11 at 11 08 11 AM" src="https://github.com/user-attachments/assets/bfb520b4-cff1-4caf-8f4f-df6a84f77541" />


## Testing

- [x] Added/updated automated tests
> Note: there's NO integration tests around any of the Add software flows, ask QA wolf to E2E test all this
- [x] QA'd all new/changed functionality manually
