### PR TITLE
Bind docker ports to 127.0.0.1

### DIFF
--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -245,7 +245,7 @@ jobs:
           S3_STORAGE_TEST=1 \
           SAML_IDP_TEST=1 \
           MAIL_TEST=1 \
-          AWS_ENDPOINT_URL="http://localhost:4566" \
+          AWS_ENDPOINT_URL="http://127.0.0.1:4566" \
           AWS_REGION=us-east-1 \
           NETWORK_TEST_GITHUB_TOKEN=${{ secrets.FLEET_RELEASE_GITHUB_PAT }} \
           CI_TEST_PKG="${{ env.CI_TEST_PKG }}" \

--- a/docker-compose-redis-cluster.yml
+++ b/docker-compose-redis-cluster.yml
@@ -19,7 +19,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7001:7001"
+      - "127.0.0.1:7001:7001"
     volumes:
       - ./tools/redis-tests/redis-cluster-1.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -30,7 +30,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7002:7002"
+      - "127.0.0.1:7002:7002"
     volumes:
       - ./tools/redis-tests/redis-cluster-2.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -41,7 +41,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7003:7003"
+      - "127.0.0.1:7003:7003"
     volumes:
       - ./tools/redis-tests/redis-cluster-3.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -52,7 +52,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7004:7004"
+      - "127.0.0.1:7004:7004"
     volumes:
       - ./tools/redis-tests/redis-cluster-4.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -63,7 +63,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7005:7005"
+      - "127.0.0.1:7005:7005"
     volumes:
       - ./tools/redis-tests/redis-cluster-5.conf:/usr/local/etc/redis/redis.conf
     networks:
@@ -74,7 +74,7 @@ services:
     image: redis:6
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
-      - "7006:7006"
+      - "127.0.0.1:7006:7006"
     volumes:
       - ./tools/redis-tests/redis-cluster-6.conf:/usr/local/etc/redis/redis.conf
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       # This is required by Percona XtraDB server.
       CLUSTER_NAME: fleet
     ports:
-      - "${FLEET_MYSQL_PORT:-3306}:3306"
+      - "127.0.0.1:${FLEET_MYSQL_PORT:-3306}:3306"
 
   mysql_test:
     image: ${FLEET_MYSQL_IMAGE:-mysql:8.0.44}
@@ -49,7 +49,7 @@ services:
       ]
     environment: *mysql-default-environment
     ports:
-      - "${FLEET_MYSQL_TEST_PORT:-3307}:3306"
+      - "127.0.0.1:${FLEET_MYSQL_TEST_PORT:-3307}:3306"
     tmpfs:
       - /var/lib/mysql:rw,noexec,nosuid
       - /tmpfs
@@ -76,7 +76,7 @@ services:
     environment: *mysql-default-environment
     ports:
       # ports 3308 and 3309 are used by the main and replica MySQL containers in tools/mysql-replica-testing/docker-compose.yml
-      - "${FLEET_MYSQL_REPLICA_TEST_PORT:-3310}:3306"
+      - "127.0.0.1:${FLEET_MYSQL_REPLICA_TEST_PORT:-3310}:3306"
     tmpfs:
       - /var/lib/mysql:rw,noexec,nosuid
       - /tmpfs
@@ -85,15 +85,15 @@ services:
   mailhog:
     image: mailhog/mailhog:latest
     ports:
-      - "${FLEET_MAILHOG_WEB_PORT:-8025}:8025"
-      - "${FLEET_MAILHOG_SMTP_PORT:-1025}:1025"
+      - "127.0.0.1:${FLEET_MAILHOG_WEB_PORT:-8025}:8025"
+      - "127.0.0.1:${FLEET_MAILHOG_SMTP_PORT:-1025}:1025"
 
   # SMTP server with Basic Authentication.
   mailpit:
     image: axllent/mailpit:latest
     ports:
-      - "${FLEET_MAILPIT_WEB_PORT:-8026}:8025"
-      - "${FLEET_MAILPIT_SMTP_PORT:-1026}:1025"
+      - "127.0.0.1:${FLEET_MAILPIT_WEB_PORT:-8026}:8025"
+      - "127.0.0.1:${FLEET_MAILPIT_SMTP_PORT:-1026}:1025"
     volumes:
       - ./tools/mailpit/auth.txt:/auth.txt
     command: ["--smtp-auth-file=/auth.txt", "--smtp-auth-allow-insecure=true"]
@@ -102,8 +102,8 @@ services:
   smtp4dev_test:
     image: rnwood/smtp4dev:v3
     ports:
-      - "${FLEET_SMTP4DEV_WEB_PORT:-8028}:80"
-      - "${FLEET_SMTP4DEV_SMTP_PORT:-1027}:25"
+      - "127.0.0.1:${FLEET_SMTP4DEV_WEB_PORT:-8028}:80"
+      - "127.0.0.1:${FLEET_SMTP4DEV_SMTP_PORT:-1027}:25"
     volumes:
       - ./tools/smtp4dev:/certs
     environment:
@@ -114,7 +114,7 @@ services:
   redis:
     image: redis:6
     ports:
-      - "${FLEET_REDIS_PORT:-6379}:6379"
+      - "127.0.0.1:${FLEET_REDIS_PORT:-6379}:6379"
 
   saml_idp:
     image: fleetdm/docker-idp:latest
@@ -122,15 +122,15 @@ services:
       - ./tools/saml/users.php:/var/www/simplesamlphp/config/authsources.php
       - ./tools/saml/config.php:/var/www/simplesamlphp/metadata/saml20-sp-remote.php
     ports:
-      - "${FLEET_SAML_IDP_HTTP_PORT:-9080}:8080"
-      - "${FLEET_SAML_IDP_HTTPS_PORT:-9443}:8443"
+      - "127.0.0.1:${FLEET_SAML_IDP_HTTP_PORT:-9080}:8080"
+      - "127.0.0.1:${FLEET_SAML_IDP_HTTPS_PORT:-9443}:8443"
 
   # CAdvisor container allows monitoring other containers. Useful for
   # development.
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:latest
     ports:
-      - "${FLEET_CADVISOR_PORT:-5678}:8080"
+      - "127.0.0.1:${FLEET_CADVISOR_PORT:-5678}:8080"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys:/sys:ro
@@ -139,7 +139,7 @@ services:
   prometheus:
     image: prom/prometheus:latest
     ports:
-      - "${FLEET_PROMETHEUS_PORT:-9090}:9090"
+      - "127.0.0.1:${FLEET_PROMETHEUS_PORT:-9090}:9090"
     volumes:
       - ./tools/app/prometheus.yml:/etc/prometheus/prometheus.yml
 
@@ -148,8 +148,8 @@ services:
   localstack:
     image: localstack/localstack
     ports:
-      - "${FLEET_LOCALSTACK_PORT:-4566}:4566"
-      - "${FLEET_LOCALSTACK_LEGACY_PORT:-4571}:4571"
+      - "127.0.0.1:${FLEET_LOCALSTACK_PORT:-4566}:4566"
+      - "127.0.0.1:${FLEET_LOCALSTACK_LEGACY_PORT:-4571}:4571"
     environment:
       - SERVICES=firehose,kinesis,s3,iam,sts,secretsmanager
 
@@ -157,8 +157,8 @@ services:
   s3:
     image: rustfs/rustfs:1.0.0-alpha.85
     ports:
-      - "${FLEET_S3_PORT:-9000}:9000"
-      - "${FLEET_S3_CONSOLE_PORT:-9001}:9001"
+      - "127.0.0.1:${FLEET_S3_PORT:-9000}:9000"
+      - "127.0.0.1:${FLEET_S3_CONSOLE_PORT:-9001}:9001"
     environment:
       - RUSTFS_ADDRESS=0.0.0.0:9000
       - RUSTFS_CONSOLE_ADDRESS=0.0.0.0:9001

--- a/docs/solutions/docker-compose/docker-compose.yml
+++ b/docs/solutions/docker-compose/docker-compose.yml
@@ -103,7 +103,7 @@ services:
       # to short-circuit region discovery
       - FLEET_S3_SOFTWARE_INSTALLERS_REGION=${FLEET_S3_SOFTWARE_INSTALLERS_REGION}
     ports:
-      - "127.0.0.1:${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
+      - "${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
     volumes:
       - data:/fleet
       - logs:/logs

--- a/docs/solutions/docker-compose/docker-compose.yml
+++ b/docs/solutions/docker-compose/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       timeout: 5s
       retries: 12
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     restart: unless-stopped
 
   redis:
@@ -42,7 +42,7 @@ services:
       timeout: 5s
       retries: 12
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     restart: unless-stopped
 
   fleet-init:
@@ -103,7 +103,7 @@ services:
       # to short-circuit region discovery
       - FLEET_S3_SOFTWARE_INSTALLERS_REGION=${FLEET_S3_SOFTWARE_INSTALLERS_REGION}
     ports:
-      - "${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
+      - "127.0.0.1:${FLEET_SERVER_PORT}:${FLEET_SERVER_PORT}" # UI/API
     volumes:
       - data:/fleet
       - logs:/logs


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42226

When doing dev in a remote environment, like a public cloud VM, don't expose ports to the public.
This is a contributor security improvement.

The localstack fail is present on main, and was not caused by this change: https://github.com/fleetdm/fleet/actions/runs/23439965808/job/68187858627

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Docker Compose configuration updated across multiple services (Redis, MySQL, mail, monitoring, and storage services) to restrict port bindings to localhost only instead of all network interfaces.
  * Documentation Docker Compose examples updated to reflect localhost-only port binding for core services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->