### PR TITLE
Use `http.MaxBytesReader` on the raw body and on the gzip decode output

### DIFF
--- a/changes/improve-body-validation
+++ b/changes/improve-body-validation
@@ -1,0 +1,1 @@
+* Improved body parsing validation by using http.MaxBytesReader and wrapping gzip decode output too.

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -32,17 +32,6 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// We use our own wrapper here, to preserve the Close method of the original io.ReadCloser
-// But also allows us to modify the limit at a laterp oint.
-type LimitedReadCloser struct {
-	*io.LimitedReader
-	Closer io.Closer
-}
-
-func (lrc *LimitedReadCloser) Close() error {
-	return lrc.Closer.Close()
-}
-
 type HandlerRoutesFunc func(r *mux.Router, opts []kithttp.ServerOption)
 
 // ParseTag parses a `url` tag and whether it's optional or not, which is an optional part of the tag
@@ -501,23 +490,7 @@ type requestValidator interface {
 // The customQueryDecoder parameter allows services to inject domain-specific
 // query parameter decoding logic.
 //
-// If adding a new way to parse/decode the requset, make sure to wrap the body in a limited reader with the maxRequestBodySize
-
-// limitExhaustedBody returns true when the LimitedReader was the cause of an
-// unexpected EOF — i.e. the underlying body actually had more data beyond the
-// limit. It does this by attempting a single-byte read from the underlying
-// reader (limitedReader.R) which bypasses the limit wrapper. A successful read
-// means the body exceeded the limit; an immediate EOF means the body ended
-// exactly at the limit (malformed JSON, not an oversized payload).
-//
-// This is used to avoid false-positive PayloadTooLargeError responses for
-// bodies whose JSON is malformed and happen to be exactly maxRequestBodySize
-// bytes long.
-func limitExhaustedBody(limitedReader *io.LimitedReader) bool {
-	var peek [1]byte
-	n, _ := limitedReader.R.Read(peek[:])
-	return n > 0
-}
+// If adding a new way to parse/decode the requset, make sure to wrap the body with http.MaxBytesReader using the maxRequestBodySize
 
 func MakeDecoder(
 	iface interface{},
@@ -537,17 +510,12 @@ func MakeDecoder(
 	}
 	if rd, ok := iface.(RequestDecoder); ok {
 		return func(ctx context.Context, r *http.Request) (interface{}, error) {
-			var limitedReader *io.LimitedReader
 			if maxRequestBodySize != -1 {
-				limitedReader = io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
-
-				r.Body = &LimitedReadCloser{
-					LimitedReader: limitedReader,
-					Closer:        r.Body,
-				}
+				r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
 			}
 			ret, err := rd.DecodeRequest(ctx, r)
-			if err != nil && errors.Is(err, io.ErrUnexpectedEOF) && limitedReader != nil && limitedReader.N == 0 && limitExhaustedBody(limitedReader) {
+			var maxBytesErr *http.MaxBytesError
+			if err != nil && errors.As(err, &maxBytesErr) {
 				return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
 			}
 			return ret, err
@@ -564,14 +532,8 @@ func MakeDecoder(
 		nilBody := false
 		var rewriter *JSONKeyRewriteReader
 
-		var limitedReader *io.LimitedReader
 		if maxRequestBodySize != -1 {
-			limitedReader = io.LimitReader(r.Body, maxRequestBodySize).(*io.LimitedReader)
-
-			r.Body = &LimitedReadCloser{
-				LimitedReader: limitedReader,
-				Closer:        r.Body,
-			}
+			r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
 		}
 
 		buf := bufio.NewReader(r.Body)
@@ -585,7 +547,13 @@ func MakeDecoder(
 					return nil, BadRequestErr("gzip decoder error", err)
 				}
 				defer gzr.Close()
-				body = gzr
+				if maxRequestBodySize != -1 {
+					// Limit decompressed bytes to prevent gzip bombs from bypassing
+					// the raw body size limit applied above.
+					body = http.MaxBytesReader(nil, gzr, maxRequestBodySize)
+				} else {
+					body = gzr
+				}
 			}
 
 			// Insert the JSON key rewriter into the reader pipeline
@@ -611,7 +579,8 @@ func MakeDecoder(
 						}
 					}
 
-					if errors.Is(err, io.ErrUnexpectedEOF) && limitedReader != nil && limitedReader.N == 0 && limitExhaustedBody(limitedReader) {
+					var maxBytesErr *http.MaxBytesError
+					if errors.As(err, &maxBytesErr) {
 						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
 					}
 
@@ -682,10 +651,11 @@ func MakeDecoder(
 					}
 				}
 
+				var maxBytesErr *http.MaxBytesError
+				if errors.As(err, &maxBytesErr) {
+					return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
+				}
 				if errors.Is(err, io.ErrUnexpectedEOF) {
-					if limitedReader != nil && limitedReader.N == 0 && limitExhaustedBody(limitedReader) {
-						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
-					}
 					return nil, BadRequestErr("json decoder error", err)
 				}
 				return nil, err

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -514,9 +514,12 @@ func MakeDecoder(
 				r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
 			}
 			ret, err := rd.DecodeRequest(ctx, r)
-			var maxBytesErr *http.MaxBytesError
-			if err != nil && errors.As(err, &maxBytesErr) {
-				return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
+			if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+				return nil, platform_http.PayloadTooLargeError{
+					ContentLength:  r.Header.Get("Content-Length"),
+					MaxRequestSize: maxRequestBodySize,
+					Gzipped:        false,
+				}
 			}
 			return ret, err
 		}
@@ -580,12 +583,13 @@ func MakeDecoder(
 							InternalErr: ace,
 						}
 					}
-
-					var maxBytesErr *http.MaxBytesError
-					if errors.As(err, &maxBytesErr) {
-						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize, Gzipped: gzipped}
+					if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+						return nil, platform_http.PayloadTooLargeError{
+							ContentLength:  r.Header.Get("Content-Length"),
+							MaxRequestSize: maxRequestBodySize,
+							Gzipped:        gzipped,
+						}
 					}
-
 					return nil, BadRequestErr("json decoder error", err)
 				}
 				v = reflect.ValueOf(req)
@@ -653,9 +657,12 @@ func MakeDecoder(
 					}
 				}
 
-				var maxBytesErr *http.MaxBytesError
-				if errors.As(err, &maxBytesErr) {
-					return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize, Gzipped: gzipped}
+				if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+					return nil, platform_http.PayloadTooLargeError{
+						ContentLength:  r.Header.Get("Content-Length"),
+						MaxRequestSize: maxRequestBodySize,
+						Gzipped:        gzipped,
+					}
 				}
 				if errors.Is(err, io.ErrUnexpectedEOF) {
 					return nil, BadRequestErr("json decoder error", err)

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -538,10 +538,12 @@ func MakeDecoder(
 
 		buf := bufio.NewReader(r.Body)
 		var body io.Reader = buf
+		gzipped := false
 		if _, err := buf.Peek(1); err == io.EOF {
 			nilBody = true
 		} else {
 			if r.Header.Get("content-encoding") == "gzip" {
+				gzipped = true
 				gzr, err := gzip.NewReader(buf)
 				if err != nil {
 					return nil, BadRequestErr("gzip decoder error", err)
@@ -581,7 +583,7 @@ func MakeDecoder(
 
 					var maxBytesErr *http.MaxBytesError
 					if errors.As(err, &maxBytesErr) {
-						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
+						return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize, Gzipped: gzipped}
 					}
 
 					return nil, BadRequestErr("json decoder error", err)
@@ -653,7 +655,7 @@ func MakeDecoder(
 
 				var maxBytesErr *http.MaxBytesError
 				if errors.As(err, &maxBytesErr) {
-					return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize}
+					return nil, platform_http.PayloadTooLargeError{ContentLength: r.Header.Get("Content-Length"), MaxRequestSize: maxRequestBodySize, Gzipped: gzipped}
 				}
 				if errors.Is(err, io.ErrUnexpectedEOF) {
 					return nil, BadRequestErr("json decoder error", err)

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -490,7 +490,7 @@ type requestValidator interface {
 // The customQueryDecoder parameter allows services to inject domain-specific
 // query parameter decoding logic.
 //
-// If adding a new way to parse/decode the requset, make sure to wrap the body with http.MaxBytesReader using the maxRequestBodySize
+// If adding a new way to parse/decode the request, make sure to wrap the body with http.MaxBytesReader using the maxRequestBodySize
 
 func MakeDecoder(
 	iface interface{},

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -518,7 +518,7 @@ func MakeDecoder(
 			// implementations from missing gzip bomb checks.
 			//
 			gzipped := false
-			if r.Header.Get("content-encoding") == "gzip" {
+			if strings.EqualFold(r.Header.Get("content-encoding"), "gzip") {
 				gzipped = true
 				gzr, err := gzip.NewReader(r.Body)
 				if err != nil {
@@ -536,7 +536,11 @@ func MakeDecoder(
 				r.Header.Del("Content-Encoding")
 			}
 			ret, err := rd.DecodeRequest(ctx, r)
-			if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
+			_, isMaxBytesError := errors.AsType[*http.MaxBytesError](err)
+			// Some DecodeRequest implementations (like getHostSoftwareRequest)
+			// themselves return platform_http.PayloadTooLargeError.
+			_, isPayloadTooLargeError := errors.AsType[platform_http.PayloadTooLargeError](err)
+			if isMaxBytesError || isPayloadTooLargeError {
 				return nil, platform_http.PayloadTooLargeError{
 					ContentLength:  r.Header.Get("Content-Length"),
 					MaxRequestSize: maxRequestBodySize,
@@ -567,7 +571,7 @@ func MakeDecoder(
 		if _, err := buf.Peek(1); err == io.EOF {
 			nilBody = true
 		} else {
-			if r.Header.Get("content-encoding") == "gzip" {
+			if strings.EqualFold(r.Header.Get("content-encoding"), "gzip") {
 				gzipped = true
 				gzr, err := gzip.NewReader(buf)
 				if err != nil {

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -536,11 +536,17 @@ func MakeDecoder(
 				r.Header.Del("Content-Encoding")
 			}
 			ret, err := rd.DecodeRequest(ctx, r)
-			_, isMaxBytesError := errors.AsType[*http.MaxBytesError](err)
+
 			// Some DecodeRequest implementations (like getHostSoftwareRequest)
 			// themselves return platform_http.PayloadTooLargeError.
-			_, isPayloadTooLargeError := errors.AsType[platform_http.PayloadTooLargeError](err)
-			if isMaxBytesError || isPayloadTooLargeError {
+			if inner, isPayloadTooLargeError := errors.AsType[platform_http.PayloadTooLargeError](err); isPayloadTooLargeError {
+				// Preserve the inner error's MaxRequestSize and ContentLength
+				// (it knows the actual limit that was hit), only add Gzipped.
+				inner.Gzipped = gzipped
+				return nil, inner
+			}
+
+			if _, isMaxBytesError := errors.AsType[*http.MaxBytesError](err); isMaxBytesError {
 				return nil, platform_http.PayloadTooLargeError{
 					ContentLength:  r.Header.Get("Content-Length"),
 					MaxRequestSize: maxRequestBodySize,

--- a/server/platform/endpointer/endpoint_utils.go
+++ b/server/platform/endpointer/endpoint_utils.go
@@ -513,12 +513,34 @@ func MakeDecoder(
 			if maxRequestBodySize != -1 {
 				r.Body = http.MaxBytesReader(nil, r.Body, maxRequestBodySize)
 			}
+			//
+			// We take care of gzip encoding here to prevent any future DecodeRequest
+			// implementations from missing gzip bomb checks.
+			//
+			gzipped := false
+			if r.Header.Get("content-encoding") == "gzip" {
+				gzipped = true
+				gzr, err := gzip.NewReader(r.Body)
+				if err != nil {
+					return nil, BadRequestErr("gzip decoder error", err)
+				}
+				defer gzr.Close()
+				if maxRequestBodySize != -1 {
+					// Limit decompressed bytes to prevent gzip bombs from bypassing
+					// the raw body size limit applied above.
+					r.Body = http.MaxBytesReader(nil, gzr, maxRequestBodySize)
+				} else {
+					r.Body = io.NopCloser(gzr)
+				}
+				// Clear so implementations don't try to decompress again.
+				r.Header.Del("Content-Encoding")
+			}
 			ret, err := rd.DecodeRequest(ctx, r)
 			if _, ok := errors.AsType[*http.MaxBytesError](err); ok {
 				return nil, platform_http.PayloadTooLargeError{
 					ContentLength:  r.Header.Get("Content-Length"),
 					MaxRequestSize: maxRequestBodySize,
-					Gzipped:        false,
+					Gzipped:        gzipped,
 				}
 			}
 			return ret, err

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -1,6 +1,8 @@
 package endpointer
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"errors"
@@ -276,9 +278,9 @@ func TestMakeDecoderRequestDecoderFalsePositive(t *testing.T) {
 
 	t.Run("malformed JSON exactly at limit returns decode error, not 413", func(t *testing.T) {
 		// Build a body of exactly `limit` bytes that is malformed JSON (no closing
-		// brace). The LimitedReader is exhausted (N==0), but a peek at the
-		// underlying reader returns EOF — the body ended at the limit, it was not
-		// cut short. Must not produce PayloadTooLargeError.
+		// brace). The MaxBytesReader allows the full read (body fits within limit),
+		// so the JSON decoder sees io.ErrUnexpectedEOF — not *http.MaxBytesError.
+		// Must not produce PayloadTooLargeError.
 		prefix := `{"data":"`
 		body := strings.NewReader(prefix + strings.Repeat("x", limit-len(prefix))) // exactly limit bytes, no closing
 		r := httptest.NewRequest("POST", "/", body)
@@ -308,5 +310,47 @@ func TestMakeDecoderRequestDecoderFalsePositive(t *testing.T) {
 		rd, ok := result.(*testRequestDecoderType)
 		require.True(t, ok)
 		assert.Equal(t, "hello", rd.Data)
+	})
+}
+
+type testGzipRequestType struct {
+	Data string `json:"data"`
+}
+
+func TestMakeDecoderGzipBomb(t *testing.T) {
+	const limit = 100
+
+	makeDecoder := func() kithttp.DecodeRequestFunc {
+		return MakeDecoder(testGzipRequestType{}, defaultJSONUnmarshal, nil, nil, nil, nil, limit)
+	}
+
+	gzipBody := func(data string) *bytes.Buffer {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write([]byte(data))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		return &buf
+	}
+
+	t.Run("gzip bomb exceeding decompressed limit returns 413", func(t *testing.T) {
+		// Compressed payload is small but decompresses well beyond the limit.
+		big := `{"data":"` + strings.Repeat("x", limit*10) + `"}`
+		r := httptest.NewRequest("POST", "/", gzipBody(big))
+		r.Header.Set("Content-Encoding", "gzip")
+		_, err := makeDecoder()(context.Background(), r)
+		require.Error(t, err)
+		var ple platform_http.PayloadTooLargeError
+		require.True(t, errors.As(err, &ple), "gzip bomb must produce PayloadTooLargeError, got: %v", err)
+	})
+
+	t.Run("valid gzip body within limit is decoded successfully", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", gzipBody(`{"data":"hi"}`))
+		r.Header.Set("Content-Encoding", "gzip")
+		result, err := makeDecoder()(context.Background(), r)
+		require.NoError(t, err)
+		rd, ok := result.(*testGzipRequestType)
+		require.True(t, ok)
+		assert.Equal(t, "hi", rd.Data)
 	})
 }

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -364,6 +364,20 @@ type testGzipRequestType struct {
 	Data string `json:"data"`
 }
 
+// testRequestDecoderPayloadTooLargeType implements RequestDecoder and returns
+// a PayloadTooLargeError directly from DecodeRequest (simulating implementations
+// like getHostSoftwareRequest that enforce their own size limits).
+type testRequestDecoderPayloadTooLargeType struct {
+	Data string `json:"data"`
+}
+
+func (d *testRequestDecoderPayloadTooLargeType) DecodeRequest(_ context.Context, r *http.Request) (any, error) {
+	return nil, platform_http.PayloadTooLargeError{
+		ContentLength:  r.Header.Get("Content-Length"),
+		MaxRequestSize: 42,
+	}
+}
+
 type testGzipBodyDecoderType struct {
 	Data string `json:"data"`
 }
@@ -439,5 +453,21 @@ func TestMakeDecoderGzipBomb(t *testing.T) {
 		rd, ok := result.(*testGzipBodyDecoderType)
 		require.True(t, ok)
 		assert.Equal(t, "hi", rd.Data)
+	})
+
+	// Sub-test for the RequestDecoder code path where DecodeRequest itself
+	// returns a PayloadTooLargeError (covers lines 545-546).
+	t.Run("DecodeRequest returning PayloadTooLargeError preserves inner fields and sets Gzipped", func(t *testing.T) {
+		makePayloadDecoder := func() kithttp.DecodeRequestFunc {
+			return MakeDecoder(&testRequestDecoderPayloadTooLargeType{}, defaultJSONUnmarshal, nil, nil, nil, nil, limit)
+		}
+		r := httptest.NewRequest("POST", "/", gzipBody(`{"data":"hi"}`))
+		r.Header.Set("Content-Encoding", "gzip")
+		_, err := makePayloadDecoder()(context.Background(), r)
+		require.Error(t, err)
+		var ple platform_http.PayloadTooLargeError
+		require.True(t, errors.As(err, &ple), "DecodeRequest returning PayloadTooLargeError must propagate, got: %v", err)
+		assert.True(t, ple.Gzipped, "Gzipped must be set when the request was gzip-encoded")
+		assert.Equal(t, int64(42), ple.MaxRequestSize, "MaxRequestSize from inner error must be preserved")
 	})
 }

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -10,8 +10,8 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
-	"reflect"
 	"net/http/httptest"
+	"reflect"
 	"strings"
 	"testing"
 

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -342,6 +342,7 @@ func TestMakeDecoderGzipBomb(t *testing.T) {
 		require.Error(t, err)
 		var ple platform_http.PayloadTooLargeError
 		require.True(t, errors.As(err, &ple), "gzip bomb must produce PayloadTooLargeError, got: %v", err)
+		assert.True(t, ple.Gzipped, "PayloadTooLargeError from gzip bomb must have Gzipped set")
 	})
 
 	t.Run("valid gzip body within limit is decoded successfully", func(t *testing.T) {

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -314,6 +314,52 @@ func TestMakeDecoderRequestDecoderFalsePositive(t *testing.T) {
 	})
 }
 
+func TestMakeDecoderRequestDecoderGzipBomb(t *testing.T) {
+	const limit = 100
+
+	makeDecoder := func() kithttp.DecodeRequestFunc {
+		return MakeDecoder(&testRequestDecoderType{}, defaultJSONUnmarshal, nil, nil, nil, nil, limit)
+	}
+
+	gzipBody := func(data string) *bytes.Buffer {
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		_, err := gw.Write([]byte(data))
+		require.NoError(t, err)
+		require.NoError(t, gw.Close())
+		return &buf
+	}
+
+	t.Run("gzip bomb exceeding decompressed limit returns 413", func(t *testing.T) {
+		big := `{"data":"` + strings.Repeat("x", limit*10) + `"}`
+		r := httptest.NewRequest("POST", "/", gzipBody(big))
+		r.Header.Set("Content-Encoding", "gzip")
+		_, err := makeDecoder()(context.Background(), r)
+		require.Error(t, err)
+		var ple platform_http.PayloadTooLargeError
+		require.True(t, errors.As(err, &ple), "gzip bomb via RequestDecoder must produce PayloadTooLargeError, got: %v", err)
+		assert.True(t, ple.Gzipped, "PayloadTooLargeError from gzip bomb must have Gzipped set")
+	})
+
+	t.Run("valid gzip body within limit is decoded successfully", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", gzipBody(`{"data":"hi"}`))
+		r.Header.Set("Content-Encoding", "gzip")
+		result, err := makeDecoder()(context.Background(), r)
+		require.NoError(t, err)
+		rd, ok := result.(*testRequestDecoderType)
+		require.True(t, ok)
+		assert.Equal(t, "hi", rd.Data)
+	})
+
+	t.Run("Content-Encoding header is cleared after decompression", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", gzipBody(`{"data":"hi"}`))
+		r.Header.Set("Content-Encoding", "gzip")
+		_, err := makeDecoder()(context.Background(), r)
+		require.NoError(t, err)
+		assert.Empty(t, r.Header.Get("Content-Encoding"), "Content-Encoding should be cleared after framework decompression")
+	})
+}
+
 type testGzipRequestType struct {
 	Data string `json:"data"`
 }

--- a/server/platform/endpointer/endpoint_utils_test.go
+++ b/server/platform/endpointer/endpoint_utils_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"log/slog"
 	"net/http"
+	"reflect"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -317,6 +318,10 @@ type testGzipRequestType struct {
 	Data string `json:"data"`
 }
 
+type testGzipBodyDecoderType struct {
+	Data string `json:"data"`
+}
+
 func TestMakeDecoderGzipBomb(t *testing.T) {
 	const limit = 100
 
@@ -351,6 +356,41 @@ func TestMakeDecoderGzipBomb(t *testing.T) {
 		result, err := makeDecoder()(context.Background(), r)
 		require.NoError(t, err)
 		rd, ok := result.(*testGzipRequestType)
+		require.True(t, ok)
+		assert.Equal(t, "hi", rd.Data)
+	})
+
+	// Sub-tests for the bodyDecoder (DecodeBody) code path, where isBodyDecoder
+	// returns true and decodeBody is called instead of jsonUnmarshal.
+	isBodyDecoder := func(v reflect.Value) bool {
+		_, ok := v.Interface().(*testGzipBodyDecoderType)
+		return ok
+	}
+	decodeBodyFn := func(_ context.Context, _ *http.Request, v reflect.Value, body io.Reader) error {
+		bd := v.Interface().(*testGzipBodyDecoderType)
+		return json.NewDecoder(body).Decode(bd)
+	}
+	makeBodyDecoder := func() kithttp.DecodeRequestFunc {
+		return MakeDecoder(testGzipBodyDecoderType{}, defaultJSONUnmarshal, nil, isBodyDecoder, decodeBodyFn, nil, limit)
+	}
+
+	t.Run("DecodeBody gzip bomb exceeding decompressed limit returns 413", func(t *testing.T) {
+		big := `{"data":"` + strings.Repeat("x", limit*10) + `"}`
+		r := httptest.NewRequest("POST", "/", gzipBody(big))
+		r.Header.Set("Content-Encoding", "gzip")
+		_, err := makeBodyDecoder()(context.Background(), r)
+		require.Error(t, err)
+		var ple platform_http.PayloadTooLargeError
+		require.True(t, errors.As(err, &ple), "gzip bomb via DecodeBody must produce PayloadTooLargeError, got: %v", err)
+		assert.True(t, ple.Gzipped, "PayloadTooLargeError from gzip bomb must have Gzipped set")
+	})
+
+	t.Run("DecodeBody valid gzip body within limit is decoded successfully", func(t *testing.T) {
+		r := httptest.NewRequest("POST", "/", gzipBody(`{"data":"hi"}`))
+		r.Header.Set("Content-Encoding", "gzip")
+		result, err := makeBodyDecoder()(context.Background(), r)
+		require.NoError(t, err)
+		rd, ok := result.(*testGzipBodyDecoderType)
 		require.True(t, ok)
 		assert.Equal(t, "hi", rd.Data)
 	})

--- a/server/platform/http/errors.go
+++ b/server/platform/http/errors.go
@@ -101,6 +101,7 @@ func (e *BadRequestError) IsClientError() bool {
 type PayloadTooLargeError struct {
 	ContentLength  string
 	MaxRequestSize int64
+	Gzipped        bool
 }
 
 func (e PayloadTooLargeError) Error() string {
@@ -117,7 +118,11 @@ func (e PayloadTooLargeError) Internal() string {
 			// We don't care if we failed to parse the number, only if we were successful
 			size = units.HumanSize(contentLengthAsNumber)
 		}
-		msg += fmt.Sprintf(", Incoming Content-Length: %s", size)
+		label := "Incoming Content-Length"
+		if e.Gzipped {
+			label = "Incoming Content-Length (compressed)"
+		}
+		msg += fmt.Sprintf(", %s: %s", label, size)
 	}
 	return msg
 }


### PR DESCRIPTION
- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually