### PR TITLE
ndes: Add allow_basic_auth option for NDES SCEP proxy

### DIFF
--- a/ee/server/service/certificate_authorities.go
+++ b/ee/server/service/certificate_authorities.go
@@ -120,6 +120,7 @@ func (svc *Service) NewCertificateAuthority(ctx context.Context, p fleet.Certifi
 		caToCreate.AdminURL = ptr.String(p.NDESSCEPProxy.AdminURL)
 		caToCreate.Username = ptr.String(p.NDESSCEPProxy.Username)
 		caToCreate.Password = &p.NDESSCEPProxy.Password
+		caToCreate.AllowBasicAuth = &p.NDESSCEPProxy.AllowBasicAuth
 		caDisplayType = "NDES SCEP"
 		activity = fleet.ActivityAddedNDESSCEPProxy{}
 	}
@@ -668,12 +669,13 @@ func (svc *Service) processNDESSCEP(ctx context.Context, batchOps *fleet.Certifi
 	if existing == nil || (existing.URL == "" && existing.AdminURL == "" && existing.Username == "" && existing.Password == "") {
 		svc.logger.DebugContext(ctx, "adding new NDES SCEP CA as none exists")
 		batchOps.Add = append(batchOps.Add, &fleet.CertificateAuthority{
-			Type:     string(fleet.CATypeNDESSCEPProxy),
-			Name:     &ndesName,
-			URL:      &incoming.URL,
-			AdminURL: &incoming.AdminURL,
-			Username: &incoming.Username,
-			Password: &incoming.Password,
+			Type:           string(fleet.CATypeNDESSCEPProxy),
+			Name:           &ndesName,
+			URL:            &incoming.URL,
+			AdminURL:       &incoming.AdminURL,
+			Username:       &incoming.Username,
+			Password:       &incoming.Password,
+			AllowBasicAuth: &incoming.AllowBasicAuth,
 		})
 		return nil
 	}
@@ -682,12 +684,13 @@ func (svc *Service) processNDESSCEP(ctx context.Context, batchOps *fleet.Certifi
 	svc.logger.DebugContext(ctx, "updating existing NDES SCEP CA")
 	incoming.ID = existing.ID
 	batchOps.Update = append(batchOps.Update, &fleet.CertificateAuthority{
-		Type:     string(fleet.CATypeNDESSCEPProxy),
-		Name:     &ndesName,
-		URL:      &incoming.URL,
-		AdminURL: &incoming.AdminURL,
-		Username: &incoming.Username,
-		Password: &incoming.Password,
+		Type:           string(fleet.CATypeNDESSCEPProxy),
+		Name:           &ndesName,
+		URL:            &incoming.URL,
+		AdminURL:       &incoming.AdminURL,
+		Username:       &incoming.Username,
+		Password:       &incoming.Password,
+		AllowBasicAuth: &incoming.AllowBasicAuth,
 	})
 
 	return nil
@@ -1183,6 +1186,7 @@ func (svc *Service) UpdateCertificateAuthority(ctx context.Context, id uint, p f
 		caToUpdate.AdminURL = p.NDESSCEPProxyCAUpdatePayload.AdminURL
 		caToUpdate.Username = p.NDESSCEPProxyCAUpdatePayload.Username
 		caToUpdate.Password = p.NDESSCEPProxyCAUpdatePayload.Password
+		caToUpdate.AllowBasicAuth = p.NDESSCEPProxyCAUpdatePayload.AllowBasicAuth
 		if caToUpdate.Name != nil {
 			caActivityName = *caToUpdate.Name
 		} else {
@@ -1437,6 +1441,11 @@ func (svc *Service) validateNDESSCEPProxyUpdate(ctx context.Context, ndesSCEP *f
 			NDESProxy.Password = *ndesSCEP.Password
 		} else {
 			NDESProxy.Password = *oldCA.Password
+		}
+		if ndesSCEP.AllowBasicAuth != nil {
+			NDESProxy.AllowBasicAuth = *ndesSCEP.AllowBasicAuth
+		} else if oldCA.AllowBasicAuth != nil {
+			NDESProxy.AllowBasicAuth = *oldCA.AllowBasicAuth
 		}
 
 		if err := svc.scepConfigService.ValidateNDESSCEPAdminURL(ctx, NDESProxy); err != nil {

--- a/ee/server/service/scep/scep_proxy.go
+++ b/ee/server/service/scep/scep_proxy.go
@@ -511,7 +511,8 @@ func (s *SCEPConfigService) GetNDESSCEPChallenge(ctx context.Context, proxy flee
 	// Get the challenge from NDES
 	client := fleethttp.NewClient(fleethttp.WithTimeout(*s.Timeout))
 	client.Transport = ntlmssp.Negotiator{
-		RoundTripper: fleethttp.NewTransport(),
+		RoundTripper:   fleethttp.NewTransport(),
+		AllowBasicAuth: proxy.AllowBasicAuth,
 	}
 	req, err := http.NewRequest(http.MethodGet, adminURL, http.NoBody)
 	if err != nil {

--- a/server/datastore/mysql/certificate_authorities.go
+++ b/server/datastore/mysql/certificate_authorities.go
@@ -37,6 +37,7 @@ func (ds *Datastore) GetCertificateAuthorityByID(ctx context.Context, id uint, i
 		certificate_user_principal_names,
 		certificate_seat_id,
 		admin_url,
+		allow_basic_auth,
 		challenge_url,
 		username,
 		password_encrypted,
@@ -132,6 +133,7 @@ func (ds *Datastore) GetAllCertificateAuthorities(ctx context.Context, includeSe
 		certificate_user_principal_names,
 		certificate_seat_id,
 		admin_url,
+		allow_basic_auth,
 		username,
 		password_encrypted,
 		challenge_url,
@@ -210,7 +212,7 @@ func (ds *Datastore) NewCertificateAuthority(ctx context.Context, ca *fleet.Cert
 	return ca, nil
 }
 
-const argsCountInsertCertificateAuthority = 15
+const argsCountInsertCertificateAuthority = 16
 
 const sqlInsertCertificateAuthority = `INSERT INTO certificate_authorities (
 	type,
@@ -222,6 +224,7 @@ const sqlInsertCertificateAuthority = `INSERT INTO certificate_authorities (
 	certificate_user_principal_names,
 	certificate_seat_id,
 	admin_url,
+	allow_basic_auth,
 	challenge_url,
 	username,
 	password_encrypted,
@@ -240,6 +243,7 @@ const sqlUpsertCertificateAuthority = sqlInsertCertificateAuthority + ` ON DUPLI
 	certificate_user_principal_names = VALUES(certificate_user_principal_names),
 	certificate_seat_id = VALUES(certificate_seat_id),
 	admin_url = VALUES(admin_url),
+	allow_basic_auth = VALUES(allow_basic_auth),
 	challenge_url = VALUES(challenge_url),
 	username = VALUES(username),
 	password_encrypted = VALUES(password_encrypted),
@@ -286,6 +290,11 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 		}
 	}
 
+	allowBasicAuth := false
+	if ca.AllowBasicAuth != nil {
+		allowBasicAuth = *ca.AllowBasicAuth
+	}
+
 	args := []interface{}{
 		ca.Type,
 		ca.Name,
@@ -296,6 +305,7 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 		upns,
 		ca.CertificateSeatID,
 		ca.AdminURL,
+		allowBasicAuth,
 		ca.ChallengeURL,
 		ca.Username,
 		encryptedPassword,
@@ -303,7 +313,7 @@ func sqlGenerateArgsForInsertCertificateAuthority(ctx context.Context, serverPri
 		ca.ClientID,
 		encryptedClientSecret,
 	}
-	placeholders := "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
+	placeholders := "(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)"
 
 	return args, placeholders, nil
 }
@@ -550,6 +560,10 @@ func (ds *Datastore) generateUpdateQueryWithArgs(ctx context.Context, ca *fleet.
 		if ca.AdminURL != nil {
 			updates = append(updates, "admin_url = ?")
 			*args = append(*args, *ca.AdminURL)
+		}
+		if ca.AllowBasicAuth != nil {
+			updates = append(updates, "allow_basic_auth = ?")
+			*args = append(*args, *ca.AllowBasicAuth)
 		}
 		if ca.Username != nil {
 			updates = append(updates, "username = ?")

--- a/server/datastore/mysql/migrations/tables/20260323000000_AddAllowBasicAuthToCertificateAuthorities.go
+++ b/server/datastore/mysql/migrations/tables/20260323000000_AddAllowBasicAuthToCertificateAuthorities.go
@@ -1,0 +1,16 @@
+package tables
+
+import "database/sql"
+
+func init() {
+	MigrationClient.AddMigration(Up_20260323000000, Down_20260323000000)
+}
+
+func Up_20260323000000(tx *sql.Tx) error {
+	_, err := tx.Exec(`ALTER TABLE certificate_authorities ADD COLUMN allow_basic_auth TINYINT(1) NOT NULL DEFAULT 0 AFTER admin_url`)
+	return err
+}
+
+func Down_20260323000000(tx *sql.Tx) error {
+	return nil
+}

--- a/server/datastore/mysql/schema.sql
+++ b/server/datastore/mysql/schema.sql
@@ -266,6 +266,7 @@ CREATE TABLE `certificate_authorities` (
   `certificate_user_principal_names` json DEFAULT NULL,
   `certificate_seat_id` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `admin_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,
+  `allow_basic_auth` tinyint(1) NOT NULL DEFAULT '0',
   `username` varchar(255) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `password_encrypted` blob,
   `challenge_url` text CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci,

--- a/server/fleet/certificate_authorities.go
+++ b/server/fleet/certificate_authorities.go
@@ -74,7 +74,8 @@ type CertificateAuthority struct {
 	CertificateSeatID             *string   `json:"certificate_seat_id,omitempty" db:"certificate_seat_id"`
 
 	// NDES SCEP Proxy
-	AdminURL *string `json:"admin_url,omitempty" db:"admin_url"`
+	AdminURL       *string `json:"admin_url,omitempty" db:"admin_url"`
+	AllowBasicAuth *bool   `json:"allow_basic_auth,omitempty" db:"allow_basic_auth"`
 
 	// Smallstep
 	ChallengeURL *string `json:"challenge_url,omitempty" db:"challenge_url"`
@@ -194,11 +195,12 @@ func (h *HydrantCA) Preprocess() {
 
 // NDESSCEPProxyCA configures SCEP proxy for NDES SCEP server. Premium feature.
 type NDESSCEPProxyCA struct {
-	ID       uint   `json:"-"`
-	URL      string `json:"url"`
-	AdminURL string `json:"admin_url"`
-	Username string `json:"username"`
-	Password string `json:"password"` // not stored here -- encrypted in DB
+	ID             uint   `json:"-"`
+	URL            string `json:"url"`
+	AdminURL       string `json:"admin_url"`
+	Username       string `json:"username"`
+	Password       string `json:"password"` // not stored here -- encrypted in DB
+	AllowBasicAuth bool   `json:"allow_basic_auth,omitempty"`
 }
 
 func (n *NDESSCEPProxyCA) Preprocess() {
@@ -316,15 +318,16 @@ func (dcp *DigiCertCAUpdatePayload) Preprocess() {
 }
 
 type NDESSCEPProxyCAUpdatePayload struct {
-	URL      *string `json:"url"`
-	AdminURL *string `json:"admin_url"`
-	Username *string `json:"username"`
-	Password *string `json:"password"`
+	URL            *string `json:"url"`
+	AdminURL       *string `json:"admin_url"`
+	Username       *string `json:"username"`
+	Password       *string `json:"password"`
+	AllowBasicAuth *bool   `json:"allow_basic_auth"`
 }
 
 // IsEmpty checks if the struct only has all empty values
 func (ndesp *NDESSCEPProxyCAUpdatePayload) IsEmpty() bool {
-	return ndesp.URL == nil && ndesp.AdminURL == nil && ndesp.Username == nil && ndesp.Password == nil
+	return ndesp.URL == nil && ndesp.AdminURL == nil && ndesp.Username == nil && ndesp.Password == nil && ndesp.AllowBasicAuth == nil
 }
 
 // ValidateRelatedFields verifies that fields that are related to each other are set correctly.
@@ -535,12 +538,17 @@ func GroupCertificateAuthoritiesByType(cas []*CertificateAuthority) (*GroupedCer
 				return nil, errors.New("multiple NDESSCEP proxy CAs found when grouping")
 			}
 
+			allowBasicAuth := false
+			if ca.AllowBasicAuth != nil {
+				allowBasicAuth = *ca.AllowBasicAuth
+			}
 			grouped.NDESSCEP = &NDESSCEPProxyCA{
-				ID:       ca.ID,
-				URL:      *ca.URL,
-				AdminURL: *ca.AdminURL,
-				Username: *ca.Username,
-				Password: *ca.Password,
+				ID:             ca.ID,
+				URL:            *ca.URL,
+				AdminURL:       *ca.AdminURL,
+				Username:       *ca.Username,
+				Password:       *ca.Password,
+				AllowBasicAuth: allowBasicAuth,
 			}
 
 		case string(CATypeHydrant):


### PR DESCRIPTION
## Summary

The `ntlmssp.Negotiator` transport wrapping Fleet's NDES HTTP client strips the `Authorization` header on the initial request and only retries with NTLM credentials when the server responds with `WWW-Authenticate: Negotiate`. Non-Windows NDES implementations (e.g. custom SCEP proxies running on AWS Lambda) respond with `WWW-Authenticate: Basic` instead, causing the negotiator to silently fail authentication and return a validation error.

This adds an `allow_basic_auth` configuration option to the `ndes_scep_proxy` settings. When enabled, it sets `AllowBasicAuth: true` on the `ntlmssp.Negotiator`, which makes it retry with HTTP Basic Auth when the server responds with `WWW-Authenticate: Basic` rather than `Negotiate`.

### Changes

- Add `allow_basic_auth` field to `NDESSCEPProxyCA`, `NDESSCEPProxyCAUpdatePayload`, and the `CertificateAuthority` DB model
- Pass the field through to `ntlmssp.Negotiator` in `GetNDESSCEPChallenge`
- Add DB migration to add the `allow_basic_auth` column to `certificate_authorities`
- Wire through create, update, and batch apply paths

### Usage

In GitOps YAML:

```yaml
certificate_authorities:
  ndes_scep_proxy:
    url: https://example.com/scep
    admin_url: https://example.com/admin
    username: scep_user
    password: scep_password
    allow_basic_auth: true
```

Or via the API:

```json
{
  "ndes_scep_proxy": {
    "url": "https://example.com/scep",
    "admin_url": "https://example.com/admin",
    "username": "scep_user",
    "password": "scep_password",
    "allow_basic_auth": true
  }
}
```

### Motivation

NTLM authentication requires a persistent TCP connection for its 3-leg handshake, which serverless backends like AWS Lambda Function URLs cannot guarantee. The `ntlmssp.Negotiator` struct already supports `AllowBasicAuth` as a public field — this change simply exposes it as a user-configurable option so that non-Windows NDES implementations can authenticate correctly.

## Test plan

- [ ] Verify existing NDES SCEP tests pass (default `allow_basic_auth: false` preserves current behavior)
- [ ] Test with a non-Windows NDES endpoint that responds with `WWW-Authenticate: Basic` and `allow_basic_auth: true`
- [ ] Verify `fleetctl gitops --dry-run` parses the new field correctly
- [ ] Verify DB migration adds the column and defaults to `false`


Made with [Cursor](https://cursor.com)