### PR TITLE
Update macOS 27 incompatible apps report

### DIFF
--- a/it-and-security/lib/macos/reports/collect-macos-27-incompatible-apps.yml
+++ b/it-and-security/lib/macos/reports/collect-macos-27-incompatible-apps.yml
@@ -13,7 +13,10 @@
       a.bundle_identifier,
       a.bundle_short_version AS version,
       m.value AS architectures,
-      DATETIME(a.last_opened_time, 'unixepoch') AS last_opened_time
+      CASE WHEN a.last_opened_time = -1
+        THEN 'Never'
+        ELSE DATETIME(a.last_opened_time, 'unixepoch')
+      END AS last_opened_time
     FROM apps a
     JOIN mdls m
       ON m.path = a.path


### PR DESCRIPTION
Update macOS report SQL to return 'Never' for apps where a.last_opened_time = -1 instead of converting -1 to a datetime. Adds a CASE expression to show 'Never' or DATETIME(...), making the last_opened_time column clearer for apps that were never opened.