### PR TITLE
add expiration to auth token via sso login

### DIFF
--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -604,6 +604,7 @@ func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 type callbackSSOResponse struct {
 	content string
 	token   string
+	expires time.Duration
 	Err     error `json:"error,omitempty"`
 }
 
@@ -616,10 +617,11 @@ func (r callbackSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter
 	deleteSSOCookie(w)
 	if r.token != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:   "__Host-token",
-			Value:  r.token,
-			Path:   "/",
-			Secure: cookieSecure,
+			Name:    "__Host-token",
+			Value:   r.token,
+			Path:    "/",
+			Secure:  cookieSecure,
+			Expires: time.Now().Add(r.expires).UTC(),
 		})
 	}
 }
@@ -674,6 +676,7 @@ func makeCallbackSSOEndpoint(urlPrefix string) handlerFunc {
 		}
 		resp.content = writer.String()
 		resp.token = session.Token
+		resp.expires = svc.GetSessionDuration(ctx)
 		return resp, nil
 	}
 }

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -616,14 +616,17 @@ func (r callbackSSOResponse) Html() string { return r.content }
 func (r callbackSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter) {
 	deleteSSOCookie(w)
 	if r.token != "" {
-		http.SetCookie(w, &http.Cookie{
+		cookie := &http.Cookie{
 			Name:     "__Host-token",
 			Value:    r.token,
 			Path:     "/",
 			Secure:   cookieSecure,
 			SameSite: http.SameSiteLaxMode,
-			Expires:  time.Now().Add(r.expires).UTC(),
-		})
+		}
+		if r.expires > 0 {
+			cookie.Expires = time.Now().Add(r.expires).UTC()
+		}
+		http.SetCookie(w, cookie)
 	}
 }
 

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -617,11 +617,12 @@ func (r callbackSSOResponse) SetCookies(_ context.Context, w http.ResponseWriter
 	deleteSSOCookie(w)
 	if r.token != "" {
 		http.SetCookie(w, &http.Cookie{
-			Name:    "__Host-token",
-			Value:   r.token,
-			Path:    "/",
-			Secure:  cookieSecure,
-			Expires: time.Now().Add(r.expires).UTC(),
+			Name:     "__Host-token",
+			Value:    r.token,
+			Path:     "/",
+			Secure:   cookieSecure,
+			SameSite: http.SameSiteLaxMode,
+			Expires:  time.Now().Add(r.expires).UTC(),
 		})
 	}
 }


### PR DESCRIPTION
**Related issue:** Resolves #42296

This fixes an issue where users who login via sso were not having an expiration date set on their host token cookie. This would cause them to have to relogin after every browser session

- [x] QA'd all new/changed functionality manually
