### PR TITLE
Improve fleetd agent release docs

### DIFF
--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -280,7 +280,7 @@ See the ["Releasing Fleet" contributor guide](https://github.com/fleetdm/fleet/b
 
 #### macOS, Windows, Linux
 
-Fleetd is an agent composed of several components. The latest released versions in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
+Fleetd for macOS, Windows and Linux is an agent composed of several components. The latest released versions in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
 For the full release steps, see the [fleetd release procedure](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md).
 
 #### Android

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -278,14 +278,20 @@ See the ["Releasing Fleet" contributor guide](https://github.com/fleetdm/fleet/b
 
 ### Prepare fleetd agent release
 
+#### macOS, Windows, Linux
+
 Fleetd is an agent composed of several components. The latest released versions in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
 For the full release steps, see the [fleetd release procedure](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md).
 
+#### Android
+
 Our Android app is managed through Google Play. Follow the [Android release guide](https://github.com/fleetdm/fleet/blob/main/android/RELEASE.md).
+
+#### ChromeOS
 
 The Chrome extension is released via [Google Admin](https://admin.google.com).
 For testing, use the [test extension deployment guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/deploying-chrome-test-ext.md).
-For production releases, follow the [Chrome extension README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
+For production releases, follow the [Chrome extension README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).### Deploy a new release to dogfood
 
 ### Deploy a new release to dogfood
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -291,7 +291,9 @@ Our Android app is managed through Google Play. Follow the [Android release guid
 
 The Chrome extension is released via [Google Admin](https://admin.google.com).
 For testing, use the [test extension deployment guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/deploying-chrome-test-ext.md).
-For production releases, follow the [Chrome extension README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).### Deploy a new release to dogfood
+For production releases, follow the [Chrome extension
+README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).### Deploy a new
+release to dogfood.
 
 ### Deploy a new release to dogfood
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -292,8 +292,7 @@ Our Android app is managed through Google Play. Follow the [Android release guid
 The Chrome extension is released via [Google Admin](https://admin.google.com).
 For testing, use the [test extension deployment guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/deploying-chrome-test-ext.md).
 For production releases, follow the [Chrome extension
-README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).### Deploy a new
-release to dogfood.
+README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
 
 ### Deploy a new release to dogfood
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -276,10 +276,18 @@ This workflow lets QA Wolf focus on test implementation while Fleet QA stays acc
 
 See the ["Releasing Fleet" contributor guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/releasing-fleet.md).
 
+
+
 ### Prepare fleetd agent release
 
-See [Fleet's TUF release documentation](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md).
+Fleetd is an agent composed of several components. The latest released versions available in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
+Refer to the [fleetd release procedure](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md) for the full release steps.
 
+Our Android app is managed through Google Play. Follow the process described in the [Android release guide](https://github.com/fleetdm/fleet/blob/main/android/RELEASE.md).
+
+The Chrome extension is managed through Google Admin, which is Google’s centralized console for controlling Chrome policies, apps, and extensions across an organization.
+For testing, use the [test extension deployment guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/deploying-chrome-test-ext.md).
+For production releases, follow the [Chrome extension README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
 
 ### Deploy a new release to dogfood
 

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -276,8 +276,6 @@ This workflow lets QA Wolf focus on test implementation while Fleet QA stays acc
 
 See the ["Releasing Fleet" contributor guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/releasing-fleet.md).
 
-
-
 ### Prepare fleetd agent release
 
 Fleetd is an agent composed of several components. The latest released versions available in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).

--- a/handbook/engineering/README.md
+++ b/handbook/engineering/README.md
@@ -278,12 +278,12 @@ See the ["Releasing Fleet" contributor guide](https://github.com/fleetdm/fleet/b
 
 ### Prepare fleetd agent release
 
-Fleetd is an agent composed of several components. The latest released versions available in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
-Refer to the [fleetd release procedure](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md) for the full release steps.
+Fleetd is an agent composed of several components. The latest released versions in TUF are documented in the [TUF version tracking doc](https://github.com/fleetdm/fleet/blob/main/orbit/TUF.md).
+For the full release steps, see the [fleetd release procedure](https://github.com/fleetdm/fleet/blob/main/tools/tuf/README.md).
 
-Our Android app is managed through Google Play. Follow the process described in the [Android release guide](https://github.com/fleetdm/fleet/blob/main/android/RELEASE.md).
+Our Android app is managed through Google Play. Follow the [Android release guide](https://github.com/fleetdm/fleet/blob/main/android/RELEASE.md).
 
-The Chrome extension is managed through Google Admin, which is Google’s centralized console for controlling Chrome policies, apps, and extensions across an organization.
+The Chrome extension is released via [Google Admin](https://admin.google.com).
 For testing, use the [test extension deployment guide](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/deploying-chrome-test-ext.md).
 For production releases, follow the [Chrome extension README](https://github.com/fleetdm/fleet/blob/main/ee/fleetd-chrome/README.md).
 


### PR DESCRIPTION
Add documentation for the full agent release process. 
Fleetd is composed of several components released through different channels, and the handbook only linked to TUF. This adds references to Android (Google Play), Chrome extension (Google Admin), and TUF version tracking, with links to the relevant release guides for each.