### PR TITLE
Handbook: Fix broken link to marketing assets handbook page

### DIFF
--- a/handbook/marketing/README.md
+++ b/handbook/marketing/README.md
@@ -41,7 +41,7 @@ The Marketing department is directly responsible for achieving revenue pipelineÂ
 
 ### Marketing Assets
 
-The complete list of all marketing assets is listed on [this handbook page](https://fleetdm.com/handbook/marketing/marketing-assets.dm).
+The complete list of all marketing assets is listed on [this handbook page](https://fleetdm.com/handbook/marketing/marketing-assets).
 
 ### Press boilerplate text
 


### PR DESCRIPTION
Changes:
- Fixed a broken link to the "Marketing assets" handbook page