### PR TITLE
Update API calls in front-end to use new, non-deprecated URLs and params

### DIFF
--- a/frontend/components/LiveQuery/SelectTargets.tests.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tests.tsx
@@ -23,7 +23,7 @@ const labelSummariesHandler = http.get(baseUrl("/labels/summary"), () => {
   return HttpResponse.json({ labels: MOCK_LABELS });
 });
 
-const teamsHandler = http.get(baseUrl("/teams"), () => {
+const teamsHandler = http.get(baseUrl("/fleets"), () => {
   return HttpResponse.json({ teams: MOCK_TEAMS });
 });
 

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -223,7 +223,10 @@ const SelectTargets = ({
     ],
     ({ queryKey }) => {
       const { query_id, selected } = queryKey[0];
-      return targetsAPI.count({ report_id: query_id, selected: selected || null });
+      return targetsAPI.count({
+        report_id: query_id,
+        selected: selected || null,
+      });
     },
     {
       enabled: !!selectedTargets.length,

--- a/frontend/components/LiveQuery/SelectTargets.tsx
+++ b/frontend/components/LiveQuery/SelectTargets.tsx
@@ -192,7 +192,7 @@ const SelectTargets = ({
     ({ queryKey }) => {
       const { query_id, query, selected } = queryKey[0];
       return targetsAPI.search({
-        query_id: query_id || null,
+        report_id: query_id || null,
         query: query || "",
         excluded_host_ids: selected?.hosts || null,
       });
@@ -223,7 +223,7 @@ const SelectTargets = ({
     ],
     ({ queryKey }) => {
       const { query_id, selected } = queryKey[0];
-      return targetsAPI.count({ query_id, selected: selected || null });
+      return targetsAPI.count({ report_id: query_id, selected: selected || null });
     },
     {
       enabled: !!selectedTargets.length,

--- a/frontend/interfaces/schedulable_query.ts
+++ b/frontend/interfaces/schedulable_query.ts
@@ -108,7 +108,7 @@ export interface ICreateQueryRequestBody {
   description?: string;
   observer_can_run?: boolean;
   discard_data?: boolean;
-  team_id?: number; // global query if undefined
+  fleet_id?: number; // global query if undefined
   interval?: number; // default 0 means never run
   platform?: CommaSeparatedPlatformString; // Might more accurately be called `platforms_to_query` – comma-separated string of platforms to query, default all platforms if omitted
   min_osquery_version?: string; // default all versions if ommitted
@@ -122,7 +122,7 @@ export interface ICreateQueryRequestBody {
 // Modify a query by id
 /** PATCH /api/v1/fleet/queries/{id} */
 export interface IModifyQueryRequestBody
-  extends Omit<ICreateQueryRequestBody, "name" | "query" | "team_id"> {
+  extends Omit<ICreateQueryRequestBody, "name" | "query" | "fleet_id"> {
   id?: number;
   name?: string;
   query?: string;
@@ -140,7 +140,7 @@ export interface IModifyQueryRequestBody
 // Delete a query by name
 /** DELETE /api/v1/fleet/queries/{name} */
 export interface IDeleteQueryRequestBody {
-  team_id?: number; // searches for a global query if omitted
+  fleet_id?: number; // searches for a global query if omitted
 }
 
 // Delete a query by id

--- a/frontend/interfaces/script.ts
+++ b/frontend/interfaces/script.ts
@@ -15,7 +15,7 @@ export const addTeamIdCriteria = (
   pred: any,
   teamId: number,
   isFreeTier?: boolean
-) => (isFreeTier ? { ...pred } : { ...pred, team_id: teamId });
+) => (isFreeTier ? { ...pred } : { ...pred, fleet_id: teamId });
 
 export type IScriptExecutionStatus = "ran" | "pending" | "error";
 

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/Certificates/Certificates.tsx
@@ -71,7 +71,7 @@ const Certificates = ({
     [
       {
         scope: "certificates",
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         page: currentPage,
         per_page: 10,
       },

--- a/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
+++ b/frontend/pages/ManageControlsPage/OSSettings/cards/CustomSettings/CustomSettings.tsx
@@ -96,7 +96,7 @@ const CustomSettings = ({
     ],
     () =>
       mdmAPI.getProfiles({
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         page: currentPage,
         per_page: PROFILES_PER_PAGE,
       }),

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/AppleOSTargetForm/AppleOSTargetForm.tests.tsx
@@ -18,7 +18,7 @@ describe("AppleOSTargetForm", () => {
     withBackendMock: true,
   });
   const updateTeamConfigHandler = http.patch(
-    baseUrl("/teams/1"),
+    baseUrl("/fleets/1"),
     async ({ request }) => {
       requestBody = await request.json();
       return HttpResponse.json({});

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptBatchProgress/ScriptBatchProgress.tsx
@@ -70,7 +70,7 @@ const ScriptBatchProgress = ({
   const DEFAULT_PAGE_SIZE = 10;
 
   const queryKey = {
-    team_id: teamId,
+    fleet_id: teamId,
     status: selectedStatus,
     page: pageNumber,
     per_page: DEFAULT_PAGE_SIZE,

--- a/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
+++ b/frontend/pages/ManageControlsPage/Scripts/cards/ScriptLibrary/ScriptLibrary.tsx
@@ -67,13 +67,13 @@ const ScriptLibrary = ({ router, teamId, location }: IScriptLibraryProps) => {
     [
       {
         scope: "scripts",
-        team_id: teamId,
+        fleet_id: teamId,
         page: currentPage,
         per_page: SCRIPTS_PER_PAGE,
       },
     ],
-    ({ queryKey: [{ team_id, page, per_page }] }) =>
-      scriptAPI.getScripts({ team_id, page, per_page }),
+    ({ queryKey: [{ fleet_id, page, per_page }] }) =>
+      scriptAPI.getScripts({ fleet_id, page, per_page }),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
       staleTime: 3000,

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/BootstrapPackage.tsx
@@ -63,7 +63,7 @@ const BootstrapPackage = ({
     () =>
       mdmAPI.getSetupExperienceSoftware({
         platform: "macos",
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         per_page: PER_PAGE_SIZE,
       }),
     {
@@ -140,7 +140,7 @@ const BootstrapPackage = ({
     try {
       await mdmAPI.deleteBootstrapPackage(currentTeamId);
       await mdmAPI.updateSetupExperienceSettings({
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         manual_agent_install: false,
       });
       renderFlash("success", "Successfully deleted.");

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/BootstrapPackage/components/BootstrapAdvancedOptions/BootstrapAdvancedOptions.tsx
@@ -33,7 +33,7 @@ const BootstrapAdvancedOptions = ({
     setIsSaving(true);
     try {
       await mdmAPI.updateSetupExperienceSettings({
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         manual_agent_install: selectManualAgentInstall,
       });
       renderFlash("success", "Successfully updated.");

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/InstallSoftware/InstallSoftware.tsx
@@ -82,7 +82,7 @@ const InstallSoftware = ({
     () =>
       mdmAPI.getSetupExperienceSoftware({
         platform: selectedPlatform,
-        team_id: currentTeamId,
+        fleet_id: currentTeamId,
         per_page: PER_PAGE_SIZE,
       }),
     {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
@@ -473,7 +473,7 @@ describe("Edit Auto Update Config Modal", () => {
           auto_update_enabled: false,
           labels_include_any: [],
           labels_exclude_any: [],
-          team_id: 1,
+          fleet_id: 1,
         });
       });
     });
@@ -514,7 +514,7 @@ describe("Edit Auto Update Config Modal", () => {
           auto_update_window_end: "04:00",
           labels_include_any: [],
           labels_exclude_any: [],
-          team_id: 1,
+          fleet_id: 1,
         });
       });
     });
@@ -547,7 +547,7 @@ describe("Edit Auto Update Config Modal", () => {
           auto_update_enabled: false,
           labels_include_any: [],
           labels_exclude_any: [],
-          team_id: 1,
+          fleet_id: 1,
         });
       });
     });
@@ -578,7 +578,7 @@ describe("Edit Auto Update Config Modal", () => {
         expect(requestSpy).toHaveBeenCalledWith({
           auto_update_enabled: false,
           labels_include_any: [mockLabels[1].name],
-          team_id: 1,
+          fleet_id: 1,
         });
       });
     });

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tests.ts
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tests.ts
@@ -32,9 +32,9 @@ describe("EditTeamsAbmModal", () => {
         macos_team: "Unassigned",
       };
       expect(getSelectedTeamIds(selectedTeamNames, availableTeams)).toEqual({
-        ios_team_id: 1,
-        ipados_team_id: 2,
-        macos_team_id: 0,
+        ios_fleet_id: 1,
+        ipados_fleet_id: 2,
+        macos_fleet_id: 0,
       });
     });
   });

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/EditTeamsAbmModal/EditTeamsAbmModal.tsx
@@ -64,9 +64,9 @@ export const getSelectedTeamIds = (
     return acc;
   }, {} as Record<string, number>);
   return {
-    ios_team_id: byName[ios_team],
-    ipados_team_id: byName[ipados_team],
-    macos_team_id: byName[macos_team],
+    ios_fleet_id: byName[ios_team],
+    ipados_fleet_id: byName[ipados_team],
+    macos_fleet_id: byName[macos_team],
   };
 };
 

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -169,8 +169,8 @@ const Advanced = ({
     // Formatting of API not UI
     const formDataToSubmit = {
       server_settings: {
-        live_query_disabled: disableLiveQuery,
-        query_reports_disabled: disableQueryReports,
+        live_reporting_disabled: disableLiveQuery,
+        discard_reports_data: disableQueryReports,
         scripts_disabled: disableScripts,
         deferred_save_host: appConfig.server_settings.deferred_save_host,
         ai_features_disabled: disableAIFeatures,

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -41,7 +41,7 @@ const Statistics = ({
       server_settings: {
         enable_analytics: enableUsageStatistics,
         deferred_save_host: appConfig.server_settings.deferred_save_host,
-        query_reports_disabled:
+        discard_reports_data:
           appConfig.server_settings.query_reports_disabled,
         scripts_disabled: appConfig.server_settings.scripts_disabled,
       },

--- a/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Statistics/Statistics.tsx
@@ -41,8 +41,7 @@ const Statistics = ({
       server_settings: {
         enable_analytics: enableUsageStatistics,
         deferred_save_host: appConfig.server_settings.deferred_save_host,
-        discard_reports_data:
-          appConfig.server_settings.query_reports_disabled,
+        discard_reports_data: appConfig.server_settings.query_reports_disabled,
         scripts_disabled: appConfig.server_settings.scripts_disabled,
       },
     };

--- a/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tests.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/RunScriptBatchModal/RunScriptBatchModal.tests.tsx
@@ -220,7 +220,7 @@ describe("RunScriptBatchModal", () => {
           filters: {
             query: "hi",
             label_id: 16,
-            team_id: 1,
+            fleet_id: 1,
             status: "",
           },
         });
@@ -364,7 +364,7 @@ describe("RunScriptBatchModal", () => {
         expect(body).toEqual({
           script_id: windowsScript.id,
           not_before: "2099-12-31T23:59:00.000Z",
-          filters: { query: "hi", label_id: 16, status: "", team_id: 1 },
+          filters: { query: "hi", label_id: 16, status: "", fleet_id: 1 },
         });
       });
     });

--- a/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/CalendarEventsModal/CalendarEventsModal.tests.tsx
@@ -19,7 +19,7 @@ const globalPoliciesHandler = http.get(baseUrl("/policies"), () => {
   });
 });
 
-const teamPoliciesHandler = http.get(baseUrl("/teams/2/policies"), () => {
+const teamPoliciesHandler = http.get(baseUrl("/fleets/2/policies"), () => {
   return HttpResponse.json({
     policies: [
       createMockPolicy({ id: 4, team_id: 2, name: "Team policy 1" }),

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tests.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesPaginatedList/PoliciesPaginatedList.tests.tsx
@@ -51,14 +51,14 @@ const globalPoliciesCountHandler = http.get(baseUrl("/policies/count"), () => {
   });
 });
 
-const teamPoliciesHandler = http.get(baseUrl("/teams/2/policies"), () => {
+const teamPoliciesHandler = http.get(baseUrl("/fleets/2/policies"), () => {
   return HttpResponse.json({
     policies: teamPolicies,
   });
 });
 
 const teamPoliciesCountHandler = http.get(
-  baseUrl("/teams/2/policies/count"),
+  baseUrl("/fleets/2/policies/count"),
   () => {
     return HttpResponse.json({
       count: teamPolicies.length,

--- a/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PolicyRunScriptModal/PolicyRunScriptModal.tsx
@@ -78,7 +78,7 @@ const PolicyRunScriptModal = ({
     [
       {
         scope: "scripts",
-        team_id: teamId,
+        fleet_id: teamId,
       },
     ],
     ({ queryKey: [queryKey] }) =>

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -963,7 +963,7 @@ const EditQueryForm = ({
             location={location}
             initialQueryData={{
               ...updateQueryData,
-              team_id: apiTeamIdForQuery,
+              fleet_id: apiTeamIdForQuery,
             }}
             hostId={hostId}
             onExit={toggleSaveAsNewQueryModal}

--- a/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveAsNewQueryModal/SaveAsNewQueryModal.tsx
@@ -72,7 +72,7 @@ const SaveAsNewQueryModal = ({
   const [formData, setFormData] = useState<ISANQFormData>({
     queryName: `Copy of ${initialQueryData.name}`,
     team: {
-      id: initialQueryData.team_id,
+      id: initialQueryData.fleet_id,
       name: undefined,
     },
   });
@@ -155,7 +155,7 @@ const SaveAsNewQueryModal = ({
     const createBody = {
       ...initialQueryData,
       name: queryName,
-      team_id: teamId === APP_CONTEXT_ALL_TEAMS_ID ? API_ALL_TEAMS_ID : teamId,
+      fleet_id: teamId === APP_CONTEXT_ALL_TEAMS_ID ? API_ALL_TEAMS_ID : teamId,
     };
     try {
       const { query: newQuery } = await queryAPI.create(createBody);

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tsx
@@ -187,7 +187,7 @@ const SaveNewQueryModal = ({
         // from previous New query page
         query: queryValue,
         // from doubly previous ManageQueriesPage
-        team_id: apiTeamIdForQuery,
+        fleet_id: apiTeamIdForQuery,
         labels_include_any:
           selectedTargetType === "Custom"
             ? Object.entries(selectedLabels)

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -47,7 +47,7 @@ export type IEditCertAuthorityBody =
 
 interface IGetCertsParams extends PaginationParams {
   // not supported: after, order key, order direction, match query, meta (always included)
-  team_id?: number;
+  fleet_id?: number;
 }
 
 export interface IQueryKeyGetCerts extends IGetCertsParams {
@@ -108,14 +108,14 @@ export default {
     return sendRequest("GET", CERTIFICATE_AUTHORITY_REQUEST_CERT(id));
   },
   getCerts: ({
-    team_id,
+    fleet_id,
     page,
     per_page,
   }: IGetCertsParams): Promise<IGetCertsResponse> => {
     const { CERTIFICATES } = endpoints;
 
     const queryString = buildQueryStringFromParams({
-      fleet_id: team_id,
+      fleet_id,
       page,
       per_page,
     });

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -114,7 +114,11 @@ export default {
   }: IGetCertsParams): Promise<IGetCertsResponse> => {
     const { CERTIFICATES } = endpoints;
 
-    const queryString = buildQueryStringFromParams({ fleet_id: team_id, page, per_page });
+    const queryString = buildQueryStringFromParams({
+      fleet_id: team_id,
+      page,
+      per_page,
+    });
 
     return sendRequest(
       "GET",

--- a/frontend/services/entities/certificates.ts
+++ b/frontend/services/entities/certificates.ts
@@ -114,7 +114,7 @@ export default {
   }: IGetCertsParams): Promise<IGetCertsResponse> => {
     const { CERTIFICATES } = endpoints;
 
-    const queryString = buildQueryStringFromParams({ team_id, page, per_page });
+    const queryString = buildQueryStringFromParams({ fleet_id: team_id, page, per_page });
 
     return sendRequest(
       "GET",
@@ -127,7 +127,7 @@ export default {
       name,
       certificate_authority_id: certAuthorityId,
       subject_name: subjectName,
-      team_id: teamId === APP_CONTEXT_ALL_TEAMS_ID ? API_ALL_TEAMS_ID : teamId,
+      fleet_id: teamId === APP_CONTEXT_ALL_TEAMS_ID ? API_ALL_TEAMS_ID : teamId,
     };
     return sendRequest("POST", CERTIFICATES, requestBody);
   },

--- a/frontend/services/entities/disk_encryption.ts
+++ b/frontend/services/entities/disk_encryption.ts
@@ -23,7 +23,7 @@ const diskEncryptionService = {
     let { DISK_ENCRYPTION: path } = endpoints;
 
     if (teamId) {
-      path = `${path}?${buildQueryStringFromParams({ team_id: teamId })}`;
+      path = `${path}?${buildQueryStringFromParams({ fleet_id: teamId })}`;
     }
     return sendRequest("GET", path);
   },
@@ -51,7 +51,7 @@ const diskEncryptionService = {
       // TODO - it would be good to be able to use an API_CONTEXT_NO_TEAM_ID here, but that is
       // currently set to 0, which should actually be undefined since the server expects teamId ==
       // nil for no teams, not 0.
-      team_id: teamId === APP_CONTEXT_NO_TEAM_ID ? undefined : teamId,
+      fleet_id: teamId === APP_CONTEXT_NO_TEAM_ID ? undefined : teamId,
     });
   },
   triggerLinuxDiskEncryptionKeyEscrow: (token: string) => {

--- a/frontend/services/entities/global_scheduled_queries.ts
+++ b/frontend/services/entities/global_scheduled_queries.ts
@@ -24,7 +24,7 @@ export default {
     const params = {
       interval: Number(interval),
       platform,
-      query_id: Number(queryID),
+      report_id: Number(queryID),
       removed,
       snapshot,
       shard: Number(shard),

--- a/frontend/services/entities/host_summary.ts
+++ b/frontend/services/entities/host_summary.ts
@@ -12,7 +12,7 @@ interface ISummaryProps {
 export default {
   getSummary: ({ teamId, platform, lowDiskSpace }: ISummaryProps) => {
     const queryParams = {
-      team_id: teamId,
+      fleet_id: teamId,
       platform,
       low_disk_space: lowDiskSpace,
     };

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -260,10 +260,10 @@ const getSortParams = (sortOptions?: ISortOption[]) => {
 
 const createMdmParams = (platform?: PlatformValueOptions, teamId?: number) => {
   if (platform === "all") {
-    return buildQueryStringFromParams({ team_id: teamId });
+    return buildQueryStringFromParams({ fleet_id: teamId });
   }
 
-  return buildQueryStringFromParams({ platform, team_id: teamId });
+  return buildQueryStringFromParams({ platform, fleet_id: teamId });
 };
 
 export default {
@@ -526,7 +526,7 @@ export default {
     const { HOSTS_TRANSFER } = endpoints;
 
     return sendRequest("POST", HOSTS_TRANSFER, {
-      team_id: teamId,
+      fleet_id: teamId,
       hosts: hostIds,
     });
   },
@@ -559,7 +559,7 @@ export default {
   }: IActionByFilter) => {
     const { HOSTS_TRANSFER_BY_FILTER } = endpoints;
     return sendRequest("POST", HOSTS_TRANSFER_BY_FILTER, {
-      team_id: teamId,
+      fleet_id: teamId,
       filters: {
         query: query || undefined, // Prevents empty string passed to API which as of 4.47 will return an error
         status,

--- a/frontend/services/entities/hosts.ts
+++ b/frontend/services/entities/hosts.ts
@@ -308,7 +308,7 @@ export default {
         query: query || undefined, // Prevents empty string passed to API which as of 4.47 will return an error
         status,
         label_id: labelId,
-        team_id: teamId,
+        fleet_id: teamId,
         policy_id: policyId,
         policy_response: policyResponse,
         software_id: softwareId,
@@ -564,7 +564,7 @@ export default {
         query: query || undefined, // Prevents empty string passed to API which as of 4.47 will return an error
         status,
         label_id: labelId,
-        team_id: currentTeam,
+        fleet_id: currentTeam,
         policy_id: policyId,
         policy_response: policyResponse,
         software_id: softwareId,

--- a/frontend/services/entities/labels.ts
+++ b/frontend/services/entities/labels.ts
@@ -115,13 +115,13 @@ export default {
 
     const queryStringParams = {
       include_host_counts: false,
-      team_id: null as null | number | string,
+      fleet_id: null as null | number | string,
     };
     if (teamID === 0) {
-      queryStringParams.team_id = "global";
+      queryStringParams.fleet_id = "global";
     } else if (teamID !== null && teamID > 0) {
       // filter out "all teams" -1
-      queryStringParams.team_id = teamID;
+      queryStringParams.fleet_id = teamID;
     }
 
     const queryString = buildQueryStringFromParams(queryStringParams);
@@ -142,12 +142,12 @@ export default {
     const { LABELS_SUMMARY } = endpoints;
 
     const queryStringParams = {
-      team_id: null as null | number | string,
+      fleet_id: null as null | number | string,
     };
     if (teamID === 0 || (teamID === -1 && treatAllTeamsAsGlobalOnly)) {
-      queryStringParams.team_id = "global";
+      queryStringParams.fleet_id = "global";
     } else if (teamID !== null && teamID > 0) {
-      queryStringParams.team_id = teamID;
+      queryStringParams.fleet_id = teamID;
     }
 
     const queryString = buildQueryStringFromParams(queryStringParams);

--- a/frontend/services/entities/macadmins.ts
+++ b/frontend/services/entities/macadmins.ts
@@ -6,7 +6,7 @@ import { buildQueryStringFromParams } from "utilities/url";
 export default {
   loadAll: (teamId?: number) => {
     const { MACADMINS } = endpoints;
-    const queryString = buildQueryStringFromParams({ team_id: teamId });
+    const queryString = buildQueryStringFromParams({ fleet_id: teamId });
     const path = `${MACADMINS}?${queryString}`;
 
     return sendRequest("GET", path);

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -411,7 +411,10 @@ const mdmService = {
     const { MDM_SETUP_EXPERIENCE_SCRIPT } = endpoints;
 
     let path = MDM_SETUP_EXPERIENCE_SCRIPT;
-    path += `?${buildQueryStringFromParams({ fleet_id: teamId, alt: "media" })}`;
+    path += `?${buildQueryStringFromParams({
+      fleet_id: teamId,
+      alt: "media",
+    })}`;
 
     return sendRequest("GET", path);
   },

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -28,7 +28,7 @@ export type ProfileStatusSummaryResponse = Record<MdmProfileStatus, number>;
 export interface IGetProfilesApiParams {
   page?: number;
   per_page?: number;
-  team_id?: number;
+  fleet_id?: number;
 }
 
 export interface IMdmProfilesResponse {
@@ -52,7 +52,7 @@ export const isDDMProfile = (profile: IMdmProfile | IHostMdmProfile) => {
 };
 
 interface IUpdateSetupExperienceBody {
-  team_id?: number;
+  fleet_id?: number;
   enable_end_user_authentication?: boolean;
   enable_release_device_manually?: boolean;
   manual_agent_install?: boolean;
@@ -89,7 +89,7 @@ export interface IGetSetupExperienceScriptResponse {
 }
 
 interface IGetSetupExperienceSoftwareParams extends Partial<PaginationParams> {
-  team_id: number;
+  fleet_id: number;
   platform: SetupExperiencePlatform;
 }
 
@@ -121,11 +121,7 @@ const mdmService = {
     params: IGetProfilesApiParams
   ): Promise<IMdmProfilesResponse> => {
     const { MDM_PROFILES } = endpoints;
-    const { team_id, ...rest } = params;
-    const path = `${MDM_PROFILES}?${buildQueryStringFromParams({
-      ...rest,
-      fleet_id: team_id,
-    })}`;
+    const path = `${MDM_PROFILES}?${buildQueryStringFromParams(params)}`;
 
     return sendRequest("GET", path);
   },
@@ -279,13 +275,13 @@ const mdmService = {
 
   updateSetupExperienceSettings: (updateData: IUpdateSetupExperienceBody) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
-    const { team_id, ...rest } = updateData;
+    const { fleet_id, ...rest } = updateData;
     const body: Record<string, unknown> = {
       ...rest,
     };
 
-    if (team_id !== API_NO_TEAM_ID) {
-      body.fleet_id = team_id;
+    if (fleet_id !== API_NO_TEAM_ID) {
+      body.fleet_id = fleet_id;
     }
 
     return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, body);
@@ -371,12 +367,8 @@ const mdmService = {
   ): Promise<IGetSetupExperienceSoftwareResponse> => {
     const { MDM_SETUP_EXPERIENCE_SOFTWARE } = endpoints;
 
-    const { team_id, ...rest } = params;
     const path = `${MDM_SETUP_EXPERIENCE_SOFTWARE}?${buildQueryStringFromParams(
-      {
-        ...rest,
-        fleet_id: team_id,
-      }
+      params
     )}`;
 
     return sendRequest("GET", path);

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -275,13 +275,12 @@ const mdmService = {
 
   updateSetupExperienceSettings: (updateData: IUpdateSetupExperienceBody) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
-    const { fleet_id, ...rest } = updateData;
-    const body: Record<string, unknown> = {
-      ...rest,
+    const body = {
+      ...updateData,
     };
 
-    if (fleet_id !== API_NO_TEAM_ID) {
-      body.fleet_id = fleet_id;
+    if (updateData.fleet_id === API_NO_TEAM_ID) {
+      delete body.fleet_id;
     }
 
     return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, body);
@@ -290,12 +289,13 @@ const mdmService = {
   updateReleaseDeviceSetting: (teamId: number, isEnabled: boolean) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
 
-    const body: Record<string, unknown> = {
+    const body: IUpdateSetupExperienceBody = {
+      fleet_id: teamId,
       enable_release_device_manually: isEnabled,
     };
 
-    if (teamId !== API_NO_TEAM_ID) {
-      body.fleet_id = teamId;
+    if (teamId === API_NO_TEAM_ID) {
+      delete body.fleet_id;
     }
 
     return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, body);

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -121,8 +121,10 @@ const mdmService = {
     params: IGetProfilesApiParams
   ): Promise<IMdmProfilesResponse> => {
     const { MDM_PROFILES } = endpoints;
+    const { team_id, ...rest } = params;
     const path = `${MDM_PROFILES}?${buildQueryStringFromParams({
-      ...params,
+      ...rest,
+      fleet_id: team_id,
     })}`;
 
     return sendRequest("GET", path);
@@ -141,7 +143,7 @@ const mdmService = {
     formData.append("profile", file);
 
     if (teamId) {
-      formData.append("team_id", teamId.toString());
+      formData.append("fleet_id", teamId.toString());
     }
 
     if (labelsIncludeAll || labelsIncludeAny || labelsExcludeAny) {
@@ -181,7 +183,7 @@ const mdmService = {
     let { PROFILES_STATUS_SUMMARY: path } = endpoints;
 
     if (teamId) {
-      path = `${path}?${buildQueryStringFromParams({ team_id: teamId })}`;
+      path = `${path}?${buildQueryStringFromParams({ fleet_id: teamId })}`;
     }
 
     return sendRequest("GET", path);
@@ -207,7 +209,7 @@ const mdmService = {
     formData.append("package", file);
 
     if (teamId) {
-      formData.append("team_id", teamId.toString());
+      formData.append("fleet_id", teamId.toString());
     }
 
     return sendRequest("POST", MDM_BOOTSTRAP_PACKAGE, formData);
@@ -224,7 +226,7 @@ const mdmService = {
     let { MDM_BOOTSTRAP_PACKAGE_SUMMARY: path } = endpoints;
 
     if (teamId) {
-      path = `${path}?${buildQueryStringFromParams({ team_id: teamId })}`;
+      path = `${path}?${buildQueryStringFromParams({ fleet_id: teamId })}`;
     }
 
     return sendRequest("GET", path);
@@ -261,7 +263,7 @@ const mdmService = {
   ) => {
     const { MDM_SETUP } = endpoints;
     return sendRequest("PATCH", MDM_SETUP, {
-      team_id: teamId,
+      fleet_id: teamId,
       enable_end_user_authentication: isEnabled,
       lock_end_user_info: canLockEndUserInfo,
     });
@@ -270,19 +272,20 @@ const mdmService = {
   updateRequireAllSoftwareMacOS: (teamId: number, isEnabled: boolean) => {
     const { MDM_SETUP } = endpoints;
     return sendRequest("PATCH", MDM_SETUP, {
-      team_id: teamId,
+      fleet_id: teamId,
       require_all_software_macos: isEnabled,
     });
   },
 
   updateSetupExperienceSettings: (updateData: IUpdateSetupExperienceBody) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
-    const body = {
-      ...updateData,
+    const { team_id, ...rest } = updateData;
+    const body: Record<string, unknown> = {
+      ...rest,
     };
 
-    if (updateData.team_id === API_NO_TEAM_ID) {
-      delete body.team_id;
+    if (team_id !== API_NO_TEAM_ID) {
+      body.fleet_id = team_id;
     }
 
     return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, body);
@@ -291,12 +294,12 @@ const mdmService = {
   updateReleaseDeviceSetting: (teamId: number, isEnabled: boolean) => {
     const { MDM_SETUP_EXPERIENCE } = endpoints;
 
-    const body: IUpdateSetupExperienceBody = {
+    const body: Record<string, unknown> = {
       enable_release_device_manually: isEnabled,
     };
 
     if (teamId !== API_NO_TEAM_ID) {
-      body.team_id = teamId;
+      body.fleet_id = teamId;
     }
 
     return sendRequest("PATCH", MDM_SETUP_EXPERIENCE, body);
@@ -309,7 +312,7 @@ const mdmService = {
     }
 
     const path = `${MDM_APPLE_SETUP_ENROLLMENT_PROFILE}?${buildQueryStringFromParams(
-      { team_id: teamId }
+      { fleet_id: teamId }
     )}`;
     return sendRequest("GET", path);
   },
@@ -328,7 +331,7 @@ const mdmService = {
             enrollment_profile: JSON.parse(reader.result as string),
           };
           if (teamId !== API_NO_TEAM_ID) {
-            body.team_id = teamId;
+            body.fleet_id = teamId;
           }
           resolve(
             sendRequest("POST", MDM_APPLE_SETUP_ENROLLMENT_PROFILE, body)
@@ -348,7 +351,7 @@ const mdmService = {
     }
 
     const path = `${MDM_APPLE_SETUP_ENROLLMENT_PROFILE}?${buildQueryStringFromParams(
-      { team_id: teamId }
+      { fleet_id: teamId }
     )}`;
     return sendRequest("DELETE", path);
   },
@@ -368,9 +371,11 @@ const mdmService = {
   ): Promise<IGetSetupExperienceSoftwareResponse> => {
     const { MDM_SETUP_EXPERIENCE_SOFTWARE } = endpoints;
 
+    const { team_id, ...rest } = params;
     const path = `${MDM_SETUP_EXPERIENCE_SOFTWARE}?${buildQueryStringFromParams(
       {
-        ...params,
+        ...rest,
+        fleet_id: team_id,
       }
     )}`;
 
@@ -384,7 +389,7 @@ const mdmService = {
   ) => {
     return sendRequest("PUT", endpoints.MDM_SETUP_EXPERIENCE_SOFTWARE, {
       software_title_ids: softwareTitlesIds,
-      team_id: teamId,
+      fleet_id: teamId,
       platform,
     });
   },
@@ -396,7 +401,7 @@ const mdmService = {
 
     let path = MDM_SETUP_EXPERIENCE_SCRIPT;
     if (teamId) {
-      path += `?${buildQueryStringFromParams({ team_id: teamId })}`;
+      path += `?${buildQueryStringFromParams({ fleet_id: teamId })}`;
     }
 
     return sendRequest("GET", path);
@@ -406,7 +411,7 @@ const mdmService = {
     const { MDM_SETUP_EXPERIENCE_SCRIPT } = endpoints;
 
     let path = MDM_SETUP_EXPERIENCE_SCRIPT;
-    path += `?${buildQueryStringFromParams({ team_id: teamId, alt: "media" })}`;
+    path += `?${buildQueryStringFromParams({ fleet_id: teamId, alt: "media" })}`;
 
     return sendRequest("GET", path);
   },
@@ -418,7 +423,7 @@ const mdmService = {
     formData.append("script", file);
 
     if (teamId) {
-      formData.append("team_id", teamId.toString());
+      formData.append("fleet_id", teamId.toString());
     }
 
     return sendRequest("POST", MDM_SETUP_EXPERIENCE_SCRIPT, formData);
@@ -428,7 +433,7 @@ const mdmService = {
     const { MDM_SETUP_EXPERIENCE_SCRIPT } = endpoints;
 
     const path = `${MDM_SETUP_EXPERIENCE_SCRIPT}?${buildQueryStringFromParams({
-      team_id: teamId,
+      fleet_id: teamId,
     })}`;
 
     return sendRequest("DELETE", path);

--- a/frontend/services/entities/mdm_apple.ts
+++ b/frontend/services/entities/mdm_apple.ts
@@ -64,7 +64,7 @@ export default {
 
   getVppApps: (teamId: number): Promise<IGetVppAppsResponse> => {
     const { SOFTWARE_APP_STORE_APPS } = endpoints;
-    const path = `${SOFTWARE_APP_STORE_APPS}?team_id=${teamId}`;
+    const path = `${SOFTWARE_APP_STORE_APPS}?fleet_id=${teamId}`;
     return sendRequest("GET", path);
   },
 
@@ -100,6 +100,6 @@ export default {
   }) => {
     const { MDM_VPP_TOKEN_TEAMS } = endpoints;
     const path = MDM_VPP_TOKEN_TEAMS(params.tokenId);
-    return sendRequest("PATCH", path, { teams: params.teamIds });
+    return sendRequest("PATCH", path, { fleets: params.teamIds });
   },
 };

--- a/frontend/services/entities/mdm_apple_bm.ts
+++ b/frontend/services/entities/mdm_apple_bm.ts
@@ -87,9 +87,9 @@ export default {
   editTeams: async (params: {
     tokenId: number;
     teams: {
-      ios_team_id: number;
-      ipados_team_id: number;
-      macos_team_id: number;
+      ios_fleet_id: number;
+      ipados_fleet_id: number;
+      macos_fleet_id: number;
     };
   }) => {
     const { MDM_ABM_TOKEN_TEAMS } = endpoints;

--- a/frontend/services/entities/operating_systems.ts
+++ b/frontend/services/entities/operating_systems.ts
@@ -75,7 +75,7 @@ export const getOSVersions = ({
 
   const params: IGetOSVersionsRequestQueryParams = {
     platform,
-    team_id: teamId,
+    fleet_id: teamId,
     os_name,
     os_version,
     order_key,
@@ -99,7 +99,7 @@ const getOSVersion = ({
 }: IGetOsVersionOptions): Promise<IOSVersionResponse> => {
   const endpoint = endpoints.OS_VERSION(os_version_id);
   const queryString = buildQueryStringFromParams({
-    team_id: teamId,
+    fleet_id: teamId,
     max_vulnerabilities,
   });
   const path = queryString ? `${endpoint}?${queryString}` : endpoint;

--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -101,7 +101,10 @@ export default {
     }
 
     const { team_id, ...restParams } = snakeCaseParams;
-    const queryString = buildQueryStringFromParams({ ...restParams, fleet_id: team_id });
+    const queryString = buildQueryStringFromParams({
+      ...restParams,
+      fleet_id: team_id,
+    });
 
     return sendRequest(
       "GET",

--- a/frontend/services/entities/queries.ts
+++ b/frontend/services/entities/queries.ts
@@ -100,7 +100,8 @@ export default {
       snakeCaseParams.platform = "macos";
     }
 
-    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const { team_id, ...restParams } = snakeCaseParams;
+    const queryString = buildQueryStringFromParams({ ...restParams, fleet_id: team_id });
 
     return sendRequest(
       "GET",
@@ -121,7 +122,7 @@ export default {
     try {
       const { campaign } = await sendRequest("POST", LIVE_QUERY, {
         query,
-        query_id: queryId,
+        report_id: queryId,
         selected,
       });
       return campaign;

--- a/frontend/services/entities/query_report.ts
+++ b/frontend/services/entities/query_report.ts
@@ -18,7 +18,7 @@ export interface ILoadQueryReportOptions {
 interface ILoadQueryReportQueryParams {
   order_key: string | undefined;
   order_direction: string | undefined;
-  team_id?: number;
+  fleet_id?: number;
 }
 
 const getSortParams = (sortOptions?: ISortOption[]) => {
@@ -42,7 +42,7 @@ export default {
       order_direction: sortParams.order_direction,
     };
     if (teamId && teamId > 0) {
-      queryParams.team_id = teamId;
+      queryParams.fleet_id = teamId;
     }
 
     const queryString = buildQueryStringFromParams(queryParams);

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -240,7 +240,10 @@ export default {
   getScripts(params: IListScriptsApiParams): Promise<IScriptsResponse> {
     const { SCRIPTS } = endpoints;
     const { team_id, ...rest } = params;
-    const path = `${SCRIPTS}?${buildQueryStringFromParams({ ...rest, fleet_id: team_id })}`;
+    const path = `${SCRIPTS}?${buildQueryStringFromParams({
+      ...rest,
+      fleet_id: team_id,
+    })}`;
 
     return sendRequest("GET", path);
   },

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -239,7 +239,8 @@ export default {
 
   getScripts(params: IListScriptsApiParams): Promise<IScriptsResponse> {
     const { SCRIPTS } = endpoints;
-    const path = `${SCRIPTS}?${buildQueryStringFromParams({ ...params })}`;
+    const { team_id, ...rest } = params;
+    const path = `${SCRIPTS}?${buildQueryStringFromParams({ ...rest, fleet_id: team_id })}`;
 
     return sendRequest("GET", path);
   },
@@ -256,7 +257,7 @@ export default {
     formData.append("script", file);
 
     if (teamId) {
-      formData.append("team_id", teamId.toString());
+      formData.append("fleet_id", teamId.toString());
     }
 
     return sendRequest("POST", SCRIPTS, formData);
@@ -325,9 +326,10 @@ export default {
   getRunScriptBatchSummaries(
     params: IScriptBatchSummariesParams
   ): Promise<IScriptBatchSummariesResponse> {
+    const { team_id, ...rest } = params;
     const path = `${
       endpoints.SCRIPT_RUN_BATCH_SUMMARIES
-    }?${buildQueryStringFromParams({ ...params })}`;
+    }?${buildQueryStringFromParams({ ...rest, fleet_id: team_id })}`;
     return sendRequest("GET", path);
   },
   getScriptBatchHostResults(

--- a/frontend/services/entities/scripts.ts
+++ b/frontend/services/entities/scripts.ts
@@ -33,7 +33,7 @@ export interface IScriptsResponse {
 export interface IListScriptsApiParams {
   page?: number;
   per_page?: number;
-  team_id?: number;
+  fleet_id?: number;
 }
 
 export interface IListScriptsQueryKey extends IListScriptsApiParams {
@@ -183,7 +183,7 @@ export interface IScriptBatchSummaryV2 extends IScriptBatchHostCountsV2 {
 }
 
 export interface IScriptBatchSummariesParams {
-  team_id: number;
+  fleet_id: number;
   status: ScriptBatchStatus;
   page: number;
   per_page: number;
@@ -239,11 +239,7 @@ export default {
 
   getScripts(params: IListScriptsApiParams): Promise<IScriptsResponse> {
     const { SCRIPTS } = endpoints;
-    const { team_id, ...rest } = params;
-    const path = `${SCRIPTS}?${buildQueryStringFromParams({
-      ...rest,
-      fleet_id: team_id,
-    })}`;
+    const path = `${SCRIPTS}?${buildQueryStringFromParams(params)}`;
 
     return sendRequest("GET", path);
   },
@@ -329,10 +325,9 @@ export default {
   getRunScriptBatchSummaries(
     params: IScriptBatchSummariesParams
   ): Promise<IScriptBatchSummariesResponse> {
-    const { team_id, ...rest } = params;
     const path = `${
       endpoints.SCRIPT_RUN_BATCH_SUMMARIES
-    }?${buildQueryStringFromParams({ ...rest, fleet_id: team_id })}`;
+    }?${buildQueryStringFromParams(params)}`;
     return sendRequest("GET", path);
   },
   getScriptBatchHostResults(

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -168,7 +168,7 @@ interface IAddFleetMaintainedAppPostBody {
 
 export interface IAddAppStoreAppPostBody {
   app_store_id: string;
-  team_id: number;
+  fleet_id: number;
   platform: ApplePlatform | "android";
   // True by default for android apps
   self_service?: boolean;
@@ -181,7 +181,7 @@ export interface IAddAppStoreAppPostBody {
 
 // 4.77 Edit for Android app is not yet available
 export interface IEditAppStoreAppPostBody {
-  team_id: number;
+  fleet_id: number;
   self_service?: boolean;
   // No automatic_install on edit VPP or android app
   labels_include_any?: string[];
@@ -205,7 +205,7 @@ const handleAndroidForm = (
 
   const body: IAddAppStoreAppPostBody = {
     app_store_id: formData.applicationID,
-    team_id: teamId,
+    fleet_id: teamId,
     platform: formData.platform,
     self_service: formData.selfService,
     automatic_install: formData.automaticInstall,
@@ -236,7 +236,7 @@ const handleVppAppForm = (teamId: number, formData: ISoftwareVppFormData) => {
 
   const body: IAddAppStoreAppPostBody = {
     app_store_id: formData.selectedApp.app_store_id,
-    team_id: teamId,
+    fleet_id: teamId,
     platform: formData.selectedApp?.platform, // Nested platform
     self_service: formData.selfService,
     automatic_install: formData.automaticInstall,
@@ -407,7 +407,8 @@ export default {
     };
 
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
-    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const { team_id, ...restParams } = snakeCaseParams;
+    const queryString = buildQueryStringFromParams({ ...restParams, fleet_id: team_id });
     const path = `${SOFTWARE}?${queryString}`;
 
     try {
@@ -433,7 +434,8 @@ export default {
       vulnerable,
     };
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
-    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const { team_id, ...restCountParams } = snakeCaseParams;
+    const queryString = buildQueryStringFromParams({ ...restCountParams, fleet_id: team_id });
 
     return sendRequest("GET", path.concat(`?${queryString}`));
   },
@@ -443,7 +445,8 @@ export default {
   ): Promise<ISoftwareTitlesResponse> => {
     const { SOFTWARE_TITLES } = endpoints;
     const snakeCaseParams = convertParamsToSnakeCase(params);
-    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const { team_id, ...restTitleParams } = snakeCaseParams;
+    const queryString = buildQueryStringFromParams({ ...restTitleParams, fleet_id: team_id });
     const path = `${SOFTWARE_TITLES}?${queryString}`;
     return sendRequest("GET", path);
   },
@@ -453,7 +456,7 @@ export default {
     teamId,
   }: IGetSoftwareTitleQueryParams): Promise<ISoftwareTitleResponse> => {
     const endpoint = endpoints.SOFTWARE_TITLE(softwareId);
-    const queryString = buildQueryStringFromParams({ team_id: teamId });
+    const queryString = buildQueryStringFromParams({ fleet_id: teamId });
     const path =
       typeof teamId === "undefined" ? endpoint : `${endpoint}?${queryString}`;
     return sendRequest("GET", path);
@@ -462,7 +465,8 @@ export default {
   getSoftwareVersions: (params: ISoftwareApiParams) => {
     const { SOFTWARE_VERSIONS } = endpoints;
     const snakeCaseParams = convertParamsToSnakeCase(params);
-    const queryString = buildQueryStringFromParams(snakeCaseParams);
+    const { team_id, ...restVersionParams } = snakeCaseParams;
+    const queryString = buildQueryStringFromParams({ ...restVersionParams, fleet_id: team_id });
     const path = `${SOFTWARE_VERSIONS}?${queryString}`;
     return sendRequest("GET", path);
   },
@@ -472,7 +476,7 @@ export default {
     teamId,
   }: IGetSoftwareVersionQueryParams) => {
     const endpoint = endpoints.SOFTWARE_VERSION(versionId);
-    const queryString = buildQueryStringFromParams({ team_id: teamId });
+    const queryString = buildQueryStringFromParams({ fleet_id: teamId });
     const path =
       typeof teamId === "undefined" ? endpoint : `${endpoint}?${queryString}`;
 
@@ -524,7 +528,7 @@ export default {
       );
     data.automaticInstall &&
       formData.append("automatic_install", data.automaticInstall.toString());
-    teamId && formData.append("team_id", teamId.toString());
+    teamId && formData.append("fleet_id", teamId.toString());
     if (data.categories) {
       data.categories.forEach((category) => {
         formData.append("categories", category);
@@ -575,7 +579,7 @@ export default {
   }) => {
     const { EDIT_SOFTWARE_PACKAGE } = endpoints;
     const formData = new FormData();
-    formData.append("team_id", teamId.toString());
+    formData.append("fleet_id", teamId.toString());
 
     if ("displayName" in data) {
       // Handles Edit display name form only
@@ -630,7 +634,7 @@ export default {
   ) => {
     const { EDIT_SOFTWARE_APP_STORE_APP } = endpoints;
 
-    const body: IEditAppStoreAppPostBody = { team_id: teamId };
+    const body: IEditAppStoreAppPostBody = { fleet_id: teamId };
 
     if ("displayName" in formData) {
       // Handles Edit display name form only
@@ -662,7 +666,7 @@ export default {
   getSoftwareIcon: (softwareId: number, teamId: number) => {
     const { SOFTWARE_ICON } = endpoints;
     const path = getPathWithQueryParams(SOFTWARE_ICON(softwareId), {
-      team_id: teamId,
+      fleet_id: teamId,
     });
     return sendRequest(
       "GET",
@@ -676,7 +680,7 @@ export default {
   },
 
   // This API call is for both:
-  // "/api/v1/fleet/software/titles/{softwareId}/icon?team_id={teamId}"
+  // "/api/v1/fleet/software/titles/{softwareId}/icon?fleet_id={teamId}"
   // "/api/v1/fleet/device/{deviceToken}/software/titles/{softwareId}/icon"
   getSoftwareIconFromApiUrl: (apiUrl: string) => {
     // sendRequest prepends "/api" to the path, so we need to remove it
@@ -689,7 +693,7 @@ export default {
   deleteSoftwareIcon: (softwareId: number, teamId: number) => {
     const { SOFTWARE_ICON } = endpoints;
     const path = getPathWithQueryParams(SOFTWARE_ICON(softwareId), {
-      team_id: teamId,
+      fleet_id: teamId,
     });
     return sendRequest("DELETE", path);
   },
@@ -701,7 +705,7 @@ export default {
   ) => {
     const { SOFTWARE_ICON } = endpoints;
     const path = getPathWithQueryParams(SOFTWARE_ICON(softwareId), {
-      team_id: teamId,
+      fleet_id: teamId,
     });
 
     const formData = new FormData();
@@ -715,7 +719,7 @@ export default {
     const { SOFTWARE_AVAILABLE_FOR_INSTALL } = endpoints;
     const path = `${SOFTWARE_AVAILABLE_FOR_INSTALL(
       softwareId
-    )}?team_id=${teamId}`;
+    )}?fleet_id=${teamId}`;
     return sendRequest("DELETE", path);
   },
 
@@ -725,7 +729,7 @@ export default {
   ): Promise<ISoftwareInstallTokenResponse> => {
     const path = `${endpoints.SOFTWARE_PACKAGE_TOKEN(
       softwareTitleId
-    )}?${buildQueryStringFromParams({ alt: "media", team_id: teamId })}`;
+    )}?${buildQueryStringFromParams({ alt: "media", fleet_id: teamId })}`;
 
     return sendRequest("POST", path);
   },
@@ -740,7 +744,8 @@ export default {
     params: ISoftwareFleetMaintainedAppsQueryParams
   ): Promise<ISoftwareFleetMaintainedAppsResponse> => {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
-    const queryStr = buildQueryStringFromParams(params);
+    const { team_id, ...rest } = params;
+    const queryStr = buildQueryStringFromParams({ ...rest, fleet_id: team_id });
     const path = `${SOFTWARE_FLEET_MAINTAINED_APPS}?${queryStr}`;
     return sendRequest("GET", path);
   },
@@ -751,7 +756,7 @@ export default {
   ): Promise<IFleetMaintainedAppResponse> => {
     const { SOFTWARE_FLEET_MAINTAINED_APP } = endpoints;
     const path = getPathWithQueryParams(SOFTWARE_FLEET_MAINTAINED_APP(id), {
-      team_id: teamId,
+      fleet_id: teamId,
     });
     return sendRequest("GET", path);
   },
@@ -763,8 +768,8 @@ export default {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
 
     // Base64 encode script fields to bypass WAF rules that block script patterns
-    const body: IAddFleetMaintainedAppPostBody = {
-      team_id: teamId,
+    const body: Record<string, unknown> = {
+      fleet_id: teamId,
       fleet_maintained_app_id: formData.appId,
       pre_install_query: encodeScriptBase64(formData.preInstallQuery),
       install_script: encodeScriptBase64(formData.installScript),

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -153,7 +153,7 @@ export interface IFleetMaintainedAppResponse {
 }
 
 interface IAddFleetMaintainedAppPostBody {
-  team_id: number;
+  fleet_id: number;
   fleet_maintained_app_id: number;
   pre_install_query?: string;
   install_script?: string;
@@ -780,7 +780,7 @@ export default {
     const { SOFTWARE_FLEET_MAINTAINED_APPS } = endpoints;
 
     // Base64 encode script fields to bypass WAF rules that block script patterns
-    const body: Record<string, unknown> = {
+    const body: IAddFleetMaintainedAppPostBody = {
       fleet_id: teamId,
       fleet_maintained_app_id: formData.appId,
       pre_install_query: encodeScriptBase64(formData.preInstallQuery),

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -408,7 +408,10 @@ export default {
 
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
     const { team_id, ...restParams } = snakeCaseParams;
-    const queryString = buildQueryStringFromParams({ ...restParams, fleet_id: team_id });
+    const queryString = buildQueryStringFromParams({
+      ...restParams,
+      fleet_id: team_id,
+    });
     const path = `${SOFTWARE}?${queryString}`;
 
     try {
@@ -435,7 +438,10 @@ export default {
     };
     const snakeCaseParams = convertParamsToSnakeCase(queryParams);
     const { team_id, ...restCountParams } = snakeCaseParams;
-    const queryString = buildQueryStringFromParams({ ...restCountParams, fleet_id: team_id });
+    const queryString = buildQueryStringFromParams({
+      ...restCountParams,
+      fleet_id: team_id,
+    });
 
     return sendRequest("GET", path.concat(`?${queryString}`));
   },
@@ -446,7 +452,10 @@ export default {
     const { SOFTWARE_TITLES } = endpoints;
     const snakeCaseParams = convertParamsToSnakeCase(params);
     const { team_id, ...restTitleParams } = snakeCaseParams;
-    const queryString = buildQueryStringFromParams({ ...restTitleParams, fleet_id: team_id });
+    const queryString = buildQueryStringFromParams({
+      ...restTitleParams,
+      fleet_id: team_id,
+    });
     const path = `${SOFTWARE_TITLES}?${queryString}`;
     return sendRequest("GET", path);
   },
@@ -466,7 +475,10 @@ export default {
     const { SOFTWARE_VERSIONS } = endpoints;
     const snakeCaseParams = convertParamsToSnakeCase(params);
     const { team_id, ...restVersionParams } = snakeCaseParams;
-    const queryString = buildQueryStringFromParams({ ...restVersionParams, fleet_id: team_id });
+    const queryString = buildQueryStringFromParams({
+      ...restVersionParams,
+      fleet_id: team_id,
+    });
     const path = `${SOFTWARE_VERSIONS}?${queryString}`;
     return sendRequest("GET", path);
   },

--- a/frontend/services/entities/targets.ts
+++ b/frontend/services/entities/targets.ts
@@ -18,7 +18,7 @@ const defaultSelected = {
 };
 
 export interface ITargetsSearchParams {
-  query_id?: number | null;
+  report_id?: number | null;
   query: string;
   excluded_host_ids: number[] | null;
 }
@@ -28,7 +28,7 @@ export interface ITargetsSearchResponse {
 }
 
 export interface ITargetsCountParams {
-  query_id?: number | null;
+  report_id?: number | null;
   selected: ISelectedTargetsForApi | null;
 }
 
@@ -54,7 +54,7 @@ export default {
 
     return sendRequest("POST", TARGETS, {
       query,
-      query_id: queryId,
+      report_id: queryId,
       selected,
     });
   },
@@ -86,7 +86,7 @@ export default {
     const { TARGETS } = endpoints;
     return sendRequest("POST", TARGETS, {
       query,
-      query_id: queryId,
+      report_id: queryId,
       selected,
     }).then((response) => {
       const { targets } = response;

--- a/frontend/services/entities/team_scheduled_queries.ts
+++ b/frontend/services/entities/team_scheduled_queries.ts
@@ -14,9 +14,9 @@ interface ICreateTeamScheduledQueryFormData {
   logging_type: string;
   name?: string;
   platform: string;
-  query_id?: number;
+  report_id?: number;
   shard: number;
-  team_id?: number;
+  fleet_id?: number;
   version: string;
 }
 
@@ -28,10 +28,10 @@ export default {
       interval,
       logging_type: loggingType,
       platform,
-      query_id: queryID,
+      report_id: queryID,
       shard,
       version,
-      team_id: teamID,
+      fleet_id: teamID,
     } = formData;
 
     const removed = loggingType === "differential";
@@ -40,12 +40,12 @@ export default {
     const params = {
       interval: Number(interval),
       platform,
-      query_id: Number(queryID),
+      report_id: Number(queryID),
       removed,
       snapshot,
       shard: Number(shard),
       version,
-      team_id: Number(teamID),
+      fleet_id: Number(teamID),
     };
 
     return sendRequest("POST", TEAM_SCHEDULE(teamID || 0), params);

--- a/frontend/services/entities/users.ts
+++ b/frontend/services/entities/users.ts
@@ -99,7 +99,7 @@ export default {
   loadAll: ({ globalFilter = "", teamId }: IUserSearchOptions = {}) => {
     const queryParams = {
       query: globalFilter,
-      team_id: teamId,
+      fleet_id: teamId,
     };
 
     const queryString = buildQueryStringFromParams(queryParams);

--- a/frontend/services/entities/vulnerabilities.ts
+++ b/frontend/services/entities/vulnerabilities.ts
@@ -59,7 +59,7 @@ export const getVulnerabilities = ({
   let path = VULNERABILITIES;
 
   const queryString = buildQueryStringFromParams({
-    team_id: teamId,
+    fleet_id: teamId,
     order_key,
     order_direction,
     page,
@@ -78,7 +78,7 @@ const getVulnerability = ({
   teamId,
 }: IGetVulnerabilityOptions): Promise<IVulnerabilityResponse> => {
   const endpoint = endpoints.VULNERABILITY(vulnerability);
-  const queryString = buildQueryStringFromParams({ team_id: teamId });
+  const queryString = buildQueryStringFromParams({ fleet_id: teamId });
   const path =
     typeof teamId === "undefined" ? endpoint : `${endpoint}?${queryString}`;
 

--- a/frontend/test/handlers/script-handlers.ts
+++ b/frontend/test/handlers/script-handlers.ts
@@ -12,7 +12,7 @@ const getTeamScriptsHandler = (
   const scripts = overrides.map((scriptOverride) =>
     createMockScript(scriptOverride)
   );
-  return http.get(baseUrl(`/scripts?team_id=${teamId}`), () =>
+  return http.get(baseUrl(`/scripts?fleet_id=${teamId}`), () =>
     HttpResponse.json({
       scripts,
     })

--- a/frontend/test/handlers/team-handlers.ts
+++ b/frontend/test/handlers/team-handlers.ts
@@ -3,7 +3,7 @@ import { IConfig } from "interfaces/config";
 import { http, HttpResponse } from "msw";
 import { baseUrl } from "test/test-utils";
 
-const teamUrl = baseUrl("/teams/:id");
+const teamUrl = baseUrl("/fleets/:id");
 
 // eslint-disable-next-line import/prefer-default-export
 export const createGetTeamHandler = (overrides?: Partial<IConfig>) => {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -75,7 +75,7 @@ export default {
   // Host endpoints
   HOST_SUMMARY: `/${API_VERSION}/fleet/host_summary`,
   HOST_QUERY_REPORT: (hostId: number, queryId: number) =>
-    `/${API_VERSION}/fleet/hosts/${hostId}/queries/${queryId}`,
+    `/${API_VERSION}/fleet/hosts/${hostId}/reports/${queryId}`,
   HOSTS: `/${API_VERSION}/fleet/hosts`,
   HOSTS_COUNT: `/${API_VERSION}/fleet/hosts/count`,
   HOSTS_DELETE: `/${API_VERSION}/fleet/hosts/delete`,
@@ -137,7 +137,7 @@ export default {
   MDM_ABM_TOKEN_RENEW: (id: number) =>
     `/${API_VERSION}/fleet/abm_tokens/${id}/renew`,
   MDM_ABM_TOKEN_TEAMS: (id: number) =>
-    `/${API_VERSION}/fleet/abm_tokens/${id}/teams`,
+    `/${API_VERSION}/fleet/abm_tokens/${id}/fleets`,
   MDM_APPLE_ABM_PUBLIC_KEY: `/${API_VERSION}/fleet/mdm/apple/abm_public_key`,
   MDM_APPLE_APNS_CERTIFICATE: `/${API_VERSION}/fleet/mdm/apple/apns_certificate`,
   MDM_APPLE_PNS: `/${API_VERSION}/fleet/apns`,
@@ -152,7 +152,7 @@ export default {
   MDM_VPP_TOKENS_RENEW: (id: number) =>
     `/${API_VERSION}/fleet/vpp_tokens/${id}/renew`,
   MDM_VPP_TOKEN_TEAMS: (id: number) =>
-    `/${API_VERSION}/fleet/vpp_tokens/${id}/teams`,
+    `/${API_VERSION}/fleet/vpp_tokens/${id}/fleets`,
 
   // MDM profile endpoints
   MDM_PROFILES: `/${API_VERSION}/fleet/mdm/profiles`,
@@ -207,10 +207,10 @@ export default {
   OSQUERY_OPTIONS: `/${API_VERSION}/fleet/spec/osquery_options`,
   PACKS: `/${API_VERSION}/fleet/packs`,
   PERFORM_REQUIRED_PASSWORD_RESET: `/${API_VERSION}/fleet/perform_required_password_reset`,
-  QUERIES: `/${API_VERSION}/fleet/queries`,
-  QUERY_REPORT: (id: number) => `/${API_VERSION}/fleet/queries/${id}/report`,
+  QUERIES: `/${API_VERSION}/fleet/reports`,
+  QUERY_REPORT: (id: number) => `/${API_VERSION}/fleet/reports/${id}/report`,
   RESET_PASSWORD: `/${API_VERSION}/fleet/reset_password`,
-  LIVE_QUERY: `/${API_VERSION}/fleet/queries/run`,
+  LIVE_QUERY: `/${API_VERSION}/fleet/reports/run`,
   SCHEDULE_QUERY: `/${API_VERSION}/fleet/packs/schedule`,
   SCHEDULED_QUERIES: (packId: number): string => {
     return `/${API_VERSION}/fleet/packs/${packId}/scheduled`;
@@ -253,23 +253,23 @@ export default {
   STATUS_RESULT_STORE: `/${API_VERSION}/fleet/status/result_store`,
   TARGETS: `/${API_VERSION}/fleet/targets`,
   TEAM_POLICIES: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/policies`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/policies`;
   },
   TEAM_SCHEDULE: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/schedule`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/schedule`;
   },
-  TEAMS: `/${API_VERSION}/fleet/teams`,
+  TEAMS: `/${API_VERSION}/fleet/fleets`,
   TEAMS_AGENT_OPTIONS: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/agent_options`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/agent_options`;
   },
   TEAMS_ENROLL_SECRETS: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/secrets`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/secrets`;
   },
   TEAM_USERS: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/users`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/users`;
   },
   TEAMS_TRANSFER_HOSTS: (teamId: number): string => {
-    return `/${API_VERSION}/fleet/teams/${teamId}/hosts`;
+    return `/${API_VERSION}/fleet/fleets/${teamId}/hosts`;
   },
   UPDATE_USER_ADMIN: (id: number): string => {
     return `/${API_VERSION}/fleet/users/${id}/admin`;

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -222,7 +222,7 @@ export const formatScheduledQueryForServer = (
     query_id: queryID,
     shard,
   } = scheduledQuery;
-  const result = omit(scheduledQuery, ["logging_type"]);
+  const result = omit(scheduledQuery, ["logging_type", "query_id"]);
 
   if (platform === "all") {
     result.platform = "";
@@ -280,7 +280,7 @@ export const formatScheduledQueryForClient = (
 
 export const formatGlobalScheduledQueryForServer = (
   scheduledQuery: IScheduledQuery
-): IScheduledQuery => {
+) => {
   const {
     interval,
     logging_type: loggingType,
@@ -288,7 +288,7 @@ export const formatGlobalScheduledQueryForServer = (
     query_id: queryID,
     shard,
   } = scheduledQuery;
-  const result = omit(scheduledQuery, ["logging_type"]);
+  const result = omit(scheduledQuery, ["logging_type", "query_id"]);
 
   if (platform === "all") {
     result.platform = "";
@@ -351,7 +351,7 @@ export const formatTeamScheduledQueryForServer = (
     shard,
     team_id: teamID,
   } = scheduledQuery;
-  const result = omit(scheduledQuery, ["logging_type"]);
+  const result = omit(scheduledQuery, ["logging_type", "query_id", "team_id"]);
 
   if (platform === "all") {
     result.platform = "";
@@ -375,7 +375,7 @@ export const formatTeamScheduledQueryForServer = (
   }
 
   if (teamID) {
-    (result as any).report_id = Number(teamID);
+    (result as any).fleet_id = Number(teamID);
   }
 
   return result;

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -242,7 +242,7 @@ export const formatScheduledQueryForServer = (
   }
 
   if (queryID) {
-    result.query_id = Number(queryID);
+    (result as any).report_id = Number(queryID);
   }
 
   if (shard) {
@@ -304,7 +304,7 @@ export const formatGlobalScheduledQueryForServer = (
   }
 
   if (queryID) {
-    result.query_id = Number(queryID);
+    (result as any).report_id = Number(queryID);
   }
 
   if (shard) {
@@ -367,7 +367,7 @@ export const formatTeamScheduledQueryForServer = (
   }
 
   if (queryID) {
-    result.query_id = Number(queryID);
+    (result as any).report_id = Number(queryID);
   }
 
   if (shard) {
@@ -375,7 +375,7 @@ export const formatTeamScheduledQueryForServer = (
   }
 
   if (teamID) {
-    result.query_id = Number(teamID);
+    (result as any).report_id = Number(teamID);
   }
 
   return result;

--- a/frontend/utilities/url/index.ts
+++ b/frontend/utilities/url/index.ts
@@ -152,7 +152,7 @@ export const reconcileSoftwareParams = ({
     return {
       software_title_id: softwareTitleId,
       [HOSTS_QUERY_PARAMS.SOFTWARE_STATUS]: softwareStatus,
-      team_id: teamId,
+      fleet_id: teamId,
     };
   }
 
@@ -177,7 +177,7 @@ export const reconcileMutuallyInclusiveHostParams = ({
   macSettingsStatus,
   osSettings,
 }: IMutuallyInclusiveHostParams) => {
-  const reconciled: Record<string, unknown> = { team_id: teamId };
+  const reconciled: Record<string, unknown> = { fleet_id: teamId };
 
   if (label) {
     // if label is present, include team_id in the query but exclude others
@@ -186,15 +186,15 @@ export const reconcileMutuallyInclusiveHostParams = ({
 
   if (macSettingsStatus) {
     // ensure macos_settings filter is always applied in
-    // conjunction with a team_id, 0 (no fleets) by default
+    // conjunction with a fleet_id, 0 (no fleets) by default
     reconciled.macos_settings = macSettingsStatus;
-    reconciled.team_id = teamId ?? 0;
+    reconciled.fleet_id = teamId ?? 0;
   }
   if (osSettings) {
     // ensure os_settings filter is always applied in
-    // conjunction with a team_id, 0 (no fleets) by default
+    // conjunction with a fleet_id, 0 (no fleets) by default
     reconciled[HOSTS_QUERY_PARAMS.OS_SETTINGS] = osSettings;
-    reconciled.team_id = teamId ?? 0;
+    reconciled.fleet_id = teamId ?? 0;
   }
 
   return reconciled;

--- a/frontend/utilities/url/url.tests.ts
+++ b/frontend/utilities/url/url.tests.ts
@@ -93,7 +93,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
       reconcileMutuallyInclusiveHostParams({ macSettingsStatus, teamId })
     ).toEqual({
       macos_settings: "pending",
-      team_id: 1,
+      fleet_id: 1,
     });
   });
 
@@ -106,18 +106,18 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
       })
     ).toEqual({
       macos_settings: "pending",
-      team_id: 0,
+      fleet_id: 0,
     });
   });
 
-  it("adds team_id: 0 when macSettingsStatus is present and teamId is not", () => {
+  it("adds fleet_id: 0 when macSettingsStatus is present and teamId is not", () => {
     const [macSettingsStatus, teamId] = ["pending" as const, undefined];
     expect(
       reconcileMutuallyInclusiveHostParams({
         macSettingsStatus,
         teamId,
       })
-    ).toEqual({ macos_settings: "pending", team_id: 0 });
+    ).toEqual({ macos_settings: "pending", fleet_id: 0 });
   });
 
   it("does not add macos_settings when teamId is present and macSettingsStatus is not", () => {
@@ -125,7 +125,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
     expect(
       reconcileMutuallyInclusiveHostParams({ macSettingsStatus, teamId })
     ).toEqual({
-      team_id: 1,
+      fleet_id: 1,
     });
   });
 
@@ -145,7 +145,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
         osSettings: "pending",
       })
     ).toEqual({
-      team_id: 1,
+      fleet_id: 1,
     });
     expect(
       reconcileMutuallyInclusiveHostParams({
@@ -154,7 +154,7 @@ describe("url utilities > reconcileMutuallyInclusiveHostParams", () => {
         osSettings: "pending",
       })
     ).toEqual({
-      team_id: undefined,
+      fleet_id: undefined,
     });
   });
 });


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41391

# Details

This PR updates front-end API calls to use new URLs and API params, so that the front end doesn't cause deprecation warnings to appear on the server.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, should not be user-visible

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
The biggest risk here is not that we missed a spot that still causes a deprecation warning, but that we might inadvertently make a change that breaks the front end, for instance by sending `fleet_id` to a function that drops it silently and thus sends no ID to the server.  Fortunately we use TypeScript in virtually every place affected by these changes, so the code would not compile if there were mismatches between the API expectation and what we're sending. Still, spot checking as many places as possible both for deprecation-warning leaks and loss of functionality is important.

## Summary by CodeRabbit

* **Refactor**
  * Updated API nomenclature across the application to use "fleets" instead of "teams" and "reports" instead of "queries" in endpoint paths and request/response payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->