### PR TITLE
Website: Update GitHub webhook to support fleet-gitops repo.

### DIFF
--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -362,6 +362,8 @@ module.exports = {
         let DRI_BY_PATH = {};
         if (repo === 'fleet') {
           DRI_BY_PATH = sails.config.custom.githubRepoDRIByPath;
+        } else if(repo === 'fleet-gitops') {
+          DRI_BY_PATH = sails.config.custom.fleetMdmGitopsRepoDRIByPath;
         } else {
           // Other repos don't have this configured.
           // FUTURE: Configure it for them
@@ -425,6 +427,12 @@ module.exports = {
           }//ﬁ
 
         }//∞
+
+        let repoHasADriForAllPaths = DRI_BY_PATH['/'];
+        // If a PR has no expected reviewers, and the repo has a DRI for all paths ('/'), add that user as a reviewer.
+        if(expectedReviewers.length === 0 && repoHasADriForAllPaths) {
+          expectedReviewers.push(repoHasADriForAllPaths);
+        }//ﬁ
 
         // Now, if reviews should be requested for this PR, do so.
         //

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -723,34 +723,33 @@ module.exports = {
       //  ██║  ██║███████╗███████╗███████╗██║  ██║███████║███████╗███████║
       //  ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝
       //
-      // 2026-03-17: @eashaw: The associated zapier automation has been turned off, so this section is commented out.
       // Handle new Fleet releases by sending a POST request to Zapier to
       // trigger an automation that updates Slack channel topics with the latest version of Fleet.
-      // let owner = repository.owner.login;
-      // let repo = repository.name;
+      let owner = repository.owner.login;
+      let repo = repository.name;
 
-      // // Only continue if this release came from the fleetdm/fleet repo,
-      // if(owner === 'fleetdm' && repo === 'fleet') {
-      //   if(release
-      //     && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
-      //     && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods.
-      //   ) {
-      //     // Send a POST request to Zapier with the release object.
-      //     await sails.helpers.http.post.with({
-      //       url: 'https://hooks.zapier.com/hooks/catch/3627242/3ozw6bk/',
-      //       data: {
-      //         'release': release,
-      //         'webhookSecret': sails.config.custom.zapierSandboxWebhookSecret,
-      //       }
-      //     })
-      //     .timeout(5000)
-      //     .tolerate(['non200Response', 'requestFailed', {name: 'TimeoutError'}], (err)=>{
-      //       // Note that Zapier responds with a 2xx status code even if something goes wrong, so just because this message is not logged doesn't mean everything is hunky dory.  More info: https://github.com/fleetdm/fleet/pull/6380#issuecomment-1204395762
-      //       sails.log.warn(`When trying to send information about a new Fleet release to Zapier, an error occured. Raw error: ${require('util').inspect(err)}`);
-      //       return;
-      //     });
-      //   }
-      // }//ﬁ
+      // Only continue if this release came from the fleetdm/fleet repo,
+      if(owner === 'fleetdm' && repo === 'fleet') {
+        if(release
+          && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
+          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods.
+        ) {
+          // Send a POST request to Zapier with the release object.
+          await sails.helpers.http.post.with({
+            url: 'https://hooks.zapier.com/hooks/catch/3627242/3ozw6bk/',
+            data: {
+              'release': release,
+              'webhookSecret': sails.config.custom.zapierSandboxWebhookSecret,
+            }
+          })
+          .timeout(5000)
+          .tolerate(['non200Response', 'requestFailed', {name: 'TimeoutError'}], (err)=>{
+            // Note that Zapier responds with a 2xx status code even if something goes wrong, so just because this message is not logged doesn't mean everything is hunky dory.  More info: https://github.com/fleetdm/fleet/pull/6380#issuecomment-1204395762
+            sails.log.warn(`When trying to send information about a new Fleet release to Zapier, an error occured. Raw error: ${require('util').inspect(err)}`);
+            return;
+          });
+        }
+      }//ﬁ
     } else if(ghNoun === 'projects_v2_item') {
       //
       //  ██████╗ ██████╗  ██████╗      ██╗███████╗ ██████╗████████╗███████╗    ██╗   ██╗██████╗

--- a/website/api/controllers/webhooks/receive-from-github.js
+++ b/website/api/controllers/webhooks/receive-from-github.js
@@ -723,33 +723,34 @@ module.exports = {
       //  ██║  ██║███████╗███████╗███████╗██║  ██║███████║███████╗███████║
       //  ╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝╚═╝  ╚═╝╚══════╝╚══════╝╚══════╝
       //
+      // 2026-03-17: @eashaw: The associated zapier automation has been turned off, so this section is commented out.
       // Handle new Fleet releases by sending a POST request to Zapier to
       // trigger an automation that updates Slack channel topics with the latest version of Fleet.
-      let owner = repository.owner.login;
-      let repo = repository.name;
+      // let owner = repository.owner.login;
+      // let repo = repository.name;
 
-      // Only continue if this release came from the fleetdm/fleet repo,
-      if(owner === 'fleetdm' && repo === 'fleet') {
-        if(release
-          && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
-          && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods.
-        ) {
-          // Send a POST request to Zapier with the release object.
-          await sails.helpers.http.post.with({
-            url: 'https://hooks.zapier.com/hooks/catch/3627242/3ozw6bk/',
-            data: {
-              'release': release,
-              'webhookSecret': sails.config.custom.zapierSandboxWebhookSecret,
-            }
-          })
-          .timeout(5000)
-          .tolerate(['non200Response', 'requestFailed', {name: 'TimeoutError'}], (err)=>{
-            // Note that Zapier responds with a 2xx status code even if something goes wrong, so just because this message is not logged doesn't mean everything is hunky dory.  More info: https://github.com/fleetdm/fleet/pull/6380#issuecomment-1204395762
-            sails.log.warn(`When trying to send information about a new Fleet release to Zapier, an error occured. Raw error: ${require('util').inspect(err)}`);
-            return;
-          });
-        }
-      }//ﬁ
+      // // Only continue if this release came from the fleetdm/fleet repo,
+      // if(owner === 'fleetdm' && repo === 'fleet') {
+      //   if(release
+      //     && _.startsWith(release.tag_name, 'fleet-v')// Only send requests for releases with tag names that start with 'fleet'
+      //     && _.endsWith(release.tag_name, '.0')// Only send requests if the release is a major or minor version. This works because all Fleet semvers have 2 periods.
+      //   ) {
+      //     // Send a POST request to Zapier with the release object.
+      //     await sails.helpers.http.post.with({
+      //       url: 'https://hooks.zapier.com/hooks/catch/3627242/3ozw6bk/',
+      //       data: {
+      //         'release': release,
+      //         'webhookSecret': sails.config.custom.zapierSandboxWebhookSecret,
+      //       }
+      //     })
+      //     .timeout(5000)
+      //     .tolerate(['non200Response', 'requestFailed', {name: 'TimeoutError'}], (err)=>{
+      //       // Note that Zapier responds with a 2xx status code even if something goes wrong, so just because this message is not logged doesn't mean everything is hunky dory.  More info: https://github.com/fleetdm/fleet/pull/6380#issuecomment-1204395762
+      //       sails.log.warn(`When trying to send information about a new Fleet release to Zapier, an error occured. Raw error: ${require('util').inspect(err)}`);
+      //       return;
+      //     });
+      //   }
+      // }//ﬁ
     } else if(ghNoun === 'projects_v2_item') {
       //
       //  ██████╗ ██████╗  ██████╗      ██╗███████╗ ██████╗████████╗███████╗    ██╗   ██╗██████╗

--- a/website/api/helpers/github-automations/get-is-pr-preapproved.js
+++ b/website/api/helpers/github-automations/get-is-pr-preapproved.js
@@ -8,7 +8,7 @@ module.exports = {
 
 
   inputs: {
-    repo: { type: 'string', example: 'fleet', required: true, isIn: ['fleet', 'confidential']},
+    repo: { type: 'string', example: 'fleet', required: true, isIn: ['fleet', 'confidential', 'fleet-gitops']},
     prNumber: { type: 'number', example: 382, required: true },
     githubUserToCheck: { type: 'string', example: 'mikermcneil', description: 'If excluded, then this returns `true` if all of the PRs changed paths are preapproved for SOMEONE.' },
     isGithubUserMaintainerOrDoesntMatter: { type: 'boolean', required: true, description: 'Whether (a) the user is a maintainer, or (b) it even matters for this check whether the user is a maintainer.' },// FUTURE: « this could be replaced with an extra GitHub API call herein, but doesn't seem worth it
@@ -85,8 +85,11 @@ module.exports = {
           numRemainingPathsToCheck--;
         }//∞
       });//∞
-
+      let repoHasMaintainersForTheEntireRepo = MAINTAINERS_BY_PATH['/'] || [];
       if (isMaintainerForAllChangedPathsStill && changedPaths.length < 100) {
+        return true;
+      } else if(repoHasMaintainersForTheEntireRepo.includes(githubUserToCheck)) {
+        // If this user is a maintainer for the entire repo, return true
         return true;
       } else {
         return false;

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -205,6 +205,10 @@ module.exports.custom = {
     'ee/maintained-apps/inputs': 'allenhouchins',
   },
 
+  fleetMdmGitopsRepoDRIByPath: {// fleetdm/fleet-gitops
+    '/': 'getvictor',// All files in the repo.
+  },
+
   // FUTURE: Support DRIs for confidential and other repos (except see other note above about a consolidated way to do it, to reduce these 4-6 config keys into one)
 
 
@@ -351,18 +355,20 @@ module.exports.custom = {
 
   },
 
-  fleetMdmGitopsRepoDRIByPath: {
-    '/': 'getvictor',
-  },
 
-  fleetMdmGitopsGithubRepoMaintainersByPath: {
-    '/': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
-    'lib': ['harrisonravazzolo'] ,
-    'teams': [ 'harrisonravazzolo'] ,
-    'default.yml': [ 'harrisonravazzolo'] ,
-    '.github': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
-    '.github-ci.yml': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
-    '.gitops.sh': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
+  fleetMdmGitopsGithubRepoMaintainersByPath: {// fleetdm/fleet-gitops
+    // Best practice file structure
+    'lib': ['harrisonravazzolo'],
+    'teams': [ 'harrisonravazzolo'],
+    'default.yml': [ 'harrisonravazzolo'],
+
+    // GitHub Action and GitLab CI/CD
+    '.github': ['lukeheath', 'noahtalerman', 'getvictor', 'allenhouchins'],
+    '.gitlab-ci.yml': ['lukeheath', 'noahtalerman', 'getvictor', 'allenhouchins'],
+    '.gitops.sh': ['lukeheath', 'noahtalerman', 'getvictor', 'allenhouchins'],
+
+    // Everything else
+    '/': ['lukeheath', 'noahtalerman', 'getvictor', 'allenhouchins'],
   },
 
   //  ███████╗ ██████╗██╗  ██╗███████╗███╗   ███╗ █████╗

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -351,8 +351,18 @@ module.exports.custom = {
 
   },
 
+  fleetMdmGitopsRepoDRIByPath: {
+    '/': 'getvictor',
+  },
+
   fleetMdmGitopsGithubRepoMaintainersByPath: {
-    '/': ['lukeheath'] // Future update this
+    '/': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
+    'lib': ['harrisonravazzolo'] ,
+    'teams': [ 'harrisonravazzolo'] ,
+    'default.yml': [ 'harrisonravazzolo'] ,
+    '.github': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
+    '.github-ci.yml': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
+    '.gitops.sh': ['lukeheath', 'noahtalerman', 'getvictor', 'harrisonravazzolo'],
   },
 
   //  ███████╗ ██████╗██╗  ██╗███████╗███╗   ███╗ █████╗


### PR DESCRIPTION
Changes:
- Updated the website's custom configuration to include maintainers and DRIs for the fleet-gitops repo.
- Update the get-is-pr-preapproved helper to support entire repo maintainers.
- Updated the receive-from-github webhook to support entire repo DRIs.