### PR TITLE
Fleet UI: Update discard data option link + styling

### DIFF
--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -30,6 +30,51 @@ const DiscardDataOption = ({
     selectedLoggingType === "differential" ||
     selectedLoggingType === "differential_ignore_removals";
 
+  const renderHelpText = () => (
+    <>
+      {isDisabled ? (
+        <>
+          This setting is ignored because reports in Fleet have been{" "}
+          <TooltipWrapper
+            tipContent={
+              <>
+                A Fleet administrator can enable reports under <br />
+                <b>
+                  Organization settings &gt; Advanced options &gt; Disable
+                  reports
+                </b>
+                .
+              </>
+            }
+          >
+            globally disabled.
+          </TooltipWrapper>
+          <Button
+            onClick={(e: React.MouseEvent) => {
+              e.preventDefault();
+              setForceEditDiscardData(true);
+            }}
+            variant="text-icon"
+            size="small"
+            className={`${baseClass}__edit-anyway`}
+            iconStroke
+          >
+            <>
+              Edit anyway
+              <Icon
+                name="chevron-right"
+                color="ui-fleet-black-75"
+                size="small"
+              />
+            </>
+          </Button>
+        </>
+      ) : (
+        "The most recent results for each host will not be available in Fleet."
+      )}
+    </>
+  );
+
   return (
     <div className={baseClass}>
       {isReportsLoggingIgnored && (
@@ -43,50 +88,7 @@ const DiscardDataOption = ({
         onChange={setDiscardData}
         value={discardData}
         disabled={isDisabled}
-        helpText={
-          <div className="help-text">
-            {isDisabled ? (
-              <>
-                This setting is ignored because reports in Fleet have been{" "}
-                <TooltipWrapper
-                  tipContent={
-                    <>
-                      A Fleet administrator can enable reports under <br />
-                      <b>
-                        Organization settings &gt; Advanced options &gt; Disable
-                        reports
-                      </b>
-                      .
-                    </>
-                  }
-                >
-                  globally disabled.
-                </TooltipWrapper>
-                <Button
-                  onClick={(e: React.MouseEvent) => {
-                    e.preventDefault();
-                    setForceEditDiscardData(true);
-                  }}
-                  variant="text-icon"
-                  size="small"
-                  className={`${baseClass}__edit-anyway`}
-                  iconStroke
-                >
-                  <>
-                    Edit anyway
-                    <Icon
-                      name="chevron-right"
-                      color="ui-fleet-black-75"
-                      size="small"
-                    />
-                  </>
-                </Button>
-              </>
-            ) : (
-              "The most recent results for each host will not be available in Fleet."
-            )}
-          </div>
-        }
+        helpText={renderHelpText()}
       >
         Discard data
       </Checkbox>

--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -1,10 +1,12 @@
+import React, { useState } from "react";
+
+import { QueryLoggingOption } from "interfaces/schedulable_query";
+
+import Button from "components/buttons/Button";
 import Checkbox from "components/forms/fields/Checkbox";
 import Icon from "components/Icon";
 import InfoBanner from "components/InfoBanner";
 import TooltipWrapper from "components/TooltipWrapper";
-import { QueryLoggingOption } from "interfaces/schedulable_query";
-import React, { useState } from "react";
-import { Link } from "react-router";
 
 const baseClass = "discard-data-option";
 
@@ -22,70 +24,69 @@ const DiscardDataOption = ({
   setDiscardData,
 }: IDiscardDataOptionProps) => {
   const [forceEditDiscardData, setForceEditDiscardData] = useState(false);
-  const disable = queryReportsDisabled && !forceEditDiscardData;
 
-  const renderHelpText = () => (
-    <div className="help-text">
-      {disable ? (
-        <>
-          This setting is ignored because reports in Fleet have been{" "}
-          <TooltipWrapper
-            tipContent={
-              <>
-                A Fleet administrator can enable reports under <br />
-                <b>
-                  Organization settings &gt; Advanced options &gt; Disable
-                  reports
-                </b>
-                .
-              </>
-            }
-          >
-            {"globally disabled."}
-          </TooltipWrapper>{" "}
-          <Link
-            to=""
-            onClick={(e: React.MouseEvent) => {
-              e.preventDefault();
-              setForceEditDiscardData(true);
-            }}
-            className={`${baseClass}__edit-anyway`}
-          >
-            <>
-              Edit anyway
-              <Icon
-                name="chevron-right"
-                color="ui-fleet-black-75"
-                size="small"
-              />
-            </>
-          </Link>
-        </>
-      ) : (
-        "The most recent results for each host will not be available in Fleet."
-      )}
-    </div>
-  );
+  const isDisabled = queryReportsDisabled && !forceEditDiscardData;
+  const isReportsLoggingIgnored =
+    selectedLoggingType === "differential" ||
+    selectedLoggingType === "differential_ignore_removals";
+
   return (
     <div className={baseClass}>
-      {["differential", "differential_ignore_removals"].includes(
-        selectedLoggingType
-      ) && (
-        <>
-          <InfoBanner color="grey">
-            The <b>Discard data</b> setting is ignored when differential logging
-            is enabled. This report&apos;s results will not be saved in Fleet.
-          </InfoBanner>
-        </>
+      {isReportsLoggingIgnored && (
+        <InfoBanner color="grey">
+          The <b>Discard data</b> setting is ignored when differential logging
+          is enabled. This report&apos;s results will not be saved in Fleet.
+        </InfoBanner>
       )}
       <Checkbox
         name="discardData"
         onChange={setDiscardData}
         value={discardData}
-        wrapperClassName={
-          disable ? `${baseClass}__disabled-discard-data-checkbox` : ""
+        disabled={isDisabled}
+        helpText={
+          <div className="help-text">
+            {isDisabled ? (
+              <>
+                This setting is ignored because reports in Fleet have been{" "}
+                <TooltipWrapper
+                  tipContent={
+                    <>
+                      A Fleet administrator can enable reports under <br />
+                      <b>
+                        Organization settings &gt; Advanced options &gt; Disable
+                        reports
+                      </b>
+                      .
+                    </>
+                  }
+                >
+                  globally disabled.
+                </TooltipWrapper>
+                <Button
+                  onClick={(e: React.MouseEvent) => {
+                    e.preventDefault();
+                    setForceEditDiscardData(true);
+                  }}
+                  variant="text-icon"
+                  size="small"
+                  className={`${baseClass}__edit-anyway`}
+                  iconStroke
+                >
+                  <>
+                    Edit anyway
+                    <Icon
+                      name="chevron-right"
+                      color="ui-fleet-black-75"
+                      size="small"
+                    />
+                  </>
+                </Button>
+              </>
+            ) : (
+              "The most recent results for each host will not be available in Fleet."
+            )}
+          </div>
         }
-        helpText={renderHelpText()}
       >
         Discard data
       </Checkbox>

--- a/frontend/pages/queries/edit/components/DiscardDataOption/_styles.scss
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/_styles.scss
@@ -1,20 +1,13 @@
 .discard-data-option {
-  .info-banner {
-    margin-bottom: 1.5rem;
-    &__info {
-      line-height: 21px;
-    }
-  }
+  @include vertical-form-layout;
 
-  &__disabled-discard-data-checkbox > .fleet-checkbox {
-    @include disabled;
+  .info-banner {
+    margin-bottom: 0; // TODO: Remove when globally info-banner gaps do not rely on margin but flex gap
   }
 
   &__edit-anyway {
-    display: inline-flex;
-    align-items: center;
-    cursor: pointer;
-    font-weight: inherit;
-    font-size: inherit;
+    margin-top: -$pad-small; // Prevents help text jump from padded button disappearing when clicked
+    margin-bottom: -$pad-small; // Prevents help text jump from padded button disappearing when clicked
+    margin-left: $pad-small; // Space between text and button, can't use flex as we have a tooltip within text
   }
 }


### PR DESCRIPTION
## Issue
Closes #35024 

## Description
- Converted the link to a button
- Realizing a lot of this code needed clean up
  - Rely on checkbox disabled instead of localizing disabled styling
  - Rely on form gaps instead of margin below discard data `InfoBanner`
  - Make `isReportsLoggingIgnored` variable for readability

## Screen recording

### Screenshot shows what the button looks like hovered over, also the proper gap under the InfoBanner

<img width="1022" height="351" alt="Screenshot 2026-03-12 at 10 23 02 AM" src="https://github.com/user-attachments/assets/940a429b-e5bb-4fd2-a432-56b9970b9c12" />


### Screenrecording shows the PR changes and then switches to main to show what it looked like before

https://fleetdm.zoom.us/clips/share/yDYnzfagRo2XAVLQWONETA

## Testing

- [x] Added/updated automated tests
  - `DiscardDataOptions.tests.tsx` already exist and they pass
- [x] QA'd all new/changed functionality manually
