### PR TITLE
Switch dogfood SSO to Okta and add metadata URL

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -84,6 +84,7 @@ jobs:
           DOGFOOD_OKTA_CA_CERTIFICATE: ${{ secrets.DOGFOOD_OKTA_CA_CERTIFICATE }}
           DOGFOOD_OKTA_VERIFY_WINDOWS_URL: ${{ secrets.DOGFOOD_OKTA_VERIFY_WINDOWS_URL }}
           DOGFOOD_ENTRA_TENANT_ID: ${{ secrets.DOGFOOD_ENTRA_TENANT_ID }}
+          DOGFOOD_OKTA_METADATA_URL: ${{ secrets.DOGFOOD_OKTA_METADATA_URL }}
 
       - name: Notify on Gitops failure
         if: failure() && github.ref_name == 'main'

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -20,7 +20,6 @@ org_settings:
     end_user_authentication:
       entity_id: fleet-end-users
       idp_name: Okta
-      metadata:
       metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
     end_user_license_agreement: ../it-and-security/lib/macos/misc/eula.pdf
     apple_business_manager:
@@ -60,7 +59,6 @@ org_settings:
     entity_id: fleet-admins
     idp_image_url: ""
     idp_name: Okta
-    metadata: 
     metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
   webhook_settings:
     failing_policies_webhook:

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -18,11 +18,10 @@ org_settings:
     zendesk: []
   mdm:
     end_user_authentication:
-      entity_id: dogfood-eula.fleetdm.com
-      idp_name: Google Workspace
-      metadata: |-
-        $DOGFOOD_END_USER_SSO_METADATA
-      metadata_url: ""
+      entity_id: fleet-end-users
+      idp_name: Okta
+      metadata:
+      metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
     end_user_license_agreement: ../it-and-security/lib/macos/misc/eula.pdf
     apple_business_manager:
       - organization_name: Fleet Device Management Inc.
@@ -58,12 +57,11 @@ org_settings:
     enable_jit_provisioning: true
     enable_sso: true
     enable_sso_idp_login: true
-    entity_id: dogfood.fleetdm.com
+    entity_id: fleet-admins
     idp_image_url: ""
-    idp_name: Google Workspace
-    metadata: |-
-      $DOGFOOD_SSO_METADATA
-    metadata_url: ""
+    idp_name: Okta
+    metadata: 
+    metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
   webhook_settings:
     failing_policies_webhook:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL


### PR DESCRIPTION
Add DOGFOOD_OKTA_METADATA_URL to the dogfood GitOps workflow environment and update SSO configuration to use Okta. it-and-security/default.yml: change end_user_authentication.entity_id to fleet-end-users and org SSO entity_id to fleet-admins, set idp_name to Okta for both, remove inline metadata values, and point metadata_url to $DOGFOOD_OKTA_METADATA_URL. This centralizes IdP metadata retrieval via a secret URL.