### PR TITLE
Add Windows Defender to Windows software inventory

### DIFF
--- a/server/service/osquery_utils/queries.go
+++ b/server/service/osquery_utils/queries.go
@@ -1334,6 +1334,18 @@ SELECT
   path AS installed_path,
   '' as upgrade_code
 FROM chocolatey_packages
+UNION
+SELECT
+  'Windows Defender' AS name,
+  product_version AS version,
+  '' AS extension_id,
+  '' AS extension_for,
+  'programs' AS source,
+  'Microsoft Corporation' AS vendor,
+  directory AS installed_path,
+  '' AS upgrade_code
+FROM file
+WHERE path = 'C:\Program Files\Windows Defender\MsMpEng.exe'
 `),
 	Platforms:        []string{"windows"},
 	DirectIngestFunc: directIngestSoftware,


### PR DESCRIPTION
Include Windows Defender in the Windows software inventory query by adding a UNION clause that retrieves Windows Defender product version and details from the file table.

- Queries the Windows Defender executable path to extract version information
- Standardizes the output format to match other software inventory entries
- Uses 'Microsoft Corporation' as vendor and 'programs' as source