### PR TITLE
Changes to set compliance status on Entra on Windows hosts when processing policy results

### DIFF
--- a/ee/server/service/condaccess/idp.go
+++ b/ee/server/service/condaccess/idp.go
@@ -432,7 +432,7 @@ func (p *deviceHealthSessionProvider) GetSession(w http.ResponseWriter, r *http.
 	if hostLite.TeamID != nil {
 		teamID = *hostLite.TeamID
 	}
-	conditionalAccessPolicyIDs, err := p.ds.GetPoliciesForConditionalAccess(ctx, teamID)
+	conditionalAccessPolicyIDs, err := p.ds.GetPoliciesForConditionalAccess(ctx, teamID, hostLite.Platform)
 	if err != nil {
 		handleInternalServerError(ctx, w, p.logger, "failed to get conditional access policies", err, "host_id", p.hostID)
 		return nil

--- a/ee/server/service/condaccess/idp_test.go
+++ b/ee/server/service/condaccess/idp_test.go
@@ -497,7 +497,6 @@ func TestParseSerialNumber(t *testing.T) {
 		require.NoError(t, err)
 		require.EqualValues(t, 10, result)
 	})
-
 }
 
 func TestServeSSO(t *testing.T) {
@@ -949,7 +948,7 @@ func TestDeviceHealthSessionProvider(t *testing.T) {
 				return tt.host, tt.hostErr
 			}
 
-			ds.GetPoliciesForConditionalAccessFunc = func(ctx context.Context, teamID uint) ([]uint, error) {
+			ds.GetPoliciesForConditionalAccessFunc = func(ctx context.Context, teamID uint, platform string) ([]uint, error) {
 				return tt.caPolicyIDs, nil
 			}
 

--- a/server/datastore/mysql/conditional_access_microsoft.go
+++ b/server/datastore/mysql/conditional_access_microsoft.go
@@ -95,7 +95,23 @@ func (ds *Datastore) LoadHostConditionalAccessStatus(ctx context.Context, hostID
 		}
 	}
 	hostConditionalAccessStatus.OSVersion = strings.TrimPrefix(hostConditionalAccessStatus.OSVersion, "macOS ")
+	if strings.HasPrefix(hostConditionalAccessStatus.OSVersion, "Windows") {
+		hostConditionalAccessStatus.OSVersion = extractWindowsBuildVersion(hostConditionalAccessStatus.OSVersion)
+	}
 	return &hostConditionalAccessStatus, nil
+}
+
+// extractWindowsBuildVersion extracts the build version from a Windows' hosts.os_version.
+// For Windows hosts, hosts.os_version is of the form e.g.:
+//   - "Windows Server 2025 Datacenter 24H2 10.0.26100.32230"
+//   - "Windows 10 Pro 22H2 10.0.19045.6456"
+func extractWindowsBuildVersion(osVersion string) string {
+	osVersion = strings.TrimSpace(osVersion)
+	lastSpace := strings.LastIndex(osVersion, " ")
+	if lastSpace == -1 {
+		return osVersion
+	}
+	return osVersion[lastSpace+1:]
 }
 
 func (ds *Datastore) CreateHostConditionalAccessStatus(ctx context.Context, hostID uint, deviceID string, userPrincipalName string) error {

--- a/server/datastore/mysql/conditional_access_microsoft_test.go
+++ b/server/datastore/mysql/conditional_access_microsoft_test.go
@@ -240,3 +240,53 @@ func testConditionalAccessHosts(t *testing.T, ds *Datastore) {
 	require.Nil(t, s.Managed)
 	require.Nil(t, s.Compliant)
 }
+
+func TestExtractWindowsBuildVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Windows 10 Pro",
+			input:    "Windows 10 Pro 22H2 10.0.19045.6456",
+			expected: "10.0.19045.6456",
+		},
+		{
+			name:     "Windows Server 2025 Datacenter",
+			input:    "Windows Server 2025 Datacenter 24H2 10.0.26100.32230",
+			expected: "10.0.26100.32230",
+		},
+		{
+			name:     "no spaces",
+			input:    "10.0.19045.6456",
+			expected: "10.0.19045.6456",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single word",
+			input:    "Windows",
+			expected: "Windows",
+		},
+		{
+			name:     "trailing whitespace",
+			input:    "Windows 10 Pro 22H2 10.0.19045.6456  ",
+			expected: "10.0.19045.6456",
+		},
+		{
+			name:     "leading whitespace",
+			input:    "  Windows 10 Pro 22H2 10.0.19045.6456",
+			expected: "10.0.19045.6456",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractWindowsBuildVersion(tt.input)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -2423,9 +2423,9 @@ func (ds *Datastore) GetCalendarPolicies(ctx context.Context, teamID uint) ([]fl
 	return policies, nil
 }
 
-func (ds *Datastore) GetPoliciesForConditionalAccess(ctx context.Context, teamID uint) ([]uint, error) {
+func (ds *Datastore) GetPoliciesForConditionalAccess(ctx context.Context, teamID uint, platform string) ([]uint, error) {
 	// Currently, the "Conditional access" feature is for macOS hosts only.
-	query := `SELECT id FROM policies WHERE team_id = ? AND conditional_access_enabled AND (platforms LIKE '%darwin%' OR platforms = '');`
+	query := `SELECT id FROM policies WHERE team_id = ? AND conditional_access_enabled AND (platforms LIKE '%` + platform + `%' OR platforms = '');`
 	var policyIDs []uint
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &policyIDs, query, teamID)
 	if err != nil {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -848,7 +848,7 @@ type Datastore interface {
 	GetPoliciesWithAssociatedScript(ctx context.Context, teamID uint, policyIDs []uint) ([]PolicyScriptData, error)
 	GetCalendarPolicies(ctx context.Context, teamID uint) ([]PolicyCalendarData, error)
 	// GetPoliciesForConditionalAccess returns the team policies that are configured for "Conditional access".
-	GetPoliciesForConditionalAccess(ctx context.Context, teamID uint) ([]uint, error)
+	GetPoliciesForConditionalAccess(ctx context.Context, teamID uint, platform string) ([]uint, error)
 	// GetPatchPolicy returns the patch policy associated with the title id
 	GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*PatchPolicyData, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -641,7 +641,7 @@ type GetPoliciesWithAssociatedScriptFunc func(ctx context.Context, teamID uint, 
 
 type GetCalendarPoliciesFunc func(ctx context.Context, teamID uint) ([]fleet.PolicyCalendarData, error)
 
-type GetPoliciesForConditionalAccessFunc func(ctx context.Context, teamID uint) ([]uint, error)
+type GetPoliciesForConditionalAccessFunc func(ctx context.Context, teamID uint, platform string) ([]uint, error)
 
 type GetPatchPolicyFunc func(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error)
 
@@ -6670,11 +6670,11 @@ func (s *DataStore) GetCalendarPolicies(ctx context.Context, teamID uint) ([]fle
 	return s.GetCalendarPoliciesFunc(ctx, teamID)
 }
 
-func (s *DataStore) GetPoliciesForConditionalAccess(ctx context.Context, teamID uint) ([]uint, error) {
+func (s *DataStore) GetPoliciesForConditionalAccess(ctx context.Context, teamID uint, platform string) ([]uint, error) {
 	s.mu.Lock()
 	s.GetPoliciesForConditionalAccessFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetPoliciesForConditionalAccessFunc(ctx, teamID)
+	return s.GetPoliciesForConditionalAccessFunc(ctx, teamID, platform)
 }
 
 func (s *DataStore) GetPatchPolicy(ctx context.Context, teamID *uint, titleID uint) (*fleet.PatchPolicyData, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -21495,7 +21495,7 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	p3 := pr.Policy
 
 	ctx := context.Background()
-	newHost := func(name string, teamID *uint, platform string) *fleet.Host {
+	newHost := func(name string, teamID *uint, platform string, osVersion string) *fleet.Host {
 		h, err := s.ds.NewHost(ctx, &fleet.Host{
 			DetailUpdatedAt: time.Now(),
 			LabelUpdatedAt:  time.Now(),
@@ -21507,6 +21507,8 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 			Hostname:        fmt.Sprintf("%s.%s.local", name, t.Name()),
 			Platform:        platform,
 			TeamID:          teamID,
+
+			OSVersion: osVersion,
 		})
 		require.NoError(t, err)
 		return h
@@ -21516,10 +21518,11 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	// Test A: host h1 in team t1.
 	//
 
-	h1 := newHost("h1", &t1.ID, "darwin")
+	h1 := newHost("h1", &t1.ID, "darwin", "macOS 15.7.3")
 	orbitKey := setOrbitEnrollment(t, h1, s.ds)
 	h1.OrbitNodeKey = &orbitKey
-	windowsHost1 := newHost("windowsHost1", &t1.ID, "windows")
+
+	windowsHost1 := newHost("windowsHost1", &t1.ID, "windows", "Windows 10 Pro 22H2 10.0.19045.6456")
 	windowsHostorbitKey := setOrbitEnrollment(t, windowsHost1, s.ds)
 	windowsHost1.OrbitNodeKey = &windowsHostorbitKey
 
@@ -21558,6 +21561,12 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 
 	// override value to reduce test time.
 	conditionalAccessSetWaitTime = 250 * time.Millisecond
+
+	var (
+		setDeviceName string
+		setOSName     string
+		setOSVersion  string
+	)
 	mockedConditionalAccessMicrosoftProxyInstance.setComplianceStatusFunc = func(
 		ctx context.Context,
 		tenantID string, secret string,
@@ -21568,6 +21577,9 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 		compliant bool,
 		lastCheckInTime time.Time,
 	) (*conditional_access_microsoft_proxy.SetComplianceStatusResponse, error) {
+		setDeviceName = deviceName
+		setOSName = osName
+		setOSVersion = osVersion
 		return &conditional_access_microsoft_proxy.SetComplianceStatusResponse{
 			MessageID: "messageID",
 		}, nil
@@ -21588,6 +21600,7 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 		}, nil
 	}
 
+	// Post policy results for the macOS host.
 	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
 		h1,
 		map[uint]*bool{
@@ -21613,7 +21626,38 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	require.NotNil(t, h1s.Compliant)
 	require.True(t, *h1s.Compliant) // the two configured policies are passing
 
-	// Enroll to MDM to update managed status.
+	// Check fields to set on Entra are correct.
+	require.Equal(t, h1.Hostname, setDeviceName)
+	require.Equal(t, "15.7.3", setOSVersion)
+	require.Equal(t, "macOS", setOSName)
+
+	// Post policy results for the windows host.
+	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		windowsHost1,
+		map[uint]*bool{
+			cp1.ID: ptr.Bool(true),
+			cp2.ID: ptr.Bool(true),
+			p3.ID:  ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+
+	time.Sleep(1 * time.Second)
+
+	wh1s, err = s.ds.LoadHostConditionalAccessStatus(ctx, windowsHost1.ID)
+	require.NoError(t, err)
+	require.Equal(t, "entraDeviceIDWindows", wh1s.DeviceID)
+	require.Equal(t, "", wh1s.UserPrincipalName)
+	require.NotNil(t, wh1s.Managed)
+	require.False(t, *wh1s.Managed) // not MDM enrolled
+	require.NotNil(t, wh1s.Compliant)
+	require.True(t, *wh1s.Compliant) // the two configured policies are passing
+
+	// Check fields to set on Entra are correct.
+	require.Equal(t, windowsHost1.Hostname, setDeviceName)
+	require.Equal(t, "10.0.19045.6456", setOSVersion)
+	require.Equal(t, "windows", setOSName)
+
+	// Enroll macOS host to MDM to update managed status.
 	err = s.ds.SetOrUpdateMDMData(ctx,
 		h1.ID, false, true /* enrolled */, s.server.URL, false, /* installedFromDEP */
 		"Fleet" /* MDM name */, "" /* fleetEnrollmentRef */, false, /* isPersonalEnrollment */
@@ -21648,9 +21692,37 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	require.NotNil(t, h1s.Compliant)
 	require.True(t, *h1s.Compliant) // the two configured policies are passing
 
+	// Enroll Windows host to MDM to update managed status.
+	err = s.ds.SetOrUpdateMDMData(ctx,
+		windowsHost1.ID, false, true /* enrolled */, s.server.URL, false, /* installedFromDEP */
+		"Fleet" /* MDM name */, "" /* fleetEnrollmentRef */, false, /* isPersonalEnrollment */
+	)
+	require.NoError(t, err)
+
+	// Publish same policy results.
+	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		windowsHost1,
+		map[uint]*bool{
+			cp1.ID: ptr.Bool(true),
+			cp2.ID: ptr.Bool(true),
+			p3.ID:  ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+
+	time.Sleep(1 * time.Second)
+
+	wh1s, err = s.ds.LoadHostConditionalAccessStatus(ctx, windowsHost1.ID)
+	require.NoError(t, err)
+	require.Equal(t, "entraDeviceIDWindows", wh1s.DeviceID)
+	require.Equal(t, "", wh1s.UserPrincipalName)
+	require.NotNil(t, wh1s.Managed)
+	require.True(t, *wh1s.Managed) // now should be MDM enrolled
+	require.NotNil(t, wh1s.Compliant)
+	require.True(t, *wh1s.Compliant) // the two configured policies are passing
+
 	setDone = make(chan struct{})
 
-	// Now the host is failing a compliance policy.
+	// Now the macOS host is failing a compliance policy.
 	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
 		h1,
 		map[uint]*bool{
@@ -21674,7 +21746,28 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	require.NotNil(t, h1s.Managed)
 	require.True(t, *h1s.Managed)
 	require.NotNil(t, h1s.Compliant)
-	require.False(t, *h1s.Compliant) // now the host is non-compliant
+	require.False(t, *h1s.Compliant) // now the macOS host is non-compliant
+
+	// Now the Windows host is failing a compliance policy.
+	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		windowsHost1,
+		map[uint]*bool{
+			cp1.ID: ptr.Bool(true),
+			cp2.ID: ptr.Bool(false),
+			p3.ID:  ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+
+	time.Sleep(1 * time.Second)
+
+	wh1s, err = s.ds.LoadHostConditionalAccessStatus(ctx, windowsHost1.ID)
+	require.NoError(t, err)
+	require.Equal(t, "entraDeviceIDWindows", wh1s.DeviceID)
+	require.Equal(t, "", wh1s.UserPrincipalName)
+	require.NotNil(t, wh1s.Managed)
+	require.True(t, *wh1s.Managed)
+	require.NotNil(t, wh1s.Compliant)
+	require.False(t, *wh1s.Compliant) // now the Windows host is non-compliant
 
 	// Now nothing changes so there's no compliance operation on the proxy.
 	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
@@ -21686,7 +21779,7 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 		},
 	), http.StatusOK, &distributedResp)
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(2 * time.Second)
 
 	h1s, err = s.ds.LoadHostConditionalAccessStatus(ctx, h1.ID)
 	require.NoError(t, err)
@@ -21697,11 +21790,32 @@ func (s *integrationEnterpriseTestSuite) TestConditionalAccessPolicies() {
 	require.NotNil(t, h1s.Compliant)
 	require.False(t, *h1s.Compliant)
 
+	// Now nothing changes on the Windows host so there's no compliance operation on the proxy.
+	s.DoJSON("POST", "/api/osquery/distributed/write", genDistributedReqWithPolicyResults(
+		windowsHost1,
+		map[uint]*bool{
+			cp1.ID: ptr.Bool(true),
+			cp2.ID: ptr.Bool(false),
+			p3.ID:  ptr.Bool(false),
+		},
+	), http.StatusOK, &distributedResp)
+
+	time.Sleep(5 * time.Second)
+
+	wh1s, err = s.ds.LoadHostConditionalAccessStatus(ctx, windowsHost1.ID)
+	require.NoError(t, err)
+	require.Equal(t, "entraDeviceIDWindows", wh1s.DeviceID)
+	require.Equal(t, "", wh1s.UserPrincipalName)
+	require.NotNil(t, wh1s.Managed)
+	require.True(t, *wh1s.Managed)
+	require.NotNil(t, wh1s.Compliant)
+	require.False(t, *wh1s.Compliant)
+
 	//
 	// Test B: host h2 in "No team".
 	//
 
-	h2 := newHost("h2", nil, "darwin")
+	h2 := newHost("h2", nil, "darwin", "macOS 26.3")
 	orbitKey2 := setOrbitEnrollment(t, h2, s.ds)
 	h2.OrbitNodeKey = &orbitKey2
 

--- a/server/service/osquery.go
+++ b/server/service/osquery.go
@@ -1159,8 +1159,8 @@ func (svc *Service) SubmitDistributedQueryResults(
 			logging.WithErr(ctx, err)
 		}
 
-		if host.Platform == "darwin" {
-			if err := svc.processConditionalAccessForNewlyFailingPolicies(ctx, host.ID, host.TeamID, host.OrbitNodeKey, policyResults); err != nil {
+		if host.Platform == "darwin" || host.Platform == "windows" {
+			if err := svc.processConditionalAccessForNewlyFailingPolicies(ctx, host.ID, host.TeamID, host.OrbitNodeKey, host.Platform, policyResults); err != nil {
 				logging.WithErr(ctx, err)
 			}
 		}
@@ -2487,6 +2487,7 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 	hostID uint,
 	hostTeamID *uint,
 	hostOrbitNodeKey *string,
+	hostPlatform string,
 	incomingPolicyResults map[uint]*bool,
 ) error {
 	if hostOrbitNodeKey == nil || *hostOrbitNodeKey == "" {
@@ -2535,7 +2536,7 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 	}
 
 	// Get policies configured for conditional access.
-	conditionalAccessPolicyIDs, err := svc.ds.GetPoliciesForConditionalAccess(ctx, policyTeamID)
+	conditionalAccessPolicyIDs, err := svc.ds.GetPoliciesForConditionalAccess(ctx, policyTeamID, hostPlatform)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "failed to get policies with conditional access")
 	}
@@ -2562,13 +2563,14 @@ func (svc *Service) processConditionalAccessForNewlyFailingPolicies(
 		return nil
 	}
 
-	svc.setHostConditionalAccessAsync(hostID, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet)
+	svc.setHostConditionalAccessAsync(hostID, hostPlatform, hostConditionalAccessStatus, mdmEnrolled, hostIsCompliantInFleet)
 
 	return nil
 }
 
 func (svc *Service) setHostConditionalAccessAsync(
 	hostID uint,
+	hostPlatform string,
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
@@ -2576,11 +2578,12 @@ func (svc *Service) setHostConditionalAccessAsync(
 	go func() {
 		logger := svc.logger.With(
 			"host_id", hostID,
+			"platform", hostPlatform,
 			"managed", managed,
 			"compliant", compliant,
 		)
 		start := time.Now()
-		if err := svc.setHostConditionalAccess(hostID, hostConditionalAccessStatus, managed, compliant); err != nil {
+		if err := svc.setHostConditionalAccess(hostID, hostPlatform, hostConditionalAccessStatus, managed, compliant); err != nil {
 			logger.ErrorContext(context.TODO(), "set host conditional access", "took", time.Since(start), "err", err)
 		}
 		logger.DebugContext(context.TODO(), "set host conditional access", "took", time.Since(start))
@@ -2593,6 +2596,7 @@ var conditionalAccessSetWaitTime = 10 * time.Second
 
 func (svc *Service) setHostConditionalAccess(
 	hostID uint,
+	hostPlatform string,
 	hostConditionalAccessStatus *fleet.HostConditionalAccessStatus,
 	managed bool,
 	compliant bool,
@@ -2605,10 +2609,18 @@ func (svc *Service) setHostConditionalAccess(
 	}
 	logger := svc.logger.With(
 		"host_id", hostID,
+		"platform", hostPlatform,
 		"managed", managed,
 		"compliant", compliant,
 	)
 	logger.DebugContext(ctx, "set compliance status")
+
+	// Currently, only macOS and Windows are supported.
+	osName := "macOS" // "macOS" is what Entra requires for darwin hosts.
+	if hostPlatform == "windows" {
+		osName = "windows"
+	}
+
 	response, err := svc.conditionalAccessMicrosoftProxy.SetComplianceStatus(ctx,
 		integration.TenantID,
 		integration.ProxyServerSecret,
@@ -2618,7 +2630,7 @@ func (svc *Service) setHostConditionalAccess(
 
 		managed,
 		hostConditionalAccessStatus.DisplayName,
-		"macOS",
+		osName,
 		hostConditionalAccessStatus.OSVersion,
 		compliant,
 		time.Now().UTC(),
@@ -2626,38 +2638,46 @@ func (svc *Service) setHostConditionalAccess(
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "failed to set compliance status")
 	}
-	const (
-		timeout = 1 * time.Minute
-	)
-	logger.DebugContext(ctx, "set compliance status message sent")
-	startTime := time.Now()
-	for range time.Tick(conditionalAccessSetWaitTime) {
-		if time.Since(startTime) > timeout {
-			return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
-		}
-		logger.DebugContext(ctx, "get compliance status message wait")
-		messageStatus, err := svc.conditionalAccessMicrosoftProxy.GetMessageStatus(ctx,
-			integration.TenantID, integration.ProxyServerSecret, response.MessageID,
+
+	//
+	// The macOS API is asynchronous, the Windows API is not.
+	// So we only need to retrieve the status of the "request" for macOS hosts.
+	//
+
+	if hostPlatform == "darwin" {
+		const (
+			timeout = 1 * time.Minute
 		)
-		if err != nil {
-			// Retry again in case of network or transient errors.
-			logger.InfoContext(ctx, "get message status, retrying", "err", err)
-			continue
-		}
-		if messageStatus.Status == conditional_access_microsoft_proxy.MessageStatusCompleted {
-			logger.DebugContext(ctx, "set device compliance status completed",
-				"took", time.Since(startTime),
+		logger.DebugContext(ctx, "set compliance status message sent")
+		startTime := time.Now()
+		for range time.Tick(conditionalAccessSetWaitTime) {
+			if time.Since(startTime) > timeout {
+				return ctxerr.Errorf(ctx, "timeout waiting for message after %s", time.Since(startTime))
+			}
+			logger.DebugContext(ctx, "get compliance status message wait")
+			messageStatus, err := svc.conditionalAccessMicrosoftProxy.GetMessageStatus(ctx,
+				integration.TenantID, integration.ProxyServerSecret, response.MessageID,
 			)
-			break
+			if err != nil {
+				// Retry again in case of network or transient errors.
+				logger.InfoContext(ctx, "get message status, retrying", "err", err)
+				continue
+			}
+			if messageStatus.Status == conditional_access_microsoft_proxy.MessageStatusCompleted {
+				logger.DebugContext(ctx, "set device compliance status completed",
+					"took", time.Since(startTime),
+				)
+				break
+			}
+			detail := ""
+			if messageStatus.Detail != nil {
+				detail = *messageStatus.Detail
+			}
+			logger.InfoContext(ctx, "get message status, retrying",
+				"status", messageStatus.Status,
+				"detail", detail,
+			)
 		}
-		detail := ""
-		if messageStatus.Detail != nil {
-			detail = *messageStatus.Detail
-		}
-		logger.InfoContext(ctx, "get message status, retrying",
-			"status", messageStatus.Status,
-			"detail", detail,
-		)
 	}
 
 	if err := svc.ds.SetHostConditionalAccessStatus(ctx, hostID, managed, compliant); err != nil {


### PR DESCRIPTION
Resolves #41478

- Generic changes file for the whole feature included in a previous PR.
- Tested with new changes in the proxy merged in https://github.com/fleetdm/fleet/commit/5a266bfaca3fa2b4a1f942ef130ad478b88b7a13.

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)
- [X] QA'd all new/changed functionality manually