### PR TITLE
First pass at creating the ACME bounded context

### DIFF
--- a/server/mdm/acme/api/directory_nonce.go
+++ b/server/mdm/acme/api/directory_nonce.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+)
+
+type DirectoryNonceService interface {
+	NewNonce(ctx context.Context, identifier string) (string, error)
+	GetDirectory(ctx context.Context, identifier string) (*types.Directory, error)
+}

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -1,0 +1,50 @@
+// Package http provides HTTP request and response types for the ACME bounded context.
+// These types are used exclusively by the ACME endpoint handler.
+package http
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+)
+
+type GetNewNonceRequest struct {
+	// HTTPMethod used to make this request, populated by the parse custom URL
+	// tag function of the ACME bounded context, which is one of the only ways
+	// with our framework to access the *http.Request value.
+	HTTPMethod string `url:"http_method"`
+	Identifier string `url:"identifier"`
+}
+
+type GetNewNonceResponse struct {
+	HTTPMethod string
+	Nonce      string
+	Err        error `json:"error,omitempty"`
+}
+
+// Error implements the platform_http.Errorer interface.
+func (r GetNewNonceResponse) Error() error { return r.Err }
+
+func (r GetNewNonceResponse) HijackRender(ctx context.Context, w http.ResponseWriter) {
+	w.Header().Set("Replay-Nonce", r.Nonce)
+	w.Header().Set("Cache-Control", "no-store")
+
+	if r.HTTPMethod == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type GetDirectoryRequest struct {
+	Identifier string `url:"identifier"`
+}
+
+type GetDirectoryResponse struct {
+	*types.Directory
+	Err error `json:"error,omitempty"`
+}
+
+// Error implements the platform_http.Errorer interface.
+func (r GetDirectoryResponse) Error() error { return r.Err }

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -1,0 +1,9 @@
+// Package api provides the public API for the ACME bounded context.
+// External code should use this package to interact with ACME.
+package api
+
+// Service is the composite interface for the ACME bounded context.
+// It embeds all method-specific interfaces. Bootstrap returns this type.
+type Service interface {
+	DirectoryNonceService
+}

--- a/server/mdm/acme/bootstrap/bootstrap.go
+++ b/server/mdm/acme/bootstrap/bootstrap.go
@@ -1,0 +1,31 @@
+// Package bootstrap provides the public entry point for the ACME bounded context.
+// It wires together internal components and exposes them for use in serve.go.
+package bootstrap
+
+import (
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/mysql"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/service"
+	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
+	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"github.com/go-kit/kit/endpoint"
+)
+
+// New creates a new ACME bounded context and returns its service and route handler.
+func New(
+	dbConns *platform_mysql.DBConnections,
+	authorizer platform_authz.Authorizer,
+	logger *slog.Logger,
+) (api.Service, func(authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc) {
+	ds := mysql.NewDatastore(dbConns, logger)
+	svc := service.NewService(authorizer, ds, logger)
+
+	routesFn := func(authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc {
+		return service.GetRoutes(svc, authMiddleware)
+	}
+
+	return svc, routesFn
+}

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -1,0 +1,34 @@
+// Package mysql provides the MySQL datastore implementation for the ACME bounded context.
+package mysql
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"github.com/jmoiron/sqlx"
+	"go.opentelemetry.io/otel"
+)
+
+// tracer is an OTEL tracer. It has no-op behavior when OTEL is not enabled.
+var tracer = otel.Tracer("github.com/fleetdm/fleet/v4/server/mdm/acme/internal/mysql")
+
+// Datastore is the MySQL implementation of the activity datastore.
+type Datastore struct {
+	primary *sqlx.DB
+	replica *sqlx.DB
+	logger  *slog.Logger
+}
+
+// NewDatastore creates a new MySQL datastore for activities.
+func NewDatastore(conns *platform_mysql.DBConnections, logger *slog.Logger) *Datastore {
+	return &Datastore{primary: conns.Primary, replica: conns.Replica, logger: logger}
+}
+
+func (ds *Datastore) reader(ctx context.Context) *sqlx.DB {
+	return ds.replica
+}
+
+// Ensure Datastore implements types.Datastore
+var _ types.Datastore = (*Datastore)(nil)

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -2,17 +2,15 @@
 package mysql
 
 import (
-	"context"
 	"log/slog"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
-	"go.opentelemetry.io/otel"
 )
 
 // tracer is an OTEL tracer. It has no-op behavior when OTEL is not enabled.
-var tracer = otel.Tracer("github.com/fleetdm/fleet/v4/server/mdm/acme/internal/mysql")
+// var tracer = otel.Tracer("github.com/fleetdm/fleet/v4/server/mdm/acme/internal/mysql")
 
 // Datastore is the MySQL implementation of the activity datastore.
 type Datastore struct {
@@ -26,9 +24,9 @@ func NewDatastore(conns *platform_mysql.DBConnections, logger *slog.Logger) *Dat
 	return &Datastore{primary: conns.Primary, replica: conns.Replica, logger: logger}
 }
 
-func (ds *Datastore) reader(ctx context.Context) *sqlx.DB {
-	return ds.replica
-}
+// func (ds *Datastore) reader(ctx context.Context) *sqlx.DB {
+// 	return ds.replica
+// }
 
 // Ensure Datastore implements types.Datastore
 var _ types.Datastore = (*Datastore)(nil)

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -15,14 +15,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const (
-	// defaultPerPage is used when per_page is not specified but page is specified.
-	defaultPerPage = 20
-
-	// maxPerPage is the maximum allowed value for per_page.
-	maxPerPage = 10000
-)
-
 // encodeResponse encodes the response as JSON.
 func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) error {
 	return eu.EncodeCommonResponse(ctx, w, response,

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -1,0 +1,89 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"reflect"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
+	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
+	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+)
+
+const (
+	// defaultPerPage is used when per_page is not specified but page is specified.
+	defaultPerPage = 20
+
+	// maxPerPage is the maximum allowed value for per_page.
+	maxPerPage = 10000
+)
+
+// encodeResponse encodes the response as JSON.
+func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) error {
+	return eu.EncodeCommonResponse(ctx, w, response,
+		func(w http.ResponseWriter, response any) error {
+			enc := json.NewEncoder(w)
+			enc.SetIndent("", "  ")
+			return enc.Encode(response)
+		},
+		nil, // no domain-specific error encoder
+	)
+}
+
+// makeDecoder creates a decoder for the given request type.
+func makeDecoder(iface any, requestBodySizeLimit int64) kithttp.DecodeRequestFunc {
+	return eu.MakeDecoder(iface, func(body io.Reader, req any) error {
+		return json.NewDecoder(body).Decode(req)
+	}, parseCustomTags, nil, nil, nil, requestBodySizeLimit)
+}
+
+// parseCustomTags handles custom URL tag values for activity requests.
+func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (bool, error) {
+	if urlTagValue == "http_method" {
+		field.Set(reflect.ValueOf(r.Method))
+		return true, nil
+	}
+	return false, nil
+}
+
+// handlerFunc is the handler function type for Activity service endpoints.
+type handlerFunc func(ctx context.Context, request any, svc api.Service) platform_http.Errorer
+
+type endpointer struct {
+	svc api.Service
+}
+
+func (e *endpointer) CallHandlerFunc(f handlerFunc, ctx context.Context,
+	request any,
+	svc any,
+) (platform_http.Errorer, error) {
+	return f(ctx, request, svc.(api.Service)), nil
+}
+
+func (e *endpointer) Service() any {
+	return e.svc
+}
+
+// Compile-time check to ensure endpointer implements Endpointer.
+var _ eu.Endpointer[handlerFunc] = &endpointer{}
+
+func newEndpointerWithAuth(svc api.Service, authMiddleware endpoint.Middleware, opts []kithttp.ServerOption, r *mux.Router,
+	versions ...string,
+) *eu.CommonEndpointer[handlerFunc] {
+	return &eu.CommonEndpointer[handlerFunc]{
+		EP: &endpointer{
+			svc: svc,
+		},
+		MakeDecoderFn:  makeDecoder,
+		EncodeFn:       encodeResponse,
+		Opts:           opts,
+		AuthMiddleware: authMiddleware,
+		Router:         r,
+		Versions:       versions,
+	}
+}

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -1,0 +1,52 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
+	api_http "github.com/fleetdm/fleet/v4/server/mdm/acme/api/http"
+	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
+	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+)
+
+// GetRoutes returns a function that registers ACME routes on the router using the provided
+// authMiddleware.
+func GetRoutes(svc api.Service, authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc {
+	return func(r *mux.Router, opts []kithttp.ServerOption) {
+		attachFleetAPIRoutes(r, svc, authMiddleware, opts)
+	}
+}
+
+func attachFleetAPIRoutes(r *mux.Router, svc api.Service, authMiddleware endpoint.Middleware, opts []kithttp.ServerOption) {
+	ae := newEndpointerWithAuth(svc, authMiddleware, opts, r)
+
+	// TODO(mna): double-check that it works with HEAD (I think we handle it automatically for GET)
+	ae.GET("/api/mdm/acme/{identifier}/new_nonce", getNewNonceEndpoint, api_http.GetNewNonceRequest{})
+	ae.GET("/api/mdm/acme/{identifier}/directory", getDirectoryEndpoint, api_http.GetDirectoryRequest{})
+}
+
+// getNewNonceEndpoint handles HEAD/GET /api/mdm/acme/{identifier}/new_nonce requests.
+func getNewNonceEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
+	req := request.(*api_http.GetNewNonceRequest)
+	nonce, err := svc.NewNonce(ctx, req.Identifier)
+	if err != nil {
+		return api_http.GetNewNonceResponse{Err: err}
+	}
+	return api_http.GetNewNonceResponse{
+		HTTPMethod: req.HTTPMethod,
+		Nonce:      nonce,
+	}
+}
+
+// getDirectoryEndpoint handles GET /api/mdm/acme/{identifier}/directory requests.
+func getDirectoryEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
+	req := request.(*api_http.GetDirectoryRequest)
+	dir, err := svc.GetDirectory(ctx, req.Identifier)
+	if err != nil {
+		return api_http.GetDirectoryResponse{Err: err}
+	}
+	return api_http.GetDirectoryResponse{Directory: dir}
+}

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -1,0 +1,42 @@
+// Package service provides the service implementation for the ACME bounded context.
+package service
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	platform_authz "github.com/fleetdm/fleet/v4/server/platform/authz"
+)
+
+// Service is the activity bounded context service implementation.
+type Service struct {
+	authz  platform_authz.Authorizer
+	store  types.Datastore
+	logger *slog.Logger
+}
+
+// NewService creates a new activity service.
+func NewService(
+	authz platform_authz.Authorizer,
+	store types.Datastore,
+	logger *slog.Logger,
+) *Service {
+	return &Service{
+		authz:  authz,
+		store:  store,
+		logger: logger,
+	}
+}
+
+// Ensure Service implements api.Service
+var _ api.Service = (*Service)(nil)
+
+func (s *Service) NewNonce(ctx context.Context, identifier string) (string, error) {
+	panic("unimplemented")
+}
+
+func (s *Service) GetDirectory(ctx context.Context, identifier string) (*types.Directory, error) {
+	panic("unimplemented")
+}

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -1,0 +1,21 @@
+package types
+
+type Directory struct {
+	NewNonce   string `json:"newNonce"`
+	NewAccount string `json:"newAccount"`
+	NewOrder   string `json:"newOrder"`
+	NewAuthz   string `json:"newAuthz,omitempty"`
+	RevokeCert string `json:"revokeCert,omitempty"`
+	KeyChange  string `json:"keyChange,omitempty"`
+	Meta       Meta   `json:"meta,omitempty"`
+}
+
+type Meta struct {
+	TermsOfService          string   `json:"termsOfService,omitempty"`
+	Website                 string   `json:"website,omitempty"`
+	CaaIdentities           []string `json:"caaIdentities,omitempty"`
+	ExternalAccountRequired bool     `json:"externalAccountRequired,omitempty"`
+}
+
+// Datastore is the datastore interface for the ACME bounded context.
+type Datastore interface{}

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -7,7 +7,7 @@ type Directory struct {
 	NewAuthz   string `json:"newAuthz,omitempty"`
 	RevokeCert string `json:"revokeCert,omitempty"`
 	KeyChange  string `json:"keyChange,omitempty"`
-	Meta       Meta   `json:"meta,omitempty"`
+	Meta       Meta   `json:"meta"`
 }
 
 type Meta struct {
@@ -18,4 +18,5 @@ type Meta struct {
 }
 
 // Datastore is the datastore interface for the ACME bounded context.
-type Datastore interface{}
+type Datastore interface {
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** (partially) Resolves #40982 

Based on the prior work of the activity bounded context. Note that it isn't wired up to the Fleet server in `cmd/serve.go` just yet.