### PR TITLE
Update CEO travel instructions in README

### DIFF
--- a/handbook/ceo/README.md
+++ b/handbook/ceo/README.md
@@ -142,6 +142,10 @@ The CEO's calendar should reflect the following schedule for travel:
  - Calendar event: Travel to NAME_OF_DESTINATION (e.g. Travel to NAME_OF_HOTEL, NAME_OF_VENUE, NAME_OF_RESTURUANT, etc.)
  - Location: Address to destination
  - Calendar event name if CEO is going home: Travel home
+- If the CEO is checking into a hotel, they need a time block to check-in,
+ - 30 minutes
+ - Calendar event: Check-in at hotel
+ - Do not schedule check-in before the hotel's check-in time. If the CEO will arrive before the hotel's check-in time, call the hotel ahead of time to request early check-in. If early check-in is not available, schedule the check-in time block at the hotel's check-in time instead.
 
 
 ### Schedule CEO interview

--- a/handbook/ceo/README.md
+++ b/handbook/ceo/README.md
@@ -142,9 +142,6 @@ The CEO's calendar should reflect the following schedule for travel:
  - Calendar event: Travel to NAME_OF_DESTINATION (e.g. Travel to NAME_OF_HOTEL, NAME_OF_VENUE, NAME_OF_RESTURUANT, etc.)
  - Location: Address to destination
  - Calendar event name if CEO is going home: Travel home
-- If the CEO is checking into a hotel, they need a time block to check-in,
- - 30 minutes
- - Calendar event: Check-in at hotel
 
 
 ### Schedule CEO interview

--- a/handbook/ceo/README.md
+++ b/handbook/ceo/README.md
@@ -145,7 +145,7 @@ The CEO's calendar should reflect the following schedule for travel:
 - If the CEO is checking into a hotel, they need a time block to check-in,
  - 30 minutes
  - Calendar event: Check-in at hotel
- - Do not schedule check-in before the hotel's check-in time. If the CEO will arrive before the hotel's check-in time, call the hotel ahead of time to request early check-in. If early check-in is not available, schedule the check-in time block at the hotel's check-in time instead.
+ - Do not schedule check-in before the hotel's check-in time. If the CEO will arrive before the hotel's check-in time, call the hotel ahead of time to request early check-in, and add a note in the calendar event agenda (e.g. "Called hotel to request early check-in"). If early check-in is not available, schedule the check-in time block at the hotel's check-in time instead.
 
 
 ### Schedule CEO interview

--- a/handbook/ceo/README.md
+++ b/handbook/ceo/README.md
@@ -143,9 +143,11 @@ The CEO's calendar should reflect the following schedule for travel:
  - Location: Address to destination
  - Calendar event name if CEO is going home: Travel home
 - If the CEO is checking into a hotel, they need a time block to check-in,
+ - If the CEO will arrive to the hotel before their check-in time, call the hotel ahead of time to request early check-in. If early check-in is not available, schedule the check-in time block at the hotel's check-in time.
+ - If the hotel says early check-in is possible, but depends on the hotel's availability, have the CEO try to check-in. 
  - 30 minutes
  - Calendar event: Check-in at hotel
- - Do not schedule check-in before the hotel's check-in time. If the CEO will arrive before the hotel's check-in time, call the hotel ahead of time to request early check-in, and add a note in the calendar event agenda (e.g. "Called hotel to request early check-in"). If early check-in is not available, schedule the check-in time block at the hotel's check-in time instead.
+ - Calednar event for CEO to try and check-in: Try to check-in
 
 
 ### Schedule CEO interview


### PR DESCRIPTION
## Summary

Instead of removing the hotel check-in time block entirely, this PR updates the CEO travel instructions to:
- Keep the 30-minute check-in time block, but never schedule it before the hotel's official check-in time
- If the CEO arrives before the hotel's check-in time, call the hotel ahead of time to request early check-in and note it in the calendar event agenda
- If early check-in is not available, schedule the check-in at the hotel's official check-in time

Built for [Savannah Friend](https://fleetdm.slack.com/archives/D0AK3T404H3/p1774560399725619) by [Kilo for Slack](https://kilo.ai/features/slack-integration)