### PR TITLE
Fixed team maintainers, admins, and GitOps users being unable to add certificate templates

### DIFF
--- a/changes/39308-team-ca-read-access
+++ b/changes/39308-team-ca-read-access
@@ -1,0 +1,1 @@
+* Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -1256,6 +1256,14 @@ allow {
   action == [read, write, list][_]
 }
 
+# Team admins, maintainers and gitops can read and list certificate authorities
+# so they can add certificate templates to their teams.
+allow {
+  object.type == "certificate_authority"
+  team_role(subject, subject.teams[_].id) == [admin, maintainer, gitops][_]
+  action == [read, list][_]
+}
+
 # Global admins and maintainers can write a certificate request
 allow {
   object.type == "certificate_request"

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -17,6 +17,7 @@ create := "create" # only for labels right now
 write_host_label := "write_host_label"
 cancel_host_activity := "cancel_host_activity"
 resend := "resend" # only for profiles, and to a single host
+read_secrets := "read_secrets"
 
 # User specific actions
 write_role := "write_role"
@@ -1249,11 +1250,19 @@ allow {
 ##
 # Certificate Authorities
 ##
-# Global admins and GitOps can configure, read and list certificate Authorities
+# Global admins and GitOps can configure, read, list, and read secrets of certificate authorities.
 allow {
   object.type == "certificate_authority"
   subject.global_role == [admin, gitops][_]
-  action == [read, write, list][_]
+  action == [read, write, list, read_secrets][_]
+}
+
+# Global maintainers can read and list certificate authorities
+# so they can create certificate templates.
+allow {
+  object.type == "certificate_authority"
+  subject.global_role == maintainer
+  action == [read, list][_]
 }
 
 # Team admins, maintainers and gitops can read and list certificate authorities

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -30,6 +30,7 @@ const (
 	selectiveList      = fleet.ActionSelectiveList
 	cancelHostActivity = fleet.ActionCancelHostActivity
 	create             = fleet.ActionCreate
+	readSecrets        = fleet.ActionReadSecrets
 )
 
 var auth *Authorizer
@@ -2901,53 +2902,68 @@ func TestCertificateAuthorities(t *testing.T) {
 	runTestCases(t, []authTestCase{
 		{user: nil, object: certificateAuthority, action: read, allow: false},
 		{user: nil, object: certificateAuthority, action: list, allow: false},
+		{user: nil, object: certificateAuthority, action: readSecrets, allow: false},
+
 		{user: test.UserGitOps, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserGitOps, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserGitOps, object: certificateAuthority, action: write, allow: true},
+		{user: test.UserGitOps, object: certificateAuthority, action: readSecrets, allow: true},
 
 		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: readSecrets, allow: false},
 		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: readSecrets, allow: false},
 
 		{user: test.UserAdmin, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserAdmin, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserAdmin, object: certificateAuthority, action: write, allow: true},
+		{user: test.UserAdmin, object: certificateAuthority, action: readSecrets, allow: true},
 
 		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: readSecrets, allow: false},
 		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: readSecrets, allow: false},
 
 		{user: test.UserObserver, object: certificateAuthority, action: read, allow: false},
 		{user: test.UserObserver, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserObserver, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserObserver, object: certificateAuthority, action: readSecrets, allow: false},
 
 		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: read, allow: false},
 		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: readSecrets, allow: false},
 		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: read, allow: false},
 		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: readSecrets, allow: false},
 
-		{user: test.UserMaintainer, object: certificateAuthority, action: read, allow: false},
-		{user: test.UserMaintainer, object: certificateAuthority, action: list, allow: false},
+		{user: test.UserMaintainer, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserMaintainer, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserMaintainer, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserMaintainer, object: certificateAuthority, action: readSecrets, allow: false},
 
 		{user: test.UserTechnician, object: certificateAuthority, action: read, allow: false},
 		{user: test.UserTechnician, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTechnician, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTechnician, object: certificateAuthority, action: readSecrets, allow: false},
 
 		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: readSecrets, allow: false},
 		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: read, allow: true},
 		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: write, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: readSecrets, allow: false},
 	})
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -2900,39 +2900,53 @@ func TestCertificateAuthorities(t *testing.T) {
 
 	runTestCases(t, []authTestCase{
 		{user: nil, object: certificateAuthority, action: read, allow: false},
+		{user: nil, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserGitOps, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserGitOps, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserGitOps, object: certificateAuthority, action: write, allow: true},
 
-		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamGitOpsTeam1, object: certificateAuthority, action: write, allow: false},
-		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamGitOpsTeam2, object: certificateAuthority, action: write, allow: false},
 
 		{user: test.UserAdmin, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserAdmin, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserAdmin, object: certificateAuthority, action: write, allow: true},
 
-		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamAdminTeam1, object: certificateAuthority, action: write, allow: false},
-		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamAdminTeam2, object: certificateAuthority, action: write, allow: false},
 
 		{user: test.UserObserver, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserObserver, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserObserver, object: certificateAuthority, action: write, allow: false},
 
 		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTeamObserverTeam1, object: certificateAuthority, action: write, allow: false},
 		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTeamObserverTeam2, object: certificateAuthority, action: write, allow: false},
 
 		{user: test.UserMaintainer, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserMaintainer, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserMaintainer, object: certificateAuthority, action: write, allow: false},
 
 		{user: test.UserTechnician, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTechnician, object: certificateAuthority, action: list, allow: false},
 		{user: test.UserTechnician, object: certificateAuthority, action: write, allow: false},
 
-		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamMaintainerTeam1, object: certificateAuthority, action: write, allow: false},
-		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: read, allow: false},
+		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: read, allow: true},
+		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: list, allow: true},
 		{user: test.UserTeamMaintainerTeam2, object: certificateAuthority, action: write, allow: false},
 	})
 }

--- a/server/fleet/authz.go
+++ b/server/fleet/authz.go
@@ -15,6 +15,8 @@ const (
 	ActionCancelHostActivity = "cancel_host_activity"
 	// ActionResend refers to resending an entity on a single host (currently used for configuration profiles).
 	ActionResend = "resend"
+	// ActionReadSecrets refers to reading secrets/credentials of an entity (e.g. CA private keys, API tokens).
+	ActionReadSecrets = "read_secrets"
 
 	//
 	// User specific actions

--- a/server/service/certificate_authorities.go
+++ b/server/service/certificate_authorities.go
@@ -233,7 +233,11 @@ func getCertificateAuthoritiesSpecEndpoint(ctx context.Context, request interfac
 }
 
 func (svc *Service) GetGroupedCertificateAuthorities(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
-	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, fleet.ActionRead); err != nil {
+	action := fleet.ActionRead
+	if includeSecrets {
+		action = fleet.ActionReadSecrets
+	}
+	if err := svc.authz.Authorize(ctx, &fleet.CertificateAuthority{}, action); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39308

Doc updates: https://github.com/fleetdm/fleet/pull/41760/changes

The reason secrets are involved here is because `gitops generate` can get them.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed access permissions for team maintainers, admins, and GitOps users, enabling them to add certificate templates by granting required read access to certificate authorities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->