### PR TITLE
Split "Fleet version" into Discovered and Reproduced fields in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -7,7 +7,9 @@ assignees: ''
 
 ---
 
-**Fleet version**: <!-- Copy this from the "My account" page in the Fleet UI, or run `fleetctl --version` -->
+**Fleet versions** <!-- Copy this from the "My account" page in the Fleet UI, or run `fleetctl --version` -->
+  - *Discovered:* <!-- Fleet version where the issue was first observed -->
+  - *Reproduced:* <!-- Fleet version where the issue was successfully reproduced/confirmed -->
 
 **Web browser and operating system**: <!-- e.g. Chrome 88.0.4324 running on macOS -->
 


### PR DESCRIPTION
Replaces the single **Fleet version** field in the bug template with two fields:

- **Discovered** – the Fleet version where the issue was first observed
- **Reproduced** – the Fleet version, where we confirmed the issue can also be reproduced