### PR TITLE
Fixed editing reports on free tier failing due to  triggering a premium license check

### DIFF
--- a/changes/41652-fix-reports-edit
+++ b/changes/41652-fix-reports-edit
@@ -1,0 +1,1 @@
+* Fixed editing reports on free tier failing due to `labels_include_any` triggering a premium license check.

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -115,6 +115,22 @@ const validateQuerySQL = (query: string) => {
   return { valid, errors };
 };
 
+const getLabelsIncludeAny = (
+  isPremiumTier: boolean | undefined,
+  selectedTargetType: string,
+  selectedLabels: Record<string, boolean>
+): string[] | undefined => {
+  if (!isPremiumTier) {
+    return undefined;
+  }
+  if (selectedTargetType === "Custom") {
+    return Object.entries(selectedLabels)
+      .filter(([, selected]) => selected)
+      .map(([labelName]) => labelName);
+  }
+  return [];
+};
+
 const EditQueryForm = ({
   router,
   location,
@@ -218,12 +234,11 @@ const EditQueryForm = ({
     min_osquery_version: lastEditedQueryMinOsqueryVersion,
     logging: lastEditedQueryLoggingType,
     discard_data: lastEditedQueryDiscardData,
-    labels_include_any:
-      selectedTargetType === "Custom"
-        ? Object.entries(selectedLabels)
-            .filter(([, selected]) => selected)
-            .map(([labelName]) => labelName)
-        : [],
+    labels_include_any: getLabelsIncludeAny(
+      isPremiumTier,
+      selectedTargetType,
+      selectedLabels
+    ),
   };
 
   useEffect(() => {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41652

Solution is to not pass `labels_include_any` to the payload of the PATCH endpoint request.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


https://github.com/user-attachments/assets/7c825b92-0b03-448a-8e42-83e39a2acdf6



For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed