### PR TITLE
Pin Localstack version

### DIFF
--- a/.github/workflows/test-go-suite.yaml
+++ b/.github/workflows/test-go-suite.yaml
@@ -227,6 +227,13 @@ jobs:
           attempt=$((attempt + 1))
         done
 
+    - name: Wait for LocalStack
+      if: ${{ env.NEED_DOCKER && contains(env.DOCKER_COMMAND, 'localstack') }}
+      run: |
+        echo "Waiting for LocalStack..."
+        timeout 60 bash -c 'until curl -sf http://localhost:4566/_localstack/health; do sleep 2; done'
+        echo "LocalStack is ready"
+        
     - name: Generate test schema
       if: ${{ env.GENERATE_TEST_SCHEMA }}
       run: make test-schema

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,7 +146,7 @@ services:
   # localstack to simulate AWS integrations like firehose & kinesis
   # use http://localhost:4566 as the `--endpoint-url` argument in awscli
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:4.5
     ports:
       - "${FLEET_LOCALSTACK_PORT:-4566}:4566"
       - "${FLEET_LOCALSTACK_LEGACY_PORT:-4571}:4571"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42252 

Pins the Localstack image to the last-known-good version (4.5) before they 🔪 'd the community edition and started requiring an auth token.  I also added a "wait for localstack" as an initial debugging step, and left it in to catch similar future issues. It's probably redundant since there likely _is_ no future for Fleet and Localstack beyond this, but it take milliseconds and would catch any other weird Localstack failures so, why not.
