### PR TITLE
Added per-IP rate limiting and response caching

### DIFF
--- a/changes/37092-idp-throttle
+++ b/changes/37092-idp-throttle
@@ -1,0 +1,1 @@
+* Added per-IP rate limiting and response caching to the unauthenticated conditional access IdP metadata and SSO endpoints to prevent DDoS-driven database overload.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1539,7 +1539,7 @@ the way that the Fleet server works.
 					}
 
 					// Conditional Access IdP (Okta)
-					if err = condaccess.RegisterIdP(rootMux, ds, logger, &config); err != nil {
+					if err = condaccess.RegisterIdP(rootMux, ds, logger, &config, limiterStore); err != nil {
 						initFatal(err, "setup conditional access IdP")
 					}
 				} else {

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -24,10 +24,10 @@ import (
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
+	"github.com/fleetdm/fleet/v4/server/platform/middleware/ratelimit"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/otel"
 	"github.com/google/uuid"
-	"github.com/realclientip/realclientip-go"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/throttled/throttled/v2"
 )
@@ -134,7 +134,11 @@ func RegisterIdP(
 	// Create per-IP rate limiter for unauthenticated IdP endpoints.
 	// These endpoints are publicly accessible (required by SAML standard),
 	// so rate limiting prevents DDoS-driven database overload.
-	rateLimiter, err := newIDPRateLimiter(limitStore, ipStrategy)
+	quota := throttled.RateQuota{
+		MaxRate:  throttled.PerMin(idpRateLimitPerMinute),
+		MaxBurst: idpRateLimitMaxBurst,
+	}
+	rateLimiter, err := ratelimit.NewHTTPRateLimiter(limitStore, quota, ipStrategy)
 	if err != nil {
 		return fmt.Errorf("create idp rate limiter: %w", err)
 	}
@@ -157,39 +161,6 @@ func RegisterIdP(
 	mux.Handle(idpSSOPath, ssoHandler)
 
 	return nil
-}
-
-// clientIPVaryBy implements throttled.VaryBy using the real client IP extracted via the configured
-// trusted_proxies strategy. This correctly identifies clients behind load balancers/reverse proxies
-// instead of rate-limiting by the proxy's IP address.
-type clientIPVaryBy struct {
-	strategy realclientip.Strategy
-}
-
-func (v *clientIPVaryBy) Key(r *http.Request) string {
-	ip := v.strategy.ClientIP(r.Header, r.RemoteAddr)
-	if ip == "" {
-		return r.RemoteAddr
-	}
-	return ip
-}
-
-// newIDPRateLimiter creates an HTTP rate limiter for the IdP endpoints.
-func newIDPRateLimiter(store throttled.GCRAStore, ipStrategy realclientip.Strategy) (*throttled.HTTPRateLimiter, error) {
-	quota := throttled.RateQuota{
-		MaxRate:  throttled.PerMin(idpRateLimitPerMinute),
-		MaxBurst: idpRateLimitMaxBurst,
-	}
-
-	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
-	if err != nil {
-		return nil, fmt.Errorf("create rate limiter: %w", err)
-	}
-
-	return &throttled.HTTPRateLimiter{
-		RateLimiter: rateLimiter,
-		VaryBy:      &clientIPVaryBy{strategy: ipStrategy},
-	}, nil
 }
 
 // handleInternalServerError logs the error, records it in context, and returns HTTP 500.

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -67,7 +67,10 @@ func (e *notFoundError) IsNotFound() bool {
 	return true
 }
 
-// metadataCache caches the SAML IdP metadata XML response (body + headers) to avoid repeated database queries.
+// metadataCache caches the SAML IdP metadata XML response (body + headers). Unlike authenticated
+// endpoints that rely on the datastore's AppConfig cache, this unauthenticated endpoint uses its own
+// cache to avoid hitting the database entirely, even the datastore cache lookup is skipped, providing
+// an extra layer of protection against DDoS-driven load.
 type metadataCache struct {
 	mu        sync.RWMutex
 	data      []byte
@@ -131,7 +134,7 @@ func RegisterIdP(
 	// Create per-IP rate limiter for unauthenticated IdP endpoints.
 	// These endpoints are publicly accessible (required by SAML standard),
 	// so rate limiting prevents DDoS-driven database overload.
-	rateLimiter, err := ratelimit.NewHTTPRateLimiter(limitStore, ratelimit.DefaultHTTPRateQuota, ipStrategy)
+	rateLimiter, err := ratelimit.NewHTTPRateLimiter(limitStore, ratelimit.DefaultHTTPRateQuota(), ipStrategy)
 	if err != nil {
 		return fmt.Errorf("create idp rate limiter: %w", err)
 	}

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -49,12 +49,9 @@ const (
 	// Policy response values
 	policyResponseFail = "fail"
 
-	// Rate limiting: 10 requests per minute per IP with burst of 9 (allows 10 initial requests before throttling)
-	idpRateLimitPerMinute = 10
-	idpRateLimitMaxBurst  = 9
-
-	// Metadata cache TTL
-	metadataCacheTTL = 5 * time.Minute
+	// Metadata cache TTL (for DDoS protection). Keep this short because the cached response
+	// depends on the server URL from AppConfig; a URL change will serve stale data until expiry.
+	metadataCacheTTL = 1 * time.Minute
 )
 
 // notFoundError implements fleet.NotFoundError interface for conditional access IdP errors.
@@ -134,11 +131,7 @@ func RegisterIdP(
 	// Create per-IP rate limiter for unauthenticated IdP endpoints.
 	// These endpoints are publicly accessible (required by SAML standard),
 	// so rate limiting prevents DDoS-driven database overload.
-	quota := throttled.RateQuota{
-		MaxRate:  throttled.PerMin(idpRateLimitPerMinute),
-		MaxBurst: idpRateLimitMaxBurst,
-	}
-	rateLimiter, err := ratelimit.NewHTTPRateLimiter(limitStore, quota, ipStrategy)
+	rateLimiter, err := ratelimit.NewHTTPRateLimiter(limitStore, ratelimit.DefaultHTTPRateQuota, ipStrategy)
 	if err != nil {
 		return fmt.Errorf("create idp rate limiter: %w", err)
 	}

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -30,7 +30,6 @@ import (
 	"github.com/realclientip/realclientip-go"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/throttled/throttled/v2"
-	"github.com/throttled/throttled/v2/store/memstore"
 )
 
 const (
@@ -112,6 +111,7 @@ func RegisterIdP(
 	ds fleet.Datastore,
 	logger *slog.Logger,
 	fleetConfig *config.FleetConfig,
+	limitStore throttled.GCRAStore,
 ) error {
 	if fleetConfig == nil {
 		return errors.New("fleet config is nil")
@@ -134,7 +134,7 @@ func RegisterIdP(
 	// Create per-IP rate limiter for unauthenticated IdP endpoints.
 	// These endpoints are publicly accessible (required by SAML standard),
 	// so rate limiting prevents DDoS-driven database overload.
-	rateLimiter, err := newIDPRateLimiter(ipStrategy)
+	rateLimiter, err := newIDPRateLimiter(limitStore, ipStrategy)
 	if err != nil {
 		return fmt.Errorf("create idp rate limiter: %w", err)
 	}
@@ -175,12 +175,7 @@ func (v *clientIPVaryBy) Key(r *http.Request) string {
 }
 
 // newIDPRateLimiter creates an HTTP rate limiter for the IdP endpoints.
-func newIDPRateLimiter(ipStrategy realclientip.Strategy) (*throttled.HTTPRateLimiter, error) {
-	store, err := memstore.New(65536)
-	if err != nil {
-		return nil, fmt.Errorf("create rate limit store: %w", err)
-	}
-
+func newIDPRateLimiter(store throttled.GCRAStore, ipStrategy realclientip.Strategy) (*throttled.HTTPRateLimiter, error) {
 	quota := throttled.RateQuota{
 		MaxRate:  throttled.PerMin(idpRateLimitPerMinute),
 		MaxBurst: idpRateLimitMaxBurst,

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/crewjam/saml"
@@ -25,6 +26,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/middleware/otel"
 	"github.com/google/uuid"
 	dsig "github.com/russellhaering/goxmldsig"
+	"github.com/throttled/throttled/v2"
+	"github.com/throttled/throttled/v2/store/memstore"
 )
 
 const (
@@ -43,6 +46,13 @@ const (
 
 	// Policy response values
 	policyResponseFail = "fail"
+
+	// Rate limiting: 10 requests per minute per IP with burst of 10
+	idpRateLimitPerMinute = 10
+	idpRateLimitMaxBurst  = 9
+
+	// Metadata cache TTL
+	metadataCacheTTL = 5 * time.Minute
 )
 
 // notFoundError implements fleet.NotFoundError interface for conditional access IdP errors.
@@ -58,11 +68,37 @@ func (e *notFoundError) IsNotFound() bool {
 	return true
 }
 
+// metadataCache caches the SAML IdP metadata XML response to avoid repeated database queries.
+type metadataCache struct {
+	mu        sync.RWMutex
+	data      []byte
+	expiresAt time.Time
+}
+
+// get returns the cached metadata if it hasn't expired.
+func (c *metadataCache) get() ([]byte, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.data == nil || time.Now().After(c.expiresAt) {
+		return nil, false
+	}
+	return c.data, true
+}
+
+// set stores the metadata in the cache with the given TTL.
+func (c *metadataCache) set(data []byte, ttl time.Duration) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.data = data
+	c.expiresAt = time.Now().Add(ttl)
+}
+
 // idpService implements the Okta conditional access IdP functionality.
 type idpService struct {
 	ds               fleet.Datastore
 	logger           *slog.Logger
 	certSerialFormat string
+	mdCache          *metadataCache
 }
 
 // RegisterIdP registers the HTTP handlers for Okta conditional access IdP endpoints.
@@ -80,23 +116,57 @@ func RegisterIdP(
 		ds:               ds,
 		logger:           logger.With("component", "conditional-access-idp"),
 		certSerialFormat: fleetConfig.ConditionalAccess.CertSerialFormat,
+		mdCache:          &metadataCache{},
+	}
+
+	// Create per-IP rate limiter for unauthenticated IdP endpoints.
+	// These endpoints are publicly accessible (required by SAML standard),
+	// so rate limiting prevents DDoS-driven database overload.
+	rateLimiter, err := newIDPRateLimiter()
+	if err != nil {
+		return fmt.Errorf("create idp rate limiter: %w", err)
 	}
 
 	// Create logging middleware
 	loggingMiddleware := log.NewLoggingMiddleware(svc.logger)
 
-	// Register handlers with logging and OpenTelemetry middleware
-	// Order: OTEL wraps logging to capture full request lifecycle
+	// Register handlers with logging, rate limiting, and OpenTelemetry middleware.
+	// Order (outermost first): OTEL -> rate limit -> logging -> handler
 	metadataHandler := loggingMiddleware(http.HandlerFunc(svc.serveMetadata))
+	metadataHandler = rateLimiter.RateLimit(metadataHandler)
 	metadataHandler = otel.WrapHandler(metadataHandler, idpMetadataPath, *fleetConfig)
 
 	ssoHandler := loggingMiddleware(http.HandlerFunc(svc.serveSSO))
+	ssoHandler = rateLimiter.RateLimit(ssoHandler)
 	ssoHandler = otel.WrapHandler(ssoHandler, idpSSOPath, *fleetConfig)
 
 	mux.Handle(idpMetadataPath, metadataHandler)
 	mux.Handle(idpSSOPath, ssoHandler)
 
 	return nil
+}
+
+// newIDPRateLimiter creates an HTTP rate limiter for the IdP endpoints.
+func newIDPRateLimiter() (*throttled.HTTPRateLimiter, error) {
+	store, err := memstore.New(65536)
+	if err != nil {
+		return nil, fmt.Errorf("create rate limit store: %w", err)
+	}
+
+	quota := throttled.RateQuota{
+		MaxRate:  throttled.PerMin(idpRateLimitPerMinute),
+		MaxBurst: idpRateLimitMaxBurst,
+	}
+
+	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	if err != nil {
+		return nil, fmt.Errorf("create rate limiter: %w", err)
+	}
+
+	return &throttled.HTTPRateLimiter{
+		RateLimiter: rateLimiter,
+		VaryBy:      &throttled.VaryBy{RemoteAddr: true},
+	}, nil
 }
 
 // handleInternalServerError logs the error, records it in context, and returns HTTP 500.
@@ -112,7 +182,16 @@ func handleInternalServerError(ctx context.Context, w http.ResponseWriter, logge
 
 // serveMetadata handles GET /api/fleet/conditional_access/idp/metadata
 // Returns SAML IdP metadata for Okta to consume.
+// Responses are cached in memory to avoid repeated database queries.
 func (s *idpService) serveMetadata(w http.ResponseWriter, r *http.Request) {
+	// Return cached response if available
+	if cached, ok := s.mdCache.get(); ok {
+		w.Header().Set("Content-Type", "application/samlmetadata+xml")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(cached)
+		return
+	}
+
 	ctx := r.Context()
 
 	// Load AppConfig to get Okta settings
@@ -142,8 +221,43 @@ func (s *idpService) serveMetadata(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// ServeMetadata writes XML directly to the response
-	idp.ServeMetadata(w, r)
+	// Capture the metadata response so we can cache it
+	rec := &responseRecorder{header: make(http.Header)}
+	idp.ServeMetadata(rec, r)
+
+	// Only cache successful responses
+	if rec.statusCode == http.StatusOK || rec.statusCode == 0 {
+		s.mdCache.set(rec.body, metadataCacheTTL)
+	}
+
+	// Write the captured response to the actual client
+	for k, v := range rec.header {
+		w.Header()[k] = v
+	}
+	if rec.statusCode > 0 {
+		w.WriteHeader(rec.statusCode)
+	}
+	_, _ = w.Write(rec.body)
+}
+
+// responseRecorder captures an HTTP response for caching purposes.
+type responseRecorder struct {
+	header     http.Header
+	body       []byte
+	statusCode int
+}
+
+func (r *responseRecorder) Header() http.Header {
+	return r.header
+}
+
+func (r *responseRecorder) Write(b []byte) (int, error) {
+	r.body = append(r.body, b...)
+	return len(b), nil
+}
+
+func (r *responseRecorder) WriteHeader(statusCode int) {
+	r.statusCode = statusCode
 }
 
 // serveSSO handles POST /api/fleet/conditional_access/idp/sso

--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"os"
@@ -22,9 +23,11 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/otel"
 	"github.com/google/uuid"
+	"github.com/realclientip/realclientip-go"
 	dsig "github.com/russellhaering/goxmldsig"
 	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
@@ -47,7 +50,7 @@ const (
 	// Policy response values
 	policyResponseFail = "fail"
 
-	// Rate limiting: 10 requests per minute per IP with burst of 10
+	// Rate limiting: 10 requests per minute per IP with burst of 9 (allows 10 initial requests before throttling)
 	idpRateLimitPerMinute = 10
 	idpRateLimitMaxBurst  = 9
 
@@ -68,28 +71,30 @@ func (e *notFoundError) IsNotFound() bool {
 	return true
 }
 
-// metadataCache caches the SAML IdP metadata XML response to avoid repeated database queries.
+// metadataCache caches the SAML IdP metadata XML response (body + headers) to avoid repeated database queries.
 type metadataCache struct {
 	mu        sync.RWMutex
 	data      []byte
+	headers   http.Header
 	expiresAt time.Time
 }
 
-// get returns the cached metadata if it hasn't expired.
-func (c *metadataCache) get() ([]byte, bool) {
+// get returns the cached metadata and headers if the cache hasn't expired.
+func (c *metadataCache) get() ([]byte, http.Header, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if c.data == nil || time.Now().After(c.expiresAt) {
-		return nil, false
+		return nil, nil, false
 	}
-	return c.data, true
+	return c.data, c.headers, true
 }
 
-// set stores the metadata in the cache with the given TTL.
-func (c *metadataCache) set(data []byte, ttl time.Duration) {
+// set stores the metadata and headers in the cache with the given TTL.
+func (c *metadataCache) set(data []byte, headers http.Header, ttl time.Duration) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.data = data
+	c.headers = headers.Clone()
 	c.expiresAt = time.Now().Add(ttl)
 }
 
@@ -119,10 +124,17 @@ func RegisterIdP(
 		mdCache:          &metadataCache{},
 	}
 
+	// Create IP extraction strategy for real client IP behind load balancers.
+	// This reuses the same trusted_proxies configuration as the main API handler.
+	ipStrategy, err := endpointer.NewClientIPStrategy(fleetConfig.Server.TrustedProxies)
+	if err != nil {
+		return fmt.Errorf("create ip strategy: %w", err)
+	}
+
 	// Create per-IP rate limiter for unauthenticated IdP endpoints.
 	// These endpoints are publicly accessible (required by SAML standard),
 	// so rate limiting prevents DDoS-driven database overload.
-	rateLimiter, err := newIDPRateLimiter()
+	rateLimiter, err := newIDPRateLimiter(ipStrategy)
 	if err != nil {
 		return fmt.Errorf("create idp rate limiter: %w", err)
 	}
@@ -131,13 +143,14 @@ func RegisterIdP(
 	loggingMiddleware := log.NewLoggingMiddleware(svc.logger)
 
 	// Register handlers with logging, rate limiting, and OpenTelemetry middleware.
-	// Order (outermost first): OTEL -> rate limit -> logging -> handler
-	metadataHandler := loggingMiddleware(http.HandlerFunc(svc.serveMetadata))
-	metadataHandler = rateLimiter.RateLimit(metadataHandler)
+	// Order (outermost first): OTEL -> logging -> rate limit -> handler
+	// Logging wraps rate limiting so that 429 responses are also logged.
+	metadataHandler := rateLimiter.RateLimit(http.HandlerFunc(svc.serveMetadata))
+	metadataHandler = loggingMiddleware(metadataHandler)
 	metadataHandler = otel.WrapHandler(metadataHandler, idpMetadataPath, *fleetConfig)
 
-	ssoHandler := loggingMiddleware(http.HandlerFunc(svc.serveSSO))
-	ssoHandler = rateLimiter.RateLimit(ssoHandler)
+	ssoHandler := rateLimiter.RateLimit(http.HandlerFunc(svc.serveSSO))
+	ssoHandler = loggingMiddleware(ssoHandler)
 	ssoHandler = otel.WrapHandler(ssoHandler, idpSSOPath, *fleetConfig)
 
 	mux.Handle(idpMetadataPath, metadataHandler)
@@ -146,8 +159,23 @@ func RegisterIdP(
 	return nil
 }
 
+// clientIPVaryBy implements throttled.VaryBy using the real client IP extracted via the configured
+// trusted_proxies strategy. This correctly identifies clients behind load balancers/reverse proxies
+// instead of rate-limiting by the proxy's IP address.
+type clientIPVaryBy struct {
+	strategy realclientip.Strategy
+}
+
+func (v *clientIPVaryBy) Key(r *http.Request) string {
+	ip := v.strategy.ClientIP(r.Header, r.RemoteAddr)
+	if ip == "" {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
 // newIDPRateLimiter creates an HTTP rate limiter for the IdP endpoints.
-func newIDPRateLimiter() (*throttled.HTTPRateLimiter, error) {
+func newIDPRateLimiter(ipStrategy realclientip.Strategy) (*throttled.HTTPRateLimiter, error) {
 	store, err := memstore.New(65536)
 	if err != nil {
 		return nil, fmt.Errorf("create rate limit store: %w", err)
@@ -165,7 +193,7 @@ func newIDPRateLimiter() (*throttled.HTTPRateLimiter, error) {
 
 	return &throttled.HTTPRateLimiter{
 		RateLimiter: rateLimiter,
-		VaryBy:      &throttled.VaryBy{RemoteAddr: true},
+		VaryBy:      &clientIPVaryBy{strategy: ipStrategy},
 	}, nil
 }
 
@@ -185,8 +213,8 @@ func handleInternalServerError(ctx context.Context, w http.ResponseWriter, logge
 // Responses are cached in memory to avoid repeated database queries.
 func (s *idpService) serveMetadata(w http.ResponseWriter, r *http.Request) {
 	// Return cached response if available
-	if cached, ok := s.mdCache.get(); ok {
-		w.Header().Set("Content-Type", "application/samlmetadata+xml")
+	if cached, cachedHeaders, ok := s.mdCache.get(); ok {
+		maps.Copy(w.Header(), cachedHeaders)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(cached)
 		return
@@ -227,13 +255,11 @@ func (s *idpService) serveMetadata(w http.ResponseWriter, r *http.Request) {
 
 	// Only cache successful responses
 	if rec.statusCode == http.StatusOK || rec.statusCode == 0 {
-		s.mdCache.set(rec.body, metadataCacheTTL)
+		s.mdCache.set(rec.body, rec.header, metadataCacheTTL)
 	}
 
 	// Write the captured response to the actual client
-	for k, v := range rec.header {
-		w.Header()[k] = v
-	}
+	maps.Copy(w.Header(), rec.header)
 	if rec.statusCode > 0 {
 		w.WriteHeader(rec.statusCode)
 	}

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -76,13 +76,13 @@ b1ctZeF7HaWwFdTC8GqWI6zzRFn+YA3f/yYibhowuEypPQeSjlI=
 func newTestService() (*idpService, *mock.Store) {
 	ds := new(mock.Store)
 	logger := slog.New(slog.DiscardHandler)
-	return &idpService{ds: ds, logger: logger, certSerialFormat: config.CertSerialFormatHex}, ds
+	return &idpService{ds: ds, logger: logger, certSerialFormat: config.CertSerialFormatHex, mdCache: &metadataCache{}}, ds
 }
 
 func newTestServiceWithCertFormat(certFormat string) (*idpService, *mock.Store) {
 	ds := new(mock.Store)
 	logger := slog.New(slog.DiscardHandler)
-	return &idpService{ds: ds, logger: logger, certSerialFormat: certFormat}, ds
+	return &idpService{ds: ds, logger: logger, certSerialFormat: certFormat, mdCache: &metadataCache{}}, ds
 }
 
 func mockAppConfigFunc(serverURL string) func(context.Context) (*fleet.AppConfig, error) {
@@ -215,6 +215,95 @@ func TestServeMetadata(t *testing.T) {
 		require.Equal(t, http.StatusNotFound, w.Code)
 		require.Contains(t, w.Body.String(), "Server URL not configured")
 	})
+
+	t.Run("caches metadata response", func(t *testing.T) {
+		svc, ds := newTestService()
+		ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
+
+		// First request should hit the datastore
+		req := httptest.NewRequest("GET", idpMetadataPath, nil)
+		w := httptest.NewRecorder()
+		svc.serveMetadata(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		firstBody := w.Body.String()
+		require.Contains(t, firstBody, "EntityDescriptor")
+		require.True(t, ds.AppConfigFuncInvoked)
+
+		// Reset invocation tracking
+		ds.AppConfigFuncInvoked = false
+		ds.GetAllMDMConfigAssetsByNameFuncInvoked = false
+
+		// Second request should be served from cache without hitting the datastore
+		req = httptest.NewRequest("GET", idpMetadataPath, nil)
+		w = httptest.NewRecorder()
+		svc.serveMetadata(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "application/samlmetadata+xml", w.Header().Get("Content-Type"))
+		require.Equal(t, firstBody, w.Body.String())
+		require.False(t, ds.AppConfigFuncInvoked)
+		require.False(t, ds.GetAllMDMConfigAssetsByNameFuncInvoked)
+	})
+
+	t.Run("does not cache error responses", func(t *testing.T) {
+		svc, ds := newTestService()
+		ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(false) // Will return 404
+
+		// First request returns 404
+		req := httptest.NewRequest("GET", idpMetadataPath, nil)
+		w := httptest.NewRecorder()
+		svc.serveMetadata(w, req)
+		require.Equal(t, http.StatusNotFound, w.Code)
+
+		// Reset and configure for success
+		ds.AppConfigFuncInvoked = false
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
+
+		// Second request should hit the datastore (not cached)
+		req = httptest.NewRequest("GET", idpMetadataPath, nil)
+		w = httptest.NewRecorder()
+		svc.serveMetadata(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+		require.True(t, ds.AppConfigFuncInvoked)
+		require.Contains(t, w.Body.String(), "EntityDescriptor")
+	})
+}
+
+func TestIDPRateLimiting(t *testing.T) {
+	ds := new(mock.Store)
+	logger := slog.New(slog.DiscardHandler)
+	cfg := &config.FleetConfig{}
+
+	ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+	ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
+
+	mux := http.NewServeMux()
+	err := RegisterIdP(mux, ds, logger, cfg)
+	require.NoError(t, err)
+
+	// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
+	for i := range idpRateLimitMaxBurst + 1 {
+		req := httptest.NewRequest("GET", idpMetadataPath, nil)
+		req.RemoteAddr = "192.0.2.1:12345"
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code, "request %d should not be rate limited", i)
+	}
+
+	// Next request from the same IP should be rate limited
+	req := httptest.NewRequest("GET", idpMetadataPath, nil)
+	req.RemoteAddr = "192.0.2.1:12345"
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	// Request from a different IP should not be rate limited
+	req = httptest.NewRequest("GET", idpMetadataPath, nil)
+	req.RemoteAddr = "198.51.100.1:12345"
+	w = httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+	require.NotEqual(t, http.StatusTooManyRequests, w.Code)
 }
 
 func TestParseSerialNumber(t *testing.T) {

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -271,39 +271,83 @@ func TestServeMetadata(t *testing.T) {
 }
 
 func TestIDPRateLimiting(t *testing.T) {
-	ds := new(mock.Store)
-	logger := slog.New(slog.DiscardHandler)
-	cfg := &config.FleetConfig{}
+	t.Run("rate limits by remote addr", func(t *testing.T) {
+		ds := new(mock.Store)
+		logger := slog.New(slog.DiscardHandler)
+		cfg := &config.FleetConfig{}
 
-	ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
-	ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
+		ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
 
-	mux := http.NewServeMux()
-	err := RegisterIdP(mux, ds, logger, cfg)
-	require.NoError(t, err)
+		mux := http.NewServeMux()
+		err := RegisterIdP(mux, ds, logger, cfg)
+		require.NoError(t, err)
 
-	// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
-	for i := range idpRateLimitMaxBurst + 1 {
+		// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
+		for i := range idpRateLimitMaxBurst + 1 {
+			req := httptest.NewRequest("GET", idpMetadataPath, nil)
+			req.RemoteAddr = "192.0.2.1:12345"
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			require.NotEqual(t, http.StatusTooManyRequests, w.Code, "request %d should not be rate limited", i)
+		}
+
+		// Next request from the same IP should be rate limited
 		req := httptest.NewRequest("GET", idpMetadataPath, nil)
 		req.RemoteAddr = "192.0.2.1:12345"
 		w := httptest.NewRecorder()
 		mux.ServeHTTP(w, req)
-		require.NotEqual(t, http.StatusTooManyRequests, w.Code, "request %d should not be rate limited", i)
-	}
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
 
-	// Next request from the same IP should be rate limited
-	req := httptest.NewRequest("GET", idpMetadataPath, nil)
-	req.RemoteAddr = "192.0.2.1:12345"
-	w := httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.Equal(t, http.StatusTooManyRequests, w.Code)
+		// Request from a different IP should not be rate limited
+		req = httptest.NewRequest("GET", idpMetadataPath, nil)
+		req.RemoteAddr = "198.51.100.1:12345"
+		w = httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+	})
 
-	// Request from a different IP should not be rate limited
-	req = httptest.NewRequest("GET", idpMetadataPath, nil)
-	req.RemoteAddr = "198.51.100.1:12345"
-	w = httptest.NewRecorder()
-	mux.ServeHTTP(w, req)
-	require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+	t.Run("rate limits by X-Forwarded-For when trusted proxies configured", func(t *testing.T) {
+		ds := new(mock.Store)
+		logger := slog.New(slog.DiscardHandler)
+		cfg := &config.FleetConfig{}
+		cfg.Server.TrustedProxies = "10.0.0.0/8"
+
+		ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
+		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
+
+		mux := http.NewServeMux()
+		err := RegisterIdP(mux, ds, logger, cfg)
+		require.NoError(t, err)
+
+		// Send requests from a proxy IP but different real client IPs via X-Forwarded-For.
+		// All come from the same RemoteAddr (the proxy), but different real client IPs.
+		// With trusted_proxies configured, rate limiting should be per real client IP.
+		for i := range idpRateLimitMaxBurst + 1 {
+			req := httptest.NewRequest("GET", idpMetadataPath, nil)
+			req.RemoteAddr = "10.0.0.1:12345"
+			req.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")
+			w := httptest.NewRecorder()
+			mux.ServeHTTP(w, req)
+			require.NotEqual(t, http.StatusTooManyRequests, w.Code, "request %d should not be rate limited", i)
+		}
+
+		// Next request from the same real client IP should be rate limited
+		req := httptest.NewRequest("GET", idpMetadataPath, nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		req.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")
+		w := httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+		// Request from the same proxy but different real client IP should NOT be rate limited
+		req = httptest.NewRequest("GET", idpMetadataPath, nil)
+		req.RemoteAddr = "10.0.0.1:12345"
+		req.Header.Set("X-Forwarded-For", "203.0.113.20, 10.0.0.1")
+		w = httptest.NewRecorder()
+		mux.ServeHTTP(w, req)
+		require.NotEqual(t, http.StatusTooManyRequests, w.Code)
+	})
 }
 
 func TestParseSerialNumber(t *testing.T) {

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -18,6 +18,7 @@ import (
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
+	"github.com/throttled/throttled/v2/store/memstore"
 )
 
 // Test certificates used across multiple tests
@@ -73,6 +74,13 @@ b1ctZeF7HaWwFdTC8GqWI6zzRFn+YA3f/yYibhowuEypPQeSjlI=
 
 // Helper functions for test setup
 
+func newTestLimitStore(t *testing.T) *memstore.MemStore {
+	t.Helper()
+	store, err := memstore.New(0)
+	require.NoError(t, err)
+	return store
+}
+
 func newTestService() (*idpService, *mock.Store) {
 	ds := new(mock.Store)
 	logger := slog.New(slog.DiscardHandler)
@@ -118,17 +126,18 @@ func TestRegisterIdP(t *testing.T) {
 	ds := new(mock.Store)
 	logger := slog.New(slog.DiscardHandler)
 	cfg := &config.FleetConfig{}
+	store := newTestLimitStore(t)
 
 	ds.AppConfigFunc = mockAppConfigFunc("https://fleet.example.com")
 	ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(false)
 
 	mux := http.NewServeMux()
 	// Try with nil config
-	err := RegisterIdP(mux, ds, logger, nil)
+	err := RegisterIdP(mux, ds, logger, nil, store)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "fleet config is nil")
 
-	err = RegisterIdP(mux, ds, logger, cfg)
+	err = RegisterIdP(mux, ds, logger, cfg, store)
 	require.NoError(t, err)
 
 	t.Run("metadata endpoint registered", func(t *testing.T) {
@@ -280,7 +289,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
 
 		mux := http.NewServeMux()
-		err := RegisterIdP(mux, ds, logger, cfg)
+		err := RegisterIdP(mux, ds, logger, cfg, newTestLimitStore(t))
 		require.NoError(t, err)
 
 		// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
@@ -317,7 +326,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		ds.GetAllMDMConfigAssetsByNameFunc = mockCertAssetsFunc(true)
 
 		mux := http.NewServeMux()
-		err := RegisterIdP(mux, ds, logger, cfg)
+		err := RegisterIdP(mux, ds, logger, cfg, newTestLimitStore(t))
 		require.NoError(t, err)
 
 		// Send requests from a proxy IP but different real client IPs via X-Forwarded-For.

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
+	"github.com/fleetdm/fleet/v4/server/platform/middleware/ratelimit"
 	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
@@ -293,7 +294,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
-		for i := range idpRateLimitMaxBurst + 1 {
+		for i := range ratelimit.DefaultHTTPRateQuota.MaxBurst + 1 {
 			req := httptest.NewRequest("GET", idpMetadataPath, nil)
 			req.RemoteAddr = "192.0.2.1:12345"
 			w := httptest.NewRecorder()
@@ -332,7 +333,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		// Send requests from a proxy IP but different real client IPs via X-Forwarded-For.
 		// All come from the same RemoteAddr (the proxy), but different real client IPs.
 		// With trusted_proxies configured, rate limiting should be per real client IP.
-		for i := range idpRateLimitMaxBurst + 1 {
+		for i := range ratelimit.DefaultHTTPRateQuota.MaxBurst + 1 {
 			req := httptest.NewRequest("GET", idpMetadataPath, nil)
 			req.RemoteAddr = "10.0.0.1:12345"
 			req.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -236,6 +236,7 @@ func TestServeMetadata(t *testing.T) {
 		w := httptest.NewRecorder()
 		svc.serveMetadata(w, req)
 		require.Equal(t, http.StatusOK, w.Code)
+		require.Equal(t, "application/samlmetadata+xml", w.Header().Get("Content-Type"))
 		firstBody := w.Body.String()
 		require.Contains(t, firstBody, "EntityDescriptor")
 		require.True(t, ds.AppConfigFuncInvoked)
@@ -294,7 +295,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		require.NoError(t, err)
 
 		// Send requests up to the burst limit (maxBurst + 1 = 10 allowed)
-		for i := range ratelimit.DefaultHTTPRateQuota.MaxBurst + 1 {
+		for i := range ratelimit.DefaultHTTPRateQuota().MaxBurst + 1 {
 			req := httptest.NewRequest("GET", idpMetadataPath, nil)
 			req.RemoteAddr = "192.0.2.1:12345"
 			w := httptest.NewRecorder()
@@ -333,7 +334,7 @@ func TestIDPRateLimiting(t *testing.T) {
 		// Send requests from a proxy IP but different real client IPs via X-Forwarded-For.
 		// All come from the same RemoteAddr (the proxy), but different real client IPs.
 		// With trusted_proxies configured, rate limiting should be per real client IP.
-		for i := range ratelimit.DefaultHTTPRateQuota.MaxBurst + 1 {
+		for i := range ratelimit.DefaultHTTPRateQuota().MaxBurst + 1 {
 			req := httptest.NewRequest("GET", idpMetadataPath, nil)
 			req.RemoteAddr = "10.0.0.1:12345"
 			req.Header.Set("X-Forwarded-For", "203.0.113.10, 10.0.0.1")

--- a/server/platform/middleware/ratelimit/http.go
+++ b/server/platform/middleware/ratelimit/http.go
@@ -23,6 +23,13 @@ func (v *clientIPVaryBy) Key(r *http.Request) string {
 	return ip
 }
 
+// DefaultHTTPRateQuota is a reasonable default for HTTP-level rate limiting:
+// 10 requests per minute per IP with burst of 9 (allows 10 initial requests before throttling).
+var DefaultHTTPRateQuota = throttled.RateQuota{
+	MaxRate:  throttled.PerMin(10),
+	MaxBurst: 9,
+}
+
 // NewHTTPRateLimiter creates an HTTP-level rate limiter that varies by real client IP.
 // The ipStrategy determines how to extract the real client IP from requests (e.g. from
 // X-Forwarded-For headers when behind a load balancer). Use endpointer.NewClientIPStrategy

--- a/server/platform/middleware/ratelimit/http.go
+++ b/server/platform/middleware/ratelimit/http.go
@@ -1,0 +1,40 @@
+package ratelimit
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/realclientip/realclientip-go"
+	"github.com/throttled/throttled/v2"
+)
+
+// clientIPVaryBy implements throttled.VaryBy using the real client IP extracted via a configured
+// realclientip strategy. This correctly identifies clients behind load balancers/reverse proxies
+// instead of rate-limiting by the proxy's IP address.
+type clientIPVaryBy struct {
+	strategy realclientip.Strategy
+}
+
+func (v *clientIPVaryBy) Key(r *http.Request) string {
+	ip := v.strategy.ClientIP(r.Header, r.RemoteAddr)
+	if ip == "" {
+		return r.RemoteAddr
+	}
+	return ip
+}
+
+// NewHTTPRateLimiter creates an HTTP-level rate limiter that varies by real client IP.
+// The ipStrategy determines how to extract the real client IP from requests (e.g. from
+// X-Forwarded-For headers when behind a load balancer). Use endpointer.NewClientIPStrategy
+// to create a strategy from the server's trusted_proxies configuration.
+func NewHTTPRateLimiter(store throttled.GCRAStore, quota throttled.RateQuota, ipStrategy realclientip.Strategy) (*throttled.HTTPRateLimiter, error) {
+	rateLimiter, err := throttled.NewGCRARateLimiter(store, quota)
+	if err != nil {
+		return nil, fmt.Errorf("create rate limiter: %w", err)
+	}
+
+	return &throttled.HTTPRateLimiter{
+		RateLimiter: rateLimiter,
+		VaryBy:      &clientIPVaryBy{strategy: ipStrategy},
+	}, nil
+}

--- a/server/platform/middleware/ratelimit/http.go
+++ b/server/platform/middleware/ratelimit/http.go
@@ -23,11 +23,13 @@ func (v *clientIPVaryBy) Key(r *http.Request) string {
 	return ip
 }
 
-// DefaultHTTPRateQuota is a reasonable default for HTTP-level rate limiting:
+// DefaultHTTPRateQuota returns a reasonable default for HTTP-level rate limiting:
 // 10 requests per minute per IP with burst of 9 (allows 10 initial requests before throttling).
-var DefaultHTTPRateQuota = throttled.RateQuota{
-	MaxRate:  throttled.PerMin(10),
-	MaxBurst: 9,
+func DefaultHTTPRateQuota() throttled.RateQuota {
+	return throttled.RateQuota{
+		MaxRate:  throttled.PerMin(10),
+		MaxBurst: 9,
+	}
 }
 
 // NewHTTPRateLimiter creates an HTTP-level rate limiter that varies by real client IP.

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -587,7 +587,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 
 	if len(opts) > 0 && opts[0].ConditionalAccess != nil {
 		require.NoError(t, condaccess.RegisterSCEP(ctx, rootMux, opts[0].ConditionalAccess.SCEPStorage, ds, logger, &cfg))
-		require.NoError(t, condaccess.RegisterIdP(rootMux, ds, logger, &cfg))
+		require.NoError(t, condaccess.RegisterIdP(rootMux, ds, logger, &cfg, limitStore))
 	}
 	var carveStore fleet.CarveStore = ds // In tests, we use MySQL as storage for carves.
 	apiHandler := MakeHandler(svc, cfg, logger, limitStore, redisPool, carveStore, featureRoutes, extra...)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37092 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per‑IP rate limiting to IdP metadata and SSO endpoints.
  * Implemented TTL-backed in‑memory caching for IdP metadata responses to reduce backend load.

* **Tests**
  * Added tests covering metadata caching behavior, cache miss/error handling, and content type preservation.
  * Added tests validating rate limiting behavior across clients, bursts, and proxy scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->