### PR TITLE
update UI to support hardware attestation

### DIFF
--- a/frontend/__mocks__/configMock.ts
+++ b/frontend/__mocks__/configMock.ts
@@ -13,6 +13,7 @@ const DEFAULT_CONFIG_MDM_MOCK: IMdmConfig = {
   apple_bm_terms_expired: false,
   enabled_and_configured: true,
   android_enabled_and_configured: false,
+  apple_require_hardware_attestation: false,
   macos_updates: {
     minimum_version: "",
     deadline: "",

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -66,6 +66,7 @@ export interface IMdmConfig {
   enable_turn_on_windows_mdm_manually: boolean;
   windows_migration_enabled: boolean;
   android_enabled_and_configured: boolean;
+  apple_require_hardware_attestation: boolean;
   end_user_authentication: IEndUserAuthentication;
   macos_updates: IAppleDeviceUpdates;
   ios_updates: IAppleDeviceUpdates;

--- a/frontend/interfaces/host.ts
+++ b/frontend/interfaces/host.ts
@@ -349,6 +349,7 @@ export interface IHost {
   /** There will be at most 1 end user */
   end_users?: IHostEndUser[];
   conditional_access_bypassed: boolean;
+  mdm_enrollment_hardware_attested?: boolean;
 }
 
 /*

--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -34,6 +34,7 @@ interface IAdvancedConfigFormData {
   disableScripts: boolean;
   disableAIFeatures: boolean;
   disableQueryReports: boolean;
+  requireHardwareAttestation: boolean;
 }
 
 interface IAdvancedConfigFormErrors {
@@ -105,6 +106,8 @@ const Advanced = ({
     disableAIFeatures: appConfig.server_settings.ai_features_disabled || false,
     disableQueryReports:
       appConfig.server_settings.query_reports_disabled || false,
+    requireHardwareAttestation:
+      appConfig.mdm?.apple_require_hardware_attestation || false,
   });
 
   const {
@@ -121,6 +124,7 @@ const Advanced = ({
     disableScripts,
     disableAIFeatures,
     disableQueryReports,
+    requireHardwareAttestation,
   } = formData;
 
   const [formErrors, setFormErrors] = useState<IAdvancedConfigFormErrors>({});
@@ -190,6 +194,7 @@ const Advanced = ({
       },
       mdm: {
         apple_server_url: mdmAppleServerURL,
+        apple_require_hardware_attestation: requireHardwareAttestation,
       },
       sso_settings: {
         sso_server_url: ssoUserURL,
@@ -514,6 +519,21 @@ const Advanced = ({
                 helpText="If enabled, only policy queries (SQL) are sent to the LLM. Fleet doesn’t use this data to train models."
               >
                 Disable generative AI features
+              </Checkbox>
+            )}
+          />
+          <GitOpsModeTooltipWrapper
+            position="left"
+            renderChildren={(disableChildren) => (
+              <Checkbox
+                disabled={disableChildren}
+                onChange={onInputChange}
+                name="requireHardwareAttestation"
+                value={requireHardwareAttestation}
+                parseTarget
+                helpText="Enabling this setting will require macOS hosts with Apple Silicon that automatically enroll (DEP) to use ACME with Managed Device Attestation"
+              >
+                Require hardware attestation
               </Checkbox>
             )}
           />

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tests.tsx
@@ -240,6 +240,41 @@ describe("Vitals Card component", () => {
   });
 });
 
+describe("MDM attestation", () => {
+  it("renders MDM attestation when mdm_enrollment_hardware_attested is true", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      mdm_enrollment_hardware_attested: true,
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.getByText("MDM attestation")).toBeInTheDocument();
+    expect(screen.getByText("Yes")).toBeInTheDocument();
+  });
+
+  it("does not render MDM attestation when mdm_enrollment_hardware_attested is false", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+      mdm_enrollment_hardware_attested: false,
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.queryByText("MDM attestation")).not.toBeInTheDocument();
+  });
+
+  it("does not render MDM attestation when mdm_enrollment_hardware_attested is undefined", () => {
+    const mockHost = createMockHost({
+      platform: "darwin",
+    });
+
+    render(<Vitals vitalsData={mockHost} mdm={mockHost.mdm} />);
+
+    expect(screen.queryByText("MDM attestation")).not.toBeInTheDocument();
+  });
+});
+
 describe("Disk encryption data", () => {
   it("renders 'On' for macOS when enabled", () => {
     const mockHost = createMockHost({

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -125,6 +125,7 @@ const Vitals = ({
   const {
     platform,
     os_version,
+    mdm_enrollment_hardware_attested,
     disk_encryption_enabled: diskEncryptionEnabled,
   } = vitalsData;
 
@@ -375,6 +376,24 @@ const Vitals = ({
         sortKey: "Location",
         element: (
           <DataSet key="location" title="Location" value={geoLocationButton} />
+        ),
+      });
+    }
+
+    // MDM attestation
+    if (mdm_enrollment_hardware_attested) {
+      vitals.push({
+        sortKey: "MDM attestation",
+        element: (
+          <DataSet
+            key="mdm-attestation"
+            title={
+              <TooltipWrapper tipContent="Host provided a Managed Device Attestation signed by Apple at enrollment.">
+                MDM attestation
+              </TooltipWrapper>
+            }
+            value="Yes"
+          />
         ),
       });
     }

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -387,12 +387,12 @@ const Vitals = ({
         element: (
           <DataSet
             key="mdm-attestation"
-            title={
+            title="MDM attestation"
+            value={
               <TooltipWrapper tipContent="Host provided a Managed Device Attestation signed by Apple at enrollment.">
-                MDM attestation
+                Yes
               </TooltipWrapper>
             }
-            value="Yes"
           />
         ),
       });

--- a/frontend/utilities/constants.tsx
+++ b/frontend/utilities/constants.tsx
@@ -446,6 +446,7 @@ export const HOST_VITALS_DATA = [
   "cpu_type",
   "os_version",
   "timezone",
+  "mdm_enrollment_hardware_attested",
 ];
 
 export const HOST_OSQUERY_DATA = [


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40993, #40994

This is the UI to support ACME hardware attestation. This includes: 

1. adding the checkbox on the advanced option card on org settings page
2. adding the dataset on the host details and my device pages"

# Checklist for submitter

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
