### PR TITLE
Cherry-pick #41805: Fix `addFleetMaintainedAppEndpoint` to accept `fleet_id` param

### DIFF
--- a/changes/41771-fix-fma-endpoint
+++ b/changes/41771-fix-fma-endpoint
@@ -1,0 +1,2 @@
+- Fixed an issue where the "add Fleet-maintained app" endpoint incorrectly added software to the Unassigned fleet.
+- Muted deprecation warnings for body params when the "deprecated-field-names" topic is not enabled.

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -620,25 +620,6 @@ func MakeDecoder(
 				v = reflect.ValueOf(req)
 			}
 
-			// Log deprecation warnings when deprecated field names are used.
-			if rewriter != nil {
-				if deprecated := rewriter.UsedDeprecatedKeys(); len(deprecated) > 0 {
-					newNames := make([]string, len(deprecated))
-					for i, old := range deprecated {
-						for _, rule := range aliasRules {
-							if rule.OldKey == old {
-								newNames[i] = rule.NewKey
-								break
-							}
-						}
-					}
-					logging.WithLevel(ctx, slog.LevelWarn)
-					logging.WithExtras(ctx,
-						"deprecated_fields", fmt.Sprintf("%v", deprecated),
-						"deprecation_warning", fmt.Sprintf("use the updated field names (%s) instead", newNames),
-					)
-				}
-			}
 		}
 
 		fields := allFields(v)
@@ -710,16 +691,25 @@ func MakeDecoder(
 				return nil, err
 			}
 
-			// Log deprecation warnings when deprecated field names are used
-			// (bodyDecoder path).
-			if rewriter != nil {
-				if deprecated := rewriter.UsedDeprecatedKeys(); len(deprecated) > 0 {
-					logging.WithLevel(ctx, slog.LevelWarn)
-					logging.WithExtras(ctx,
-						"deprecated_fields", fmt.Sprintf("%v", deprecated),
-						"deprecation_warning", "use the updated field names instead",
-					)
+		}
+
+		// Log deprecation warnings when deprecated field names are used.
+		if rewriter != nil && platform_logging.TopicEnabled(platform_logging.DeprecatedFieldTopic) {
+			if deprecated := rewriter.UsedDeprecatedKeys(); len(deprecated) > 0 {
+				newNames := make([]string, len(deprecated))
+				for i, old := range deprecated {
+					for _, rule := range aliasRules {
+						if rule.OldKey == old {
+							newNames[i] = rule.NewKey
+							break
+						}
+					}
 				}
+				logging.WithLevel(ctx, slog.LevelWarn)
+				logging.WithExtras(ctx,
+					"deprecated_fields", fmt.Sprintf("%v", deprecated),
+					"deprecation_warning", fmt.Sprintf("use the updated field names (%s) instead", newNames),
+				)
 			}
 		}
 

--- a/server/service/maintained_apps.go
+++ b/server/service/maintained_apps.go
@@ -6,12 +6,18 @@ import (
 	"errors"
 	"net/http"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/logging"
 	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
+	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
+	platform_logging "github.com/fleetdm/fleet/v4/server/platform/logging"
 )
 
 type addFleetMaintainedAppRequest struct {
-	TeamID            *uint    `json:"team_id" renameto:"fleet_id"`
+	TeamID *uint `json:"team_id"`
+	// Note that we're adding an explicit FleetID field rather than using `renameto`.
+	// The POST /software/fleet_maintained_apps endpoint has a custom decoder
+	// and in this special case it's easier to handle the aliasing manually.
+	FleetID           *uint    `json:"fleet_id"`
 	AppID             uint     `json:"fleet_maintained_app_id"`
 	InstallScript     string   `json:"install_script"`
 	PreInstallQuery   string   `json:"pre_install_query"`
@@ -39,6 +45,23 @@ func (addFleetMaintainedAppRequest) DecodeRequest(ctx context.Context, r *http.R
 		}
 	}
 
+	// Resolve fleet_id → team_id aliasing. The struct has both fields so
+	// json.Decode populates whichever the caller sent; we normalize here.
+	if req.FleetID != nil {
+		if req.TeamID != nil {
+			return nil, &fleet.BadRequestError{
+				Message: `Specify only one of "team_id" or "fleet_id"`,
+			}
+		}
+		req.TeamID = req.FleetID
+		req.FleetID = nil
+	} else if req.TeamID != nil && platform_logging.TopicEnabled(platform_logging.DeprecatedFieldTopic) {
+		// Add a deprecation warning.
+		logging.WithExtras(ctx,
+			"deprecated_fields", "[team_id]",
+			"deprecation_warning", "use the updated field names (fleet_id) instead",
+		)
+	}
 	// Check if scripts are base64 encoded
 	if isScriptsEncoded(r) {
 		var err error

--- a/server/service/maintained_apps_test.go
+++ b/server/service/maintained_apps_test.go
@@ -1,0 +1,73 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddFleetMaintainedAppDecodeRequest(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		body       string
+		wantTeamID *uint
+		wantErr    string
+	}{
+		{
+			name:       "fleet_id accepted",
+			body:       `{"fleet_id": 42, "fleet_maintained_app_id": 1}`,
+			wantTeamID: ptr.Uint(42),
+		},
+		{
+			name:       "team_id still accepted",
+			body:       `{"team_id": 7, "fleet_maintained_app_id": 1}`,
+			wantTeamID: ptr.Uint(7),
+		},
+		{
+			name:       "neither provided",
+			body:       `{"fleet_maintained_app_id": 1}`,
+			wantTeamID: nil,
+		},
+		{
+			name:    "both provided is an error",
+			body:    `{"team_id": 1, "fleet_id": 2, "fleet_maintained_app_id": 1}`,
+			wantErr: `Specify only one of "team_id" or "fleet_id"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := http.NewRequestWithContext(context.Background(), http.MethodPost, "/", io.NopCloser(bytes.NewBufferString(tt.body)))
+			require.NoError(t, err)
+
+			result, err := addFleetMaintainedAppRequest{}.DecodeRequest(context.Background(), r)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			req := result.(*addFleetMaintainedAppRequest)
+			if tt.wantTeamID == nil {
+				assert.Nil(t, req.TeamID)
+			} else {
+				require.NotNil(t, req.TeamID)
+				assert.Equal(t, *tt.wantTeamID, *req.TeamID)
+			}
+			// FleetID should always be nil after normalization
+			assert.Nil(t, req.FleetID)
+		})
+	}
+}


### PR DESCRIPTION
Cherry-pick of #41805 into `rc-minor-fleet-v4.83.0`.