### PR TITLE
Save logo URL for dark and light backgrounds during setup

### DIFF
--- a/changes/39082-setup-logo-light-background
+++ b/changes/39082-setup-logo-light-background
@@ -1,0 +1,1 @@
+* Fixed a bug where the organization logo URL entered during setup was only saved for dark backgrounds and not for light backgrounds.

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -1,5 +1,5 @@
 import { getPastDate, getFutureDate } from "test/test-utils";
-import { IRegistrationFormData } from "interfaces/registration_form_data";
+import type { IRegistrationFormData } from "interfaces/registration_form_data";
 import helpers, {
   removeOSPrefix,
   compareVersions,

--- a/frontend/utilities/helpers.tests.tsx
+++ b/frontend/utilities/helpers.tests.tsx
@@ -1,5 +1,6 @@
 import { getPastDate, getFutureDate } from "test/test-utils";
-import {
+import { IRegistrationFormData } from "interfaces/registration_form_data";
+import helpers, {
   removeOSPrefix,
   compareVersions,
   willExpireWithinXDays,
@@ -75,6 +76,50 @@ describe("helpers utilities", () => {
 
       const fiftyDaysAgo = getPastDate(50);
       expect(willExpireWithinXDays(fiftyDaysAgo, 30)).toEqual(false);
+    });
+  });
+
+  describe("setupData function", () => {
+    it("sets org_logo_url_light_background to the same value as org_logo_url", () => {
+      const formData: IRegistrationFormData = {
+        email: "admin@example.com",
+        name: "Admin",
+        password: "password123",
+        password_confirmation: "password123",
+        org_name: "Fleet",
+        org_web_url: "",
+        org_logo_url: "https://example.com/logo.png",
+        fleet_web_address: "",
+        server_url: "https://fleet.example.com",
+      };
+
+      const result = helpers.setupData(formData);
+
+      expect(result.org_info.org_logo_url).toEqual(
+        "https://example.com/logo.png"
+      );
+      expect(result.org_info.org_logo_url_light_background).toEqual(
+        "https://example.com/logo.png"
+      );
+    });
+
+    it("sets org_logo_url_light_background to empty string when org_logo_url is not provided", () => {
+      const formData: IRegistrationFormData = {
+        email: "admin@example.com",
+        name: "Admin",
+        password: "password123",
+        password_confirmation: "password123",
+        org_name: "Fleet",
+        org_web_url: "",
+        org_logo_url: "",
+        fleet_web_address: "",
+        server_url: "https://fleet.example.com",
+      };
+
+      const result = helpers.setupData(formData);
+
+      expect(result.org_info.org_logo_url).toEqual("");
+      expect(result.org_info.org_logo_url_light_background).toEqual("");
     });
   });
 });

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -56,6 +56,7 @@ import {
   isPlatformLabelNameFromAPI,
 } from "utilities/constants";
 import { IDropdownOption } from "interfaces/dropdownOption";
+import { IRegistrationFormData } from "interfaces/registration_form_data";
 import CustomLink from "components/CustomLink";
 
 const ORG_INFO_ATTRS = ["org_name", "org_logo_url"];
@@ -517,7 +518,7 @@ export const greyCell = (roleOrTeamText: string): boolean => {
   );
 };
 
-const setupData = (formData: any) => {
+const setupData = (formData: IRegistrationFormData) => {
   const orgInfo = pick(formData, ORG_INFO_ATTRS);
   const adminInfo = pick(formData, ADMIN_ATTRS);
 
@@ -525,6 +526,7 @@ const setupData = (formData: any) => {
     server_url: formData.server_url,
     org_info: {
       ...orgInfo,
+      org_logo_url_light_background: orgInfo.org_logo_url || "",
     },
     admin: {
       admin: true,

--- a/frontend/utilities/helpers.tsx
+++ b/frontend/utilities/helpers.tsx
@@ -56,7 +56,7 @@ import {
   isPlatformLabelNameFromAPI,
 } from "utilities/constants";
 import { IDropdownOption } from "interfaces/dropdownOption";
-import { IRegistrationFormData } from "interfaces/registration_form_data";
+import type { IRegistrationFormData } from "interfaces/registration_form_data";
 import CustomLink from "components/CustomLink";
 
 const ORG_INFO_ATTRS = ["org_name", "org_logo_url"];


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #39082 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

https://github.com/user-attachments/assets/51ede24f-3317-455a-8995-fd50e9281a47

