### PR TITLE
Add macOS 27 incompatible apps report

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -154,6 +154,7 @@ policies:
 reports:
   - path: ../lib/macos/reports/detect-apple-intelligence.yml
   - path: ../lib/macos/reports/collect-santa-denied-logs.yml
+  - path: ../lib/macos/reports/collect-macos-27-incompatible-apps.yml
   - path: ../lib/all/reports/dex-queries.yml
 software:
   packages:

--- a/it-and-security/lib/macos/reports/collect-macos-27-incompatible-apps.yml
+++ b/it-and-security/lib/macos/reports/collect-macos-27-incompatible-apps.yml
@@ -1,0 +1,24 @@
+- name: Intel-only apps incompatible with macOS 27
+  automations_enabled: false
+  description: Collects Intel-only app bundles that will not run on macOS 27. Uses Spotlight metadata via the mdls table joined with the apps table.
+  discard_data: false
+  interval: 604800
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: >-
+    SELECT
+      a.name AS app_name,
+      a.path AS app_path,
+      a.bundle_identifier,
+      a.bundle_short_version AS version,
+      m.value AS architectures,
+      DATETIME(a.last_opened_time, 'unixepoch') AS last_opened_time
+    FROM apps a
+    JOIN mdls m
+      ON m.path = a.path
+    WHERE m.key = 'kMDItemExecutableArchitectures'
+      AND m.value LIKE '%x86_64%'
+      AND m.value NOT LIKE '%arm64%'
+    ORDER BY
+      app_name ASC;


### PR DESCRIPTION
Introduce a new report lib/macos/reports/collect-macos-27-incompatible-apps.yml that queries apps joined with Spotlight mdls to find Intel-only (x86_64 without arm64) bundles. The report collects app name, path, bundle identifier, version, architectures and last opened time, runs weekly (interval 604800), has snapshot logging and automations disabled. Also add the report to the workstations.yml reports list so it runs for the macOS workstation fleet.