### PR TITLE
Set osquery_policy_update_interval to 30m in dogfood

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -73,6 +73,7 @@ locals {
     FLEET_MYSQL_READ_REPLICA_MAX_OPEN_CONNS    = "10"
     FLEET_VULNERABILITIES_DATABASES_PATH       = "/home/fleet"
     FLEET_OSQUERY_ENABLE_ASYNC_HOST_PROCESSING = "false"
+    FLEET_OSQUERY_POLICY_UPDATE_INTERVAL       = "30m"
     # ELASTIC_APM_SERVER_URL                     = var.elastic_url
     # ELASTIC_APM_SECRET_TOKEN                   = var.elastic_token
     # ELASTIC_APM_SERVICE_NAME                   = "dogfood"


### PR DESCRIPTION
## Changes

- Added `FLEET_OSQUERY_POLICY_UPDATE_INTERVAL` environment variable set to `30m` in the dogfood Terraform configuration
- This configures osquery policy updates to occur every 30 minutes in the dogfood environment