### PR TITLE
Dogfood & Loadtest - Updating mysql engine version to 8.0.mysql_aurora.3.10.3

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/free.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/free.tf
@@ -72,7 +72,7 @@ module "free" {
   rds_config = {
     preferred_maintenance_window = "fri:04:00-fri:05:00"
     name                         = local.customer_free
-    engine_version               = "8.0.mysql_aurora.3.08.2"
+    engine_version               = "8.0.mysql_aurora.3.10.3"
     snapshot_identifier          = "arn:aws:rds:us-east-2:611884880216:cluster-snapshot:a2023-03-06-pre-migration"
     db_parameters = {
       # 8mb up from 262144 (256k) default

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -150,7 +150,7 @@ module "main" {
   rds_config = {
     preferred_maintenance_window = "fri:04:00-fri:05:00"
     name                         = "${local.customer}-1"
-    engine_version               = "8.0.mysql_aurora.3.08.2"
+    engine_version               = "8.0.mysql_aurora.3.10.3"
     restore_to_point_in_time = {
       source_cluster_identifier = local.customer
       restore_to_time           = "2026-03-09T22:40:59Z"

--- a/infrastructure/loadtesting/terraform/infra/main.tf
+++ b/infrastructure/loadtesting/terraform/infra/main.tf
@@ -42,7 +42,7 @@ module "loadtest" {
     name                         = local.customer
     instance_class               = var.database_instance_size
     replicas                     = var.database_instance_count
-    engine_version               = "8.0.mysql_aurora.3.08.2"
+    engine_version               = "8.0.mysql_aurora.3.10.3"
     snapshot_identifier          = "arn:aws:rds:us-east-2:917007347864:cluster-snapshot:cleaned-8-0-teams-fixes-v4-55-0-minimum"
     preferred_maintenance_window = "fri:04:00-fri:05:00"
     # VPN


### PR DESCRIPTION
- Bumps Dogfood and Loadtest environment Aurora MySQL engine verison from `8.0.mysql_aurora.3.08.2` -> `8.0.mysql_aurora.3.10.3`