### PR TITLE
Add MSRC App bulletin infrastructure and generator

### DIFF
--- a/cmd/msrc/generate_apps.go
+++ b/cmd/msrc/generate_apps.go
@@ -1,0 +1,172 @@
+//go:build ignore
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/io"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc"
+	msrcapps "github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc/apps"
+	"github.com/google/go-github/v37/github"
+)
+
+func panicif(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func main() {
+	wd, err := os.Getwd()
+	panicif(err)
+
+	inPath := filepath.Join(wd, "msrc_app_in")
+	err = os.MkdirAll(inPath, 0o755)
+	panicif(err)
+
+	outPath := filepath.Join(wd, "msrc_app_out")
+	err = os.MkdirAll(outPath, 0o755)
+	panicif(err)
+
+	now := time.Now()
+
+	ctx := context.Background()
+
+	githubHttp := fleethttp.NewGithubClient()
+	ghAPI := io.NewGitHubClient(githubHttp, github.NewClient(githubHttp).Repositories, wd)
+
+	msrcHttp := fleethttp.NewClient()
+	msrcAPI := msrc.NewMSRCClient(msrcHttp, inPath, msrc.MSRCBaseURL)
+
+	fmt.Println("Downloading existing MSRC app bulletin...")
+	existingMeta, existingURL, err := ghAPI.MSRCAppBulletin(ctx)
+	panicif(err)
+
+	var bulletins map[string]*msrcapps.AppBulletin
+	if existingURL == "" {
+		fmt.Println("None found, backfilling...")
+		bulletins, err = backfillApps(now.Month(), now.Year(), msrcAPI)
+		panicif(err)
+	} else {
+		fmt.Println("Updating existing bulletins")
+		bulletins, err = updateApps(now.Month(), now.Year(), existingMeta, existingURL, msrcAPI, ghAPI)
+		panicif(err)
+	}
+
+	fmt.Println("Saving app bulletins...")
+	bulletinFile := msrcapps.FromMap(bulletins).WithMappings(msrcapps.DefaultMappings())
+	err = bulletinFile.Serialize(now, outPath)
+	panicif(err)
+
+	fmt.Println("Done processing MSRC app feed.")
+}
+
+func updateApps(
+	m time.Month,
+	y int,
+	existingMeta io.MetadataFileName,
+	existingURL string,
+	msrcClient msrc.MSRCAPI,
+	ghClient io.GitHubAPI,
+) (map[string]*msrcapps.AppBulletin, error) {
+	fmt.Println("Downloading current feed...")
+	currentFeed, err := msrcClient.GetFeed(m, y)
+	if err != nil {
+		if errors.Is(err, msrc.FeedNotFound) && windowsBulletinGracePeriod(m, y) {
+			fmt.Printf("Current month feed %d-%d was not found, skipping...\n", y, m)
+		} else {
+			return nil, err
+		}
+	}
+
+	var newBulletins map[string]*msrcapps.AppBulletin
+	if currentFeed != "" {
+		fmt.Println("Parsing current feed for apps...")
+		newBulletins, err = msrc.ParseAppFeed(currentFeed)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Download existing bulletin file and load it
+	bulletins := make(map[string]*msrcapps.AppBulletin)
+
+	if existingURL != "" {
+		fPath, err := ghClient.Download(existingURL)
+		if err != nil {
+			return nil, err
+		}
+
+		existingFile, err := msrcapps.LoadAppBulletinFile(fPath)
+		if err != nil {
+			return nil, err
+		}
+
+		// Convert existing file to map for merging
+		for _, p := range existingFile.Products {
+			bulletins[p.Product] = &msrcapps.AppBulletin{
+				ProductID:       p.ProductID,
+				Product:         p.Product,
+				SecurityUpdates: p.SecurityUpdates,
+			}
+		}
+	}
+
+	// Merge new updates into existing bulletins
+	for name, newB := range newBulletins {
+		if existing, ok := bulletins[name]; ok {
+			msrcapps.MergeBulletins(existing, newB)
+		} else {
+			bulletins[name] = newB
+		}
+	}
+
+	return bulletins, nil
+}
+
+func backfillApps(upToM time.Month, upToY int, client msrc.MSRCAPI) (map[string]*msrcapps.AppBulletin, error) {
+	from := time.Date(msrc.MSRCMinYear, 1, 1, 0, 0, 0, 0, time.UTC)
+	upTo := time.Date(upToY, upToM+1, 1, 0, 0, 0, 0, time.UTC)
+
+	bulletins := make(map[string]*msrcapps.AppBulletin)
+	for d := from; d.Before(upTo); d = d.AddDate(0, 1, 0) {
+		fmt.Printf("Downloading feed for %d-%d...\n", d.Year(), d.Month())
+		f, err := client.GetFeed(d.Month(), d.Year())
+		if err != nil {
+			if errors.Is(err, msrc.FeedNotFound) && windowsBulletinGracePeriod(d.Month(), d.Year()) {
+				fmt.Printf("Current month feed %d-%d was not found, skipping...\n", d.Year(), d.Month())
+				continue
+			}
+			return nil, err
+		}
+
+		fmt.Printf("Parsing feed for %d-%d for apps...\n", d.Year(), d.Month())
+		r, err := msrc.ParseAppFeed(f)
+		if err != nil {
+			return nil, err
+		}
+
+		for name, newB := range r {
+			if existing, ok := bulletins[name]; ok {
+				msrcapps.MergeBulletins(existing, newB)
+			} else {
+				bulletins[name] = newB
+			}
+		}
+	}
+
+	return bulletins, nil
+}
+
+// windowsBulletinGracePeriod returns whether we are within the grace period for a MSRC monthly feed to exist.
+func windowsBulletinGracePeriod(month time.Month, year int) bool {
+	now := time.Now()
+	return month == now.Month() && year == now.Year() && now.Day() <= 15
+}

--- a/server/vulnerabilities/io/fs.go
+++ b/server/vulnerabilities/io/fs.go
@@ -8,6 +8,7 @@ import (
 
 type FSAPI interface {
 	MSRCBulletins() ([]MetadataFileName, error)
+	MSRCAppBulletin() ([]MetadataFileName, error)
 	MacOfficeReleaseNotes() ([]MetadataFileName, error)
 	Delete(MetadataFileName) error
 }
@@ -31,6 +32,11 @@ func (fs FSClient) Delete(b MetadataFileName) error {
 // MSRCBulletins walks 'dir' returning all security bulletin files.
 func (fs FSClient) MSRCBulletins() ([]MetadataFileName, error) {
 	return fs.list(mSRCFilePrefix, NewMSRCMetadata)
+}
+
+// MSRCAppBulletin walks 'dir' returning all MSRC app bulletin files.
+func (fs FSClient) MSRCAppBulletin() ([]MetadataFileName, error) {
+	return fs.list(mSRCAppFilePrefix, NewMSRCAppMetadata)
 }
 
 // MacOfficeReleaseNotes walks 'dir' returning all mac office release notes

--- a/server/vulnerabilities/io/github.go
+++ b/server/vulnerabilities/io/github.go
@@ -29,6 +29,7 @@ type ReleaseLister interface {
 type GitHubAPI interface {
 	Download(string) (string, error)
 	MSRCBulletins(context.Context) (map[MetadataFileName]string, error)
+	MSRCAppBulletin(context.Context) (MetadataFileName, string, error)
 	MacOfficeReleaseNotes(context.Context) (MetadataFileName, string, error)
 }
 
@@ -68,6 +69,27 @@ func (gh GitHubClient) Download(urlStr string) (string, error) {
 // stored in our Github NVD repo (https://github.com/fleetdm/nvd/releases)
 func (gh GitHubClient) MSRCBulletins(ctx context.Context) (map[MetadataFileName]string, error) {
 	return gh.list(ctx, mSRCFilePrefix, NewMSRCMetadata)
+}
+
+// MSRCAppBulletin returns the 'MetadataFilename' and 'download URL' of the latest MSRC app bulletin
+// stored in our Github NVD repo (https://github.com/fleetdm/nvd/releases)
+func (gh GitHubClient) MSRCAppBulletin(ctx context.Context) (MetadataFileName, string, error) {
+	resultMap, err := gh.list(ctx, mSRCAppFilePrefix, NewMSRCAppMetadata)
+	if err != nil {
+		return MetadataFileName{}, "", err
+	}
+
+	// Find the most recent bulletin
+	var latest MetadataFileName
+	var latestURL string
+	for k, v := range resultMap {
+		if latest.filename == "" || latest.Before(k) {
+			latest = k
+			latestURL = v
+		}
+	}
+
+	return latest, latestURL, nil
 }
 
 // MacOfficeReleaseNotes returns the 'MetadataFilename' and the 'download URL' of the latest Mac Office Release

--- a/server/vulnerabilities/io/metadata.go
+++ b/server/vulnerabilities/io/metadata.go
@@ -9,6 +9,7 @@ import (
 
 const (
 	mSRCFilePrefix              = "fleet_msrc_"
+	mSRCAppFilePrefix           = "fleet_msrc_app_"
 	macOfficeReleaseNotesPrefix = "fleet_macoffice_release_notes_"
 	fileExt                     = "json"
 	dateLayout                  = "2006_01_02"
@@ -33,6 +34,15 @@ func NewMSRCMetadata(filename string) (MetadataFileName, error) {
 
 func NewMacOfficeRelNotesMetadata(filename string) (MetadataFileName, error) {
 	mfn := MetadataFileName{prefix: macOfficeReleaseNotesPrefix, filename: filename}
+
+	// Check that the filename contains a valid timestamp
+	_, err := mfn.date()
+
+	return mfn, err
+}
+
+func NewMSRCAppMetadata(filename string) (MetadataFileName, error) {
+	mfn := MetadataFileName{prefix: mSRCAppFilePrefix, filename: filename}
 
 	// Check that the filename contains a valid timestamp
 	_, err := mfn.date()
@@ -92,4 +102,8 @@ func MSRCFileName(productName string, date time.Time) string {
 
 func MacOfficeRelNotesFileName(date time.Time) string {
 	return fmt.Sprintf("%s%s-%d_%02d_%02d.%s", macOfficeReleaseNotesPrefix, "macoffice", date.Year(), date.Month(), date.Day(), fileExt)
+}
+
+func MSRCAppFileName(date time.Time) string {
+	return fmt.Sprintf("%s%s-%d_%02d_%02d.%s", mSRCAppFilePrefix, "apps", date.Year(), date.Month(), date.Day(), fileExt)
 }

--- a/server/vulnerabilities/msrc/app_parser.go
+++ b/server/vulnerabilities/msrc/app_parser.go
@@ -1,0 +1,162 @@
+package msrc
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	msrcapps "github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc/apps"
+	msrcxml "github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc/xml"
+)
+
+// ParseAppFeed parses an MSRC XML feed and extracts vulnerabilities for Microsoft applications.
+func ParseAppFeed(fPath string) (map[string]*msrcapps.AppBulletin, error) {
+	r, err := os.Open(fPath)
+	if err != nil {
+		return nil, fmt.Errorf("msrc app parser: %w", err)
+	}
+	defer r.Close()
+
+	feedResult, err := parseAppXML(r)
+	if err != nil {
+		return nil, fmt.Errorf("msrc app parser: %w", err)
+	}
+
+	bulletins, err := mapToAppBulletins(feedResult)
+	if err != nil {
+		return nil, fmt.Errorf("msrc app parser: %w", err)
+	}
+
+	return bulletins, nil
+}
+
+type appFeedResult struct {
+	AppProducts        map[string]msrcxml.Product
+	AppVulnerabilities []msrcxml.Vulnerability
+}
+
+// isAppVendorFix checks if a remediation is a vendor fix for an app product.
+// Unlike OS vendor fixes which use KB-based URLs, app vendor fixes just need
+// to have Type "Vendor Fix" and a FixedBuild version.
+// We also exclude entries where FixedBuild is a URL (e.g., Office products
+// that link to release notes instead of providing a version).
+func isAppVendorFix(rem *msrcxml.VulnerabilityRemediation) bool {
+	if rem.Type != "Vendor Fix" || rem.FixedBuild == "" {
+		return false
+	}
+	// Skip URL-based "versions" (e.g., Office products)
+	if strings.HasPrefix(rem.FixedBuild, "http") {
+		return false
+	}
+	return true
+}
+
+// includesAppVendorFix checks if the vulnerability has an app vendor fix for the given product ID.
+func includesAppVendorFix(v *msrcxml.Vulnerability, pID string) bool {
+	for _, rem := range v.Remediations {
+		if isAppVendorFix(&rem) {
+			for _, vfPID := range rem.ProductIDs {
+				if vfPID == pID {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+func mapToAppBulletins(feed *appFeedResult) (map[string]*msrcapps.AppBulletin, error) {
+	// Map product ID to product name for lookup
+	pIDToName := make(map[string]string, len(feed.AppProducts))
+	bulletins := make(map[string]*msrcapps.AppBulletin)
+
+	for pID, p := range feed.AppProducts {
+		// Use the full product name as the key
+		name := p.FullName
+		pIDToName[pID] = name
+
+		if bulletins[name] == nil {
+			bulletins[name] = &msrcapps.AppBulletin{
+				ProductID:       pID,
+				Product:         name,
+				SecurityUpdates: []msrcapps.SecurityUpdate{},
+			}
+		}
+	}
+
+	// Process vulnerabilities
+	for _, v := range feed.AppVulnerabilities {
+		for _, rem := range v.Remediations {
+			if !isAppVendorFix(&rem) {
+				continue
+			}
+
+			for _, pID := range rem.ProductIDs {
+				productName, ok := pIDToName[pID]
+				if !ok {
+					continue
+				}
+
+				bulletin := bulletins[productName]
+				if bulletin == nil {
+					continue
+				}
+
+				// Add the security update
+				bulletin.SecurityUpdates = append(bulletin.SecurityUpdates, msrcapps.SecurityUpdate{
+					CVE:          v.CVE,
+					FixedVersion: rem.FixedBuild,
+				})
+			}
+		}
+	}
+
+	return bulletins, nil
+}
+
+func parseAppXML(reader io.Reader) (*appFeedResult, error) {
+	r := &appFeedResult{
+		AppProducts: make(map[string]msrcxml.Product),
+	}
+	d := xml.NewDecoder(reader)
+
+	for {
+		t, err := d.Token()
+		if err != nil {
+			if err == io.EOF {
+				return r, nil
+			}
+			return nil, fmt.Errorf("decoding token: %v", err)
+		}
+
+		if t, ok := t.(xml.StartElement); ok {
+			if t.Name.Local == "Branch" {
+				branch := msrcxml.ProductBranch{}
+				if err = d.DecodeElement(&branch, &t); err != nil {
+					return nil, err
+				}
+
+				for _, p := range branch.AppProducts() {
+					r.AppProducts[p.ProductID] = p
+				}
+			}
+
+			if t.Name.Local == "Vulnerability" {
+				vuln := msrcxml.Vulnerability{}
+				if err = d.DecodeElement(&vuln, &t); err != nil {
+					return nil, err
+				}
+
+				// Check if this vulnerability affects any of our app products
+				for pID := range r.AppProducts {
+					if includesAppVendorFix(&vuln, pID) {
+						r.AppVulnerabilities = append(r.AppVulnerabilities, vuln)
+						break
+					}
+				}
+			}
+		}
+	}
+}

--- a/server/vulnerabilities/msrc/apps/bulletin.go
+++ b/server/vulnerabilities/msrc/apps/bulletin.go
@@ -1,0 +1,145 @@
+package msrcapps
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/io"
+)
+
+// SecurityUpdate represents a CVE that was fixed in a specific version.
+type SecurityUpdate struct {
+	CVE          string `json:"cve"`
+	FixedVersion string `json:"fixed_version"`
+}
+
+// AppBulletin contains vulnerability information for a Microsoft application.
+type AppBulletin struct {
+	// ProductID is the MSRC product identifier (e.g., "11655" for Edge).
+	ProductID string `json:"product_id"`
+	// Product is the MSRC product name (e.g., "Microsoft Edge (Chromium-based)").
+	Product string `json:"product"`
+	// SecurityUpdates is the list of CVEs with their fixed versions.
+	SecurityUpdates []SecurityUpdate `json:"security_updates"`
+}
+
+// MatchCriteria defines patterns for matching software.
+// Multiple values in an array are OR-matched (any can match).
+// Multiple fields are AND-matched (all must match).
+type MatchCriteria struct {
+	// Name patterns to match against software name (OR-matched).
+	// Supports regex patterns enclosed in "/" delimiters (e.g., "/^Microsoft Edge.*/").
+	Name []string `json:"name"`
+	// Vendor patterns to match against software vendor (OR-matched).
+	Vendor []string `json:"vendor"`
+}
+
+// ProductMapping represents a single software-to-product mapping rule.
+type ProductMapping struct {
+	Match     MatchCriteria `json:"match"`
+	ProductID string        `json:"product_id"`
+}
+
+// AppBulletinFile contains all app bulletins in a single file.
+type AppBulletinFile struct {
+	// Mappings define rules for matching software to product IDs.
+	// If empty, default mappings are used.
+	Mappings []ProductMapping `json:"mappings,omitempty"`
+	Products []AppBulletin    `json:"products"`
+}
+
+// Serialize writes the bulletins to a JSON file in the specified directory.
+func (b *AppBulletinFile) Serialize(d time.Time, dir string) error {
+	payload, err := json.Marshal(b)
+	if err != nil {
+		return err
+	}
+
+	fileName := io.MSRCAppFileName(d)
+	filePath := filepath.Join(dir, fileName)
+
+	return os.WriteFile(filePath, payload, 0o644)
+}
+
+// LoadAppBulletinFile reads and parses an app bulletin file from the given path.
+func LoadAppBulletinFile(filePath string) (*AppBulletinFile, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var bulletinFile AppBulletinFile
+	if err := json.Unmarshal(data, &bulletinFile); err != nil {
+		return nil, err
+	}
+
+	return &bulletinFile, nil
+}
+
+// ToMap converts the bulletin file to a map keyed by product ID.
+func (b *AppBulletinFile) ToMap() map[string]AppBulletin {
+	result := make(map[string]AppBulletin, len(b.Products))
+	for _, p := range b.Products {
+		result[p.ProductID] = p
+	}
+	return result
+}
+
+// FromMap creates an AppBulletinFile from a map of bulletins.
+func FromMap(bulletins map[string]*AppBulletin) *AppBulletinFile {
+	var products []AppBulletin
+	for _, b := range bulletins {
+		if b != nil && len(b.SecurityUpdates) > 0 {
+			products = append(products, *b)
+		}
+	}
+
+	// Sort for deterministic output
+	sort.Slice(products, func(i, j int) bool {
+		return products[i].Product < products[j].Product
+	})
+
+	return &AppBulletinFile{Products: products}
+}
+
+// WithMappings returns a copy of the bulletin file with the given mappings.
+func (b *AppBulletinFile) WithMappings(mappings []ProductMapping) *AppBulletinFile {
+	return &AppBulletinFile{
+		Mappings: mappings,
+		Products: b.Products,
+	}
+}
+
+// NormalizeProductName normalizes a product name for consistent matching.
+// This handles variations in how products appear in the MSRC feed.
+func NormalizeProductName(name string) string {
+	// Common normalizations
+	name = strings.TrimSpace(name)
+	return name
+}
+
+// MergeBulletins merges security updates from src into dst, avoiding duplicates.
+func MergeBulletins(dst, src *AppBulletin) {
+	if dst == nil || src == nil {
+		return
+	}
+
+	existing := make(map[string]bool)
+	for _, su := range dst.SecurityUpdates {
+		key := fmt.Sprintf("%s:%s", su.CVE, su.FixedVersion)
+		existing[key] = true
+	}
+
+	for _, su := range src.SecurityUpdates {
+		key := fmt.Sprintf("%s:%s", su.CVE, su.FixedVersion)
+		if !existing[key] {
+			dst.SecurityUpdates = append(dst.SecurityUpdates, su)
+			existing[key] = true
+		}
+	}
+}

--- a/server/vulnerabilities/msrc/apps/sync.go
+++ b/server/vulnerabilities/msrc/apps/sync.go
@@ -1,0 +1,77 @@
+package msrcapps
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/fleetdm/fleet/v4/pkg/fleethttp"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/io"
+	"github.com/google/go-github/v37/github"
+)
+
+// SyncFromGithub keeps local MSRC app bulletin in sync with the one published on GitHub.
+func SyncFromGithub(ctx context.Context, dstDir string) error {
+	client := fleethttp.NewGithubClient()
+	rep := github.NewClient(client).Repositories
+
+	gh := io.NewGitHubClient(client, rep, dstDir)
+	fs := io.NewFSClient(dstDir)
+
+	if err := sync(ctx, fs, gh); err != nil {
+		return fmt.Errorf("msrc app sync: %w", err)
+	}
+
+	return nil
+}
+
+func sync(
+	ctx context.Context,
+	fsClient io.FSAPI,
+	ghClient io.GitHubAPI,
+) error {
+	remote, url, err := ghClient.MSRCAppBulletin(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Nothing published yet on remote repo
+	if url == "" {
+		return nil
+	}
+
+	local, err := fsClient.MSRCAppBulletin()
+	if err != nil {
+		return err
+	}
+
+	if len(local) == 0 {
+		if _, err := ghClient.Download(url); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Sort to find the latest local file
+	sort.Slice(local, func(i, j int) bool {
+		return local[j].Before(local[i])
+	})
+
+	// If remote is newer, download it
+	if local[0].Before(remote) {
+		if _, err := ghClient.Download(url); err != nil {
+			return err
+		}
+	}
+
+	// Clean up old local files
+	for _, l := range local {
+		if l.Before(remote) {
+			if err := fsClient.Delete(l); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/server/vulnerabilities/msrc/apps/sync_test.go
+++ b/server/vulnerabilities/msrc/apps/sync_test.go
@@ -1,4 +1,4 @@
-package macoffice
+package msrcapps
 
 import (
 	"context"
@@ -10,14 +10,15 @@ import (
 )
 
 func newMetadataFile(t *testing.T, name string) io.MetadataFileName {
-	mfn, err := io.NewMSRCMetadata(name)
+	mfn, err := io.NewMSRCAppMetadata(name)
 	require.NoError(t, err)
 	return mfn
 }
 
 type testData struct {
-	RemoteList          map[io.MetadataFileName]string
-	RemoteListError     error
+	RemoteFile          io.MetadataFileName
+	RemoteURL           string
+	RemoteError         error
 	RemoteDownloaded    []string
 	RemoteDownloadError error
 	LocalList           []io.MetadataFileName
@@ -29,21 +30,15 @@ type testData struct {
 type ghMock struct{ TestData *testData }
 
 func (gh ghMock) MSRCBulletins(ctx context.Context) (map[io.MetadataFileName]string, error) {
-	return gh.TestData.RemoteList, gh.TestData.RemoteListError
+	return nil, nil
 }
 
 func (gh ghMock) MSRCAppBulletin(ctx context.Context) (io.MetadataFileName, string, error) {
-	for k, v := range gh.TestData.RemoteList {
-		return k, v, gh.TestData.RemoteListError
-	}
-	return io.MetadataFileName{}, "", gh.TestData.RemoteListError
+	return gh.TestData.RemoteFile, gh.TestData.RemoteURL, gh.TestData.RemoteError
 }
 
 func (gh ghMock) MacOfficeReleaseNotes(ctx context.Context) (io.MetadataFileName, string, error) {
-	for k, v := range gh.TestData.RemoteList {
-		return k, v, gh.TestData.RemoteListError
-	}
-	return io.MetadataFileName{}, "", gh.TestData.RemoteListError
+	return io.MetadataFileName{}, "", nil
 }
 
 func (gh ghMock) Download(url string) (string, error) {
@@ -54,7 +49,7 @@ func (gh ghMock) Download(url string) (string, error) {
 type fsMock struct{ TestData *testData }
 
 func (fs fsMock) MSRCBulletins() ([]io.MetadataFileName, error) {
-	return fs.TestData.LocalList, fs.TestData.LocalListError
+	return nil, nil
 }
 
 func (fs fsMock) MSRCAppBulletin() ([]io.MetadataFileName, error) {
@@ -62,7 +57,7 @@ func (fs fsMock) MSRCAppBulletin() ([]io.MetadataFileName, error) {
 }
 
 func (fs fsMock) MacOfficeReleaseNotes() ([]io.MetadataFileName, error) {
-	return fs.TestData.LocalList, fs.TestData.LocalListError
+	return nil, nil
 }
 
 func (fs fsMock) Delete(d io.MetadataFileName) error {
@@ -71,14 +66,14 @@ func (fs fsMock) Delete(d io.MetadataFileName) error {
 }
 
 func TestSync(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("#sync", func(t *testing.T) {
-		remote := newMetadataFile(t, "macoffice-2023_10_10.json")
+		remote := newMetadataFile(t, "fleet_msrc_app_apps-2023_10_10.json")
 
 		t.Run("on GH error", func(t *testing.T) {
 			testData := testData{
-				RemoteListError: errors.New("some error"),
+				RemoteError: errors.New("some error"),
 			}
 			err := sync(ctx, fsMock{TestData: &testData}, ghMock{TestData: &testData})
 			require.Error(t, err, "some error")
@@ -92,7 +87,8 @@ func TestSync(t *testing.T) {
 
 		t.Run("on FS error", func(t *testing.T) {
 			testData := testData{
-				RemoteList:     map[io.MetadataFileName]string{{}: "http://someurl.com"},
+				RemoteFile:     remote,
+				RemoteURL:      "http://someurl.com",
 				LocalListError: errors.New("some error"),
 			}
 			err := sync(ctx, fsMock{TestData: &testData}, ghMock{TestData: &testData})
@@ -101,9 +97,10 @@ func TestSync(t *testing.T) {
 
 		t.Run("on error when downloading GH asset", func(t *testing.T) {
 			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{remote: "http://someurl.com"},
+				RemoteFile: remote,
+				RemoteURL:  "http://someurl.com",
 				LocalList: []io.MetadataFileName{
-					newMetadataFile(t, "macoffice-2020_10_10.json"),
+					newMetadataFile(t, "fleet_msrc_app_apps-2020_10_10.json"),
 				},
 				RemoteDownloadError: errors.New("some error"),
 			}
@@ -113,7 +110,8 @@ func TestSync(t *testing.T) {
 
 		t.Run("when there are no local files", func(t *testing.T) {
 			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{{}: "http://someurl.com"},
+				RemoteFile: remote,
+				RemoteURL:  "http://someurl.com",
 			}
 
 			err := sync(ctx, fsMock{TestData: &testData}, ghMock{TestData: &testData})
@@ -122,29 +120,15 @@ func TestSync(t *testing.T) {
 			require.Contains(t, testData.RemoteDownloaded, "http://someurl.com")
 		})
 
-		t.Run("when there are no remote rel notes", func(t *testing.T) {
-			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{{}: "http://someurl.com"},
-				LocalList: []io.MetadataFileName{
-					newMetadataFile(t, "macoffice-2022_09_10.json"),
-				},
-			}
-
-			err := sync(ctx, fsMock{TestData: &testData}, ghMock{TestData: &testData})
-			require.NoError(t, err)
-
-			require.Empty(t, testData.LocalDeleted)
-			require.Empty(t, testData.RemoteDownloaded)
-		})
-
 		t.Run("removes multiple out of date copies", func(t *testing.T) {
 			local := []io.MetadataFileName{
-				newMetadataFile(t, "macoffice-2022_09_10.json"),
-				newMetadataFile(t, "macoffice-2022_08_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2022_09_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2022_08_10.json"),
 			}
 
 			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{remote: "http://someurl.com"},
+				RemoteFile: remote,
+				RemoteURL:  "http://someurl.com",
 				LocalList:  local,
 			}
 
@@ -157,12 +141,13 @@ func TestSync(t *testing.T) {
 
 		t.Run("on error when deleting", func(t *testing.T) {
 			local := []io.MetadataFileName{
-				newMetadataFile(t, "macoffice-2022_09_10.json"),
-				newMetadataFile(t, "macoffice-2022_08_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2022_09_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2022_08_10.json"),
 			}
 
 			testData := testData{
-				RemoteList:       map[io.MetadataFileName]string{remote: "http://someurl.com"},
+				RemoteFile:       remote,
+				RemoteURL:        "http://someurl.com",
 				LocalList:        local,
 				LocalDeleteError: errors.New("some error"),
 			}
@@ -172,10 +157,11 @@ func TestSync(t *testing.T) {
 		})
 
 		t.Run("when local copy is out of date", func(t *testing.T) {
-			local := newMetadataFile(t, "macoffice-2022_09_10.json")
+			local := newMetadataFile(t, "fleet_msrc_app_apps-2022_09_10.json")
 
 			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{remote: "http://someurl.com"},
+				RemoteFile: remote,
+				RemoteURL:  "http://someurl.com",
 				LocalList:  []io.MetadataFileName{local},
 			}
 
@@ -188,12 +174,13 @@ func TestSync(t *testing.T) {
 
 		t.Run("when local copy is not out of date", func(t *testing.T) {
 			local := []io.MetadataFileName{
-				newMetadataFile(t, "macoffice-2023_11_10.json"),
-				newMetadataFile(t, "macoffice-2023_01_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2023_11_10.json"),
+				newMetadataFile(t, "fleet_msrc_app_apps-2023_01_10.json"),
 			}
 
 			testData := testData{
-				RemoteList: map[io.MetadataFileName]string{remote: "http://someurl.com"},
+				RemoteFile: remote,
+				RemoteURL:  "http://someurl.com",
 				LocalList:  local,
 			}
 

--- a/server/vulnerabilities/msrc/sync_test.go
+++ b/server/vulnerabilities/msrc/sync_test.go
@@ -28,6 +28,13 @@ func (gh ghMock) MSRCBulletins(ctx context.Context) (map[io.MetadataFileName]str
 	return gh.TestData.RemoteList, nil
 }
 
+func (gh ghMock) MSRCAppBulletin(ctx context.Context) (io.MetadataFileName, string, error) {
+	for k, v := range gh.TestData.RemoteList {
+		return k, v, nil
+	}
+	return io.MetadataFileName{}, "", nil
+}
+
 func (gh ghMock) MacOfficeReleaseNotes(ctx context.Context) (io.MetadataFileName, string, error) {
 	for k, v := range gh.TestData.RemoteList {
 		return k, v, nil
@@ -43,6 +50,10 @@ func (gh ghMock) Download(url string) (string, error) {
 type fsMock struct{ TestData *testData }
 
 func (fs fsMock) MSRCBulletins() ([]io.MetadataFileName, error) {
+	return fs.TestData.LocalList, nil
+}
+
+func (fs fsMock) MSRCAppBulletin() ([]io.MetadataFileName, error) {
 	return fs.TestData.LocalList, nil
 }
 

--- a/server/vulnerabilities/msrc/xml/app_product.go
+++ b/server/vulnerabilities/msrc/xml/app_product.go
@@ -1,0 +1,46 @@
+package xml
+
+import "strings"
+
+// AppProducts traverses the ProductBranch tree returning Microsoft application products
+// like Edge, Office 365, etc.
+func (b *ProductBranch) AppProducts() []Product {
+	var r []Product
+	queue := []ProductBranch{*b}
+
+	// Product families we care about for apps
+	// Note: "Browser" contains Microsoft Edge, "Microsoft Office" contains Office products
+	appFamilies := map[string]bool{
+		"Browser":          true,
+		"Microsoft Office": true,
+		"Developer Tools":  true,
+		"Apps":             true,
+	}
+
+	// Product name prefixes we want to include
+	appPrefixes := []string{
+		"Microsoft Edge",
+		"Microsoft 365 Apps",
+		"Microsoft Office",
+	}
+
+	for len(queue) > 0 {
+		next := queue[0]
+
+		if next.Type == "Product Family" && appFamilies[next.Name] {
+			for _, p := range next.Products {
+				for _, prefix := range appPrefixes {
+					if strings.HasPrefix(p.FullName, prefix) {
+						r = append(r, p)
+						break
+					}
+				}
+			}
+		}
+
+		queue = queue[1:]
+		queue = append(queue, next.Branches...)
+	}
+
+	return r
+}


### PR DESCRIPTION


## Summary

This PR adds the foundation for detecting vulnerabilities in Windows applications (Edge, Office 365, etc.) using MSRC security bulletins. This is part 1 of 2 - the analyzer that uses these bulletins will be added in a follow-up PR.

### Changes

- `cmd/msrc/generate_apps.go` - Offline tool to generate app bulletin JSON files from MSRC feeds
- `server/vulnerabilities/msrc/app_parser.go` - XML parsing for app products and vulnerabilities
- `server/vulnerabilities/msrc/apps/bulletin.go` - AppBulletin data types with product mappings
- `server/vulnerabilities/msrc/apps/sync.go` - Sync mechanism to download bulletins from GitHub
- `server/vulnerabilities/msrc/xml/app_product.go` - XML types for MSRC app products
- `server/vulnerabilities/io/*.go` - Interface additions for MSRCAppBulletin

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements)

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually