### PR TITLE
Followup #35528: Fix iOS app still changing platform when uploading macOS installer

### DIFF
--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -563,8 +563,8 @@ func (ds *Datastore) addSoftwareTitleToMatchingSoftware(ctx context.Context, tit
 	whereClause := "WHERE (s.name, s.source, s.extension_for) = (?, ?, '')"
 	whereArgs := []any{payload.Title, payload.Source}
 	if payload.BundleIdentifier != "" {
-		whereClause = "WHERE s.bundle_identifier = ?"
-		whereArgs = []any{payload.BundleIdentifier}
+		whereClause = "WHERE s.bundle_identifier = ? AND source = ?"
+		whereArgs = []any{payload.BundleIdentifier, payload.Source}
 	}
 	if payload.UpgradeCode != "" {
 		// match only by upgrade code

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4245,37 +4245,89 @@ func testMatchOrCreateSoftwareInstallerDuplicateHash(t *testing.T, ds *Datastore
 
 func testAddSoftwareTitleToMatchingSoftware(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
 	host1 := test.NewHost(t, ds, "host1", "", "host1key", "host1uuid", time.Now())
 	software1 := []fleet.Software{
-		{Name: "Win Title", Version: "0.0.1", Source: "programs", UpgradeCode: ptr.String("CODE_1")},
+		{Name: "Win Title", Version: "1.0", Source: "programs", UpgradeCode: ptr.String("CODE_1")},
 	}
 
-	_, err := ds.UpdateHostSoftware(ctx, host1.ID, software1)
+	// create a vpp app
+	test.CreateInsertGlobalVPPToken(t, ds)
+	app, err := ds.InsertVPPAppWithTeam(ctx, &fleet.VPPApp{
+		VPPAppTeam:       fleet.VPPAppTeam{VPPAppID: fleet.VPPAppID{AdamID: "adam_vpp_1", Platform: "ios"}, DisplayName: ptr.String("VPP1")},
+		Name:             "iOS Title",
+		BundleIdentifier: "com.foo",
+	}, nil)
+	require.NoError(t, err)
+
+	host2, err := ds.NewHost(ctx, &fleet.Host{
+		Hostname:      "ios-test",
+		OsqueryHostID: ptr.String("osquery-ios"),
+		NodeKey:       ptr.String("node-key-ios"),
+		UUID:          uuid.NewString(),
+		Platform:      "ios",
+	})
+	software2 := []fleet.Software{
+		{Name: "iOS Title", Version: "1.0", Source: "ios_apps", BundleIdentifier: "com.foo"},
+	}
+
+	_, err = ds.UpdateHostSoftware(ctx, host1.ID, software1)
+	require.NoError(t, err)
+	_, err = ds.UpdateHostSoftware(ctx, host2.ID, software2)
 	require.NoError(t, err)
 	require.NoError(t, ds.SyncHostsSoftware(ctx, time.Now()))
 	require.NoError(t, ds.SyncHostsSoftwareTitles(ctx, time.Now()))
 
 	// creates a second software title with the same name
 	payload := &fleet.UploadSoftwareInstallerPayload{
-		Title:       "Win Title",
-		Source:      "programs",
-		UpgradeCode: "CODE_2",
+		Title:           "Win Title",
+		Source:          "programs",
+		UpgradeCode:     "CODE_2",
+		Filename:        "something.msi",
+		Version:         "1.0",
+		UserID:          user.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
 	}
-	titleID, err := ds.getOrGenerateSoftwareInstallerTitleID(ctx, payload)
-	require.NoError(t, err)
-	require.NotEmpty(t, titleID)
 
-	err = ds.addSoftwareTitleToMatchingSoftware(ctx, titleID, payload)
+	_, newTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, payload)
 	require.NoError(t, err)
+	require.NotEmpty(t, newTitleID)
 
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		var gotTitleID uint
 		err := sqlx.GetContext(ctx, q, &gotTitleID, `SELECT title_id FROM software WHERE name = ?`, "Win Title")
 		require.NoError(t, err)
-		require.NotEqual(t, titleID, gotTitleID)
+		require.NotEqual(t, newTitleID, gotTitleID) // title with different upgrade code is new
 		return nil
 	})
 
+	// check that host has the ios app installed and title is correct.
+	found, err := hostInstalledSoftware(ds, ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, app.TitleID, found[0].ID)
+
+	// add macOS installer with the same bundle identifier
+	payloadMacOS := &fleet.UploadSoftwareInstallerPayload{
+		Title:            "A Mac Title",
+		Source:           "apps",
+		Platform:         "darwin",
+		Filename:         "something.pkg",
+		Version:          "1.0",
+		BundleIdentifier: "com.foo",
+		UserID:           user.ID,
+		ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+	}
+
+	_, titleIDMacOS, err := ds.MatchOrCreateSoftwareInstaller(ctx, payloadMacOS)
+	require.NoError(t, err)
+	require.NotEqual(t, app.TitleID, titleIDMacOS)
+
+	// check that the installed ios app did not change title ID to the new installer
+	found, err = hostInstalledSoftware(ds, ctx, host2.ID)
+	require.NoError(t, err)
+	require.Len(t, found, 1)
+	require.Equal(t, app.TitleID, found[0].ID)
 }
 
 func testFleetMaintainedAppInstallerUpdates(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4267,6 +4267,7 @@ func testAddSoftwareTitleToMatchingSoftware(t *testing.T, ds *Datastore) {
 		UUID:          uuid.NewString(),
 		Platform:      "ios",
 	})
+	require.NoError(t, err)
 	software2 := []fleet.Software{
 		{Name: "iOS Title", Version: "1.0", Source: "ios_apps", BundleIdentifier: "com.foo"},
 	}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35528
The existing migrations were bumped in #41624 so they should be good for the 4.83 release 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
  - Changes file exists in main (`changes/35528-wrong-title-platform`) but was reverted out of 4.82 release.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually
