### PR TITLE
check awaiting configuration before declaring scep renewal in authenticate

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -3388,7 +3388,7 @@ func (svc *MDMAppleCheckinAndCommandService) Authenticate(r *mdm.Request, m *mdm
 		}
 	}
 	if existingDeviceInfo != nil {
-		scepRenewalInProgress = existingDeviceInfo.SCEPRenewalInProgress
+		scepRenewalInProgress = existingDeviceInfo.SCEPRenewalInProgress && !m.AwaitingConfiguration
 	}
 
 	// iPhones, iPads, and iPods send ProductName but not Model/ModelName,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (Unreleased bug found while doing local testing)


## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually