### PR TITLE
Remove change entry that was reverted

### DIFF
--- a/articles/fleet-4.82.0.md
+++ b/articles/fleet-4.82.0.md
@@ -59,7 +59,6 @@ GitHub issue: [#36337](https://github.com/fleetdm/fleet/issues/36337)
 - Added AWS GovCloud RDS CA certificates to the RDS MySQL TLS bundle, enabling IAM authentication for Fleet deployments connecting to RDS in AWS GovCloud regions (us-gov-east-1, us-gov-west-1).
 - Added CVE alias for python visual studio code extension.
 - Added new activity for edited enroll secrets.
-- Added deny list for checking external urls the Fleet server will attempt to contact that are user submitted. Refer to pkg/fleethttp/ssrf.go for full list. In development, the --dev flag skips this check so that testing locally is not impacted. Certificate authorities is the first place this is implemented. 
 
 ### Other improvements and bug fixes
 - Renamed teams and queries to fleets and reports in the UI, API, CLI, and GitOps.


### PR DESCRIPTION
The original code PR (including the changefile) was reverted https://github.com/fleetdm/fleet/pull/40452
Not sure how it made it in, but this removes it again.