### PR TITLE
Add failed install activities for when VPP installs are cancelled as a result of cancelling setup experience

### DIFF
--- a/changes/34288-vpp-setup-experience-failures
+++ b/changes/34288-vpp-setup-experience-failures
@@ -1,0 +1,1 @@
+* Added an activity for each VPP app install skipped when setup experience is cancelled

--- a/ee/server/service/devices.go
+++ b/ee/server/service/devices.go
@@ -319,7 +319,7 @@ func (svc *Service) getHostSetupExperienceStatus(ctx context.Context, host *flee
 	}
 
 	// Mark canceled items as failed.
-	err = svc.failCancelledSetupExperienceInstalls(ctx, host.ID, hostUUID, host.DisplayName(), results)
+	err = svc.failCancelledSetupExperienceInstalls(ctx, host.ID, hostUUID, host.DisplayName(), host.FleetPlatform(), results)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "failing cancelled setup experience installs")
 	}

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -289,20 +289,12 @@ func (svc *Service) failCancelledSetupExperienceInstalls(
 				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience software install")
 			}
 		} else if r.VPPAppTeamID != nil && r.SoftwareTitleID != nil { // VPP
-			appStoreID := ""
-			if r.VPPAppAdamID != nil {
-				appStoreID = *r.VPPAppAdamID
-			}
-			commandUUID := ""
-			if r.NanoCommandUUID != nil {
-				commandUUID = *r.NanoCommandUUID
-			}
 			activity := &fleet.ActivityInstalledAppStoreApp{
 				HostID:          hostID,
 				HostDisplayName: hostDisplayName,
 				SoftwareTitle:   r.Name,
-				AppStoreID:      appStoreID,
-				CommandUUID:     commandUUID,
+				AppStoreID:      ptr.ValOrZero(r.VPPAppAdamID),
+				CommandUUID:     ptr.ValOrZero(r.NanoCommandUUID),
 				Status:          "failed",
 				HostPlatform:    hostPlatform, // The only supported VPP platform for setup experience here is darwin
 			}

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -173,7 +173,7 @@ func (svc *Service) GetOrbitSetupExperienceStatus(ctx context.Context, orbitNode
 		}
 	}
 
-	err = svc.failCancelledSetupExperienceInstalls(ctx, host.ID, host.UUID, host.DisplayName(), res)
+	err = svc.failCancelledSetupExperienceInstalls(ctx, host.ID, host.UUID, host.DisplayName(), host.FleetPlatform(), res)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "failing cancelled setup experience installs")
 	}
@@ -238,6 +238,7 @@ func (svc *Service) failCancelledSetupExperienceInstalls(
 	hostID uint,
 	hostUUID string,
 	hostDisplayName string,
+	hostPlatform string,
 	results []*fleet.SetupExperienceStatusResult,
 ) error {
 	for _, r := range results {
@@ -286,6 +287,20 @@ func (svc *Service) failCancelledSetupExperienceInstalls(
 			err = svc.NewActivity(ctx, nil, activity)
 			if err != nil {
 				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience software install")
+			}
+		} else if r.VPPAppTeamID != nil && r.SoftwareTitleID != nil { // VPP
+			activity := &fleet.ActivityInstalledAppStoreApp{
+				HostID:          hostID,
+				HostDisplayName: hostDisplayName,
+				SoftwareTitle:   r.Name,
+				AppStoreID:      *r.VPPAppAdamID,
+				CommandUUID:     *r.NanoCommandUUID,
+				Status:          "failed",
+				HostPlatform:    hostPlatform, // The only supported VPP platform for setup experience here is darwin
+			}
+			err = svc.NewActivity(ctx, nil, activity)
+			if err != nil {
+				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience VPP install")
 			}
 		}
 		continue

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -289,12 +289,20 @@ func (svc *Service) failCancelledSetupExperienceInstalls(
 				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience software install")
 			}
 		} else if r.VPPAppTeamID != nil && r.SoftwareTitleID != nil { // VPP
+			appStoreID := ""
+			if r.VPPAppAdamID != nil {
+				appStoreID = *r.VPPAppAdamID
+			}
+			commandUUID := ""
+			if r.NanoCommandUUID != nil {
+				commandUUID = *r.NanoCommandUUID
+			}
 			activity := &fleet.ActivityInstalledAppStoreApp{
 				HostID:          hostID,
 				HostDisplayName: hostDisplayName,
 				SoftwareTitle:   r.Name,
-				AppStoreID:      *r.VPPAppAdamID,
-				CommandUUID:     *r.NanoCommandUUID,
+				AppStoreID:      appStoreID,
+				CommandUUID:     commandUUID,
 				Status:          "failed",
 				HostPlatform:    hostPlatform, // The only supported VPP platform for setup experience here is darwin
 			}

--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
@@ -306,5 +307,262 @@ func TestSetupExperienceSetWithManualAgentInstall(t *testing.T) {
 			err := svc.SetSetupExperienceSoftware(ctx, platform, 0, []uint{1, 2})
 			require.NoError(t, err)
 		}
+	})
+}
+
+func TestFailCancelledSetupExperienceInstalls(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	svc, baseSvc := newTestServiceWithMock(t, ds)
+	svc.logger = slog.Default()
+
+	ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+		return nil
+	}
+
+	t.Run("cancelled VPP app creates failed activity", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		vppTeamID := uint(1)
+		adamID := "12345"
+		cmdUUID := "cmd-uuid-1"
+		titleID := uint(10)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", results)
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+
+		act, ok := activities[0].(*fleet.ActivityInstalledAppStoreApp)
+		require.True(t, ok)
+		assert.Equal(t, uint(1), act.HostID)
+		assert.Equal(t, "Test Host", act.HostDisplayName)
+		assert.Equal(t, "VPP App", act.SoftwareTitle)
+		assert.Equal(t, "12345", act.AppStoreID)
+		assert.Equal(t, "cmd-uuid-1", act.CommandUUID)
+		assert.Equal(t, "failed", act.Status)
+		assert.Equal(t, "darwin", act.HostPlatform)
+
+		// Verify the status was changed to failure
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+	})
+
+	t.Run("non-cancelled VPP app is skipped", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		vppTeamID := uint(1)
+		adamID := "12345"
+		cmdUUID := "cmd-uuid-1"
+		titleID := uint(10)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App Pending",
+				Status:          fleet.SetupExperienceStatusPending,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App Success",
+				Status:          fleet.SetupExperienceStatusSuccess,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App Running",
+				Status:          fleet.SetupExperienceStatusRunning,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App Failed",
+				Status:          fleet.SetupExperienceStatusFailure,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", results)
+		require.NoError(t, err)
+		assert.Empty(t, activities)
+
+		// Statuses should be unchanged
+		assert.Equal(t, fleet.SetupExperienceStatusPending, results[0].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusSuccess, results[1].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusRunning, results[2].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[3].Status)
+	})
+
+	t.Run("cancelled software package and VPP app both create activities", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		installerID := uint(5)
+		executionID := "exec-uuid-1"
+		vppTeamID := uint(1)
+		adamID := "67890"
+		cmdUUID := "cmd-uuid-2"
+		titleID := uint(20)
+
+		ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+			return &fleet.SoftwareInstaller{
+				Name:    "installer.pkg",
+				TitleID: ptr.Uint(30),
+			}, nil
+		}
+		ds.SoftwareTitleByIDFunc = func(ctx context.Context, id uint, teamID *uint, tmFilter fleet.TeamFilter) (*fleet.SoftwareTitle, error) {
+			source := "apps"
+			return &fleet.SoftwareTitle{Source: source}, nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:                        "host-uuid",
+				Name:                            "Software Package",
+				Status:                          fleet.SetupExperienceStatusCancelled,
+				SoftwareInstallerID:             &installerID,
+				HostSoftwareInstallsExecutionID: &executionID,
+			},
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", results)
+		require.NoError(t, err)
+		require.Len(t, activities, 2)
+
+		// First activity should be the software package install
+		swAct, ok := activities[0].(fleet.ActivityTypeInstalledSoftware)
+		require.True(t, ok)
+		assert.Equal(t, "failed", swAct.Status)
+		assert.Equal(t, "Software Package", swAct.SoftwareTitle)
+		assert.Equal(t, "installer.pkg", swAct.SoftwarePackage)
+		assert.True(t, swAct.FromSetupExperience)
+		assert.False(t, swAct.SelfService)
+
+		// Second activity should be the VPP app install
+		vppAct, ok := activities[1].(*fleet.ActivityInstalledAppStoreApp)
+		require.True(t, ok)
+		assert.Equal(t, "failed", vppAct.Status)
+		assert.Equal(t, "VPP App", vppAct.SoftwareTitle)
+		assert.Equal(t, "67890", vppAct.AppStoreID)
+		assert.Equal(t, "cmd-uuid-2", vppAct.CommandUUID)
+		assert.Equal(t, "darwin", vppAct.HostPlatform)
+		assert.Equal(t, uint(1), vppAct.HostID)
+		assert.Equal(t, "Test Host", vppAct.HostDisplayName)
+	})
+
+	t.Run("hostPlatform is propagated to VPP activity", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		vppTeamID := uint(1)
+		adamID := "99999"
+		cmdUUID := "cmd-uuid-3"
+		titleID := uint(30)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        "host-uuid-2",
+				Name:            "iOS VPP App",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 2, "host-uuid-2", "iOS Host", "ios", results)
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+
+		act, ok := activities[0].(*fleet.ActivityInstalledAppStoreApp)
+		require.True(t, ok)
+		assert.Equal(t, "ios", act.HostPlatform)
+		assert.Equal(t, uint(2), act.HostID)
+		assert.Equal(t, "iOS Host", act.HostDisplayName)
+		assert.Equal(t, "iOS VPP App", act.SoftwareTitle)
+	})
+
+	t.Run("empty results is a no-op", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", []*fleet.SetupExperienceStatusResult{})
+		require.NoError(t, err)
+		assert.Empty(t, activities)
+	})
+
+	t.Run("user is nil for VPP activity", func(t *testing.T) {
+		var capturedUser *fleet.User
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			capturedUser = user
+			return nil
+		}
+
+		vppTeamID := uint(1)
+		adamID := "12345"
+		cmdUUID := "cmd-uuid-1"
+		titleID := uint(10)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				NanoCommandUUID: &cmdUUID,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", results)
+		require.NoError(t, err)
+		assert.Nil(t, capturedUser)
 	})
 }

--- a/ee/server/service/setup_experience_test.go
+++ b/ee/server/service/setup_experience_test.go
@@ -538,6 +538,40 @@ func TestFailCancelledSetupExperienceInstalls(t *testing.T) {
 		assert.Empty(t, activities)
 	})
 
+	t.Run("cancelled VPP app with nil NanoCommandUUID and VPPAppAdamID does not panic", func(t *testing.T) {
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		vppTeamID := uint(1)
+		titleID := uint(10)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        "host-uuid",
+				Name:            "VPP App No Command",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    nil,
+				NanoCommandUUID: nil,
+				SoftwareTitleID: &titleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, 1, "host-uuid", "Test Host", "darwin", results)
+		require.NoError(t, err)
+		require.Len(t, activities, 1)
+
+		act, ok := activities[0].(*fleet.ActivityInstalledAppStoreApp)
+		require.True(t, ok)
+		assert.Equal(t, "", act.AppStoreID)
+		assert.Equal(t, "", act.CommandUUID)
+		assert.Equal(t, "failed", act.Status)
+		assert.Equal(t, "VPP App No Command", act.SoftwareTitle)
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+	})
+
 	t.Run("user is nil for VPP activity", func(t *testing.T) {
 		var capturedUser *fleet.User
 		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {


### PR DESCRIPTION
For #34288.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [ ] QA'd all new/changed functionality manually