### PR TITLE
Fixed Microsoft NDES CA not being selectable

### DIFF
--- a/changes/38585-ndes-selection
+++ b/changes/38585-ndes-selection
@@ -1,0 +1,1 @@
+* Fixed Microsoft NDES CA not being selectable after deleting an existing NDES CA without a page refresh.

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/AddCertAuthorityModal/helpers.tsx
@@ -47,21 +47,16 @@ const DEFAULT_CERT_AUTHORITY_OPTIONS: IDropdownOption[] = [
  * if one already exists
  */
 export const generateDropdownOptions = (hasNDESCert: boolean) => {
-  if (!hasNDESCert) {
-    return DEFAULT_CERT_AUTHORITY_OPTIONS;
-  }
-
-  // We only allow one NDES configuration, if ones exists disable the option and
-  // add a tooltip.
-  const ndesOption = DEFAULT_CERT_AUTHORITY_OPTIONS.find((option) => {
-    return option.value === "ndes_scep_proxy";
+  return DEFAULT_CERT_AUTHORITY_OPTIONS.map((option) => {
+    if (option.value === "ndes_scep_proxy" && hasNDESCert) {
+      return {
+        ...option,
+        disabled: true,
+        tooltipContent: "Only one NDES can be added.",
+      };
+    }
+    return option;
   });
-  if (ndesOption) {
-    ndesOption.disabled = true;
-    ndesOption.tooltipContent = "Only one NDES can be added.";
-  }
-
-  return DEFAULT_CERT_AUTHORITY_OPTIONS;
 };
 
 /**


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38585

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Microsoft NDES CA selection to work immediately after deleting an existing NDES CA without requiring a page refresh.
  * Added validation preventing multiple NDES CAs from being added, with a tooltip message explaining the limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->