### PR TITLE
Add vulnerability scan tracker

### DIFF
--- a/security/vulnerability-tracker.md
+++ b/security/vulnerability-tracker.md
@@ -1,0 +1,39 @@
+# Vulnerability Scan Tracker
+
+Current status of vulnerabilities detected by daily Trivy scans on Fleet Docker images.
+
+Last updated: 2026-03-23
+
+## Active Vulnerabilities
+
+| Vulnerability | CVE / Advisory | Severity | Affected Image(s) | Fix Available? | Days Failing | Exploitability in Fleet | In status.md? | Related Ticket | Latest Failed Run | Suggested Action | PR | Decision |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| gRPC-Go authorization bypass via missing leading slash in `:path` header | [CVE-2026-33186](https://avd.aquasec.com/nvd/cve-2026-33186) | **CRITICAL** | `fleet` (server binary, v4.82.1) | Yes — `google.golang.org/grpc` v1.78.0 → v1.79.3 | 4 (since Mar 20) | **High** — Fleet server uses gRPC internally; attacker could bypass authorization on gRPC endpoints by crafting requests without the leading slash | No | [#42261](https://github.com/fleetdm/fleet/issues/42261) | [Mar 23](https://github.com/fleetdm/fleet/actions/runs/23424343881) | **Already bumped in main** — needs Docker image rebuild to pick up fix | [#42261](https://github.com/fleetdm/fleet/issues/42261) | Already at v1.79.3 in main; awaiting image rebuild |
+| XML digital signature bypass in goxmldsig (loop variable capture) | [GHSA-479m-364c-43vc](https://github.com/advisories/GHSA-479m-364c-43vc) | **HIGH** | `fleetctl` (gobinary) | Yes — `github.com/russellhaering/goxmldsig` v1.4.0 → v1.6.0 | 4 (since Mar 20) | **Medium** — Affects SAML SSO signature validation in fleetctl; could allow authentication bypass if SAML is in use | No | [#42262](https://github.com/fleetdm/fleet/issues/42262) | [Mar 23](https://github.com/fleetdm/fleet/actions/runs/23424438962) | **PR to bump goxmldsig** — Affects SAML auth, needs testing with SSO flows | [PR #42263](https://github.com/fleetdm/fleet/pull/42263) | |
+| glibc integer overflow in `memalign` causes heap corruption | [CVE-2026-0861](https://avd.aquasec.com/nvd/cve-2026-0861) | **HIGH** | `wix` (Debian 13.3), `bomutils` (Debian 13.3) | Yes — `libc-bin`/`libc6` 2.41-12+deb13u1 → deb13u2 | 4 (since Mar 20) | **Low** — These are build-time packaging images, not runtime; the overflow requires specific allocation patterns unlikely in these tools | No | — | wix: [Mar 23](https://github.com/fleetdm/fleet/actions/runs/23424184716), bomutils: [Mar 23](https://github.com/fleetdm/fleet/actions/runs/23424608837) | **Rebuild base images** or **VEX suppress** — Low risk in build-only images, either approach works | — | |
+| GStreamer arbitrary code execution via RIFF palette integer overflow in AVI | [CVE-2026-2921](https://avd.aquasec.com/nvd/cve-2026-2921) | **HIGH** | `wix` (Debian 13.3) | Yes — `libgstreamer-plugins-base1.0-0` 1.26.2-1 → 1.26.2-1+deb13u1 | 4 (since Mar 20) | **Very low** — Fleet does not process AVI or multimedia files; GStreamer is an unused inherited Debian dependency | No | — | [Mar 23](https://github.com/fleetdm/fleet/actions/runs/23424184716) | **VEX suppress** — Fleet never processes multimedia; fixing adds churn with zero security benefit | — | |
+
+## Scan Failure Log (Last 4 Days)
+
+| Date | wix | bomutils | docker images (fleet) | fleetctl |
+|---|---|---|---|---|
+| Mar 23 | [failed](https://github.com/fleetdm/fleet/actions/runs/23424184716) | [failed](https://github.com/fleetdm/fleet/actions/runs/23424608837) | [failed](https://github.com/fleetdm/fleet/actions/runs/23424343881) | [failed](https://github.com/fleetdm/fleet/actions/runs/23424438962) |
+| Mar 22 | [failed](https://github.com/fleetdm/fleet/actions/runs/23397126085) | [failed](https://github.com/fleetdm/fleet/actions/runs/23397290377) | [failed](https://github.com/fleetdm/fleet/actions/runs/23397186570) | [failed](https://github.com/fleetdm/fleet/actions/runs/23397218229) |
+| Mar 21 | [failed](https://github.com/fleetdm/fleet/actions/runs/23373558552) | [failed](https://github.com/fleetdm/fleet/actions/runs/23373729027) | [failed](https://github.com/fleetdm/fleet/actions/runs/23373620931) | [failed](https://github.com/fleetdm/fleet/actions/runs/23373659458) |
+| Mar 20 | [failed](https://github.com/fleetdm/fleet/actions/runs/23331394124) | [failed](https://github.com/fleetdm/fleet/actions/runs/23331676474) | [failed](https://github.com/fleetdm/fleet/actions/runs/23331491952) | [failed](https://github.com/fleetdm/fleet/actions/runs/23331557385) |
+
+## Decision Legend
+
+| Decision | Meaning |
+|---|---|
+| *(empty)* | Not yet triaged |
+| **Fix in progress** | A PR or dependency bump is underway |
+| **Ignored — [reason]** | Assessed and decided not to fix (e.g., "Ignored — GStreamer unused in Fleet") |
+| **VEX suppressed** | Added to `vex/` directory to suppress in future scans |
+| **Fixed** | Resolved — move to Resolved section below |
+
+## Resolved Vulnerabilities
+
+| Vulnerability | CVE / Advisory | Severity | Resolution | Date Resolved |
+|---|---|---|---|---|
+| *(none yet)* | | | | |


### PR DESCRIPTION
Adds a living document to track Trivy scan vulnerabilities across Fleet Docker images. Includes active CVEs, scan failure log, and decision tracking. Lives alongside status.md in security/.