### PR TITLE
Enforce GitOps exceptions

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1656,6 +1656,92 @@ func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]in
 	return result, nil
 }
 
+// generateSoftwareForValidation is a lightweight version of generateSoftware
+// that produces a minimal software spec from server-side data for GitOps
+// validation (policy install_software and patch policy references). It skips
+// GetSoftwareTitleByID, scripts, icons, setup experience, labels, etc.
+func generateSoftwareForValidation(client generateGitopsClient, teamID uint) (map[string]interface{}, error) {
+	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
+	software, err := client.ListSoftwareTitles(query)
+	if err != nil {
+		return nil, err
+	}
+	if len(software) == 0 {
+		return nil, nil
+	}
+
+	result := make(map[string]any)
+	packages := make([]map[string]any, 0)
+	appStoreApps := make([]map[string]any, 0)
+	fmas := make([]map[string]any, 0)
+	dedupeInHouseAppsByFilename := make(map[string]struct{})
+
+	var appsList *maintained_apps.AppsList
+	var byUniqueID map[string]string
+
+	for _, sw := range software {
+		softwareSpec := make(map[string]interface{})
+		switch {
+		case sw.SoftwarePackage != nil:
+			// In-house app dedup (same logic as generateSoftware)
+			if isInHouseApp := filepath.Ext(sw.SoftwarePackage.Name) == ".ipa"; isInHouseApp {
+				if _, ok := dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name]; ok {
+					continue
+				}
+				dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name] = struct{}{}
+			}
+
+			if sw.HashSHA256 != nil {
+				softwareSpec["hash_sha256"] = *sw.HashSHA256
+			}
+			if sw.SoftwarePackage.PackageURL != nil {
+				softwareSpec["url"] = *sw.SoftwarePackage.PackageURL
+			}
+
+			if sw.SoftwarePackage.FleetMaintainedAppID != nil {
+				// FMA slug resolution (same logic as generateSoftware)
+				if byUniqueID == nil {
+					if appsList == nil {
+						appsList, err = maintained_apps.FetchAppsList(context.Background())
+						if err != nil {
+							return nil, err
+						}
+					}
+					byUniqueID = make(map[string]string, len(appsList.Apps))
+					for _, a := range appsList.Apps {
+						byUniqueID[a.UniqueIdentifier] = a.Slug
+					}
+				}
+				lookupKey := ptr.ValOrZero(sw.BundleIdentifier)
+				if lookupKey == "" {
+					lookupKey = sw.Name
+				}
+				slug := byUniqueID[lookupKey]
+				softwareSpec["slug"] = slug
+				fmas = append(fmas, softwareSpec)
+			} else {
+				packages = append(packages, softwareSpec)
+			}
+
+		case sw.AppStoreApp != nil:
+			softwareSpec["app_store_id"] = sw.AppStoreApp.AppStoreID
+			appStoreApps = append(appStoreApps, softwareSpec)
+		}
+	}
+
+	if len(packages) > 0 {
+		result["packages"] = packages
+	}
+	if len(appStoreApps) > 0 {
+		result["app_store_apps"] = appStoreApps
+	}
+	if len(fmas) > 0 {
+		result["fleet_maintained_apps"] = fmas
+	}
+
+	return result, nil
+}
+
 func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint, teamFilename string, downloadIcons bool) (map[string]interface{}, error) {
 	if !cmd.AppConfig.License.IsPremium() {
 		return nil, nil // software is premium-only

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -88,6 +88,7 @@ type generateGitopsClient interface {
 	GetAppleMDMEnrollmentProfile(teamID uint) (*fleet.MDMAppleSetupAssistant, error)
 	GetCertificateAuthoritiesSpec(includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error)
 	GetCertificateTemplates(teamID string) ([]*fleet.CertificateTemplateResponseSummary, error)
+	ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, error)
 	GetFleetMaintainedApp(id uint) (*fleet.MaintainedApp, error)
 	GetVPPTokens() ([]*fleet.VPPTokenDB, error)
 	ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, error)
@@ -1656,35 +1657,30 @@ func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]in
 	return result, nil
 }
 
-// fmaSlugResolver lazily fetches the Fleet Maintained Apps catalog and
-// resolves FMA slugs by bundle identifier or software title name.
+// fmaSlugResolver lazily fetches Fleet-maintained apps for a team via the API
+// and builds a map of FMA ID to slug for slug resolution.
 type fmaSlugResolver struct {
-	appsList   *maintained_apps.AppsList
-	byUniqueID map[string]string
+	client   generateGitopsClient
+	teamID   uint
+	appsList []fleet.MaintainedApp
+	byID     map[uint]string
 }
 
-func (r *fmaSlugResolver) resolve(bundleIdentifier *string, name string) (string, error) {
-	if r.byUniqueID == nil {
+func (r *fmaSlugResolver) resolve(fmaID uint) (string, error) {
+	if r.byID == nil {
 		if r.appsList == nil {
 			var err error
-			r.appsList, err = maintained_apps.FetchAppsList(context.Background())
+			r.appsList, err = r.client.ListFleetMaintainedApps(r.teamID)
 			if err != nil {
 				return "", err
 			}
 		}
-		r.byUniqueID = make(map[string]string, len(r.appsList.Apps))
-		for _, a := range r.appsList.Apps {
-			r.byUniqueID[a.UniqueIdentifier] = a.Slug
+		r.byID = make(map[uint]string, len(r.appsList))
+		for _, a := range r.appsList {
+			r.byID[a.ID] = a.Slug
 		}
 	}
-	// Look up slug by bundle identifier (macOS) or software title name (Windows).
-	// Windows FMAs don't have a bundle identifier; their unique_identifier
-	// in the manifest is the program name (e.g., "1Password").
-	lookupKey := ptr.ValOrZero(bundleIdentifier)
-	if lookupKey == "" {
-		lookupKey = name
-	}
-	return r.byUniqueID[lookupKey], nil
+	return r.byID[fmaID], nil
 }
 
 // isDuplicateInHouseApp returns true if this in-house app (.ipa) has already
@@ -1738,7 +1734,7 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 	appStoreApps := make([]map[string]any, 0)
 	fmas := make([]map[string]any, 0)
 	dedupeInHouseApps := make(map[string]struct{})
-	var slugResolver fmaSlugResolver
+	slugResolver := &fmaSlugResolver{client: client, teamID: teamID}
 
 	for _, sw := range titles {
 		if isDuplicateInHouseApp(sw, dedupeInHouseApps) {
@@ -1759,7 +1755,7 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 			}
 
 			if sw.SoftwarePackage.FleetMaintainedAppID != nil {
-				slug, err := slugResolver.resolve(sw.BundleIdentifier, sw.Name)
+				slug, err := slugResolver.resolve(*sw.SoftwarePackage.FleetMaintainedAppID)
 				if err != nil {
 					return nil, nil, nil, err
 				}
@@ -1846,7 +1842,7 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	appStoreApps := make([]map[string]any, 0)
 	fmas := make([]map[string]any, 0)
 	dedupeInHouseApps := make(map[string]struct{})
-	var slugResolver fmaSlugResolver
+	slugResolver := &fmaSlugResolver{client: cmd.Client, teamID: teamID}
 	for _, sw := range software {
 		if isDuplicateInHouseApp(sw, dedupeInHouseApps) {
 			continue
@@ -1909,7 +1905,7 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 
 			var fmaInstallScriptModified, fmaUninstallScriptModified bool
 			if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {
-				slug, err = slugResolver.resolve(softwareTitle.BundleIdentifier, softwareTitle.Name)
+				slug, err = slugResolver.resolve(*softwareTitle.SoftwarePackage.FleetMaintainedAppID)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -284,11 +284,6 @@ type GenerateGitopsCommand struct {
 	AppConfig    *fleet.EnrichedAppConfig
 	SoftwareList map[uint]Software
 	ScriptList   map[uint]string
-
-	// Populated by generateSoftware in validation-only mode for use by
-	// doGitOpsPolicies to resolve policy title IDs.
-	ValidationInstallers []fleet.SoftwarePackageResponse
-	ValidationVPPApps    []fleet.VPPAppResponse
 }
 
 func generateGitopsCommand() *cli.Command {
@@ -581,7 +576,6 @@ func (cmd *GenerateGitopsCommand) Run() error {
 				team.ID,
 				teamFileName,
 				!cmd.CLI.Bool("print") && (cmd.CLI.String("key") == "" || cmd.CLI.String("key") == "software"),
-				false,
 			)
 			if err != nil {
 				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating software for %s: %s\n", teamFileName, err)
@@ -1662,41 +1656,153 @@ func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]in
 	return result, nil
 }
 
+// fmaSlugResolver lazily fetches the Fleet Maintained Apps catalog and
+// resolves FMA slugs by bundle identifier or software title name.
+type fmaSlugResolver struct {
+	appsList   *maintained_apps.AppsList
+	byUniqueID map[string]string
+}
+
+func (r *fmaSlugResolver) resolve(bundleIdentifier *string, name string) (string, error) {
+	if r.byUniqueID == nil {
+		if r.appsList == nil {
+			var err error
+			r.appsList, err = maintained_apps.FetchAppsList(context.Background())
+			if err != nil {
+				return "", err
+			}
+		}
+		r.byUniqueID = make(map[string]string, len(r.appsList.Apps))
+		for _, a := range r.appsList.Apps {
+			r.byUniqueID[a.UniqueIdentifier] = a.Slug
+		}
+	}
+	// Look up slug by bundle identifier (macOS) or software title name (Windows).
+	// Windows FMAs don't have a bundle identifier; their unique_identifier
+	// in the manifest is the program name (e.g., "1Password").
+	lookupKey := ptr.ValOrZero(bundleIdentifier)
+	if lookupKey == "" {
+		lookupKey = name
+	}
+	return r.byUniqueID[lookupKey], nil
+}
+
+// isDuplicateInHouseApp returns true if this in-house app (.ipa) has already
+// been seen, tracking by filename. In-house apps generate two software titles
+// (one for iOS, one for iPadOS) so we deduplicate them.
+func isDuplicateInHouseApp(sw fleet.SoftwareTitleListResult, seen map[string]struct{}) bool {
+	if sw.SoftwarePackage == nil {
+		return false
+	}
+	if filepath.Ext(sw.SoftwarePackage.Name) != ".ipa" {
+		return false
+	}
+	if _, ok := seen[sw.SoftwarePackage.Name]; ok {
+		return true
+	}
+	seen[sw.SoftwarePackage.Name] = struct{}{}
+	return false
+}
+
 // generateSoftwareForValidation produces a minimal software spec from
 // server-side data for GitOps validation (policy install_software and patch
-// policy references). It wraps generateSoftware with forValidationOnly=true,
-// skipping expensive per-title API calls, scripts, icons, setup experience, etc.
+// policy references). It only calls ListSoftwareTitles (not GetSoftwareTitleByID
+// per title), skipping scripts, icons, setup experience, labels, etc.
 // It also returns SoftwarePackageResponse/VPPAppResponse slices with title IDs
-// for policy resolution in doGitOpsPolicies.
+// for policy title ID resolution in doGitOpsPolicies.
 func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet.EnrichedAppConfig, teamID uint) (
 	softwareSpec map[string]interface{},
 	installers []fleet.SoftwarePackageResponse,
 	vppApps []fleet.VPPAppResponse,
 	err error,
 ) {
-	cmd := &GenerateGitopsCommand{
-		Client:       client,
-		AppConfig:    appConfig,
-		SoftwareList: make(map[uint]Software),
+	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
+	titles, err := client.ListSoftwareTitles(query)
+	if err != nil {
+		return nil, nil, nil, err
 	}
-	softwareSpec, err = cmd.generateSoftware("", teamID, "", false, true)
-	return softwareSpec, cmd.ValidationInstallers, cmd.ValidationVPPApps, err
+	if len(titles) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	result := make(map[string]any)
+	packages := make([]map[string]any, 0)
+	appStoreApps := make([]map[string]any, 0)
+	fmas := make([]map[string]any, 0)
+	dedupeInHouseApps := make(map[string]struct{})
+	var slugResolver fmaSlugResolver
+
+	for _, sw := range titles {
+		if isDuplicateInHouseApp(sw, dedupeInHouseApps) {
+			continue
+		}
+
+		spec := make(map[string]interface{})
+		titleID := sw.ID
+
+		switch {
+		case sw.SoftwarePackage != nil:
+			if sw.HashSHA256 != nil {
+				spec["hash_sha256"] = *sw.HashSHA256
+			}
+			if sw.SoftwarePackage.PackageURL != nil {
+				spec["url"] = *sw.SoftwarePackage.PackageURL
+			}
+
+			installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
+			if sw.SoftwarePackage.PackageURL != nil {
+				installer.URL = *sw.SoftwarePackage.PackageURL
+			}
+			if sw.HashSHA256 != nil {
+				installer.HashSHA256 = *sw.HashSHA256
+			}
+
+			if sw.SoftwarePackage.FleetMaintainedAppID != nil {
+				slug, err := slugResolver.resolve(sw.BundleIdentifier, sw.Name)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				spec["slug"] = slug
+				installer.Slug = slug
+				fmas = append(fmas, spec)
+			} else {
+				packages = append(packages, spec)
+			}
+			installers = append(installers, installer)
+
+		case sw.AppStoreApp != nil:
+			spec["app_store_id"] = sw.AppStoreApp.AppStoreID
+			appStoreApps = append(appStoreApps, spec)
+			vppApps = append(vppApps, fleet.VPPAppResponse{
+				TitleID:    &titleID,
+				AppStoreID: sw.AppStoreApp.AppStoreID,
+				Platform:   fleet.InstallableDevicePlatform(sw.AppStoreApp.Platform),
+			})
+		}
+	}
+
+	if len(packages) > 0 {
+		result["packages"] = packages
+	}
+	if len(appStoreApps) > 0 {
+		result["app_store_apps"] = appStoreApps
+	}
+	if len(fmas) > 0 {
+		result["fleet_maintained_apps"] = fmas
+	}
+
+	return result, installers, vppApps, nil
 }
 
-func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint, teamFilename string, downloadIcons bool, validationOnly bool) (map[string]interface{}, error) {
-	if !validationOnly && !cmd.AppConfig.License.IsPremium() {
+func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint, teamFilename string, downloadIcons bool) (map[string]interface{}, error) {
+	if !cmd.AppConfig.License.IsPremium() {
 		return nil, nil // software is premium-only
 	}
 
 	query := fmt.Sprintf("available_for_install=1&fleet_id=%d", teamID)
-	if validationOnly {
-		query += "&per_page=1000"
-	}
 	software, err := cmd.Client.ListSoftwareTitles(query)
 	if err != nil {
-		if !validationOnly {
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software: %s\n", err)
-		}
+		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software: %s\n", err)
 		return nil, err
 	}
 	if len(software) == 0 {
@@ -1706,25 +1812,23 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	setupSoftwareBySoftwareTitle := make(map[uint]struct{})
 	setupSoftwareByPlatformAndAppID := make(map[string]struct{})
 
-	if !validationOnly {
-		// Fill in InstallDuringSetup for software, as that information is only available
-		// from the setup experience endpoint
-		platforms := "macos,windows,linux,ios,ipados,android"
-		setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(platforms, teamID)
-		if err != nil {
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
-			return nil, err
+	// Fill in InstallDuringSetup for software, as that information is only available
+	// from the setup experience endpoint
+	platforms := "macos,windows,linux,ios,ipados,android"
+	setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(platforms, teamID)
+	if err != nil {
+		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
+		return nil, err
+	}
+	for _, software := range setupSoftware {
+		pkg := software.SoftwarePackage
+		if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
+			setupSoftwareBySoftwareTitle[software.ID] = struct{}{}
 		}
-		for _, software := range setupSoftware {
-			pkg := software.SoftwarePackage
-			if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
-				setupSoftwareBySoftwareTitle[software.ID] = struct{}{}
-			}
-			if software.AppStoreApp != nil {
-				appStoreApp := software.AppStoreApp
-				if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
-					setupSoftwareByPlatformAndAppID[appStoreApp.FullyQualifiedName()] = struct{}{}
-				}
+		if software.AppStoreApp != nil {
+			appStoreApp := software.AppStoreApp
+			if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
+				setupSoftwareByPlatformAndAppID[appStoreApp.FullyQualifiedName()] = struct{}{}
 			}
 		}
 	}
@@ -1733,53 +1837,38 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	packages := make([]map[string]any, 0)
 	appStoreApps := make([]map[string]any, 0)
 	fmas := make([]map[string]any, 0)
-	var appsList *maintained_apps.AppsList
-
-	// in-house apps generate two software titles for the same gitops entry: one
-	// for iOS and one for iPadOS. Use this set to deduplicate them (by filename,
-	// which is unique for a given team and platform).
-	dedupeInHouseAppsByFilename := make(map[string]struct{})
-	var byUniqueID map[string]string
+	dedupeInHouseApps := make(map[string]struct{})
+	var slugResolver fmaSlugResolver
 	for _, sw := range software {
+		if isDuplicateInHouseApp(sw, dedupeInHouseApps) {
+			continue
+		}
+
 		softwareSpec := make(map[string]interface{})
 		switch {
 		case sw.SoftwarePackage != nil:
-			if isInHouseApp := filepath.Ext(sw.SoftwarePackage.Name) == ".ipa"; isInHouseApp {
-				if _, ok := dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name]; ok {
-					// ignore duplicate in-house app
-					continue
-				}
-				dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name] = struct{}{}
+			pkgName := ""
+			if sw.SoftwarePackage.Name != "" {
+				pkgName = fmt.Sprintf(" (%s)", sw.SoftwarePackage.Name)
 			}
-
-			if validationOnly {
-				if sw.HashSHA256 != nil {
-					softwareSpec["hash_sha256"] = *sw.HashSHA256
-				}
+			comment := cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
+			if sw.HashSHA256 == nil {
+				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
+					Filename: filePath,
+					Note:     fmt.Sprintf("Warning: software %s has no hash_sha256.  This is required for GitOps to work.  Please add it manually.", sw.Name),
+				})
+				softwareSpec["hash_sha256"] = cmd.AddComment(filePath, "TODO: Add your hash_sha256 here")
 			} else {
-				pkgName := ""
-				if sw.SoftwarePackage.Name != "" {
-					pkgName = fmt.Sprintf(" (%s)", sw.SoftwarePackage.Name)
+				softwareSpec["hash_sha256"] = *sw.HashSHA256 + " " + comment
+				swEntry := Software{
+					Hash:    *sw.HashSHA256,
+					Comment: comment,
 				}
-				comment := cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
-				if sw.HashSHA256 == nil {
-					cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
-						Filename: filePath,
-						Note:     fmt.Sprintf("Warning: software %s has no hash_sha256.  This is required for GitOps to work.  Please add it manually.", sw.Name),
-					})
-					softwareSpec["hash_sha256"] = cmd.AddComment(filePath, "TODO: Add your hash_sha256 here")
-				} else {
-					softwareSpec["hash_sha256"] = *sw.HashSHA256 + " " + comment
-					swEntry := Software{
-						Hash:    *sw.HashSHA256,
-						Comment: comment,
-					}
-					if sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil {
-						swEntry.MaintainedAppID = *sw.SoftwarePackage.FleetMaintainedAppID
-					}
+				if sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil {
+					swEntry.MaintainedAppID = *sw.SoftwarePackage.FleetMaintainedAppID
+				}
 
-					cmd.SoftwareList[sw.ID] = swEntry
-				}
+				cmd.SoftwareList[sw.ID] = swEntry
 			}
 		case sw.AppStoreApp != nil:
 			softwareSpec["app_store_id"] = sw.AppStoreApp.AppStoreID
@@ -1787,318 +1876,249 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 				AppStoreId: sw.AppStoreApp.AppStoreID,
 			}
 		default:
-			if !validationOnly {
-				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error: software %s has no software package or app store app\n", sw.Name)
-			}
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error: software %s has no software package or app store app\n", sw.Name)
 			continue
+		}
+
+		softwareTitle, err := cmd.Client.GetSoftwareTitleByID(sw.ID, &teamID)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software title %s: %s\n", sw.Name, err)
+			return nil, err
 		}
 
 		var slug string
 
-		// In validation mode, resolve URL and FMA slug from list result
-		// fields without calling GetSoftwareTitleByID per title. Also build
-		// SoftwarePackageResponse/VPPAppResponse slices with title IDs for
-		// policy resolution in doGitOpsPolicies.
-		if validationOnly {
-			titleID := sw.ID
-			if sw.SoftwarePackage != nil {
-				if sw.SoftwarePackage.PackageURL != nil {
-					softwareSpec["url"] = *sw.SoftwarePackage.PackageURL
+		if softwareTitle.SoftwarePackage != nil {
+			filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
+
+			// Detect if this is a script package (.sh or .ps1 file)
+			// Script packages have the file contents as the install script internally,
+			// but these fields should NOT be exposed in GitOps YAML as they are not
+			// user-configurable for script packages.
+			isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
+				(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
+					strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
+
+			var fmaInstallScriptModified, fmaUninstallScriptModified bool
+			if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {
+				slug, err = slugResolver.resolve(softwareTitle.BundleIdentifier, softwareTitle.Name)
+				if err != nil {
+					return nil, err
 				}
-				installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
-				if sw.SoftwarePackage.PackageURL != nil {
-					installer.URL = *sw.SoftwarePackage.PackageURL
+				fma, err := maintained_apps.Hydrate(context.Background(), &fleet.MaintainedApp{
+					ID:   *softwareTitle.SoftwarePackage.FleetMaintainedAppID,
+					Slug: slug,
+				}, "", nil, nil)
+				if err != nil {
+					return nil, err
 				}
-				if sw.HashSHA256 != nil {
-					installer.HashSHA256 = *sw.HashSHA256
+
+				fmaInstallScriptModified = fma.InstallScript != softwareTitle.SoftwarePackage.InstallScript
+				fmaUninstallScriptModified = fma.UninstallScript != softwareTitle.SoftwarePackage.UninstallScript
+			}
+
+			shouldWriteScript := func(fmaID *uint, scriptContents string, scriptModified bool) bool {
+				if fmaID != nil {
+					return scriptModified && scriptContents != ""
 				}
-				if sw.SoftwarePackage.FleetMaintainedAppID != nil {
-					if byUniqueID == nil {
-						if appsList == nil {
-							appsList, err = maintained_apps.FetchAppsList(context.Background())
-							if err != nil {
-								return nil, err
-							}
-						}
-						byUniqueID = make(map[string]string, len(appsList.Apps))
-						for _, a := range appsList.Apps {
-							byUniqueID[a.UniqueIdentifier] = a.Slug
-						}
+
+				return scriptContents != ""
+			}
+
+			// Only output install_script, post_install_script, uninstall_script, and
+			// pre_install_query for non-script packages
+			if !isScriptPackage {
+				if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.InstallScript, fmaInstallScriptModified) {
+					script := softwareTitle.SoftwarePackage.InstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["install_script"] = map[string]interface{}{
+						"path": path,
 					}
-					lookupKey := ptr.ValOrZero(sw.BundleIdentifier)
-					if lookupKey == "" {
-						lookupKey = sw.Name
-					}
-					slug = byUniqueID[lookupKey]
-					installer.Slug = slug
+					cmd.FilesToWrite[fileName] = script
 				}
-				cmd.ValidationInstallers = append(cmd.ValidationInstallers, installer)
-			} else if sw.AppStoreApp != nil {
-				cmd.ValidationVPPApps = append(cmd.ValidationVPPApps, fleet.VPPAppResponse{
-					TitleID:    &titleID,
-					AppStoreID: sw.AppStoreApp.AppStoreID,
-					Platform:   fleet.InstallableDevicePlatform(sw.AppStoreApp.Platform),
-				})
+
+				if softwareTitle.SoftwarePackage.PostInstallScript != "" {
+					script := softwareTitle.SoftwarePackage.PostInstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["post_install_script"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = script
+				}
+
+				if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.UninstallScript, fmaUninstallScriptModified) {
+					script := softwareTitle.SoftwarePackage.UninstallScript
+					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["uninstall_script"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = script
+				}
+
+				if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
+					query := softwareTitle.SoftwarePackage.PreInstallQuery
+					fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["pre_install_query"] = map[string]interface{}{
+						"path": path,
+					}
+					cmd.FilesToWrite[fileName] = []map[string]interface{}{{
+						"query": query,
+					}}
+				}
+			}
+
+			if softwareTitle.SoftwarePackage.SelfService {
+				softwareSpec["self_service"] = softwareTitle.SoftwarePackage.SelfService
+			}
+
+			if softwareTitle.SoftwarePackage.URL != "" {
+				softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
+			}
+
+			if softwareTitle.SoftwarePackage.Categories != nil {
+				softwareSpec["categories"] = softwareTitle.SoftwarePackage.Categories
+			}
+
+			if softwareTitle.DisplayName != "" {
+				softwareSpec["display_name"] = softwareTitle.DisplayName
+			}
+
+			// each package is listed once in software, so we can pull icon directly here
+			if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
+				fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
+				path := fmt.Sprintf("../%s", fileName)
+				softwareSpec["icon"] = map[string]interface{}{
+					"path": path,
+				}
+				icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
+				if err != nil {
+					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
+					return nil, err
+				}
+
+				// TODO write files immediately rather than queueing them up
+				cmd.FilesToWrite[fileName] = icon
+			}
+		}
+
+		if softwareTitle.AppStoreApp != nil {
+			filenamePrefix := generateFilename(sw.Name) + "-" + sw.AppStoreApp.Platform
+			softwareSpec["platform"] = softwareTitle.AppStoreApp.Platform
+			if softwareTitle.AppStoreApp.SelfService {
+				softwareSpec["self_service"] = softwareTitle.AppStoreApp.SelfService
+			}
+
+			if softwareTitle.AppStoreApp.Categories != nil {
+				softwareSpec["categories"] = softwareTitle.AppStoreApp.Categories
+			}
+
+			if softwareTitle.DisplayName != "" {
+				softwareSpec["display_name"] = softwareTitle.DisplayName
+			}
+
+			if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
+				fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
+				path := fmt.Sprintf("../%s", fileName)
+				softwareSpec["icon"] = map[string]any{
+					"path": path,
+				}
+				icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
+				if err != nil {
+					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
+					return nil, err
+				}
+
+				// TODO write files immediately rather than queueing them up
+				cmd.FilesToWrite[fileName] = icon
+			}
+
+			config := softwareTitle.AppStoreApp.Configuration
+			if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
+				// all per-team software-related artifacts are generated in lib/{team}/software
+				fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
+				path := fmt.Sprintf("../%s", fileName)
+				softwareSpec["configuration"] = map[string]any{
+					"path": path,
+				}
+
+				// format config because it is received with incorrect indentation
+				var buf bytes.Buffer
+				err := json.Indent(&buf, softwareTitle.AppStoreApp.Configuration, "", "  ")
+				if err != nil {
+					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error formatting android app configuration %s: %s\n", sw.Name, err)
+					return nil, err
+				}
+
+				cmd.FilesToWrite[fileName] = buf.Bytes()
+			}
+
+			// export auto-update schedule settings for iOS/iPadOS VPP apps when present.
+			// only VPP apps (those with an AdamID) support auto-update schedules.
+			if softwareTitle.AutoUpdateEnabled != nil || softwareTitle.AutoUpdateStartTime != nil || softwareTitle.AutoUpdateEndTime != nil {
+				platform := softwareTitle.AppStoreApp.Platform
+				adamID := softwareTitle.AppStoreApp.VPPAppID.AdamID
+				if (platform == fleet.IOSPlatform || platform == fleet.IPadOSPlatform) && adamID != "" {
+					if softwareTitle.AutoUpdateEnabled != nil {
+						softwareSpec["auto_update_enabled"] = *softwareTitle.AutoUpdateEnabled
+					}
+					if softwareTitle.AutoUpdateStartTime != nil {
+						softwareSpec["auto_update_window_start"] = *softwareTitle.AutoUpdateStartTime
+					}
+					if softwareTitle.AutoUpdateEndTime != nil {
+						softwareSpec["auto_update_window_end"] = *softwareTitle.AutoUpdateEndTime
+					}
+				}
+			}
+		}
+
+		var labels []fleet.SoftwareScopeLabel
+		var labelKey string
+		if softwareTitle.SoftwarePackage != nil {
+			if len(softwareTitle.SoftwarePackage.LabelsIncludeAny) > 0 {
+				labels = softwareTitle.SoftwarePackage.LabelsIncludeAny
+				labelKey = "labels_include_any"
+			}
+			if len(softwareTitle.SoftwarePackage.LabelsExcludeAny) > 0 {
+				labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
+				labelKey = "labels_exclude_any"
+			}
+			if len(softwareTitle.SoftwarePackage.LabelsIncludeAll) > 0 {
+				labels = softwareTitle.SoftwarePackage.LabelsIncludeAll
+				labelKey = "labels_include_all"
+			}
+			if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
+				softwareSpec["setup_experience"] = true
 			}
 		} else {
+			platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()
 
-			softwareTitle, err := cmd.Client.GetSoftwareTitleByID(sw.ID, &teamID)
-			if err != nil {
-				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software title %s: %s\n", sw.Name, err)
-				return nil, err
+			if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
+				labels = softwareTitle.AppStoreApp.LabelsIncludeAny
+				labelKey = "labels_include_any"
 			}
-
-			if softwareTitle.SoftwarePackage != nil {
-				filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
-
-				// Detect if this is a script package (.sh or .ps1 file)
-				// Script packages have the file contents as the install script internally,
-				// but these fields should NOT be exposed in GitOps YAML as they are not
-				// user-configurable for script packages.
-				isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
-					(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
-						strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
-
-				var fmaInstallScriptModified, fmaUninstallScriptModified bool
-				if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {
-					if byUniqueID == nil {
-						if appsList == nil {
-							var err error
-							appsList, err = maintained_apps.FetchAppsList(context.Background())
-							if err != nil {
-								return nil, err
-							}
-						}
-						byUniqueID = make(map[string]string, len(appsList.Apps))
-						for _, a := range appsList.Apps {
-							byUniqueID[a.UniqueIdentifier] = a.Slug
-						}
-					}
-
-					// Look up slug by bundle identifier (macOS) or software title name (Windows).
-					// Windows FMAs don't have a bundle identifier; their unique_identifier
-					// in the manifest is the program name (e.g., "1Password").
-					lookupKey := ptr.ValOrZero(softwareTitle.BundleIdentifier)
-					if lookupKey == "" {
-						lookupKey = softwareTitle.Name
-					}
-					slug = byUniqueID[lookupKey]
-					fma, err := maintained_apps.Hydrate(context.Background(), &fleet.MaintainedApp{
-						ID:   *softwareTitle.SoftwarePackage.FleetMaintainedAppID,
-						Slug: slug,
-					}, "", nil, nil)
-					if err != nil {
-						return nil, err
-					}
-
-					fmaInstallScriptModified = fma.InstallScript != softwareTitle.SoftwarePackage.InstallScript
-					fmaUninstallScriptModified = fma.UninstallScript != softwareTitle.SoftwarePackage.UninstallScript
-				}
-
-				shouldWriteScript := func(fmaID *uint, scriptContents string, scriptModified bool) bool {
-					if fmaID != nil {
-						return scriptModified && scriptContents != ""
-					}
-
-					return scriptContents != ""
-				}
-
-				// Only output install_script, post_install_script, uninstall_script, and
-				// pre_install_query for non-script packages
-				if !isScriptPackage {
-					if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.InstallScript, fmaInstallScriptModified) {
-						script := softwareTitle.SoftwarePackage.InstallScript
-						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
-						path := fmt.Sprintf("../%s", fileName)
-						softwareSpec["install_script"] = map[string]interface{}{
-							"path": path,
-						}
-						cmd.FilesToWrite[fileName] = script
-					}
-
-					if softwareTitle.SoftwarePackage.PostInstallScript != "" {
-						script := softwareTitle.SoftwarePackage.PostInstallScript
-						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
-						path := fmt.Sprintf("../%s", fileName)
-						softwareSpec["post_install_script"] = map[string]interface{}{
-							"path": path,
-						}
-						cmd.FilesToWrite[fileName] = script
-					}
-
-					if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.UninstallScript, fmaUninstallScriptModified) {
-						script := softwareTitle.SoftwarePackage.UninstallScript
-						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
-						path := fmt.Sprintf("../%s", fileName)
-						softwareSpec["uninstall_script"] = map[string]interface{}{
-							"path": path,
-						}
-						cmd.FilesToWrite[fileName] = script
-					}
-
-					if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
-						query := softwareTitle.SoftwarePackage.PreInstallQuery
-						fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
-						path := fmt.Sprintf("../%s", fileName)
-						softwareSpec["pre_install_query"] = map[string]interface{}{
-							"path": path,
-						}
-						cmd.FilesToWrite[fileName] = []map[string]interface{}{{
-							"query": query,
-						}}
-					}
-				}
-
-				if softwareTitle.SoftwarePackage.SelfService {
-					softwareSpec["self_service"] = softwareTitle.SoftwarePackage.SelfService
-				}
-
-				if softwareTitle.SoftwarePackage.URL != "" {
-					softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
-				}
-
-				if softwareTitle.SoftwarePackage.Categories != nil {
-					softwareSpec["categories"] = softwareTitle.SoftwarePackage.Categories
-				}
-
-				if softwareTitle.DisplayName != "" {
-					softwareSpec["display_name"] = softwareTitle.DisplayName
-				}
-
-				// each package is listed once in software, so we can pull icon directly here
-				if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
-					fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["icon"] = map[string]interface{}{
-						"path": path,
-					}
-					icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
-					if err != nil {
-						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
-						return nil, err
-					}
-
-					// TODO write files immediately rather than queueing them up
-					cmd.FilesToWrite[fileName] = icon
-				}
+			if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
+				labels = softwareTitle.AppStoreApp.LabelsExcludeAny
+				labelKey = "labels_exclude_any"
 			}
-
-			if softwareTitle.AppStoreApp != nil {
-				filenamePrefix := generateFilename(sw.Name) + "-" + sw.AppStoreApp.Platform
-				softwareSpec["platform"] = softwareTitle.AppStoreApp.Platform
-				if softwareTitle.AppStoreApp.SelfService {
-					softwareSpec["self_service"] = softwareTitle.AppStoreApp.SelfService
-				}
-
-				if softwareTitle.AppStoreApp.Categories != nil {
-					softwareSpec["categories"] = softwareTitle.AppStoreApp.Categories
-				}
-
-				if softwareTitle.DisplayName != "" {
-					softwareSpec["display_name"] = softwareTitle.DisplayName
-				}
-
-				if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
-					fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["icon"] = map[string]any{
-						"path": path,
-					}
-					icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
-					if err != nil {
-						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
-						return nil, err
-					}
-
-					// TODO write files immediately rather than queueing them up
-					cmd.FilesToWrite[fileName] = icon
-				}
-
-				config := softwareTitle.AppStoreApp.Configuration
-				if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
-					// all per-team software-related artifacts are generated in lib/{team}/software
-					fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["configuration"] = map[string]any{
-						"path": path,
-					}
-
-					// format config because it is received with incorrect indentation
-					var buf bytes.Buffer
-					err := json.Indent(&buf, softwareTitle.AppStoreApp.Configuration, "", "  ")
-					if err != nil {
-						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error formatting android app configuration %s: %s\n", sw.Name, err)
-						return nil, err
-					}
-
-					cmd.FilesToWrite[fileName] = buf.Bytes()
-				}
-
-				// export auto-update schedule settings for iOS/iPadOS VPP apps when present.
-				// only VPP apps (those with an AdamID) support auto-update schedules.
-				if softwareTitle.AutoUpdateEnabled != nil || softwareTitle.AutoUpdateStartTime != nil || softwareTitle.AutoUpdateEndTime != nil {
-					platform := softwareTitle.AppStoreApp.Platform
-					adamID := softwareTitle.AppStoreApp.VPPAppID.AdamID
-					if (platform == fleet.IOSPlatform || platform == fleet.IPadOSPlatform) && adamID != "" {
-						if softwareTitle.AutoUpdateEnabled != nil {
-							softwareSpec["auto_update_enabled"] = *softwareTitle.AutoUpdateEnabled
-						}
-						if softwareTitle.AutoUpdateStartTime != nil {
-							softwareSpec["auto_update_window_start"] = *softwareTitle.AutoUpdateStartTime
-						}
-						if softwareTitle.AutoUpdateEndTime != nil {
-							softwareSpec["auto_update_window_end"] = *softwareTitle.AutoUpdateEndTime
-						}
-					}
-				}
+			if len(softwareTitle.AppStoreApp.LabelsIncludeAll) > 0 {
+				labels = softwareTitle.AppStoreApp.LabelsIncludeAll
+				labelKey = "labels_include_all"
 			}
-
-			var labels []fleet.SoftwareScopeLabel
-			var labelKey string
-			if softwareTitle.SoftwarePackage != nil {
-				if len(softwareTitle.SoftwarePackage.LabelsIncludeAny) > 0 {
-					labels = softwareTitle.SoftwarePackage.LabelsIncludeAny
-					labelKey = "labels_include_any"
-				}
-				if len(softwareTitle.SoftwarePackage.LabelsExcludeAny) > 0 {
-					labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
-					labelKey = "labels_exclude_any"
-				}
-				if len(softwareTitle.SoftwarePackage.LabelsIncludeAll) > 0 {
-					labels = softwareTitle.SoftwarePackage.LabelsIncludeAll
-					labelKey = "labels_include_all"
-				}
-				if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
-					softwareSpec["setup_experience"] = true
-				}
-			} else {
-				platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()
-
-				if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
-					labels = softwareTitle.AppStoreApp.LabelsIncludeAny
-					labelKey = "labels_include_any"
-				}
-				if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
-					labels = softwareTitle.AppStoreApp.LabelsExcludeAny
-					labelKey = "labels_exclude_any"
-				}
-				if len(softwareTitle.AppStoreApp.LabelsIncludeAll) > 0 {
-					labels = softwareTitle.AppStoreApp.LabelsIncludeAll
-					labelKey = "labels_include_all"
-				}
-				if _, exists := setupSoftwareByPlatformAndAppID[platformAndAppID]; exists {
-					softwareSpec["setup_experience"] = true
-				}
+			if _, exists := setupSoftwareByPlatformAndAppID[platformAndAppID]; exists {
+				softwareSpec["setup_experience"] = true
 			}
-			if len(labels) > 0 {
-				labelsList := make([]string, len(labels))
-				for i, label := range labels {
-					labelsList[i] = label.LabelName
-				}
-				softwareSpec[labelKey] = labelsList
+		}
+		if len(labels) > 0 {
+			labelsList := make([]string, len(labels))
+			for i, label := range labels {
+				labelsList[i] = label.LabelName
 			}
-
-		} // end if !validationOnly
+			softwareSpec[labelKey] = labelsList
+		}
 
 		switch {
 		case sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil:

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1711,7 +1711,7 @@ func isDuplicateInHouseApp(sw fleet.SoftwareTitleListResult, seen map[string]str
 // It also returns SoftwarePackageResponse/VPPAppResponse slices with title IDs
 // for policy title ID resolution in doGitOpsPolicies.
 func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet.EnrichedAppConfig, teamID uint) (
-	softwareSpec map[string]interface{},
+	softwareSpec map[string]any,
 	installers []fleet.SoftwarePackageResponse,
 	vppApps []fleet.VPPAppResponse,
 	err error,
@@ -1737,7 +1737,7 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 			continue
 		}
 
-		spec := make(map[string]interface{})
+		spec := make(map[string]any)
 		titleID := sw.ID
 
 		switch {

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -284,6 +284,11 @@ type GenerateGitopsCommand struct {
 	AppConfig    *fleet.EnrichedAppConfig
 	SoftwareList map[uint]Software
 	ScriptList   map[uint]string
+
+	// Populated by generateSoftware in validation-only mode for use by
+	// doGitOpsPolicies to resolve policy title IDs.
+	ValidationInstallers []fleet.SoftwarePackageResponse
+	ValidationVPPApps    []fleet.VPPAppResponse
 }
 
 func generateGitopsCommand() *cli.Command {
@@ -576,6 +581,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 				team.ID,
 				teamFileName,
 				!cmd.CLI.Bool("print") && (cmd.CLI.String("key") == "" || cmd.CLI.String("key") == "software"),
+				false,
 			)
 			if err != nil {
 				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error generating software for %s: %s\n", teamFileName, err)
@@ -1656,101 +1662,41 @@ func (cmd *GenerateGitopsCommand) generateQueries(teamId *uint) ([]map[string]in
 	return result, nil
 }
 
-// generateSoftwareForValidation is a lightweight version of generateSoftware
-// that produces a minimal software spec from server-side data for GitOps
-// validation (policy install_software and patch policy references). It skips
-// GetSoftwareTitleByID, scripts, icons, setup experience, labels, etc.
-func generateSoftwareForValidation(client generateGitopsClient, teamID uint) (map[string]interface{}, error) {
-	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
-	software, err := client.ListSoftwareTitles(query)
-	if err != nil {
-		return nil, err
+// generateSoftwareForValidation produces a minimal software spec from
+// server-side data for GitOps validation (policy install_software and patch
+// policy references). It wraps generateSoftware with forValidationOnly=true,
+// skipping expensive per-title API calls, scripts, icons, setup experience, etc.
+// It also returns SoftwarePackageResponse/VPPAppResponse slices with title IDs
+// for policy resolution in doGitOpsPolicies.
+func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet.EnrichedAppConfig, teamID uint) (
+	softwareSpec map[string]interface{},
+	installers []fleet.SoftwarePackageResponse,
+	vppApps []fleet.VPPAppResponse,
+	err error,
+) {
+	cmd := &GenerateGitopsCommand{
+		Client:       client,
+		AppConfig:    appConfig,
+		SoftwareList: make(map[uint]Software),
 	}
-	if len(software) == 0 {
-		return nil, nil
-	}
-
-	result := make(map[string]any)
-	packages := make([]map[string]any, 0)
-	appStoreApps := make([]map[string]any, 0)
-	fmas := make([]map[string]any, 0)
-	dedupeInHouseAppsByFilename := make(map[string]struct{})
-
-	var appsList *maintained_apps.AppsList
-	var byUniqueID map[string]string
-
-	for _, sw := range software {
-		softwareSpec := make(map[string]interface{})
-		switch {
-		case sw.SoftwarePackage != nil:
-			// In-house app dedup (same logic as generateSoftware)
-			if isInHouseApp := filepath.Ext(sw.SoftwarePackage.Name) == ".ipa"; isInHouseApp {
-				if _, ok := dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name]; ok {
-					continue
-				}
-				dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name] = struct{}{}
-			}
-
-			if sw.HashSHA256 != nil {
-				softwareSpec["hash_sha256"] = *sw.HashSHA256
-			}
-			if sw.SoftwarePackage.PackageURL != nil {
-				softwareSpec["url"] = *sw.SoftwarePackage.PackageURL
-			}
-
-			if sw.SoftwarePackage.FleetMaintainedAppID != nil {
-				// FMA slug resolution (same logic as generateSoftware)
-				if byUniqueID == nil {
-					if appsList == nil {
-						appsList, err = maintained_apps.FetchAppsList(context.Background())
-						if err != nil {
-							return nil, err
-						}
-					}
-					byUniqueID = make(map[string]string, len(appsList.Apps))
-					for _, a := range appsList.Apps {
-						byUniqueID[a.UniqueIdentifier] = a.Slug
-					}
-				}
-				lookupKey := ptr.ValOrZero(sw.BundleIdentifier)
-				if lookupKey == "" {
-					lookupKey = sw.Name
-				}
-				slug := byUniqueID[lookupKey]
-				softwareSpec["slug"] = slug
-				fmas = append(fmas, softwareSpec)
-			} else {
-				packages = append(packages, softwareSpec)
-			}
-
-		case sw.AppStoreApp != nil:
-			softwareSpec["app_store_id"] = sw.AppStoreApp.AppStoreID
-			appStoreApps = append(appStoreApps, softwareSpec)
-		}
-	}
-
-	if len(packages) > 0 {
-		result["packages"] = packages
-	}
-	if len(appStoreApps) > 0 {
-		result["app_store_apps"] = appStoreApps
-	}
-	if len(fmas) > 0 {
-		result["fleet_maintained_apps"] = fmas
-	}
-
-	return result, nil
+	softwareSpec, err = cmd.generateSoftware("", teamID, "", false, true)
+	return softwareSpec, cmd.ValidationInstallers, cmd.ValidationVPPApps, err
 }
 
-func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint, teamFilename string, downloadIcons bool) (map[string]interface{}, error) {
-	if !cmd.AppConfig.License.IsPremium() {
+func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint, teamFilename string, downloadIcons bool, validationOnly bool) (map[string]interface{}, error) {
+	if !validationOnly && !cmd.AppConfig.License.IsPremium() {
 		return nil, nil // software is premium-only
 	}
 
 	query := fmt.Sprintf("available_for_install=1&fleet_id=%d", teamID)
+	if validationOnly {
+		query += "&per_page=1000"
+	}
 	software, err := cmd.Client.ListSoftwareTitles(query)
 	if err != nil {
-		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software: %s\n", err)
+		if !validationOnly {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software: %s\n", err)
+		}
 		return nil, err
 	}
 	if len(software) == 0 {
@@ -1760,23 +1706,25 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	setupSoftwareBySoftwareTitle := make(map[uint]struct{})
 	setupSoftwareByPlatformAndAppID := make(map[string]struct{})
 
-	// Fill in InstallDuringSetup for software, as that information is only available
-	// from the setup experience endpoint
-	platforms := "macos,windows,linux,ios,ipados,android"
-	setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(platforms, teamID)
-	if err != nil {
-		fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
-		return nil, err
-	}
-	for _, software := range setupSoftware {
-		pkg := software.SoftwarePackage
-		if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
-			setupSoftwareBySoftwareTitle[software.ID] = struct{}{}
+	if !validationOnly {
+		// Fill in InstallDuringSetup for software, as that information is only available
+		// from the setup experience endpoint
+		platforms := "macos,windows,linux,ios,ipados,android"
+		setupSoftware, err := cmd.Client.GetSetupExperienceSoftware(platforms, teamID)
+		if err != nil {
+			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting setup software: %s\n", err)
+			return nil, err
 		}
-		if software.AppStoreApp != nil {
-			appStoreApp := software.AppStoreApp
-			if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
-				setupSoftwareByPlatformAndAppID[appStoreApp.FullyQualifiedName()] = struct{}{}
+		for _, software := range setupSoftware {
+			pkg := software.SoftwarePackage
+			if pkg != nil && pkg.InstallDuringSetup != nil && *pkg.InstallDuringSetup {
+				setupSoftwareBySoftwareTitle[software.ID] = struct{}{}
+			}
+			if software.AppStoreApp != nil {
+				appStoreApp := software.AppStoreApp
+				if appStoreApp != nil && appStoreApp.InstallDuringSetup != nil && *appStoreApp.InstallDuringSetup {
+					setupSoftwareByPlatformAndAppID[appStoreApp.FullyQualifiedName()] = struct{}{}
+				}
 			}
 		}
 	}
@@ -1785,13 +1733,13 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 	packages := make([]map[string]any, 0)
 	appStoreApps := make([]map[string]any, 0)
 	fmas := make([]map[string]any, 0)
-	var appsList []fleet.MaintainedApp
+	var appsList *maintained_apps.AppsList
 
 	// in-house apps generate two software titles for the same gitops entry: one
 	// for iOS and one for iPadOS. Use this set to deduplicate them (by filename,
 	// which is unique for a given team and platform).
 	dedupeInHouseAppsByFilename := make(map[string]struct{})
-	var byFMAID map[uint]string
+	var byUniqueID map[string]string
 	for _, sw := range software {
 		softwareSpec := make(map[string]interface{})
 		switch {
@@ -1804,28 +1752,34 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 				dedupeInHouseAppsByFilename[sw.SoftwarePackage.Name] = struct{}{}
 			}
 
-			pkgName := ""
-			if sw.SoftwarePackage.Name != "" {
-				pkgName = fmt.Sprintf(" (%s)", sw.SoftwarePackage.Name)
-			}
-			comment := cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
-			if sw.HashSHA256 == nil {
-				cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
-					Filename: filePath,
-					Note:     fmt.Sprintf("Warning: software %s has no hash_sha256.  This is required for GitOps to work.  Please add it manually.", sw.Name),
-				})
-				softwareSpec["hash_sha256"] = cmd.AddComment(filePath, "TODO: Add your hash_sha256 here")
+			if validationOnly {
+				if sw.HashSHA256 != nil {
+					softwareSpec["hash_sha256"] = *sw.HashSHA256
+				}
 			} else {
-				softwareSpec["hash_sha256"] = *sw.HashSHA256 + " " + comment
-				swEntry := Software{
-					Hash:    *sw.HashSHA256,
-					Comment: comment,
+				pkgName := ""
+				if sw.SoftwarePackage.Name != "" {
+					pkgName = fmt.Sprintf(" (%s)", sw.SoftwarePackage.Name)
 				}
-				if sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil {
-					swEntry.MaintainedAppID = *sw.SoftwarePackage.FleetMaintainedAppID
-				}
+				comment := cmd.AddComment(filePath, fmt.Sprintf("%s%s version %s", sw.Name, pkgName, sw.SoftwarePackage.Version))
+				if sw.HashSHA256 == nil {
+					cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
+						Filename: filePath,
+						Note:     fmt.Sprintf("Warning: software %s has no hash_sha256.  This is required for GitOps to work.  Please add it manually.", sw.Name),
+					})
+					softwareSpec["hash_sha256"] = cmd.AddComment(filePath, "TODO: Add your hash_sha256 here")
+				} else {
+					softwareSpec["hash_sha256"] = *sw.HashSHA256 + " " + comment
+					swEntry := Software{
+						Hash:    *sw.HashSHA256,
+						Comment: comment,
+					}
+					if sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil {
+						swEntry.MaintainedAppID = *sw.SoftwarePackage.FleetMaintainedAppID
+					}
 
-				cmd.SoftwareList[sw.ID] = swEntry
+					cmd.SoftwareList[sw.ID] = swEntry
+				}
 			}
 		case sw.AppStoreApp != nil:
 			softwareSpec["app_store_id"] = sw.AppStoreApp.AppStoreID
@@ -1833,261 +1787,318 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 				AppStoreId: sw.AppStoreApp.AppStoreID,
 			}
 		default:
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error: software %s has no software package or app store app\n", sw.Name)
+			if !validationOnly {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error: software %s has no software package or app store app\n", sw.Name)
+			}
 			continue
-		}
-
-		softwareTitle, err := cmd.Client.GetSoftwareTitleByID(sw.ID, &teamID)
-		if err != nil {
-			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software title %s: %s\n", sw.Name, err)
-			return nil, err
 		}
 
 		var slug string
 
-		if softwareTitle.SoftwarePackage != nil {
-			filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
-
-			// Detect if this is a script package (.sh or .ps1 file)
-			// Script packages have the file contents as the install script internally,
-			// but these fields should NOT be exposed in GitOps YAML as they are not
-			// user-configurable for script packages.
-			isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
-				(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
-					strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
-
-			var fmaInstallScriptModified, fmaUninstallScriptModified bool
-			if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {
-				if byFMAID == nil {
-					if appsList == nil {
-						var err error
-						// currently, the list FMA endpoint has no default pagination
-						appsList, err = cmd.Client.ListFleetMaintainedApps(teamID)
-						if err != nil {
-							return nil, err
+		// In validation mode, resolve URL and FMA slug from list result
+		// fields without calling GetSoftwareTitleByID per title. Also build
+		// SoftwarePackageResponse/VPPAppResponse slices with title IDs for
+		// policy resolution in doGitOpsPolicies.
+		if validationOnly {
+			titleID := sw.ID
+			if sw.SoftwarePackage != nil {
+				if sw.SoftwarePackage.PackageURL != nil {
+					softwareSpec["url"] = *sw.SoftwarePackage.PackageURL
+				}
+				installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
+				if sw.SoftwarePackage.PackageURL != nil {
+					installer.URL = *sw.SoftwarePackage.PackageURL
+				}
+				if sw.HashSHA256 != nil {
+					installer.HashSHA256 = *sw.HashSHA256
+				}
+				if sw.SoftwarePackage.FleetMaintainedAppID != nil {
+					if byUniqueID == nil {
+						if appsList == nil {
+							appsList, err = maintained_apps.FetchAppsList(context.Background())
+							if err != nil {
+								return nil, err
+							}
+						}
+						byUniqueID = make(map[string]string, len(appsList.Apps))
+						for _, a := range appsList.Apps {
+							byUniqueID[a.UniqueIdentifier] = a.Slug
 						}
 					}
-					byFMAID = make(map[uint]string, len(appsList))
-					for _, a := range appsList {
-						byFMAID[a.ID] = a.Slug
+					lookupKey := ptr.ValOrZero(sw.BundleIdentifier)
+					if lookupKey == "" {
+						lookupKey = sw.Name
 					}
+					slug = byUniqueID[lookupKey]
+					installer.Slug = slug
 				}
-
-				slug = byFMAID[*softwareTitle.SoftwarePackage.FleetMaintainedAppID]
-				fma, err := maintained_apps.Hydrate(context.Background(), &fleet.MaintainedApp{
-					ID:   *softwareTitle.SoftwarePackage.FleetMaintainedAppID,
-					Slug: slug,
-				}, "", nil, nil)
-				if err != nil {
-					return nil, err
-				}
-
-				fmaInstallScriptModified = fma.InstallScript != softwareTitle.SoftwarePackage.InstallScript
-				fmaUninstallScriptModified = fma.UninstallScript != softwareTitle.SoftwarePackage.UninstallScript
-			}
-
-			shouldWriteScript := func(fmaID *uint, scriptContents string, scriptModified bool) bool {
-				if fmaID != nil {
-					return scriptModified && scriptContents != ""
-				}
-
-				return scriptContents != ""
-			}
-
-			// Only output install_script, post_install_script, uninstall_script, and
-			// pre_install_query for non-script packages
-			if !isScriptPackage {
-				if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.InstallScript, fmaInstallScriptModified) {
-					script := softwareTitle.SoftwarePackage.InstallScript
-					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["install_script"] = map[string]interface{}{
-						"path": path,
-					}
-					cmd.FilesToWrite[fileName] = script
-				}
-
-				if softwareTitle.SoftwarePackage.PostInstallScript != "" {
-					script := softwareTitle.SoftwarePackage.PostInstallScript
-					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["post_install_script"] = map[string]interface{}{
-						"path": path,
-					}
-					cmd.FilesToWrite[fileName] = script
-				}
-
-				if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.UninstallScript, fmaUninstallScriptModified) {
-					script := softwareTitle.SoftwarePackage.UninstallScript
-					fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["uninstall_script"] = map[string]interface{}{
-						"path": path,
-					}
-					cmd.FilesToWrite[fileName] = script
-				}
-
-				if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
-					query := softwareTitle.SoftwarePackage.PreInstallQuery
-					fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
-					path := fmt.Sprintf("../%s", fileName)
-					softwareSpec["pre_install_query"] = map[string]interface{}{
-						"path": path,
-					}
-					cmd.FilesToWrite[fileName] = []map[string]interface{}{{
-						"query": query,
-					}}
-				}
-			}
-
-			if softwareTitle.SoftwarePackage.SelfService {
-				softwareSpec["self_service"] = softwareTitle.SoftwarePackage.SelfService
-			}
-
-			if softwareTitle.SoftwarePackage.URL != "" {
-				softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
-			}
-
-			if softwareTitle.SoftwarePackage.Categories != nil {
-				softwareSpec["categories"] = softwareTitle.SoftwarePackage.Categories
-			}
-
-			if softwareTitle.DisplayName != "" {
-				softwareSpec["display_name"] = softwareTitle.DisplayName
-			}
-
-			// each package is listed once in software, so we can pull icon directly here
-			if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
-				fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["icon"] = map[string]interface{}{
-					"path": path,
-				}
-				icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
-				if err != nil {
-					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
-					return nil, err
-				}
-
-				// TODO write files immediately rather than queueing them up
-				cmd.FilesToWrite[fileName] = icon
-			}
-		}
-
-		if softwareTitle.AppStoreApp != nil {
-			filenamePrefix := generateFilename(sw.Name) + "-" + sw.AppStoreApp.Platform
-			softwareSpec["platform"] = softwareTitle.AppStoreApp.Platform
-			if softwareTitle.AppStoreApp.SelfService {
-				softwareSpec["self_service"] = softwareTitle.AppStoreApp.SelfService
-			}
-
-			if softwareTitle.AppStoreApp.Categories != nil {
-				softwareSpec["categories"] = softwareTitle.AppStoreApp.Categories
-			}
-
-			if softwareTitle.DisplayName != "" {
-				softwareSpec["display_name"] = softwareTitle.DisplayName
-			}
-
-			if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
-				fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["icon"] = map[string]any{
-					"path": path,
-				}
-				icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
-				if err != nil {
-					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
-					return nil, err
-				}
-
-				// TODO write files immediately rather than queueing them up
-				cmd.FilesToWrite[fileName] = icon
-			}
-
-			config := softwareTitle.AppStoreApp.Configuration
-			if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
-				// all per-team software-related artifacts are generated in lib/{team}/software
-				fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
-				path := fmt.Sprintf("../%s", fileName)
-				softwareSpec["configuration"] = map[string]any{
-					"path": path,
-				}
-
-				// format config because it is received with incorrect indentation
-				var buf bytes.Buffer
-				err := json.Indent(&buf, softwareTitle.AppStoreApp.Configuration, "", "  ")
-				if err != nil {
-					fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error formatting android app configuration %s: %s\n", sw.Name, err)
-					return nil, err
-				}
-
-				cmd.FilesToWrite[fileName] = buf.Bytes()
-			}
-
-			// export auto-update schedule settings for iOS/iPadOS VPP apps when present.
-			// only VPP apps (those with an AdamID) support auto-update schedules.
-			if softwareTitle.AutoUpdateEnabled != nil || softwareTitle.AutoUpdateStartTime != nil || softwareTitle.AutoUpdateEndTime != nil {
-				platform := softwareTitle.AppStoreApp.Platform
-				adamID := softwareTitle.AppStoreApp.VPPAppID.AdamID
-				if (platform == fleet.IOSPlatform || platform == fleet.IPadOSPlatform) && adamID != "" {
-					if softwareTitle.AutoUpdateEnabled != nil {
-						softwareSpec["auto_update_enabled"] = *softwareTitle.AutoUpdateEnabled
-					}
-					if softwareTitle.AutoUpdateStartTime != nil {
-						softwareSpec["auto_update_window_start"] = *softwareTitle.AutoUpdateStartTime
-					}
-					if softwareTitle.AutoUpdateEndTime != nil {
-						softwareSpec["auto_update_window_end"] = *softwareTitle.AutoUpdateEndTime
-					}
-				}
-			}
-		}
-
-		var labels []fleet.SoftwareScopeLabel
-		var labelKey string
-		if softwareTitle.SoftwarePackage != nil {
-			if len(softwareTitle.SoftwarePackage.LabelsIncludeAny) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsIncludeAny
-				labelKey = "labels_include_any"
-			}
-			if len(softwareTitle.SoftwarePackage.LabelsExcludeAny) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
-				labelKey = "labels_exclude_any"
-			}
-			if len(softwareTitle.SoftwarePackage.LabelsIncludeAll) > 0 {
-				labels = softwareTitle.SoftwarePackage.LabelsIncludeAll
-				labelKey = "labels_include_all"
-			}
-			if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
-				softwareSpec["setup_experience"] = true
+				cmd.ValidationInstallers = append(cmd.ValidationInstallers, installer)
+			} else if sw.AppStoreApp != nil {
+				cmd.ValidationVPPApps = append(cmd.ValidationVPPApps, fleet.VPPAppResponse{
+					TitleID:    &titleID,
+					AppStoreID: sw.AppStoreApp.AppStoreID,
+					Platform:   fleet.InstallableDevicePlatform(sw.AppStoreApp.Platform),
+				})
 			}
 		} else {
-			platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()
 
-			if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsIncludeAny
-				labelKey = "labels_include_any"
+			softwareTitle, err := cmd.Client.GetSoftwareTitleByID(sw.ID, &teamID)
+			if err != nil {
+				fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software title %s: %s\n", sw.Name, err)
+				return nil, err
 			}
-			if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsExcludeAny
-				labelKey = "labels_exclude_any"
+
+			if softwareTitle.SoftwarePackage != nil {
+				filenamePrefix := generateFilename(sw.Name) + "-" + sw.SoftwarePackage.Platform
+
+				// Detect if this is a script package (.sh or .ps1 file)
+				// Script packages have the file contents as the install script internally,
+				// but these fields should NOT be exposed in GitOps YAML as they are not
+				// user-configurable for script packages.
+				isScriptPackage := sw.SoftwarePackage != nil && sw.SoftwarePackage.Name != "" &&
+					(strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".sh") ||
+						strings.HasSuffix(strings.ToLower(sw.SoftwarePackage.Name), ".ps1"))
+
+				var fmaInstallScriptModified, fmaUninstallScriptModified bool
+				if softwareTitle.SoftwarePackage.FleetMaintainedAppID != nil {
+					if byUniqueID == nil {
+						if appsList == nil {
+							var err error
+							appsList, err = maintained_apps.FetchAppsList(context.Background())
+							if err != nil {
+								return nil, err
+							}
+						}
+						byUniqueID = make(map[string]string, len(appsList.Apps))
+						for _, a := range appsList.Apps {
+							byUniqueID[a.UniqueIdentifier] = a.Slug
+						}
+					}
+
+					// Look up slug by bundle identifier (macOS) or software title name (Windows).
+					// Windows FMAs don't have a bundle identifier; their unique_identifier
+					// in the manifest is the program name (e.g., "1Password").
+					lookupKey := ptr.ValOrZero(softwareTitle.BundleIdentifier)
+					if lookupKey == "" {
+						lookupKey = softwareTitle.Name
+					}
+					slug = byUniqueID[lookupKey]
+					fma, err := maintained_apps.Hydrate(context.Background(), &fleet.MaintainedApp{
+						ID:   *softwareTitle.SoftwarePackage.FleetMaintainedAppID,
+						Slug: slug,
+					}, "", nil, nil)
+					if err != nil {
+						return nil, err
+					}
+
+					fmaInstallScriptModified = fma.InstallScript != softwareTitle.SoftwarePackage.InstallScript
+					fmaUninstallScriptModified = fma.UninstallScript != softwareTitle.SoftwarePackage.UninstallScript
+				}
+
+				shouldWriteScript := func(fmaID *uint, scriptContents string, scriptModified bool) bool {
+					if fmaID != nil {
+						return scriptModified && scriptContents != ""
+					}
+
+					return scriptContents != ""
+				}
+
+				// Only output install_script, post_install_script, uninstall_script, and
+				// pre_install_query for non-script packages
+				if !isScriptPackage {
+					if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.InstallScript, fmaInstallScriptModified) {
+						script := softwareTitle.SoftwarePackage.InstallScript
+						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-install")
+						path := fmt.Sprintf("../%s", fileName)
+						softwareSpec["install_script"] = map[string]interface{}{
+							"path": path,
+						}
+						cmd.FilesToWrite[fileName] = script
+					}
+
+					if softwareTitle.SoftwarePackage.PostInstallScript != "" {
+						script := softwareTitle.SoftwarePackage.PostInstallScript
+						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-postinstall")
+						path := fmt.Sprintf("../%s", fileName)
+						softwareSpec["post_install_script"] = map[string]interface{}{
+							"path": path,
+						}
+						cmd.FilesToWrite[fileName] = script
+					}
+
+					if shouldWriteScript(softwareTitle.SoftwarePackage.FleetMaintainedAppID, softwareTitle.SoftwarePackage.UninstallScript, fmaUninstallScriptModified) {
+						script := softwareTitle.SoftwarePackage.UninstallScript
+						fileName := fmt.Sprintf("lib/%s/scripts/%s", teamFilename, filenamePrefix+"-uninstall")
+						path := fmt.Sprintf("../%s", fileName)
+						softwareSpec["uninstall_script"] = map[string]interface{}{
+							"path": path,
+						}
+						cmd.FilesToWrite[fileName] = script
+					}
+
+					if softwareTitle.SoftwarePackage.PreInstallQuery != "" {
+						query := softwareTitle.SoftwarePackage.PreInstallQuery
+						fileName := fmt.Sprintf("lib/%s/queries/%s", teamFilename, filenamePrefix+"-preinstallquery.yml")
+						path := fmt.Sprintf("../%s", fileName)
+						softwareSpec["pre_install_query"] = map[string]interface{}{
+							"path": path,
+						}
+						cmd.FilesToWrite[fileName] = []map[string]interface{}{{
+							"query": query,
+						}}
+					}
+				}
+
+				if softwareTitle.SoftwarePackage.SelfService {
+					softwareSpec["self_service"] = softwareTitle.SoftwarePackage.SelfService
+				}
+
+				if softwareTitle.SoftwarePackage.URL != "" {
+					softwareSpec["url"] = softwareTitle.SoftwarePackage.URL
+				}
+
+				if softwareTitle.SoftwarePackage.Categories != nil {
+					softwareSpec["categories"] = softwareTitle.SoftwarePackage.Categories
+				}
+
+				if softwareTitle.DisplayName != "" {
+					softwareSpec["display_name"] = softwareTitle.DisplayName
+				}
+
+				// each package is listed once in software, so we can pull icon directly here
+				if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
+					fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["icon"] = map[string]interface{}{
+						"path": path,
+					}
+					icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
+					if err != nil {
+						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
+						return nil, err
+					}
+
+					// TODO write files immediately rather than queueing them up
+					cmd.FilesToWrite[fileName] = icon
+				}
 			}
-			if len(softwareTitle.AppStoreApp.LabelsIncludeAll) > 0 {
-				labels = softwareTitle.AppStoreApp.LabelsIncludeAll
-				labelKey = "labels_include_all"
+
+			if softwareTitle.AppStoreApp != nil {
+				filenamePrefix := generateFilename(sw.Name) + "-" + sw.AppStoreApp.Platform
+				softwareSpec["platform"] = softwareTitle.AppStoreApp.Platform
+				if softwareTitle.AppStoreApp.SelfService {
+					softwareSpec["self_service"] = softwareTitle.AppStoreApp.SelfService
+				}
+
+				if softwareTitle.AppStoreApp.Categories != nil {
+					softwareSpec["categories"] = softwareTitle.AppStoreApp.Categories
+				}
+
+				if softwareTitle.DisplayName != "" {
+					softwareSpec["display_name"] = softwareTitle.DisplayName
+				}
+
+				if downloadIcons && softwareTitle.IconUrl != nil && strings.HasPrefix(*softwareTitle.IconUrl, "/api") {
+					fileName := fmt.Sprintf("lib/%s/icons/%s", teamFilename, filenamePrefix+"-icon.png")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["icon"] = map[string]any{
+						"path": path,
+					}
+					icon, err := cmd.Client.GetSoftwareTitleIcon(softwareTitle.ID, teamID)
+					if err != nil {
+						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error getting software icon %s: %s\n", sw.Name, err)
+						return nil, err
+					}
+
+					// TODO write files immediately rather than queueing them up
+					cmd.FilesToWrite[fileName] = icon
+				}
+
+				config := softwareTitle.AppStoreApp.Configuration
+				if config != nil && !slices.Equal(config, json.RawMessage("{}")) {
+					// all per-team software-related artifacts are generated in lib/{team}/software
+					fileName := fmt.Sprintf("lib/%s/software/%s", teamFilename, filenamePrefix+"-config.json")
+					path := fmt.Sprintf("../%s", fileName)
+					softwareSpec["configuration"] = map[string]any{
+						"path": path,
+					}
+
+					// format config because it is received with incorrect indentation
+					var buf bytes.Buffer
+					err := json.Indent(&buf, softwareTitle.AppStoreApp.Configuration, "", "  ")
+					if err != nil {
+						fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error formatting android app configuration %s: %s\n", sw.Name, err)
+						return nil, err
+					}
+
+					cmd.FilesToWrite[fileName] = buf.Bytes()
+				}
+
+				// export auto-update schedule settings for iOS/iPadOS VPP apps when present.
+				// only VPP apps (those with an AdamID) support auto-update schedules.
+				if softwareTitle.AutoUpdateEnabled != nil || softwareTitle.AutoUpdateStartTime != nil || softwareTitle.AutoUpdateEndTime != nil {
+					platform := softwareTitle.AppStoreApp.Platform
+					adamID := softwareTitle.AppStoreApp.VPPAppID.AdamID
+					if (platform == fleet.IOSPlatform || platform == fleet.IPadOSPlatform) && adamID != "" {
+						if softwareTitle.AutoUpdateEnabled != nil {
+							softwareSpec["auto_update_enabled"] = *softwareTitle.AutoUpdateEnabled
+						}
+						if softwareTitle.AutoUpdateStartTime != nil {
+							softwareSpec["auto_update_window_start"] = *softwareTitle.AutoUpdateStartTime
+						}
+						if softwareTitle.AutoUpdateEndTime != nil {
+							softwareSpec["auto_update_window_end"] = *softwareTitle.AutoUpdateEndTime
+						}
+					}
+				}
 			}
-			if _, exists := setupSoftwareByPlatformAndAppID[platformAndAppID]; exists {
-				softwareSpec["setup_experience"] = true
+
+			var labels []fleet.SoftwareScopeLabel
+			var labelKey string
+			if softwareTitle.SoftwarePackage != nil {
+				if len(softwareTitle.SoftwarePackage.LabelsIncludeAny) > 0 {
+					labels = softwareTitle.SoftwarePackage.LabelsIncludeAny
+					labelKey = "labels_include_any"
+				}
+				if len(softwareTitle.SoftwarePackage.LabelsExcludeAny) > 0 {
+					labels = softwareTitle.SoftwarePackage.LabelsExcludeAny
+					labelKey = "labels_exclude_any"
+				}
+				if len(softwareTitle.SoftwarePackage.LabelsIncludeAll) > 0 {
+					labels = softwareTitle.SoftwarePackage.LabelsIncludeAll
+					labelKey = "labels_include_all"
+				}
+				if _, exists := setupSoftwareBySoftwareTitle[softwareTitle.ID]; exists {
+					softwareSpec["setup_experience"] = true
+				}
+			} else {
+				platformAndAppID := softwareTitle.AppStoreApp.VPPAppID.String()
+
+				if len(softwareTitle.AppStoreApp.LabelsIncludeAny) > 0 {
+					labels = softwareTitle.AppStoreApp.LabelsIncludeAny
+					labelKey = "labels_include_any"
+				}
+				if len(softwareTitle.AppStoreApp.LabelsExcludeAny) > 0 {
+					labels = softwareTitle.AppStoreApp.LabelsExcludeAny
+					labelKey = "labels_exclude_any"
+				}
+				if len(softwareTitle.AppStoreApp.LabelsIncludeAll) > 0 {
+					labels = softwareTitle.AppStoreApp.LabelsIncludeAll
+					labelKey = "labels_include_all"
+				}
+				if _, exists := setupSoftwareByPlatformAndAppID[platformAndAppID]; exists {
+					softwareSpec["setup_experience"] = true
+				}
 			}
-		}
-		if len(labels) > 0 {
-			labelsList := make([]string, len(labels))
-			for i, label := range labels {
-				labelsList[i] = label.LabelName
+			if len(labels) > 0 {
+				labelsList := make([]string, len(labels))
+				for i, label := range labels {
+					labelsList[i] = label.LabelName
+				}
+				softwareSpec[labelKey] = labelsList
 			}
-			softwareSpec[labelKey] = labelsList
-		}
+
+		} // end if !validationOnly
 
 		switch {
 		case sw.SoftwarePackage != nil && sw.SoftwarePackage.FleetMaintainedAppID != nil:

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -91,7 +91,6 @@ type generateGitopsClient interface {
 	ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, error)
 	GetFleetMaintainedApp(id uint) (*fleet.MaintainedApp, error)
 	GetVPPTokens() ([]*fleet.VPPTokenDB, error)
-	ListFleetMaintainedApps(teamID uint) ([]fleet.MaintainedApp, error)
 }
 
 // Given a struct type and a field name, return the JSON field name.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1716,10 +1716,18 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 	vppApps []fleet.VPPAppResponse,
 	err error,
 ) {
-	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
-	titles, err := client.ListSoftwareTitles(query)
-	if err != nil {
-		return nil, nil, nil, err
+	const perPage = 1000
+	var titles []fleet.SoftwareTitleListResult
+	for page := 0; ; page++ {
+		query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=%d&page=%d", teamID, perPage, page)
+		pageTitles, err := client.ListSoftwareTitles(query)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		titles = append(titles, pageTitles...)
+		if len(pageTitles) < perPage {
+			break
+		}
 	}
 	if len(titles) == 0 {
 		return nil, nil, nil, nil

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1742,13 +1742,6 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 
 		switch {
 		case sw.SoftwarePackage != nil:
-			if sw.HashSHA256 != nil {
-				spec["hash_sha256"] = *sw.HashSHA256
-			}
-			if sw.SoftwarePackage.PackageURL != nil {
-				spec["url"] = *sw.SoftwarePackage.PackageURL
-			}
-
 			installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
 			if sw.SoftwarePackage.PackageURL != nil {
 				installer.URL = *sw.SoftwarePackage.PackageURL
@@ -1766,6 +1759,13 @@ func generateSoftwareForValidation(client generateGitopsClient, appConfig *fleet
 				installer.Slug = slug
 				fmas = append(fmas, spec)
 			} else {
+				// hash_sha256 and url are only valid for packages, not FMAs.
+				if sw.HashSHA256 != nil {
+					spec["hash_sha256"] = *sw.HashSHA256
+				}
+				if sw.SoftwarePackage.PackageURL != nil {
+					spec["url"] = *sw.SoftwarePackage.PackageURL
+				}
 				packages = append(packages, spec)
 			}
 			installers = append(installers, installer)

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1142,7 +1142,7 @@ func TestGenerateSoftwareAutoUpdateSchedule(t *testing.T) {
 	cmd.FilesToWrite["fleets/test.yml"] = map[string]any{}
 
 	// generate software for team 1
-	res, err := cmd.generateSoftware("fleets/test.yml", 1, "team-a", false, false)
+	res, err := cmd.generateSoftware("fleets/test.yml", 1, "team-a", false)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -1529,7 +1529,7 @@ func TestGenerateSoftware(t *testing.T) {
 		SoftwareList: make(map[uint]Software),
 	}
 
-	softwareRaw, err := cmd.generateSoftware("team.yml", 1, "some-team", false, false)
+	softwareRaw, err := cmd.generateSoftware("team.yml", 1, "some-team", false)
 	require.NoError(t, err)
 	require.NotNil(t, softwareRaw)
 	var software map[string]any
@@ -1608,7 +1608,7 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 		SoftwareList: make(map[uint]Software),
 	}
 
-	softwareRaw, err := cmd.generateSoftware("team.yml", 2, "script-team", false, false)
+	softwareRaw, err := cmd.generateSoftware("team.yml", 2, "script-team", false)
 	require.NoError(t, err)
 	require.NotNil(t, softwareRaw)
 

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -1142,7 +1142,7 @@ func TestGenerateSoftwareAutoUpdateSchedule(t *testing.T) {
 	cmd.FilesToWrite["fleets/test.yml"] = map[string]any{}
 
 	// generate software for team 1
-	res, err := cmd.generateSoftware("fleets/test.yml", 1, "team-a", false)
+	res, err := cmd.generateSoftware("fleets/test.yml", 1, "team-a", false, false)
 	require.NoError(t, err)
 	require.NotNil(t, res)
 
@@ -1529,7 +1529,7 @@ func TestGenerateSoftware(t *testing.T) {
 		SoftwareList: make(map[uint]Software),
 	}
 
-	softwareRaw, err := cmd.generateSoftware("team.yml", 1, "some-team", false)
+	softwareRaw, err := cmd.generateSoftware("team.yml", 1, "some-team", false, false)
 	require.NoError(t, err)
 	require.NotNil(t, softwareRaw)
 	var software map[string]any
@@ -1608,7 +1608,7 @@ func TestGenerateSoftwareScriptPackages(t *testing.T) {
 		SoftwareList: make(map[uint]Software),
 	}
 
-	softwareRaw, err := cmd.generateSoftware("team.yml", 2, "script-team", false)
+	softwareRaw, err := cmd.generateSoftware("team.yml", 2, "script-team", false, false)
 	require.NoError(t, err)
 	require.NotNil(t, softwareRaw)
 

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -1142,6 +1142,3 @@ func applyVPPTokenAssignmentIfNeeded(
 	}
 	return nil
 }
-
-// buildExceptedTeamSoftwareResponses fetches a team's software titles and
-// builds SoftwarePackageResponse/VPPAppResponse slices with title IDs, used by

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -331,19 +331,19 @@ func gitopsCommand() *cli.Command {
 						}
 					}
 				}
-				// When GitOps mode is on and labels are not excepted, treat absent labels
+				// When labels are not excepted from GitOps, treat absent labels
 				// as "delete all" (i.e. as if `labels:` was present but empty).
 				labelsExcepted := appConfig.GitOpsConfig.Exceptions.Labels
-				processMissingLabels := config.LabelsPresent
+				deleteMissingLabels := config.LabelsPresent
 				if !labelsExcepted {
-					processMissingLabels = true
+					deleteMissingLabels = true
 				}
 				labelChanges[teamName] = computeLabelChanges(
 					flFilename,
 					teamName,
 					existingLabels,
 					config.Labels,
-					processMissingLabels,
+					deleteMissingLabels,
 				)
 			}
 
@@ -759,7 +759,7 @@ func computeLabelChanges(
 	teamName string,
 	existingLabels []*fleet.LabelSpec,
 	specifiedLabels []*fleet.LabelSpec,
-	processMissingLabels bool,
+	deleteMissingLabels bool,
 ) []spec.LabelChange {
 	var regularLabels []*fleet.LabelSpec
 	var labelOperations []spec.LabelChange
@@ -774,7 +774,7 @@ func computeLabelChanges(
 	// or else delete them all.
 	if len(specifiedLabels) == 0 {
 		op := "~" // preserved (excepted from GitOps, no action needed)
-		if processMissingLabels {
+		if deleteMissingLabels {
 			op = "-"
 		}
 		for _, l := range regularLabels {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -218,7 +218,7 @@ func gitopsCommand() *cli.Command {
 					if teamID == nil || *teamID == 0 {
 						continue // skip global
 					}
-					softwareMap, err := generateSoftwareForValidation(fleetClient, *teamID)
+					softwareMap, installers, vppApps, err := generateSoftwareForValidation(fleetClient, appConfig, *teamID)
 					if err != nil {
 						return fmt.Errorf("getting software for team %q: %w", teamName, err)
 					}
@@ -230,9 +230,6 @@ func gitopsCommand() *cli.Command {
 						return fmt.Errorf("marshaling software for team %q: %w", teamName, err)
 					}
 					syntheticSoftwareByTeam[teamName] = raw
-
-					// Also build the title ID maps needed by doGitOpsPolicies.
-					installers, vppApps := buildExceptedTeamSoftwareResponses(fleetClient, *teamID)
 					teamsSoftwareInstallers[teamName] = installers
 					teamsVPPApps[teamName] = vppApps
 				}
@@ -1148,45 +1145,3 @@ func applyVPPTokenAssignmentIfNeeded(
 
 // buildExceptedTeamSoftwareResponses fetches a team's software titles and
 // builds SoftwarePackageResponse/VPPAppResponse slices with title IDs, used by
-// doGitOpsPolicies to resolve policy software automation when software is
-// excepted from GitOps.
-func buildExceptedTeamSoftwareResponses(client *service.Client, teamID uint) ([]fleet.SoftwarePackageResponse, []fleet.VPPAppResponse) {
-	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
-	titles, err := client.ListSoftwareTitles(query)
-	if err != nil {
-		return nil, nil
-	}
-
-	var installers []fleet.SoftwarePackageResponse
-	var vppApps []fleet.VPPAppResponse
-
-	for _, title := range titles {
-		titleID := title.ID
-		switch {
-		case title.SoftwarePackage != nil:
-			installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
-			if title.SoftwarePackage.PackageURL != nil {
-				installer.URL = *title.SoftwarePackage.PackageURL
-			}
-			if title.HashSHA256 != nil {
-				installer.HashSHA256 = *title.HashSHA256
-			}
-			// Look up FMA slug for patch policy resolution.
-			if title.SoftwarePackage.FleetMaintainedAppID != nil {
-				fma, err := client.GetFleetMaintainedApp(*title.SoftwarePackage.FleetMaintainedAppID)
-				if err == nil && fma != nil {
-					installer.Slug = fma.Slug
-				}
-			}
-			installers = append(installers, installer)
-		case title.AppStoreApp != nil:
-			vppApps = append(vppApps, fleet.VPPAppResponse{
-				TitleID:    &titleID,
-				AppStoreID: title.AppStoreApp.AppStoreID,
-				Platform:   fleet.InstallableDevicePlatform(title.AppStoreApp.Platform),
-			})
-		}
-	}
-
-	return installers, vppApps
-}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -198,11 +198,11 @@ func gitopsCommand() *cli.Command {
 			}
 
 			// Check if a no-team/unassigned file is present (by filename, before parsing).
-			noTeamPresent := false
+			prefetchNoTeamSoftware := false
 			for _, flFilename := range flFilenames.Value() {
 				fn := filepath.Base(flFilename)
 				if fn == "no-team.yml" || fn == "unassigned.yml" {
-					noTeamPresent = true
+					prefetchNoTeamSoftware = true
 					break
 				}
 			}
@@ -214,9 +214,25 @@ func gitopsCommand() *cli.Command {
 			// and would otherwise fail validating policy software references.
 			if appConfig.GitOpsConfig.Exceptions.Software {
 				syntheticSoftwareByTeam := make(map[string]json.RawMessage)
+				// Pre-fetch for "No team" (unassigned hosts, teamID=0) if present.
+				if prefetchNoTeamSoftware {
+					softwareMap, installers, vppApps, err := generateSoftwareForValidation(fleetClient, appConfig, 0)
+					if err != nil {
+						return fmt.Errorf("getting software for unassigned hosts: %w", err)
+					}
+					if softwareMap != nil {
+						raw, err := json.Marshal(softwareMap)
+						if err != nil {
+							return fmt.Errorf("marshaling software for unassigned hosts: %w", err)
+						}
+						syntheticSoftwareByTeam[fleet.TeamNameNoTeam] = raw
+						teamsSoftwareInstallers[fleet.TeamNameNoTeam] = installers
+						teamsVPPApps[fleet.TeamNameNoTeam] = vppApps
+					}
+				}
 				for teamName, teamID := range teamIDLookup {
 					if teamID == nil || *teamID == 0 {
-						continue // skip global
+						continue // skip global and no-team/unassigned (handled above).
 					}
 					softwareMap, installers, vppApps, err := generateSoftwareForValidation(fleetClient, appConfig, *teamID)
 					if err != nil {
@@ -233,31 +249,14 @@ func gitopsCommand() *cli.Command {
 					teamsSoftwareInstallers[teamName] = installers
 					teamsVPPApps[teamName] = vppApps
 				}
-				// Also pre-fetch for "No team" (unassigned hosts, teamID=0) if present.
-				if noTeamPresent {
-					softwareMap, installers, vppApps, err := generateSoftwareForValidation(fleetClient, appConfig, 0)
-					if err != nil {
-						return fmt.Errorf("getting software for unassigned hosts: %w", err)
-					}
-					if softwareMap != nil {
-						raw, err := json.Marshal(softwareMap)
-						if err != nil {
-							return fmt.Errorf("marshaling software for unassigned hosts: %w", err)
-						}
-						syntheticSoftwareByTeam[fleet.TeamNameNoTeam] = raw
-						teamsSoftwareInstallers[fleet.TeamNameNoTeam] = installers
-						teamsVPPApps[fleet.TeamNameNoTeam] = vppApps
-					}
-				}
 				gitOpsOpts.SyntheticSoftwareByTeam = syntheticSoftwareByTeam
 			}
 
 			// We need the controls from no-team.yml to apply them when applying the global app config.
-			noTeamControls, noTeamParsed, noTeamFilename, err := extractControlsForNoTeam(flFilenames, appConfig, gitOpsOpts)
+			noTeamControls, noTeamPresent, noTeamFilename, err := extractControlsForNoTeam(flFilenames, appConfig, gitOpsOpts)
 			if err != nil {
 				return fmt.Errorf("extracting controls from %s: %w", noTeamFilename, err)
 			}
-			noTeamPresent = noTeamParsed
 			// Log a deprecation warning if the user is still using no-team.yml
 			if noTeamPresent && noTeamFilename == "no-team.yml" {
 				if logging.TopicEnabled(logging.DeprecatedFieldTopic) {
@@ -331,19 +330,15 @@ func gitopsCommand() *cli.Command {
 						}
 					}
 				}
-				// When labels are not excepted from GitOps, treat absent labels
-				// as "delete all" (i.e. as if `labels:` was present but empty).
-				labelsExcepted := appConfig.GitOpsConfig.Exceptions.Labels
-				deleteMissingLabels := config.LabelsPresent
-				if !labelsExcepted {
-					deleteMissingLabels = true
-				}
+				// When labels are excepted and the key is omitted, preserve
+				// existing labels (no-op). Otherwise delete/update as normal.
+				preserveLabels := appConfig.GitOpsConfig.Exceptions.Labels && !config.LabelsPresent
 				labelChanges[teamName] = computeLabelChanges(
 					flFilename,
 					teamName,
 					existingLabels,
 					config.Labels,
-					deleteMissingLabels,
+					preserveLabels,
 				)
 			}
 
@@ -759,7 +754,7 @@ func computeLabelChanges(
 	teamName string,
 	existingLabels []*fleet.LabelSpec,
 	specifiedLabels []*fleet.LabelSpec,
-	deleteMissingLabels bool,
+	preserveLabels bool,
 ) []spec.LabelChange {
 	var regularLabels []*fleet.LabelSpec
 	var labelOperations []spec.LabelChange
@@ -770,12 +765,12 @@ func computeLabelChanges(
 		}
 	}
 
-	// If no labels are specified: either no-op if labels are exempted from GitOps,
+	// If no labels are specified: either no-op if labels are excepted from GitOps,
 	// or else delete them all.
 	if len(specifiedLabels) == 0 {
-		op := "~" // preserved (excepted from GitOps, no action needed)
-		if deleteMissingLabels {
-			op = "-"
+		op := "-"
+		if preserveLabels {
+			op = "~" // preserved (excepted from GitOps, no action needed)
 		}
 		for _, l := range regularLabels {
 			change := spec.LabelChange{Name: l.Name, Op: op, TeamName: teamName, FileName: filename}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -210,8 +210,8 @@ func gitopsCommand() *cli.Command {
 			}
 
 			// When software is excepted from GitOps, pre-fetch server-side software
-			// for all existing teams so the parser can validate policy references,
-			// and DoGitOps can resolve policy title IDs.
+			// for all existing teams (including "No team") so the parser can validate
+			// policy references, and DoGitOps can resolve policy title IDs.
 			if appConfig.GitOpsConfig.Exceptions.Software {
 				syntheticSoftwareByTeam := make(map[string]json.RawMessage)
 				for teamName, teamID := range teamIDLookup {
@@ -232,6 +232,22 @@ func gitopsCommand() *cli.Command {
 					syntheticSoftwareByTeam[teamName] = raw
 					teamsSoftwareInstallers[teamName] = installers
 					teamsVPPApps[teamName] = vppApps
+				}
+				// Also pre-fetch for "No team" (unassigned hosts, teamID=0) if present.
+				if noTeamPresent {
+					softwareMap, installers, vppApps, err := generateSoftwareForValidation(fleetClient, appConfig, 0)
+					if err != nil {
+						return fmt.Errorf("getting software for unassigned hosts: %w", err)
+					}
+					if softwareMap != nil {
+						raw, err := json.Marshal(softwareMap)
+						if err != nil {
+							return fmt.Errorf("marshaling software for unassigned hosts: %w", err)
+						}
+						syntheticSoftwareByTeam[fleet.TeamNameNoTeam] = raw
+						teamsSoftwareInstallers[fleet.TeamNameNoTeam] = installers
+						teamsVPPApps[fleet.TeamNameNoTeam] = vppApps
+					}
 				}
 				gitOpsOpts.SyntheticSoftwareByTeam = syntheticSoftwareByTeam
 			}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -405,7 +405,7 @@ func gitopsCommand() *cli.Command {
 				validLabelNames := make(map[string]struct{})
 				if globalLabelChanges, ok := labelChanges[spec.LabelAPIGlobalTeamName]; ok {
 					for _, label := range globalLabelChanges {
-						if label.Op == "+" || label.Op == "=" {
+						if label.Op == "+" || label.Op == "=" || label.Op == "~" {
 							validLabelNames[label.Name] = struct{}{}
 						}
 					}
@@ -420,7 +420,7 @@ func gitopsCommand() *cli.Command {
 				}
 				if config.CoercedTeamName() != spec.LabelAPIGlobalTeamName {
 					for _, label := range labelChanges[config.CoercedTeamName()] {
-						if label.Op == "+" || label.Op == "=" {
+						if label.Op == "+" || label.Op == "=" || label.Op == "~" {
 							validLabelNames[label.Name] = struct{}{}
 						}
 					}
@@ -773,7 +773,7 @@ func computeLabelChanges(
 	// If no labels are specified: either no-op if labels are exempted from GitOps,
 	// or else delete them all.
 	if len(specifiedLabels) == 0 {
-		op := "="
+		op := "~" // preserved (excepted from GitOps, no action needed)
 		if processMissingLabels {
 			op = "-"
 		}

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -332,13 +332,12 @@ func gitopsCommand() *cli.Command {
 				}
 				// When labels are excepted and the key is omitted, preserve
 				// existing labels (no-op). Otherwise delete/update as normal.
-				preserveLabels := appConfig.GitOpsConfig.Exceptions.Labels && !config.LabelsPresent
 				labelChanges[teamName] = computeLabelChanges(
 					flFilename,
 					teamName,
 					existingLabels,
 					config.Labels,
-					preserveLabels,
+					appConfig.GitOpsConfig.Exceptions.Labels,
 				)
 			}
 
@@ -754,7 +753,7 @@ func computeLabelChanges(
 	teamName string,
 	existingLabels []*fleet.LabelSpec,
 	specifiedLabels []*fleet.LabelSpec,
-	preserveLabels bool,
+	labelsExcepted bool,
 ) []spec.LabelChange {
 	var regularLabels []*fleet.LabelSpec
 	var labelOperations []spec.LabelChange
@@ -769,7 +768,7 @@ func computeLabelChanges(
 	// or else delete them all.
 	if len(specifiedLabels) == 0 {
 		op := "-"
-		if preserveLabels {
+		if labelsExcepted {
 			op = "~" // preserved (excepted from GitOps, no action needed)
 		}
 		for _, l := range regularLabels {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -144,18 +144,6 @@ func gitopsCommand() *cli.Command {
 				return errors.New("no license struct found in app config")
 			}
 
-			// We need the controls from no-team.yml to apply them when applying the global app config.
-			noTeamControls, noTeamPresent, noTeamFilename, err := extractControlsForNoTeam(flFilenames, appConfig, gitOpsOpts)
-			if err != nil {
-				return fmt.Errorf("extracting controls from %s: %w", noTeamFilename, err)
-			}
-			// Log a deprecation warning if the user is still using no-team.yml
-			if noTeamPresent && noTeamFilename == "no-team.yml" {
-				if logging.TopicEnabled(logging.DeprecatedFieldTopic) {
-					logf("[!] no-team.yml is deprecated; please rename the file to 'unassigned.yml' and update the team name to 'Unassigned'.\n")
-				}
-			}
-
 			var originalABMConfig []any
 			var originalVPPConfig []any
 			var teamNames []string
@@ -209,9 +197,21 @@ func gitopsCommand() *cli.Command {
 				}
 			}
 
+			// Check if a no-team/unassigned file is present (by filename, before parsing).
+			noTeamPresent := false
+			for _, flFilename := range flFilenames.Value() {
+				fn := filepath.Base(flFilename)
+				if fn == "no-team.yml" || fn == "unassigned.yml" {
+					noTeamPresent = true
+					break
+				}
+			}
+
 			// When software is excepted from GitOps, pre-fetch server-side software
 			// for all existing teams (including "No team") so the parser can validate
-			// policy references, and DoGitOps can resolve policy title IDs.
+			// policy references, and DoGitOps can resolve policy title IDs. This must
+			// happen before extractControlsForNoTeam, which parses the no-team file
+			// and would otherwise fail validating policy software references.
 			if appConfig.GitOpsConfig.Exceptions.Software {
 				syntheticSoftwareByTeam := make(map[string]json.RawMessage)
 				for teamName, teamID := range teamIDLookup {
@@ -250,6 +250,19 @@ func gitopsCommand() *cli.Command {
 					}
 				}
 				gitOpsOpts.SyntheticSoftwareByTeam = syntheticSoftwareByTeam
+			}
+
+			// We need the controls from no-team.yml to apply them when applying the global app config.
+			noTeamControls, noTeamParsed, noTeamFilename, err := extractControlsForNoTeam(flFilenames, appConfig, gitOpsOpts)
+			if err != nil {
+				return fmt.Errorf("extracting controls from %s: %w", noTeamFilename, err)
+			}
+			noTeamPresent = noTeamParsed
+			// Log a deprecation warning if the user is still using no-team.yml
+			if noTeamPresent && noTeamFilename == "no-team.yml" {
+				if logging.TopicEnabled(logging.DeprecatedFieldTopic) {
+					logf("[!] no-team.yml is deprecated; please rename the file to 'unassigned.yml' and update the team name to 'Unassigned'.\n")
+				}
 			}
 
 			// Used for keeping track of all label changes in this run.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -274,11 +274,19 @@ func gitopsCommand() *cli.Command {
 						}
 					}
 				}
+				// When GitOps mode is on and labels are not excepted, treat absent labels
+				// as "delete all" (i.e. as if `labels:` was present but empty).
+				labelsExcepted := appConfig.GitOpsConfig.Exceptions.Labels
+				processMissingLabels := config.LabelsPresent
+				if !labelsExcepted {
+					processMissingLabels = true
+				}
 				labelChanges[teamName] = computeLabelChanges(
 					flFilename,
 					teamName,
 					existingLabels,
 					config.Labels,
+					processMissingLabels,
 				)
 			}
 
@@ -694,6 +702,7 @@ func computeLabelChanges(
 	teamName string,
 	existingLabels []*fleet.LabelSpec,
 	specifiedLabels []*fleet.LabelSpec,
+	processMissingLabels bool,
 ) []spec.LabelChange {
 	var regularLabels []*fleet.LabelSpec
 	var labelOperations []spec.LabelChange
@@ -704,11 +713,11 @@ func computeLabelChanges(
 		}
 	}
 
-	// Handle the cases where the 'labels:' section is either nil (an empty 'labels:' section was specified,
-	// meaning remove-all) or an empty list (the 'labels:' section was not specified, so we do a no-op).
+	// If no labels are specified: either no-op if labels are exempted from GitOps,
+	// or else delete them all.
 	if len(specifiedLabels) == 0 {
 		op := "="
-		if specifiedLabels == nil {
+		if processMissingLabels {
 			op = "-"
 		}
 		for _, l := range regularLabels {

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -1,6 +1,7 @@
 package fleetctl
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -206,6 +207,36 @@ func gitopsCommand() *cli.Command {
 				for _, tm := range teams {
 					teamIDLookup[tm.Name] = &tm.ID
 				}
+			}
+
+			// When software is excepted from GitOps, pre-fetch server-side software
+			// for all existing teams so the parser can validate policy references,
+			// and DoGitOps can resolve policy title IDs.
+			if appConfig.GitOpsConfig.Exceptions.Software {
+				syntheticSoftwareByTeam := make(map[string]json.RawMessage)
+				for teamName, teamID := range teamIDLookup {
+					if teamID == nil || *teamID == 0 {
+						continue // skip global
+					}
+					softwareMap, err := generateSoftwareForValidation(fleetClient, *teamID)
+					if err != nil {
+						return fmt.Errorf("getting software for team %q: %w", teamName, err)
+					}
+					if softwareMap == nil {
+						continue
+					}
+					raw, err := json.Marshal(softwareMap)
+					if err != nil {
+						return fmt.Errorf("marshaling software for team %q: %w", teamName, err)
+					}
+					syntheticSoftwareByTeam[teamName] = raw
+
+					// Also build the title ID maps needed by doGitOpsPolicies.
+					installers, vppApps := buildExceptedTeamSoftwareResponses(fleetClient, *teamID)
+					teamsSoftwareInstallers[teamName] = installers
+					teamsVPPApps[teamName] = vppApps
+				}
+				gitOpsOpts.SyntheticSoftwareByTeam = syntheticSoftwareByTeam
 			}
 
 			// Used for keeping track of all label changes in this run.
@@ -1113,4 +1144,49 @@ func applyVPPTokenAssignmentIfNeeded(
 		return fmt.Errorf("applying fleet config for volume_purchasing_program teams: %w", err)
 	}
 	return nil
+}
+
+// buildExceptedTeamSoftwareResponses fetches a team's software titles and
+// builds SoftwarePackageResponse/VPPAppResponse slices with title IDs, used by
+// doGitOpsPolicies to resolve policy software automation when software is
+// excepted from GitOps.
+func buildExceptedTeamSoftwareResponses(client *service.Client, teamID uint) ([]fleet.SoftwarePackageResponse, []fleet.VPPAppResponse) {
+	query := fmt.Sprintf("available_for_install=1&fleet_id=%d&per_page=1000", teamID)
+	titles, err := client.ListSoftwareTitles(query)
+	if err != nil {
+		return nil, nil
+	}
+
+	var installers []fleet.SoftwarePackageResponse
+	var vppApps []fleet.VPPAppResponse
+
+	for _, title := range titles {
+		titleID := title.ID
+		switch {
+		case title.SoftwarePackage != nil:
+			installer := fleet.SoftwarePackageResponse{TitleID: &titleID}
+			if title.SoftwarePackage.PackageURL != nil {
+				installer.URL = *title.SoftwarePackage.PackageURL
+			}
+			if title.HashSHA256 != nil {
+				installer.HashSHA256 = *title.HashSHA256
+			}
+			// Look up FMA slug for patch policy resolution.
+			if title.SoftwarePackage.FleetMaintainedAppID != nil {
+				fma, err := client.GetFleetMaintainedApp(*title.SoftwarePackage.FleetMaintainedAppID)
+				if err == nil && fma != nil {
+					installer.Slug = fma.Slug
+				}
+			}
+			installers = append(installers, installer)
+		case title.AppStoreApp != nil:
+			vppApps = append(vppApps, fleet.VPPAppResponse{
+				TitleID:    &titleID,
+				AppStoreID: title.AppStoreApp.AppStoreID,
+				Platform:   fleet.InstallableDevicePlatform(title.AppStoreApp.Platform),
+			})
+		}
+	}
+
+	return installers, vppApps
 }

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1269,7 +1269,7 @@ policies:
   - name: VPP Policy
     query: SELECT 1
     install_software:
-      app_store_id: 5128675309
+      app_store_id: "5128675309"
 agent_options:
 reports:
 `), 0o644))

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1454,6 +1454,10 @@ func TestGitOpsFullGlobal(t *testing.T) {
 	// Reset labels arrays
 	deletedLabels = make([]string, 0)
 	appliedLabelSpecs = make([]*fleet.LabelSpec, 0)
+	// Except labels so that omitting the `labels:` key is a no-op.
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}, UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
+	}
 	// Real run w/out top-level labels key
 	logs = RunAppForTest(t, []string{"gitops", "-f", "./testdata/gitops/global_config_no_paths_no_labels.yml"})
 	fmt.Printf("%s", logs)
@@ -1491,6 +1495,7 @@ func TestGitOpsFullTeam(t *testing.T) {
 			EnabledAndConfigured:        true,
 			WindowsEnabledAndConfigured: true,
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -1871,8 +1876,8 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 		},
 	)
 
-	// Mock appConfig
-	savedAppConfig := &fleet.AppConfig{}
+	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
+	savedAppConfig := &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		appConfig := savedAppConfig.Copy()
 		return appConfig, nil
@@ -2205,16 +2210,17 @@ software:
 
 	// Dry run
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
-	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
+	emptyWithExceptions := fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
 
 	// Dry run should not attempt to get the VPP token when applying VPP apps (it may not exist).
 	require.False(t, ds.GetVPPTokenByTeamIDFuncInvoked)
 	ds.ListTeamsFuncInvoked = false
 
 	// Dry run, deleting other teams
-	savedAppConfig = &fleet.AppConfig{}
+	savedAppConfig = &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run", "--delete-other-teams"})
-	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
+	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
 	assert.True(t, ds.ListTeamsFuncInvoked)
 
 	// Real run
@@ -2287,10 +2293,10 @@ func TestGitOpsBasicGlobalAndNoTeam(t *testing.T) {
 	// Mock Apple GDMF API (required for validating OS update minimum version settings)
 	mdmtest.StartNewAppleGDMFTestServer(t)
 
-	// Mock appConfig
+	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
 	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{}, nil
+		return &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
 	}
 	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
 		savedAppConfig = config
@@ -2851,6 +2857,9 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 	ds, savedAppConfigPtr, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
 	testing_utils.StartSoftwareInstallerServer(t)
 
+	// This test includes `labels:` in its YAML, so disable the labels exception.
+	(*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = false
+
 	var enrolledSecrets []*fleet.EnrollSecret
 	var enrolledTeamSecrets []*fleet.EnrollSecret
 	var appliedPolicySpecs []*fleet.PolicySpec
@@ -2981,6 +2990,10 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 	require.Len(t, enrolledTeamSecrets, 2)
 
 	t.Run("no-team.yml using relative paths", func(t *testing.T) {
+		// Re-enable labels exception since these YAML files don't include `labels:`.
+		(*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = true
+		t.Cleanup(func() { (*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = false })
+
 		globalFileBasic := createGlobalFileBasic(t, fleetServerURL, orgName)
 		teamFileBasic := createTeamFileBasic(t, teamName)
 
@@ -3917,6 +3930,7 @@ func TestGitOpsFeatures(t *testing.T) {
 				"detail_query_b": nil,
 			},
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	globalFileUpdatedFeatures, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -4001,6 +4015,7 @@ func TestGitOpsSSOSettings(t *testing.T) {
 			EnableJITProvisioning: true,
 			EnableJITRoleSync:     true,
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4047,7 +4062,7 @@ org_settings:
 
 	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 
-	appConfig := fleet.AppConfig{}
+	appConfig := fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()}}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -4088,6 +4103,7 @@ func TestGitOpsSMTPSettings(t *testing.T) {
 			SMTPVerifySSLCerts:       true,
 			SMTPEnableStartTLS:       true,
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4138,6 +4154,7 @@ func TestGitOpsMDMAuthSettings(t *testing.T) {
 				},
 			},
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4207,6 +4224,7 @@ func TestGitOpsNoTeamConditionalAccess(t *testing.T) {
 		Integrations: fleet.Integrations{
 			ConditionalAccessEnabled: optjson.SetBool(true),
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -584,9 +584,9 @@ software:
 	// GitOps should not overwrite GitOps UI Mode.
 	assert.Equal(t, savedAppConfig.GitOpsConfig.GitopsModeEnabled, true)
 	assert.Equal(t, savedAppConfig.GitOpsConfig.RepositoryURL, "https://didsomeonesaygitops.biz")
-	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Labels, true)
-	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Secrets, true)
-	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Software, false)
+	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Labels, false)
+	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Software, true)
+	assert.Equal(t, savedAppConfig.GitOpsConfig.Exceptions.Secrets, false)
 
 	// Check MDM settings
 	require.True(t, savedAppConfig.MDM.EnableDiskEncryption.Value)
@@ -825,7 +825,7 @@ agent_options:
 	// Test: exceptions enforced even when GitOps mode is OFF (decoupled from UI mode)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &fleet.AppConfig{
-			UIGitOpsMode: fleet.UIGitOpsModeConfig{
+			GitOpsConfig: fleet.GitOpsConfig{
 				GitopsModeEnabled: false,
 				Exceptions:        fleet.GitOpsExceptions{Labels: true},
 			},
@@ -1456,7 +1456,7 @@ func TestGitOpsFullGlobal(t *testing.T) {
 	appliedLabelSpecs = make([]*fleet.LabelSpec, 0)
 	// Except labels so that omitting the `labels:` key is a no-op.
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}, UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
+		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}, GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
 	}
 	// Real run w/out top-level labels key
 	logs = RunAppForTest(t, []string{"gitops", "-f", "./testdata/gitops/global_config_no_paths_no_labels.yml"})
@@ -1495,7 +1495,7 @@ func TestGitOpsFullTeam(t *testing.T) {
 			EnabledAndConfigured:        true,
 			WindowsEnabledAndConfigured: true,
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -1877,7 +1877,7 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 	)
 
 	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
-	savedAppConfig := &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	savedAppConfig := &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		appConfig := savedAppConfig.Copy()
 		return appConfig, nil
@@ -2210,7 +2210,7 @@ software:
 
 	// Dry run
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
-	emptyWithExceptions := fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	emptyWithExceptions := fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
 	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
 
 	// Dry run should not attempt to get the VPP token when applying VPP apps (it may not exist).
@@ -2218,7 +2218,7 @@ software:
 	ds.ListTeamsFuncInvoked = false
 
 	// Dry run, deleting other teams
-	savedAppConfig = &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	savedAppConfig = &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run", "--delete-other-teams"})
 	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
 	assert.True(t, ds.ListTeamsFuncInvoked)
@@ -2296,7 +2296,7 @@ func TestGitOpsBasicGlobalAndNoTeam(t *testing.T) {
 	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
 	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
+		return &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
 	}
 	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
 		savedAppConfig = config
@@ -2858,7 +2858,7 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 	testing_utils.StartSoftwareInstallerServer(t)
 
 	// This test includes `labels:` in its YAML, so disable the labels exception.
-	(*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = false
+	(*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = false
 
 	var enrolledSecrets []*fleet.EnrollSecret
 	var enrolledTeamSecrets []*fleet.EnrollSecret
@@ -2991,8 +2991,8 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 
 	t.Run("no-team.yml using relative paths", func(t *testing.T) {
 		// Re-enable labels exception since these YAML files don't include `labels:`.
-		(*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = true
-		t.Cleanup(func() { (*savedAppConfigPtr).UIGitOpsMode.Exceptions.Labels = false })
+		(*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = true
+		t.Cleanup(func() { (*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = false })
 
 		globalFileBasic := createGlobalFileBasic(t, fleetServerURL, orgName)
 		teamFileBasic := createTeamFileBasic(t, teamName)
@@ -3930,7 +3930,7 @@ func TestGitOpsFeatures(t *testing.T) {
 				"detail_query_b": nil,
 			},
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	globalFileUpdatedFeatures, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -4015,7 +4015,7 @@ func TestGitOpsSSOSettings(t *testing.T) {
 			EnableJITProvisioning: true,
 			EnableJITRoleSync:     true,
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4062,7 +4062,7 @@ org_settings:
 
 	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 
-	appConfig := fleet.AppConfig{UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()}}
+	appConfig := fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()}}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -4103,7 +4103,7 @@ func TestGitOpsSMTPSettings(t *testing.T) {
 			SMTPVerifySSLCerts:       true,
 			SMTPEnableStartTLS:       true,
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4154,7 +4154,7 @@ func TestGitOpsMDMAuthSettings(t *testing.T) {
 				},
 			},
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4224,7 +4224,7 @@ func TestGitOpsNoTeamConditionalAccess(t *testing.T) {
 		Integrations: fleet.Integrations{
 			ConditionalAccessEnabled: optjson.SetBool(true),
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1039,6 +1039,237 @@ agent_options:
 	// (not via separate mock-trackable calls).
 }
 
+// TestGitOpsSoftwareExceptionPolicyValidation verifies that when software is excepted
+// and the software: key is omitted from YAML, policies with install_software references
+// (hash_sha256 for packages, app_store_id for VPP apps) still validate successfully
+// against server-side software data.
+func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(
+		t, &service.TestServerOpts{
+			License:       license,
+			KeyValueStore: testing_utils.NewMemKeyValueStore(),
+		},
+	)
+
+	// --- Shared mocks ---
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			GitOpsConfig: fleet.GitOpsConfig{
+				Exceptions: fleet.GitOpsExceptions{Labels: true, Secrets: true, Software: true},
+			},
+		}, nil
+	}
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error { return nil }
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+		macDecls []*fleet.MDMAppleDeclaration, androidProfiles []*fleet.MDMAndroidConfigProfile, vars []fleet.MDMProfileIdentifierFleetVariables,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) ([]fleet.ScriptResponse, error) {
+		return []fleet.ScriptResponse{}, nil
+	}
+	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+		return nil, nil
+	}
+	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, 0, nil, nil
+	}
+	ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+		return []*fleet.Team{{ID: 1, Name: "Test Fleet"}}, nil
+	}
+	setupDefaultTeamConfigMocks(ds)
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+		return nil
+	}
+	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
+		return nil
+	}
+	ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+		return &fleet.Label{ID: 1, Name: name}, nil
+	}
+	ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+		return nil
+	}
+	ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+		return map[string]*fleet.Label{}, nil
+	}
+	ds.ApplyEnrollSecretsFunc = func(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
+		return nil
+	}
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return nil, nil }
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return nil, nil }
+	ds.BatchApplyCertificateAuthoritiesFunc = func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error {
+		return nil
+	}
+	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+		return &fleet.GroupedCertificateAuthorities{}, nil
+	}
+	ds.BatchSetSoftwareInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.BatchSetInHouseAppsInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.GetSoftwareInstallersFunc = func(ctx context.Context, tmID uint) ([]fleet.SoftwarePackageResponse, error) {
+		return nil, nil
+	}
+	ds.DeleteSetupExperienceScriptFunc = func(ctx context.Context, teamID *uint) error { return nil }
+	ds.SetTeamVPPAppsFunc = func(ctx context.Context, teamID *uint, adamIDs []fleet.VPPAppTeam, _ map[string]uint) (bool, error) {
+		return false, nil
+	}
+	ds.ListSoftwareAutoUpdateSchedulesFunc = func(ctx context.Context, teamID uint, source string, optionalFilter ...fleet.SoftwareAutoUpdateScheduleFilter) ([]fleet.SoftwareAutoUpdateSchedule, error) {
+		return nil, nil
+	}
+	ds.ListTeamPoliciesFunc = func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+		return nil, nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+	ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
+		return &fleet.MDMAppleDeclaration{}, nil
+	}
+	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+		return &fleet.Job{}, nil
+	}
+	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+		return nil, nil
+	}
+	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+		if name == "Test Fleet" {
+			return &fleet.Team{ID: 1, Name: "Test Fleet"}, nil
+		}
+		return nil, &notFoundError{}
+	}
+	ds.BatchInsertVPPAppsFunc = func(ctx context.Context, apps []*fleet.VPPApp) error { return nil }
+	ds.DeleteIconsAssociatedWithTitlesWithoutInstallersFunc = func(ctx context.Context, teamID uint) error {
+		return nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		return team, nil
+	}
+	ds.IsEnrollSecretAvailableFunc = func(ctx context.Context, secret string, isNew bool, teamID *uint) (bool, error) {
+		return true, nil
+	}
+	ds.DeleteMDMAppleDeclarationByNameFunc = func(ctx context.Context, teamID *uint, name string) error {
+		return nil
+	}
+	ds.GetVPPAppsFunc = func(ctx context.Context, teamID *uint) ([]fleet.VPPAppResponse, error) {
+		return nil, nil
+	}
+	ds.GetSoftwareCategoryIDsFunc = func(ctx context.Context, names []string) ([]uint, error) {
+		return nil, nil
+	}
+
+	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+		return nil
+	}
+
+	// Server-side software for "Test Fleet" (teamID=1) and "No team" (teamID=0).
+	// This is what the pre-fetch will retrieve and inject as synthetic data into the parser.
+	ds.ListSoftwareTitlesFunc = func(ctx context.Context, opt fleet.SoftwareTitleListOptions, tmFilter fleet.TeamFilter) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {
+		if opt.TeamID != nil && *opt.TeamID == 0 {
+			// No-team software
+			return []fleet.SoftwareTitleListResult{
+				{
+					ID:         30,
+					Name:       "No-Team Package",
+					HashSHA256: ptr.String("eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111"),
+					SoftwarePackage: &fleet.SoftwarePackageOrApp{
+						Name:       "noteam-pkg.deb",
+						Platform:   "linux",
+						Version:    "2.0",
+						PackageURL: ptr.String("https://example.com/noteam-pkg.deb"),
+					},
+				},
+			}, 1, nil, nil
+		}
+		// Team software
+		return []fleet.SoftwareTitleListResult{
+			{
+				// Custom package — referenced by policy via hash_sha256
+				ID:         10,
+				Name:       "Custom Package",
+				HashSHA256: ptr.String("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd"),
+				SoftwarePackage: &fleet.SoftwarePackageOrApp{
+					Name:       "custom-pkg.deb",
+					Platform:   "linux",
+					Version:    "1.0",
+					PackageURL: ptr.String("https://example.com/custom-pkg.deb"),
+				},
+			},
+			{
+				// VPP app — referenced by policy via app_store_id
+				ID:   20,
+				Name: "VPP App",
+				AppStoreApp: &fleet.SoftwarePackageOrApp{
+					AppStoreID: "com.example.vpp-app",
+					Platform:   string(fleet.MacOSPlatform),
+				},
+			},
+		}, 2, nil, nil
+	}
+
+	// Config files that omit software: but have policies referencing server-side software
+	tmpDir := t.TempDir()
+	globalFile := filepath.Join(tmpDir, "default.yml")
+	require.NoError(t, os.WriteFile(globalFile, []byte(`
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    org_name: Test
+controls:
+policies:
+agent_options:
+reports:
+`), 0o644))
+
+	teamFile := filepath.Join(tmpDir, "test-team.yml")
+	require.NoError(t, os.WriteFile(teamFile, []byte(`
+name: Test Fleet
+policies:
+  - name: Package Policy
+    query: SELECT 1
+    install_software:
+      hash_sha256: a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd
+  - name: VPP Policy
+    query: SELECT 1
+    install_software:
+      app_store_id: com.example.vpp-app
+agent_options:
+reports:
+`), 0o644))
+
+	unassignedFile := filepath.Join(tmpDir, "unassigned.yml")
+	require.NoError(t, os.WriteFile(unassignedFile, []byte(`
+name: Unassigned
+policies:
+  - name: No-Team Package Policy
+    query: SELECT 1
+    install_software:
+      hash_sha256: eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111eeee1111
+`), 0o644))
+
+	// Run gitops — should succeed because the synthetic software injection
+	// provides the server-side data for policy validation on both team and no-team.
+	_, err := RunAppNoChecks([]string{"gitops", "-f", globalFile, "-f", teamFile, "-f", unassignedFile})
+	require.NoError(t, err, "gitops should succeed when policies reference server-side software and software is excepted")
+}
+
 // TestGitOpsNoExceptionsClearOmittedKeys verifies that when exceptions are OFF,
 // omitting keys from YAML clears existing data.
 func TestGitOpsNoExceptionsClearOmittedKeys(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -6089,37 +6089,51 @@ software:
 
 func TestComputeLabelChanges(t *testing.T) {
 	testCases := []struct {
-		name                  string
-		filename              string
-		teamName              string
-		existingLabels        []*fleet.LabelSpec
-		specifiedLabels       []*fleet.LabelSpec
-		preserveMissingLabels bool
-		expected              []spec.LabelChange
+		name            string
+		filename        string
+		teamName        string
+		existingLabels  []*fleet.LabelSpec
+		specifiedLabels []*fleet.LabelSpec
+		labelsExcepted  bool
+		expected        []spec.LabelChange
 	}{
 		{
-			name:     "labels present but empty removes all regular labels",
+			name:     "labels omitted removes all regular labels when not excepted",
 			filename: "config.yml",
 			teamName: "team1",
 			existingLabels: []*fleet.LabelSpec{
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 				{Name: "built-in", LabelType: fleet.LabelTypeBuiltIn},
 			},
-			specifiedLabels:       nil,
-			preserveMissingLabels: false,
+			specifiedLabels: nil,
+			labelsExcepted:  false,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "-", TeamName: "team1", FileName: "config.yml"},
 			},
 		},
 		{
-			name:     "labels absent is a no-op",
+			name:     "labels empty removes all regular labels when not excepted",
+			filename: "config.yml",
+			teamName: "team1",
+			existingLabels: []*fleet.LabelSpec{
+				{Name: "label1", LabelType: fleet.LabelTypeRegular},
+				{Name: "built-in", LabelType: fleet.LabelTypeBuiltIn},
+			},
+			specifiedLabels: []*fleet.LabelSpec{},
+			labelsExcepted:  false,
+			expected: []spec.LabelChange{
+				{Name: "label1", Op: "-", TeamName: "team1", FileName: "config.yml"},
+			},
+		},
+		{
+			name:     "labels omitted is a no-op when excepted",
 			filename: "config.yml",
 			teamName: "team1",
 			existingLabels: []*fleet.LabelSpec{
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 			},
-			specifiedLabels:       nil,
-			preserveMissingLabels: true,
+			specifiedLabels: nil,
+			labelsExcepted:  true,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "~", TeamName: "team1", FileName: "config.yml"},
 			},
@@ -6136,7 +6150,7 @@ func TestComputeLabelChanges(t *testing.T) {
 				{Name: "to-keep"},
 				{Name: "to-add"},
 			},
-			preserveMissingLabels: false,
+			labelsExcepted: false,
 			expected: []spec.LabelChange{
 				{Name: "to-remove", Op: "-", TeamName: "team1", FileName: "config.yml"},
 				{Name: "to-keep", Op: "=", TeamName: "team1", FileName: "config.yml"},
@@ -6147,7 +6161,7 @@ func TestComputeLabelChanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels, tc.preserveMissingLabels)
+			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels, tc.labelsExcepted)
 			require.ElementsMatch(t, tc.expected, changes)
 		})
 	}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -6067,13 +6067,13 @@ software:
 
 func TestComputeLabelChanges(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		filename             string
-		teamName             string
-		existingLabels       []*fleet.LabelSpec
-		specifiedLabels      []*fleet.LabelSpec
-		processMissingLabels bool
-		expected             []spec.LabelChange
+		name                  string
+		filename              string
+		teamName              string
+		existingLabels        []*fleet.LabelSpec
+		specifiedLabels       []*fleet.LabelSpec
+		preserveMissingLabels bool
+		expected              []spec.LabelChange
 	}{
 		{
 			name:     "labels present but empty removes all regular labels",
@@ -6083,8 +6083,8 @@ func TestComputeLabelChanges(t *testing.T) {
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 				{Name: "built-in", LabelType: fleet.LabelTypeBuiltIn},
 			},
-			specifiedLabels:      nil,
-			processMissingLabels: true,
+			specifiedLabels:       nil,
+			preserveMissingLabels: false,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "-", TeamName: "team1", FileName: "config.yml"},
 			},
@@ -6096,8 +6096,8 @@ func TestComputeLabelChanges(t *testing.T) {
 			existingLabels: []*fleet.LabelSpec{
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 			},
-			specifiedLabels:      nil,
-			processMissingLabels: false,
+			specifiedLabels:       nil,
+			preserveMissingLabels: true,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "~", TeamName: "team1", FileName: "config.yml"},
 			},
@@ -6114,7 +6114,7 @@ func TestComputeLabelChanges(t *testing.T) {
 				{Name: "to-keep"},
 				{Name: "to-add"},
 			},
-			processMissingLabels: true,
+			preserveMissingLabels: false,
 			expected: []spec.LabelChange{
 				{Name: "to-remove", Op: "-", TeamName: "team1", FileName: "config.yml"},
 				{Name: "to-keep", Op: "=", TeamName: "team1", FileName: "config.yml"},
@@ -6125,7 +6125,7 @@ func TestComputeLabelChanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels, tc.processMissingLabels)
+			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels, tc.preserveMissingLabels)
 			require.ElementsMatch(t, tc.expected, changes)
 		})
 	}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1450,19 +1450,6 @@ func TestGitOpsFullGlobal(t *testing.T) {
 	}
 	require.NotNil(t, labelD, "label d should be in applied specs")
 	assert.Nil(t, labelD.Hosts, "omitting hosts key should result in nil Hosts (preserve membership)")
-
-	// Reset labels arrays
-	deletedLabels = make([]string, 0)
-	appliedLabelSpecs = make([]*fleet.LabelSpec, 0)
-	// Except labels so that omitting the `labels:` key is a no-op.
-	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{MDM: fleet.MDM{EnabledAndConfigured: true}, GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
-	}
-	// Real run w/out top-level labels key
-	logs = RunAppForTest(t, []string{"gitops", "-f", "./testdata/gitops/global_config_no_paths_no_labels.yml"})
-	fmt.Printf("%s", logs)
-	assert.Len(t, appliedLabelSpecs, 0)
-	assert.Len(t, deletedLabels, 0)
 }
 
 func TestGitOpsFullTeam(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -5849,7 +5849,7 @@ func TestComputeLabelChanges(t *testing.T) {
 			specifiedLabels:      nil,
 			processMissingLabels: false,
 			expected: []spec.LabelChange{
-				{Name: "label1", Op: "=", TeamName: "team1", FileName: "config.yml"},
+				{Name: "label1", Op: "~", TeamName: "team1", FileName: "config.yml"},
 			},
 		},
 		{

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1216,7 +1216,7 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 					},
 				}
 			}
-			return bogus, int(opt.ListOptions.PerPage), nil, nil
+			return bogus, int(opt.ListOptions.PerPage), nil, nil //nolint:gosec // dismiss G115
 		}
 		// Page 1: the real software that policies reference.
 		return []fleet.SoftwareTitleListResult{

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1391,20 +1391,6 @@ func TestGitOpsFullGlobal(t *testing.T) {
 	assert.Len(t, appliedLabelSpecs, 0)
 	assert.Len(t, deletedLabels, 0)
 
-	// Dry run w/out top-level labels key
-	logs = RunAppForTest(t, []string{"gitops", "-f", "./testdata/gitops/global_config_no_paths_no_labels.yml", "--dry-run"})
-	fmt.Printf("%s", logs)
-	fmt.Printf("-----------\n")
-	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
-	assert.Len(t, enrolledSecrets, 0)
-	assert.Len(t, appliedPolicySpecs, 0)
-	assert.Len(t, appliedQueries, 0)
-	assert.Len(t, appliedScripts, 0)
-	assert.Len(t, appliedMacProfiles, 0)
-	assert.Len(t, appliedWinProfiles, 0)
-	assert.Len(t, appliedLabelSpecs, 0)
-	assert.Len(t, deletedLabels, 0)
-
 	// Real run w/ top-level labels key
 	logs = RunAppForTest(t, []string{"gitops", "-f", "./testdata/gitops/global_config_no_paths.yml"})
 	fmt.Printf("%s", logs)
@@ -1482,7 +1468,6 @@ func TestGitOpsFullTeam(t *testing.T) {
 			EnabledAndConfigured:        true,
 			WindowsEnabledAndConfigured: true,
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
 	}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -1863,8 +1848,8 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 		},
 	)
 
-	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
-	savedAppConfig := &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	// Mock appConfig
+	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		appConfig := savedAppConfig.Copy()
 		return appConfig, nil
@@ -1964,7 +1949,12 @@ func TestGitOpsBasicGlobalAndTeam(t *testing.T) {
 		return nil
 	}
 
-	testing_utils.AddLabelMocks(ds)
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+		return nil
+	}
 
 	// Mock DefaultTeamConfig functions for No Team webhook settings
 	setupDefaultTeamConfigMocks(ds)
@@ -2197,17 +2187,16 @@ software:
 
 	// Dry run
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run"})
-	emptyWithExceptions := fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
-	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
+	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
 
 	// Dry run should not attempt to get the VPP token when applying VPP apps (it may not exist).
 	require.False(t, ds.GetVPPTokenByTeamIDFuncInvoked)
 	ds.ListTeamsFuncInvoked = false
 
 	// Dry run, deleting other teams
-	savedAppConfig = &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}
+	savedAppConfig = &fleet.AppConfig{}
 	_ = RunAppForTest(t, []string{"gitops", "-f", globalFile.Name(), "-f", teamFile.Name(), "--dry-run", "--delete-other-teams"})
-	assert.Equal(t, emptyWithExceptions, *savedAppConfig, "AppConfig should be empty")
+	assert.Equal(t, fleet.AppConfig{}, *savedAppConfig, "AppConfig should be empty")
 	assert.True(t, ds.ListTeamsFuncInvoked)
 
 	// Real run
@@ -2280,10 +2269,10 @@ func TestGitOpsBasicGlobalAndNoTeam(t *testing.T) {
 	// Mock Apple GDMF API (required for validating OS update minimum version settings)
 	mdmtest.StartNewAppleGDMFTestServer(t)
 
-	// Mock appConfig — labels excepted because YAML omits `labels:` and AddLabelMocks creates existing labels.
+	// Mock appConfig
 	savedAppConfig := &fleet.AppConfig{}
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-		return &fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: fleet.GitOpsExceptions{Labels: true}}}, nil
+		return &fleet.AppConfig{}, nil
 	}
 	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error {
 		savedAppConfig = config
@@ -2372,7 +2361,12 @@ func TestGitOpsBasicGlobalAndNoTeam(t *testing.T) {
 	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
 		return nil, 0, 0, nil, nil
 	}
-	testing_utils.AddLabelMocks(ds)
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+		return nil
+	}
 
 	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 		job.ID = 1
@@ -2844,9 +2838,6 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 	ds, savedAppConfigPtr, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
 	testing_utils.StartSoftwareInstallerServer(t)
 
-	// This test includes `labels:` in its YAML, so disable the labels exception.
-	(*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = false
-
 	var enrolledSecrets []*fleet.EnrollSecret
 	var enrolledTeamSecrets []*fleet.EnrollSecret
 	var appliedPolicySpecs []*fleet.PolicySpec
@@ -2977,9 +2968,11 @@ func TestGitOpsFullGlobalAndTeam(t *testing.T) {
 	require.Len(t, enrolledTeamSecrets, 2)
 
 	t.Run("no-team.yml using relative paths", func(t *testing.T) {
-		// Re-enable labels exception since these YAML files don't include `labels:`.
-		(*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = true
-		t.Cleanup(func() { (*savedAppConfigPtr).GitOpsConfig.Exceptions.Labels = false })
+		// Override label mocks to return no existing labels, since these YAML files
+		// don't include `labels:` and multi-file deletion would cause dedup errors.
+		ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+			return nil, nil
+		}
 
 		globalFileBasic := createGlobalFileBasic(t, fleetServerURL, orgName)
 		teamFileBasic := createTeamFileBasic(t, teamName)
@@ -3489,6 +3482,10 @@ software:
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			ds, savedAppConfigPtr, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+			// No existing labels — this test doesn't test label behavior.
+			ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+				return nil, nil
+			}
 
 			ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) {
 				if len(tt.tokens) > 0 {
@@ -3917,7 +3914,7 @@ func TestGitOpsFeatures(t *testing.T) {
 				"detail_query_b": nil,
 			},
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+
 	}
 
 	globalFileUpdatedFeatures, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -4002,7 +3999,7 @@ func TestGitOpsSSOSettings(t *testing.T) {
 			EnableJITProvisioning: true,
 			EnableJITRoleSync:     true,
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4049,7 +4046,7 @@ org_settings:
 
 	ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 
-	appConfig := fleet.AppConfig{GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()}}
+	appConfig := fleet.AppConfig{}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
 		return &appConfig, nil
@@ -4090,7 +4087,7 @@ func TestGitOpsSMTPSettings(t *testing.T) {
 			SMTPVerifySSLCerts:       true,
 			SMTPEnableStartTLS:       true,
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4141,7 +4138,7 @@ func TestGitOpsMDMAuthSettings(t *testing.T) {
 				},
 			},
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4211,7 +4208,7 @@ func TestGitOpsNoTeamConditionalAccess(t *testing.T) {
 		Integrations: fleet.Integrations{
 			ConditionalAccessEnabled: optjson.SetBool(true),
 		},
-		GitOpsConfig: fleet.GitOpsConfig{Exceptions: testing_utils.DefaultGitOpsExceptions()},
+
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1180,9 +1180,11 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 
 	// Server-side software for "Test Fleet" (teamID=1) and "No team" (teamID=0).
 	// This is what the pre-fetch will retrieve and inject as synthetic data into the parser.
+	// For team software, page 0 returns a full page of bogus results to exercise pagination,
+	// and page 1 returns the actual software that policies reference.
 	ds.ListSoftwareTitlesFunc = func(ctx context.Context, opt fleet.SoftwareTitleListOptions, tmFilter fleet.TeamFilter) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {
 		if opt.TeamID != nil && *opt.TeamID == 0 {
-			// No-team software
+			// No-team software — single page
 			return []fleet.SoftwareTitleListResult{
 				{
 					ID:         30,
@@ -1197,10 +1199,28 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 				},
 			}, 1, nil, nil
 		}
-		// Team software
+		// Team software — paginated
+		if opt.ListOptions.Page == 0 {
+			// Page 0: full page of bogus packages that don't match any policy references.
+			bogus := make([]fleet.SoftwareTitleListResult, opt.ListOptions.PerPage)
+			for i := range bogus {
+				bogus[i] = fleet.SoftwareTitleListResult{
+					ID:         uint(1000 + i),
+					Name:       fmt.Sprintf("Bogus Package %d", i),
+					HashSHA256: ptr.String(fmt.Sprintf("%064x", i)),
+					SoftwarePackage: &fleet.SoftwarePackageOrApp{
+						Name:       fmt.Sprintf("bogus-%d.deb", i),
+						Platform:   "linux",
+						Version:    "0.0.1",
+						PackageURL: ptr.String(fmt.Sprintf("https://example.com/bogus-%d.deb", i)),
+					},
+				}
+			}
+			return bogus, int(opt.ListOptions.PerPage), nil, nil
+		}
+		// Page 1: the real software that policies reference.
 		return []fleet.SoftwareTitleListResult{
 			{
-				// Custom package — referenced by policy via hash_sha256
 				ID:         10,
 				Name:       "Custom Package",
 				HashSHA256: ptr.String("a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6abcd"),
@@ -1212,7 +1232,6 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 				},
 			},
 			{
-				// VPP app — referenced by policy via app_store_id
 				ID:   20,
 				Name: "VPP App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -769,6 +769,12 @@ func TestGitOpsExceptionEnforcement(t *testing.T) {
 	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
 		return &fleet.Job{}, nil
 	}
+	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+		return nil, nil
+	}
+	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+		return nil, nil
+	}
 
 	// Test: excepted keys present in YAML → error
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -776,7 +782,7 @@ func TestGitOpsExceptionEnforcement(t *testing.T) {
 			GitOpsConfig: fleet.GitOpsConfig{
 				GitopsModeEnabled: true,
 				RepositoryURL:     "https://example.com/repo",
-				Exceptions:        fleet.GitOpsExceptions{Labels: true, Secrets: true},
+				Exceptions:        fleet.GitOpsExceptions{Labels: true, Secrets: true, Software: true},
 			},
 		}, nil
 	}
@@ -821,6 +827,21 @@ agent_options:
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile2.Name()})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"secrets" is excepted from GitOps management`)
+
+	// Secrets excepted + present → error
+	tmpFile3, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile3.WriteString(`
+name: test
+controls:
+policies:
+agent_options:
+software:
+`)
+	require.NoError(t, err)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile3.Name()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"software" is excepted from GitOps management`)
 
 	// Test: exceptions enforced even when GitOps mode is OFF (decoupled from UI mode)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -855,10 +855,404 @@ software:
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"labels" is excepted from GitOps management`)
+}
 
-	// NOTE: The "excepted keys omitted → no-op succeeds" case is tested in the integration
-	// tests (TestGitOpsBasicGlobalPremium), which has the full mock setup needed for a
-	// successful GitOps run.
+// TestGitOpsExceptionsPreserveOmittedKeys verifies that when exceptions are ON,
+// omitting the excepted keys from YAML preserves existing data.
+func TestGitOpsExceptionsPreserveOmittedKeys(t *testing.T) {
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(
+		t, &service.TestServerOpts{
+			License:       license,
+			KeyValueStore: testing_utils.NewMemKeyValueStore(),
+		},
+	)
+
+	// Tracking variables
+	var appliedSecrets []*fleet.EnrollSecret
+	var deletedLabels []string
+
+	// --- Shared mocks ---
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			GitOpsConfig: fleet.GitOpsConfig{
+				Exceptions: fleet.GitOpsExceptions{Labels: true, Secrets: true, Software: true},
+			},
+		}, nil
+	}
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error { return nil }
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+		macDecls []*fleet.MDMAppleDeclaration, androidProfiles []*fleet.MDMAndroidConfigProfile, vars []fleet.MDMProfileIdentifierFleetVariables,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) ([]fleet.ScriptResponse, error) {
+		return []fleet.ScriptResponse{}, nil
+	}
+	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+		return nil, nil
+	}
+	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, 0, nil, nil
+	}
+	ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+		return nil, nil
+	}
+	setupDefaultTeamConfigMocks(ds)
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return []*fleet.LabelSpec{
+			{Name: "existing-label", LabelType: fleet.LabelTypeRegular, LabelMembershipType: fleet.LabelMembershipTypeDynamic, Query: "SELECT 1"},
+		}, nil
+	}
+	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+		return nil
+	}
+	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
+		return nil
+	}
+	ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+		return &fleet.Label{ID: 1, Name: name}, nil
+	}
+	ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+		deletedLabels = append(deletedLabels, name)
+		return nil
+	}
+	ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+		return map[string]*fleet.Label{}, nil
+	}
+	ds.ApplyEnrollSecretsFunc = func(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
+		appliedSecrets = secrets
+		return nil
+	}
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return nil, nil }
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return nil, nil }
+	ds.BatchApplyCertificateAuthoritiesFunc = func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error {
+		return nil
+	}
+	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+		return &fleet.GroupedCertificateAuthorities{}, nil
+	}
+	ds.BatchSetSoftwareInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.BatchSetInHouseAppsInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.GetSoftwareInstallersFunc = func(ctx context.Context, tmID uint) ([]fleet.SoftwarePackageResponse, error) {
+		return nil, nil
+	}
+	ds.DeleteSetupExperienceScriptFunc = func(ctx context.Context, teamID *uint) error { return nil }
+	ds.SetTeamVPPAppsFunc = func(ctx context.Context, teamID *uint, adamIDs []fleet.VPPAppTeam, _ map[string]uint) (bool, error) {
+		return false, nil
+	}
+	ds.ListSoftwareAutoUpdateSchedulesFunc = func(ctx context.Context, teamID uint, source string, optionalFilter ...fleet.SoftwareAutoUpdateScheduleFilter) ([]fleet.SoftwareAutoUpdateSchedule, error) {
+		return nil, nil
+	}
+	ds.ListTeamPoliciesFunc = func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+		return nil, nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+	ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
+		return &fleet.MDMAppleDeclaration{}, nil
+	}
+	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+		return &fleet.Job{}, nil
+	}
+	var savedTeam *fleet.Team
+	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+		return nil, nil
+	}
+	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+		if savedTeam != nil && savedTeam.Name == name {
+			return savedTeam, nil
+		}
+		return nil, &notFoundError{}
+	}
+	ds.BatchInsertVPPAppsFunc = func(ctx context.Context, apps []*fleet.VPPApp) error { return nil }
+	ds.DeleteIconsAssociatedWithTitlesWithoutInstallersFunc = func(ctx context.Context, teamID uint) error {
+		return nil
+	}
+	ds.NewTeamFunc = func(ctx context.Context, newTeam *fleet.Team) (*fleet.Team, error) {
+		newTeam.ID = 1
+		savedTeam = newTeam
+		return newTeam, nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		savedTeam = team
+		return team, nil
+	}
+	ds.IsEnrollSecretAvailableFunc = func(ctx context.Context, secret string, isNew bool, teamID *uint) (bool, error) {
+		return true, nil
+	}
+	ds.DeleteMDMAppleDeclarationByNameFunc = func(ctx context.Context, teamID *uint, name string) error {
+		return nil
+	}
+	ds.ListSoftwareTitlesFunc = func(ctx context.Context, opt fleet.SoftwareTitleListOptions, tmFilter fleet.TeamFilter) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, nil, nil
+	}
+	ds.GetVPPAppsFunc = func(ctx context.Context, teamID *uint) ([]fleet.VPPAppResponse, error) {
+		return nil, nil
+	}
+	ds.GetSoftwareCategoryIDsFunc = func(ctx context.Context, names []string) ([]uint, error) {
+		return nil, nil
+	}
+
+	// Global config that omits labels, secrets, and software
+	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = globalFile.WriteString(`
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    org_name: Test
+controls:
+policies:
+agent_options:
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", globalFile.Name()})
+	require.NoError(t, err)
+
+	// Labels should NOT have been deleted (excepted)
+	assert.Empty(t, deletedLabels, "labels should be preserved when excepted and key is omitted")
+	// Secrets should NOT have been applied (excepted)
+	assert.Nil(t, appliedSecrets, "secrets should be preserved when excepted and key is omitted")
+	// Software is global — not applicable (software exceptions only apply to team configs)
+	// so we don't assert on appliedSoftware here.
+
+	// Team secrets and software preservation are verified in the integration test
+	// TestOmittedTopLevelKeysFleet, since both are applied as part of the team spec payload
+	// (not via separate mock-trackable calls).
+}
+
+// TestGitOpsNoExceptionsClearOmittedKeys verifies that when exceptions are OFF,
+// omitting keys from YAML clears existing data.
+func TestGitOpsNoExceptionsClearOmittedKeys(t *testing.T) {
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(
+		t, &service.TestServerOpts{
+			License:       license,
+			KeyValueStore: testing_utils.NewMemKeyValueStore(),
+		},
+	)
+
+	// Tracking variables
+	var appliedSecrets []*fleet.EnrollSecret
+	var deletedLabels []string
+
+	savedTeam := &fleet.Team{
+		Name:    "TestTeam",
+		ID:      1,
+		Secrets: []*fleet.EnrollSecret{{Secret: "existing-secret"}},
+		Config: fleet.TeamConfig{
+			Software: &fleet.SoftwareSpec{
+				Packages:            optjson.SetSlice([]fleet.SoftwarePackageSpec{{URL: "http://example.com"}}),
+				FleetMaintainedApps: optjson.SetSlice([]fleet.MaintainedAppSpec{{Slug: "someapp"}}),
+				AppStoreApps:        optjson.SetSlice([]fleet.TeamSpecAppStoreApp{{AppStoreID: "someapp"}}),
+			},
+		},
+	}
+
+	// --- Shared mocks (all exceptions OFF) ---
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			GitOpsConfig: fleet.GitOpsConfig{
+				Exceptions: fleet.GitOpsExceptions{}, // all false
+			},
+		}, nil
+	}
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error { return nil }
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+		macDecls []*fleet.MDMAppleDeclaration, androidProfiles []*fleet.MDMAndroidConfigProfile, vars []fleet.MDMProfileIdentifierFleetVariables,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) ([]fleet.ScriptResponse, error) {
+		return []fleet.ScriptResponse{}, nil
+	}
+	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+		return nil, nil
+	}
+	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, 0, nil, nil
+	}
+	ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+		return []*fleet.Team{savedTeam}, nil
+	}
+	setupDefaultTeamConfigMocks(ds)
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		if filter.TeamID != nil && *filter.TeamID == 1 {
+			return []*fleet.LabelSpec{
+				{Name: "existing-team-label", LabelType: fleet.LabelTypeRegular, LabelMembershipType: fleet.LabelMembershipTypeDynamic, Query: "SELECT 1", TeamID: ptr.Uint(1)},
+			}, nil
+		}
+		return []*fleet.LabelSpec{
+			{Name: "existing-label", LabelType: fleet.LabelTypeRegular, LabelMembershipType: fleet.LabelMembershipTypeDynamic, Query: "SELECT 1"},
+		}, nil
+	}
+	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
+		return nil
+	}
+	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
+		return nil
+	}
+	ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+		return &fleet.Label{ID: 1, Name: name}, nil
+	}
+	ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
+		deletedLabels = append(deletedLabels, name)
+		return nil
+	}
+	ds.LabelsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]*fleet.Label, error) {
+		return map[string]*fleet.Label{}, nil
+	}
+	ds.ApplyEnrollSecretsFunc = func(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
+		appliedSecrets = secrets
+		return nil
+	}
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return nil, nil }
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return nil, nil }
+	ds.BatchApplyCertificateAuthoritiesFunc = func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error {
+		return nil
+	}
+	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+		return &fleet.GroupedCertificateAuthorities{}, nil
+	}
+	ds.BatchSetSoftwareInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.BatchSetInHouseAppsInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.GetSoftwareInstallersFunc = func(ctx context.Context, tmID uint) ([]fleet.SoftwarePackageResponse, error) {
+		return nil, nil
+	}
+	ds.DeleteSetupExperienceScriptFunc = func(ctx context.Context, teamID *uint) error { return nil }
+	ds.SetTeamVPPAppsFunc = func(ctx context.Context, teamID *uint, adamIDs []fleet.VPPAppTeam, _ map[string]uint) (bool, error) {
+		return false, nil
+	}
+	ds.ListSoftwareAutoUpdateSchedulesFunc = func(ctx context.Context, teamID uint, source string, optionalFilter ...fleet.SoftwareAutoUpdateScheduleFilter) ([]fleet.SoftwareAutoUpdateSchedule, error) {
+		return nil, nil
+	}
+	ds.ListTeamPoliciesFunc = func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+		return nil, nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+	ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
+		return &fleet.MDMAppleDeclaration{}, nil
+	}
+	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+		return &fleet.Job{}, nil
+	}
+
+	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+		return savedTeam, nil
+	}
+	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+		if savedTeam != nil && savedTeam.Name == name {
+			return savedTeam, nil
+		}
+		return nil, &notFoundError{}
+	}
+	ds.BatchInsertVPPAppsFunc = func(ctx context.Context, apps []*fleet.VPPApp) error { return nil }
+	ds.DeleteIconsAssociatedWithTitlesWithoutInstallersFunc = func(ctx context.Context, teamID uint) error {
+		return nil
+	}
+	ds.NewTeamFunc = func(ctx context.Context, newTeam *fleet.Team) (*fleet.Team, error) {
+		newTeam.ID = 1
+		savedTeam = newTeam
+		return newTeam, nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		savedTeam = team
+		return team, nil
+	}
+	ds.IsEnrollSecretAvailableFunc = func(ctx context.Context, secret string, isNew bool, teamID *uint) (bool, error) {
+		return true, nil
+	}
+	ds.DeleteMDMAppleDeclarationByNameFunc = func(ctx context.Context, teamID *uint, name string) error {
+		return nil
+	}
+	ds.ListSoftwareTitlesFunc = func(ctx context.Context, opt fleet.SoftwareTitleListOptions, tmFilter fleet.TeamFilter) ([]fleet.SoftwareTitleListResult, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, nil, nil
+	}
+	ds.GetVPPAppsFunc = func(ctx context.Context, teamID *uint) ([]fleet.VPPAppResponse, error) {
+		return nil, nil
+	}
+	ds.GetSoftwareCategoryIDsFunc = func(ctx context.Context, names []string) ([]uint, error) {
+		return nil, nil
+	}
+
+	// Global config that omits labels and secrets
+	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = globalFile.WriteString(`
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    org_name: Test
+controls:
+policies:
+agent_options:
+`)
+	require.NoError(t, err)
+
+	_, err = RunAppNoChecks([]string{"gitops", "-f", globalFile.Name()})
+	require.NoError(t, err)
+
+	// Labels SHOULD have been deleted (not excepted, key omitted)
+	assert.Equal(t, []string{"existing-label"}, deletedLabels, "labels should be cleared when not excepted and key is omitted")
+	// Secrets SHOULD have been applied as empty (not excepted, key omitted)
+	assert.NotNil(t, appliedSecrets, "secrets should be cleared when not excepted and key is omitted")
+	assert.Empty(t, appliedSecrets, "secrets should be applied as empty list")
+
+	// Clear out deletedLabels
+	deletedLabels = nil
+	// Clear out appliedSecrets
+	appliedSecrets = nil
+
+	// Now test team config: omit secrets and software
+	teamFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = teamFile.WriteString(`
+name: TestTeam
+controls:
+policies:
+agent_options:
+`)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
+	require.NoError(t, err)
+	// Check that secrets is empty on the saved team
+	assert.NotNil(t, savedTeam.Secrets, "team secrets should not be nil")
+	assert.Empty(t, savedTeam.Secrets, "team secrets should be cleared when not excepted and key is omitted")
+	// Labels SHOULD have been deleted (not excepted, key omitted)
+	assert.Equal(t, []string{"existing-team-label"}, deletedLabels, "labels should be cleared when not excepted and key is omitted")
+	// Software clearing requires enterprise setup, which is tested in the integration test TestOmittedTopLevelKeysFleet.
 }
 
 func TestGitOpsBasicTeam(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1245,6 +1245,7 @@ controls:
 policies:
 agent_options:
 `)
+	require.NoError(t, err)
 	_, err = RunAppNoChecks([]string{"gitops", "-f", teamFile.Name()})
 	require.NoError(t, err)
 	// Check that secrets is empty on the saved team

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3914,7 +3914,6 @@ func TestGitOpsFeatures(t *testing.T) {
 				"detail_query_b": nil,
 			},
 		},
-
 	}
 
 	globalFileUpdatedFeatures, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -3999,7 +3998,6 @@ func TestGitOpsSSOSettings(t *testing.T) {
 			EnableJITProvisioning: true,
 			EnableJITRoleSync:     true,
 		},
-
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4087,7 +4085,6 @@ func TestGitOpsSMTPSettings(t *testing.T) {
 			SMTPVerifySSLCerts:       true,
 			SMTPEnableStartTLS:       true,
 		},
-
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4138,7 +4135,6 @@ func TestGitOpsMDMAuthSettings(t *testing.T) {
 				},
 			},
 		},
-
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -4208,7 +4204,6 @@ func TestGitOpsNoTeamConditionalAccess(t *testing.T) {
 		Integrations: fleet.Integrations{
 			ConditionalAccessEnabled: optjson.SetBool(true),
 		},
-
 	}
 
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1043,6 +1043,7 @@ agent_options:
 // (hash_sha256 for packages, app_store_id for VPP apps) still validate successfully
 // against server-side software data.
 func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
+	policySpecsByTeam := make(map[string][]*fleet.PolicySpec)
 	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
 	_, ds := testing_utils.RunServerWithMockedDS(
 		t, &service.TestServerOpts{
@@ -1174,6 +1175,7 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 	}
 
 	ds.ApplyPolicySpecsFunc = func(ctx context.Context, authorID uint, specs []*fleet.PolicySpec) error {
+		policySpecsByTeam[specs[0].Team] = specs
 		return nil
 	}
 
@@ -1234,7 +1236,7 @@ func TestGitOpsSoftwareExceptionPolicyValidation(t *testing.T) {
 				ID:   20,
 				Name: "VPP App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{
-					AppStoreID: "com.example.vpp-app",
+					AppStoreID: "5128675309",
 					Platform:   string(fleet.MacOSPlatform),
 				},
 			},
@@ -1267,7 +1269,7 @@ policies:
   - name: VPP Policy
     query: SELECT 1
     install_software:
-      app_store_id: com.example.vpp-app
+      app_store_id: 5128675309
 agent_options:
 reports:
 `), 0o644))
@@ -1286,6 +1288,23 @@ policies:
 	// provides the server-side data for policy validation on both team and no-team.
 	_, err := RunAppNoChecks([]string{"gitops", "-f", globalFile, "-f", teamFile, "-f", unassignedFile})
 	require.NoError(t, err, "gitops should succeed when policies reference server-side software and software is excepted")
+	// Check that policies for "Test Fleet" contained the expected software title IDs.
+	testFleetPolicySpecs := policySpecsByTeam["Test Fleet"]
+	require.Len(t, testFleetPolicySpecs, 2, "expected 2 policies for Test Fleet")
+	for _, spec := range testFleetPolicySpecs {
+		switch spec.Name {
+		case "Package Policy":
+			assert.Equal(t, uint(10), *spec.SoftwareTitleID, "expected server-side software ID to be injected into Package Policy spec")
+		case "VPP Policy":
+			assert.Equal(t, uint(20), *spec.SoftwareTitleID, "expected server-side software ID to be injected into VPP Policy spec")
+		default:
+			t.Errorf("unexpected policy name: %s", spec.Name)
+		}
+	}
+	// Check that no-team policy also had the expected software title ID.
+	noTeamPolicySpecs := policySpecsByTeam["No team"]
+	require.Len(t, noTeamPolicySpecs, 1, "expected 1 no-team policy")
+	assert.Equal(t, uint(30), *noTeamPolicySpecs[0].SoftwareTitleID, "expected server-side software ID to be injected into no-team policy spec")
 }
 
 // TestGitOpsNoExceptionsClearOmittedKeys verifies that when exceptions are OFF,
@@ -1300,7 +1319,10 @@ func TestGitOpsNoExceptionsClearOmittedKeys(t *testing.T) {
 	)
 
 	// Tracking variables
-	var appliedSecrets []*fleet.EnrollSecret
+	appliedSecrets := []*fleet.EnrollSecret{
+		{Secret: "existing-secret"},
+		{Secret: "another-secret"},
+	}
 	var deletedLabels []string
 
 	savedTeam := &fleet.Team{

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -912,7 +912,7 @@ func TestGitOpsExceptionsPreserveOmittedKeys(t *testing.T) {
 		}, nil
 	}
 	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
-		return nil
+		return errors.New("unexpected ApplyLabelSpecsWithAuthorFunc call - should not apply labels when excepted")
 	}
 	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
 		return nil
@@ -928,8 +928,7 @@ func TestGitOpsExceptionsPreserveOmittedKeys(t *testing.T) {
 		return map[string]*fleet.Label{}, nil
 	}
 	ds.ApplyEnrollSecretsFunc = func(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
-		appliedSecrets = secrets
-		return nil
+		return errors.New("unexpected ApplyEnrollSecretsFunc call - should not apply enroll secrets when excepted")
 	}
 	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
 		return map[string]uint{}, nil
@@ -1361,7 +1360,7 @@ func TestGitOpsNoExceptionsClearOmittedKeys(t *testing.T) {
 		}, nil
 	}
 	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
-		return errors.New("unexpected ApplyLabelSpecsWithAuthorFunc call - should not apply labels when excepted")
+		return errors.New("unexpected ApplyLabelSpecsWithAuthorFunc call - should not apply labels when all are deleted")
 	}
 	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
 		return nil

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -822,6 +822,19 @@ agent_options:
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `"secrets" is excepted from GitOps management`)
 
+	// Test: exceptions enforced even when GitOps mode is OFF (decoupled from UI mode)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			UIGitOpsMode: fleet.UIGitOpsModeConfig{
+				GitopsModeEnabled: false,
+				Exceptions:        fleet.GitOpsExceptions{Labels: true},
+			},
+		}, nil
+	}
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"labels" is excepted from GitOps management`)
+
 	// NOTE: The "excepted keys omitted → no-op succeeds" case is tested in the integration
 	// tests (TestGitOpsBasicGlobalPremium), which has the full mock setup needed for a
 	// successful GitOps run.
@@ -5391,34 +5404,37 @@ software:
 
 func TestComputeLabelChanges(t *testing.T) {
 	testCases := []struct {
-		name            string
-		filename        string
-		teamName        string
-		existingLabels  []*fleet.LabelSpec
-		specifiedLabels []*fleet.LabelSpec
-		expected        []spec.LabelChange
+		name                 string
+		filename             string
+		teamName             string
+		existingLabels       []*fleet.LabelSpec
+		specifiedLabels      []*fleet.LabelSpec
+		processMissingLabels bool
+		expected             []spec.LabelChange
 	}{
 		{
-			name:     "no specified labels removes all regular labels",
+			name:     "labels present but empty removes all regular labels",
 			filename: "config.yml",
 			teamName: "team1",
 			existingLabels: []*fleet.LabelSpec{
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 				{Name: "built-in", LabelType: fleet.LabelTypeBuiltIn},
 			},
-			specifiedLabels: nil,
+			specifiedLabels:      nil,
+			processMissingLabels: true,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "-", TeamName: "team1", FileName: "config.yml"},
 			},
 		},
 		{
-			name:     "empty list of specified labels is a no-op",
+			name:     "labels absent is a no-op",
 			filename: "config.yml",
 			teamName: "team1",
 			existingLabels: []*fleet.LabelSpec{
 				{Name: "label1", LabelType: fleet.LabelTypeRegular},
 			},
-			specifiedLabels: []*fleet.LabelSpec{},
+			specifiedLabels:      nil,
+			processMissingLabels: false,
 			expected: []spec.LabelChange{
 				{Name: "label1", Op: "=", TeamName: "team1", FileName: "config.yml"},
 			},
@@ -5435,6 +5451,7 @@ func TestComputeLabelChanges(t *testing.T) {
 				{Name: "to-keep"},
 				{Name: "to-add"},
 			},
+			processMissingLabels: true,
 			expected: []spec.LabelChange{
 				{Name: "to-remove", Op: "-", TeamName: "team1", FileName: "config.yml"},
 				{Name: "to-keep", Op: "=", TeamName: "team1", FileName: "config.yml"},
@@ -5445,7 +5462,7 @@ func TestComputeLabelChanges(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels)
+			changes := computeLabelChanges(tc.filename, tc.teamName, tc.existingLabels, tc.specifiedLabels, tc.processMissingLabels)
 			require.ElementsMatch(t, tc.expected, changes)
 		})
 	}

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1110,7 +1111,7 @@ func TestGitOpsNoExceptionsClearOmittedKeys(t *testing.T) {
 		}, nil
 	}
 	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) error {
-		return nil
+		return errors.New("unexpected ApplyLabelSpecsWithAuthorFunc call - should not apply labels when excepted")
 	}
 	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
 		return nil

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -379,9 +379,9 @@ func TestGitOpsBasicGlobalPremium(t *testing.T) {
 				GitopsModeEnabled: true,
 				RepositoryURL:     "https://didsomeonesaygitops.biz",
 				Exceptions: fleet.GitOpsExceptions{
-					Software: false,
-					Secrets:  true,
-					Labels:   true,
+					Labels:   false,
+					Software: true,
+					Secrets:  false,
 				},
 			},
 		}, nil
@@ -687,6 +687,144 @@ software:
 	// assert.Equal(t, "https://hydrant2.example.com", h2.URL)
 	// assert.Equal(t, "hydrant2_id", h2.ClientID)
 	// assert.Equal(t, "hydrant2_secret", h2.ClientSecret)
+}
+
+func TestGitOpsExceptionEnforcement(t *testing.T) {
+	// Cannot run t.Parallel() because it sets environment variables
+	license := &fleet.LicenseInfo{Tier: fleet.TierPremium, Expiration: time.Now().Add(24 * time.Hour)}
+	_, ds := testing_utils.RunServerWithMockedDS(
+		t, &service.TestServerOpts{
+			License:       license,
+			KeyValueStore: testing_utils.NewMemKeyValueStore(),
+		},
+	)
+
+	ds.BatchSetMDMProfilesFunc = func(
+		ctx context.Context, tmID *uint, macProfiles []*fleet.MDMAppleConfigProfile, winProfiles []*fleet.MDMWindowsConfigProfile,
+		macDecls []*fleet.MDMAppleDeclaration, androidProfiles []*fleet.MDMAndroidConfigProfile, vars []fleet.MDMProfileIdentifierFleetVariables,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BulkSetPendingMDMHostProfilesFunc = func(
+		ctx context.Context, hostIDs []uint, teamIDs []uint, profileUUIDs []string, hostUUIDs []string,
+	) (updates fleet.MDMProfilesUpdates, err error) {
+		return fleet.MDMProfilesUpdates{}, nil
+	}
+	ds.BatchSetScriptsFunc = func(ctx context.Context, tmID *uint, scripts []*fleet.Script) ([]fleet.ScriptResponse, error) {
+		return []fleet.ScriptResponse{}, nil
+	}
+	ds.ListGlobalPoliciesFunc = func(ctx context.Context, opts fleet.ListOptions) ([]*fleet.Policy, error) {
+		return nil, nil
+	}
+	ds.ListQueriesFunc = func(ctx context.Context, opts fleet.ListQueryOptions) ([]*fleet.Query, int, int, *fleet.PaginationMetadata, error) {
+		return nil, 0, 0, nil, nil
+	}
+	ds.ListTeamsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {
+		return nil, nil
+	}
+	setupDefaultTeamConfigMocks(ds)
+	ds.SaveAppConfigFunc = func(ctx context.Context, config *fleet.AppConfig) error { return nil }
+	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+		return nil, nil
+	}
+	ds.ApplyEnrollSecretsFunc = func(ctx context.Context, teamID *uint, secrets []*fleet.EnrollSecret) error {
+		return nil
+	}
+	ds.LabelIDsByNameFunc = func(ctx context.Context, names []string, filter fleet.TeamFilter) (map[string]uint, error) {
+		return map[string]uint{}, nil
+	}
+	ds.ListABMTokensFunc = func(ctx context.Context) ([]*fleet.ABMToken, error) { return nil, nil }
+	ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) { return nil, nil }
+	ds.BatchApplyCertificateAuthoritiesFunc = func(ctx context.Context, ops fleet.CertificateAuthoritiesBatchOperations) error {
+		return nil
+	}
+	ds.GetGroupedCertificateAuthoritiesFunc = func(ctx context.Context, includeSecrets bool) (*fleet.GroupedCertificateAuthorities, error) {
+		return &fleet.GroupedCertificateAuthorities{}, nil
+	}
+	ds.BatchSetSoftwareInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.BatchSetInHouseAppsInstallersFunc = func(ctx context.Context, teamID *uint, installers []*fleet.UploadSoftwareInstallerPayload) error {
+		return nil
+	}
+	ds.GetSoftwareInstallersFunc = func(ctx context.Context, tmID uint) ([]fleet.SoftwarePackageResponse, error) {
+		return nil, nil
+	}
+	ds.DeleteSetupExperienceScriptFunc = func(ctx context.Context, teamID *uint) error { return nil }
+	ds.SetTeamVPPAppsFunc = func(ctx context.Context, teamID *uint, adamIDs []fleet.VPPAppTeam, _ map[string]uint) (bool, error) {
+		return false, nil
+	}
+	ds.ListSoftwareAutoUpdateSchedulesFunc = func(ctx context.Context, teamID uint, source string, optionalFilter ...fleet.SoftwareAutoUpdateScheduleFilter) ([]fleet.SoftwareAutoUpdateSchedule, error) {
+		return nil, nil
+	}
+	ds.ListTeamPoliciesFunc = func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+		return nil, nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{}, nil
+	}
+	ds.SetOrUpdateMDMAppleDeclarationFunc = func(ctx context.Context, declaration *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
+		return &fleet.MDMAppleDeclaration{}, nil
+	}
+	ds.NewJobFunc = func(ctx context.Context, job *fleet.Job) (*fleet.Job, error) {
+		return &fleet.Job{}, nil
+	}
+
+	// Test: excepted keys present in YAML → error
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			GitOpsConfig: fleet.GitOpsConfig{
+				GitopsModeEnabled: true,
+				RepositoryURL:     "https://example.com/repo",
+				Exceptions:        fleet.GitOpsExceptions{Labels: true, Secrets: true},
+			},
+		}, nil
+	}
+
+	// Labels excepted + present → error
+	tmpFile, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString(`
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    org_name: Test
+labels:
+  - name: test-label
+    query: SELECT 1
+controls:
+policies:
+agent_options:
+`)
+	require.NoError(t, err)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"labels" is excepted from GitOps management`)
+
+	// Secrets excepted + present → error
+	tmpFile2, err := os.CreateTemp(t.TempDir(), "*.yml")
+	require.NoError(t, err)
+	_, err = tmpFile2.WriteString(`
+org_settings:
+  server_settings:
+    server_url: https://fleet.example.com
+  org_info:
+    org_name: Test
+  secrets:
+    - secret: mysecret
+controls:
+policies:
+agent_options:
+`)
+	require.NoError(t, err)
+	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile2.Name()})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `"secrets" is excepted from GitOps management`)
+
+	// NOTE: The "excepted keys omitted → no-op succeeds" case is tested in the integration
+	// tests (TestGitOpsBasicGlobalPremium), which has the full mock setup needed for a
+	// successful GitOps run.
 }
 
 func TestGitOpsBasicTeam(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/testdata/gitops/global_macos_windows_custom_settings_valid.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/global_macos_windows_custom_settings_valid.yml
@@ -97,4 +97,16 @@ org_settings:
     databases_path: ""
   secrets: 
     - secret: ABC
+labels:
+  - name: A
+    label_membership_type: manual
+    hosts:
+      - host2
+      - host3
+  - name: B
+    label_membership_type: dynamic
+    query: SELECT 1 from osquery_info
+  - name: C
+    label_membership_type: dynamic
+    query: SELECT 1 from osquery_info
 software:

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -267,7 +267,7 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 			EnabledAndConfigured:        true,
 			AndroidEnabledAndConfigured: true,
 		},
-		UIGitOpsMode: fleet.UIGitOpsModeConfig{
+		GitOpsConfig: fleet.GitOpsConfig{
 			Exceptions: DefaultGitOpsExceptions(),
 		},
 	}

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -267,6 +267,9 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 			EnabledAndConfigured:        true,
 			AndroidEnabledAndConfigured: true,
 		},
+		UIGitOpsMode: fleet.UIGitOpsModeConfig{
+			Exceptions: DefaultGitOpsExceptions(),
+		},
 	}
 	AddLabelMocks(ds)
 
@@ -796,6 +799,15 @@ func (m *MemKeyValueStore) Get(ctx context.Context, key string) (*string, error)
 	}
 	vAsString := v.(string)
 	return &vAsString, nil
+}
+
+// DefaultGitOpsExceptions returns a GitOpsExceptions config suitable for tests.
+// Labels are excepted because many tests omit the `labels:` key from YAML but have mock labels set up.
+// Tests that explicitly include `labels:` in their YAML should set Labels to false.
+func DefaultGitOpsExceptions() fleet.GitOpsExceptions {
+	return fleet.GitOpsExceptions{
+		Labels: true,
+	}
 }
 
 func AddLabelMocks(ds *mock.Store) {

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -267,9 +267,6 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 			EnabledAndConfigured:        true,
 			AndroidEnabledAndConfigured: true,
 		},
-		GitOpsConfig: fleet.GitOpsConfig{
-			Exceptions: DefaultGitOpsExceptions(),
-		},
 	}
 	AddLabelMocks(ds)
 
@@ -801,15 +798,6 @@ func (m *MemKeyValueStore) Get(ctx context.Context, key string) (*string, error)
 	return &vAsString, nil
 }
 
-// DefaultGitOpsExceptions returns a GitOpsExceptions config suitable for tests.
-// Labels are excepted because many tests omit the `labels:` key from YAML but have mock labels set up.
-// Tests that explicitly include `labels:` in their YAML should set Labels to false.
-func DefaultGitOpsExceptions() fleet.GitOpsExceptions {
-	return fleet.GitOpsExceptions{
-		Labels: true,
-	}
-}
-
 func AddLabelMocks(ds *mock.Store) {
 	var deletedLabels []string
 	ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
@@ -831,7 +819,13 @@ func AddLabelMocks(ds *mock.Store) {
 	ds.ApplyLabelSpecsWithAuthorFunc = func(ctx context.Context, specs []*fleet.LabelSpec, authorID *uint) (err error) {
 		return nil
 	}
+	ds.SetAsideLabelsFunc = func(ctx context.Context, teamID *uint, names []string, user fleet.User) error {
+		return nil
+	}
 
+	ds.LabelByNameFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) (*fleet.Label, error) {
+		return &fleet.Label{ID: 1, Name: name}, nil
+	}
 	ds.DeleteLabelFunc = func(ctx context.Context, name string, filter fleet.TeamFilter) error {
 		deletedLabels = append(deletedLabels, name)
 		return nil

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_deprecated_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_deprecated_test.go
@@ -150,16 +150,11 @@ team_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabelsDeprecated() {
 	t := s.T()
 	t.Setenv("FLEET_ENABLE_LOG_TOPICS", logging.DeprecatedFieldTopic)
-	s.exceptLabels(t)
 
 	ctx := context.Background()
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
-	lbl, err := s.DS.NewLabel(ctx, &fleet.Label{Name: "Label1", Query: "SELECT 1"})
-	require.NoError(t, err)
-	require.NotZero(t, lbl.ID)
-
 	profileFile, err := os.CreateTemp(t.TempDir(), "*.mobileconfig")
 	require.NoError(t, err)
 	_, err = profileFile.WriteString(test.GenerateMDMAppleProfile("test", "test", uuid.NewString()))
@@ -170,6 +165,9 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabe
 	const (
 		globalTemplate = `
 agent_options:
+labels:
+  - name: Label1
+    query: select 1
 controls:
   macos_settings:
     custom_settings:
@@ -276,19 +274,18 @@ team_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetSoftwareInstallerLabelsDeprecated() {
 	t := s.T()
 	t.Setenv("FLEET_ENABLE_LOG_TOPICS", logging.DeprecatedFieldTopic)
-	s.exceptLabels(t)
 
 	ctx := context.Background()
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
-	lbl, err := s.DS.NewLabel(ctx, &fleet.Label{Name: "Label1", Query: "SELECT 1"})
-	require.NoError(t, err)
-	require.NotZero(t, lbl.ID)
 
 	const (
 		globalTemplate = `
 agent_options:
+labels:
+  - name: Label1
+    query: select 1
 controls:
 org_settings:
   server_settings:

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_deprecated_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_deprecated_test.go
@@ -150,6 +150,7 @@ team_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabelsDeprecated() {
 	t := s.T()
 	t.Setenv("FLEET_ENABLE_LOG_TOPICS", logging.DeprecatedFieldTopic)
+	s.exceptLabels(t)
 
 	ctx := context.Background()
 
@@ -275,6 +276,7 @@ team_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetSoftwareInstallerLabelsDeprecated() {
 	t := s.T()
 	t.Setenv("FLEET_ENABLE_LOG_TOPICS", logging.DeprecatedFieldTopic)
+	s.exceptLabels(t)
 
 	ctx := context.Background()
 

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -931,7 +931,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabe
 agent_options:
 labels:
   - name: Label1
-	query: select 1
+    query: select 1
 controls:
   macos_settings:
     custom_settings:
@@ -1047,7 +1047,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetSoftwareInstallerLabels(
 	const (
 		globalTemplate = `
 agent_options:
-label:
+labels:
   - name: Label1
     query: select 1
 controls:

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -204,25 +204,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) TearDownTest() {
 	}
 }
 
-// exceptLabels enables the labels exception for a test (because its YAML omits `labels:` but
-// relies on labels existing in the DB). It registers a cleanup to restore the exception.
-func (s *enterpriseIntegrationGitopsTestSuite) exceptLabels(t *testing.T) {
-	t.Helper()
-	ctx := context.Background()
-	appConf, err := s.DS.AppConfig(ctx)
-	require.NoError(t, err)
-	appConf.GitOpsConfig.Exceptions.Labels = true
-	err = s.DS.SaveAppConfig(ctx, appConf)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		appConf, err := s.DS.AppConfig(ctx)
-		require.NoError(t, err)
-		appConf.GitOpsConfig.Exceptions.Labels = false
-		err = s.DS.SaveAppConfig(ctx, appConf)
-		require.NoError(t, err)
-	})
-}
-
 func (s *enterpriseIntegrationGitopsTestSuite) assertDryRunOutput(t *testing.T, output string) {
 	s.assertDryRunOutputWithDeprecation(t, output, false)
 }
@@ -934,13 +915,9 @@ func (s *enterpriseIntegrationGitopsTestSuite) writeConfigFile(t *testing.T, con
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabels() {
 	t := s.T()
 	ctx := context.Background()
-	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
-	lbl, err := s.DS.NewLabel(ctx, &fleet.Label{Name: "Label1", Query: "SELECT 1"})
-	require.NoError(t, err)
-	require.NotZero(t, lbl.ID)
 
 	profileFile, err := os.CreateTemp(t.TempDir(), "*.mobileconfig")
 	require.NoError(t, err)
@@ -952,6 +929,9 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabe
 	const (
 		globalTemplate = `
 agent_options:
+labels:
+  - name: Label1
+	query: select 1
 controls:
   macos_settings:
     custom_settings:
@@ -1060,17 +1040,16 @@ settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetSoftwareInstallerLabels() {
 	t := s.T()
 	ctx := context.Background()
-	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
-	lbl, err := s.DS.NewLabel(ctx, &fleet.Label{Name: "Label1", Query: "SELECT 1"})
-	require.NoError(t, err)
-	require.NotZero(t, lbl.ID)
 
 	const (
 		globalTemplate = `
 agent_options:
+label:
+  - name: Label1
+    query: select 1
 controls:
 org_settings:
   server_settings:
@@ -4090,14 +4069,6 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysGlobal() {
 	t := s.T()
 	ctx := context.Background()
 
-	t.Cleanup(func() {
-		appConf, err := s.DS.AppConfig(ctx)
-		require.NoError(t, err)
-		appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
-		err = s.DS.SaveAppConfig(ctx, appConf)
-		require.NoError(t, err)
-	})
-
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
@@ -4163,13 +4134,6 @@ labels:
 	require.NoError(t, err)
 	require.Len(t, labels, 1)
 
-	// Enable labels and secrets exceptions so that omitting these keys in step 2 preserves existing data.
-	appConf, err := s.DS.AppConfig(ctx)
-	require.NoError(t, err)
-	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{Labels: true, Secrets: true}
-	err = s.DS.SaveAppConfig(ctx, appConf)
-	require.NoError(t, err)
-
 	// Step 2: Apply a minimal global config that omits policies, agent_options, reports, labels.
 	const minimalGlobalConfig = `
 controls:
@@ -4206,16 +4170,15 @@ org_settings:
 	require.NoError(t, err)
 	require.Len(t, queries, 0)
 
-	// Verify secrets are unchanged.
+	// Verify secrets are cleared.
 	globalSecrets, err = s.DS.GetEnrollSecrets(ctx, nil)
 	require.NoError(t, err)
-	require.Len(t, globalSecrets, 1)
-	require.Equal(t, "boofar", globalSecrets[0].Secret)
+	require.Len(t, globalSecrets, 0)
 
-	// Verify labels are unchanged.
+	// Verify labels are cleared..
 	labels, err = s.DS.LabelsByName(ctx, []string{"Test Global Label"}, fleet.TeamFilter{})
 	require.NoError(t, err)
-	require.Len(t, labels, 1)
+	require.Len(t, labels, 0)
 }
 
 // TestOmittedTopLevelKeysFleet verifies that omitting top-level keys from a fleet
@@ -4223,14 +4186,6 @@ org_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysFleet() {
 	t := s.T()
 	ctx := context.Background()
-
-	t.Cleanup(func() {
-		appConf, err := s.DS.AppConfig(ctx)
-		require.NoError(t, err)
-		appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
-		err = s.DS.SaveAppConfig(ctx, appConf)
-		require.NoError(t, err)
-	})
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
@@ -4263,6 +4218,11 @@ reports:
 software:
   packages:
     - url: ${SOFTWARE_INSTALLER_URL}/ruby.deb
+labels:
+  - name: Test Fleet Label
+    label_membership_type: dynamic
+    query: SELECT 1
+  
 `, fleetName)
 
 	fullFleetFile, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -4304,13 +4264,6 @@ software:
 	require.NoError(t, err)
 	require.Len(t, titles, 1)
 
-	// Enable secrets exception so that omitting the `secrets:` key in step 2 preserves existing data.
-	appConf, err := s.DS.AppConfig(ctx)
-	require.NoError(t, err)
-	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{Secrets: true}
-	err = s.DS.SaveAppConfig(ctx, appConf)
-	require.NoError(t, err)
-
 	// Step 2: Apply a minimal fleet config that omits policies, agent_options, controls, reports, software, settings.
 	minimalFleetConfig := fmt.Sprintf(`
 name: %s
@@ -4348,17 +4301,21 @@ name: %s
 	require.NoError(t, err)
 	require.Len(t, flQueries, 0)
 
-	// Verify secrets are unchanged.
+	// Verify secrets are cleared.
 	flSecrets, err = s.DS.GetEnrollSecrets(ctx, &fl.ID)
 	require.NoError(t, err)
-	require.Len(t, flSecrets, 1)
-	require.Equal(t, "foobar", flSecrets[0].Secret)
+	require.Len(t, flSecrets, 0)
 
 	// Verify software was cleared.
 	titles, _, _, err = s.DS.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{AvailableForInstall: true, TeamID: &fl.ID},
 		fleet.TeamFilter{User: test.UserAdmin})
 	require.NoError(t, err)
 	require.Len(t, titles, 0)
+
+	// Verify labels are cleared.
+	labels, err := s.DS.LabelsByName(ctx, []string{"Test Fleet Label"}, fleet.TeamFilter{TeamID: &fl.ID})
+	require.NoError(t, err)
+	require.Len(t, labels, 0)
 }
 
 // TestFMALabelsIncludeAll tests that labels_include_all is correctly applied and
@@ -4366,20 +4323,19 @@ name: %s
 func (s *enterpriseIntegrationGitopsTestSuite) TestFMALabelsIncludeAll() {
 	t := s.T()
 	ctx := context.Background()
-	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 
-	lbl, err := s.DS.NewLabel(ctx, &fleet.Label{Name: "Label1" + t.Name(), Query: "SELECT 1"})
-	require.NoError(t, err)
-	require.NotZero(t, lbl.ID)
-
 	slug := fmt.Sprintf("foo%s/darwin", t.Name())
-
+	lblName := "Label1" + t.Name()
 	const (
 		globalTemplate = `
 agent_options:
+labels:
+  - name: %s
+    label_membership_type: dynamic
+    query: SELECT 1
 controls:
 org_settings:
   server_settings:
@@ -4417,11 +4373,11 @@ settings:
 	withLabelsIncludeAll := fmt.Sprintf(`
       labels_include_all:
         - %s
-`, lbl.Name)
+`, lblName)
 
 	globalFile, err := os.CreateTemp(t.TempDir(), "*.yml")
 	require.NoError(t, err)
-	_, err = globalFile.WriteString(globalTemplate)
+	_, err = fmt.Fprintf(globalFile, globalTemplate, lblName)
 	require.NoError(t, err)
 	err = globalFile.Close()
 	require.NoError(t, err)
@@ -4515,7 +4471,7 @@ settings:
 	require.Empty(t, noTeamMeta.LabelsIncludeAny)
 	require.Empty(t, noTeamMeta.LabelsExcludeAny)
 	require.Len(t, noTeamMeta.LabelsIncludeAll, 1)
-	require.Equal(t, lbl.Name, noTeamMeta.LabelsIncludeAll[0].LabelName)
+	require.Equal(t, lblName, noTeamMeta.LabelsIncludeAll[0].LabelName)
 
 	// Locate the FMA installer for the team and assert labels_include_all is set
 	teamTitles, _, _, err := s.DS.ListSoftwareTitles(ctx,
@@ -4530,7 +4486,7 @@ settings:
 	require.Empty(t, teamMeta.LabelsIncludeAny)
 	require.Empty(t, teamMeta.LabelsExcludeAny)
 	require.Len(t, teamMeta.LabelsIncludeAll, 1)
-	require.Equal(t, lbl.Name, teamMeta.LabelsIncludeAll[0].LabelName)
+	require.Equal(t, lblName, teamMeta.LabelsIncludeAll[0].LabelName)
 
 	// Now re-apply without labels_include_all and confirm they are cleared
 	err = os.WriteFile(noTeamFilePath, fmt.Appendf(nil, noTeamTemplate, slug, noLabels), 0o644)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -4175,7 +4175,7 @@ org_settings:
 	require.NoError(t, err)
 	require.Len(t, globalSecrets, 0)
 
-	// Verify labels are cleared..
+	// Verify labels are cleared.
 	labels, err = s.DS.LabelsByName(ctx, []string{"Test Global Label"}, fleet.TeamFilter{})
 	require.NoError(t, err)
 	require.Len(t, labels, 0)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -204,6 +204,25 @@ func (s *enterpriseIntegrationGitopsTestSuite) TearDownTest() {
 	}
 }
 
+// exceptLabels enables the labels exception for a test (because its YAML omits `labels:` but
+// relies on labels existing in the DB). It registers a cleanup to restore the exception.
+func (s *enterpriseIntegrationGitopsTestSuite) exceptLabels(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	appConf, err := s.DS.AppConfig(ctx)
+	require.NoError(t, err)
+	appConf.UIGitOpsMode.Exceptions.Labels = true
+	err = s.DS.SaveAppConfig(ctx, appConf)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		appConf, err := s.DS.AppConfig(ctx)
+		require.NoError(t, err)
+		appConf.UIGitOpsMode.Exceptions.Labels = false
+		err = s.DS.SaveAppConfig(ctx, appConf)
+		require.NoError(t, err)
+	})
+}
+
 func (s *enterpriseIntegrationGitopsTestSuite) assertDryRunOutput(t *testing.T, output string) {
 	s.assertDryRunOutputWithDeprecation(t, output, false)
 }
@@ -915,6 +934,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) writeConfigFile(t *testing.T, con
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetConfigurationProfileLabels() {
 	t := s.T()
 	ctx := context.Background()
+	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
@@ -1040,6 +1060,7 @@ settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestUnsetSoftwareInstallerLabels() {
 	t := s.T()
 	ctx := context.Background()
+	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
@@ -4069,6 +4090,14 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysGlobal() {
 	t := s.T()
 	ctx := context.Background()
 
+	t.Cleanup(func() {
+		appConf, err := s.DS.AppConfig(ctx)
+		require.NoError(t, err)
+		appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+		err = s.DS.SaveAppConfig(ctx, appConf)
+		require.NoError(t, err)
+	})
+
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
 	t.Setenv("FLEET_URL", s.Server.URL)
@@ -4134,6 +4163,13 @@ labels:
 	require.NoError(t, err)
 	require.Len(t, labels, 1)
 
+	// Enable labels and secrets exceptions so that omitting these keys in step 2 preserves existing data.
+	appConf, err := s.DS.AppConfig(ctx)
+	require.NoError(t, err)
+	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{Labels: true, Secrets: true}
+	err = s.DS.SaveAppConfig(ctx, appConf)
+	require.NoError(t, err)
+
 	// Step 2: Apply a minimal global config that omits policies, agent_options, reports, labels.
 	const minimalGlobalConfig = `
 controls:
@@ -4187,6 +4223,14 @@ org_settings:
 func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysFleet() {
 	t := s.T()
 	ctx := context.Background()
+
+	t.Cleanup(func() {
+		appConf, err := s.DS.AppConfig(ctx)
+		require.NoError(t, err)
+		appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+		err = s.DS.SaveAppConfig(ctx, appConf)
+		require.NoError(t, err)
+	})
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)
@@ -4260,6 +4304,13 @@ software:
 	require.NoError(t, err)
 	require.Len(t, titles, 1)
 
+	// Enable secrets exception so that omitting the `secrets:` key in step 2 preserves existing data.
+	appConf, err := s.DS.AppConfig(ctx)
+	require.NoError(t, err)
+	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{Secrets: true}
+	err = s.DS.SaveAppConfig(ctx, appConf)
+	require.NoError(t, err)
+
 	// Step 2: Apply a minimal fleet config that omits policies, agent_options, controls, reports, software, settings.
 	minimalFleetConfig := fmt.Sprintf(`
 name: %s
@@ -4315,6 +4366,7 @@ name: %s
 func (s *enterpriseIntegrationGitopsTestSuite) TestFMALabelsIncludeAll() {
 	t := s.T()
 	ctx := context.Background()
+	s.exceptLabels(t)
 
 	user := s.createGitOpsUser(t)
 	fleetctlConfig := s.createFleetctlConfig(t, user)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -132,6 +132,9 @@ func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
 	appConf, err = s.DS.AppConfig(context.Background())
 	require.NoError(s.T(), err)
 	appConf.ServerSettings.ServerURL = server.URL
+	// Disable gitops exceptions so that existing tests can freely use labels, secrets, etc. in their YAML.
+	// Tests that specifically test exception enforcement should re-enable them.
+	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
 	err = s.DS.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)
 }

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -134,7 +134,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) SetupSuite() {
 	appConf.ServerSettings.ServerURL = server.URL
 	// Disable gitops exceptions so that existing tests can freely use labels, secrets, etc. in their YAML.
 	// Tests that specifically test exception enforcement should re-enable them.
-	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
 	err = s.DS.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)
 }
@@ -211,13 +211,13 @@ func (s *enterpriseIntegrationGitopsTestSuite) exceptLabels(t *testing.T) {
 	ctx := context.Background()
 	appConf, err := s.DS.AppConfig(ctx)
 	require.NoError(t, err)
-	appConf.UIGitOpsMode.Exceptions.Labels = true
+	appConf.GitOpsConfig.Exceptions.Labels = true
 	err = s.DS.SaveAppConfig(ctx, appConf)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		appConf, err := s.DS.AppConfig(ctx)
 		require.NoError(t, err)
-		appConf.UIGitOpsMode.Exceptions.Labels = false
+		appConf.GitOpsConfig.Exceptions.Labels = false
 		err = s.DS.SaveAppConfig(ctx, appConf)
 		require.NoError(t, err)
 	})
@@ -4093,7 +4093,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysGlobal() {
 	t.Cleanup(func() {
 		appConf, err := s.DS.AppConfig(ctx)
 		require.NoError(t, err)
-		appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+		appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
 		err = s.DS.SaveAppConfig(ctx, appConf)
 		require.NoError(t, err)
 	})
@@ -4166,7 +4166,7 @@ labels:
 	// Enable labels and secrets exceptions so that omitting these keys in step 2 preserves existing data.
 	appConf, err := s.DS.AppConfig(ctx)
 	require.NoError(t, err)
-	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{Labels: true, Secrets: true}
+	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{Labels: true, Secrets: true}
 	err = s.DS.SaveAppConfig(ctx, appConf)
 	require.NoError(t, err)
 
@@ -4227,7 +4227,7 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestOmittedTopLevelKeysFleet() {
 	t.Cleanup(func() {
 		appConf, err := s.DS.AppConfig(ctx)
 		require.NoError(t, err)
-		appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+		appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
 		err = s.DS.SaveAppConfig(ctx, appConf)
 		require.NoError(t, err)
 	})
@@ -4307,7 +4307,7 @@ software:
 	// Enable secrets exception so that omitting the `secrets:` key in step 2 preserves existing data.
 	appConf, err := s.DS.AppConfig(ctx)
 	require.NoError(t, err)
-	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{Secrets: true}
+	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{Secrets: true}
 	err = s.DS.SaveAppConfig(ctx, appConf)
 	require.NoError(t, err)
 

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -86,6 +86,8 @@ func (s *integrationGitopsTestSuite) SetupSuite() {
 	appConf, err = s.DS.AppConfig(context.Background())
 	require.NoError(s.T(), err)
 	appConf.ServerSettings.ServerURL = server.URL
+	// Disable gitops exceptions so that existing tests can freely use labels, secrets, etc. in their YAML.
+	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
 	err = s.DS.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)
 }

--- a/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_integration_test.go
@@ -87,7 +87,7 @@ func (s *integrationGitopsTestSuite) SetupSuite() {
 	require.NoError(s.T(), err)
 	appConf.ServerSettings.ServerURL = server.URL
 	// Disable gitops exceptions so that existing tests can freely use labels, secrets, etc. in their YAML.
-	appConf.UIGitOpsMode.Exceptions = fleet.GitOpsExceptions{}
+	appConf.GitOpsConfig.Exceptions = fleet.GitOpsExceptions{}
 	err = s.DS.SaveAppConfig(context.Background(), appConf)
 	require.NoError(s.T(), err)
 }

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -249,11 +249,7 @@ func TestGitOpsNoTeamVPPPolicies(t *testing.T) {
 	for _, c := range cases {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
-			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
-			// Disable labels exception only for tests using the global file that includes `labels:`.
-			if !strings.HasPrefix(filepath.Base(c.noTeamFile), "no_team_setup_software") {
-				(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
-			}
+			ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)
@@ -385,11 +381,7 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 	for _, c := range cases {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
-			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
-			// Disable labels exception only for tests using the global file that includes `labels:`.
-			if !strings.HasPrefix(filepath.Base(c.noTeamFile), "no_team_setup_software") {
-				(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
-			}
+			ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -978,6 +978,10 @@ software:
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			ds, savedAppConfigPtr, savedTeams := testing_utils.SetupFullGitOpsPremiumServer(t)
+			// No existing labels — this test doesn't test label behavior.
+			ds.GetLabelSpecsFunc = func(ctx context.Context, filter fleet.TeamFilter) ([]*fleet.LabelSpec, error) {
+				return nil, nil
+			}
 
 			ds.ListVPPTokensFunc = func(ctx context.Context) ([]*fleet.VPPTokenDB, error) {
 				return []*fleet.VPPTokenDB{{Location: "Fleet Device Management Inc."}, {Location: "Acme Inc."}}, nil

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -250,8 +250,10 @@ func TestGitOpsNoTeamVPPPolicies(t *testing.T) {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
 			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
-			// Disable labels exception because the global YAML includes `labels:`.
-			(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
+			// Disable labels exception only for tests using the global file that includes `labels:`.
+			if !strings.HasPrefix(filepath.Base(c.noTeamFile), "no_team_setup_software") {
+				(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
+			}
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)
@@ -384,8 +386,10 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
 			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
-			// Disable labels exception because the global YAML includes `labels:`.
-			(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
+			// Disable labels exception only for tests using the global file that includes `labels:`.
+			if !strings.HasPrefix(filepath.Base(c.noTeamFile), "no_team_setup_software") {
+				(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
+			}
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -251,7 +251,7 @@ func TestGitOpsNoTeamVPPPolicies(t *testing.T) {
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
 			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 			// Disable labels exception because the global YAML includes `labels:`.
-			(*savedAppConfig).UIGitOpsMode.Exceptions.Labels = false
+			(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)
@@ -385,7 +385,7 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
 			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
 			// Disable labels exception because the global YAML includes `labels:`.
-			(*savedAppConfig).UIGitOpsMode.Exceptions.Labels = false
+			(*savedAppConfig).GitOpsConfig.Exceptions.Labels = false
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -249,7 +249,9 @@ func TestGitOpsNoTeamVPPPolicies(t *testing.T) {
 	for _, c := range cases {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
-			ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+			// Disable labels exception because the global YAML includes `labels:`.
+			(*savedAppConfig).UIGitOpsMode.Exceptions.Labels = false
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)
@@ -381,7 +383,9 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 	for _, c := range cases {
 		c.noTeamFile = filepath.Join("../../fleetctl", c.noTeamFile)
 		t.Run(filepath.Base(c.noTeamFile), func(t *testing.T) {
-			ds, _, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+			ds, savedAppConfig, _ := testing_utils.SetupFullGitOpsPremiumServer(t)
+			// Disable labels exception because the global YAML includes `labels:`.
+			(*savedAppConfig).UIGitOpsMode.Exceptions.Labels = false
 			tokExpire := time.Now().Add(time.Hour)
 			token, err := test.CreateVPPTokenEncoded(tokExpire, "fleet", "ca")
 			require.NoError(t, err)

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -335,6 +335,13 @@ type GitOps struct {
 	Software GitOpsSoftware
 	// FleetSecrets is a map of secret names to their values, extracted from FLEET_SECRET_ environment variables used in profiles and scripts.
 	FleetSecrets map[string]string
+
+	// LabelsPresent indicates that the `labels:` key was explicitly present in the YAML file.
+	LabelsPresent bool
+	// SoftwarePresent indicates that the `software:` key was explicitly present in the YAML file.
+	SoftwarePresent bool
+	// SecretsPresent indicates that the `secrets:` key was explicitly present in the YAML file.
+	SecretsPresent bool
 }
 
 type GitOpsSoftware struct {
@@ -457,9 +464,9 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 
 	for _, topKey := range topKeys {
 		// "name" is handled later with special logic based on the filename.
-		// "labels" is a special case where omitting is a no-op, rather than a directive to clear settings.
-		// settings keys were handled above.
-		if topKey == "name" || topKey == "labels" || topKey == "settings" || topKey == "org_settings" {
+		// "labels" and "software" are special cases where omitting may be a no-op (based on exception settings),
+		// rather than a directive to clear settings. settings keys were handled above.
+		if topKey == "name" || topKey == "labels" || topKey == "software" || topKey == "settings" || topKey == "org_settings" {
 			continue
 		}
 		// "controls" can be set on _either_ global or "no team" file, and we can't say which it is if both
@@ -484,6 +491,7 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	if _, ok := top["labels"]; !ok {
 		result.Labels = make([]*fleet.LabelSpec, 0)
 	} else {
+		result.LabelsPresent = true
 		multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 	}
 	// Get other top-level entities.
@@ -777,6 +785,7 @@ func parseSecrets(result *GitOps, multiError *multierror.Error) *multierror.Erro
 		// Any secrets present on the server will be retained.
 		return multiError
 	}
+	result.SecretsPresent = true
 	// When secrets slice is empty, all secrets are removed.
 	enrollSecrets := make([]*fleet.EnrollSecret, 0)
 	if rawSecrets != nil {
@@ -1723,12 +1732,17 @@ var validSHA256Value = regexp.MustCompile(`\b[a-f0-9]{64}\b`)
 
 func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir string, filePath string, multiError *multierror.Error) *multierror.Error {
 	softwareRaw, ok := top["software"]
+	if ok {
+		result.SoftwarePresent = true
+	}
 	if result.global() {
 		if ok && string(softwareRaw) != "null" {
 			return multierror.Append(multiError, errors.New("'software' cannot be set on global file"))
 		}
 	} else if !ok {
-		return multierror.Append(multiError, errors.New("'software' is required"))
+		// Software key is absent — this is allowed (will be a no-op if excepted,
+		// or will be treated as "delete all" if not excepted).
+		return multiError
 	}
 	var software Software
 	if len(softwareRaw) > 0 {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -362,6 +362,13 @@ type GitOpsOptions struct {
 	// AllowUnknownKeys causes unknown key errors to be logged as warnings
 	// instead of returned as errors.
 	AllowUnknownKeys bool
+	// SyntheticSoftwareByTeam maps team names to JSON-encoded software specs
+	// from the server. When the software: key is excepted from GitOps and
+	// omitted from the YAML, this data is injected so that parseSoftware can
+	// populate result.Software for policy validation (install_software and
+	// patch policy references). SoftwarePresent remains false so that
+	// downstream exception enforcement still works correctly.
+	SyntheticSoftwareByTeam map[string]json.RawMessage
 }
 
 // GitOpsFromFile parses a GitOps yaml file.
@@ -501,7 +508,7 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 	multiError = parseReports(top, result, baseDir, logFn, filePath, multiError)
 
 	if appConfig != nil && appConfig.License.IsPremium() {
-		multiError = parseSoftware(top, result, baseDir, filePath, multiError)
+		multiError = parseSoftware(top, result, baseDir, filePath, options, multiError)
 	}
 
 	// Policies can reference software installers and scripts, thus we parse them after parseSoftware and parseControls.
@@ -1731,7 +1738,7 @@ func parseReports(top map[string]json.RawMessage, result *GitOps, baseDir string
 
 var validSHA256Value = regexp.MustCompile(`\b[a-f0-9]{64}\b`)
 
-func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir string, filePath string, multiError *multierror.Error) *multierror.Error {
+func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir string, filePath string, options GitOpsOptions, multiError *multierror.Error) *multierror.Error {
 	softwareRaw, ok := top["software"]
 	if ok {
 		result.SoftwarePresent = true
@@ -1741,9 +1748,19 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			return multierror.Append(multiError, errors.New("'software' cannot be set on global file"))
 		}
 	} else if !ok {
-		// Software key is absent — this is allowed (will be a no-op if excepted,
-		// or will be treated as "delete all" if not excepted).
-		return multiError
+		// Software key is absent. If we have synthetic server-side data for this
+		// team (because software is excepted from GitOps), inject it so that
+		// policy install_software and patch policy references can be validated.
+		// SoftwarePresent remains false so downstream exception enforcement works.
+		if result.TeamName != nil && options.SyntheticSoftwareByTeam != nil {
+			if synthetic, hasSynthetic := options.SyntheticSoftwareByTeam[*result.TeamName]; hasSynthetic {
+				softwareRaw = synthetic
+				ok = true // allow processing below
+			}
+		}
+		if !ok {
+			return multiError
+		}
 	}
 	var software Software
 	if len(softwareRaw) > 0 {

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -32,6 +32,11 @@ type LabelChangesSummary struct {
 	LabelsMovements []LabelMovement
 }
 
+// HasChanges returns true if there are any label additions, removals, updates, or movements.
+func (s LabelChangesSummary) HasChanges() bool {
+	return len(s.LabelsToAdd) > 0 || len(s.LabelsToRemove) > 0 || len(s.LabelsToUpdate) > 0 || len(s.LabelsMovements) > 0
+}
+
 func NewLabelChangesSummary(changes []LabelChange, moves []LabelMovement) LabelChangesSummary {
 	r := LabelChangesSummary{
 		LabelsMovements: moves,
@@ -485,12 +490,8 @@ func GitOpsFromFile(filePath, baseDir string, appConfig *fleet.EnrichedAppConfig
 		}
 	}
 
-	// Get the labels. If `labels:` is specified but no labels are listed, this will
-	// set Labels as nil.  If `labels:` isn't present at all, it will be set as an
-	// empty array.
-	if _, ok := top["labels"]; !ok {
-		result.Labels = make([]*fleet.LabelSpec, 0)
-	} else {
+	// Get the labels. LabelsPresent tracks whether the key was in the YAML.
+	if _, ok := top["labels"]; ok {
 		result.LabelsPresent = true
 		multiError = parseLabels(top, result, baseDir, logFn, filePath, multiError)
 	}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3403,3 +3403,101 @@ func TestParsePolicyInstallSoftware(t *testing.T) {
 		assert.Equal(t, "bad_field", unknownErr.Field)
 	})
 }
+
+func TestGitOpsPresenceTracking(t *testing.T) {
+	t.Run("labels present", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+labels:
+  - name: test-label
+    query: SELECT 1
+`)
+		require.NoError(t, err)
+		assert.True(t, gitops.LabelsPresent)
+	})
+
+	t.Run("labels absent", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+`)
+		require.NoError(t, err)
+		assert.False(t, gitops.LabelsPresent)
+		assert.NotNil(t, gitops.Labels, "absent labels should be empty non-nil slice")
+		assert.Empty(t, gitops.Labels)
+	})
+
+	t.Run("labels present but empty", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+labels:
+`)
+		require.NoError(t, err)
+		assert.True(t, gitops.LabelsPresent)
+		assert.Nil(t, gitops.Labels, "empty labels section should result in nil")
+	})
+
+	t.Run("secrets present", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+  secrets:
+    - secret: mysecret
+`)
+		require.NoError(t, err)
+		assert.True(t, gitops.SecretsPresent)
+	})
+
+	t.Run("secrets absent", func(t *testing.T) {
+		gitops, err := gitOpsFromString(t, `
+org_settings:
+  server_settings:
+    server_url: https://example.com
+  org_info:
+    org_name: Test
+`)
+		require.NoError(t, err)
+		assert.False(t, gitops.SecretsPresent)
+	})
+
+	t.Run("software present on team", func(t *testing.T) {
+		premiumConfig := &fleet.EnrichedAppConfig{}
+		premiumConfig.License = &fleet.LicenseInfo{Tier: fleet.TierPremium}
+
+		path, basePath := createTempFile(t, "", `
+name: TestTeam
+software:
+  packages:
+    - url: https://example.com/pkg.deb
+`)
+		gitops, err := GitOpsFromFile(path, basePath, premiumConfig, nopLogf)
+		require.NoError(t, err)
+		assert.True(t, gitops.SoftwarePresent)
+	})
+
+	t.Run("software absent on team", func(t *testing.T) {
+		premiumConfig := &fleet.EnrichedAppConfig{}
+		premiumConfig.License = &fleet.LicenseInfo{Tier: fleet.TierPremium}
+
+		path, basePath := createTempFile(t, "", `
+name: TestTeam
+`)
+		gitops, err := GitOpsFromFile(path, basePath, premiumConfig, nopLogf)
+		require.NoError(t, err)
+		assert.False(t, gitops.SoftwarePresent)
+	})
+}

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -3430,8 +3430,7 @@ org_settings:
 `)
 		require.NoError(t, err)
 		assert.False(t, gitops.LabelsPresent)
-		assert.NotNil(t, gitops.Labels, "absent labels should be empty non-nil slice")
-		assert.Empty(t, gitops.Labels)
+		assert.Nil(t, gitops.Labels, "absent labels should be nil")
 	})
 
 	t.Run("labels present but empty", func(t *testing.T) {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1884,7 +1884,7 @@ func (c *Client) DoGitOps(
 	// When an entity type is NOT excepted:
 	// - If the key is absent, all entities of that type are deleted.
 	var exceptions fleet.GitOpsExceptions
-	if appConfig != nil && appConfig.GitOpsConfig.GitopsModeEnabled {
+	if appConfig != nil {
 		exceptions = appConfig.GitOpsConfig.Exceptions
 		if exceptions.Labels && incoming.LabelsPresent {
 			return nil, errors.New(
@@ -1928,17 +1928,11 @@ func (c *Client) DoGitOps(
 		group.CertificateAuthorities = groupedCAs
 		delete(incoming.OrgSettings, "certificate_authorities")
 
-		// Labels: skip if excepted (key already validated as absent above).
-		// If not excepted and key is absent, treat as delete-all.
-		if !exceptions.Labels {
-			if !incoming.LabelsPresent {
-				incoming.Labels = nil // triggers delete-all in computeLabelChanges
-			}
-			if incoming.Labels == nil || len(incoming.Labels) > 0 {
-				err := c.doGitOpsLabels(incoming, logFn, dryRun)
-				if err != nil {
-					return nil, err
-				}
+		// Update labels if there were any changes.
+		if incoming.LabelChangesSummary.HasChanges() {
+			err := c.doGitOpsLabels(incoming, logFn, dryRun)
+			if err != nil {
+				return nil, err
 			}
 		}
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -927,7 +927,7 @@ func (c *Client) ApplyGroup(
 		// the team spec doesn't include software. Additionally, setup_experience
 		// references packages by file path which server-side data doesn't have.
 		// The server will validate when the setup experience is applied.
-		softwareExcepted := appconfig != nil && appconfig.GitOpsConfig.Exceptions.Software
+		softwareExcepted := viaGitOps && appconfig != nil && appconfig.GitOpsConfig.Exceptions.Software
 		for tmName, setupSw := range tmMacSetupSoftware {
 			if softwareExcepted {
 				continue

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2148,7 +2148,7 @@ func (c *Client) DoGitOps(
 		// Secrets: if not excepted and key is absent, treat as delete-all.
 		if !exceptions.Secrets && !incoming.SecretsPresent {
 			if incoming.TeamSettings == nil {
-				incoming.TeamSettings = make(map[string]interface{})
+				incoming.TeamSettings = make(map[string]any)
 			}
 			incoming.TeamSettings["secrets"] = make([]*fleet.EnrollSecret, 0)
 		}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -922,8 +922,16 @@ func (c *Client) ApplyGroup(
 		}
 
 		// if setup_experience.software has some values, they must exist in the software
-		// packages or vpp apps.
+		// packages or vpp apps. When software is excepted from GitOps, the validation
+		// maps (tmSoftwarePackagesWithPaths/tmSoftwareAppsByAppID) are empty because
+		// the team spec doesn't include software. Additionally, setup_experience
+		// references packages by file path which server-side data doesn't have.
+		// The server will validate when the setup experience is applied.
+		softwareExcepted := appconfig != nil && appconfig.GitOpsConfig.Exceptions.Software
 		for tmName, setupSw := range tmMacSetupSoftware {
+			if softwareExcepted {
+				continue
+			}
 			if err := validateTeamOrNoTeamMacOSSetupSoftware(tmName, setupSw, tmSoftwarePackagesWithPaths[tmName], tmSoftwareAppsByAppID[tmName]); err != nil {
 				return nil, nil, nil, nil, err
 			}

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2432,7 +2432,7 @@ func (c *Client) DoGitOps(
 			teamVPPApps = teamsVPPApps[*incoming.TeamName]
 			teamScripts = teamsScripts[*incoming.TeamName]
 		} else {
-			noTeamSoftwareInstallers, noTeamVPPApps, err := c.doGitOpsNoTeamSetupAndSoftware(incoming, baseDir, appConfig, logFn, dryRun)
+			noTeamSoftwareInstallers, noTeamVPPApps, err := c.doGitOpsNoTeamSetupAndSoftware(incoming, baseDir, appConfig, exceptions.Software, logFn, dryRun)
 			if err != nil {
 				return nil, err
 			}
@@ -2440,8 +2440,15 @@ func (c *Client) DoGitOps(
 			if err := c.doGitOpsNoTeamWebhookSettings(incoming, appConfig, logFn, dryRun); err != nil {
 				return nil, fmt.Errorf("applying webhook settings for unassigned hosts: %w", err)
 			}
-			teamSoftwareInstallers = noTeamSoftwareInstallers
-			teamVPPApps = noTeamVPPApps
+			if exceptions.Software && !incoming.SoftwarePresent {
+				// Software is excepted and not present in YAML — use pre-fetched data
+				// for policy validation instead of the empty data from the parser.
+				teamSoftwareInstallers = teamsSoftwareInstallers[*incoming.TeamName]
+				teamVPPApps = teamsVPPApps[*incoming.TeamName]
+			} else {
+				teamSoftwareInstallers = noTeamSoftwareInstallers
+				teamVPPApps = noTeamVPPApps
+			}
 			teamScripts = teamsScripts["No team"]
 		}
 	}
@@ -2546,6 +2553,7 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 	config *spec.GitOps,
 	baseDir string,
 	appconfig *fleet.EnrichedAppConfig,
+	softwareExcepted bool,
 	logFn func(format string, args ...interface{}),
 	dryRun bool,
 ) ([]fleet.SoftwarePackageResponse, []fleet.VPPAppResponse, error) {
@@ -2567,6 +2575,26 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 			return nil, nil, fmt.Errorf("applying setup_experience.macos_script for unassigned hosts: %w", err)
 		}
 		macosSetupScript = &fileContent{Filename: filepath.Base(macOSSetup.Script.Value), Content: b}
+	}
+
+	// Apply the setup experience script regardless of software exception status,
+	// since it's part of controls, not software.
+	if !dryRun {
+		if macosSetupScript != nil {
+			logFn("[+] applying macos setup experience script for unassigned hosts\n")
+			if err := c.uploadMacOSSetupScript(macosSetupScript.Filename, macosSetupScript.Content, nil); err != nil {
+				return nil, nil, fmt.Errorf("uploading setup experience script for unassigned hosts: %w", err)
+			}
+		} else if err := c.deleteMacOSSetupScript(nil); err != nil {
+			return nil, nil, fmt.Errorf("deleting setup experience script for unassigned hosts: %w", err)
+		}
+	}
+
+	// When software is excepted from GitOps, don't apply software for no-team
+	// (which would wipe existing software with an empty payload). The caller
+	// uses pre-fetched server data for policy validation instead.
+	if softwareExcepted && !config.SoftwarePresent {
+		return nil, nil, nil
 	}
 
 	noTeamSoftwareMacOSSetup, err := extractTeamOrNoTeamMacOSSetupSoftware(baseDir, macOSSetup.Software.Value)
@@ -2647,16 +2675,6 @@ func (c *Client) doGitOpsNoTeamSetupAndSoftware(
 	swPkgPayload, err := buildSoftwarePackagesPayload(packages, noTeamSoftwareMacOSSetup)
 	if err != nil {
 		return nil, nil, fmt.Errorf("applying software installers: %w", err)
-	}
-	if !dryRun {
-		if macosSetupScript != nil {
-			logFn("[+] applying macos setup experience script for unassigned hosts\n")
-			if err := c.uploadMacOSSetupScript(macosSetupScript.Filename, macosSetupScript.Content, nil); err != nil {
-				return nil, nil, fmt.Errorf("uploading setup experience script for unassigned hosts: %w", err)
-			}
-		} else if err := c.deleteMacOSSetupScript(nil); err != nil {
-			return nil, nil, fmt.Errorf("deleting setup experience script for unassigned hosts: %w", err)
-		}
 	}
 
 	format := applyingTeamFormat

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -2147,6 +2147,9 @@ func (c *Client) DoGitOps(
 		}
 		// Secrets: if not excepted and key is absent, treat as delete-all.
 		if !exceptions.Secrets && !incoming.SecretsPresent {
+			if incoming.TeamSettings == nil {
+				incoming.TeamSettings = make(map[string]interface{})
+			}
 			incoming.TeamSettings["secrets"] = make([]*fleet.EnrollSecret, 0)
 		}
 		if teamSecrets, ok := incoming.TeamSettings["secrets"]; ok && !exceptions.Secrets {

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1878,6 +1878,28 @@ func (c *Client) DoGitOps(
 
 	group := spec.Group{} // as we parse the incoming gitops spec, we'll build out various group specs that will each be applied separately
 
+	// Check GitOps exception enforcement. When an entity type is excepted:
+	// - If the key is present in the YAML, fail with an error.
+	// - If the key is absent, it's a no-op (existing entities preserved).
+	// When an entity type is NOT excepted:
+	// - If the key is absent, all entities of that type are deleted.
+	var exceptions fleet.GitOpsExceptions
+	if appConfig != nil && appConfig.GitOpsConfig.GitopsModeEnabled {
+		exceptions = appConfig.GitOpsConfig.Exceptions
+		if exceptions.Labels && incoming.LabelsPresent {
+			return nil, errors.New(
+				`"labels" is excepted from GitOps management. Remove the "labels:" key from your GitOps file or disable the exception in Fleet settings.`)
+		}
+		if exceptions.Secrets && incoming.SecretsPresent {
+			return nil, errors.New(
+				`"secrets" is excepted from GitOps management. Remove the "secrets:" key from your GitOps file or disable the exception in Fleet settings.`)
+		}
+		if exceptions.Software && incoming.SoftwarePresent && incoming.TeamName != nil {
+			return nil, errors.New(
+				`"software" is excepted from GitOps management. Remove the "software:" key from your GitOps file or disable the exception in Fleet settings.`)
+		}
+	}
+
 	if incoming.TeamName == nil {
 		// OrgSettings is the basis of the group AppConfig, but we will be adding and removing some
 		// items because the GitOps structure is not the same as the AppConfig structure.
@@ -1888,10 +1910,14 @@ func (c *Client) DoGitOps(
 
 		// Enroll secrets are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
-		if orgSecrets, ok := incoming.OrgSettings["secrets"]; ok {
-			group.EnrollSecret = &fleet.EnrollSecretSpec{Secrets: orgSecrets.([]*fleet.EnrollSecret)}
-			delete(incoming.OrgSettings, "secrets")
+		// If secrets are not excepted and key is absent, treat as delete-all.
+		if !exceptions.Secrets && !incoming.SecretsPresent {
+			incoming.OrgSettings["secrets"] = make([]*fleet.EnrollSecret, 0)
 		}
+		if orgSecrets, ok := incoming.OrgSettings["secrets"]; ok && !exceptions.Secrets {
+			group.EnrollSecret = &fleet.EnrollSecretSpec{Secrets: orgSecrets.([]*fleet.EnrollSecret)}
+		}
+		delete(incoming.OrgSettings, "secrets")
 
 		// Certificate authorities are managed separately in Client.ApplyGroup, so we remove them from the
 		// OrgSettings so that they are not applied as part of the AppConfig.
@@ -1902,11 +1928,17 @@ func (c *Client) DoGitOps(
 		group.CertificateAuthorities = groupedCAs
 		delete(incoming.OrgSettings, "certificate_authorities")
 
-		// Labels
-		if incoming.Labels == nil || len(incoming.Labels) > 0 {
-			err := c.doGitOpsLabels(incoming, logFn, dryRun)
-			if err != nil {
-				return nil, err
+		// Labels: skip if excepted (key already validated as absent above).
+		// If not excepted and key is absent, treat as delete-all.
+		if !exceptions.Labels {
+			if !incoming.LabelsPresent {
+				incoming.Labels = nil // triggers delete-all in computeLabelChanges
+			}
+			if incoming.Labels == nil || len(incoming.Labels) > 0 {
+				err := c.doGitOpsLabels(incoming, logFn, dryRun)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 
@@ -2112,11 +2144,18 @@ func (c *Client) DoGitOps(
 			team["features"] = features
 		}
 		team["scripts"] = scripts
-		team["software"] = map[string]any{}
-		team["software"].(map[string]any)["app_store_apps"] = incoming.Software.AppStoreApps
-		team["software"].(map[string]any)["packages"] = incoming.Software.Packages
-		team["software"].(map[string]any)["fleet_maintained_apps"] = incoming.Software.FleetMaintainedApps
-		if teamSecrets, ok := incoming.TeamSettings["secrets"]; ok {
+		// Software: skip if excepted (key already validated as absent above).
+		if !exceptions.Software {
+			team["software"] = map[string]any{}
+			team["software"].(map[string]any)["app_store_apps"] = incoming.Software.AppStoreApps
+			team["software"].(map[string]any)["packages"] = incoming.Software.Packages
+			team["software"].(map[string]any)["fleet_maintained_apps"] = incoming.Software.FleetMaintainedApps
+		}
+		// Secrets: if not excepted and key is absent, treat as delete-all.
+		if !exceptions.Secrets && !incoming.SecretsPresent {
+			incoming.TeamSettings["secrets"] = make([]*fleet.EnrollSecret, 0)
+		}
+		if teamSecrets, ok := incoming.TeamSettings["secrets"]; ok && !exceptions.Secrets {
 			team["secrets"] = teamSecrets
 		}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42180 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GitOps exception handling for labels, secrets, and software with clearer enforcement and omission semantics.
  * Server-side prefetch of team software so omitted team software can preserve existing installers during validation.
  * Presence flags track whether top-level keys (labels, secrets, software) were provided versus omitted.

* **Behavior Changes**
  * Omitted vs empty sections are now distinguished: omission can mean “no-op” or “delete-all” depending on exception settings.
  * GitOps YAML can define and manage labels directly; validations now reject YAML that includes keys marked as excepted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
    * **Labels**
      - [ ] Validated that with label exceptions off, omitting `labels:` key from default.yml clears all global labels 
      - [ ] Validated that with label exceptions off, omitting `labels:` key from a fleet .yml clears all labels for that fleet
      - [ ] Validated that with label exceptions off, setting empty `labels:` key from default.yml clears all global labels 
      - [ ] Validated that with label exceptions off, setting empty `labels:` key from a fleet .yml clears all labels for that fleet
      - [ ] Validated that with label exceptions on, omitting `labels:` key from default .yml leaves existing global labels as-is
      - [ ] Validated that with label exceptions on, omitting `labels:` key from a fleet .yml leaves existing labels as-is
      - [ ] Validated that with label exceptions on, setting `labels:` key on default .yml generates an error
      - [ ] Validated that with label exceptions on, setting `labels:` key on a fleet .yml generates an error
      - [ ] Validated that with label exceptions on, a policy using `labels_include_any` referencing an existing label succeeds without `labels:` key
      - [ ] Validated that with label exceptions on, a query using `labels_include_any` referencing an existing label succeeds without `labels:` key
      - [ ] Validated that with label exceptions on, an MDM profile using `labels_include_any` referencing an existing label succeeds without `labels:` key
      - [ ] Validated that with label exceptions on, a software package using `labels_include_any` referencing an existing label succeeds without `labels:` key (requires software exceptions off)
      - [ ] Validated that with label exceptions on, an app store app using `labels_include_any` referencing an existing label succeeds without `labels:` key (requires software exceptions off)
      - [ ] Validated that with label exceptions on, a fleet maintained app using `labels_include_any` referencing an existing label succeeds without `labels:` key (requires software exceptions off)
    * **Secrets**
      - [ ] Validated that with secrets exceptions off, omitting `secrets:` key from default.yml clears all global secrets
      - [ ] Validated that with secrets exceptions off, omitting `secrets:` key from a fleet .yml clears all secrets for that fleet 
      - [ ] Validated that with secrets exceptions on, omitting `secrets:` key from default .yml leaves existing global secrets as-is
      - [ ] Validated that with secrets exceptions on, omitting `secrets:` key from a fleet .yml leaves existing secrets as-is
      - [ ] Validated that with secrets exceptions on, setting `secrets:` key on default .yml generates an error
      - [ ] Validated that with secrets exceptions on, setting `secrets:` key on a fleet .yml generates an error
    * **Software**
      - [ ] Validated that with software exceptions off, omitting `software:` key from no-team.yml/unassigned.yml clears all software for "no team"
      - [ ] Validated that with software exceptions off, omitting `software:` key from a fleet .yml clears all software for that fleet
      - [ ] Validated that with software exceptions off, setting empty `software:` key on a fleet .yml clears all software for that fleet
      - [ ] Validated that with software exceptions off, setting empty `software:` key on no-team.yml/unassigned.yml clears all software for "no team
      - [ ] Validated that with software exceptions on, omitting `software:` key from a fleet .yml leaves existing software as-is
      - [ ] Validated that with software exceptions on, setting `software:` key on a fleet .yml generates an error    
      - [ ] Validated that with software exceptions on, omitting `software:` key from no-team.yml/unassigned.yml leaves existing software as-is for "no team"
      - [ ] Validated that with software exceptions on, setting `software:` key on no-team.yml/unassigned.yml generates an error          
      - [ ] Validated that with software exceptions on, a policy using `install_software.hash_sha256` referencing an existing package succeeds without `software:` key
      - [ ] Validated that with software exceptions on, a policy using `install_software.app_store_id` referencing an existing VPP app succeeds without `software:` key
      - [ ] Validated that with software exceptions on, a patch policy using `fleet_maintained_app_slug` referencing an existing FMA succeeds without `software:` key
      - [ ] Validated that with software exceptions on, omitting `software:` from no-team.yml/unassigned.yml preserves existing no-team software
      - [ ] Validated that with software exceptions on, a policy in no-team.yml/unassigned.yml using `install_software.hash_sha256` referencing existing no-team software succeeds without `software:` key
For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
I don't think so. There is a bit of overhead when this feature is used since we have to fetch software from the server, but it would be done in a specific test, so even if there is an impact it should affect existing load testing, only new, specific tests.

