### PR TITLE
Attempt to fix TestSSO

### DIFF
--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -6202,6 +6202,7 @@ func (s *integrationMDMTestSuite) setTokenForTest(t *testing.T, email, password 
 
 func (s *integrationMDMTestSuite) TestSSO() {
 	t := s.T()
+	s.setSkipWorkerJobs(t)
 
 	lastSubmittedProfile := &godep.Profile{}
 	mdmDevice, wantSettings := s.setUpEndUserAuthentication(t, lastSubmittedProfile, true)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41745
Attempt to fix TestIntegrationsMDM/TestSSO by adding s.setSkipWorkerJobs(t). It looks like that test uses s.runWorker() manually anyway and it still passes.

