### PR TITLE
Updated ingestion/CVE logic to support Jetbrains software with 2 version numbers

### DIFF
--- a/changes/37323-jetbrains-cve
+++ b/changes/37323-jetbrains-cve
@@ -1,1 +1,1 @@
-* Updated ingestion/CVE logic to support Jetbrains software with 2 version numbers, like WebStorm 2025.1
+* Updated ingestion/CVE logic to support JetBrains software with 2 version numbers, like WebStorm 2025.1

--- a/changes/37323-jetbrains-cve
+++ b/changes/37323-jetbrains-cve
@@ -1,0 +1,1 @@
+* Updated ingestion/CVE logic to support Jetbrains software with 2 version numbers, like WebStorm 2025.1

--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -2158,9 +2158,9 @@ func directIngestSoftware(ctx context.Context, logger *slog.Logger, host *fleet.
 var (
 	dcvVersionFormat         = regexp.MustCompile(`^(\d+\.\d+)\s*\(r(\d+)\)$`)
 	tunnelblickVersionFormat = regexp.MustCompile(`^(.+?)\s*\(build\s+\d+\)$`)
-	// jetbrainsNameVersion extracts version from JetBrains product names like "GoLand 2025.3.3"
-	// or "IntelliJ IDEA 2025.3.1.1" (supports 3 or 4 part versions)
-	jetbrainsNameVersion = regexp.MustCompile(`\s(\d{4}\.\d+\.\d+(?:\.\d+)?)$`)
+	// jetbrainsNameVersion extracts version from JetBrains product names like "WebStorm 2025.1",
+	// "GoLand 2025.3.3", or "IntelliJ IDEA 2025.3.1.1" (supports 2, 3, or 4 part versions)
+	jetbrainsNameVersion = regexp.MustCompile(`\s(\d{4}\.\d+(?:\.\d+){0,2})$`)
 	basicAppSanitizers   = []struct {
 		matchBundleIdentifier string
 		matchName             string

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -143,7 +143,7 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 	MutateSoftwareOnIngestion(t.Context(), jetbrainsGoLand, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2025.3.3", jetbrainsGoLand.Version)
 
-	// Test JetBrains with 2-part version (dot-zero release like "WebStorm 2025.1")
+	// Test JetBrains with 2-part year.minor version (like "WebStorm 2025.1")
 	jetbrainsWebStorm := &fleet.Software{
 		Name:    "WebStorm 2025.1",
 		Source:  "programs",

--- a/server/service/osquery_utils/queries_test.go
+++ b/server/service/osquery_utils/queries_test.go
@@ -143,6 +143,16 @@ func TestSoftwareIngestionMutations(t *testing.T) {
 	MutateSoftwareOnIngestion(t.Context(), jetbrainsGoLand, slog.New(slog.DiscardHandler))
 	assert.Equal(t, "2025.3.3", jetbrainsGoLand.Version)
 
+	// Test JetBrains with 2-part version (dot-zero release like "WebStorm 2025.1")
+	jetbrainsWebStorm := &fleet.Software{
+		Name:    "WebStorm 2025.1",
+		Source:  "programs",
+		Vendor:  "JetBrains s.r.o.",
+		Version: "251.23774.424",
+	}
+	MutateSoftwareOnIngestion(t.Context(), jetbrainsWebStorm, slog.New(slog.DiscardHandler))
+	assert.Equal(t, "2025.1", jetbrainsWebStorm.Version)
+
 	// Test JetBrains with 4-part version number
 	jetbrainsIntelliJ := &fleet.Software{
 		Name:    "IntelliJ IDEA 2025.3.1.1",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37323

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JetBrains software version detection to support the newer two-part version format (e.g., WebStorm 2025.1).
  * Enhanced CVE/vulnerability tracking accuracy for JetBrains products with updated version number parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->