### PR TITLE
Fix apps.json: replace non-ASCII characters in descriptions

### DIFF
--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -83,7 +83,7 @@
       "slug": "adobe-creative-cloud/darwin",
       "platform": "darwin",
       "unique_identifier": "com.adobe.acc.AdobeCreativeCloud",
-      "description": "Adobe Creative Cloud is a platform for creative software management and installation, including access to Adobe’s suite of tools like Photoshop, Illustrator, and Premiere Pro."
+      "description": "Adobe Creative Cloud is a platform for creative software management and installation, including access to Adobe's suite of tools like Photoshop, Illustrator, and Premiere Pro."
     },
     {
       "name": "Adobe Digital Editions",
@@ -118,14 +118,14 @@
       "slug": "airtame/darwin",
       "platform": "darwin",
       "unique_identifier": "com.airtame.airtame-application",
-      "description": "Airtame is an app that makes shared screens easy to use — for screen sharing, conferencing, digital signage, and alerts."
+      "description": "Airtame is an app that makes shared screens easy to use - for screen sharing, conferencing, digital signage, and alerts."
     },
     {
       "name": "Airtame",
       "slug": "airtame/windows",
       "platform": "windows",
       "unique_identifier": "Airtame 4.15.0",
-      "description": "Airtame is an app that makes shared screens easy to use — for screen sharing, conferencing, digital signage, and alerts."
+      "description": "Airtame is an app that makes shared screens easy to use - for screen sharing, conferencing, digital signage, and alerts."
     },
     {
       "name": "Amazon Chime",
@@ -475,14 +475,14 @@
       "slug": "cursor/darwin",
       "platform": "darwin",
       "unique_identifier": "com.todesktop.230313mzl4w4u92",
-      "description": "Cursor AI boosts your coding productivity by giving smart, context-aware code suggestions, quick explanations, and easy refactors — all inside your editor."
+      "description": "Cursor AI boosts your coding productivity by giving smart, context-aware code suggestions, quick explanations, and easy refactors - all inside your editor."
     },
     {
       "name": "Cursor",
       "slug": "cursor/windows",
       "platform": "windows",
       "unique_identifier": "Cursor",
-      "description": "Cursor AI boosts your coding productivity by giving smart, context-aware code suggestions, quick explanations, and easy refactors — all inside your editor."
+      "description": "Cursor AI boosts your coding productivity by giving smart, context-aware code suggestions, quick explanations, and easy refactors - all inside your editor."
     },
     {
       "name": "Cyberduck",


### PR DESCRIPTION
## Summary

- Replaces 5 non-ASCII characters in existing `apps.json` descriptions with ASCII equivalents
- Adobe Creative Cloud: curly apostrophe (`'`) → straight apostrophe (`'`)
- Airtame (darwin + windows): em-dash (`—`) → hyphen (`-`)
- Cursor (darwin + windows): em-dash (`—`) → hyphen (`-`)

## Why

Go's `json.Encoder` escapes all non-ASCII code points as `\uXXXX` when re-encoding a file, regardless of `SetEscapeHTML(false)`. The `updateAppsListFile()` function re-encodes the entire `apps.json` on every new app addition. As long as these 3 entries contain non-ASCII characters, every FMA PR that adds a new app will show spurious diffs to these existing lines.

## Validation checklist

- [ ] Only 5 lines changed in `apps.json`
- [ ] No other files touched