### PR TITLE
add keymap for new renames, and shallow duplication

### DIFF
--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -2519,7 +2519,7 @@ spec:
 
 		b, err = os.ReadFile(filepath.Join("testdata", "macosSetupExpectedAppConfigSet.yml"))
 		require.NoError(t, err)
-		expectedAppCfgSet := fmt.Sprintf(string(b), "", emptyMacosSetup)
+		expectedAppCfgSet := fmt.Sprintf(string(b), "", emptyMacosSetup, "", emptyMacosSetup)
 		expectedAppCfgSetReleaseEnabled := strings.ReplaceAll(expectedAppCfgSet, `enable_release_device_manually: false`, `enable_release_device_manually: true`)
 
 		b, err = os.ReadFile(filepath.Join("testdata", "macosSetupExpectedTeam1Empty.yml"))

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -147,10 +147,25 @@ var aliasRules = map[string]string{
 	"team_ids":             "fleet_ids",
 	"team_name":            "fleet_name",
 	"teams":                "fleets",
+
+	// MDM settings renames
+	"bootstrap_package":              "macos_bootstrap_package",
+	"custom_settings":                "configuration_profiles",
+	"enable_release_device_manually": "apple_enable_release_device_manually",
+	"macos_settings":                 "apple_settings",
+	"macos_setup":                    "setup_experience",
+	"macos_setup_assistant":          "apple_setup_assistant",
+	"manual_agent_install":           "macos_manual_agent_install",
+	"script":                         "macos_script",
 }
 
 // Replace deprecated keys with their new canonical names.
 // If deleteOld is true, the old keys are removed; otherwise both old and new keys are present.
+//
+// When deleteOld is false and a renamed key's value is a map, the old key keeps
+// its original child keys untouched and the new key receives a deep copy with
+// children recursively renamed (old child keys removed). This avoids duplicating
+// every nested key under both the old and new parent.
 func replaceAliasKeys(v any, rules map[string]string, deleteOld bool) {
 	switch val := v.(type) {
 	case map[string]any:
@@ -164,19 +179,60 @@ func replaceAliasKeys(v any, rules map[string]string, deleteOld bool) {
 				renames = append(renames, rename{k, newKey})
 			}
 		}
+
+		// Track keys whose subtrees we've already fully processed so the
+		// general recursion below can skip them.
+		handled := make(map[string]bool, len(renames)*2)
+
 		for _, r := range renames {
-			val[r.newKey] = val[r.oldKey]
 			if deleteOld {
+				val[r.newKey] = val[r.oldKey]
 				delete(val, r.oldKey)
+			} else if childMap, ok := val[r.oldKey].(map[string]any); ok {
+				// Container key: old copy keeps original children,
+				// new copy gets a deep copy with children renamed.
+				copied := deepCopyAny(childMap).(map[string]any)
+				replaceAliasKeys(copied, rules, true)
+				val[r.newKey] = copied
+				handled[r.oldKey] = true
+				handled[r.newKey] = true
+			} else {
+				// Leaf/non-map value: just duplicate the key.
+				val[r.newKey] = val[r.oldKey]
 			}
 		}
-		for _, v := range val {
+
+		for k, v := range val {
+			if handled[k] {
+				continue
+			}
 			replaceAliasKeys(v, rules, deleteOld)
 		}
 	case []any:
 		for _, item := range val {
 			replaceAliasKeys(item, rules, deleteOld)
 		}
+	}
+}
+
+// deepCopyAny returns a deep copy of a value produced by json.Unmarshal
+// (maps, slices, and primitives).
+func deepCopyAny(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		m := make(map[string]any, len(val))
+		for k, v := range val {
+			m[k] = deepCopyAny(v)
+		}
+		return m
+	case []any:
+		s := make([]any, len(val))
+		for i, v := range val {
+			s[i] = deepCopyAny(v)
+		}
+		return s
+	default:
+		return v
 	}
 }
 

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -2030,6 +2030,54 @@ func TestReplaceAliasKeys(t *testing.T) {
 		require.Equal(t, "in_array", item["old_key"])
 	})
 
+	t.Run("container key deleteOld=false: old keeps old children, new gets new children", func(t *testing.T) {
+		rules := map[string]string{
+			"old_container": "new_container",
+			"child_old":     "child_new",
+		}
+		data := map[string]any{
+			"old_container": map[string]any{
+				"child_old": "val",
+				"unchanged": "stays",
+			},
+		}
+		replaceAliasKeys(data, rules, false)
+
+		// Old container keeps original child keys only.
+		oldC := data["old_container"].(map[string]any)
+		require.Equal(t, "val", oldC["child_old"])
+		_, exists := oldC["child_new"]
+		require.False(t, exists, "old container should not gain new child key")
+		require.Equal(t, "stays", oldC["unchanged"])
+
+		// New container has children renamed.
+		newC := data["new_container"].(map[string]any)
+		require.Equal(t, "val", newC["child_new"])
+		_, exists = newC["child_old"]
+		require.False(t, exists, "new container should not have old child key")
+		require.Equal(t, "stays", newC["unchanged"])
+	})
+
+	t.Run("container key deleteOld=true: children renamed, old container removed", func(t *testing.T) {
+		rules := map[string]string{
+			"old_container": "new_container",
+			"child_old":     "child_new",
+		}
+		data := map[string]any{
+			"old_container": map[string]any{
+				"child_old": "val",
+			},
+		}
+		replaceAliasKeys(data, rules, true)
+
+		_, exists := data["old_container"]
+		require.False(t, exists)
+		newC := data["new_container"].(map[string]any)
+		require.Equal(t, "val", newC["child_new"])
+		_, exists = newC["child_old"]
+		require.False(t, exists)
+	})
+
 	t.Run("nil map is safe", func(t *testing.T) {
 		replaceAliasKeys(nil, rules, true)
 		replaceAliasKeys(nil, rules, false)

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigJson.json
@@ -146,6 +146,9 @@
         "mode": "",
         "webhook_url": ""
       },
+      "apple_settings": {
+        "configuration_profiles": null
+      },
       "macos_settings": {
         "custom_settings": null
       },
@@ -160,12 +163,25 @@
         "manual_agent_install": null,
         "require_all_software_macos": false
       },
+      "setup_experience": {
+        "macos_bootstrap_package": null,
+        "enable_end_user_authentication": false,
+        "lock_end_user_info": false,
+        "apple_setup_assistant": null,
+        "apple_enable_release_device_manually": false,
+        "macos_script": null,
+        "software": null,
+        "macos_manual_agent_install": null,
+        "require_all_software_macos": false
+      },
       "windows_settings": {
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "android_settings": {
         "certificates": null,
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "end_user_authentication": {
         "entity_id": "",

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerJson.json
@@ -118,6 +118,9 @@
         "mode": "",
         "webhook_url": ""
       },
+      "apple_settings": {
+        "configuration_profiles": null
+      },
       "macos_settings": {
         "custom_settings": null
       },
@@ -132,12 +135,25 @@
         "manual_agent_install": null,
         "require_all_software_macos": false
       },
+      "setup_experience": {
+        "macos_bootstrap_package": null,
+        "enable_end_user_authentication": false,
+        "apple_setup_assistant": null,
+        "apple_enable_release_device_manually": false,
+        "lock_end_user_info": false,
+        "macos_script": null,
+        "software": null,
+        "macos_manual_agent_install": null,
+        "require_all_software_macos": false
+      },
       "windows_settings": {
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "android_settings": {
         "certificates": null,
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "end_user_authentication": {
         "entity_id": "",

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigTeamMaintainerYaml.yml
@@ -61,6 +61,8 @@ spec:
     windows_updates:
       deadline_days: 7
       grace_period_days: 3
+    apple_settings:
+      configuration_profiles: null
     macos_settings:
       custom_settings: null
     macos_setup:
@@ -73,11 +75,23 @@ spec:
       require_all_software_macos: false
       script:
       software:
+    setup_experience:
+      macos_bootstrap_package:
+      enable_end_user_authentication: false
+      apple_enable_release_device_manually: false
+      lock_end_user_info: false
+      apple_setup_assistant:
+      macos_manual_agent_install:
+      require_all_software_macos: false
+      macos_script:
+      software:
     windows_settings:
       custom_settings: null
+      configuration_profiles: null
     android_settings:
       certificates: null
       custom_settings: null
+      configuration_profiles: null
     end_user_authentication:
       idp_name: ""
       issuer_uri: ""

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigAppConfigYaml.yml
@@ -61,6 +61,8 @@ spec:
     windows_updates:
       deadline_days: 7
       grace_period_days: 3
+    apple_settings:
+      configuration_profiles:
     macos_settings:
       custom_settings:
     macos_setup:
@@ -73,11 +75,23 @@ spec:
       require_all_software_macos: false
       script:
       software:
+    setup_experience:
+      macos_bootstrap_package:
+      enable_end_user_authentication: false
+      apple_enable_release_device_manually: false
+      lock_end_user_info: false
+      apple_setup_assistant:
+      macos_manual_agent_install:
+      require_all_software_macos: false
+      macos_script:
+      software:
     windows_settings:
       custom_settings: null
+      configuration_profiles: null
     android_settings:
       certificates: null
       custom_settings: null
+      configuration_profiles: null
     end_user_authentication:
       idp_name: ""
       issuer_uri: ""

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigJson.json
@@ -96,6 +96,9 @@
         "mode": "",
         "webhook_url": ""
       },
+      "apple_settings": {
+        "configuration_profiles": null
+      },
       "macos_settings": {
         "custom_settings": null
       },
@@ -110,12 +113,25 @@
         "manual_agent_install": null,
         "require_all_software_macos": false
       },
+      "setup_experience": {
+        "macos_bootstrap_package": null,
+        "enable_end_user_authentication": false,
+        "apple_setup_assistant": null,
+        "apple_enable_release_device_manually": false,
+        "lock_end_user_info": false,
+        "macos_script": null,
+        "software": null,
+        "macos_manual_agent_install": null,
+        "require_all_software_macos": false
+      },
       "windows_settings": {
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "android_settings": {
         "certificates": null,
-        "custom_settings": null
+        "custom_settings": null,
+        "configuration_profiles": null
       },
       "end_user_authentication": {
         "entity_id": "",

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetConfigIncludeServerConfigYaml.yml
@@ -61,6 +61,8 @@ spec:
     windows_updates:
       deadline_days: 7
       grace_period_days: 3
+    apple_settings:
+      configuration_profiles:
     macos_settings:
       custom_settings:
     macos_setup:
@@ -73,11 +75,23 @@ spec:
       require_all_software_macos: false
       script:
       software:
+    setup_experience:
+      macos_bootstrap_package:
+      enable_end_user_authentication: false
+      apple_enable_release_device_manually: false
+      lock_end_user_info: false
+      apple_setup_assistant:
+      macos_manual_agent_install:
+      require_all_software_macos: false
+      macos_script:
+      software:
     windows_settings:
       custom_settings: null
+      configuration_profiles: null
     android_settings:
       certificates: null
       custom_settings: null
+      configuration_profiles: null
     end_user_authentication:
       idp_name: ""
       issuer_uri: ""

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsJson.json
@@ -24,7 +24,10 @@
       "mdm": {
         "android_settings": {
           "certificates": null,
-          "custom_settings": null
+          "configuration_profiles": null
+        },
+        "apple_settings": {
+          "configuration_profiles": null
         },
         "enable_disk_encryption": false,
         "enable_recovery_lock_password": false,
@@ -38,28 +41,25 @@
           "minimum_version": null,
           "update_new_hosts": null
         },
-        "macos_settings": {
-          "custom_settings": null
-        },
-        "macos_setup": {
-          "bootstrap_package": null,
-          "enable_end_user_authentication": false,
-          "enable_release_device_manually": false,
-          "lock_end_user_info": false,
-          "macos_setup_assistant": null,
-          "manual_agent_install": null,
-          "require_all_software_macos": false,
-          "script": null,
-          "software": null
-        },
         "macos_updates": {
           "deadline": null,
           "minimum_version": null,
           "update_new_hosts": null
         },
+        "setup_experience": {
+          "apple_enable_release_device_manually": false,
+          "apple_setup_assistant": null,
+          "enable_end_user_authentication": false,
+          "lock_end_user_info": false,
+          "macos_bootstrap_package": null,
+          "macos_manual_agent_install": null,
+          "macos_script": null,
+          "require_all_software_macos": false,
+          "software": null
+        },
         "windows_require_bitlocker_pin": false,
         "windows_settings": {
-          "custom_settings": null
+          "configuration_profiles": null
         },
         "windows_updates": {
           "deadline_days": null,
@@ -199,7 +199,10 @@
       "mdm": {
         "android_settings": {
           "certificates": null,
-          "custom_settings": null
+          "configuration_profiles": null
+        },
+        "apple_settings": {
+          "configuration_profiles": null
         },
         "enable_disk_encryption": false,
         "enable_recovery_lock_password": true,
@@ -213,28 +216,25 @@
           "minimum_version": "18.0",
           "update_new_hosts": null
         },
-        "macos_settings": {
-          "custom_settings": null
-        },
-        "macos_setup": {
-          "bootstrap_package": null,
-          "enable_end_user_authentication": false,
-          "enable_release_device_manually": false,
-          "lock_end_user_info": false,
-          "macos_setup_assistant": null,
-          "manual_agent_install": null,
-          "require_all_software_macos": false,
-          "script": null,
-          "software": null
-        },
         "macos_updates": {
           "deadline": "2021-12-14",
           "minimum_version": "12.3.1",
           "update_new_hosts": null
         },
+        "setup_experience": {
+          "apple_enable_release_device_manually": false,
+          "apple_setup_assistant": null,
+          "enable_end_user_authentication": false,
+          "lock_end_user_info": false,
+          "macos_bootstrap_package": null,
+          "macos_manual_agent_install": null,
+          "macos_script": null,
+          "require_all_software_macos": false,
+          "software": null
+        },
         "windows_require_bitlocker_pin": false,
         "windows_settings": {
-          "custom_settings": null
+          "configuration_profiles": null
         },
         "windows_updates": {
           "deadline_days": 7,

--- a/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
+++ b/cmd/fleetctl/fleetctl/testdata/expectedGetTeamsYaml.yml
@@ -31,22 +31,22 @@ spec:
       windows_updates:
         deadline_days: null
         grace_period_days: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package:
+      setup_experience:
+        macos_bootstrap_package:
         enable_end_user_authentication: false
-        enable_release_device_manually: false
+        apple_enable_release_device_manually: false
         lock_end_user_info: false
-        macos_setup_assistant:
-        manual_agent_install:
+        apple_setup_assistant:
+        macos_manual_agent_install:
         require_all_software_macos: false
-        script:
+        macos_script:
         software:
     scripts: null
     secrets: null
@@ -142,22 +142,22 @@ spec:
       windows_updates:
         deadline_days: 7
         grace_period_days: 3
-      macos_settings:
-        custom_settings:
+      apple_settings:
+        configuration_profiles:
       windows_settings:
-        custom_settings:
+        configuration_profiles:
       android_settings:
-        custom_settings:
+        configuration_profiles:
         certificates:
-      macos_setup:
-        bootstrap_package:
+      setup_experience:
+        macos_bootstrap_package:
         enable_end_user_authentication: false
-        enable_release_device_manually: false
+        apple_enable_release_device_manually: false
         lock_end_user_info: false
-        macos_setup_assistant:
-        manual_agent_install:
+        apple_setup_assistant:
+        macos_manual_agent_install:
         require_all_software_macos: false
-        script:
+        macos_script:
         software:
     scripts: null
     webhook_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigEmpty.yml
@@ -48,10 +48,14 @@ spec:
       webhook_url: ""
     macos_settings:
       custom_settings: null
+    apple_settings:
+      configuration_profiles: null
     windows_settings:
       custom_settings: null
+      configuration_profiles: null
     android_settings:
       custom_settings: null
+      configuration_profiles: null
       certificates: null
     macos_setup:
       bootstrap_package: null
@@ -62,6 +66,16 @@ spec:
       require_all_software_macos: false
       enable_release_device_manually: false
       script: null
+      software: null
+    setup_experience:
+      macos_bootstrap_package: null
+      enable_end_user_authentication: false
+      lock_end_user_info: false
+      apple_setup_assistant: null
+      macos_manual_agent_install: null
+      require_all_software_macos: false
+      apple_enable_release_device_manually: false
+      macos_script: null
       software: null
     macos_updates:
       deadline: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedAppConfigSet.yml
@@ -48,10 +48,14 @@ spec:
       webhook_url: ""
     macos_settings:
       custom_settings: null
+    apple_settings:
+      configuration_profiles: null
     windows_settings:
       custom_settings: null
+      configuration_profiles: null
     android_settings:
       custom_settings: null
+      configuration_profiles: null
       certificates: null
     macos_setup:
       bootstrap_package: %s
@@ -62,6 +66,16 @@ spec:
       require_all_software_macos: false
       enable_release_device_manually: false
       script: null
+      software: null
+    setup_experience:
+      macos_bootstrap_package: %s
+      enable_end_user_authentication: false
+      lock_end_user_info: false
+      apple_setup_assistant: %s
+      macos_manual_agent_install: null
+      require_all_software_macos: false
+      apple_enable_release_device_manually: false
+      macos_script: null
       software: null
     macos_updates:
       deadline: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Empty.yml
@@ -16,22 +16,22 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: null
+      setup_experience:
+        macos_bootstrap_package: null
         enable_end_user_authentication: false
         lock_end_user_info: false
-        macos_setup_assistant: null
-        manual_agent_install: null
+        apple_setup_assistant: null
+        macos_manual_agent_install: null
         require_all_software_macos: false
-        enable_release_device_manually: false
-        script: null
+        apple_enable_release_device_manually: false
+        macos_script: null
         software: null
       macos_updates:
         deadline: null
@@ -124,20 +124,20 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: null
-        macos_setup_assistant: null
-        manual_agent_install: null
-        enable_release_device_manually: false
+      setup_experience:
+        macos_bootstrap_package: null
+        apple_setup_assistant: null
+        macos_manual_agent_install: null
+        apple_enable_release_device_manually: false
         lock_end_user_info: false
-        script: null
+        macos_script: null
         software: null
       macos_updates:
         deadline: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1And2Set.yml
@@ -16,22 +16,22 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: %s
+      setup_experience:
+        macos_bootstrap_package: %s
         enable_end_user_authentication: false
         lock_end_user_info: false
-        macos_setup_assistant: %s
-        manual_agent_install: null
-        enable_release_device_manually: false
+        apple_setup_assistant: %s
+        macos_manual_agent_install: null
+        apple_enable_release_device_manually: false
         require_all_software_macos: false
-        script: null
+        macos_script: null
         software: null
       macos_updates:
         deadline: null
@@ -124,20 +124,20 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: %s
-        macos_setup_assistant: %s
-        manual_agent_install: null
-        enable_release_device_manually: false
+      setup_experience:
+        macos_bootstrap_package: %s
+        apple_setup_assistant: %s
+        macos_manual_agent_install: null
+        apple_enable_release_device_manually: false
         lock_end_user_info: false
-        script: null
+        macos_script: null
         software: null
       macos_updates:
         deadline: null

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Empty.yml
@@ -16,20 +16,20 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: null
+      setup_experience:
+        macos_bootstrap_package: null
         enable_end_user_authentication: false
         lock_end_user_info: false
-        macos_setup_assistant: null
-        manual_agent_install: null
+        apple_setup_assistant: null
+        macos_manual_agent_install: null
         require_all_software_macos: false
-        enable_release_device_manually: false
-        script: null
+        apple_enable_release_device_manually: false
+        macos_script: null
         software: null
       macos_updates:
         deadline: null
@@ -47,7 +47,7 @@ spec:
         deadline_days: null
         grace_period_days: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
     scripts: null
     secrets: null
     webhook_settings:

--- a/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
+++ b/cmd/fleetctl/fleetctl/testdata/macosSetupExpectedTeam1Set.yml
@@ -15,22 +15,22 @@ spec:
       enable_disk_encryption: false
       enable_recovery_lock_password: false
       windows_require_bitlocker_pin: null
-      macos_settings:
-        custom_settings: null
+      apple_settings:
+        configuration_profiles: null
       windows_settings:
-        custom_settings: null
+        configuration_profiles: null
       android_settings:
-        custom_settings: null
+        configuration_profiles: null
         certificates: null
-      macos_setup:
-        bootstrap_package: %s
+      setup_experience:
+        macos_bootstrap_package: %s
         enable_end_user_authentication: false
         lock_end_user_info: false
-        macos_setup_assistant: %s
-        manual_agent_install: null
+        apple_setup_assistant: %s
+        macos_manual_agent_install: null
         require_all_software_macos: false
-        enable_release_device_manually: false
-        script: null
+        apple_enable_release_device_manually: false
+        macos_script: null
         software: null
       macos_updates:
         deadline: null

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -349,7 +349,7 @@ settings:
 
 	// Check that all the teams exist
 	teamsJSON := fleetctl.RunAppForTest(t, []string{"get", "teams", "--config", fleetctlConfig.Name(), "--json"})
-	assert.Equal(t, 6, strings.Count(teamsJSON, "fleet_id"))
+	assert.Equal(t, 3, strings.Count(teamsJSON, "fleet_id"))
 
 	// Real run with all the files, and delete other teams
 	args = []string{"gitops", "--config", fleetctlConfig.Name(), "--delete-other-teams", "-f", globalFile}
@@ -360,7 +360,7 @@ settings:
 
 	// Check that only the right teams exist
 	teamsJSON = fleetctl.RunAppForTest(t, []string{"get", "teams", "--config", fleetctlConfig.Name(), "--json"})
-	assert.Equal(t, 4, strings.Count(teamsJSON, "fleet_id"))
+	assert.Equal(t, 2, strings.Count(teamsJSON, "fleet_id"))
 	assert.NotContains(t, teamsJSON, deletedTeamName)
 
 	// Real run with one file at a time

--- a/server/platform/endpointer/json_key_duplicator.go
+++ b/server/platform/endpointer/json_key_duplicator.go
@@ -131,25 +131,31 @@ func DuplicateJSONKeys(data []byte, rules []AliasRule, opts ...DuplicateJSONKeys
 						return data
 					}
 
-					// Read the value, capturing it for deferred duplication.
+					// Read the raw value.
 					val, err := dec.ReadValue()
 					if err != nil {
 						return data
 					}
 
-					// Recursively duplicate keys within the value.
-					processedVal := DuplicateJSONKeys([]byte(val), rules, opts...)
-
-					// Write the value for the old key.
-					if err := enc.WriteValue(jsontext.Value(processedVal)); err != nil {
+					// Write the original value as-is for the old key — it
+					// already uses old names from json.Marshal, so no
+					// transformation is needed.
+					if err := enc.WriteValue(val); err != nil {
 						return data
+					}
+
+					// For the new key, rename nested keys to new names only
+					// (removing old names) so the new-name subtree is clean.
+					newVal, renameErr := RewriteOldToNewKeys([]byte(val), rules)
+					if renameErr != nil {
+						newVal = []byte(val) // fall back to original value on error
 					}
 
 					// Defer the duplicate for emission at '}'.
 					if len(scopes) > 0 {
 						scopes[len(scopes)-1].pending = append(
 							scopes[len(scopes)-1].pending,
-							pendingDup{newKey: newKey, value: jsontext.Value(processedVal)},
+							pendingDup{newKey: newKey, value: jsontext.Value(newVal)},
 						)
 					}
 				} else { // !shouldDuplicate (no old key match) — just write the key as-is

--- a/server/platform/endpointer/json_key_duplicator_test.go
+++ b/server/platform/endpointer/json_key_duplicator_test.go
@@ -154,6 +154,8 @@ func TestDuplicateJSONKeys(t *testing.T) {
 			// This simulates the ABM tokens response pattern where a duplicated
 			// outer key (e.g., ios_team→ios_fleet) has an object value that itself
 			// contains keys needing duplication (e.g., team_id→fleet_id).
+			// The old-name container keeps both old+new child keys;
+			// the new-name container has children renamed to new keys only.
 			name:  "DuplicatedKeyWithNestedDuplicatableKeys",
 			input: `{"ios_team": {"name": "Default", "team_id": 5}}`,
 			rules: []AliasRule{
@@ -167,13 +169,16 @@ func TestDuplicateJSONKeys(t *testing.T) {
 				// Both ios_team and ios_fleet should exist.
 				iosTeam := m["ios_team"].(map[string]any)
 				iosFleet := m["ios_fleet"].(map[string]any)
-				// Both should have team_id AND fleet_id.
+				// Old-name container keeps only old child keys.
 				assert.Equal(t, "Default", iosTeam["name"])
 				assert.Equal(t, float64(5), iosTeam["team_id"])
-				assert.Equal(t, float64(5), iosTeam["fleet_id"])
+				_, hasNewKey := iosTeam["fleet_id"]
+				assert.False(t, hasNewKey, "old-name container should not have new child key")
+				// New-name container has children renamed to new keys only.
 				assert.Equal(t, "Default", iosFleet["name"])
-				assert.Equal(t, float64(5), iosFleet["team_id"])
 				assert.Equal(t, float64(5), iosFleet["fleet_id"])
+				_, hasOldKey := iosFleet["team_id"]
+				assert.False(t, hasOldKey, "new-name container should not have old child key")
 			},
 		},
 		{
@@ -460,13 +465,17 @@ func TestDuplicateJSONKeysCompact(t *testing.T) {
 		var m map[string]any
 		require.NoError(t, json.Unmarshal(result, &m))
 
+		// Old-name container keeps only old child keys.
 		iosTeam := m["ios_team"].(map[string]any)
 		assert.Equal(t, float64(5), iosTeam["team_id"])
-		assert.Equal(t, float64(5), iosTeam["fleet_id"])
+		_, hasNewKey := iosTeam["fleet_id"]
+		assert.False(t, hasNewKey)
 
+		// New-name container has children renamed to new keys only.
 		iosFleet := m["ios_fleet"].(map[string]any)
-		assert.Equal(t, float64(5), iosFleet["team_id"])
 		assert.Equal(t, float64(5), iosFleet["fleet_id"])
+		_, hasOldKey := iosFleet["team_id"]
+		assert.False(t, hasOldKey)
 	})
 
 	t.Run("default (no opts) is indented", func(t *testing.T) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #41091 

# Details

This PR finishes the work of aliasing multi-platform keys by:

* Added the renames to the list maintained by generate-gitops so that `fleetctl get` can use the new names
* Updated the code that adds the new names to API and `fleetctl get` output to only add new nested keys under new parents, e.g. add `apple_settings.configuration_profiles`, but not `macos_settings.configuration_profiles`.

The API key duplicator now runs through `RewriteDeprecatedKeys` which is a little heavier per-token, but for old keys we're doing less work so I think this ends up being slightly more performant than before, at least for large payloads.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, changelog for new keys added in previous PR

## Testing

- [X] Added/updated automated tests
  updated tests for the duplicators 
- [X] QA'd all new/changed functionality manually
  - [X] `/config` and `/fleets` APIs now only return new keys under new parents
  - [X] `fleetctl get fleets` now returns new multiplatform keys

