### PR TITLE
Add kilocode SKILL.md for Fleet GitOps

### DIFF
--- a/.kilocode/skills/fleet-gitops/SKILL.md
+++ b/.kilocode/skills/fleet-gitops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fleet-gitops
-description: Use when working on Fleet GitOps configuration files, including osquery queries, configuration profiles, and DDM declarations in the it-and-security folder.
+description: Use when working on Fleet GitOps configuration files, including osquery queries, configuration profiles, DDM declarations, software management, and CVE remediation in the it-and-security folder.
 ---
 
 # Fleet GitOps – Kilocode Skill
@@ -30,7 +30,7 @@ When generating or modifying configuration profiles:
 - When adding software for macOS or Windows hosts, **always check the Fleet-maintained app catalog first** before using a custom package:
   - https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps
 - In GitOps YAML, use the `fleet_maintained_apps` key with the app's `slug` to reference a Fleet-maintained app.
-- If a Fleet-maintained app is not available for the required software, note this and proceed with a custom package.
+- When remediating a CVE, use Fleet's built-in vulnerability detection to identify affected software, then follow the Software section above to deploy a fix — preferring a Fleet-maintained app update where available, otherwise a custom package.
 
 ## Declarative Device Management (DDM)
 

--- a/.kilocode/skills/fleet-gitops/SKILL.md
+++ b/.kilocode/skills/fleet-gitops/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: fleet-gitops
+description: Use when working on Fleet GitOps configuration files, including osquery queries, configuration profiles, and DDM declarations in the it-and-security folder.
+---
+
+# Fleet GitOps – Kilocode Skill
+
+## Queries & Reports
+
+- Only use **Fleet tables and supported columns** when writing osquery queries or Fleet reports.
+- Do not reference tables or columns that are not present in the Fleet schema for the target platform.
+- Validate tables and column names against the Fleet schema before including them in a query:
+  - https://github.com/fleetdm/fleet/tree/main/schema
+
+## Configuration Profiles
+
+When generating or modifying configuration profiles:
+
+- **First-party Apple payloads** (`.mobileconfig`) — validate payload keys, types, and allowed values against the Apple Device Management reference:
+  - https://github.com/apple/device-management/tree/release/mdm/profiles
+- **Third-party Apple payloads** (`.mobileconfig`) — validate against the ProfileManifests community reference:
+  - https://github.com/ProfileManifests/ProfileManifests
+- **Windows CSPs** (`.xml`) — validate CSP paths, formats, and allowed values against Microsoft's MDM protocol reference:
+  - https://learn.microsoft.com/en-us/windows/client-management/mdm/
+- **Android profiles** (`.json`) — validate keys and values against the Android Management API `enterprises.policies` reference:
+  - https://developers.google.com/android/management/reference/rest/v1/enterprises.policies
+
+## Software
+
+- When adding software for macOS or Windows hosts, **always check the Fleet-maintained app catalog first** before using a custom package:
+  - https://github.com/fleetdm/fleet/tree/main/ee/maintained-apps
+- In GitOps YAML, use the `fleet_maintained_apps` key with the app's `slug` to reference a Fleet-maintained app.
+- If a Fleet-maintained app is not available for the required software, note this and proceed with a custom package.
+
+## Declarative Device Management (DDM)
+
+When generating or modifying DDM declarations:
+
+- Validate declaration types, keys, and values against the Apple DDM reference:
+  - https://github.com/apple/device-management/tree/release/declarative/declarations
+- Ensure the `Type` identifier matches a supported declaration type from the reference.
+
+---
+
+## References
+
+- Fleet GitOps documentation: https://fleetdm.com/docs/configuration/yaml-files
+- Fleet API documentation: https://fleetdm.com/docs/rest-api/rest-api
+
+---
+
+*This file will grow as new patterns and constraints are established.*


### PR DESCRIPTION
Create initial .kilocode/skills/fleet-gitops/SKILL.md to document guidelines for working with Fleet GitOps configuration. Includes rules for osquery queries and Fleet reports, validation guidance for Apple, Windows, and Android configuration profiles, guidance on using Fleet-maintained apps vs custom packages, and Declarative Device Management (DDM) declaration validation. Also includes references to Fleet, Apple, ProfileManifests, and Microsoft documentation. This is the first version and will be expanded as patterns and constraints evolve.