### PR TITLE
Refactor Jamf vs Fleet comparison table: requirements + red/green marks

### DIFF
--- a/articles/compare-fleet-and-jamf.md
+++ b/articles/compare-fleet-and-jamf.md
@@ -13,16 +13,14 @@ Jamf has evolved over two decades as a management solution focused on Apple devi
 
 Fleet and Jamf serve different strategic purposes based on fleet composition and workflow needs.
 
-|                    | Fleet                                                                                                     | Jamf                                                                                          |
-| ------------------ | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Architecture       | API-first design, unified API, osquery validation and data collection                                     | GUI-first, multiple APis                                                                      |
-| Development        | Open-core, public code, contributions welcome                                                             | Proprietary, slow customer feature request intake                                             |
-| Console Management | GUI or GitOps / configuration-as-code console management                                                  | GUI-first, no comprehensive built-in version history or console state management with code    |
-| Platform Support   | Linux, macOS, iOS, iPadOS, Windows, Android, Chromebook                                                   | macOS, iOS, iPadOS, tvOS, visionOS, Android                                                   |
-| Apple MDM          | MDM + DDM protocol, API supports any arbitrary MDM command                                                | MDM protocol, DDM protocol supported in Jamf Cloud only, only specific MDM commands available |
-| Security           | On-demand osquery data collection, YARA rules, event monitoring, CIS benchmark queries publicly available | Deep security features require additional product purchases                                   |
-
-
+| Requirement | Fleet | Jamf |
+| --- | --- | --- |
+| API-first architecture | ✅ | ❌ |
+| Open-source / open-core development | ✅ | ❌ |
+| GitOps / configuration-as-code console management | ✅ | ❌ |
+| Multi-platform support (Linux, Windows, macOS, iOS, iPadOS, Android, Chromebook) | ✅ | ❌ |
+| Full MDM + DDM protocol support on any deployment | ✅ | ❌ |
+| Built-in security features (no additional purchase required) | ✅ | ❌ |
 
 ## Device management workflow comparisons
 


### PR DESCRIPTION
## Summary

Refactors the "Key differences" comparison table on the [Jamf vs Fleet page](https://fleetdm.com/compare/jamf-vs-fleet).

**Before:** Generic row labels with long-form text descriptions in each product column.

**After:** "Requirement" column on the left with concise capability statements, and ✅/❌ marks in the Fleet and Jamf columns for quick visual comparison.

**Related issue:** NA

## Checklist for submitter

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
