### PR TITLE
Fixed 500 and 402 on My Device page.

### DIFF
--- a/changes/41742-fix-my-device-500-fleet-free
+++ b/changes/41742-fix-my-device-500-fleet-free
@@ -1,1 +1,1 @@
-- Fixed a crash (500 error) on the "My device" page for Fleet Free instances caused by accessing undefined policies data.
+- Fixed a crash on the "My device" page for Fleet Free instances. The page returned a 402 error when the host was assigned to a team because the device endpoint called a premium-only API, and also crashed when accessing undefined policies data.

--- a/changes/41742-fix-my-device-500-fleet-free
+++ b/changes/41742-fix-my-device-500-fleet-free
@@ -1,0 +1,1 @@
+- Fixed a crash (500 error) on the "My device" page for Fleet Free instances caused by accessing undefined policies data.

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -674,7 +674,7 @@ const DeviceUserPage = ({
       );
     }
 
-    const hasAnyCriticalFailingCAPolicy = host?.policies.some(
+    const hasAnyCriticalFailingCAPolicy = host?.policies?.some(
       (p) => p.response === "fail" && p.conditional_access_enabled && p.critical
     );
 

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -195,7 +195,7 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	if resp.TeamID != nil {
 		// load the team to get the device's team's software inventory config.
 		tm, err := svc.GetTeam(ctx, *resp.TeamID)
-		if err != nil && !fleet.IsNotFound(err) {
+		if err != nil && !fleet.IsNotFound(err) && !errors.Is(err, fleet.ErrMissingLicense) {
 			return getDeviceHostResponse{Err: err}, nil
 		}
 		if tm != nil {

--- a/server/service/devices.go
+++ b/server/service/devices.go
@@ -195,7 +195,12 @@ func getDeviceHostEndpoint(ctx context.Context, request interface{}, svc fleet.S
 	if resp.TeamID != nil {
 		// load the team to get the device's team's software inventory config.
 		tm, err := svc.GetTeam(ctx, *resp.TeamID)
-		if err != nil && !fleet.IsNotFound(err) && !errors.Is(err, fleet.ErrMissingLicense) {
+		if errors.Is(err, fleet.ErrMissingLicense) {
+			// Fleet Free does not support teams, so team-specific config
+			// (software inventory, conditional access, etc.) falls back to
+			// the global defaults set above.
+			tm = nil
+		} else if err != nil && !fleet.IsNotFound(err) {
 			return getDeviceHostResponse{Err: err}, nil
 		}
 		if tm != nil {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41742

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes on the "My device" page for Fleet Free instances when a host is assigned to a team.
  * Improved error handling to prevent application crashes when policy data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->