### PR TITLE
Allow OTEL service name to be overridden

### DIFF
--- a/changes/41888-otel-service-name
+++ b/changes/41888-otel-service-name
@@ -1,1 +1,1 @@
-* Allow OTEL service name to be overridden with standard OTEL OTEL_SERVICE_NAME env var.
+* Allow OTEL service name to be overridden with standard OTEL_SERVICE_NAME env var.

--- a/changes/41888-otel-service-name
+++ b/changes/41888-otel-service-name
@@ -1,0 +1,1 @@
+* Allow OTEL service name to be overridden with standard OTEL OTEL_SERVICE_NAME env var.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -172,14 +172,17 @@ the way that the Fleet server works.
 			var tracerProvider *sdktrace.TracerProvider
 			var meterProvider *sdkmetric.MeterProvider
 			if config.OTELEnabled() {
-				// Create shared resource with service identification attributes
-				res, err := resource.Merge(
-					resource.Default(),
-					resource.NewWithAttributes(
-						semconv.SchemaURL,
+				// Create shared resource with service identification attributes.
+				// OTEL_SERVICE_NAME and OTEL_RESOURCE_ATTRIBUTES env vars can override
+				// the defaults below.
+				res, err := resource.New(context.Background(),
+					resource.WithSchemaURL(semconv.SchemaURL),
+					resource.WithAttributes(
 						semconv.ServiceName("fleet"),
 						semconv.ServiceVersion(version.Version().Version),
 					),
+					resource.WithFromEnv(),
+					resource.WithTelemetrySDK(),
 				)
 				if err != nil {
 					initFatal(err, "Failed to create OTEL resource")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41888

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenTelemetry service name can now be configured via the standard OTEL_SERVICE_NAME environment variable
  * Support for OTEL_RESOURCE_ATTRIBUTES environment variable to customize telemetry resource attributes

* **Chores**
  * Enhanced OpenTelemetry resource initialization to support environment variable overrides for improved deployment flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->