### PR TITLE
Config for contributors reference

### DIFF
--- a/docs/Contributing/reference/configuration-for-contributors.md
+++ b/docs/Contributing/reference/configuration-for-contributors.md
@@ -244,15 +244,14 @@ Enables exporting logs to an OpenTelemetry collector in addition to stderr outpu
 
 ### mdm.allow_all_declarations
 
-> Experimental feature. Use with caution.
+> Experimental feature. This feature will be removed when Fleet adds the ability to add any declaration via Fleet's UI, API, and YAML.
+
+This configuration option is not production ready. It hasn't been tested by Fleet. Enabling this option bypasses all safety checks for declarations, including checks for forbidden declaration types, reserved identifiers, and required prefixes. Use only when you need to
+deploy declarations that Fleet would otherwise block.
 
 If set to `true`, you can add all types of Apple [declaration profiles](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations). By default, Fleet doesn't allow [these configurations](https://github.com/fleetdm/fleet/blob/9589631a7f25a342ed24571c08deffbc959661ec/server/fleet/apple_mdm.go#L704-L717).
 
-**Note:** [Asset](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations#Assets) declarations require additional infrastructure. You need to self-host the asset and include the URL in the [declaration](https://developer.apple.com/documentation/devicemanagement/assetdata#Asset-example).
-
-**Warning:** Enabling this option bypasses all safety checks for declarations, including checks for
-forbidden declaration types, reserved identifiers, and required prefixes. Use only when you need to
-deploy declarations that Fleet would otherwise block.
+[Asset](https://developer.apple.com/documentation/devicemanagement/devicemanagement-declarations#Assets) declarations require additional infrastructure. You need to self-host the asset and include the URL in the [declaration](https://developer.apple.com/documentation/devicemanagement/assetdata#Asset-example).
 
 - Default value: `false`
 - Environment variable: `FLEET_MDM_ALLOW_ALL_DECLARATIONS`


### PR DESCRIPTION
- Make experimental `allow_all_declarations` use language that's consistent w/ the FileVault/OS updates experimental config
