### PR TITLE
Fleet UI: Update link cell truncation to remove white space

### DIFF
--- a/frontend/components/TableContainer/DataTable/SoftwareNameCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SoftwareNameCell/_styles.scss
@@ -12,17 +12,6 @@
     height: 24px;
   }
 
-  .software-name {
-    @include ellipse-text();
-    max-width: 300px;
-  }
-
-  @media (max-width: ($break-md - 1)) {
-    .software-name {
-      max-width: 250px;
-    }
-  }
-
   &__install-icon {
     // TODO: we do not want to use !important but have to for now. This is
     // the same issue as the .software-name-cell class display value.

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/TooltipTruncatedTextCell.tsx
@@ -14,8 +14,6 @@ interface ITooltipTruncatedTextCellProps {
   /** If set to `true` the text inside the tooltip will break on words instead of any character.
    * By default the tooltip text breaks on any character. Default: false */
   tooltipBreakOnWord?: boolean;
-  /** @deprecated use the prop `className` in order to add custom classes to this component */
-  classes?: string;
   className?: string;
   /** Content does not get truncated */
   prefix?: React.ReactNode;
@@ -29,12 +27,11 @@ const TooltipTruncatedTextCell = ({
   value,
   tooltip,
   tooltipBreakOnWord = false,
-  classes = "w250",
   className,
   prefix,
   suffix,
 }: ITooltipTruncatedTextCellProps): JSX.Element => {
-  const classNames = classnames(baseClass, classes, className, {
+  const classNames = classnames(baseClass, className, {
     "tooltip-break-on-word": tooltipBreakOnWord,
   });
 

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
@@ -2,6 +2,7 @@
   display: flex;
   align-items: center; // For badges, etc
   gap: $pad-small;
+  max-width: 100%;
 
   .text-muted {
     color: $ui-fleet-black-50;

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -321,6 +321,8 @@ $shadow-transition-width: 10px;
           }
 
           &.link-cell--tooltip-truncate {
+            min-width: 100%; // Take up as much of cell as possible
+
             .data-table__tooltip-truncated-text-container {
               position: relative;
               @include bottom-border;

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -112,7 +112,7 @@ export const generateTableColumnConfigs = (
           >
             <TooltipTruncatedTextCell
               value={cellProps.row.original.name}
-              classes="w400"
+              className="w400"
             />
           </Button>
         );

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/ScriptsTableConfig.tsx
@@ -109,10 +109,11 @@ export const generateTableColumnConfigs = (
             className="script-info"
             onClick={onClickScriptName}
             variant="inverse"
+            size="small"
           >
             <TooltipTruncatedTextCell
               value={cellProps.row.original.name}
-              className="w400"
+              className="w400" // Funky workaround for a truncation text cell WITHIN a button
             />
           </Button>
         );

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/_styles.scss
@@ -27,6 +27,12 @@
     }
   }
 
+  .button {
+    .truncated-tooltip {
+      font-weight: $regular; // Undo button font-weight of 600 to match other tooltips 400
+    }
+  }
+
   // style a basic span that doesn't use the dropdown component (which relies on react-select
   // and makes it difficult for us to style the disabled tooltip underline on the placeholder text.
   .run-script-action--disabled {

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { memo, useMemo } from "react";
+import React, { useMemo } from "react";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { IHostMdmData } from "interfaces/host";

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import Button from "components/buttons/Button";
 import Modal from "components/Modal";
 import { IHostMdmData } from "interfaces/host";

--- a/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
+++ b/frontend/pages/hosts/details/OSSettingsModal/OSSettingsTable/OSSettingsErrorCell/OSSettingsErrorCell.tsx
@@ -323,8 +323,6 @@ const OSSettingsErrorCell = ({
         tooltipBreakOnWord
         tooltip={tooltip}
         value={value}
-        // we dont want the default "w250" class so we pass in empty string
-        classes=""
         className={
           isFailed || showRefetchButton || showRotateButton
             ? `${baseClass}__failed-message`

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
@@ -83,6 +83,9 @@
       .data-table__table {
         tbody {
           tr {
+            .name__cell {
+              max-width: 250px;
+            }
             .status__cell {
               display: table-cell;
               min-width: 140px; // Fixed width when status changes after clicking install/uninstall

--- a/frontend/pages/hosts/details/cards/Software/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/_styles.scss
@@ -56,6 +56,11 @@
             max-width: px-to-rem(140);
           }
         }
+        tbody {
+          .name__cell {
+            max-width: 250px;
+          }
+        }
       }
 
       @media (max-width: ($break-sm - 1)) {


### PR DESCRIPTION
## Issue
Closes #40178 

## Description
- Main fix: `max-width: 100%;` and `max-width: 100%; // Take up as much of cell as possible` are the main fixes
- Other fix: run script modal tooltip shouldn't be bold, button should be size small to match other table row buttons
- Removes deprecated `classes` prop
- Removes unused CSS styling
- Confirm looks good in various areas code covers

## Screenshots of fixes

https://github.com/user-attachments/assets/bc335343-19d4-47a5-8a48-2f09be69a842

https://github.com/user-attachments/assets/a2aba9c9-80b1-4fba-9c64-ae861f48bae4

https://github.com/user-attachments/assets/4c5b5e40-9b04-4b3c-9b11-f442e0351850

<img width="808" height="339" alt="Screenshot 2026-03-16 at 7 57 54 PM" src="https://github.com/user-attachments/assets/227deaff-0a55-4195-b455-f9be81edc365" />



## Testing

- [x] QA'd all new/changed functionality manually
