### PR TITLE
Jve fix fqn

### DIFF
--- a/ee/server/service/vpp.go
+++ b/ee/server/service/vpp.go
@@ -63,14 +63,14 @@ func (svc *Service) hasAppStoreAppChanged(ctx context.Context, teamID *uint, inc
 	var categoriesChanged, labelsChanged, installDuringSetupChanged, displayNameChanged, configurationChanged bool
 
 	if isExistingApp {
-		existingLabels, err := ds.getExistingLabels(ctx, incomingApp.AppTeamID)
+		existingLabels, err := svc.ds.getExistingLabels(ctx, incomingApp.AppTeamID)
 		if err != nil {
 			return fleet.AppStoreAppChanges{}, ctxerr.Wrap(ctx, err, "getting existing labels for vpp app")
 		}
 
 		labelsChanged = !existingLabels.Equal(incomingApp.ValidatedLabels)
 
-		existingCatIDs, err := ds.getVPPAppTeamCategoryIDs(ctx, incomingApp.AppTeamID)
+		existingCatIDs, err := svc.ds.getVPPAppTeamCategoryIDs(ctx, incomingApp.AppTeamID)
 		if err != nil {
 			return fleet.AppStoreAppChanges{}, ctxerr.Wrap(ctx, err, "getting existing categories for vpp app")
 		}
@@ -429,6 +429,7 @@ func (svc *Service) BatchAssociateVPPApps(ctx context.Context, teamName string, 
 			}
 
 			o.Changed = changed
+
 		}
 
 		// TODO: should these be some opts for the next call?

--- a/server/fleet/software.go
+++ b/server/fleet/software.go
@@ -666,12 +666,8 @@ type VPPBatchPayload struct {
 	Configuration json.RawMessage           `json:"configuration,omitempty"`
 }
 
-func (v VPPBatchPayload) GetPlatform() string {
-	return string(v.Platform)
-}
-
-func (v VPPBatchPayload) GetAppStoreID() string {
-	return v.AppStoreID
+func (v VPPBatchPayload) FullyQualifiedName() string {
+	return fmt.Sprintf("%s_%s", v.AppStoreID, v.Platform)
 }
 
 type VPPBatchPayloadWithPlatform struct {

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -177,3 +177,19 @@ type AppStoreAppUpdatePayload struct {
 	DisplayName      *string
 	Configuration    json.RawMessage
 }
+
+type AppStoreAppChanges struct {
+	Any                bool
+	Categories         bool
+	Labels             bool
+	InstallDuringSetup bool
+	DisplayName        bool
+	Configuration      bool
+}
+
+type SetTeamAppStoreAppsOpts struct {
+	Changed               AppStoreAppChanges
+	VPPTokenID            *uint
+	TeamName              string
+	AppsWithChangedLabels map[uint]map[uint]struct{}
+}

--- a/server/fleet/vpp.go
+++ b/server/fleet/vpp.go
@@ -57,12 +57,8 @@ type VPPAppTeam struct {
 	Configuration json.RawMessage `json:"configuration,omitempty"`
 }
 
-func (v VPPAppTeam) GetPlatform() string {
-	return string(v.Platform)
-}
-
-func (v VPPAppTeam) GetAppStoreID() string {
-	return v.AdamID
+func (v VPPAppTeam) FullyQualifiedName() string {
+	return fmt.Sprintf("%s_%s", v.AdamID, v.Platform)
 }
 
 // VPPApp represents a VPP (Volume Purchase Program) application,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
