### PR TITLE
Set recovery key: add remove state

### DIFF
--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -7347,11 +7347,20 @@ func (ds *Datastore) GetHostRecoveryLockPassword(ctx context.Context, hostUUID s
 }
 
 func (ds *Datastore) GetHostRecoveryLockPasswordStatus(ctx context.Context, hostUUID string) (*fleet.HostMDMRecoveryLockPassword, error) {
-	const stmt = `SELECT status, COALESCE(error_message, '') AS detail FROM host_recovery_key_passwords WHERE host_uuid = ? AND deleted = 0`
+	const stmt = `
+		SELECT
+			status,
+			operation_type,
+			COALESCE(error_message, '') AS detail,
+			encrypted_password IS NOT NULL AS password_available
+		FROM host_recovery_key_passwords
+		WHERE host_uuid = ? AND deleted = 0`
 
 	var row struct {
-		Status *fleet.MDMDeliveryStatus `db:"status"`
-		Detail string                   `db:"detail"`
+		Status            *fleet.MDMDeliveryStatus `db:"status"`
+		OperationType     fleet.MDMOperationType   `db:"operation_type"`
+		Detail            string                   `db:"detail"`
+		PasswordAvailable bool                     `db:"password_available"`
 	}
 	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, stmt, hostUUID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -7363,13 +7372,15 @@ func (ds *Datastore) GetHostRecoveryLockPasswordStatus(ctx context.Context, host
 	// Treat NULL status as pending (retry state after failed command enqueue)
 	status := row.Status
 	if status == nil {
-		status = ptr.T(fleet.MDMDeliveryPending)
+		status = &fleet.MDMDeliveryPending
 	}
 
-	return &fleet.HostMDMRecoveryLockPassword{
-		Status: status,
-		Detail: row.Detail,
-	}, nil
+	result := &fleet.HostMDMRecoveryLockPassword{
+		Detail:            row.Detail,
+		PasswordAvailable: row.PasswordAvailable,
+	}
+	result.SetRawStatus(status, row.OperationType)
+	return result, nil
 }
 
 func (ds *Datastore) GetHostsForRecoveryLockAction(ctx context.Context) ([]string, error) {

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -10945,7 +10945,7 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		assert.Nil(t, status)
 	})
 
-	t.Run("returns pending status", func(t *testing.T) {
+	t.Run("returns enforcing status for pending install", func(t *testing.T) {
 		host := test.NewHost(t, ds, "pending-rlp-host", "1.2.6.2", "pendingrlpkey", "pendingrlpuuid", time.Now())
 		pw := apple_mdm.GenerateRecoveryLockPassword()
 		err := ds.SetHostsRecoveryLockPasswords(ctx, []fleet.HostRecoveryLockPasswordPayload{{HostUUID: host.UUID, Password: pw}})
@@ -10954,9 +10954,11 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
 		require.NoError(t, err)
 		require.NotNil(t, status)
+		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.MDMDeliveryPending, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusEnforcing, *status.Status)
 		assert.Empty(t, status.Detail)
+		assert.True(t, status.PasswordAvailable)
 	})
 
 	t.Run("returns verified status", func(t *testing.T) {
@@ -10970,9 +10972,11 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
 		require.NoError(t, err)
 		require.NotNil(t, status)
+		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.MDMDeliveryVerified, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusVerified, *status.Status)
 		assert.Empty(t, status.Detail)
+		assert.True(t, status.PasswordAvailable)
 	})
 
 	t.Run("returns failed status with error message", func(t *testing.T) {
@@ -10987,8 +10991,9 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
 		require.NoError(t, err)
 		require.NotNil(t, status)
+		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.MDMDeliveryFailed, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusFailed, *status.Status)
 		assert.Equal(t, errMsg, status.Detail)
 	})
 
@@ -11005,12 +11010,13 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
 		require.NoError(t, err)
 		require.NotNil(t, status)
+		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.MDMDeliveryVerifying, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusVerifying, *status.Status)
 		assert.Empty(t, status.Detail)
 	})
 
-	t.Run("returns pending status when status column is NULL (retry state)", func(t *testing.T) {
+	t.Run("returns enforcing status when status column is NULL (retry state)", func(t *testing.T) {
 		host := test.NewHost(t, ds, "null-status-host", "1.2.6.6", "nullstatuskey", "nullstatusuuid", time.Now())
 		pw := apple_mdm.GenerateRecoveryLockPassword()
 		err := ds.SetHostsRecoveryLockPasswords(ctx, []fleet.HostRecoveryLockPasswordPayload{{HostUUID: host.UUID, Password: pw}})
@@ -11022,10 +11028,60 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
 		require.NoError(t, err)
 		require.NotNil(t, status)
-		// NULL status is coalesced to pending for API response
+		// NULL status is coalesced to pending, which becomes enforcing
+		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.MDMDeliveryPending, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusEnforcing, *status.Status)
 		assert.Empty(t, status.Detail)
+	})
+
+	t.Run("returns removing_enforcement status for pending removal after PopulateStatus", func(t *testing.T) {
+		host := test.NewHost(t, ds, "remove-pending-host", "1.2.6.7", "removependingkey", "removependinguuid", time.Now())
+		pw := apple_mdm.GenerateRecoveryLockPassword()
+		err := ds.SetHostsRecoveryLockPasswords(ctx, []fleet.HostRecoveryLockPasswordPayload{{HostUUID: host.UUID, Password: pw}})
+		require.NoError(t, err)
+		err = ds.SetRecoveryLockVerified(ctx, host.UUID)
+		require.NoError(t, err)
+		// Set operation_type to 'remove' and status to 'pending' (simulates pending removal)
+		_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE host_recovery_key_passwords SET operation_type = ?, status = ? WHERE host_uuid = ?`,
+			fleet.MDMOperationTypeRemove, fleet.MDMDeliveryPending, host.UUID)
+		require.NoError(t, err)
+
+		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+
+		// Before PopulateStatus, Status is nil (raw status is internal)
+		assert.Nil(t, status.Status)
+
+		// After PopulateStatus, Status is removing_enforcement
+		status.PopulateStatus()
+		require.NotNil(t, status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusRemovingEnforcement, *status.Status)
+	})
+
+	t.Run("returns failed status when operation_type is remove and status is failed", func(t *testing.T) {
+		host := test.NewHost(t, ds, "remove-failed-host", "1.2.6.8", "removefailedkey", "removefaileduuid", time.Now())
+		pw := apple_mdm.GenerateRecoveryLockPassword()
+		err := ds.SetHostsRecoveryLockPasswords(ctx, []fleet.HostRecoveryLockPasswordPayload{{HostUUID: host.UUID, Password: pw}})
+		require.NoError(t, err)
+		err = ds.SetRecoveryLockVerified(ctx, host.UUID)
+		require.NoError(t, err)
+		// Set operation_type to 'remove' and status to 'failed'
+		errMsg := "ClearRecoveryLock command failed"
+		_, err = ds.writer(ctx).ExecContext(ctx, `UPDATE host_recovery_key_passwords SET operation_type = ?, status = ?, error_message = ? WHERE host_uuid = ?`,
+			fleet.MDMOperationTypeRemove, fleet.MDMDeliveryFailed, errMsg, host.UUID)
+		require.NoError(t, err)
+
+		status, err := ds.GetHostRecoveryLockPasswordStatus(ctx, host.UUID)
+		require.NoError(t, err)
+		require.NotNil(t, status)
+		assert.Equal(t, errMsg, status.Detail)
+
+		// After PopulateStatus, Status is failed
+		status.PopulateStatus()
+		require.NotNil(t, status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusFailed, *status.Status)
 	})
 }
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -11012,7 +11012,7 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		require.NotNil(t, status)
 		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.RecoveryLockStatusVerifying, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusPending, *status.Status)
 		assert.Empty(t, status.Detail)
 	})
 

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -10956,7 +10956,7 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		require.NotNil(t, status)
 		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.RecoveryLockStatusEnforcing, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusPending, *status.Status)
 		assert.Empty(t, status.Detail)
 		assert.True(t, status.PasswordAvailable)
 	})
@@ -11031,7 +11031,7 @@ func testGetHostRecoveryLockPasswordStatus(t *testing.T, ds *Datastore) {
 		// NULL status is coalesced to pending, which becomes enforcing
 		status.PopulateStatus()
 		require.NotNil(t, status.Status)
-		assert.Equal(t, fleet.RecoveryLockStatusEnforcing, *status.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusPending, *status.Status)
 		assert.Empty(t, status.Detail)
 	})
 

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -603,8 +603,60 @@ type HostMDMDiskEncryption struct {
 }
 
 type HostMDMRecoveryLockPassword struct {
-	Status *MDMDeliveryStatus `json:"status" db:"-" csv:"-"`
-	Detail string             `json:"detail" db:"-" csv:"-"`
+	Status            *RecoveryLockStatus `json:"status" db:"-" csv:"-"`
+	Detail            string              `json:"detail" db:"-" csv:"-"`
+	PasswordAvailable bool                `json:"password_available" db:"-" csv:"-"`
+	// rawStatus and operationType are used internally to determine the status translation, not serialized.
+	rawStatus     *MDMDeliveryStatus `json:"-" db:"-" csv:"-"`
+	operationType MDMOperationType   `json:"-" db:"-" csv:"-"`
+}
+
+// RecoveryLockStatus represents the status of recovery lock password enforcement.
+type RecoveryLockStatus string
+
+const (
+	RecoveryLockStatusVerified            RecoveryLockStatus = "verified"
+	RecoveryLockStatusVerifying           RecoveryLockStatus = "verifying"
+	RecoveryLockStatusPending             RecoveryLockStatus = "pending"
+	RecoveryLockStatusFailed              RecoveryLockStatus = "failed"
+	RecoveryLockStatusRemovingEnforcement RecoveryLockStatus = "removing_enforcement"
+)
+
+func (s RecoveryLockStatus) addrOf() *RecoveryLockStatus {
+	return &s
+}
+
+// PopulateStatus converts the raw MDMDeliveryStatus based on operation type to RecoveryLockStatus.
+func (r *HostMDMRecoveryLockPassword) PopulateStatus() {
+	if r == nil || r.rawStatus == nil {
+		return
+	}
+	switch r.operationType {
+	case MDMOperationTypeRemove:
+		switch {
+		case *r.rawStatus == MDMDeliveryFailed:
+			r.Status = RecoveryLockStatusFailed.addrOf()
+		default:
+			r.Status = RecoveryLockStatusRemovingEnforcement.addrOf()
+		}
+	default:
+		switch *r.rawStatus {
+		case MDMDeliveryFailed:
+			r.Status = RecoveryLockStatusFailed.addrOf()
+		case MDMDeliveryVerified:
+			r.Status = RecoveryLockStatusVerified.addrOf()
+		case MDMDeliveryVerifying:
+			r.Status = RecoveryLockStatusVerifying.addrOf()
+		case MDMDeliveryPending:
+			r.Status = RecoveryLockStatusPending.addrOf()
+		}
+	}
+}
+
+// SetRawStatus sets the raw status and operation type for later translation.
+func (r *HostMDMRecoveryLockPassword) SetRawStatus(status *MDMDeliveryStatus, opType MDMOperationType) {
+	r.rawStatus = status
+	r.operationType = opType
 }
 
 type DiskEncryptionStatus string

--- a/server/fleet/hosts.go
+++ b/server/fleet/hosts.go
@@ -616,7 +616,6 @@ type RecoveryLockStatus string
 
 const (
 	RecoveryLockStatusVerified            RecoveryLockStatus = "verified"
-	RecoveryLockStatusVerifying           RecoveryLockStatus = "verifying"
 	RecoveryLockStatusPending             RecoveryLockStatus = "pending"
 	RecoveryLockStatusFailed              RecoveryLockStatus = "failed"
 	RecoveryLockStatusRemovingEnforcement RecoveryLockStatus = "removing_enforcement"
@@ -645,9 +644,7 @@ func (r *HostMDMRecoveryLockPassword) PopulateStatus() {
 			r.Status = RecoveryLockStatusFailed.addrOf()
 		case MDMDeliveryVerified:
 			r.Status = RecoveryLockStatusVerified.addrOf()
-		case MDMDeliveryVerifying:
-			r.Status = RecoveryLockStatusVerifying.addrOf()
-		case MDMDeliveryPending:
+		case MDMDeliveryVerifying, MDMDeliveryPending:
 			r.Status = RecoveryLockStatusPending.addrOf()
 		}
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1751,6 +1751,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 						return nil, ctxerr.Wrap(ctx, err, "get host recovery lock password status")
 					}
 					if rlpStatus != nil {
+						rlpStatus.PopulateStatus()
 						host.MDM.OSSettings.RecoveryLockPassword = *rlpStatus
 					}
 				}

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -811,10 +811,11 @@ func TestHostDetailsRecoveryLockPasswordStatus(t *testing.T) {
 	t.Run("recovery lock password status populates for macOS", func(t *testing.T) {
 		failedStatus := fleet.MDMDeliveryFailed
 		ds.GetHostRecoveryLockPasswordStatusFunc = func(ctx context.Context, hostUUID string) (*fleet.HostMDMRecoveryLockPassword, error) {
-			return &fleet.HostMDMRecoveryLockPassword{
-				Status: &failedStatus,
+			result := &fleet.HostMDMRecoveryLockPassword{
 				Detail: "SetRecoveryLock command failed",
-			}, nil
+			}
+			result.SetRawStatus(&failedStatus, fleet.MDMOperationTypeInstall)
+			return result, nil
 		}
 
 		ctx := license.NewContext(t.Context(), &fleet.LicenseInfo{Tier: fleet.TierPremium})
@@ -826,7 +827,7 @@ func TestHostDetailsRecoveryLockPasswordStatus(t *testing.T) {
 		require.NotNil(t, hostDetail)
 		require.True(t, ds.GetHostRecoveryLockPasswordStatusFuncInvoked)
 		require.NotNil(t, hostDetail.MDM.OSSettings.RecoveryLockPassword.Status)
-		assert.Equal(t, fleet.MDMDeliveryFailed, *hostDetail.MDM.OSSettings.RecoveryLockPassword.Status)
+		assert.Equal(t, fleet.RecoveryLockStatusFailed, *hostDetail.MDM.OSSettings.RecoveryLockPassword.Status)
 		assert.Equal(t, "SetRecoveryLock command failed", hostDetail.MDM.OSSettings.RecoveryLockPassword.Detail)
 	})
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41930 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced Recovery Lock Password status model with explicit states (pending, verified, failed, removing_enforcement) and clearer status translation.
  * Added a Password Available indicator to surface whether a recovery password is present.

* **Bug Fixes**
  * Improved handling of missing/raw status values so pending retries display correctly.
  * Ensures recovery lock status is computed before being shown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->