### PR TITLE
Removing Slack to prep for demo

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -127,7 +127,6 @@ policies:
   - path: ../lib/macos/policies/update-firefox.yml
   - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/macos/policies/all-software-updates-installed.yml
-  - path: ../lib/macos/policies/update-slack.yml
   - path: ../lib/macos/policies/update-1password.yml
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
@@ -224,22 +223,6 @@ software:
         - Communication
       labels_include_any:
         - "RPM-based Linux hosts"
-    - path: ../lib/linux/software/slack-deb.yml # Slack for Ubuntu
-      self_service: true
-      setup_experience: true
-      categories:
-        - Productivity
-        - Communication
-      labels_include_any:
-        - "Debian-based Linux hosts"
-    - path: ../lib/linux/software/slack-rpm.yml # Slack for RedHat
-      self_service: true
-      setup_experience: true
-      categories:
-        - Productivity
-        - Communication
-      labels_include_any:
-        - "RPM-based Linux hosts"
     # Windows apps
     # Commenting out until #25407 is implemented
     # - path: ../lib/windows/software/zoom-arm.yml # Zoom for Windows (ARM)
@@ -284,12 +267,6 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
-    - slug: slack/darwin # Slack for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Communication
-        - Productivity
     - slug: google-chrome/darwin # Google Chrome for macOS
       self_service: true
       setup_experience: true
@@ -337,12 +314,6 @@ software:
         - "x86-based Windows hosts"
       categories:
         - Productivity
-    - slug: slack/windows # Slack for Windows
-      self_service: true
-      setup_experience: true
-      categories:
-        - Productivity
-        - Communication
       labels_include_any:
         - "x86-based Windows hosts"
     - slug: google-chrome/windows # Google Chrome for Windows

--- a/it-and-security/lib/macos/policies/update-slack.yml
+++ b/it-and-security/lib/macos/policies/update-slack.yml
@@ -1,7 +1,0 @@
-- name: macOS - Slack up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Slack.app' AND version_compare(bundle_short_version, '4.47.72') < 0);
-  critical: false
-  description: The host may be running an outdated version of Slack, which could pose security vulnerabilities or compatibility issues.
-  resolution: Slack can be updated by downloading the latest version from the App Store or by using Slack's built-in update functionality.
-  platform: darwin
-  calendar_events_enabled: false


### PR DESCRIPTION
This pull request removes Slack from the managed software and policy lists for all platforms (macOS, Linux, and Windows) in the workstation fleet configuration. The associated policy file for keeping Slack up to date on macOS has also been deleted.

Key removals by theme:

Slack software and policy removal:

* Removed the `update-slack.yml` policy from the list of enforced macOS policies in `workstations.yml`.
* Deleted the `update-slack.yml` policy file for macOS, which checked that Slack was up to date.

Slack application removal from managed software:

* Removed Slack from the list of managed apps for macOS (`slack/darwin`), Linux (`slack-deb.yml` and `slack-rpm.yml`), and Windows (`slack/windows`) in the `workstations.yml` configuration. [[1]](diffhunk://#diff-48e4b7825d0b94911c4b33cccbe16ac3698dfb4b3e365a86432b58f06294daaaL227-L242) [[2]](diffhunk://#diff-48e4b7825d0b94911c4b33cccbe16ac3698dfb4b3e365a86432b58f06294daaaL287-L292) [[3]](diffhunk://#diff-48e4b7825d0b94911c4b33cccbe16ac3698dfb4b3e365a86432b58f06294daaaL340-L345)