### PR TITLE
Fixed GitOps failing to delete a certificate authority

### DIFF
--- a/changes/38036-gitops-ca-delete-order
+++ b/changes/38036-gitops-ca-delete-order
@@ -1,0 +1,1 @@
+* Fixed GitOps failing to delete a certificate authority when certificate templates still reference it in fleet configs.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -494,10 +494,11 @@ func gitopsCommand() *cli.Command {
 				// before the CA itself is deleted (by the global config).
 				// During dry run, no actual deletions happen, so there's no FK ordering issue
 				// and CAs can be processed inline for validation.
+				// We capture deferredCAs before DoGitOps because DoGitOps deletes the key from OrgSettings.
 				var deferredCAs any
 				if isGlobalConfig && !flDryRun {
 					deferredCAs = config.OrgSettings["certificate_authorities"]
-					delete(config.OrgSettings, "certificate_authorities")
+					config.SkipCertificateAuthorities = true
 				}
 
 				assumptions, err := fleetClient.DoGitOps(
@@ -521,16 +522,12 @@ func gitopsCommand() *cli.Command {
 				// Certificate authority deletions may fail if certificate templates still reference
 				// them, so we defer CA processing until after team configs have cleaned up their
 				// certificate templates.
-				if isGlobalConfig && deferredCAs != nil {
-					config.OrgSettings["certificate_authorities"] = deferredCAs
+				if isGlobalConfig && !flDryRun {
 					caFilename := flFilename
 					allPostOps = append(allPostOps, func() error {
 						groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
 						if caErr != nil {
 							return fmt.Errorf("invalid certificate_authorities: %w", caErr)
-						}
-						if groupedCAs == nil {
-							return nil
 						}
 						if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}); caErr != nil {
 							if caErr.Error() == "missing or invalid license" {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -490,10 +490,9 @@ func gitopsCommand() *cli.Command {
 				}
 
 				// Capture CAs before DoGitOps (which deletes the key from OrgSettings).
-				// CAs are processed inline by DoGitOps — creates/updates always succeed because
-				// the datastore uses separate transactions for upserts and deletes.
-				// If a CA deletion fails due to FK constraints (certificate templates still reference it),
-				// we schedule a retry as a post-op that runs after team configs have cleaned up their templates.
+				// DoGitOps processes CA creates/updates inline (with skipDeletes=true).
+				// CA deletions are always deferred to a post-op so that team configs can
+				// clean up certificate templates (which have FK references to CAs) first.
 				var deferredCAs any
 				if isGlobalConfig && !flDryRun {
 					deferredCAs = config.OrgSettings["certificate_authorities"]
@@ -513,32 +512,21 @@ func gitopsCommand() *cli.Command {
 					&iconSettings,
 				)
 				if err != nil {
-					// If CA deletion failed due to FK constraints, schedule a retry after team configs.
-					if isGlobalConfig && !flDryRun && strings.Contains(err.Error(), "Certificate templates still reference it") {
-						logf("[-] CA deletion deferred until after team configs process\n")
-						caFilename := flFilename
-						allPostOps = append(allPostOps, func() error {
-							groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
-							if caErr != nil {
-								return fmt.Errorf("invalid certificate_authorities: %w", caErr)
-							}
-							if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}); caErr != nil {
-								if caErr.Error() == "missing or invalid license" {
-									return fmt.Errorf(
-										"Couldn't edit %q at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.",
-										filepath.Base(caFilename),
-									)
-								}
-								return fmt.Errorf("applying certificate authorities: %w", caErr)
-							}
-							logf("[+] applied certificate authorities\n")
-							return nil
-						})
-						err = nil
-					}
-					if err != nil {
-						return err
-					}
+					return err
+				}
+
+				// Schedule CA deletions as a post-op after all team configs have been processed.
+				if isGlobalConfig && !flDryRun {
+					allPostOps = append(allPostOps, func() error {
+						groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
+						if caErr != nil {
+							return fmt.Errorf("invalid certificate_authorities: %w", caErr)
+						}
+						if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}, fleet.BatchApplyCertificateAuthoritiesOpts{}); caErr != nil {
+							return fmt.Errorf("applying certificate authorities: %w", caErr)
+						}
+						return nil
+					})
 				}
 
 				if config.TeamName != nil {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -489,16 +489,14 @@ func gitopsCommand() *cli.Command {
 					return err
 				}
 
-				// Defer certificate authority processing to after all team configs are processed.
-				// This ensures certificate templates referencing a CA are deleted (by team configs)
-				// before the CA itself is deleted (by the global config).
-				// During dry run, no actual deletions happen, so there's no FK ordering issue
-				// and CAs can be processed inline for validation.
-				// We capture deferredCAs before DoGitOps because DoGitOps deletes the key from OrgSettings.
+				// Capture CAs before DoGitOps (which deletes the key from OrgSettings).
+				// CAs are processed inline by DoGitOps — creates/updates always succeed because
+				// the datastore uses separate transactions for upserts and deletes.
+				// If a CA deletion fails due to FK constraints (certificate templates still reference it),
+				// we schedule a retry as a post-op that runs after team configs have cleaned up their templates.
 				var deferredCAs any
 				if isGlobalConfig && !flDryRun {
 					deferredCAs = config.OrgSettings["certificate_authorities"]
-					config.SkipCertificateAuthorities = true
 				}
 
 				assumptions, err := fleetClient.DoGitOps(
@@ -515,13 +513,19 @@ func gitopsCommand() *cli.Command {
 					&iconSettings,
 				)
 				if err != nil {
-					return err
+					// If CA deletion failed due to FK constraints, schedule a retry after team configs.
+					if isGlobalConfig && !flDryRun && strings.Contains(err.Error(), "certificate authority") &&
+						strings.Contains(err.Error(), "Certificate templates still reference it") {
+						logf("[-] CA deletion deferred until after team configs process\n")
+						err = nil
+					}
+					if err != nil {
+						return err
+					}
 				}
 
-				// Schedule CA application as a post-op so it runs after all team configs.
-				// Certificate authority deletions may fail if certificate templates still reference
-				// them, so we defer CA processing until after team configs have cleaned up their
-				// certificate templates.
+				// If we have deferred CAs and this is the global config, schedule a post-op to retry
+				// CA application after team configs have cleaned up their certificate templates.
 				if isGlobalConfig && !flDryRun {
 					caFilename := flFilename
 					allPostOps = append(allPostOps, func() error {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -489,6 +489,17 @@ func gitopsCommand() *cli.Command {
 					return err
 				}
 
+				// Defer certificate authority processing to after all team configs are processed.
+				// This ensures certificate templates referencing a CA are deleted (by team configs)
+				// before the CA itself is deleted (by the global config).
+				// During dry run, no actual deletions happen, so there's no FK ordering issue
+				// and CAs can be processed inline for validation.
+				var deferredCAs any
+				if isGlobalConfig && !flDryRun {
+					deferredCAs = config.OrgSettings["certificate_authorities"]
+					delete(config.OrgSettings, "certificate_authorities")
+				}
+
 				assumptions, err := fleetClient.DoGitOps(
 					c.Context,
 					config,
@@ -505,6 +516,36 @@ func gitopsCommand() *cli.Command {
 				if err != nil {
 					return err
 				}
+
+				// Schedule CA application as a post-op so it runs after all team configs.
+				// Certificate authority deletions may fail if certificate templates still reference
+				// them, so we defer CA processing until after team configs have cleaned up their
+				// certificate templates.
+				if isGlobalConfig && deferredCAs != nil {
+					config.OrgSettings["certificate_authorities"] = deferredCAs
+					caFilename := flFilename
+					allPostOps = append(allPostOps, func() error {
+						groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
+						if caErr != nil {
+							return fmt.Errorf("invalid certificate_authorities: %w", caErr)
+						}
+						if groupedCAs == nil {
+							return nil
+						}
+						if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}); caErr != nil {
+							if caErr.Error() == "missing or invalid license" {
+								return fmt.Errorf(
+									"Couldn't edit %q at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.",
+									filepath.Base(caFilename),
+								)
+							}
+							return fmt.Errorf("applying certificate authorities: %w", caErr)
+						}
+						logf("[+] applied certificate authorities\n")
+						return nil
+					})
+				}
+
 				if config.TeamName != nil {
 					teamNames = append(teamNames, *config.TeamName)
 				} else {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -514,37 +514,31 @@ func gitopsCommand() *cli.Command {
 				)
 				if err != nil {
 					// If CA deletion failed due to FK constraints, schedule a retry after team configs.
-					if isGlobalConfig && !flDryRun && strings.Contains(err.Error(), "certificate authority") &&
-						strings.Contains(err.Error(), "Certificate templates still reference it") {
+					if isGlobalConfig && !flDryRun && strings.Contains(err.Error(), "Certificate templates still reference it") {
 						logf("[-] CA deletion deferred until after team configs process\n")
+						caFilename := flFilename
+						allPostOps = append(allPostOps, func() error {
+							groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
+							if caErr != nil {
+								return fmt.Errorf("invalid certificate_authorities: %w", caErr)
+							}
+							if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}); caErr != nil {
+								if caErr.Error() == "missing or invalid license" {
+									return fmt.Errorf(
+										"Couldn't edit %q at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.",
+										filepath.Base(caFilename),
+									)
+								}
+								return fmt.Errorf("applying certificate authorities: %w", caErr)
+							}
+							logf("[+] applied certificate authorities\n")
+							return nil
+						})
 						err = nil
 					}
 					if err != nil {
 						return err
 					}
-				}
-
-				// If we have deferred CAs and this is the global config, schedule a post-op to retry
-				// CA application after team configs have cleaned up their certificate templates.
-				if isGlobalConfig && !flDryRun {
-					caFilename := flFilename
-					allPostOps = append(allPostOps, func() error {
-						groupedCAs, caErr := fleet.ValidateCertificateAuthoritiesSpec(deferredCAs)
-						if caErr != nil {
-							return fmt.Errorf("invalid certificate_authorities: %w", caErr)
-						}
-						if caErr = fleetClient.ApplyCertificateAuthoritiesSpec(*groupedCAs, fleet.ApplySpecOptions{}); caErr != nil {
-							if caErr.Error() == "missing or invalid license" {
-								return fmt.Errorf(
-									"Couldn't edit %q at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.",
-									filepath.Base(caFilename),
-								)
-							}
-							return fmt.Errorf("applying certificate authorities: %w", caErr)
-						}
-						logf("[+] applied certificate authorities\n")
-						return nil
-					})
 				}
 
 				if config.TeamName != nil {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -453,14 +453,18 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 		if len(ops.Delete) > 0 {
 			storedCAs = fleet.GroupedCertificateAuthorities{}
 		}
-		upserts := make([]*fleet.CertificateAuthority, 0, len(ops.Add)+len(ops.Update))
-		upserts = append(upserts, ops.Add...)
-		upserts = append(upserts, ops.Update...)
-		g, err := fleet.GroupCertificateAuthoritiesByType(upserts)
-		if err != nil {
-			return err
+		// Adds replace the stored CAs entirely (like the first apply).
+		// Updates are a no-op for the mock since the data is already stored.
+		if len(ops.Add) > 0 {
+			all := make([]*fleet.CertificateAuthority, 0, len(ops.Add)+len(ops.Update))
+			all = append(all, ops.Add...)
+			all = append(all, ops.Update...)
+			g, err := fleet.GroupCertificateAuthoritiesByType(all)
+			if err != nil {
+				return err
+			}
+			storedCAs = *g
 		}
-		storedCAs = *g
 		return nil
 	}
 

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -453,8 +453,8 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 		if len(ops.Delete) > 0 {
 			storedCAs = fleet.GroupedCertificateAuthorities{}
 		}
-		// Adds replace the stored CAs entirely (like the first apply).
-		// Updates are a no-op for the mock since the data is already stored.
+		// Only overwrite storedCAs when new CAs are being added to avoid losing data
+		// on subsequent calls that only contain updates.
 		if len(ops.Add) > 0 {
 			all := make([]*fleet.CertificateAuthority, 0, len(ops.Add)+len(ops.Update))
 			all = append(all, ops.Add...)

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -453,17 +453,27 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 		if len(ops.Delete) > 0 {
 			storedCAs = fleet.GroupedCertificateAuthorities{}
 		}
-		// Only overwrite storedCAs when new CAs are being added to avoid losing data
-		// on subsequent calls that only contain updates.
-		if len(ops.Add) > 0 {
-			all := make([]*fleet.CertificateAuthority, 0, len(ops.Add)+len(ops.Update))
-			all = append(all, ops.Add...)
-			all = append(all, ops.Update...)
-			g, err := fleet.GroupCertificateAuthoritiesByType(all)
+		upserts := make([]*fleet.CertificateAuthority, 0, len(ops.Add)+len(ops.Update))
+		upserts = append(upserts, ops.Add...)
+		upserts = append(upserts, ops.Update...)
+		if len(upserts) > 0 {
+			g, err := fleet.GroupCertificateAuthoritiesByType(upserts)
 			if err != nil {
 				return err
 			}
-			storedCAs = *g
+			// Merge into stored state per CA type, like a real DB upsert.
+			if g.NDESSCEP != nil {
+				storedCAs.NDESSCEP = g.NDESSCEP
+			}
+			if len(g.DigiCert) > 0 {
+				storedCAs.DigiCert = g.DigiCert
+			}
+			if len(g.CustomScepProxy) > 0 {
+				storedCAs.CustomScepProxy = g.CustomScepProxy
+			}
+			if len(g.Hydrant) > 0 {
+				storedCAs.Hydrant = g.Hydrant
+			}
 		}
 		return nil
 	}

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -148,12 +148,24 @@ func (s *enterpriseIntegrationGitopsTestSuite) TearDownTest() {
 	t := s.T()
 	ctx := context.Background()
 
+	// Delete certificate templates before teams and CAs to avoid FK constraints.
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM certificate_templates;`)
+		return err
+	})
+
 	teams, err := s.DS.ListTeams(ctx, fleet.TeamFilter{User: test.UserAdmin}, fleet.ListOptions{})
 	require.NoError(t, err)
 	for _, tm := range teams {
 		err := s.DS.DeleteTeam(ctx, tm.ID)
 		require.NoError(t, err)
 	}
+
+	// Delete certificate authorities after teams and templates are cleaned up.
+	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM certificate_authorities;`)
+		return err
+	})
 
 	// Delete policies in "No team" (the others are deleted in ts.DS.DeleteTeam above).
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
@@ -749,6 +761,157 @@ reports:
 	require.NoError(t, err)
 	assert.Empty(t, groupedCAs.DigiCert)
 	assert.Empty(t, groupedCAs.CustomScepProxy)
+}
+
+// TestDeleteCAWithCertificateTemplates tests the GitOps ordering when deleting a certificate
+// authority that is referenced by certificate templates on a team.
+func (s *enterpriseIntegrationGitopsTestSuite) TestDeleteCAWithCertificateTemplates() {
+	t := s.T()
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	scepServer := scep_server.StartTestSCEPServer(t)
+
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	// Step 1: Create a CA and a team with a certificate template referencing it.
+	challenge := "challenge"
+	ca, err := s.DS.NewCertificateAuthority(t.Context(), &fleet.CertificateAuthority{
+		Type:      string(fleet.CATypeCustomSCEPProxy),
+		Name:      ptr.String("TestSCEP"),
+		URL:       &scepServer.URL,
+		Challenge: &challenge,
+	})
+	require.NoError(t, err)
+
+	globalFileWithCA := s.writeConfigFile(t, fmt.Sprintf(`
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+  certificate_authorities:
+    custom_scep_proxy:
+      - name: TestSCEP
+        url: %s
+        challenge: challenge
+policies:
+reports:
+`, scepServer.URL+"/scep"))
+
+	teamFileWithCert := s.writeConfigFile(t, `
+name: CA Test Team
+controls:
+  android_settings:
+    certificates:
+      - name: TestCert
+        certificate_authority_name: TestSCEP
+        subject_name: "CN=$FLEET_VAR_HOST_END_USER_EMAIL_IDP,O=Fleet"
+settings:
+  secrets:
+    - secret: ca_test_team_secret
+agent_options:
+policies:
+reports:
+software:
+`)
+
+	// Apply both files to create the team and certificate template.
+	fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(),
+		"-f", globalFileWithCA, "-f", teamFileWithCert,
+	})
+
+	// Verify the team was created and the certificate template exists.
+	teams, err := s.DS.ListTeams(t.Context(), fleet.TeamFilter{User: test.UserAdmin}, fleet.ListOptions{})
+	require.NoError(t, err)
+	var teamID uint
+	for _, tm := range teams {
+		if tm.Name == "CA Test Team" {
+			teamID = tm.ID
+			break
+		}
+	}
+	require.NotZero(t, teamID, "team 'CA Test Team' should exist")
+
+	certTemplates, _, err := s.DS.GetCertificateTemplatesByTeamID(t.Context(), teamID, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, certTemplates, 1)
+	require.Equal(t, "TestCert", certTemplates[0].Name)
+	require.Equal(t, ca.ID, certTemplates[0].CertificateAuthorityId)
+
+	// Step 2: Run gitops removing the CA but WITHOUT the team file.
+	// This should fail because the team's certificate templates still reference the CA.
+	globalFileWithoutCA := s.writeConfigFile(t, `
+agent_options:
+controls:
+org_settings:
+  server_settings:
+    server_url: $FLEET_URL
+  org_info:
+    org_name: Fleet
+  secrets:
+policies:
+reports:
+`)
+
+	_, err = fleetctl.RunAppNoChecks([]string{
+		"gitops", "--config", fleetctlConfig.Name(),
+		"-f", globalFileWithoutCA,
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "certificate authority")
+
+	// Verify CA and certificate template still exist.
+	groupedCAs, err := s.DS.GetGroupedCertificateAuthorities(t.Context(), false)
+	require.NoError(t, err)
+	require.Len(t, groupedCAs.CustomScepProxy, 1)
+
+	certTemplates, _, err = s.DS.GetCertificateTemplatesByTeamID(t.Context(), teamID, fleet.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, certTemplates, 1)
+
+	// Step 3: Run gitops removing BOTH the CA and the certificate template.
+	// This should succeed because the postOp ordering ensures certificate templates
+	// are deleted before the CA.
+	teamFileWithoutCert := s.writeConfigFile(t, `
+name: CA Test Team
+controls:
+settings:
+  secrets:
+    - secret: ca_test_team_secret
+agent_options:
+policies:
+reports:
+software:
+`)
+
+	fleetctl.RunAppForTest(t, []string{
+		"gitops", "--config", fleetctlConfig.Name(),
+		"-f", globalFileWithoutCA, "-f", teamFileWithoutCert,
+	})
+
+	// Verify CA and certificate template are deleted.
+	groupedCAs, err = s.DS.GetGroupedCertificateAuthorities(t.Context(), false)
+	require.NoError(t, err)
+	assert.Empty(t, groupedCAs.CustomScepProxy)
+
+	certTemplates, _, err = s.DS.GetCertificateTemplatesByTeamID(t.Context(), teamID, fleet.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, certTemplates)
+}
+
+func (s *enterpriseIntegrationGitopsTestSuite) writeConfigFile(t *testing.T, content string) string {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = f.WriteString(content)
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	return f.Name()
 }
 
 // TestUnsetConfigurationProfileLabels tests the removal of labels associated with a

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -809,7 +809,7 @@ controls:
     certificates:
       - name: TestCert
         certificate_authority_name: TestSCEP
-        subject_name: "CN=$FLEET_VAR_HOST_END_USER_EMAIL_IDP,O=Fleet"
+        subject_name: "CN=test,O=Fleet"
 settings:
   secrets:
     - secret: ca_test_team_secret

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -148,9 +148,12 @@ func (s *enterpriseIntegrationGitopsTestSuite) TearDownTest() {
 	t := s.T()
 	ctx := context.Background()
 
-	// Delete certificate templates before teams and CAs to avoid FK constraints.
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(ctx, `DELETE FROM certificate_templates;`)
+		// Delete certificate templates before CAs and teams to avoid FK constraints.
+		if _, err := q.ExecContext(ctx, `DELETE FROM certificate_templates`); err != nil {
+			return err
+		}
+		_, err := q.ExecContext(ctx, `DELETE FROM certificate_authorities`)
 		return err
 	})
 
@@ -160,12 +163,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) TearDownTest() {
 		err := s.DS.DeleteTeam(ctx, tm.ID)
 		require.NoError(t, err)
 	}
-
-	// Delete certificate authorities after teams and templates are cleaned up.
-	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
-		_, err := q.ExecContext(ctx, `DELETE FROM certificate_authorities;`)
-		return err
-	})
 
 	// Delete policies in "No team" (the others are deleted in ts.DS.DeleteTeam above).
 	mysql.ExecAdhocSQL(t, s.DS, func(q sqlx.ExtContext) error {
@@ -859,7 +856,7 @@ reports:
 		"-f", globalFileWithoutCA,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "Certificate templates still reference it")
+	require.Contains(t, err.Error(), fleet.DeleteCAReferencedByTemplatesErrMsg)
 
 	// Verify CA and certificate template still exist.
 	groupedCAs, err = s.DS.GetGroupedCertificateAuthorities(t.Context(), false)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -774,16 +774,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestDeleteCAWithCertificateTempla
 
 	t.Setenv("FLEET_URL", s.Server.URL)
 
-	// Step 1: Create a CA and a team with a certificate template referencing it.
-	challenge := "challenge"
-	ca, err := s.DS.NewCertificateAuthority(t.Context(), &fleet.CertificateAuthority{
-		Type:      string(fleet.CATypeCustomSCEPProxy),
-		Name:      ptr.String("TestSCEP"),
-		URL:       &scepServer.URL,
-		Challenge: &challenge,
-	})
-	require.NoError(t, err)
-
+	// Step 1: Create a CA and a team with a certificate template referencing it via GitOps.
 	globalFileWithCA := s.writeConfigFile(t, fmt.Sprintf(`
 agent_options:
 controls:
@@ -819,11 +810,17 @@ reports:
 software:
 `)
 
-	// Apply both files to create the team and certificate template.
+	// Apply both files to create the CA, team, and certificate template.
 	fleetctl.RunAppForTest(t, []string{
 		"gitops", "--config", fleetctlConfig.Name(),
 		"-f", globalFileWithCA, "-f", teamFileWithCert,
 	})
+
+	// Verify the CA was created via GitOps.
+	groupedCAs, err := s.DS.GetGroupedCertificateAuthorities(t.Context(), false)
+	require.NoError(t, err)
+	require.Len(t, groupedCAs.CustomScepProxy, 1)
+	require.Equal(t, "TestSCEP", groupedCAs.CustomScepProxy[0].Name)
 
 	// Verify the team was created and the certificate template exists.
 	teams, err := s.DS.ListTeams(t.Context(), fleet.TeamFilter{User: test.UserAdmin}, fleet.ListOptions{})
@@ -841,7 +838,6 @@ software:
 	require.NoError(t, err)
 	require.Len(t, certTemplates, 1)
 	require.Equal(t, "TestCert", certTemplates[0].Name)
-	require.Equal(t, ca.ID, certTemplates[0].CertificateAuthorityId)
 
 	// Step 2: Run gitops removing the CA but WITHOUT the team file.
 	// This should fail because the team's certificate templates still reference the CA.
@@ -863,10 +859,10 @@ reports:
 		"-f", globalFileWithoutCA,
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "certificate authority")
+	require.Contains(t, err.Error(), "Certificate templates still reference it")
 
 	// Verify CA and certificate template still exist.
-	groupedCAs, err := s.DS.GetGroupedCertificateAuthorities(t.Context(), false)
+	groupedCAs, err = s.DS.GetGroupedCertificateAuthorities(t.Context(), false)
 	require.NoError(t, err)
 	require.Len(t, groupedCAs.CustomScepProxy, 1)
 

--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -481,12 +481,12 @@ func (svc *Service) DeleteCertificateAuthority(ctx context.Context, certificateA
 	return nil
 }
 
-func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error {
+func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, opts fleet.BatchApplyCertificateAuthoritiesOpts) error {
 	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionWrite); err != nil {
 		return err
 	}
 
-	if !viaGitOps {
+	if !opts.ViaGitOps {
 		// Note: This check is here primarily for future reference to help make the usage intent
 		// clear and to differentiate behavior from dual-use endpoints that support patch semantics (e.g., app config)
 		return fleet.NewInvalidArgumentError("gitops", "certificate_authorities: batch apply is intended only for use with gitops")
@@ -502,7 +502,11 @@ func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incomi
 		return nil
 	}
 
-	if dryRun {
+	if opts.SkipDeletes {
+		ops.Delete = nil
+	}
+
+	if opts.DryRun {
 		svc.logger.DebugContext(ctx, "batch apply certificate authorities: no certificate authority changes to apply")
 		return nil
 	}

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -333,8 +333,6 @@ type GitOps struct {
 	Software GitOpsSoftware
 	// FleetSecrets is a map of secret names to their values, extracted from FLEET_SECRET_ environment variables used in profiles and scripts.
 	FleetSecrets map[string]string
-	// SkipCertificateAuthorities is set when CA processing is deferred (e.g., to run after team configs in gitops).
-	SkipCertificateAuthorities bool
 }
 
 type GitOpsSoftware struct {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -333,6 +333,8 @@ type GitOps struct {
 	Software GitOpsSoftware
 	// FleetSecrets is a map of secret names to their values, extracted from FLEET_SECRET_ environment variables used in profiles and scripts.
 	FleetSecrets map[string]string
+	// SkipCertificateAuthorities is set when CA processing is deferred (e.g., to run after team configs in gitops).
+	SkipCertificateAuthorities bool
 }
 
 type GitOpsSoftware struct {

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -350,6 +350,11 @@ func batchDeleteCertificateAuthorities(ctx context.Context, tx sqlx.ExtContext, 
 
 	_, err := tx.ExecContext(ctx, stmt, args...)
 	if err != nil {
+		if isMySQLForeignKey(err) {
+			return &fleet.ConflictError{
+				Message: "Couldn't delete certificate authority. Certificate templates still reference it. Please remove the certificate templates first.",
+			}
+		}
 		return ctxerr.Wrap(ctx, err, "deleting certificate authorities")
 	}
 

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -352,7 +352,7 @@ func batchDeleteCertificateAuthorities(ctx context.Context, tx sqlx.ExtContext, 
 	if err != nil {
 		if isMySQLForeignKey(err) {
 			return &fleet.ConflictError{
-				Message: "Couldn't delete certificate authority. Certificate templates still reference it. Please remove the certificate templates first.",
+				Message: "Couldn't delete certificate authority. " + fleet.DeleteCAReferencedByTemplatesErrMsg + ". Please remove the certificate templates first.",
 			}
 		}
 		return ctxerr.Wrap(ctx, err, "deleting certificate authorities")
@@ -367,24 +367,19 @@ func (ds *Datastore) BatchApplyCertificateAuthorities(ctx context.Context, ops f
 	upserts = append(upserts, ops.Add...)
 	upserts = append(upserts, ops.Update...)
 
-	// Upserts and deletes are in separate transactions so that creates/updates succeed even if
-	// deletes fail due to FK constraints (e.g., certificate templates still reference a CA).
-	// This is important for GitOps where CAs are applied before team configs that clean up templates.
-	if len(upserts) > 0 {
-		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-			return batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts)
-		}); err != nil {
-			return err
+	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if len(upserts) > 0 {
+			if err := batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts); err != nil {
+				return err
+			}
 		}
-	}
-	if len(ops.Delete) > 0 {
-		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-			return batchDeleteCertificateAuthorities(ctx, tx, ops.Delete)
-		}); err != nil {
-			return err
+		if len(ops.Delete) > 0 {
+			if err := batchDeleteCertificateAuthorities(ctx, tx, ops.Delete); err != nil {
+				return err
+			}
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error) {
@@ -410,7 +405,7 @@ func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificate
 	if err != nil {
 		if isMySQLForeignKey(err) {
 			return nil, fleet.ConflictError{
-				Message: "Couldn't delete certificate authority. Certificate templates still reference it. Please remove the certificate templates first.",
+				Message: "Couldn't delete certificate authority. " + fleet.DeleteCAReferencedByTemplatesErrMsg + ". Please remove the certificate templates first.",
 			}
 		}
 		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("deleting certificate authority with id %d", certificateAuthorityID))

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -367,15 +367,24 @@ func (ds *Datastore) BatchApplyCertificateAuthorities(ctx context.Context, ops f
 	upserts = append(upserts, ops.Add...)
 	upserts = append(upserts, ops.Update...)
 
-	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		if err := batchDeleteCertificateAuthorities(ctx, tx, ops.Delete); err != nil {
+	// Upserts and deletes are in separate transactions so that creates/updates succeed even if
+	// deletes fail due to FK constraints (e.g., certificate templates still reference a CA).
+	// This is important for GitOps where CAs are applied before team configs that clean up templates.
+	if len(upserts) > 0 {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			return batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts)
+		}); err != nil {
 			return err
 		}
-		if err := batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts); err != nil {
+	}
+	if len(ops.Delete) > 0 {
+		if err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			return batchDeleteCertificateAuthorities(ctx, tx, ops.Delete)
+		}); err != nil {
 			return err
 		}
-		return nil
-	})
+	}
+	return nil
 }
 
 func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificateAuthorityID uint) (*fleet.CertificateAuthoritySummary, error) {
@@ -401,7 +410,7 @@ func (ds *Datastore) DeleteCertificateAuthority(ctx context.Context, certificate
 	if err != nil {
 		if isMySQLForeignKey(err) {
 			return nil, fleet.ConflictError{
-				Message: "Couldn't delete. This certificate authority is used in a certificate. Please remove the certificate first.",
+				Message: "Couldn't delete certificate authority. Certificate templates still reference it. Please remove the certificate templates first.",
 			}
 		}
 		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("deleting certificate authority with id %d", certificateAuthorityID))

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -368,15 +368,11 @@ func (ds *Datastore) BatchApplyCertificateAuthorities(ctx context.Context, ops f
 	upserts = append(upserts, ops.Update...)
 
 	return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		if len(upserts) > 0 {
-			if err := batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts); err != nil {
-				return err
-			}
+		if err := batchUpsertCertificateAuthorities(ctx, tx, ds.serverPrivateKey, upserts); err != nil {
+			return err
 		}
-		if len(ops.Delete) > 0 {
-			if err := batchDeleteCertificateAuthorities(ctx, tx, ops.Delete); err != nil {
-				return err
-			}
+		if err := batchDeleteCertificateAuthorities(ctx, tx, ops.Delete); err != nil {
+			return err
 		}
 		return nil
 	})

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -402,7 +402,7 @@ func testDeleteCertificateAuthority(t *testing.T, ds *Datastore) {
 	require.Error(t, err)
 	var conflictErr fleet.ConflictError
 	require.ErrorAs(t, err, &conflictErr)
-	require.Contains(t, conflictErr.Error(), "certificate authority is used in a certificate")
+	require.Contains(t, conflictErr.Error(), "Certificate templates still reference it")
 }
 
 func testUpdateCertificateAuthorityByID(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/certificate_authorities_test.go
+++ b/server/datastore/mysql/certificate_authorities_test.go
@@ -402,7 +402,7 @@ func testDeleteCertificateAuthority(t *testing.T, ds *Datastore) {
 	require.Error(t, err)
 	var conflictErr fleet.ConflictError
 	require.ErrorAs(t, err, &conflictErr)
-	require.Contains(t, conflictErr.Error(), "Certificate templates still reference it")
+	require.Contains(t, conflictErr.Error(), fleet.DeleteCAReferencedByTemplatesErrMsg)
 }
 
 func testUpdateCertificateAuthorityByID(t *testing.T, ds *Datastore) {

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -701,6 +701,13 @@ func ValidateCertificateAuthoritiesSpec(incoming interface{}) (*GroupedCertifica
 	return &groupedCAs, nil
 }
 
+// BatchApplyCertificateAuthoritiesOpts controls which operations the batch apply endpoint performs.
+type BatchApplyCertificateAuthoritiesOpts struct {
+	DryRun      bool
+	ViaGitOps   bool
+	SkipDeletes bool // Process creates/updates only; skip deletions.
+}
+
 // CertificateAuthoritiesBatchOperations groups the operations for batch processing of certificate authorities.
 type CertificateAuthoritiesBatchOperations struct {
 	Delete []*CertificateAuthority

--- a/server/fleet/errors.go
+++ b/server/fleet/errors.go
@@ -534,6 +534,11 @@ var (
 	SCEPRenewalIDWithoutURLChallengeErrMsg = "Variable \"$FLEET_VAR_" + string(FleetVarSCEPRenewalID) + "\" can't be used if variables for SCEP URL and Challenge are not specified."
 )
 
+const (
+	// DeleteCAReferencedByTemplatesErrMsg is the error substring used when a CA cannot be deleted because certificate templates still reference it.
+	DeleteCAReferencedByTemplatesErrMsg = "Certificate templates still reference it"
+)
+
 // ConflictError is used to indicate a conflict, such as a UUID conflict in the DB.
 type ConflictError struct {
 	Message string

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -1438,7 +1438,7 @@ type Service interface {
 	UpdateCertificateAuthority(ctx context.Context, id uint, p CertificateAuthorityUpdatePayload) error
 	RequestCertificate(ctx context.Context, p RequestCertificatePayload) (*string, error)
 	// BatchApplyCertificateAuthorities applies the given certificate authorities spec
-	BatchApplyCertificateAuthorities(ctx context.Context, groupedCAs GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error
+	BatchApplyCertificateAuthorities(ctx context.Context, groupedCAs GroupedCertificateAuthorities, opts BatchApplyCertificateAuthoritiesOpts) error
 	// GetGroupedCertificateAuthorities retrieves the grouped certificate authorities
 	GetGroupedCertificateAuthorities(ctx context.Context, includeSecrets bool) (*GroupedCertificateAuthorities, error)
 

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -883,7 +883,7 @@ type UpdateCertificateAuthorityFunc func(ctx context.Context, id uint, p fleet.C
 
 type RequestCertificateFunc func(ctx context.Context, p fleet.RequestCertificatePayload) (*string, error)
 
-type BatchApplyCertificateAuthoritiesFunc func(ctx context.Context, groupedCAs fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error
+type BatchApplyCertificateAuthoritiesFunc func(ctx context.Context, groupedCAs fleet.GroupedCertificateAuthorities, opts fleet.BatchApplyCertificateAuthoritiesOpts) error
 
 type GetGroupedCertificateAuthoritiesFunc func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error)
 
@@ -5222,11 +5222,11 @@ func (s *Service) RequestCertificate(ctx context.Context, p fleet.RequestCertifi
 	return s.RequestCertificateFunc(ctx, p)
 }
 
-func (s *Service) BatchApplyCertificateAuthorities(ctx context.Context, groupedCAs fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error {
+func (s *Service) BatchApplyCertificateAuthorities(ctx context.Context, groupedCAs fleet.GroupedCertificateAuthorities, opts fleet.BatchApplyCertificateAuthoritiesOpts) error {
 	s.mu.Lock()
 	s.BatchApplyCertificateAuthoritiesFuncInvoked = true
 	s.mu.Unlock()
-	return s.BatchApplyCertificateAuthoritiesFunc(ctx, groupedCAs, dryRun, viaGitOps)
+	return s.BatchApplyCertificateAuthoritiesFunc(ctx, groupedCAs, opts)
 }
 
 func (s *Service) GetGroupedCertificateAuthorities(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -177,6 +177,15 @@ func (svc *Service) RequestCertificate(ctx context.Context, p fleet.RequestCerti
 type batchApplyCertificateAuthoritiesRequest struct {
 	CertificateAuthorities fleet.GroupedCertificateAuthorities `json:"certificate_authorities"`
 	DryRun                 bool                                `json:"dry_run"`
+	SkipDeletes            bool                                `json:"skip_deletes"`
+}
+
+func (r *batchApplyCertificateAuthoritiesRequest) opts() fleet.BatchApplyCertificateAuthoritiesOpts {
+	return fleet.BatchApplyCertificateAuthoritiesOpts{
+		DryRun:      r.DryRun,
+		ViaGitOps:   true,
+		SkipDeletes: r.SkipDeletes,
+	}
 }
 
 // TODO(hca): do we need to return anything to facilitate logging by the gitops client?
@@ -190,7 +199,7 @@ func batchApplyCertificateAuthoritiesEndpoint(ctx context.Context, request inter
 	req := request.(*batchApplyCertificateAuthoritiesRequest)
 
 	// Call the service method to apply the certificate authorities spec
-	err := svc.BatchApplyCertificateAuthorities(ctx, req.CertificateAuthorities, req.DryRun, true)
+	err := svc.BatchApplyCertificateAuthorities(ctx, req.CertificateAuthorities, req.opts())
 	if err != nil {
 		return &batchApplyCertificateAuthoritiesResponse{Err: err}, nil
 	}
@@ -198,7 +207,7 @@ func batchApplyCertificateAuthoritiesEndpoint(ctx context.Context, request inter
 	return &batchApplyCertificateAuthoritiesResponse{}, nil
 }
 
-func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, dryRun bool, viaGitOps bool) error {
+func (svc *Service) BatchApplyCertificateAuthorities(ctx context.Context, incoming fleet.GroupedCertificateAuthorities, opts fleet.BatchApplyCertificateAuthoritiesOpts) error {
 	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionWrite); err != nil {
 		return err
 	}

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -180,14 +180,6 @@ type batchApplyCertificateAuthoritiesRequest struct {
 	SkipDeletes            bool                                `json:"skip_deletes"`
 }
 
-func (r *batchApplyCertificateAuthoritiesRequest) opts() fleet.BatchApplyCertificateAuthoritiesOpts {
-	return fleet.BatchApplyCertificateAuthoritiesOpts{
-		DryRun:      r.DryRun,
-		ViaGitOps:   true,
-		SkipDeletes: r.SkipDeletes,
-	}
-}
-
 // TODO(hca): do we need to return anything to facilitate logging by the gitops client?
 type batchApplyCertificateAuthoritiesResponse struct {
 	Err error `json:"error,omitempty"`
@@ -198,8 +190,11 @@ func (r batchApplyCertificateAuthoritiesResponse) Error() error { return r.Err }
 func batchApplyCertificateAuthoritiesEndpoint(ctx context.Context, request interface{}, svc fleet.Service) (fleet.Errorer, error) {
 	req := request.(*batchApplyCertificateAuthoritiesRequest)
 
-	// Call the service method to apply the certificate authorities spec
-	err := svc.BatchApplyCertificateAuthorities(ctx, req.CertificateAuthorities, req.opts())
+	err := svc.BatchApplyCertificateAuthorities(ctx, req.CertificateAuthorities, fleet.BatchApplyCertificateAuthoritiesOpts{
+		DryRun:      req.DryRun,
+		ViaGitOps:   true,
+		SkipDeletes: req.SkipDeletes,
+	})
 	if err != nil {
 		return &batchApplyCertificateAuthoritiesResponse{Err: err}, nil
 	}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -578,7 +578,9 @@ func (c *Client) ApplyGroup(
 	}
 
 	if specs.CertificateAuthorities != nil {
-		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions); err != nil {
+		// Skip deletes here — CA deletions are deferred to a post-op in GitOps so that team configs
+		// can clean up certificate templates (which have FK references to CAs) first.
+		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions, fleet.BatchApplyCertificateAuthoritiesOpts{SkipDeletes: true}); err != nil {
 			// only do this custom message for gitops as we reference the applying filename which only makes sense in gitops
 			if err.Error() == "missing or invalid license" && viaGitOps && filename != nil {
 				return nil, nil, nil, nil, fmt.Errorf("Couldn't edit \"%s\" at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.", *filename)

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1894,15 +1894,11 @@ func (c *Client) DoGitOps(
 
 		// Certificate authorities are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
-		// When SkipCertificateAuthorities is set (e.g., CAs are deferred by gitops for ordering),
-		// we skip validation and leave group.CertificateAuthorities nil so ApplyGroup won't process them.
-		if !incoming.SkipCertificateAuthorities {
-			groupedCAs, err := fleet.ValidateCertificateAuthoritiesSpec(incoming.OrgSettings["certificate_authorities"])
-			if err != nil {
-				return nil, fmt.Errorf("invalid certificate_authorities: %w", err)
-			}
-			group.CertificateAuthorities = groupedCAs
+		groupedCAs, err := fleet.ValidateCertificateAuthoritiesSpec(incoming.OrgSettings["certificate_authorities"])
+		if err != nil {
+			return nil, fmt.Errorf("invalid certificate_authorities: %w", err)
 		}
+		group.CertificateAuthorities = groupedCAs
 		delete(incoming.OrgSettings, "certificate_authorities")
 
 		// Labels

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -578,7 +578,7 @@ func (c *Client) ApplyGroup(
 	}
 
 	if specs.CertificateAuthorities != nil {
-		// In GitOps, skip deletes here — CA deletions are deferred to a post-op so that team configs
+		// In GitOps, skip deletes here. CA deletions are deferred to a post-op so that team configs
 		// can clean up certificate templates (which have FK references to CAs) first.
 		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions, fleet.BatchApplyCertificateAuthoritiesOpts{SkipDeletes: viaGitOps}); err != nil {
 			// only do this custom message for gitops as we reference the applying filename which only makes sense in gitops

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -578,7 +578,7 @@ func (c *Client) ApplyGroup(
 	}
 
 	if specs.CertificateAuthorities != nil {
-		// Skip deletes here — CA deletions are deferred to a post-op in GitOps so that team configs
+		// Skip deletes here. CA deletions are deferred to a post-op in GitOps so that team configs
 		// can clean up certificate templates (which have FK references to CAs) first.
 		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions, fleet.BatchApplyCertificateAuthoritiesOpts{SkipDeletes: true}); err != nil {
 			// only do this custom message for gitops as we reference the applying filename which only makes sense in gitops

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1894,11 +1894,15 @@ func (c *Client) DoGitOps(
 
 		// Certificate authorities are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
-		groupedCAs, err := fleet.ValidateCertificateAuthoritiesSpec(incoming.OrgSettings["certificate_authorities"])
-		if err != nil {
-			return nil, fmt.Errorf("invalid certificate_authorities: %w", err)
+		// When SkipCertificateAuthorities is set (e.g., CAs are deferred by gitops for ordering),
+		// we skip validation and leave group.CertificateAuthorities nil so ApplyGroup won't process them.
+		if !incoming.SkipCertificateAuthorities {
+			groupedCAs, err := fleet.ValidateCertificateAuthoritiesSpec(incoming.OrgSettings["certificate_authorities"])
+			if err != nil {
+				return nil, fmt.Errorf("invalid certificate_authorities: %w", err)
+			}
+			group.CertificateAuthorities = groupedCAs
 		}
-		group.CertificateAuthorities = groupedCAs
 		delete(incoming.OrgSettings, "certificate_authorities")
 
 		// Labels

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -578,9 +578,9 @@ func (c *Client) ApplyGroup(
 	}
 
 	if specs.CertificateAuthorities != nil {
-		// Skip deletes here. CA deletions are deferred to a post-op in GitOps so that team configs
+		// In GitOps, skip deletes here — CA deletions are deferred to a post-op so that team configs
 		// can clean up certificate templates (which have FK references to CAs) first.
-		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions, fleet.BatchApplyCertificateAuthoritiesOpts{SkipDeletes: true}); err != nil {
+		if err := c.ApplyCertificateAuthoritiesSpec(*specs.CertificateAuthorities, opts.ApplySpecOptions, fleet.BatchApplyCertificateAuthoritiesOpts{SkipDeletes: viaGitOps}); err != nil {
 			// only do this custom message for gitops as we reference the applying filename which only makes sense in gitops
 			if err.Error() == "missing or invalid license" && viaGitOps && filename != nil {
 				return nil, nil, nil, nil, fmt.Errorf("Couldn't edit \"%s\" at \"certificate_authorities\": Missing or invalid license. Certificate authorities are available in Fleet Premium only.", *filename)

--- a/server/service/client_certificate_authorities.go
+++ b/server/service/client_certificate_authorities.go
@@ -15,11 +15,15 @@ func (c *Client) GetCertificateAuthoritiesSpec(includeSecrets bool) (*fleet.Grou
 }
 
 // ApplyCertificateAuthoritiesSpec applies the certificate authorities.
-func (c *Client) ApplyCertificateAuthoritiesSpec(groupedCAs fleet.GroupedCertificateAuthorities, opts fleet.ApplySpecOptions) error {
-	req := batchApplyCertificateAuthoritiesRequest{CertificateAuthorities: groupedCAs, DryRun: opts.DryRun}
+func (c *Client) ApplyCertificateAuthoritiesSpec(groupedCAs fleet.GroupedCertificateAuthorities, specOpts fleet.ApplySpecOptions, opts fleet.BatchApplyCertificateAuthoritiesOpts) error {
+	req := batchApplyCertificateAuthoritiesRequest{
+		CertificateAuthorities: groupedCAs,
+		DryRun:                 specOpts.DryRun,
+		SkipDeletes:            opts.SkipDeletes,
+	}
 	verb, path := "POST", "/api/latest/fleet/spec/certificate_authorities"
 	var responseBody batchApplyCertificateAuthoritiesResponse
-	return c.authenticatedRequestWithQuery(req, verb, path, &responseBody, opts.RawQuery())
+	return c.authenticatedRequestWithQuery(req, verb, path, &responseBody, specOpts.RawQuery())
 }
 
 // GetCertificateAuthorities fetches the list of certificate authorities


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38036

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps now correctly orders operations so certificate authorities can be removed only after referencing certificate templates are handled, preventing failed deletions during config updates.
  * Improved user-facing error when a CA cannot be deleted because certificate templates still reference it, with guidance to remove templates first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->