### PR TITLE
Fixed Admin By Request false positive CVEs

### DIFF
--- a/changes/41586-admin-by-request-false-positive
+++ b/changes/41586-admin-by-request-false-positive
@@ -1,0 +1,1 @@
+* Fixed false positive vulnerabilities (CVE-2019-17201, CVE-2019-17202) reported for Admin By Request on macOS and Linux hosts. These CVEs are Windows-specific.

--- a/server/vulnerabilities/nvd/cpe_matching_rule_test.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rule_test.go
@@ -281,6 +281,24 @@ func TestGetKnownNVDBugRules(t *testing.T) {
 	ok = rule.CPEMatches(gitCPEMeta)
 	require.False(t, ok, "CVE-2025-46835 should not match git:git")
 
+	// Test that Admin By Request CVEs only match on Windows (not macOS/Linux). See #41586.
+	for _, cve := range []string{"CVE-2019-17201", "CVE-2019-17202"} {
+		rule, ok = cpeMatchingRules.FindMatch(cve)
+		require.True(t, ok)
+
+		abrMacOS, err := wfn.Parse("cpe:2.3:a:fasttracksoftware:admin_by_request:5.2:*:*:*:*:macos:*:*")
+		require.NoError(t, err)
+		require.False(t, rule.CPEMatches(abrMacOS), "%s should not match on macOS", cve)
+
+		abrLinux, err := wfn.Parse("cpe:2.3:a:fasttracksoftware:admin_by_request:4.0:*:*:*:*:linux:*:*")
+		require.NoError(t, err)
+		require.False(t, rule.CPEMatches(abrLinux), "%s should not match on Linux", cve)
+
+		abrWindows, err := wfn.Parse("cpe:2.3:a:fasttracksoftware:admin_by_request:5.0:*:*:*:*:windows:*:*")
+		require.NoError(t, err)
+		require.True(t, rule.CPEMatches(abrWindows), "%s should match on Windows", cve)
+	}
+
 	// Test that CVE-2024-7006 (libtiff) only matches on Linux.
 	rule, ok = cpeMatchingRules.FindMatch("CVE-2024-7006")
 	require.True(t, ok)

--- a/server/vulnerabilities/nvd/cpe_matching_rules.go
+++ b/server/vulnerabilities/nvd/cpe_matching_rules.go
@@ -315,6 +315,19 @@ func GetKnownNVDBugRules() (CPEMatchingRules, error) {
 				return cpeMeta.Vendor == "git" && cpeMeta.Product == "git"
 			},
 		},
+		// CVE-2019-17201 and CVE-2019-17202 are Windows-only privilege escalation vulnerabilities
+		// in Admin By Request (named pipe bypass and PIN challenge-response bypass).
+		// The NVD CPE data uses target_sw=* with no platform differentiation, causing false positives
+		// on macOS and Linux where the software uses independent version numbering. See #41586.
+		CPEMatchingRule{
+			CVEs: map[string]struct{}{
+				"CVE-2019-17201": {},
+				"CVE-2019-17202": {},
+			},
+			IgnoreIf: func(cpeMeta *wfn.Attributes) bool {
+				return cpeMeta.TargetSW != "windows"
+			},
+		},
 		// CVE-2023-28205 WebKit vulnerability
 		// Apple released fixes via:
 		// - Safari 16.4.1 standalone update for Big Sur/Monterey (HT213722)

--- a/server/vulnerabilities/nvd/cve_test.go
+++ b/server/vulnerabilities/nvd/cve_test.go
@@ -678,6 +678,17 @@ func TestTranslateCPEToCVE(t *testing.T) {
 			includedCVEs:      []cve{{ID: "CVE-2025-9074", resolvedInVersion: "4.44.3"}},
 			continuesToUpdate: true,
 		},
+		// #41586 - Admin By Request false positives on macOS/Linux
+		// These CVEs are Windows-only but NVD data uses target_sw=* so they would match any platform without our fix.
+		"cpe:2.3:a:fasttracksoftware:admin_by_request:5.2:*:*:*:*:macos:*:*": {
+			excludedCVEs: []string{"CVE-2019-17201", "CVE-2019-17202"},
+		},
+		"cpe:2.3:a:fasttracksoftware:admin_by_request:5.2:*:*:*:*:windows:*:*": {
+			includedCVEs: []cve{
+				{ID: "CVE-2019-17201", resolvedInVersion: "6.2.0.0"},
+				{ID: "CVE-2019-17202", resolvedInVersion: "6.2.0.0"},
+			},
+		},
 	}
 
 	cveOSTests := []struct {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41586

The fix is speculative since I wasn't able to find/get the "Admin By Request" app to install.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed false-positive vulnerability reports for "Admin By Request" on macOS and Linux. Vulnerabilities CVE-2019-17201 and CVE-2019-17202 are Windows-specific and will now only be reported on Windows systems, eliminating unnecessary alerts on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->