### PR TITLE
Surface correct HTTP status on SCIM data constraint errors (40260)

### DIFF
--- a/changes/40260-5xx-on-scim-users-endpoint
+++ b/changes/40260-5xx-on-scim-users-endpoint
@@ -1,0 +1,1 @@
+* Made sure that data constraint errors are surfaced using the proper HTTP status code.

--- a/changes/40260-5xx-on-scim-users-endpoint
+++ b/changes/40260-5xx-on-scim-users-endpoint
@@ -1,1 +1,1 @@
-* Made sure that data constraint errors are surfaced using the proper HTTP status code.
+* Made sure that data constraint errors are surfaced using the proper HTTP status code on the /api/v1/fleet/scim/Users endpoint.

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -106,10 +106,9 @@ func (u *UserHandler) Create(r *http.Request, attributes scim.ResourceAttributes
 	}
 	user.ID, err = u.ds.CreateScimUser(ctx, user)
 	if err != nil {
-		var existsErr fleet.AlreadyExistsError
-		if errors.As(err, &existsErr) {
-			u.logger.InfoContext(ctx, "constraint violation: user already exists", userNameAttr, userName)
-			return scim.Resource{}, scimerrors.ScimErrorUniqueness
+		if scimErr := mapDatastoreErrorToScimError(err); scimErr != nil {
+			u.logger.InfoContext(ctx, "create scim user client error", userNameAttr, userName, "err", err)
+			return scim.Resource{}, scimErr
 		}
 		u.logger.ErrorContext(ctx, "failed to create scim user", userNameAttr, userName, "err", err)
 		return scim.Resource{}, err
@@ -491,6 +490,10 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 		u.logger.InfoContext(ctx, "failed to find user to replace", "id", id)
 		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	case err != nil:
+		if scimErr := mapDatastoreErrorToScimError(err); scimErr != nil {
+			u.logger.InfoContext(ctx, "replace scim user client error", "id", id, userNameAttr, user.UserName, "err", err)
+			return scim.Resource{}, scimErr
+		}
 		u.logger.ErrorContext(ctx, "failed to replace user", "id", id, "err", err)
 		return scim.Resource{}, err
 	}
@@ -786,6 +789,10 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 			u.logger.InfoContext(ctx, "failed to find user to patch", "id", id)
 			return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 		case err != nil:
+			if scimErr := mapDatastoreErrorToScimError(err); scimErr != nil {
+				u.logger.InfoContext(ctx, "patch scim user client error", "id", id, userNameAttr, user.UserName, "err", err)
+				return scim.Resource{}, scimErr
+			}
 			u.logger.ErrorContext(ctx, "failed to patch user", "id", id, "err", err)
 			return scim.Resource{}, err
 		}
@@ -1238,6 +1245,20 @@ func scimUserID(userID uint) string {
 }
 
 // extractUserIDFromValue extracts the user ID from a value like "123"
+// mapDatastoreErrorToScimError translates known datastore errors into SCIM protocol errors.
+// Returns nil if the error is not a recognized type.
+func mapDatastoreErrorToScimError(err error) error {
+	var existsErr fleet.AlreadyExistsError
+	if errors.As(err, &existsErr) {
+		return scimerrors.ScimErrorUniqueness
+	}
+	var validationErr *fleet.SCIMValidationError
+	if errors.As(err, &validationErr) {
+		return scimerrors.ScimErrorBadParams([]string{validationErr.Field})
+	}
+	return nil
+}
+
 func extractUserIDFromValue(value string) (uint, error) {
 	id, err := strconv.ParseUint(value, 10, 64)
 	if err != nil {

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -1244,7 +1244,6 @@ func scimUserID(userID uint) string {
 	return fmt.Sprintf("%d", userID)
 }
 
-// extractUserIDFromValue extracts the user ID from a value like "123"
 // mapDatastoreErrorToScimError translates known datastore errors into SCIM protocol errors.
 // Returns nil if the error is not a recognized type.
 func mapDatastoreErrorToScimError(err error) error {
@@ -1259,6 +1258,7 @@ func mapDatastoreErrorToScimError(err error) error {
 	return nil
 }
 
+// extractUserIDFromValue extracts the user ID from a value like "123"
 func extractUserIDFromValue(value string) (uint, error) {
 	id, err := strconv.ParseUint(value, 10, 64)
 	if err != nil {

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -2,6 +2,7 @@ package scim
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -12,7 +13,7 @@ import (
 	"unicode"
 
 	"github.com/elimity-com/scim"
-	"github.com/elimity-com/scim/errors"
+	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/elimity-com/scim/optional"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -66,7 +67,7 @@ func (u *UserHandler) Create(r *http.Request, attributes scim.ResourceAttributes
 	// In IETF documents, “non-empty” is generally used in the literal sense of “having at least one character.” That means if a value contains one or more spaces (and nothing else), it is still considered non-empty.
 	if len(userName) == 0 {
 		u.logger.InfoContext(ctx, "userName is empty")
-		return scim.Resource{}, errors.ScimErrorBadParams([]string{userNameAttr})
+		return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{userNameAttr})
 	}
 	existingUser, err := u.ds.ScimUserByUserName(ctx, userName)
 	switch {
@@ -95,7 +96,7 @@ func (u *UserHandler) Create(r *http.Request, attributes scim.ResourceAttributes
 			return createUserResource(user), nil
 		}
 		u.logger.InfoContext(ctx, "user already exists", userNameAttr, userName)
-		return scim.Resource{}, errors.ScimErrorUniqueness
+		return scim.Resource{}, scimerrors.ScimErrorUniqueness
 	}
 
 	user, err := u.createUserFromAttributes(ctx, attributes)
@@ -105,6 +106,12 @@ func (u *UserHandler) Create(r *http.Request, attributes scim.ResourceAttributes
 	}
 	user.ID, err = u.ds.CreateScimUser(ctx, user)
 	if err != nil {
+		var existsErr fleet.AlreadyExistsError
+		if errors.As(err, &existsErr) {
+			u.logger.InfoContext(ctx, "constraint violation: user already exists", userNameAttr, userName)
+			return scim.Resource{}, scimerrors.ScimErrorUniqueness
+		}
+		u.logger.ErrorContext(ctx, "failed to create scim user", userNameAttr, userName, "err", err)
 		return scim.Resource{}, err
 	}
 
@@ -137,7 +144,7 @@ func (u *UserHandler) createUserFromAttributes(
 		return nil, err
 	}
 	if user.FamilyName == nil || len(*user.FamilyName) == 0 {
-		return nil, errors.ScimErrorInvalidValue // Disallow non set field and empty value
+		return nil, scimerrors.ScimErrorInvalidValue // Disallow non set field and empty value
 	}
 
 	user.GivenName, err = getOptionalResource[string](name, givenNameAttr)
@@ -145,7 +152,7 @@ func (u *UserHandler) createUserFromAttributes(
 		return nil, err
 	}
 	if user.GivenName == nil || len(*user.GivenName) == 0 {
-		return nil, errors.ScimErrorInvalidValue // Disallow non set field and empty value
+		return nil, scimerrors.ScimErrorInvalidValue // Disallow non set field and empty value
 	}
 	emails, err := getComplexResourceSlice(attributes, emailsAttr)
 	if err != nil {
@@ -162,7 +169,7 @@ func (u *UserHandler) createUserFromAttributes(
 		// https://datatracker.ietf.org/doc/html/rfc7643#section-4.1.2
 		userEmail.Email, err = normalizeEmail(userEmail.Email)
 		if err != nil {
-			return nil, errors.ScimErrorBadParams([]string{valueAttr})
+			return nil, scimerrors.ScimErrorBadParams([]string{valueAttr})
 		}
 		userEmail.Type, err = getOptionalResource[string](email, typeAttr)
 		if err != nil {
@@ -223,11 +230,11 @@ func getRequiredResource[T string | bool](attributes scim.ResourceAttributes, ke
 	var val T
 	valIntf, ok := attributes[key]
 	if !ok || valIntf == nil {
-		return val, errors.ScimErrorBadParams([]string{key})
+		return val, scimerrors.ScimErrorBadParams([]string{key})
 	}
 	val, ok = valIntf.(T)
 	if !ok {
-		return val, errors.ScimErrorBadParams([]string{key})
+		return val, scimerrors.ScimErrorBadParams([]string{key})
 	}
 	return val, nil
 }
@@ -238,7 +245,7 @@ func getOptionalResource[T string | bool](attributes scim.ResourceAttributes, ke
 	if ok && valIntf != nil {
 		val, ok := valIntf.(T)
 		if !ok {
-			return nil, errors.ScimErrorBadParams([]string{key})
+			return nil, scimerrors.ScimErrorBadParams([]string{key})
 		}
 		valPtr = &val
 	}
@@ -250,7 +257,7 @@ func getComplexResource(attributes scim.ResourceAttributes, key string) (map[str
 	if ok && valIntf != nil {
 		val, ok := valIntf.(map[string]interface{})
 		if !ok {
-			return nil, errors.ScimErrorBadParams([]string{key})
+			return nil, scimerrors.ScimErrorBadParams([]string{key})
 		}
 		return val, nil
 	}
@@ -262,13 +269,13 @@ func getComplexResourceSlice(attributes scim.ResourceAttributes, key string) ([]
 	if ok && valIntf != nil {
 		valSliceIntf, ok := valIntf.([]interface{})
 		if !ok {
-			return nil, errors.ScimErrorBadParams([]string{key})
+			return nil, scimerrors.ScimErrorBadParams([]string{key})
 		}
 		val := make([]map[string]interface{}, 0, len(valSliceIntf))
 		for _, v := range valSliceIntf {
 			valMap, ok := v.(map[string]interface{})
 			if !ok {
-				return nil, errors.ScimErrorBadParams([]string{key})
+				return nil, scimerrors.ScimErrorBadParams([]string{key})
 			}
 			if len(valMap) > 0 {
 				val = append(val, valMap)
@@ -285,14 +292,14 @@ func (u *UserHandler) Get(r *http.Request, id string) (scim.Resource, error) {
 	idUint, err := extractUserIDFromValue(id)
 	if err != nil {
 		u.logger.InfoContext(ctx, "failed to parse id", "id", id, "err", err)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	}
 
 	user, err := u.ds.ScimUserByID(ctx, idUint)
 	switch {
 	case fleet.IsNotFound(err):
 		u.logger.InfoContext(ctx, "failed to find user", "id", id)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	case err != nil:
 		u.logger.ErrorContext(ctx, "failed to get user", "id", id, "err", err)
 		return scim.Resource{}, err
@@ -380,7 +387,7 @@ func (u *UserHandler) GetAll(r *http.Request, params scim.ListRequestParams) (sc
 	}
 	count := params.Count
 	if count > maxResults {
-		return scim.Page{}, errors.ScimErrorTooMany
+		return scim.Page{}, scimerrors.ScimErrorTooMany
 	}
 	if count < 1 {
 		count = maxResults
@@ -397,7 +404,7 @@ func (u *UserHandler) GetAll(r *http.Request, params scim.ListRequestParams) (sc
 		expr, err := filter.ParseAttrExp([]byte(resourceFilter))
 		if err != nil {
 			u.logger.ErrorContext(ctx, "failed to parse filter", "filter", resourceFilter, "err", err)
-			return scim.Page{}, errors.ScimErrorInvalidFilter
+			return scim.Page{}, scimerrors.ScimErrorInvalidFilter
 		}
 		if !strings.EqualFold(expr.AttributePath.String(), "userName") || expr.Operator != "eq" {
 			u.logger.InfoContext(ctx, "unsupported filter", "filter", resourceFilter)
@@ -440,7 +447,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 	idUint, err := extractUserIDFromValue(id)
 	if err != nil {
 		u.logger.InfoContext(ctx, "failed to parse id", "id", id, "err", err)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	}
 
 	user, err := u.createUserFromAttributes(ctx, attributes)
@@ -460,7 +467,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 		return scim.Resource{}, err
 	case err == nil && user.ID != userWithSameUsername.ID:
 		u.logger.InfoContext(ctx, "user already exists with this username", userNameAttr, user.UserName)
-		return scim.Resource{}, errors.ScimErrorUniqueness
+		return scim.Resource{}, scimerrors.ScimErrorUniqueness
 	case err == nil && user.ID == userWithSameUsername.ID:
 		// Same user, username not changing - use this for previous active state
 		previousActive = userWithSameUsername.Active
@@ -469,7 +476,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 		existingUser, err := u.ds.ScimUserByID(ctx, idUint)
 		if fleet.IsNotFound(err) {
 			u.logger.InfoContext(ctx, "failed to find scim user by id", "id", id)
-			return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+			return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 		}
 		if err != nil {
 			u.logger.ErrorContext(ctx, "failed to get existing scim user by id", "id", id, "err", err)
@@ -482,7 +489,7 @@ func (u *UserHandler) Replace(r *http.Request, id string, attributes scim.Resour
 	switch {
 	case fleet.IsNotFound(err):
 		u.logger.InfoContext(ctx, "failed to find user to replace", "id", id)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	case err != nil:
 		u.logger.ErrorContext(ctx, "failed to replace user", "id", id, "err", err)
 		return scim.Resource{}, err
@@ -507,7 +514,7 @@ func (u *UserHandler) Delete(r *http.Request, id string) error {
 	idUint, err := extractUserIDFromValue(id)
 	if err != nil {
 		u.logger.InfoContext(ctx, "failed to parse id", "id", id, "err", err)
-		return errors.ScimErrorResourceNotFound(id)
+		return scimerrors.ScimErrorResourceNotFound(id)
 	}
 
 	scimUser, err := u.ds.ScimUserByID(ctx, idUint)
@@ -530,7 +537,7 @@ func (u *UserHandler) Delete(r *http.Request, id string) error {
 	switch {
 	case fleet.IsNotFound(err):
 		u.logger.InfoContext(ctx, "failed to find user to delete", "id", id)
-		return errors.ScimErrorResourceNotFound(id)
+		return scimerrors.ScimErrorResourceNotFound(id)
 	case err != nil:
 		u.logger.ErrorContext(ctx, "failed to delete user", "id", id, "err", err)
 		return err
@@ -642,13 +649,13 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 	idUint, err := extractUserIDFromValue(id)
 	if err != nil {
 		u.logger.InfoContext(ctx, "failed to parse id", "id", id, "err", err)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	}
 	user, err := u.ds.ScimUserByID(ctx, idUint)
 	switch {
 	case fleet.IsNotFound(err):
 		u.logger.InfoContext(ctx, "failed to find user to patch", "id", id)
-		return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+		return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 	case err != nil:
 		u.logger.ErrorContext(ctx, "failed to get user to patch", "id", id, "err", err)
 		return scim.Resource{}, err
@@ -660,19 +667,19 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			u.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
-			return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 		}
 		switch {
 		// If path is not specified, we look for the path in the value attribute.
 		case op.Path == nil:
 			if op.Op == scim.PatchOperationRemove {
 				u.logger.InfoContext(ctx, "the 'path' attribute is REQUIRED for 'remove' operations", "op", op.Op)
-				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			newValues, ok := op.Value.(map[string]interface{})
 			if !ok {
 				u.logger.InfoContext(ctx, "unsupported patch value", "value", op.Value)
-				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			for k, v := range newValues {
 				switch k {
@@ -718,7 +725,7 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 					}
 				default:
 					u.logger.InfoContext(ctx, "unsupported patch value field", "field", k)
-					return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+					return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 				}
 			}
 		case op.Path.String() == externalIdAttr:
@@ -768,7 +775,7 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 			}
 		default:
 			u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-			return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 		}
 	}
 
@@ -777,7 +784,7 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 		switch {
 		case fleet.IsNotFound(err):
 			u.logger.InfoContext(ctx, "failed to find user to patch", "id", id)
-			return scim.Resource{}, errors.ScimErrorResourceNotFound(id)
+			return scim.Resource{}, scimerrors.ScimErrorResourceNotFound(id)
 		case err != nil:
 			u.logger.ErrorContext(ctx, "failed to patch user", "id", id, "err", err)
 			return scim.Resource{}, err
@@ -812,7 +819,7 @@ func (u *UserHandler) patchEmailsWithPathFiltering(
 	}
 	if !emailFound && op.Op != scim.PatchOperationAdd {
 		u.logger.InfoContext(ctx, "email not found", "email_type", emailType, "op", fmt.Sprintf("%v", op))
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	if op.Path.SubAttribute == nil {
 		if op.Op == scim.PatchOperationRemove {
@@ -832,7 +839,7 @@ func (u *UserHandler) patchEmailsWithPathFiltering(
 			emailsList = []interface{}{val}
 		default:
 			u.logger.InfoContext(ctx, fmt.Sprintf("unsupported '%s' patch value", emailsAttr), "value", op.Value)
-			return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 		}
 
 		switch op.Op {
@@ -843,7 +850,7 @@ func (u *UserHandler) patchEmailsWithPathFiltering(
 			}
 			if len(emailsList) != 1 {
 				u.logger.InfoContext(ctx, "only 1 email should be present for replacement", "emails", emailsList)
-				return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			userEmail, err := u.extractEmail(ctx, emailsList[0], op)
 			if err != nil {
@@ -857,7 +864,7 @@ func (u *UserHandler) patchEmailsWithPathFiltering(
 		case scim.PatchOperationAdd:
 			if len(emailsList) == 0 {
 				u.logger.InfoContext(ctx, "no emails provided to add", "emails", emailsList)
-				return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			var newEmails []fleet.ScimUserEmail
 			for e := range emailsList {
@@ -931,7 +938,7 @@ func (u *UserHandler) patchEmailsWithPathFiltering(
 		user.Emails[emailIndex].Type = &newEmailType
 	default:
 		u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	return nil
 }
@@ -940,19 +947,19 @@ func (u *UserHandler) getEmailType(ctx context.Context, op scim.PatchOperation) 
 	attrExpression, ok := op.Path.ValueExpression.(*filter.AttributeExpression)
 	if !ok {
 		u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-		return "", errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return "", scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	// Only matching by email type (work, etc.) is supported.
 	if attrExpression.AttributePath.String() != typeAttr || attrExpression.Operator != filter.EQ {
 		u.logger.InfoContext(ctx, "unsupported patch path",
 			"path", op.Path, "expression", attrExpression.AttributePath.String())
-		return "", errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return "", scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	emailType, ok := attrExpression.CompareValue.(string)
 	if !ok {
 		u.logger.InfoContext(ctx, "unsupported patch path",
 			"path", op.Path, "compare_value", attrExpression.CompareValue)
-		return "", errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return "", scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	return emailType, nil
 }
@@ -962,7 +969,7 @@ func getConcreteType[T string | bool](ctx context.Context, u *UserHandler, v any
 	if !ok {
 		var zeroValue T
 		u.logger.InfoContext(ctx, fmt.Sprintf("unsupported '%s' value", name), "value", v)
-		return zeroValue, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", v)})
+		return zeroValue, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", v)})
 	}
 	return concreteType, nil
 }
@@ -970,7 +977,7 @@ func getConcreteType[T string | bool](ctx context.Context, u *UserHandler, v any
 func (u *UserHandler) patchFamilyName(ctx context.Context, op string, v any, user *fleet.ScimUser) error {
 	if op == scim.PatchOperationRemove {
 		u.logger.InfoContext(ctx, "cannot remove required attribute", "attribute", nameAttr+"."+familyNameAttr)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	familyName, err := getConcreteType[string](ctx, u, v, nameAttr+"."+familyNameAttr)
 	if err != nil {
@@ -983,7 +990,7 @@ func (u *UserHandler) patchFamilyName(ctx context.Context, op string, v any, use
 func (u *UserHandler) patchGivenName(ctx context.Context, op string, v any, user *fleet.ScimUser) error {
 	if op == scim.PatchOperationRemove {
 		u.logger.InfoContext(ctx, "cannot remove required attribute", "attribute", nameAttr+"."+givenNameAttr)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	givenName, err := getConcreteType[string](ctx, u, v, nameAttr+"."+givenNameAttr)
 	if err != nil {
@@ -1022,7 +1029,7 @@ func (u *UserHandler) patchExternalId(ctx context.Context, op string, v any, use
 func (u *UserHandler) patchUserName(ctx context.Context, op string, v any, user *fleet.ScimUser) error {
 	if op == scim.PatchOperationRemove {
 		u.logger.InfoContext(ctx, "cannot remove required attribute", "attribute", userNameAttr)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	userName, err := getConcreteType[string](ctx, u, v, userNameAttr)
 	if err != nil {
@@ -1030,7 +1037,7 @@ func (u *UserHandler) patchUserName(ctx context.Context, op string, v any, user 
 	}
 	if userName == "" {
 		u.logger.InfoContext(ctx, fmt.Sprintf("'%s' cannot be empty", userNameAttr), "value", v)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", v)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", v)})
 	}
 	user.UserName = userName
 	return nil
@@ -1077,12 +1084,12 @@ func (u *UserHandler) patchEmails(
 		emailsList = []interface{}{val}
 	default:
 		u.logger.InfoContext(ctx, fmt.Sprintf("unsupported '%s' patch value", emailsAttr), "value", op.Value)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 
 	if op.Op == scim.PatchOperationAdd && len(emailsList) == 0 {
 		u.logger.InfoContext(ctx, "no emails provided to add", "emails", emailsList)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	// Convert the emails to the expected format
 	userEmails := make([]fleet.ScimUserEmail, 0, len(emailsList))
@@ -1118,7 +1125,7 @@ func (u *UserHandler) checkEmailPrimary(ctx context.Context, userEmails []fleet.
 			primaryEmailCount++
 			if primaryEmailCount > 1 {
 				u.logger.InfoContext(ctx, "multiple primary emails found")
-				return false, errors.ScimErrorBadParams([]string{"Only one email can be marked as primary"})
+				return false, scimerrors.ScimErrorBadParams([]string{"Only one email can be marked as primary"})
 			}
 		}
 	}
@@ -1131,21 +1138,21 @@ func (u *UserHandler) extractEmail(
 	emailMap, ok := emailIntf.(map[string]interface{})
 	if !ok {
 		u.logger.InfoContext(ctx, "email is not a map", "email", emailIntf)
-		return fleet.ScimUserEmail{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return fleet.ScimUserEmail{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 
 	// Extract the email value (required)
 	emailValue, ok := emailMap[valueAttr].(string)
 	if !ok || emailValue == "" {
 		u.logger.InfoContext(ctx, "email value is missing or invalid", "email", emailMap)
-		return fleet.ScimUserEmail{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return fleet.ScimUserEmail{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 
 	// Normalize the email
 	normalizedEmail, err := normalizeEmail(emailValue)
 	if err != nil {
 		u.logger.InfoContext(ctx, "failed to normalize email", "email", emailValue, "err", err)
-		return fleet.ScimUserEmail{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return fleet.ScimUserEmail{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 
 	// Create the email object
@@ -1170,12 +1177,12 @@ func (u *UserHandler) extractEmail(
 func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperation, user *fleet.ScimUser) error {
 	if op.Op == scim.PatchOperationRemove {
 		u.logger.InfoContext(ctx, "cannot remove required attribute", "attribute", nameAttr)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	name, ok := v.(map[string]interface{})
 	if !ok {
 		u.logger.InfoContext(ctx, fmt.Sprintf("unsupported '%s' patch value", nameAttr), "value", op.Value)
-		return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+		return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 	}
 	for nameKey, nameValue := range name {
 		switch nameKey {
@@ -1184,7 +1191,7 @@ func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperati
 			if !ok {
 				u.logger.InfoContext(ctx,
 					fmt.Sprintf("unsupported '%s' patch value", nameAttr+"."+givenNameAttr), "value", op.Value)
-				return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			user.GivenName = &givenName
 		case familyNameAttr:
@@ -1192,12 +1199,12 @@ func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperati
 			if !ok {
 				u.logger.InfoContext(ctx,
 					fmt.Sprintf("unsupported '%s' patch value", nameAttr+"."+familyNameAttr), "value", op.Value)
-				return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+				return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
 			user.FamilyName = &familyName
 		default:
 			u.logger.InfoContext(ctx, "unsupported patch value field", "field", nameAttr+"."+nameKey)
-			return errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 		}
 	}
 	return nil

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -2,12 +2,14 @@ package scim
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/elimity-com/scim"
+	scimerrors "github.com/elimity-com/scim/errors"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	mockservice "github.com/fleetdm/fleet/v4/server/mock/service"
@@ -17,6 +19,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// alreadyExistsErr implements fleet.AlreadyExistsError for testing.
+type alreadyExistsErr struct {
+	msg string
+}
+
+func (e *alreadyExistsErr) Error() string  { return e.msg }
+func (e *alreadyExistsErr) IsExists() bool { return true }
 
 type testMocks struct {
 	ds  *mock.Store
@@ -845,6 +855,33 @@ func TestUserHandlerCreateReactivation(t *testing.T) {
 		// Should not have called Replace or Create
 		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
 		assert.False(t, mocks.ds.CreateScimUserFuncInvoked)
+	})
+
+	t.Run("returns uniqueness error when CreateScimUser returns wrapped AlreadyExistsError", func(t *testing.T) {
+		mocks := newTestMocks()
+
+		// No existing user found during pre-check (simulating race condition)
+		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
+			return nil, platform_mysql.NotFound("ScimUser")
+		}
+
+		// CreateScimUser returns a wrapped AlreadyExistsError (as ctxerr.Wrap produces in production)
+		mocks.ds.CreateScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) (uint, error) {
+			return 0, fmt.Errorf("insert scim user: %w", &alreadyExistsErr{msg: "user_name already exists"})
+		}
+
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", nil)
+		attrs := newTestAttrs("user@example.com", ptr.Bool(true), "John", "Doe")
+
+		_, err := handler.Create(req, attrs)
+		require.Error(t, err)
+
+		// Should be a SCIM uniqueness error (409), not a 500
+		scimErr, ok := err.(scimerrors.ScimError)
+		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
+		assert.Equal(t, http.StatusConflict, scimErr.Status)
+		assert.Equal(t, scimerrors.ScimTypeUniqueness, scimErr.ScimType)
 	})
 
 	t.Run("returns uniqueness error for user with nil active", func(t *testing.T) {

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -622,6 +622,69 @@ func TestUserHandlerReplaceDeactivation(t *testing.T) {
 
 		assert.False(t, mocks.ds.DeleteUserFuncInvoked)
 	})
+
+	t.Run("returns uniqueness error when ReplaceScimUser returns wrapped AlreadyExistsError", func(t *testing.T) {
+		mocks := newTestMocks()
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     ptr.Bool(true),
+			givenName:  "John",
+			familyName: "Doe",
+		})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		// Pre-check passes (no other user with this username)
+		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
+			return nil, platform_mysql.NotFound("ScimUser")
+		}
+		// ReplaceScimUser returns a wrapped AlreadyExistsError (race condition: concurrent update took the username)
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) error {
+			return fmt.Errorf("update scim user: %w", &alreadyExistsErr{msg: "user_name already exists"})
+		}
+
+		handler := mocks.newTestHandler()
+		attrs := newTestAttrs("taken@example.com", ptr.Bool(true), "John", "Doe")
+
+		_, err := handler.Replace(httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", nil), "1", attrs)
+		require.Error(t, err)
+
+		scimErr, ok := err.(scimerrors.ScimError)
+		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
+		assert.Equal(t, http.StatusConflict, scimErr.Status)
+		assert.Equal(t, scimerrors.ScimTypeUniqueness, scimErr.ScimType)
+	})
+
+	t.Run("returns bad params error when ReplaceScimUser returns SCIMValidationError", func(t *testing.T) {
+		mocks := newTestMocks()
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     ptr.Bool(true),
+			givenName:  "John",
+			familyName: "Doe",
+		})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		// ReplaceScimUser returns a validation error (field too long)
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) error {
+			return &fleet.SCIMValidationError{Field: "given_name", Message: "exceeds maximum length of 255 characters"}
+		}
+
+		handler := mocks.newTestHandler()
+		attrs := newTestAttrs("user@example.com", ptr.Bool(true), "John", "Doe")
+
+		_, err := handler.Replace(httptest.NewRequest(http.MethodPut, "/scim/v2/Users/1", nil), "1", attrs)
+		require.Error(t, err)
+
+		scimErr, ok := err.(scimerrors.ScimError)
+		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
+		assert.Equal(t, http.StatusBadRequest, scimErr.Status)
+		assert.Contains(t, scimErr.Detail, "given_name")
+	})
 }
 
 func TestUserHandlerPatchDeactivation(t *testing.T) {
@@ -767,6 +830,41 @@ func TestUserHandlerPatchDeactivation(t *testing.T) {
 
 		assert.False(t, mocks.ds.DeleteUserFuncInvoked)
 	})
+
+	t.Run("returns uniqueness error when ReplaceScimUser returns wrapped AlreadyExistsError via Patch", func(t *testing.T) {
+		mocks := newTestMocks()
+		existingScimUser := newTestScimUser(&scimUserOpts{
+			active:     ptr.Bool(true),
+			givenName:  "John",
+			familyName: "Doe",
+		})
+
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingScimUser, nil
+		}
+		// ReplaceScimUser returns a wrapped AlreadyExistsError (race condition: concurrent update took the username)
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) error {
+			return fmt.Errorf("update scim user: %w", &alreadyExistsErr{msg: "user_name already exists"})
+		}
+
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		userNamePath, err := filter.ParsePath([]byte("userName"))
+		require.NoError(t, err)
+
+		patchOps := []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &userNamePath, Value: "taken@example.com"},
+		}
+
+		_, err = handler.Patch(req, "1", patchOps)
+		require.Error(t, err)
+
+		scimErr, ok := err.(scimerrors.ScimError)
+		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
+		assert.Equal(t, http.StatusConflict, scimErr.Status)
+		assert.Equal(t, scimerrors.ScimTypeUniqueness, scimErr.ScimType)
+	})
 }
 
 func TestUserHandlerCreateReactivation(t *testing.T) {
@@ -882,6 +980,33 @@ func TestUserHandlerCreateReactivation(t *testing.T) {
 		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
 		assert.Equal(t, http.StatusConflict, scimErr.Status)
 		assert.Equal(t, scimerrors.ScimTypeUniqueness, scimErr.ScimType)
+	})
+
+	t.Run("returns bad params error when CreateScimUser returns SCIMValidationError", func(t *testing.T) {
+		mocks := newTestMocks()
+
+		// No existing user found during pre-check
+		mocks.ds.ScimUserByUserNameFunc = func(ctx context.Context, userName string) (*fleet.ScimUser, error) {
+			return nil, platform_mysql.NotFound("ScimUser")
+		}
+
+		// CreateScimUser returns a validation error (field too long)
+		mocks.ds.CreateScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) (uint, error) {
+			return 0, &fleet.SCIMValidationError{Field: "user_name", Message: "exceeds maximum length of 255 characters"}
+		}
+
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPost, "/scim/v2/Users", nil)
+		attrs := newTestAttrs("user@example.com", ptr.Bool(true), "John", "Doe")
+
+		_, err := handler.Create(req, attrs)
+		require.Error(t, err)
+
+		// Should be a SCIM bad params error (400), not a 500
+		scimErr, ok := err.(scimerrors.ScimError)
+		require.True(t, ok, "expected ScimError, got %T: %v", err, err)
+		assert.Equal(t, http.StatusBadRequest, scimErr.Status)
+		assert.Contains(t, scimErr.Detail, "user_name")
 	})
 
 	t.Run("returns uniqueness error for user with nil active", func(t *testing.T) {

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -309,6 +309,9 @@ func (ds *Datastore) ReplaceScimUser(ctx context.Context, user *fleet.ScimUser) 
 			user.ID,
 		)
 		if err != nil {
+			if IsDuplicate(err) {
+				return ctxerr.Wrap(ctx, alreadyExists("ScimUser", user.UserName), "update scim user")
+			}
 			return ctxerr.Wrap(ctx, err, "update scim user")
 		}
 
@@ -608,19 +611,19 @@ func getScimUserGroups(ctx context.Context, q sqlx.QueryerContext, userID uint) 
 // validateScimUserFields checks if the user fields exceed the maximum allowed length
 func validateScimUserFields(user *fleet.ScimUser) error {
 	if user.ExternalID != nil && len(*user.ExternalID) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("external_id exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "external_id", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	if len(user.UserName) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("user_name exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "user_name", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	if user.GivenName != nil && len(*user.GivenName) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("given_name exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "given_name", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	if user.FamilyName != nil && len(*user.FamilyName) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("family_name exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "family_name", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	if user.Department != nil && len(*user.Department) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("department exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "department", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	return nil
 }
@@ -628,10 +631,10 @@ func validateScimUserFields(user *fleet.ScimUser) error {
 // validateScimGroupFields checks if the group fields exceed the maximum allowed length
 func validateScimGroupFields(group *fleet.ScimGroup) error {
 	if group.ExternalID != nil && len(*group.ExternalID) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("external_id exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "external_id", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	if len(group.DisplayName) > fleet.SCIMMaxFieldLength {
-		return fmt.Errorf("display_name exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)
+		return &fleet.SCIMValidationError{Field: "display_name", Message: fmt.Sprintf("exceeds maximum length of %d characters", fleet.SCIMMaxFieldLength)}
 	}
 	return nil
 }

--- a/server/datastore/mysql/scim.go
+++ b/server/datastore/mysql/scim.go
@@ -43,6 +43,9 @@ func (ds *Datastore) CreateScimUser(ctx context.Context, user *fleet.ScimUser) (
 			user.Active,
 		)
 		if err != nil {
+			if IsDuplicate(err) {
+				return ctxerr.Wrap(ctx, alreadyExists("ScimUser", user.UserName), "insert scim user")
+			}
 			return ctxerr.Wrap(ctx, err, "insert scim user")
 		}
 

--- a/server/fleet/scim.go
+++ b/server/fleet/scim.go
@@ -1,9 +1,22 @@
 package fleet
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // SCIMMaxFieldLength is the default maximum length for SCIM fields
 const SCIMMaxFieldLength = 255
+
+// SCIMValidationError is returned when a SCIM field fails validation (e.g., exceeds max length).
+type SCIMValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e *SCIMValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
 
 // ScimUser represents a SCIM user in the database
 type ScimUser struct {

--- a/server/fleet/scim.go
+++ b/server/fleet/scim.go
@@ -15,7 +15,7 @@ type SCIMValidationError struct {
 }
 
 func (e *SCIMValidationError) Error() string {
-	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+	return fmt.Sprintf("%s %s", e.Field, e.Message)
 }
 
 // ScimUser represents a SCIM user in the database


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40260 

# Checklist for submitter

Made sure Scim errors are reported with the correct HTTP status code in case a data constraint violation happens.

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* SCIM Users endpoint now returns the correct HTTP status code (409 Conflict) when data constraint violations occur, such as duplicate user entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->