### PR TITLE
ACME: DEP enrollment changes (Part 1)

### DIFF
--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -367,7 +367,7 @@ func (c *TestAppleMDMClient) enrollDevice(awaitingConfiguration bool) error {
 
 	// TODO: simulate ACME enrollment instead of SCEP enrollment for now just do some basic checks
 	// on the profile content.
-	if c.EnrollInfo.SCEPURL == "" || !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
+	if c.EnrollInfo.SCEPURL == "" && !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
 		if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.acme")) {
 			return fmt.Errorf("enrollment profile should contain either SCEP or ACME payload")
 		}

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -369,7 +369,7 @@ func (c *TestAppleMDMClient) enrollDevice(awaitingConfiguration bool) error {
 	// on the profile content.
 	if c.EnrollInfo.SCEPURL == "" && !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
 		if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.acme")) {
-			return fmt.Errorf("enrollment profile should contain either SCEP or ACME payload")
+			return errors.New("enrollment profile should contain either SCEP or ACME payload")
 		}
 		return nil
 	}

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -121,6 +121,10 @@ type TestAppleMDMClient struct {
 	// is not a full simulation of legacy enrollments (especially, as it related to IdP). Rather it
 	// is enough to test certain SCEP renewal scenarios for iOS/IPadOS devices
 	legacyIDeviceEnrollRef string
+
+	// skipParseEnrollProf, when set to true, will skip parsing the enrollment profile after
+	// fetching it. Instead, the raw profile bytes will still be stored in enrollProfBytes.
+	skipParseEnrollProf bool
 }
 
 // TestMDMAppleClientOption allows configuring a TestMDMClient.
@@ -147,6 +151,12 @@ func WithOTAIdpUUID(idpUUID string) TestMDMAppleClientOption {
 	}
 }
 
+func WithSkipParseEnrollProf(skip bool) TestMDMAppleClientOption {
+	return func(c *TestAppleMDMClient) {
+		c.skipParseEnrollProf = skip
+	}
+}
+
 // Will add the specified reference as a query parameter to the MDMURL after the
 // client fetches the enrollment profile but prior to attempting SCEP enrollment. Note that this
 // is not a full simulation of legacy enrollments (especially, as it relates to IdP). Rather it
@@ -168,6 +178,17 @@ type AppleEnrollInfo struct {
 	// AssignedManagedAppleID is the Assigned Managed Apple account for the device. Only used for
 	// account driven enrollment flows, so it will not always be available.
 	AssignedManagedAppleID string
+	// ACMEURL is the optional URL that will be used for ACME enrollment instead of the SCEP.
+	// Currently, this is only used for certain enrollment scenarios when
+	// config.mdm.apple_require_hardware_attestation is true.
+	//
+	// TODO: use this when we have full ACME auth flow implemented
+	ACMEURL string
+
+	// RawProfile contains the raw bytes of the enrollment profile. This is useful for tests that
+	// want to inspect the actual profile content. This field is populated regardless of the value
+	// of skipParseEnrollProf.
+	RawProfile []byte
 }
 
 // NewTestMDMClientAppleDesktopManual will create a simulated device that will fetch
@@ -344,6 +365,15 @@ func (c *TestAppleMDMClient) enrollDevice(awaitingConfiguration bool) error {
 		c.EnrollInfo.MDMURL = parsedMDMURL.String()
 	}
 
+	// TODO: simulate ACME enrollment instead of SCEP enrollment for now just do some basic checks
+	// on the profile content.
+	if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
+		if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.acme")) {
+			return fmt.Errorf("enrollment profile should contain either SCEP or ACME payload")
+		}
+		return nil
+	}
+
 	if err := c.SCEPEnroll(); err != nil {
 		return fmt.Errorf("scep enroll: %w", err)
 	}
@@ -419,8 +449,9 @@ func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDesktopURL() error {
 
 func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURL() error {
 	di, err := EncodeDeviceInfo(fleet.MDMAppleMachineInfo{
-		Serial: c.SerialNumber,
-		UDID:   c.UUID,
+		Serial:  c.SerialNumber,
+		UDID:    c.UUID,
+		Product: c.Model,
 	})
 	if err != nil {
 		return fmt.Errorf("test client: encoding device info: %w", err)
@@ -432,8 +463,9 @@ func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURL() error {
 
 func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURLUsingPost() error {
 	buf, err := MachineInfoAsPKCS7(fleet.MDMAppleMachineInfo{
-		Serial: c.SerialNumber,
-		UDID:   c.UUID,
+		Serial:  c.SerialNumber,
+		UDID:    c.UUID,
+		Product: c.Model,
 	})
 	if err != nil {
 		return fmt.Errorf("test client: encoding device info: %w", err)
@@ -619,10 +651,15 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 	if err != nil {
 		return fmt.Errorf("verifying enrollment profile: %w", err)
 	}
+	if c.skipParseEnrollProf {
+		c.EnrollInfo.RawProfile = p7.Content
+		return nil
+	}
 	enrollInfo, err := ParseEnrollmentProfile(p7.Content)
 	if err != nil {
 		return fmt.Errorf("parse OTA SCEP profile: %w", err)
 	}
+	enrollInfo.RawProfile = p7.Content
 	c.EnrollInfo = *enrollInfo
 	return nil
 }
@@ -678,11 +715,15 @@ func (c *TestAppleMDMClient) fetchEnrollmentProfile(path string, body []byte) (e
 
 		rawProfile = p7.Content
 	}
-
+	if c.skipParseEnrollProf {
+		c.EnrollInfo.RawProfile = rawProfile
+		return nil
+	}
 	enrollInfo, err := ParseEnrollmentProfile(rawProfile)
 	if err != nil {
 		return fmt.Errorf("parse enrollment profile: %w", err)
 	}
+	enrollInfo.RawProfile = rawProfile
 	c.EnrollInfo = *enrollInfo
 
 	return nil

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -367,7 +367,7 @@ func (c *TestAppleMDMClient) enrollDevice(awaitingConfiguration bool) error {
 
 	// TODO: simulate ACME enrollment instead of SCEP enrollment for now just do some basic checks
 	// on the profile content.
-	if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
+	if c.EnrollInfo.SCEPURL == "" || !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.scep")) {
 		if !bytes.Contains(c.EnrollInfo.RawProfile, []byte("com.apple.security.acme")) {
 			return fmt.Errorf("enrollment profile should contain either SCEP or ACME payload")
 		}

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2036,6 +2036,20 @@ func (ds *Datastore) GetHostDEPAssignment(ctx context.Context, hostID uint) (*fl
 	return &res, nil
 }
 
+func (ds *Datastore) GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+	var res []*fleet.HostDEPAssignment
+	// TODO: update this query to rely on the new hardware_serial column to be added to
+	// host_dep_assignments and remove the subselect to hosts
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &res, `
+		SELECT host_id, added_at, deleted_at, abm_token_id, mdm_migration_deadline, mdm_migration_completed 
+		FROM host_dep_assignments hdep
+		WHERE hdep.host_id IN (SELECT id FROM hosts WHERE hardware_serial = ?) AND hdep.deleted_at IS NULL`, serial)
+	if err != nil {
+		return nil, ctxerr.Wrapf(ctx, err, "getting host dep assignments by serial")
+	}
+	return res, nil
+}
+
 func (ds *Datastore) SetHostMDMMigrationCompleted(ctx context.Context, hostID uint) error {
 	_, err := ds.writer(ctx).ExecContext(ctx, `
 		UPDATE host_dep_assignments

--- a/server/fleet/apple_mdm.go
+++ b/server/fleet/apple_mdm.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1019,6 +1020,66 @@ type MDMAppleMachineInfo struct {
 	SupplementalOSVersionExtra  string `plist:"SUPPLEMENTAL_OS_VERSION_EXTRA,omitempty"`
 	UDID                        string `plist:"UDID"`
 	Version                     string `plist:"VERSION"`
+}
+
+// macProductRe matches a macOS model identifier such as "MacBookPro18,3", capturing the
+// alphabetic family prefix (group 1) and the numeric major version (group 2).
+var macProductRe = regexp.MustCompile(`^([A-Za-z]+)(\d+),\d+$`)
+
+// appleSiliconMajorThreshold maps each traditional Mac product family to the first major
+// version number that corresponds to an Apple Silicon model. Any major version equal to or
+// greater than the threshold is Apple Silicon; lower versions are x86.
+var appleSiliconMajorThreshold = map[string]int{
+	// MacBookAir10,1 was the first Apple Silicon MacBook Air (M1, Late 2020).
+	"MacBookAir": 10,
+	// MacBookPro17,1 was the first Apple Silicon MacBook Pro (M1, Late 2020).
+	"MacBookPro": 17,
+	// Macmini9,1 was the first Apple Silicon Mac mini (M1, Late 2020).
+	"Macmini": 9,
+	// iMac21,1 was the first Apple Silicon iMac (M1, Early 2021).
+	"iMac": 21,
+}
+
+// IsMacAppleSilicon determines whether the device is an Apple Silicon Mac. If the model identifier
+// starts with iPhone, iPod, or iPad, it returns false with no error; however, other non-Mac Apple
+// devices like AppleTV will return an error.
+func IsMacAppleSilicon(modelIdentifier string) (bool, error) {
+	if strings.HasPrefix(modelIdentifier, "iPhone") ||
+		strings.HasPrefix(modelIdentifier, "iPod") ||
+		strings.HasPrefix(modelIdentifier, "iPad") {
+		// If the model identifier starts with iPhone, iPod, or iPad, we'll return false with no
+		// error; however, other non-Mac Apple devices like AppleTV will return an error
+		return false, nil
+	}
+
+	matches := macProductRe.FindStringSubmatch(modelIdentifier)
+	if matches == nil {
+		return false, fmt.Errorf("unrecognized product identifier format: %q", modelIdentifier)
+	}
+
+	family := matches[1]
+	major, _ := strconv.Atoi(matches[2])
+
+	// Model identifiers starting with "Mac" immediately followed by a digit (e.g. "Mac13,1")
+	// represent the unified naming scheme Apple adopted for Apple Silicon products such as the
+	// Mac Studio and the M2/M3/M4-era Mac Pro. All such identifiers are Apple Silicon.
+	if family == "Mac" {
+		return true, nil
+	}
+
+	// MacBook (no suffix), iMacPro, and MacPro were all discontinued before Apple Silicon
+	// was introduced; every model in these families is x86.
+	switch family {
+	case "MacBook", "iMacPro", "MacPro":
+		return false, nil
+	}
+
+	threshold, ok := appleSiliconMajorThreshold[family]
+	if !ok {
+		return false, fmt.Errorf("unrecognized Mac product family in identifier: %q", modelIdentifier)
+	}
+
+	return major >= threshold, nil
 }
 
 // MDMAppleAccountDrivenUserEnrollDeviceInfo is a more minimal version of DeviceInfo sent on Account

--- a/server/fleet/apple_mdm_test.go
+++ b/server/fleet/apple_mdm_test.go
@@ -829,3 +829,92 @@ func TestValidateNoSecretsInProfileName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMacAppleSilicon(t *testing.T) {
+	cases := []struct {
+		product string
+		wantAS  bool
+		wantErr bool
+	}{
+		// --- MacBookPro ---
+		// x86: last Intel model before Apple Silicon transition
+		{product: "MacBookPro16,1", wantAS: false},
+		{product: "MacBookPro16,4", wantAS: false},
+		// Apple Silicon: first AS model (M1, Late 2020) and later
+		{product: "MacBookPro17,1", wantAS: true},
+		{product: "MacBookPro18,3", wantAS: true},
+		{product: "MacBookPro18,4", wantAS: true},
+
+		// --- MacBookAir ---
+		// x86: last Intel model before Apple Silicon transition
+		{product: "MacBookAir9,1", wantAS: false},
+		// Apple Silicon: first AS model (M1, Late 2020) and later
+		{product: "MacBookAir10,1", wantAS: true},
+		{product: "MacBookAir14,2", wantAS: true},
+
+		// --- Macmini ---
+		// x86: last Intel model before Apple Silicon transition
+		{product: "Macmini8,1", wantAS: false},
+		// Apple Silicon: first AS model (M1, Late 2020) and later
+		{product: "Macmini9,1", wantAS: true},
+		{product: "Macmini9,2", wantAS: true},
+
+		// --- iMac ---
+		// x86: last Intel models before Apple Silicon transition
+		{product: "iMac20,1", wantAS: false},
+		{product: "iMac20,2", wantAS: false},
+		// Apple Silicon: first AS model (M1, Early 2021) and later
+		{product: "iMac21,1", wantAS: true},
+		{product: "iMac21,2", wantAS: true},
+
+		// --- MacBook (no suffix) — all x86, line discontinued before Apple Silicon ---
+		{product: "MacBook10,1", wantAS: false},
+		{product: "MacBook9,1", wantAS: false},
+
+		// --- iMacPro — all x86, discontinued before Apple Silicon ---
+		{product: "iMacPro1,1", wantAS: false},
+
+		// --- MacPro — old numbering, all x86 ---
+		// (the AS Mac Pro uses the "Mac" prefix, e.g. Mac14,8)
+		{product: "MacPro7,1", wantAS: false},
+		{product: "MacPro6,1", wantAS: false},
+
+		// --- Mac (bare prefix) — unified Apple Silicon naming ---
+		// Mac Studio (M1 Ultra, 2022)
+		{product: "Mac13,1", wantAS: true},
+		{product: "Mac13,2", wantAS: true},
+		// Mac Pro (M2 Ultra, 2023)
+		{product: "Mac14,8", wantAS: true},
+		// Mac mini (M4, 2024)
+		{product: "Mac16,10", wantAS: true},
+
+		// --- Non-Mac Apple devices — return false without error ---
+		{product: "iPhone15,2", wantAS: false},
+		{product: "iPhone14,3", wantAS: false},
+		{product: "iPad13,18", wantAS: false},
+		{product: "iPodTouch9,1", wantAS: false},
+
+		// --- Error cases ---
+		// Empty string
+		{product: "", wantErr: true},
+		// No comma separator
+		{product: "MacBookPro18", wantErr: true},
+		// Garbage input
+		{product: "not-a-model", wantErr: true},
+		// Non-Mac Apple devices that don't start with iPhone/iPod/iPad return an error
+		{product: "AppleTV6,2", wantErr: true},
+		{product: "AppleTV14,1", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.product, func(t *testing.T) {
+			got, err := IsMacAppleSilicon(tc.product)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantAS, got)
+			}
+		})
+	}
+}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1404,6 +1404,9 @@ type Datastore interface {
 	// GetHostDEPAssignment returns the DEP assignment for the host.
 	GetHostDEPAssignment(ctx context.Context, hostID uint) (*HostDEPAssignment, error)
 
+	// GetHostDEPAssignmentsBySerial returns the DEP assignment for the host with the specified serial number.
+	GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*HostDEPAssignment, error)
+
 	// GetNanoMDMEnrollment returns the nano enrollment information for the device id.
 	GetNanoMDMEnrollment(ctx context.Context, id string) (*NanoEnrollment, error)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -916,7 +916,7 @@ type Service interface {
 	GetMDMAppleProfilesSummary(ctx context.Context, teamID *uint) (*MDMProfilesSummary, error)
 
 	// GetMDMAppleEnrollmentProfileByToken returns the Apple enrollment from its secret token.
-	GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error)
+	GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string, machineInfo *MDMAppleMachineInfo) (profile []byte, err error)
 
 	// GetMDMAppleEnrollmentProfileByToken returns the Apple account-driven user enrollment profile for a given enrollment reference.
 	GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enrollReference string) (profile []byte, err error)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -83,6 +83,10 @@ func ResolveAppleSCEPURL(serverURL string) (string, error) {
 	return commonmdm.ResolveURL(serverURL, SCEPPath, true)
 }
 
+func ResolveAppleACMEDirectoryURL(serverURL string, acmeIdent string) (string, error) {
+	return commonmdm.ResolveURL(serverURL, fmt.Sprintf("/api/mdm/acme/%s/directory", acmeIdent), true)
+}
+
 // DEPService is used to encapsulate tasks related to DEP enrollment.
 //
 // This service doesn't perform any authentication checks, so its suitable for
@@ -1269,6 +1273,89 @@ var accountDrivenUserEnrollmentProfileMobileconfigTemplate = template.Must(templ
 </dict>
 </plist>`))
 
+var acmeEnrollmentProfileMobileconfigTemplate = template.Must(template.New("").Funcs(funcMap).Parse(`
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>Attest</key>
+			<true/>
+			<key>ClientIdentifier</key>
+			<string>{{ .ClientIdentifier | xml }}</string>
+			<key>DirectoryURL</key>
+			<string>{{ .DirectoryURL | xml }}</string>
+			<key>HardwareBound</key>
+			<true/>
+			<key>KeySize</key>
+			<integer>384</integer>
+			<key>KeyType</key>
+			<string>ECSECPrimeRandom</string>
+			<key>PayloadDisplayName</key>
+			<string>Fleet Identity ACME</string>
+			<key>PayloadIdentifier</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadType</key>
+			<string>com.apple.security.acme</string>
+			<key>PayloadUUID</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>Subject</key>
+			<array>
+				<array>
+					<array>
+						<string>CN</string>
+						<string>{{ .SerialTemplate | xml }}</string>
+					</array>
+				</array>
+			</array>
+		</dict>
+		<dict>
+			<key>AccessRights</key>
+			<integer>8191</integer>
+			<key>CheckOutWhenRemoved</key>
+			<true/>
+			<key>IdentityCertificateUUID</key>
+			<string>BCA53F9D-5DD2-494D-98D3-0D0F20FF6BA1</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.fleet.mdm.apple.mdm</string>
+			<key>PayloadType</key>
+			<string>com.apple.mdm</string>
+			<key>PayloadUUID</key>
+			<string>29713130-1602-4D27-90C9-B822A295E44E</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+			<key>ServerCapabilities</key>
+			<array>
+				<string>com.apple.mdm.per-user-connections</string>
+				<string>com.apple.mdm.bootstraptoken</string>
+			</array>
+			<key>ServerURL</key>
+			<string>{{ .ServerURL | xml }}</string>
+			<key>SignMessage</key>
+			<true/>
+			<key>Topic</key>
+			<string>{{ .Topic | xml }}</string>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>{{ .Organization | xml }} enrollment</string>
+	<key>PayloadIdentifier</key>
+	<string>` + FleetPayloadIdentifier + `</string>
+	<key>PayloadOrganization</key>
+	<string>{{ .Organization | xml }}</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>5ACABE91-CE30-4C05-93E3-B235C152404E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`))
+
 func GenerateEnrollmentProfileMobileconfig(orgName, fleetURL, scepChallenge, topic string) ([]byte, error) {
 	scepURL, err := ResolveAppleSCEPURL(fleetURL)
 	if err != nil {
@@ -1342,6 +1429,41 @@ func AddEnrollmentRefToFleetURL(fleetURL, reference string) (string, error) {
 	q.Add(mobileconfig.FleetEnrollReferenceKey, reference)
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, deviceSerial, topic string) ([]byte, error) {
+	serverURL, err := ResolveAppleMDMURL(mdmURL)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Apple MDM url: %w", err)
+	}
+
+	acmeURL, err := commonmdm.ResolveURL(mdmURL, fmt.Sprintf("/api/mdm/acme/%s/directory", acmeIdent), true)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	if err := acmeEnrollmentProfileMobileconfigTemplate.Funcs(funcMap).Execute(&buf, struct {
+		Organization     string
+		DirectoryURL     string
+		Topic            string
+		ServerURL        string
+		ClientIdentifier string
+		SerialTemplate   string
+	}{
+		Organization:     orgName,
+		DirectoryURL:     acmeURL,
+		Topic:            topic,
+		ServerURL:        serverURL,
+		ClientIdentifier: deviceSerial,
+		SerialTemplate:   `%SerialNumber%`, // Apple replaces this placeholder with the device's serial number during enrollment
+	}); err != nil {
+		return nil, fmt.Errorf("execute template: %w", err)
+	}
+
+	// TODO: Figure out why the generated profile escaopes the left angle bracket in the opening
+	// `<?xml` tag and remove the need for this replacement.
+	return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
 }
 
 // ProfileBimap implements bidirectional mapping for profiles, and utility

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1437,7 +1437,7 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		return nil, fmt.Errorf("resolve Apple MDM url: %w", err)
 	}
 
-	acmeURL, err := commonmdm.ResolveURL(mdmURL, fmt.Sprintf("/api/mdm/acme/%s/directory", acmeIdent), true)
+	acmeURL, err := ResolveAppleACMEDirectoryURL(mdmURL, acmeIdent)
 	if err != nil {
 		return nil, err
 	}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -981,6 +981,8 @@ type ListMDMAppleDEPSerialsInHostIDsFunc func(ctx context.Context, hostIDs []uin
 
 type GetHostDEPAssignmentFunc func(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, error)
 
+type GetHostDEPAssignmentsBySerialFunc func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error)
+
 type GetNanoMDMEnrollmentFunc func(ctx context.Context, id string) (*fleet.NanoEnrollment, error)
 
 type GetNanoMDMUserEnrollmentFunc func(ctx context.Context, id string) (*fleet.NanoEnrollment, error)
@@ -3252,6 +3254,9 @@ type DataStore struct {
 
 	GetHostDEPAssignmentFunc        GetHostDEPAssignmentFunc
 	GetHostDEPAssignmentFuncInvoked bool
+
+	GetHostDEPAssignmentsBySerialFunc        GetHostDEPAssignmentsBySerialFunc
+	GetHostDEPAssignmentsBySerialFuncInvoked bool
 
 	GetNanoMDMEnrollmentFunc        GetNanoMDMEnrollmentFunc
 	GetNanoMDMEnrollmentFuncInvoked bool
@@ -7858,6 +7863,13 @@ func (s *DataStore) GetHostDEPAssignment(ctx context.Context, hostID uint) (*fle
 	s.GetHostDEPAssignmentFuncInvoked = true
 	s.mu.Unlock()
 	return s.GetHostDEPAssignmentFunc(ctx, hostID)
+}
+
+func (s *DataStore) GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+	s.mu.Lock()
+	s.GetHostDEPAssignmentsBySerialFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostDEPAssignmentsBySerialFunc(ctx, serial)
 }
 
 func (s *DataStore) GetNanoMDMEnrollment(ctx context.Context, id string) (*fleet.NanoEnrollment, error) {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -577,7 +577,7 @@ type GetMDMAppleFileVaultSummaryFunc func(ctx context.Context, teamID *uint) (*f
 
 type GetMDMAppleProfilesSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error)
 
-type GetMDMAppleEnrollmentProfileByTokenFunc func(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error)
+type GetMDMAppleEnrollmentProfileByTokenFunc func(ctx context.Context, enrollmentToken string, enrollmentRef string, machineInfo *fleet.MDMAppleMachineInfo) (profile []byte, err error)
 
 type GetMDMAppleAccountEnrollmentProfileFunc func(ctx context.Context, enrollReference string) (profile []byte, err error)
 
@@ -4156,11 +4156,11 @@ func (s *Service) GetMDMAppleProfilesSummary(ctx context.Context, teamID *uint) 
 	return s.GetMDMAppleProfilesSummaryFunc(ctx, teamID)
 }
 
-func (s *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string) (profile []byte, err error) {
+func (s *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, enrollmentToken string, enrollmentRef string, machineInfo *fleet.MDMAppleMachineInfo) (profile []byte, err error) {
 	s.mu.Lock()
 	s.GetMDMAppleEnrollmentProfileByTokenFuncInvoked = true
 	s.mu.Unlock()
-	return s.GetMDMAppleEnrollmentProfileByTokenFunc(ctx, enrollmentToken, enrollmentRef)
+	return s.GetMDMAppleEnrollmentProfileByTokenFunc(ctx, enrollmentToken, enrollmentRef, machineInfo)
 }
 
 func (s *Service) GetMDMAppleAccountEnrollmentProfile(ctx context.Context, enrollReference string) (profile []byte, err error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2019,7 +2019,7 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 	svc.authz.SkipAuthorization(ctx)
 
 	if machineInfo == nil {
-		// this should never happen since we check for it in the handler, but adding this check for extra safety
+		// TODO: confirm how we want to handle this case
 		return nil, ctxerr.New(ctx, "get enrollment profile: missing machine info")
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2048,35 +2048,24 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 
 	var requireACME bool
 	if appConfig.MDM.AppleRequireHardwareAttestation {
-		requireACME, err = fleet.IsMacAppleSilicon(machineInfo.Product)
+		requireACME, err = svc.isMDMAppleACMERequired(ctx, appConfig, machineInfo)
 		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "checking if device is Apple Silicon")
+			return nil, ctxerr.Wrap(ctx, err, "checking if ACME enrollment is required")
 		}
-		svc.logger.InfoContext(ctx, "require ACME enrollment profile", "require_acme", requireACME, "product", machineInfo.Product)
+
+		svc.logger.InfoContext(ctx, "hardware attestastion required", "require_acme", requireACME, "product", machineInfo.Product, "serial", machineInfo.Serial)
+
 	}
 
 	var enrollProf []byte
 	if requireACME {
-		enrollProf, err = svc.stubGetACMEEnrollProfile(ctx, appConfig, machineInfo, mdmURL, topic)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "getting ACME enroll profile")
-		}
+		enrollProf, err = svc.generateMDMAppleACMEEnrollProfile(ctx, machineInfo.Serial, appConfig.OrgInfo.OrgName, mdmURL, topic)
 	} else {
-		assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
-			fleet.MDMAssetSCEPChallenge,
-		}, nil)
-		if err != nil {
-			return nil, fmt.Errorf("loading SCEP challenge from the database: %w", err)
-		}
-		enrollProf, err = apple_mdm.GenerateEnrollmentProfileMobileconfig(
-			appConfig.OrgInfo.OrgName,
-			mdmURL,
-			string(assets[fleet.MDMAssetSCEPChallenge].Value),
-			topic,
-		)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "generating enrollment profile")
-		}
+		enrollProf, err = svc.generateMDMAppleSCEPEnrollProfile(ctx, appConfig.OrgInfo.OrgName, mdmURL, topic)
+	}
+
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generating enrollment profile")
 	}
 
 	signed, err := mdmcrypto.Sign(ctx, enrollProf, svc.ds)
@@ -2087,108 +2076,64 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 	return signed, nil
 }
 
-func (svc *Service) stubGetACMEEnrollProfile(ctx context.Context, appConfig *fleet.AppConfig, machineInfo *fleet.MDMAppleMachineInfo, mdmURL string, topic string) ([]byte, error) {
-	if appConfig == nil {
-		return nil, ctxerr.New(ctx, "app config is nil")
-	}
+func (svc *Service) isMDMAppleACMERequired(ctx context.Context, appConfig *fleet.AppConfig, machineInfo *fleet.MDMAppleMachineInfo) (bool, error) {
 	if machineInfo == nil {
-		return nil, ctxerr.New(ctx, "machine info is nil")
+		return false, ctxerr.New(ctx, "machine info is nil")
 	}
 
-	hostIdents, err := svc.GetHostMDMIdentifiersFromMachineInfo(ctx, machineInfo)
+	// we only require ACME for Apple Silicon Macs, so check the product to see if it's an Apple Silicon Mac before doing any further checks
+	if isMacAppleSilicon, err := fleet.IsMacAppleSilicon(machineInfo.Product); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "checking if device is Apple Silicon")
+	} else if !isMacAppleSilicon {
+		return false, nil
+	}
+
+	// check dep assignment status, we only require ACME if the serial is DEP-assigned to Fleet
+	assignments, err := svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "getting host MDM identifiers")
+		return false, ctxerr.Wrap(ctx, err, "checking DEP assignment status")
 	}
+	svc.logger.InfoContext(ctx, "device is Apple Silicon, checking DEP assignment status for ACME requirement", "serial", machineInfo.Serial, "dep_assignments_count", len(assignments))
 
+	return len(assignments) > 0, nil
+}
+
+func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string) ([]byte, error) {
 	acmeIdent := "foobar" // TODO: replace this with call to upsert acme enrollments
 
 	b, err := apple_mdm.GenerateACMEEnrollmentProfileMobileconfig(
-		appConfig.OrgInfo.OrgName,
+		orgName,
 		mdmURL,
 		acmeIdent,
-		hostIdents.HardwareSerial,
+		hardwareSerial,
 		topic,
 	)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "generating ACME enrollment profile")
+		return nil, ctxerr.Wrap(ctx, err, "generateMDMAppleACMEEnrollProfile: generating ACME enrollment profile")
 	}
 
 	return b, nil
 }
 
-func (svc *Service) GetHostMDMIdentifiersFromMachineInfo(ctx context.Context, machineInfo *fleet.MDMAppleMachineInfo) (*fleet.HostMDMIdentifiers, error) {
-	if machineInfo == nil {
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "machine info is nil"),
-		}
-	}
-	if machineInfo.Serial == "" {
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "serial number is required in machine info"),
-		}
+func (svc *Service) generateMDMAppleSCEPEnrollProfile(ctx context.Context, orgName string, mdmURL string, topic string) ([]byte, error) {
+	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
+		fleet.MDMAssetSCEPChallenge,
+	}, nil)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generateMDMAppleSCEPEnrollProfile: loading SCEP challenge from the database")
 	}
 
-	// TODO: make this datastore call plus switch into a service method that can be mocked and tested more easily; we want to be able to test various scenarios around the returned idents and how we handle them in the enrollment flow
-	idents, err := svc.ds.GetHostMDMIdentifiers(ctx, machineInfo.Serial, fleet.TeamFilter{
-		// TODO: do we have specific team filter for system users (e.g., cron, MDM enroll handlers, ACME
-		// webhook, etc.)
-		User: &fleet.User{
-			Name:       "dummy", // TODO: figure this out, we just need to pass something here to satisfy the authz checks in the datastore method but it would be good to have a more robust solution for system users
-			GlobalRole: ptr.String(fleet.RoleAdmin),
-		},
-	})
-	switch {
-	case err != nil:
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.Wrap(ctx, err, "getting host MDM identifiers from the database"),
-		}
-	case len(idents) != 1:
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, fmt.Sprintf("expected to find exactly 1 host with the given serial number, but found %d", len(idents))),
-		}
-	case idents[0] == nil:
-		// this should never happen, but sanity check just in case
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "host found with the given serial number has nil MDM identifiers"),
-		}
-	case idents[0].HardwareSerial != machineInfo.Serial:
-		// this should never happen since we're querying by the serial number, but we check just to
-		// be safe and to avoid any potential shenanigans like matching on a different identifier
-		// and then having a mismatch on the serial number
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different serial number than the one provided in the machine info"),
-		}
-	case idents[0].UUID != "" && idents[0].UUID != machineInfo.UDID:
-		// Similar to the hardware serial check above, this is a sanity check to ensure that if we
-		// have stored a UDID for the host (i.e., not a pending DEP host), it matches the UDID provided in the machine info
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different UDID than the one provided in the machine info"),
-		}
-	case idents[0].Platform != "darwin":
-		// TODO: expand this to work for iOS/iPadOS as well
-		return nil, &fleet.BadRequestError{
-			Message:     "machine info is required",
-			InternalErr: ctxerr.New(ctx, "host found with the given serial number is not a darwin device"),
-		}
+	enrollProf, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
+		orgName,
+		mdmURL,
+		string(assets[fleet.MDMAssetSCEPChallenge].Value),
+		topic,
+	)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generateMDMAppleSCEPEnrollProfile: generating enrollment profile")
 	}
 
-	// TODO: add check that host is dep assigned to Fleet (and deleted_at is null)
-
-	// TODO: if mdm idp enabled, add check that host_mdm_idp_accounts has a record for the host uuid
-	// (and confirm account_uuid exists, not empty, additional validation of account details?)
-
-	// TODO: we can add other checks here as well to potentially validate other information we have
-	// from fleetd, DEP sync, any prior MDM enrollments (in case of renewal or return to service?),
-	// or other device inventory sources (e.g., maybe allow admin to upload list?)
-
-	return idents[0], nil
+	return enrollProf, nil
 }
 
 func (svc *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -1836,7 +1836,7 @@ func mdmAppleEnrollEndpoint(ctx context.Context, request interface{}, svc fleet.
 		return mdmAppleEnrollResponse{Err: err}, nil
 	}
 
-	profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, req.Token, legacyRef)
+	profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, req.Token, legacyRef, req.MachineInfo)
 	if err != nil {
 		return mdmAppleEnrollResponse{Err: err}, nil
 	}
@@ -2014,9 +2014,14 @@ func (svc *Service) ReconcileMDMAppleEnrollRef(ctx context.Context, enrollRef st
 	return legacyRef, nil
 }
 
-func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, token string, ref string) (profile []byte, err error) {
+func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, token string, ref string, machineInfo *fleet.MDMAppleMachineInfo) (profile []byte, err error) {
 	// skipauth: The enroll profile endpoint is unauthenticated.
 	svc.authz.SkipAuthorization(ctx)
+
+	if machineInfo == nil {
+		// this should never happen since we check for it in the handler, but adding this check for extra safety
+		return nil, ctxerr.New(ctx, "get enrollment profile: missing machine info")
+	}
 
 	_, err = svc.ds.GetMDMAppleEnrollmentProfileByToken(ctx, token)
 	if err != nil {
@@ -2031,7 +2036,7 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err)
 	}
 
-	enrollURL, err := apple_mdm.AddEnrollmentRefToFleetURL(appConfig.MDMUrl(), ref)
+	mdmURL, err := apple_mdm.AddEnrollmentRefToFleetURL(appConfig.MDMUrl(), ref)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "adding reference to fleet URL")
 	}
@@ -2041,28 +2046,149 @@ func (svc *Service) GetMDMAppleEnrollmentProfileByToken(ctx context.Context, tok
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")
 	}
 
-	assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
-		fleet.MDMAssetSCEPChallenge,
-	}, nil)
-	if err != nil {
-		return nil, fmt.Errorf("loading SCEP challenge from the database: %w", err)
-	}
-	enrollmentProf, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
-		appConfig.OrgInfo.OrgName,
-		enrollURL,
-		string(assets[fleet.MDMAssetSCEPChallenge].Value),
-		topic,
-	)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "generating enrollment profile")
+	var requireACME bool
+	if appConfig.MDM.AppleRequireHardwareAttestation {
+		requireACME, err = fleet.IsMacAppleSilicon(machineInfo.Product)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "checking if device is Apple Silicon")
+		}
+		svc.logger.InfoContext(ctx, "require ACME enrollment profile", "require_acme", requireACME, "product", machineInfo.Product)
 	}
 
-	signed, err := mdmcrypto.Sign(ctx, enrollmentProf, svc.ds)
+	var enrollProf []byte
+	if requireACME {
+		enrollProf, err = svc.stubGetACMEEnrollProfile(ctx, appConfig, machineInfo, mdmURL, topic)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "getting ACME enroll profile")
+		}
+	} else {
+		assets, err := svc.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{
+			fleet.MDMAssetSCEPChallenge,
+		}, nil)
+		if err != nil {
+			return nil, fmt.Errorf("loading SCEP challenge from the database: %w", err)
+		}
+		enrollProf, err = apple_mdm.GenerateEnrollmentProfileMobileconfig(
+			appConfig.OrgInfo.OrgName,
+			mdmURL,
+			string(assets[fleet.MDMAssetSCEPChallenge].Value),
+			topic,
+		)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "generating enrollment profile")
+		}
+	}
+
+	signed, err := mdmcrypto.Sign(ctx, enrollProf, svc.ds)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "signing profile")
 	}
 
 	return signed, nil
+}
+
+func (svc *Service) stubGetACMEEnrollProfile(ctx context.Context, appConfig *fleet.AppConfig, machineInfo *fleet.MDMAppleMachineInfo, mdmURL string, topic string) ([]byte, error) {
+	if appConfig == nil {
+		return nil, ctxerr.New(ctx, "app config is nil")
+	}
+	if machineInfo == nil {
+		return nil, ctxerr.New(ctx, "machine info is nil")
+	}
+
+	hostIdents, err := svc.GetHostMDMIdentifiersFromMachineInfo(ctx, machineInfo)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting host MDM identifiers")
+	}
+
+	acmeIdent := "foobar" // TODO: replace this with call to upsert acme enrollments
+
+	b, err := apple_mdm.GenerateACMEEnrollmentProfileMobileconfig(
+		appConfig.OrgInfo.OrgName,
+		mdmURL,
+		acmeIdent,
+		hostIdents.HardwareSerial,
+		topic,
+	)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "generating ACME enrollment profile")
+	}
+
+	return b, nil
+}
+
+func (svc *Service) GetHostMDMIdentifiersFromMachineInfo(ctx context.Context, machineInfo *fleet.MDMAppleMachineInfo) (*fleet.HostMDMIdentifiers, error) {
+	if machineInfo == nil {
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "machine info is nil"),
+		}
+	}
+	if machineInfo.Serial == "" {
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "serial number is required in machine info"),
+		}
+	}
+
+	// TODO: make this datastore call plus switch into a service method that can be mocked and tested more easily; we want to be able to test various scenarios around the returned idents and how we handle them in the enrollment flow
+	idents, err := svc.ds.GetHostMDMIdentifiers(ctx, machineInfo.Serial, fleet.TeamFilter{
+		// TODO: do we have specific team filter for system users (e.g., cron, MDM enroll handlers, ACME
+		// webhook, etc.)
+		User: &fleet.User{
+			Name:       "dummy", // TODO: figure this out, we just need to pass something here to satisfy the authz checks in the datastore method but it would be good to have a more robust solution for system users
+			GlobalRole: ptr.String(fleet.RoleAdmin),
+		},
+	})
+	switch {
+	case err != nil:
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.Wrap(ctx, err, "getting host MDM identifiers from the database"),
+		}
+	case len(idents) != 1:
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, fmt.Sprintf("expected to find exactly 1 host with the given serial number, but found %d", len(idents))),
+		}
+	case idents[0] == nil:
+		// this should never happen, but sanity check just in case
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number has nil MDM identifiers"),
+		}
+	case idents[0].HardwareSerial != machineInfo.Serial:
+		// this should never happen since we're querying by the serial number, but we check just to
+		// be safe and to avoid any potential shenanigans like matching on a different identifier
+		// and then having a mismatch on the serial number
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different serial number than the one provided in the machine info"),
+		}
+	case idents[0].UUID != "" && idents[0].UUID != machineInfo.UDID:
+		// Similar to the hardware serial check above, this is a sanity check to ensure that if we
+		// have stored a UDID for the host (i.e., not a pending DEP host), it matches the UDID provided in the machine info
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number has a different UDID than the one provided in the machine info"),
+		}
+	case idents[0].Platform != "darwin":
+		// TODO: expand this to work for iOS/iPadOS as well
+		return nil, &fleet.BadRequestError{
+			Message:     "machine info is required",
+			InternalErr: ctxerr.New(ctx, "host found with the given serial number is not a darwin device"),
+		}
+	}
+
+	// TODO: add check that host is dep assigned to Fleet (and deleted_at is null)
+
+	// TODO: if mdm idp enabled, add check that host_mdm_idp_accounts has a record for the host uuid
+	// (and confirm account_uuid exists, not empty, additional validation of account details?)
+
+	// TODO: we can add other checks here as well to potentially validate other information we have
+	// from fleetd, DEP sync, any prior MDM enrollments (in case of renewal or return to service?),
+	// or other device inventory sources (e.g., maybe allow admin to upload list?)
+
+	return idents[0], nil
 }
 
 func (svc *Service) CheckMDMAppleEnrollmentWithMinimumOSVersion(ctx context.Context, m *fleet.MDMAppleMachineInfo) (*fleet.MDMAppleSoftwareUpdateRequired, error) {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -7034,3 +7034,238 @@ func TestMDMTokenUpdateSCEPRenewal(t *testing.T) {
 		require.False(t, newActivityFuncInvoked)
 	})
 }
+
+// decodeSignedEnrollmentProfile parses a PKCS7-signed enrollment profile and
+// returns the inner raw mobileconfig bytes for content assertions.
+func decodeSignedEnrollmentProfile(t *testing.T, signed []byte) []byte {
+	t.Helper()
+	p7, err := pkcs7.Parse(signed)
+	require.NoError(t, err, "parsing PKCS7 signed profile")
+	require.NoError(t, p7.Verify(), "verifying PKCS7 signature")
+	require.NotEmpty(t, p7.Content, "PKCS7 content should not be empty")
+	return p7.Content
+}
+
+// assertSCEPProfile checks that the decoded mobileconfig XML contains a SCEP
+// payload (com.apple.security.scep) and does not contain an ACME payload.
+func assertSCEPProfile(t *testing.T, content []byte) {
+	t.Helper()
+	require.Contains(t, string(content), "com.apple.security.scep", "expected SCEP payload type in profile")
+	require.NotContains(t, string(content), "com.apple.security.acme", "SCEP profile must not contain an ACME payload")
+}
+
+// assertACMEProfile checks that the decoded mobileconfig XML contains an ACME
+// payload (com.apple.security.acme) and does not contain a SCEP payload.
+func assertACMEProfile(t *testing.T, content []byte, deviceSerial string) {
+	t.Helper()
+	require.Contains(t, string(content), "com.apple.security.acme", "expected ACME payload type in profile")
+	require.NotContains(t, string(content), "com.apple.security.scep", "ACME profile must not contain a SCEP payload")
+	require.Contains(t, string(content), deviceSerial, "ACME profile should embed the device serial as ClientIdentifier")
+}
+
+func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
+	svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+	// Extend the existing asset mock to also include the SCEP challenge needed
+	// by generateMDMAppleSCEPEnrollProfile.
+	apnsCert, apnsKey, err := mysql.GenerateTestCertBytes(mdmtesting.NewTestMDMAppleCertTemplate())
+	require.NoError(t, err)
+	crt, key, err := apple_mdm.NewSCEPCACertKey()
+	require.NoError(t, err)
+	certPEM := tokenpki.PEMCertificate(crt.Raw)
+	keyPEM := tokenpki.PEMRSAPrivateKey(key)
+	ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, assetNames []fleet.MDMAssetName, _ sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+		return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+			fleet.MDMAssetAPNSCert:      {Value: apnsCert},
+			fleet.MDMAssetAPNSKey:       {Value: apnsKey},
+			fleet.MDMAssetCACert:        {Value: certPEM},
+			fleet.MDMAssetCAKey:         {Value: keyPEM},
+			fleet.MDMAssetSCEPChallenge: {Value: []byte("test-scep-challenge")},
+		}, nil
+	}
+
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{
+			OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+			ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+			MDM:            fleet.MDM{EnabledAndConfigured: true, AppleRequireHardwareAttestation: true},
+		}, nil
+	}
+
+	foundProfileFunc := func(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error) {
+		require.Equal(t, "valid-token", token)
+		return &fleet.MDMAppleEnrollmentProfile{
+			ID:    1,
+			Token: "valid-token",
+			// Type:  fleet.MDMAppleEnrollmentTypeManual,
+			// other fields are not relevant for this test
+		}, nil
+	}
+	ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
+
+	t.Run("happy path", func(t *testing.T) {
+		ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
+
+		testDevices := []struct {
+			name       string
+			mi         fleet.MDMAppleMachineInfo
+			expectACME bool // if true, the profile should contain an ACME payload when hardware attestation is required; if false, it should contain a SCEP payload
+		}{
+			{
+				name: "Apple Silicon Mac", mi: fleet.MDMAppleMachineInfo{
+					Product: "MacBookPro18,3", // major 18 >= threshold of 17 → Apple Silicon
+					Serial:  "MACSILSERIAL",
+					UDID:    "mac-sil-udid",
+				},
+				expectACME: true,
+			},
+			{
+				name: "Intel Mac",
+				mi: fleet.MDMAppleMachineInfo{
+					Product: "MacBookPro16,1", // major 16 < threshold of 17 → Intel
+					Serial:  "INTELSERIAL",
+					UDID:    "intel-udid",
+				},
+				expectACME: false,
+			},
+			{
+				name: "iPhone",
+				mi: fleet.MDMAppleMachineInfo{
+					Product: "iPhone14,3",
+					Serial:  "IPHONESERIAL",
+					UDID:    "iphone-udid",
+				},
+				expectACME: false,
+			},
+		}
+
+		t.Run("hardware attestation enabled", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM:            fleet.MDM{EnabledAndConfigured: true, AppleRequireHardwareAttestation: true},
+				}, nil
+			}
+			for _, device := range testDevices {
+				t.Run(device.name, func(t *testing.T) {
+					t.Run(fmt.Sprintf("not DEP assigned requires ACME %t", device.expectACME), func(t *testing.T) {
+						ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+							return []*fleet.HostDEPAssignment{}, nil
+						}
+						profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &device.mi)
+						require.NoError(t, err)
+						// always expect SCEP if not DEP assigned, even for Apple Silicon, since we currently limit ACME to DEP enrollment
+						assertSCEPProfile(t, decodeSignedEnrollmentProfile(t, profile))
+					})
+					t.Run(fmt.Sprintf("DEP assigned requires ACME %t", device.expectACME), func(t *testing.T) {
+						ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+							return []*fleet.HostDEPAssignment{{HostID: 1}}, nil
+						}
+						profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &device.mi)
+						require.NoError(t, err)
+						if device.expectACME {
+							assertACMEProfile(t, decodeSignedEnrollmentProfile(t, profile), device.mi.Serial)
+						} else {
+							assertSCEPProfile(t, decodeSignedEnrollmentProfile(t, profile))
+						}
+					})
+				})
+			}
+		})
+
+		t.Run("hardware attestation disabled", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+					ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+					MDM:            fleet.MDM{EnabledAndConfigured: true},
+				}, nil
+			}
+			for _, device := range testDevices {
+				t.Run(device.name, func(t *testing.T) {
+					profile, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &device.mi)
+					require.NoError(t, err)
+					// always expect SCEP if hardware attestation is disabled; DEP assignment and Apple Silicon do not matter in this case
+					assertSCEPProfile(t, decodeSignedEnrollmentProfile(t, profile))
+				})
+			}
+		})
+	})
+
+	t.Run("miscellaneous error handling", func(t *testing.T) {
+		// For these tests we can just use a single device type since we're not asserting on the
+		// profile content, just that errors are handled and returned properly.
+		machineInfo := fleet.MDMAppleMachineInfo{
+			Product: "MacBookPro18,3",
+			Serial:  "MACSILSERIAL",
+			UDID:    "mac-sil-udid",
+		}
+
+		t.Run("AppConfig error returns error", func(t *testing.T) {
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return nil, errors.New("some unexpected error")
+			}
+			_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &machineInfo)
+			require.Error(t, err)
+		})
+
+		// now test the various error cases for both hardware attestation enabled and disabled, since that changes the logic flow and we want to ensure all cases are covered
+		for _, hardwareAttestationRequired := range []bool{true, false} {
+			t.Run(fmt.Sprintf("hardware attestation required %t", hardwareAttestationRequired), func(t *testing.T) {
+				ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+					return &fleet.AppConfig{
+						OrgInfo:        fleet.OrgInfo{OrgName: "Foo Inc."},
+						ServerSettings: fleet.ServerSettings{ServerURL: "https://foo.example.com"},
+						MDM:            fleet.MDM{EnabledAndConfigured: true, AppleRequireHardwareAttestation: hardwareAttestationRequired},
+					}, nil
+				}
+				t.Run("nil machineInfo returns error", func(t *testing.T) {
+					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "some-token", "", nil)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "missing machine info")
+				})
+				t.Run("token not found returns auth failed error", func(t *testing.T) {
+					ds.GetMDMAppleEnrollmentProfileByTokenFunc = func(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error) {
+						return nil, newNotFoundError()
+					}
+					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "unknown-token", "", &machineInfo)
+					require.Error(t, err)
+					var authErr *fleet.AuthFailedError
+					require.ErrorAs(t, err, &authErr)
+					// restore the happy path for subsequent tests
+					ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
+				})
+				t.Run("datastore error returns wrapped error", func(t *testing.T) {
+					ds.GetMDMAppleEnrollmentProfileByTokenFunc = func(ctx context.Context, token string) (*fleet.MDMAppleEnrollmentProfile, error) {
+						return nil, errors.New("some unexpected error")
+					}
+					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &machineInfo)
+					require.Error(t, err)
+					require.Contains(t, err.Error(), "get enrollment profile")
+					// restore the happy path for subsequent tests
+					ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
+				})
+
+				t.Run("error fetching DEP assignments returns error", func(t *testing.T) {
+					ds.GetHostDEPAssignmentsBySerialFunc = func(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+						return nil, errors.New("some unexpected error")
+					}
+					ds.GetHostDEPAssignmentsBySerialFuncInvoked = false // reset invocation flag
+
+					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &machineInfo)
+					if hardwareAttestationRequired {
+						// when hardware attestation is required, DEP assignment is checked before deciding on ACME vs SCEP, so an error here should be returned
+						require.True(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						require.Error(t, err)
+						require.Contains(t, err.Error(), "checking DEP assignment")
+					} else {
+						// when hardware attestation is not required, DEP assignment is not relevant since we always return SCEP, so an error here should not be returned
+						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						require.NoError(t, err)
+					}
+				})
+			})
+		}
+	})
+}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -339,7 +339,7 @@ func TestAppleMDMAuthorization(t *testing.T) {
 	ctx = test.UserContext(ctx, test.UserNoRoles)
 	_, err := svc.GetMDMAppleInstallerByToken(ctx, "foo")
 	require.NoError(t, err)
-	_, err = svc.GetMDMAppleEnrollmentProfileByToken(ctx, "foo", "")
+	_, err = svc.GetMDMAppleEnrollmentProfileByToken(ctx, "foo", "", &fleet.MDMAppleMachineInfo{})
 	require.NoError(t, err)
 	_, err = svc.GetMDMAppleInstallerDetailsByToken(ctx, "foo")
 	require.NoError(t, err)

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3268,7 +3268,7 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	})
 	t.Cleanup(func() {
 		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-			_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+			_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', false)`)
 			return err
 		})
 	})

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3199,3 +3199,91 @@ func (s *integrationMDMTestSuite) TestSoftwareInventoryForADEMacOSAfterWipeAndRe
 	require.Equal(t, titleID2, getHostSw.Software[1].ID)
 	require.Equal(t, installerPayload2.Title, getHostSw.Software[1].Name)
 }
+
+func (s *integrationMDMTestSuite) TestDEPRequireACME() {
+	t := s.T()
+	s.enableABM(t.Name())
+
+	// for our tests, we'll crete two devices: devices[0] will be enrolled with ACME and
+	// devices[1] will be enrolled with SCEP
+	devices := []godep.Device{
+		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
+	}
+	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		encoder := json.NewEncoder(w)
+		switch r.URL.Path {
+		case "/session":
+			err := encoder.Encode(map[string]string{"auth_session_token": "xyz"})
+			require.NoError(t, err)
+		case "/profile":
+			err := encoder.Encode(godep.ProfileResponse{ProfileUUID: uuid.New().String()})
+			require.NoError(t, err)
+		case "/server/devices":
+			// This endpoint  is used to get an initial list of
+			// devices, return a single device
+			err := encoder.Encode(godep.DeviceResponse{Devices: devices})
+			require.NoError(t, err)
+		case "/devices/sync":
+			// This endpoint is polled over time to sync devices from
+			// ABM, send a repeated serial and a new one
+			err := encoder.Encode(godep.DeviceResponse{Devices: devices, Cursor: "foo"})
+			require.NoError(t, err)
+		case "/profile/devices":
+			b, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			var prof profileAssignmentReq
+			require.NoError(t, json.Unmarshal(b, &prof))
+			var resp godep.ProfileResponse
+			resp.ProfileUUID = prof.ProfileUUID
+			resp.Devices = make(map[string]string, len(prof.Devices))
+			for _, device := range prof.Devices {
+				resp.Devices[device] = string(fleet.DEPAssignProfileResponseSuccess)
+			}
+			err = encoder.Encode(resp)
+			require.NoError(t, err)
+		default:
+			_, _ = w.Write([]byte(`{}`))
+		}
+	}))
+	s.runDEPSchedule()
+
+	// confirm that the devices were created
+	listHostsRes := listHostsResponse{}
+	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
+	require.Len(t, listHostsRes.Hosts, 2)
+	bySerial := make(map[string]*fleet.Host, len(devices))
+	for _, h := range listHostsRes.Hosts {
+		bySerial[h.HardwareSerial] = h.Host
+	}
+
+	// set config.mdm.apple_require_hardware_attestation to true
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+		return err
+	})
+
+	// enroll the host
+	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
+	clientOpts := make([]mdmtest.TestMDMAppleClientOption, 0)
+	clientOpts = append(clientOpts, mdmtest.WithSkipParseEnrollProf(true))
+
+	appleSiliconDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, clientOpts...)
+	appleSiliconDevice.SerialNumber = devices[0].SerialNumber
+	appleSiliconDevice.Model = devices[0].Model
+	err := appleSiliconDevice.Enroll()
+	require.NoError(t, err)
+
+	expectIdent := "foobar" // TODO: update this once we implement upserts for acme_enrollments
+	require.Contains(t, string(appleSiliconDevice.EnrollInfo.RawProfile), "/api/mdm/acme/"+expectIdent+"/directory", "enrollment profile should contain the ACME directory URL")
+
+	// TODO: expand when full ACME flow is implemented
+
+	intelDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken)
+	intelDevice.SerialNumber = devices[1].SerialNumber
+	intelDevice.Model = devices[1].Model
+	err = intelDevice.Enroll()
+	require.NoError(t, err)
+	require.NotContains(t, string(intelDevice.EnrollInfo.RawProfile), "/api/mdm/acme/"+expectIdent+"/directory", "enrollment profile should not contain the ACME directory URL")
+}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -2299,8 +2299,8 @@ func (s *integrationMDMTestSuite) TestEnforceMiniumOSVersion() {
 	// for our tests, we'll crete two devices: devices[0] will be enrolled with no team and
 	// devices[1] will be enrolled with a team (created later in this test)
 	devices := []godep.Device{
-		{SerialNumber: uuid.New().String(), Model: "MacBook Pro", OS: "osx", OpType: "added"},
-		{SerialNumber: uuid.New().String(), Model: "MacBook Pro", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
 	}
 	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -3200,6 +3200,7 @@ func (s *integrationMDMTestSuite) TestSoftwareInventoryForADEMacOSAfterWipeAndRe
 	require.Equal(t, installerPayload2.Title, getHostSw.Software[1].Name)
 }
 
+// TODO: expand when full ACME flow is implemented
 func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	t := s.T()
 	s.enableABM(t.Name())
@@ -3249,6 +3250,8 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	}))
 	s.runDEPSchedule()
 
+	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
+
 	// confirm that the devices were created
 	listHostsRes := listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
@@ -3264,22 +3267,24 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 		return err
 	})
 
-	// enroll the host
-	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
-	clientOpts := make([]mdmtest.TestMDMAppleClientOption, 0)
-	clientOpts = append(clientOpts, mdmtest.WithSkipParseEnrollProf(true))
-
-	appleSiliconDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, clientOpts...)
+	// Apple Silicon Mac enrolls via ACME, should contain ACME directory URL in the profile
+	appleSiliconDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, mdmtest.WithSkipParseEnrollProf(true))
 	appleSiliconDevice.SerialNumber = devices[0].SerialNumber
 	appleSiliconDevice.Model = devices[0].Model
 	err := appleSiliconDevice.Enroll()
 	require.NoError(t, err)
 
-	expectIdent := "foobar" // TODO: update this once we implement upserts for acme_enrollments
+	var expectIdent string
+	// mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+	// 	stmt := `SELECT path_identifier FROM acme_enrollments WHERE host_identifier = ?`
+	// 	err := sqlx.GetContext(context.Background(), q, &expectIdent, stmt, appleSiliconDevice.SerialNumber)
+	// 	return err
+	// })
+	expectIdent = "foobar" // TODO: delete this and uncoment above
+
 	require.Contains(t, string(appleSiliconDevice.EnrollInfo.RawProfile), "/api/mdm/acme/"+expectIdent+"/directory", "enrollment profile should contain the ACME directory URL")
 
-	// TODO: expand when full ACME flow is implemented
-
+	// Intel Mac enrolls via SCEP, should not contain ACME directory URL in the profile
 	intelDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken)
 	intelDevice.SerialNumber = devices[1].SerialNumber
 	intelDevice.Model = devices[1].Model

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3266,6 +3266,12 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 		_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
 		return err
 	})
+	t.Cleanup(func() {
+		mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(context.Background(), `UPDATE app_config_json SET json_value = JSON_SET(json_value, '$.mdm.apple_require_hardware_attestation', true)`)
+			return err
+		})
+	})
 
 	// Apple Silicon Mac enrolls via ACME, should contain ACME directory URL in the profile
 	appleSiliconDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, mdmtest.WithSkipParseEnrollProf(true))


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40991 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
