### PR TITLE
Trim ARM suffixes from arch linux OS names

### DIFF
--- a/changes/33495-list-arch-linux-together
+++ b/changes/33495-list-arch-linux-together
@@ -1,0 +1,2 @@
+- Trimmed incoming " ARM" suffix for Arch Linux hosts so Arch OSs are grouped together in the
+database and UI.

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1721,6 +1721,9 @@ func directIngestOSUnixLike(ctx context.Context, logger *slog.Logger, host *flee
 		return ctxerr.Errorf(ctx, "directIngestOSUnixLike invalid number of rows: %d", len(rows))
 	}
 	name := rows[0]["name"]
+	if strings.HasPrefix(name, "Arch Linux") {
+		name = strings.TrimSuffix(name, " ARM")
+	}
 	version := rows[0]["version"]
 	major := rows[0]["major"]
 	minor := rows[0]["minor"]

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -1515,6 +1515,46 @@ func TestDirectIngestOSUnixLike(t *testing.T) {
 				KernelVersion: "5.10.76-linuxkit",
 			},
 		},
+		{
+			data: []map[string]string{
+				{
+					"name":           "Arch Linux ARM",
+					"version":        "",
+					"major":          "1",
+					"minor":          "2",
+					"patch":          "3",
+					"build":          "",
+					"arch":           "aarch64",
+					"kernel_version": "6.6.10-1-ARCH",
+				},
+			},
+			expected: fleet.OperatingSystem{
+				Name:          "Arch Linux",
+				Version:       "1.2.3",
+				Arch:          "aarch64",
+				KernelVersion: "6.6.10-1-ARCH",
+			},
+		},
+		{
+			data: []map[string]string{
+				{
+					"name":           "Arch Linux",
+					"version":        "",
+					"major":          "1",
+					"minor":          "2",
+					"patch":          "3",
+					"build":          "",
+					"arch":           "x86_64",
+					"kernel_version": "6.6.10-1-ARCH",
+				},
+			},
+			expected: fleet.OperatingSystem{
+				Name:          "Arch Linux",
+				Version:       "1.2.3",
+				Arch:          "x86_64",
+				KernelVersion: "6.6.10-1-ARCH",
+			},
+		},
 	} {
 		t.Run(tc.expected.Name, func(t *testing.T) {
 			ds.UpdateHostOperatingSystemFunc = func(ctx context.Context, hostID uint, hostOS fleet.OperatingSystem) error {


### PR DESCRIPTION
**Related issue:** Resolves #33495 
OSs still discreet on host page:
<img width="1223" height="366" alt="Screenshot 2026-03-13 at 3 41 33 PM" src="https://github.com/user-attachments/assets/696a2b6a-934b-4842-89f1-6ac214acda0c" />

and rolled into one row on OS page: 
<img width="1223" height="435" alt="Screenshot 2026-03-13 at 3 41 12 PM" src="https://github.com/user-attachments/assets/cc4af190-babf-4a98-9999-22dad1d219eb" />

- [x] Changes file added for user-visible changes in `changes/`
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OS name normalization for Arch Linux ARM hosts by removing redundant system identifiers for cleaner display.

* **Tests**
  * Added validation tests for Arch Linux ARM and standard Arch Linux host configurations to ensure consistent OS naming and architecture mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->