### PR TITLE
Generate correct CPE from malformed ipswitch whatsup CPE, ensure matches relevant CVEs

### DIFF
--- a/changes/32662-include-correct-cpe
+++ b/changes/32662-include-correct-cpe
@@ -1,0 +1,1 @@
+- Generate correct CPE from malformed ipswitch whatsup CPE, ensuring applicable CVEs are matched.

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -606,6 +606,18 @@ func expandCPEAliases(cpeItem *wfn.Attributes) []*wfn.Attributes {
 		}
 	}
 
+	// The NVD CPE dictionary contains an invalid CPE for Ipswitch WhatsUp with product="whatsup",
+	// but CVE-2006-2354 references product="whatsup_professional".
+	// See https://github.com/fleetdm/fleet/issues/32662.
+	for _, cpeItem := range cpeItems {
+		if cpeItem.Vendor == "ipswitch" && cpeItem.Product == "whatsup" && cpeItem.Language == "premium" {
+			cpeItem2 := *cpeItem
+			cpeItem2.Product = "whatsup_professional"
+			cpeItem2.Language = wfn.Any
+			cpeItems = append(cpeItems, &cpeItem2)
+		}
+	}
+
 	// pgAdmin CVEs in NVD use target_sw=postgresql and product=pgadmin_4, but Fleet generates
 	// CPEs with platform-based target_sw (macos, windows) and may use different product
 	// names (pgadmin, pgadmin4). Add aliases with target_sw=postgresql and product name

--- a/server/vulnerabilities/nvd/cve.go
+++ b/server/vulnerabilities/nvd/cve.go
@@ -610,10 +610,9 @@ func expandCPEAliases(cpeItem *wfn.Attributes) []*wfn.Attributes {
 	// but CVE-2006-2354 references product="whatsup_professional".
 	// See https://github.com/fleetdm/fleet/issues/32662.
 	for _, cpeItem := range cpeItems {
-		if cpeItem.Vendor == "ipswitch" && cpeItem.Product == "whatsup" && cpeItem.Language == "premium" {
+		if cpeItem.Vendor == "ipswitch" && cpeItem.Product == "whatsup" {
 			cpeItem2 := *cpeItem
 			cpeItem2.Product = "whatsup_professional"
-			cpeItem2.Language = wfn.Any
 			cpeItems = append(cpeItems, &cpeItem2)
 		}
 	}

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -457,7 +457,13 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		// See https://github.com/fleetdm/fleet/issues/32662.
 		"cpe:2.3:a:ipswitch:whatsup:2006:-:professional:premium:*:*:*:*": {
 			includedCVEs: []cve{
+				{ID: "CVE-2006-2351"},
+				{ID: "CVE-2006-2352"},
+				{ID: "CVE-2006-2353"},
 				{ID: "CVE-2006-2354"},
+				{ID: "CVE-2006-2355"},
+				{ID: "CVE-2006-2356"},
+				{ID: "CVE-2006-2357"},
 			},
 		},
 		// Tests the expandCPEAliases rule for virtualbox on macOS
@@ -1255,14 +1261,12 @@ func TestExpandCPEAliases(t *testing.T) {
 	python3130RC1Alias.Update = ""
 
 	ipswitchWhatsup := &wfn.Attributes{
-		Vendor:   "ipswitch",
-		Product:  "whatsup",
-		Version:  "2006",
-		Language: "premium",
+		Vendor:  "ipswitch",
+		Product: "whatsup",
+		Version: "2006",
 	}
 	ipswitchWhatsupAlias := *ipswitchWhatsup
 	ipswitchWhatsupAlias.Product = "whatsup_professional"
-	ipswitchWhatsupAlias.Language = ""
 
 	pgadminMacOS := &wfn.Attributes{
 		Vendor:   "pgadmin",

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -1247,6 +1247,16 @@ func TestExpandCPEAliases(t *testing.T) {
 	python3130RC1Alias.Version = "3.13.0rc1"
 	python3130RC1Alias.Update = ""
 
+	ipswitchWhatsup := &wfn.Attributes{
+		Vendor:   "ipswitch",
+		Product:  "whatsup",
+		Version:  "2006",
+		Language: "premium",
+	}
+	ipswitchWhatsupAlias := *ipswitchWhatsup
+	ipswitchWhatsupAlias.Product = "whatsup_professional"
+	ipswitchWhatsupAlias.Language = ""
+
 	pgadminMacOS := &wfn.Attributes{
 		Vendor:   "pgadmin",
 		Product:  "pgadmin",
@@ -1316,6 +1326,11 @@ func TestExpandCPEAliases(t *testing.T) {
 			name:            "pre-release python: 3.13.0 rc1",
 			cpeItem:         python3130RC1,
 			expectedAliases: []*wfn.Attributes{python3130RC1, &python3130RC1Alias},
+		},
+		{
+			name:            "ipswitch whatsup alias",
+			cpeItem:         ipswitchWhatsup,
+			expectedAliases: []*wfn.Attributes{ipswitchWhatsup, &ipswitchWhatsupAlias},
 		},
 		{
 			name:    "pgadmin on macos",

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -453,6 +453,13 @@ func TestTranslateCPEToCVE(t *testing.T) {
 		// 	},
 		// 	continuesToUpdate: true,
 		// },
+		// Ensure malformed ipswitch whatsup cpe is successfully matched to CVE
+		// See https://github.com/fleetdm/fleet/issues/32662.
+		"cpe:2.3:a:ipswitch:whatsup:2006:-:professional:premium:*:*:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2006-2354"},
+			},
+		},
 		// Tests the expandCPEAliases rule for virtualbox on macOS
 		"cpe:2.3:a:oracle:virtualbox:7.0.6:*:*:*:*:macos:*:*": {
 			includedCVEs: []cve{


### PR DESCRIPTION
**Related issue:** Resolves #32662 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Use CPE alias handling to generate correct CPE from malformed one, ensuring correct CVEs are matched.

* **Tests**
  * Added comprehensive test coverage for the enhanced CPE alias expansion, including malformed CPE mapping scenarios and CVE matching validation for Ipswitch WhatsUp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->