### PR TITLE
fix flashing error message when turning off apple mdm

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/IntegrationsPage.tsx
@@ -3,6 +3,7 @@ import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useQuery } from "react-query";
 
 import deepDifference from "utilities/deep_difference";
+import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 
 import { NotificationContext } from "context/notification";
 import { AppContext } from "context/app";
@@ -43,12 +44,11 @@ const IntegrationsPage = ({
   const {
     data: appConfig,
     isLoading: isLoadingAppConfig,
+    isFetching: isFetchingAppConfig,
     refetch: refetchConfig,
-  } = useQuery<IConfig, Error, IConfig>(
-    ["config"],
-    () => configAPI.loadAll(),
-    {}
-  );
+  } = useQuery<IConfig, Error, IConfig>(["config"], () => configAPI.loadAll(), {
+    ...DEFAULT_USE_QUERY_OPTIONS,
+  });
 
   /** The common submission logic for settings that are rendered on the Integrations page, but use
    * the common configAPI.update method, the same one used by cards of the OrgSettingsPage */
@@ -96,6 +96,7 @@ const IntegrationsPage = ({
     DEFAULT_SETTINGS_SECTION;
 
   const CurrentCard = currentSection.Card;
+  const isLoading = isLoadingAppConfig || isFetchingAppConfig;
 
   return (
     <div className={`${baseClass}`}>
@@ -104,7 +105,7 @@ const IntegrationsPage = ({
         navItems={navItems}
         activeItem={currentSection.urlSection}
         CurrentCard={
-          !isLoadingAppConfig && appConfig ? (
+          !isLoading && appConfig ? (
             <CurrentCard
               router={router}
               appConfig={appConfig}

--- a/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/CertificateAuthorities/components/NDESForm/NDESForm.tsx
@@ -7,8 +7,6 @@ import TooltipWrapper from "components/TooltipWrapper";
 
 import { INDESFormValidation, validateFormData } from "./helpers";
 
-const baseClass = "ndes-form";
-
 export interface INDESFormData {
   scepURL: string;
   adminURL: string;

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/AppleMdmPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useContext, useState } from "react";
-import { useQuery } from "react-query";
+import { useQuery, useQueryClient } from "react-query";
 import { InjectedRouter } from "react-router";
 
 import { AxiosError } from "axios";
@@ -24,6 +24,7 @@ import TurnOffAppleMdmModal from "./components/modals/TurnOffAppleMdmModal";
 export const baseClass = "apple-mdm-page";
 
 const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
+  const queryClient = useQueryClient();
   const { config } = useContext(AppContext);
   const { renderFlash } = useContext(NotificationContext);
 
@@ -68,13 +69,14 @@ const AppleMdmPage = ({ router }: { router: InjectedRouter }) => {
     toggleTurnOffMdmModal();
     try {
       await mdmAppleAPI.deleteApplePushCertificate();
+      await queryClient.invalidateQueries(["config"]);
       router.push(PATHS.ADMIN_INTEGRATIONS_MDM);
       renderFlash("success", "MDM turned off successfully.");
     } catch (e) {
       renderFlash("error", "Couldn't turn off MDM. Please try again.");
       setIsUpdating(false);
     }
-  }, [renderFlash, router]);
+  }, [queryClient, renderFlash, router]);
 
   const onRenewCert = useCallback(() => {
     refetch();

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MdmSettings.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/MdmSettings.tsx
@@ -39,20 +39,13 @@ const MdmSettings = ({
     data: APNSInfo,
     isLoading: isLoadingAPNSInfo,
     isError: isAPNSInfoError,
-    isIdle: isAPNSInfoIdle,
     error: errorAPNSInfo,
   } = useQuery<IMdmApple, AxiosError, IMdmApple>(
     ["appleAPNInfo", { isMdmEnabled }],
     () => mdmAppleAPI.getAppleAPNInfo(),
     {
       ...DEFAULT_USE_QUERY_OPTIONS,
-      retry: (tries, error) =>
-        error.status !== 404 && error.status !== 400 && tries <= 3,
-      // TODO: There is a potential race condition here immediately after MDM is turned off. This
-      // component gets remounted and stale config data is used to determine it this API call is
-      // enabled, resulting in a 400 response. The race really should  be fixed higher up the chain where
-      // we're fetching and setting the config, but for now we'll just assume that any 400 response
-      // means that MDM is not enabled and we'll show the "Turn on MDM" button.
+      retry: (tries, error) => error.status !== 404 && tries <= 3,
       staleTime: 5000,
       enabled: isMdmEnabled,
     }


### PR DESCRIPTION
**Related issue:** Resolves #38546

This fixes a quick error message flash on the mdm settings page when apple mdm is turned off. We have a finally fixed an issue of stale data on the integration page getting passed down to the mdm card when turning apple mdm off. We now invalidate the cache of the config when apple mdm is turned off, that way we make a request to get the most recent config which will have the up to date data for `mdm.enabled_and_configured`.

# Checklist for submitter

- [x] QA'd all new/changed functionality manually
