### PR TITLE
Update Apple's identity to sign `pkg`s

### DIFF
--- a/.github/workflows/build-fleetd-base-pkg.yml
+++ b/.github/workflows/build-fleetd-base-pkg.yml
@@ -68,7 +68,7 @@ jobs:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PACKAGE_SIGNING_IDENTITY_SHA1: D52080FD1F0941DE31346F06DA0F08AED6FACBBF
+          PACKAGE_SIGNING_IDENTITY_SHA1: EA5AF8822A38D28CF99DB14CD61DACD121B2386E
         run: |
           fleetctl package --type pkg --fleet-desktop \
             --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize \

--- a/.github/workflows/build-fleetd-base-pkg.yml
+++ b/.github/workflows/build-fleetd-base-pkg.yml
@@ -68,7 +68,7 @@ jobs:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PACKAGE_SIGNING_IDENTITY_SHA1: EA5AF8822A38D28CF99DB14CD61DACD121B2386E
+          PACKAGE_SIGNING_IDENTITY_SHA1: 4608F71FB42E1845C7FC9B2D2B6A7A8D11BBD940
         run: |
           fleetctl package --type pkg --fleet-desktop \
             --use-system-configuration --sign-identity $PACKAGE_SIGNING_IDENTITY_SHA1 --notarize \

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -129,7 +129,7 @@ jobs:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PACKAGE_SIGNING_IDENTITY_SHA1: D52080FD1F0941DE31346F06DA0F08AED6FACBBF
+          PACKAGE_SIGNING_IDENTITY_SHA1: EA5AF8822A38D28CF99DB14CD61DACD121B2386E
         # We use retry because we've seen Apple notarization fail or timeout
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:

--- a/.github/workflows/release-fleetd-base.yml
+++ b/.github/workflows/release-fleetd-base.yml
@@ -129,7 +129,7 @@ jobs:
           AC_USERNAME: ${{ secrets.APPLE_USERNAME }}
           AC_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
           AC_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          PACKAGE_SIGNING_IDENTITY_SHA1: EA5AF8822A38D28CF99DB14CD61DACD121B2386E
+          PACKAGE_SIGNING_IDENTITY_SHA1: 4608F71FB42E1845C7FC9B2D2B6A7A8D11BBD940
         # We use retry because we've seen Apple notarization fail or timeout
         uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
         with:


### PR DESCRIPTION
Updating the Apple identity for the new certificate to sign `pkg`s.

Run: https://github.com/fleetdm/fleet/actions/runs/23159085327