### PR TITLE
Add secrets in dogfood-gitops workflow to support Okta SSO

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -84,7 +84,8 @@ jobs:
           DOGFOOD_OKTA_CA_CERTIFICATE: ${{ secrets.DOGFOOD_OKTA_CA_CERTIFICATE }}
           DOGFOOD_OKTA_VERIFY_WINDOWS_URL: ${{ secrets.DOGFOOD_OKTA_VERIFY_WINDOWS_URL }}
           DOGFOOD_ENTRA_TENANT_ID: ${{ secrets.DOGFOOD_ENTRA_TENANT_ID }}
-          DOGFOOD_OKTA_METADATA_URL: ${{ secrets.DOGFOOD_OKTA_METADATA_URL }}
+          DOGFOOD_OKTA_METADATA_URL_ADMINS: ${{ secrets.DOGFOOD_OKTA_METADATA_URL_ADMINS }}
+          DOGFOOD_OKTA_METADATA_URL_END_USERS: ${{ secrets.DOGFOOD_OKTA_METADATA_URL_END_USERS }}
 
       - name: Notify on Gitops failure
         if: failure() && github.ref_name == 'main'

--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -20,7 +20,7 @@ org_settings:
     end_user_authentication:
       entity_id: fleet-end-users
       idp_name: Okta
-      metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
+      metadata_url: "$DOGFOOD_OKTA_METADATA_URL_END_USERS"
     end_user_license_agreement: ../it-and-security/lib/macos/misc/eula.pdf
     apple_business_manager:
       - organization_name: Fleet Device Management Inc.
@@ -59,7 +59,7 @@ org_settings:
     entity_id: fleet-admins
     idp_image_url: ""
     idp_name: Okta
-    metadata_url: "$DOGFOOD_OKTA_METADATA_URL"
+    metadata_url: "$DOGFOOD_OKTA_METADATA_URL_ADMINS"
   webhook_settings:
     failing_policies_webhook:
       destination_url: $DOGFOOD_FAILING_POLICIES_WEBHOOK_URL


### PR DESCRIPTION
This pull request updates the environment variable configuration for Okta metadata URLs in the `dogfood-gitops` GitHub Actions workflow. Instead of using a single metadata URL, the workflow now distinguishes between admin and end user metadata URLs.

Workflow configuration changes:

* Split the `DOGFOOD_OKTA_METADATA_URL` environment variable into two separate variables: `DOGFOOD_OKTA_METADATA_URL_ADMINS` and `DOGFOOD_OKTA_METADATA_URL_END_USERS` in the `.github/workflows/dogfood-gitops.yml` workflow file.