### PR TITLE
Update 1Password macOS policy to enable scheduled maintenance

### DIFF
--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -1,7 +1,7 @@
 - name: macOS - 1Password up to date
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.8') < 0);
   critical: false
-  description: The host may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Check for updates using 1Password's built-in update functionality or download the latest version from self-service.
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
   platform: darwin
-  calendar_events_enabled: false
+  calendar_events_enabled: true


### PR DESCRIPTION
Refine policy description and resolution messaging for the macOS 1Password check: change 'The host' to 'This device', direct users to download from Self-service and note automatic install during scheduled maintenance, and enable calendar events by setting calendar_events_enabled to true.