### PR TITLE
Disallow manage hosts page header buttons from wrapping text

### DIFF
--- a/changes/41653-disallow-header-button-wraps
+++ b/changes/41653-disallow-header-button-wraps
@@ -1,0 +1,1 @@
+- Fixed a bug where manage hosts page header button text would wrap and distort at certain widths.

--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -110,6 +110,10 @@
     .input-with-icon {
       height: 36px;
     }
+
+    .children-wrapper {
+      white-space: nowrap;
+    }
   }
 
   &__header-left {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41653 
<img width="810" height="597" alt="Screenshot 2026-03-13 at 8 44 23 AM" src="https://github.com/user-attachments/assets/b5e7feff-e576-4c0d-a9ee-b2ef1a17a7ea" />


- [x] Changes file added for user-visible changes in `changes/`
- [x] QA'd all new/changed functionality manually