### PR TITLE
Website: update publishedOn meta tag of Thumbtack case study

### DIFF
--- a/articles/thumbtack.md
+++ b/articles/thumbtack.md
@@ -56,7 +56,7 @@ Manager, IT Endpoint Engineering, Thumbtack
 <meta name="description" value="Thumbtack migrated more than 90% of Macs to Fleet with no IT intervention and now manages devices with GitOps and fast Slack support.">
 
 
-<meta name="publishedOn" value="2026-03-26">
+<meta name="publishedOn" value="2026-03-13">
 <meta name="authorGitHubUsername" value="n/a">
 <meta name="authorFullName" value="Fleetdm">
 


### PR DESCRIPTION
Changes:
- Updated the `publishedOn` meta tag in the Thumbtack case study to be the date the article was published.