### PR TITLE
Fix gzip expansion attack — limit decompressed payload size (#14825)

### DIFF
--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -585,7 +585,11 @@ func MakeDecoder(
 					return nil, BadRequestErr("gzip decoder error", err)
 				}
 				defer gzr.Close()
-				body = gzr
+				if maxRequestBodySize != -1 {
+					body = io.LimitReader(gzr, maxRequestBodySize)
+				} else {
+					body = gzr
+				}
 			}
 
 			// Insert the JSON key rewriter into the reader pipeline


### PR DESCRIPTION
## Summary
- Wraps the gzip-decompressed reader in `io.LimitReader(gzr, maxRequestBodySize)` so the size cap applies to decompressed output, not just compressed input
- Preserves no-limit behavior for endpoints that opt out via `SkipRequestBodySizeLimit()`
- Addresses CWE-409 (Improper Handling of Highly Compressed Data)

## Test plan
- [ ] Run the PoC from #14825 — should now return HTTP 413 instead of HTTP 401
- [ ] Verify normal gzip-compressed requests under the size limit still work
- [ ] Verify endpoints using `SkipRequestBodySizeLimit()` are unaffected
- [ ] `go test ./server/platform/endpointer/...`
- [ ] `MYSQL_TEST=1 go test ./server/service/...`