### PR TITLE
Fix FMA UI showing shared bundle identifier apps as both added

### DIFF
--- a/server/datastore/mysql/maintained_apps.go
+++ b/server/datastore/mysql/maintained_apps.go
@@ -47,7 +47,7 @@ ON DUPLICATE KEY UPDATE
 const teamFMATitlesJoin = `
 			team_titles.id software_title_id FROM fleet_maintained_apps fma
 			LEFT JOIN (
-				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform
+				SELECT DISTINCT st.id, st.unique_identifier, st.name, si.platform, si.fleet_maintained_app_id
 				FROM software_titles st
 				LEFT JOIN
 					software_installers si
@@ -63,14 +63,22 @@ const teamFMATitlesJoin = `
 					AND vat.platform = va.platform
 					AND vat.global_or_team_id = ?
 				WHERE si.id IS NOT NULL OR vat.id IS NOT NULL
-			) team_titles 
-				ON team_titles.unique_identifier = fma.unique_identifier
-				-- pattern match fma name to a similar title name, since upgrade_code is not surfaced in fma table
+			) team_titles
+				-- prefer direct FMA link (avoids ambiguity when apps share a bundle identifier,
+				-- e.g. Firefox and Firefox ESR both use org.mozilla.firefox)
+				ON team_titles.fleet_maintained_app_id = fma.id
 				OR (
-					team_titles.platform = fma.platform 
-					AND fma.platform = 'windows' 
-					-- Box Drive is the only FMA at the point of writing this where unique_identifier is shorter than name
-					AND team_titles.name LIKE CONCAT(LEAST(fma.name, fma.unique_identifier), '%')
+					team_titles.fleet_maintained_app_id IS NULL
+					AND (
+						team_titles.unique_identifier = fma.unique_identifier
+						-- pattern match fma name to a similar title name, since upgrade_code is not surfaced in fma table
+						OR (
+							team_titles.platform = fma.platform
+							AND fma.platform = 'windows'
+							-- Box Drive is the only FMA at the point of writing this where unique_identifier is shorter than name
+							AND team_titles.name LIKE CONCAT(LEAST(fma.name, fma.unique_identifier), '%')
+						)
+					)
 				)
 `
 

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -676,7 +676,7 @@ func testSharedBundleIdentifier(t *testing.T, ds *Datastore) {
 		TeamID:               &team.ID,
 		InstallScript:        "echo install",
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: ptr.Uint(firefox.ID),
+		FleetMaintainedAppID: &firefox.ID,
 	})
 	require.NoError(t, err)
 
@@ -721,7 +721,7 @@ func testSharedBundleIdentifier(t *testing.T, ds *Datastore) {
 		TeamID:               &team.ID,
 		InstallScript:        "echo install",
 		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: ptr.Uint(firefoxESR.ID),
+		FleetMaintainedAppID: &firefoxESR.ID,
 	})
 	require.NoError(t, err)
 

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -25,6 +25,7 @@ func TestMaintainedApps(t *testing.T) {
 		{"SyncAndRemoveApps", testSyncAndRemoveApps},
 		{"GetMaintainedAppBySlug", testGetMaintainedAppBySlug},
 		{"ListAvailableAppsWindows", testListAvailableAppsWindows},
+		{"SharedBundleIdentifier", testSharedBundleIdentifier},
 	}
 
 	for _, c := range cases {
@@ -628,4 +629,115 @@ func testListAvailableAppsWindows(t *testing.T, ds *Datastore) {
 	require.Equal(t, titleID, *apps[0].TitleID)
 	// the darwin app should not be matched by name
 	require.Nil(t, apps[1].TitleID)
+}
+
+func testSharedBundleIdentifier(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Team 1"})
+	require.NoError(t, err)
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+
+	// Create two FMAs that share the same bundle identifier (like Firefox and Firefox ESR)
+	firefox, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox",
+		Slug:             "firefox/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox",
+	})
+	require.NoError(t, err)
+
+	firefoxESR, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "Mozilla Firefox ESR",
+		Slug:             "firefox@esr/darwin",
+		Platform:         "darwin",
+		UniqueIdentifier: "org.mozilla.firefox", // same bundle identifier
+	})
+	require.NoError(t, err)
+
+	// Neither should be marked as added yet
+	apps, _, err := ds.ListAvailableFleetMaintainedApps(ctx, &team.ID, fleet.ListOptions{IncludeMetadata: true})
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+	require.Nil(t, apps[0].TitleID)
+	require.Nil(t, apps[1].TitleID)
+
+	// Add only Firefox (not ESR) as an FMA installer
+	_, firefoxTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "Mozilla Firefox",
+		BundleIdentifier:     "org.mozilla.firefox",
+		Source:               "apps",
+		StorageID:            "firefox-storage",
+		Filename:             "Firefox.dmg",
+		Extension:            "dmg",
+		Platform:             "darwin",
+		Version:              "125.0",
+		UserID:               user.ID,
+		TeamID:               &team.ID,
+		InstallScript:        "echo install",
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: ptr.Uint(firefox.ID),
+	})
+	require.NoError(t, err)
+
+	// Only Firefox should show as added, NOT Firefox ESR
+	apps, _, err = ds.ListAvailableFleetMaintainedApps(ctx, &team.ID, fleet.ListOptions{IncludeMetadata: true})
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+	// Find Firefox and Firefox ESR in results (order by id)
+	var gotFirefox, gotFirefoxESR fleet.MaintainedApp
+	for _, app := range apps {
+		if app.ID == firefox.ID {
+			gotFirefox = app
+		} else if app.ID == firefoxESR.ID {
+			gotFirefoxESR = app
+		}
+	}
+	require.NotNil(t, gotFirefox.TitleID, "Firefox should be marked as added")
+	require.Equal(t, firefoxTitleID, *gotFirefox.TitleID)
+	require.Nil(t, gotFirefoxESR.TitleID, "Firefox ESR should NOT be marked as added")
+
+	// Also verify GetMaintainedAppByID returns correct results
+	gotApp, err := ds.GetMaintainedAppByID(ctx, firefox.ID, &team.ID)
+	require.NoError(t, err)
+	require.NotNil(t, gotApp.TitleID)
+	require.Equal(t, firefoxTitleID, *gotApp.TitleID)
+
+	gotApp, err = ds.GetMaintainedAppByID(ctx, firefoxESR.ID, &team.ID)
+	require.NoError(t, err)
+	require.Nil(t, gotApp.TitleID, "Firefox ESR should NOT have a title ID when only Firefox was added")
+
+	// Now also add Firefox ESR
+	_, esrTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:                "Mozilla Firefox ESR",
+		BundleIdentifier:     "org.mozilla.firefox",
+		Source:               "apps",
+		StorageID:            "firefox-esr-storage",
+		Filename:             "FirefoxESR.dmg",
+		Extension:            "dmg",
+		Platform:             "darwin",
+		Version:              "115.0",
+		UserID:               user.ID,
+		TeamID:               &team.ID,
+		InstallScript:        "echo install",
+		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+		FleetMaintainedAppID: ptr.Uint(firefoxESR.ID),
+	})
+	require.NoError(t, err)
+
+	// Both should now show as added, each pointing to their own title
+	apps, _, err = ds.ListAvailableFleetMaintainedApps(ctx, &team.ID, fleet.ListOptions{IncludeMetadata: true})
+	require.NoError(t, err)
+	require.Len(t, apps, 2)
+	for _, app := range apps {
+		if app.ID == firefox.ID {
+			gotFirefox = app
+		} else if app.ID == firefoxESR.ID {
+			gotFirefoxESR = app
+		}
+	}
+	require.NotNil(t, gotFirefox.TitleID)
+	require.Equal(t, firefoxTitleID, *gotFirefox.TitleID)
+	require.NotNil(t, gotFirefoxESR.TitleID)
+	require.Equal(t, esrTitleID, *gotFirefoxESR.TitleID)
 }

--- a/server/datastore/mysql/maintained_apps_test.go
+++ b/server/datastore/mysql/maintained_apps_test.go
@@ -706,38 +706,4 @@ func testSharedBundleIdentifier(t *testing.T, ds *Datastore) {
 	gotApp, err = ds.GetMaintainedAppByID(ctx, firefoxESR.ID, &team.ID)
 	require.NoError(t, err)
 	require.Nil(t, gotApp.TitleID, "Firefox ESR should NOT have a title ID when only Firefox was added")
-
-	// Now also add Firefox ESR
-	_, esrTitleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
-		Title:                "Mozilla Firefox ESR",
-		BundleIdentifier:     "org.mozilla.firefox",
-		Source:               "apps",
-		StorageID:            "firefox-esr-storage",
-		Filename:             "FirefoxESR.dmg",
-		Extension:            "dmg",
-		Platform:             "darwin",
-		Version:              "115.0",
-		UserID:               user.ID,
-		TeamID:               &team.ID,
-		InstallScript:        "echo install",
-		ValidatedLabels:      &fleet.LabelIdentsWithScope{},
-		FleetMaintainedAppID: &firefoxESR.ID,
-	})
-	require.NoError(t, err)
-
-	// Both should now show as added, each pointing to their own title
-	apps, _, err = ds.ListAvailableFleetMaintainedApps(ctx, &team.ID, fleet.ListOptions{IncludeMetadata: true})
-	require.NoError(t, err)
-	require.Len(t, apps, 2)
-	for _, app := range apps {
-		if app.ID == firefox.ID {
-			gotFirefox = app
-		} else if app.ID == firefoxESR.ID {
-			gotFirefoxESR = app
-		}
-	}
-	require.NotNil(t, gotFirefox.TitleID)
-	require.Equal(t, firefoxTitleID, *gotFirefox.TitleID)
-	require.NotNil(t, gotFirefoxESR.TitleID)
-	require.Equal(t, esrTitleID, *gotFirefoxESR.TitleID)
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -19898,12 +19898,14 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 	require.False(t, listMAResp.Meta.HasNextResults)
 	require.Len(t, listMAResp.FleetMaintainedApps, len(expectedApps))
 
-	slices.SortFunc(listMAResp.FleetMaintainedApps, func(a, b fleet.MaintainedApp) int {
-		return cmp.Compare(a.Name, b.Name)
-	})
-	slices.SortFunc(expectedApps, func(a, b fleet.MaintainedApp) int {
-		return cmp.Compare(a.Name, b.Name)
-	})
+	sortFMAs := func(a, b fleet.MaintainedApp) int {
+		if c := cmp.Compare(a.Name, b.Name); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.Slug, b.Slug)
+	}
+	slices.SortFunc(listMAResp.FleetMaintainedApps, sortFMAs)
+	slices.SortFunc(expectedApps, sortFMAs)
 	require.Equal(t, expectedApps, listMAResp.FleetMaintainedApps)
 
 	var listMAResp2 listFleetMaintainedAppsResponse


### PR DESCRIPTION
## Problem
When multiple Fleet Maintained Apps (FMAs) share the same bundle identifier (e.g., Firefox and Firefox ESR both use `org.mozilla.firefox`), the UI incorrectly showed both as added when only one had an installer.

## Solution
Updated the `teamFMATitlesJoin` SQL query to:
1. Add `fleet_maintained_app_id` to the subquery to track direct FMA-to-installer links
2. Prefer direct FMA ID matching to avoid ambiguity from shared bundle identifiers
3. Fall back to pattern matching only when no direct link exists

This ensures each FMA is matched only to its own software installer, not to installers for other FMAs with the same bundle identifier.

## Testing
Added comprehensive test case `testSharedBundleIdentifier` that:
- Creates two FMAs with identical bundle identifiers
- Verifies only the FMA with an installer shows as added
- Confirms correct title IDs are assigned when both have installers