### PR TITLE
Fixed bug where Windows hosts would get 0 CVEs.

### DIFF
--- a/changes/35067-windows-pro-missing-vulnerabilities
+++ b/changes/35067-windows-pro-missing-vulnerabilities
@@ -1,0 +1,1 @@
+* Fixed a bug where Windows hosts with an empty `display_version` in the database would get 0 CVEs from MSRC vulnerability scanning.

--- a/server/vulnerabilities/msrc/parsed/product.go
+++ b/server/vulnerabilities/msrc/parsed/product.go
@@ -224,7 +224,7 @@ func (p Product) Name() string {
 }
 
 // extractDisplayVersionFromName attempts to extract a Windows display version
-// (e.g., "22H2", "1809") from an OS name string like "Microsoft Windows 10 Pro 22H2".
+// (e.g., "22H2", "23H2", "24H2") from an OS name string like "Microsoft Windows 10 Pro 22H2".
 // Returns an empty string if no display version is found.
 func extractDisplayVersionFromName(name string) string {
 	match := displayVersionPattern.FindString(name)

--- a/server/vulnerabilities/msrc/parsed/product.go
+++ b/server/vulnerabilities/msrc/parsed/product.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 )
+
+// displayVersionPattern matches Windows display version strings like "22H2", "23H2", "24H2".
+var displayVersionPattern = regexp.MustCompile(`\b\d{2}H[12]\b`)
 
 // Product abstracts a MS full product name.
 // A full product name includes the name of the product plus its arch
@@ -33,9 +37,19 @@ func (p Products) GetMatchForOS(ctx context.Context, os fleet.OperatingSystem) (
 			continue
 		}
 
-		if product.HasDisplayVersion() && os.DisplayVersion != "" && strings.Contains(string(product), os.DisplayVersion) {
-			dvMatch = pID
-			break
+		if product.HasDisplayVersion() {
+			// Use os.DisplayVersion if available, otherwise try to extract it from the OS name.
+			// The OS name may already contain the display version (e.g., "Microsoft Windows 10 Pro 22H2")
+			// even when the DisplayVersion field is empty, which can happen when osquery includes
+			// the version in the name but the Windows registry query for DisplayVersion returns empty.
+			dv := os.DisplayVersion
+			if dv == "" {
+				dv = extractDisplayVersionFromName(os.Name)
+			}
+			if dv != "" && strings.Contains(string(product), dv) {
+				dvMatch = pID
+				break
+			}
 		}
 
 		// If os.DisplayVersion is empty, we need to confirm that the product
@@ -207,6 +221,14 @@ func (p Product) Name() string {
 	default:
 		return ""
 	}
+}
+
+// extractDisplayVersionFromName attempts to extract a Windows display version
+// (e.g., "22H2", "1809") from an OS name string like "Microsoft Windows 10 Pro 22H2".
+// Returns an empty string if no display version is found.
+func extractDisplayVersionFromName(name string) string {
+	match := displayVersionPattern.FindString(name)
+	return match
 }
 
 // Matches checks whehter product A matches product B by checking to see if both are for the same

--- a/server/vulnerabilities/msrc/parsed/product_test.go
+++ b/server/vulnerabilities/msrc/parsed/product_test.go
@@ -552,6 +552,34 @@ func TestProductHasDisplayVersion(t *testing.T) {
 	}
 }
 
+func TestExtractDisplayVersionFromName(t *testing.T) {
+	tc := []struct {
+		name string
+		want string
+	}{
+		{"Microsoft Windows 10 Pro 22H2", "22H2"},
+		{"Microsoft Windows 10 Enterprise 22H2", "22H2"},
+		{"Microsoft Windows 10 Pro N 22H2", "22H2"},
+		{"Microsoft Windows 11 Pro 25H2", "25H2"},
+		{"Microsoft Windows 11 Enterprise 23H2", "23H2"},
+		{"Microsoft Windows 11 Enterprise 24H2", "24H2"},
+		{"Microsoft Windows 10 Version 1809", ""},
+		{"Microsoft Windows 10 Version 1607", ""},
+		{"Microsoft Windows Server 2022 Datacenter 21H2", "21H2"},
+		{"Microsoft Windows 10 Pro", ""},
+		{"Microsoft Windows 11 Enterprise", ""},
+		{"Microsoft Windows Server 2022", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tc {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractDisplayVersionFromName(tt.name)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
 var msrcWinProducts = Products{
 	"10729": "Windows 10 for 32-bit Systems",
 	"10735": "Windows 10 for x64-based Systems",

--- a/server/vulnerabilities/msrc/parsed/product_test.go
+++ b/server/vulnerabilities/msrc/parsed/product_test.go
@@ -569,7 +569,7 @@ func TestExtractDisplayVersionFromName(t *testing.T) {
 		{"Microsoft Windows 10 Pro", ""},
 		{"Microsoft Windows 11 Enterprise", ""},
 		{"Microsoft Windows Server 2022", ""},
-		{"", ""},
+		{"empty string", ""},
 	}
 
 	for _, tt := range tc {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35067

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MSRC vulnerability scanning on Windows hosts with empty display version data, ensuring CVEs are now correctly retrieved instead of returning zero vulnerabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->