### PR TITLE
ACME: cleanups and refactorings after new_account implementation

### DIFF
--- a/server/mdm/acme/api/account.go
+++ b/server/mdm/acme/api/account.go
@@ -9,7 +9,7 @@ import (
 )
 
 type AccountService interface {
-	CreateAccount(ctx context.Context, enrollmentID uint, jwk jose.JSONWebKey, onlyReturnExisting bool) (*types.AccountResponse, error)
+	CreateAccount(ctx context.Context, pathIdentifier string, enrollmentID uint, jwk jose.JSONWebKey, onlyReturnExisting bool) (*types.AccountResponse, error)
 	AuthenticateMessageFromAccount(ctx context.Context, message *api_http.JWSRequestContainer, request types.AccountAuthenticatedRequest) error
 	AuthenticateNewAccountMessage(ctx context.Context, message *api_http.JWSRequestContainer, request *api_http.CreateNewAccountRequest) error
 }

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -157,6 +157,7 @@ type JWSRequestContainer struct {
 	Key        *jose.JSONWebKey
 	KeyID      *string
 	Identifier string `url:"identifier"`
+	HTTPPath   string `url:"http_path"`
 }
 
 func (req *JWSRequestContainer) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -92,13 +92,14 @@ type CreateNewAccountResponse struct {
 
 // BeforeRender implements the beforeRenderer interface.
 func (r *CreateNewAccountResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error or the error is an ACME error,
-	// indicating a client issue.
-	var acmeErr *types.ACMEError
-	if r.Err != nil && !errors.As(r.Err, &acmeErr) {
-		return
+	// only generate a new nonce if there is no error or the error is due to a client error
+	// other than "enrollment not found" (in which case the client has no reason to retry).
+	if r.Err != nil {
+		var acmeErr *types.ACMEError
+		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
+			return
+		}
 	}
-
 	if err := generateAndRenderNonce(ctx, r.Nonces, w); err != nil {
 		r.Err = err
 		return
@@ -128,11 +129,13 @@ type CreateNewOrderResponse struct {
 }
 
 func (r *CreateNewOrderResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error or the error is an ACME error,
-	// indicating a client issue.
-	var acmeErr *types.ACMEError
-	if r.Err != nil && !errors.As(r.Err, &acmeErr) {
-		return
+	// only generate a new nonce if there is no error or the error is due to a client error
+	// other than "enrollment not found" (in which case the client has no reason to retry).
+	if r.Err != nil {
+		var acmeErr *types.ACMEError
+		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
+			return
+		}
 	}
 	if err := generateAndRenderNonce(ctx, r.Nonces, w); err != nil {
 		r.Err = err

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -182,6 +182,9 @@ func (req *JWSRequestContainer) DecodeBody(ctx context.Context, r io.Reader, u u
 	if jws.Signatures[0].Protected.JSONWebKey == nil && jws.Signatures[0].Protected.KeyID == "" {
 		return ctxerr.New(ctx, "jws must have a key or key ID in the protected header")
 	}
+	if jws.Signatures[0].Protected.JSONWebKey != nil && jws.Signatures[0].Protected.KeyID != "" {
+		return ctxerr.New(ctx, "jws must have a key or key ID in the protected header")
+	}
 
 	req.JWS = *jws
 

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -104,6 +104,9 @@ func (r *CreateNewAccountResponse) BeforeRender(ctx context.Context, w http.Resp
 		r.Err = err
 		return
 	}
+	if r.AccountResponse != nil && r.AccountResponse.Location != "" {
+		w.Header().Set("Location", r.AccountResponse.Location)
+	}
 }
 
 // Status implements the statuser interface.

--- a/server/mdm/acme/internal/mysql/account_order.go
+++ b/server/mdm/acme/internal/mysql/account_order.go
@@ -114,6 +114,7 @@ func (ds *Datastore) GetAccountByID(ctx context.Context, enrollmentID uint, acco
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &dbAcc, stmt, enrollmentID, accountID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
+			// TODO: use an ACME error probably
 			return nil, platform_mysql.NotFound("acme account").WithID(accountID)
 		}
 		return nil, ctxerr.Wrap(ctx, err, "select acme account")

--- a/server/mdm/acme/internal/mysql/account_order.go
+++ b/server/mdm/acme/internal/mysql/account_order.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
@@ -18,46 +19,55 @@ const maxAccountsPerEnrollment = 3
 func (ds *Datastore) CreateAccount(ctx context.Context, account *types.Account, onlyReturnExisting bool) (*types.Account, bool, error) {
 	var didCreate bool
 	err := platform_mysql.WithRetryTxx(ctx, ds.primary, func(tx sqlx.ExtContext) error {
-		lockEnrollmentStmt := `SELECT id FROM acme_enrollments WHERE id = ? FOR UPDATE`
+		// Mark the enrollment as locked to prevent concurrent account creation for
+		// the same enrollment, so we can enforce limits on account creation
+		const lockEnrollmentStmt = `SELECT id FROM acme_enrollments WHERE id = ? FOR UPDATE`
 		var enrollmentID uint
-
-		// Mark the enrollment as locked to prevent concurrent account creation for the same enrollment, so we can enforce limits on account creation
-		err := tx.QueryRowxContext(ctx, lockEnrollmentStmt, account.EnrollmentID).Scan(&enrollmentID)
+		err := sqlx.GetContext(ctx, tx, &enrollmentID, lockEnrollmentStmt, account.EnrollmentID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "lock acme enrollment")
 		}
 
-		// TODO: what if it's revoked? do not return it but do not create it either?
-		// if the account already exists, we return it
-		findExistingAccountStmt := `SELECT id FROM acme_accounts WHERE acme_enrollment_id = ? AND json_web_key_thumbprint = ?`
 		thumbprint, err := jose.Thumbprint(&account.JSONWebKey)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "compute jwk thumbprint for new account")
 		}
-		var existingAccountID uint
-		err = tx.QueryRowxContext(ctx, findExistingAccountStmt, account.EnrollmentID, thumbprint).Scan(&existingAccountID)
+
+		// if the account already exists (and is not revoked), we return it
+		const findExistingAccountStmt = `SELECT id, revoked FROM acme_accounts WHERE acme_enrollment_id = ? AND json_web_key_thumbprint = ?`
+		var existingAccount struct {
+			ID      uint `db:"id"`
+			Revoked bool `db:"revoked"`
+		}
+		err = sqlx.GetContext(ctx, tx, &existingAccount, findExistingAccountStmt, account.EnrollmentID, thumbprint)
 		if err != nil && !errors.Is(err, sql.ErrNoRows) {
 			return ctxerr.Wrap(ctx, err, "check for existing account with same jwk thumbprint")
 		}
 		if err == nil {
-			account.ID = existingAccountID
+			if existingAccount.Revoked {
+				err = types.AccountRevokedError(fmt.Sprintf("Account %d is revoked", existingAccount.ID))
+				return ctxerr.Wrap(ctx, err)
+			}
+			account.ID = existingAccount.ID
 			return nil
 		}
 
 		// If we got here we didn't find an existing account so, if requested by the caller, return a notFound
 		if onlyReturnExisting {
-			return platform_mysql.NotFound("acme account").WithName(thumbprint)
+			err = types.AccountDoesNotExistError(fmt.Sprintf("No account exists for enrollment id %d with the provided jwk", account.EnrollmentID))
+			return ctxerr.Wrap(ctx, err)
 		}
 
 		// check if maximum number of accounts for this enrollment has been reached before creating a new one
-		countAccountsStmt := `SELECT COUNT(*) FROM acme_accounts WHERE acme_enrollment_id = ?`
+		const countAccountsStmt = `SELECT COUNT(*) FROM acme_accounts WHERE acme_enrollment_id = ?`
 		var accountCount int
-		err = tx.QueryRowxContext(ctx, countAccountsStmt, enrollmentID).Scan(&accountCount)
+		err = sqlx.GetContext(ctx, tx, &accountCount, countAccountsStmt, enrollmentID)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "count acme accounts for enrollment")
 		}
 		if accountCount >= maxAccountsPerEnrollment {
-			return ctxerr.Errorf(ctx, "account creation limit reached for enrollment id %d", enrollmentID)
+			err = types.TooManyAccountsError(fmt.Sprintf("Enrollment id %d already has %d accounts, which is the maximum allowed", enrollmentID, accountCount))
+			return ctxerr.Wrap(ctx, err)
 		}
 
 		// create the new account
@@ -66,7 +76,7 @@ func (ds *Datastore) CreateAccount(ctx context.Context, account *types.Account, 
 			return ctxerr.Wrap(ctx, err, "marshal new account jwk")
 		}
 
-		insertStmt := `INSERT INTO acme_accounts (acme_enrollment_id, json_web_key, json_web_key_thumbprint) VALUES (?, ?, ?)`
+		const insertStmt = `INSERT INTO acme_accounts (acme_enrollment_id, json_web_key, json_web_key_thumbprint) VALUES (?, ?, ?)`
 		res, err := tx.ExecContext(ctx, insertStmt, account.EnrollmentID, jwkSerialized, thumbprint)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "insert acme account")

--- a/server/mdm/acme/internal/mysql/account_order_test.go
+++ b/server/mdm/acme/internal/mysql/account_order_test.go
@@ -160,7 +160,7 @@ func testOnlyReturnExistingNotFound(t *testing.T, env *testEnv) {
 	require.Error(t, err)
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error:accountDoesNotExist")
+	require.Contains(t, acmeErr.Type, "error:accountDoesNotExist") // nolint:nilaway // cannot be nil due to previous require
 	require.False(t, didCreate)
 }
 
@@ -190,7 +190,7 @@ func testAccountCreationLimit(t *testing.T, env *testEnv) {
 	require.Error(t, err)
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error/tooManyAccounts")
+	require.Contains(t, acmeErr.Type, "error/tooManyAccounts") // nolint:nilaway // cannot be nil due to previous require
 }
 
 func testAccountRevoked(t *testing.T, env *testEnv) {
@@ -221,7 +221,7 @@ func testAccountRevoked(t *testing.T, env *testEnv) {
 	require.Error(t, err)
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error/accountRevoked")
+	require.Contains(t, acmeErr.Type, "error/accountRevoked") // nolint:nilaway // cannot be nil due to previous require
 }
 
 func testInvalidEnrollmentID(t *testing.T, env *testEnv) {

--- a/server/mdm/acme/internal/mysql/account_order_test.go
+++ b/server/mdm/acme/internal/mysql/account_order_test.go
@@ -34,6 +34,7 @@ func TestCreateAccount(t *testing.T) {
 		{"OnlyReturnExistingFound", testOnlyReturnExistingFound},
 		{"OnlyReturnExistingNotFound", testOnlyReturnExistingNotFound},
 		{"AccountCreationLimit", testAccountCreationLimit},
+		{"AccountRevoked", testAccountRevoked},
 		{"InvalidEnrollmentID", testInvalidEnrollmentID},
 	}
 	for _, c := range cases {
@@ -190,6 +191,37 @@ func testAccountCreationLimit(t *testing.T, env *testEnv) {
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
 	require.Contains(t, acmeErr.Type, "error/tooManyAccounts")
+}
+
+func testAccountRevoked(t *testing.T, env *testEnv) {
+	enrollment := &types.Enrollment{}
+	env.InsertACMEEnrollment(t, enrollment)
+
+	jwk := generateTestJWK(t)
+	account := &types.Account{
+		EnrollmentID: enrollment.ID,
+		JSONWebKey:   jwk,
+	}
+
+	created, didCreate, err := env.ds.CreateAccount(t.Context(), account, false)
+	require.NoError(t, err)
+	require.NotNil(t, created)
+	require.True(t, didCreate)
+
+	// revoke the account directly in the DB
+	_, err = env.DB.ExecContext(t.Context(), `UPDATE acme_accounts SET revoked = 1 WHERE id = ?`, created.ID)
+	require.NoError(t, err)
+
+	// try to create again with the same JWK — should get accountRevoked error
+	account2 := &types.Account{
+		EnrollmentID: enrollment.ID,
+		JSONWebKey:   jwk,
+	}
+	_, _, err = env.ds.CreateAccount(t.Context(), account2, false)
+	require.Error(t, err)
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "error/accountRevoked")
 }
 
 func testInvalidEnrollmentID(t *testing.T, env *testEnv) {

--- a/server/mdm/acme/internal/mysql/account_order_test.go
+++ b/server/mdm/acme/internal/mysql/account_order_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/testutils"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"github.com/stretchr/testify/require"
@@ -158,7 +157,9 @@ func testOnlyReturnExistingNotFound(t *testing.T, env *testEnv) {
 	result, didCreate, err := env.ds.CreateAccount(t.Context(), account, true)
 	require.Nil(t, result)
 	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "error:accountDoesNotExist")
 	require.False(t, didCreate)
 }
 
@@ -186,7 +187,9 @@ func testAccountCreationLimit(t *testing.T, env *testEnv) {
 	result, _, err := env.ds.CreateAccount(t.Context(), account, false)
 	require.Nil(t, result)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "account creation limit reached")
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "error/tooManyAccounts")
 }
 
 func testInvalidEnrollmentID(t *testing.T, env *testEnv) {

--- a/server/mdm/acme/internal/mysql/directory_nonce.go
+++ b/server/mdm/acme/internal/mysql/directory_nonce.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
-	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
 )
 
@@ -32,7 +32,8 @@ LIMIT 1
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &enrollment, stmt, pathIdentifier)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.Wrap(ctx, common_mysql.NotFound("ACME enrollment").WithName(pathIdentifier))
+			err = types.EnrollmentNotFoundError(fmt.Sprintf("ACME enrollment with path identifier %s not found", pathIdentifier))
+			return nil, ctxerr.Wrap(ctx, err)
 		}
 		return nil, ctxerr.Wrap(ctx, err, "getting ACME enrollment")
 	}

--- a/server/mdm/acme/internal/mysql/directory_nonce_test.go
+++ b/server/mdm/acme/internal/mysql/directory_nonce_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/testutils"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -34,8 +33,9 @@ func testGetACMEEnrollment(t *testing.T, env *testEnv) {
 	// non-existing
 	enrollment, err := env.ds.GetACMEEnrollment(t.Context(), "non-existing")
 	require.Nil(t, enrollment)
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 
 	// existing and valid
 	enrollValid := &types.Enrollment{}

--- a/server/mdm/acme/internal/mysql/directory_nonce_test.go
+++ b/server/mdm/acme/internal/mysql/directory_nonce_test.go
@@ -35,7 +35,7 @@ func testGetACMEEnrollment(t *testing.T, env *testEnv) {
 	require.Nil(t, enrollment)
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
+	require.Contains(t, acmeErr.Type, "error/enrollmentNotFound") // nolint:nilaway // cannot be nil due to previous require
 
 	// existing and valid
 	enrollValid := &types.Enrollment{}

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -9,7 +9,7 @@ import (
 	"go.step.sm/crypto/jose"
 )
 
-func (s *Service) CreateAccount(ctx context.Context, enrollmentID uint, jwk jose.JSONWebKey, onlyReturnExisting bool) (*types.AccountResponse, error) {
+func (s *Service) CreateAccount(ctx context.Context, pathIdentifier string, enrollmentID uint, jwk jose.JSONWebKey, onlyReturnExisting bool) (*types.AccountResponse, error) {
 	// authorization is checked in the endpoint implementation for JWS-protected endpoints
 
 	account := &types.Account{
@@ -26,11 +26,11 @@ func (s *Service) CreateAccount(ctx context.Context, enrollmentID uint, jwk jose
 		return nil, ctxerr.Wrap(ctx, err, "getting base URL")
 	}
 
-	ordersURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, "accounts", fmt.Sprint(account.ID), "orders")
+	ordersURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, "accounts", fmt.Sprint(account.ID), "orders")
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "constructing orders URL for account")
 	}
-	acctURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, "accounts", fmt.Sprint(account.ID))
+	acctURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, "accounts", fmt.Sprint(account.ID))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "constructing account URL for account")
 	}

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -21,11 +21,10 @@ func (s *Service) CreateAccount(ctx context.Context, enrollmentID uint, jwk jose
 		return nil, ctxerr.Wrap(ctx, err, "creating account in datastore")
 	}
 
-	appCfg, err := s.providers.AppConfig(ctx)
+	baseURL, err := s.getACMEBaseURL(ctx)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "getting app config")
+		return nil, ctxerr.Wrap(ctx, err, "getting base URL")
 	}
-	baseURL := appCfg.MDMUrl()
 
 	ordersURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, "accounts", fmt.Sprint(account.ID), "orders")
 	if err != nil {

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -2,12 +2,10 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
-	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"go.step.sm/crypto/jose"
 )
 
@@ -20,10 +18,6 @@ func (s *Service) CreateAccount(ctx context.Context, enrollmentID uint, jwk jose
 	}
 	account, didCreate, err := s.store.CreateAccount(ctx, account, onlyReturnExisting)
 	if err != nil {
-		var notFoundErr *platform_mysql.NotFoundError
-		if errors.As(err, &notFoundErr) {
-			err = types.AccountDoesNotExistError(err.Error())
-		}
 		return nil, ctxerr.Wrap(ctx, err, "creating account in datastore")
 	}
 

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	api_http "github.com/fleetdm/fleet/v4/server/mdm/acme/api/http"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/fleetdm/fleet/v4/server/mdm/internal/commonmdm"
 	"go.step.sm/crypto/jose"
 )
 
@@ -34,31 +35,54 @@ func (s *Service) authenticateWithACMEEnrollment(ctx context.Context, identifier
 	return enrollment, nil
 }
 
-func (s *Service) AuthenticateNewAccountMessage(ctx context.Context, message *api_http.JWSRequestContainer, request *api_http.CreateNewAccountRequest) error {
-	// Validate the JWS message includes a JWK
-	if message.Key == nil {
-		return ctxerr.New(ctx, "missing JWK in JWS message")
+// common authentication logic for both AuthenticateNewAccountMessage and AuthenticateMessageFromAccount, only
+// one of createNewAccount or otherRequest must be non-nil.
+func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_http.JWSRequestContainer, createNewAccount *api_http.CreateNewAccountRequest, otherRequest types.AccountAuthenticatedRequest) error {
+	if createNewAccount != nil {
+		// must have the JWK
+		if message.Key == nil {
+			return ctxerr.New(ctx, "missing JWK in JWS message")
+		}
+		// For Apple ACME purposes we only support ECDSA hardware-bound keys so validate the key is of the correct type
+		// and the algorithm is of a proper type for the key (which also ensures it isn't none)
+		_, ok := message.Key.Key.(*ecdsa.PublicKey)
+		if !ok {
+			return ctxerr.New(ctx, "JWK in JWS message is not an ECDSA public key")
+		}
 	}
-	// For Apple ACME purposes we only support ECDSA hardware-bound keys so validate the key is of the correct type
-	// and the algorithm is of a proper type for the key (which also ensures it isn't none)
-	_, ok := message.Key.Key.(*ecdsa.PublicKey)
-	if !ok {
-		return ctxerr.New(ctx, "JWK in JWS message is not an ECDSA public key")
+
+	if otherRequest != nil {
+		// must have the kid
+		if message.KeyID == nil || *message.KeyID == "" {
+			return ctxerr.New(ctx, "missing kid in JWS message")
+		}
 	}
+
 	if !slices.Contains(acceptableSignatureAlgorithms[:], message.JWS.Signatures[0].Protected.Algorithm) {
 		return ctxerr.New(ctx, "unsupported signature algorithm in JWS message")
 	}
-	// TODO(mna): "url" field in protected header validation https://datatracker.ietf.org/doc/html/rfc8555/#section-6.4.1
+
+	// "url" field validation: https://datatracker.ietf.org/doc/html/rfc8555/#section-6.4.1
+	baseURL, err := s.getACMEBaseURL(ctx)
+	if err != nil {
+		return ctxerr.New(ctx, "get base ACME URL")
+	}
+	expectedURL, err := commonmdm.ResolveURL(baseURL, message.HTTPPath, true)
+	if err != nil {
+		return ctxerr.New(ctx, "get expected ACME URL")
+	}
+	if message.JWSHeaderURL != expectedURL {
+		return ctxerr.New(ctx, "invalid url in JWS protected header")
+	}
 
 	// consume the nonce
 	nonce := message.JWS.Signatures[0].Protected.Nonce
 	nonceValid, err := s.nonces.Consume(ctx, nonce)
 	if !nonceValid || err != nil {
-		var detail string
-		if err != nil {
-			detail = err.Error()
+		// if there is an error, it is a Redis/network issue, so keep it as a 500
+		if err == nil {
+			err = types.BadNonceError("")
 		}
-		err = types.BadNonceError(detail)
 		return ctxerr.Wrapf(ctx, err, "invalid nonce in JWS message for identifier %s", message.Identifier)
 	}
 
@@ -68,67 +92,54 @@ func (s *Service) AuthenticateNewAccountMessage(ctx context.Context, message *ap
 		return err
 	}
 
-	payload, err := message.JWS.Verify(message.Key)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "verifying JWS message", "identifier", message.Identifier)
-	}
-	err = json.Unmarshal(payload, request)
-	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "unmarshalling JWS payload into CreateNewAccountRequest with identifier: %s", message.Identifier)
-	}
-
-	request.JSONWebKey = message.Key
-	request.Enrollment = enrollment
-	return nil
-}
-
-func (s *Service) AuthenticateMessageFromAccount(ctx context.Context, message *api_http.JWSRequestContainer, request types.AccountAuthenticatedRequest) error {
-	if message.KeyID == nil || *message.KeyID == "" {
-		return ctxerr.New(ctx, "missing kid in JWS message")
-	}
-	if !slices.Contains(acceptableSignatureAlgorithms[:], message.JWS.Signatures[0].Protected.Algorithm) {
-		return ctxerr.New(ctx, "unsupported signature algorithm in JWS message")
-	}
-	// TODO(mna): "url" field in protected header validation https://datatracker.ietf.org/doc/html/rfc8555/#section-6.4.1
-
-	// consume the nonce
-	nonce := message.JWS.Signatures[0].Protected.Nonce
-	nonceValid, err := s.nonces.Consume(ctx, nonce)
-	if !nonceValid || err != nil {
-		var detail string
+	webKeyToVerify := message.Key
+	var account *types.Account
+	if otherRequest != nil {
+		accountID, err := accountIDFromKeyID(ctx, *message.KeyID, message.Identifier)
 		if err != nil {
-			detail = err.Error()
+			return ctxerr.Wrap(ctx, err, "parsing account ID from key ID")
 		}
-		err = types.BadNonceError(detail)
-		return ctxerr.Wrapf(ctx, err, "invalid nonce in JWS message for identifier %s", message.Identifier)
+		account, err = s.store.GetAccountByID(ctx, enrollment.ID, accountID)
+		if err != nil {
+			// TODO not found vs other errors, see RFC for how we should respond
+			return ctxerr.Wrap(ctx, err, "fetching account by ID")
+		}
+		webKeyToVerify = &account.JSONWebKey
 	}
 
-	// authenticate the enrollment identifier from the path
-	enrollment, err := s.authenticateWithACMEEnrollment(ctx, message.Identifier)
-	if err != nil {
-		return err
-	}
-
-	accountID, err := accountIDFromKeyID(ctx, *message.KeyID, message.Identifier)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "parsing account ID from key ID")
-	}
-	account, err := s.store.GetAccountByID(ctx, enrollment.ID, accountID)
-	if err != nil {
-		// TODO not found vs other errors, see RFC for how we should respond
-		return ctxerr.Wrap(ctx, err, "fetching account by ID")
-	}
-
-	payload, err := message.JWS.Verify(account.JSONWebKey)
+	payload, err := message.JWS.Verify(webKeyToVerify)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "verifying JWS message for identifier: %s", message.Identifier)
 	}
-	err = json.Unmarshal(payload, request)
+
+	var requestPayload any
+	requestPayload = createNewAccount
+	if otherRequest != nil {
+		requestPayload = otherRequest
+	}
+	err = json.Unmarshal(payload, requestPayload)
 	if err != nil {
 		return ctxerr.Wrapf(ctx, err, "unmarshalling JWS payload into request for identifier: %s", message.Identifier)
 	}
 
+	if createNewAccount != nil {
+		createNewAccount.JSONWebKey = message.Key
+		createNewAccount.Enrollment = enrollment
+	}
+	if otherRequest != nil {
+		otherRequest.SetEnrollmentAndAccount(enrollment, account)
+	}
 	return nil
+}
+
+func (s *Service) AuthenticateNewAccountMessage(ctx context.Context, message *api_http.JWSRequestContainer, request *api_http.CreateNewAccountRequest) error {
+	// TODO: return proper ACME errors for those validations...
+	return s.commonAuthenticateMessage(ctx, message, request, nil)
+}
+
+func (s *Service) AuthenticateMessageFromAccount(ctx context.Context, message *api_http.JWSRequestContainer, request types.AccountAuthenticatedRequest) error {
+	// TODO: return proper ACME errors for those validations...
+	return s.commonAuthenticateMessage(ctx, message, nil, request)
 }
 
 func accountIDFromKeyID(ctx context.Context, keyID, pathIdentifier string) (uint, error) {

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -40,6 +40,17 @@ func (s *Service) authenticateWithACMEEnrollment(ctx context.Context, identifier
 func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_http.JWSRequestContainer, createNewAccount *api_http.CreateNewAccountRequest, otherRequest types.AccountAuthenticatedRequest) error {
 	var err error
 
+	// consume the nonce as first validation
+	nonce := message.JWS.Signatures[0].Protected.Nonce
+	nonceValid, err := s.nonces.Consume(ctx, nonce)
+	if !nonceValid || err != nil {
+		// if there is an error, it is a Redis/network issue, so keep it as a 500
+		if err == nil {
+			err = types.BadNonceError("")
+		}
+		return ctxerr.Wrapf(ctx, err, "invalid nonce in JWS message for identifier %s", message.Identifier)
+	}
+
 	if createNewAccount != nil {
 		// must have the JWK
 		if message.Key == nil {
@@ -80,17 +91,6 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 	if message.JWSHeaderURL != expectedURL {
 		err = types.UnauthorizedError("invalid url in JWS protected header")
 		return ctxerr.Wrap(ctx, err)
-	}
-
-	// consume the nonce
-	nonce := message.JWS.Signatures[0].Protected.Nonce
-	nonceValid, err := s.nonces.Consume(ctx, nonce)
-	if !nonceValid || err != nil {
-		// if there is an error, it is a Redis/network issue, so keep it as a 500
-		if err == nil {
-			err = types.BadNonceError("")
-		}
-		return ctxerr.Wrapf(ctx, err, "invalid nonce in JWS message for identifier %s", message.Identifier)
 	}
 
 	// authenticate the enrollment identifier from the path

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -13,7 +13,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	api_http "github.com/fleetdm/fleet/v4/server/mdm/acme/api/http"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
-	common_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"go.step.sm/crypto/jose"
 )
 
@@ -29,7 +28,8 @@ func (s *Service) authenticateWithACMEEnrollment(ctx context.Context, identifier
 		return nil, err
 	}
 	if !enrollment.IsValid() {
-		return nil, ctxerr.Wrap(ctx, common_mysql.NotFound("ACME enrollment").WithName(identifier))
+		err = types.EnrollmentNotFoundError(fmt.Sprintf("ACME enrollment with path identifier %s not found", identifier))
+		return nil, ctxerr.Wrap(ctx, err)
 	}
 	return enrollment, nil
 }

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -102,7 +102,7 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 	webKeyToVerify := message.Key
 	var account *types.Account
 	if otherRequest != nil {
-		accountID, err := accountIDFromKeyID(ctx, *message.KeyID, message.Identifier)
+		accountID, err := s.accountIDFromKeyID(ctx, *message.KeyID, message.Identifier)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "parsing account ID from key ID")
 		}
@@ -149,14 +149,24 @@ func (s *Service) AuthenticateMessageFromAccount(ctx context.Context, message *a
 	return s.commonAuthenticateMessage(ctx, message, nil, request)
 }
 
-func accountIDFromKeyID(ctx context.Context, keyID, pathIdentifier string) (uint, error) {
+func (s *Service) accountIDFromKeyID(ctx context.Context, keyID, pathIdentifier string) (uint, error) {
 	// The key ID is the account URL, which should be in the format /api/mdm/acme/{identifier}/account/{accountID}
 	// We can parse the account ID out of the URL to look up the account in the database
 	urlParsed, err := url.Parse(keyID)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "parsing key ID URL")
 	}
-	prefix := fmt.Sprintf("/api/mdm/acme/%s/account/", pathIdentifier)
+
+	expectedURL, err := s.getACMEURL(ctx, pathIdentifier, "accounts")
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "getting expected account URL")
+	}
+	expectedParsed, err := url.Parse(expectedURL)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "parsing expected account URL")
+	}
+
+	prefix := expectedParsed.Path + "/"
 	if !strings.HasPrefix(urlParsed.Path, prefix) {
 		return 0, ctxerr.New(ctx, "invalid key ID URL format")
 	}

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -127,7 +127,8 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 	}
 	err = json.Unmarshal(payload, requestPayload)
 	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "unmarshalling JWS payload into request for identifier: %s", message.Identifier)
+		err = types.MalformedError(fmt.Sprintf("Failed to unmarshal JWS payload: %v", err))
+		return ctxerr.Wrap(ctx, err)
 	}
 
 	if createNewAccount != nil {

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -18,9 +18,9 @@ import (
 )
 
 var acceptableSignatureAlgorithms = [...]string{
-	string(jose.ES256),
-	string(jose.ES384),
-	string(jose.ES512),
+	jose.ES256,
+	jose.ES384,
+	jose.ES512,
 }
 
 func (s *Service) authenticateWithACMEEnrollment(ctx context.Context, identifier string) (*types.Enrollment, error) {
@@ -38,28 +38,34 @@ func (s *Service) authenticateWithACMEEnrollment(ctx context.Context, identifier
 // common authentication logic for both AuthenticateNewAccountMessage and AuthenticateMessageFromAccount, only
 // one of createNewAccount or otherRequest must be non-nil.
 func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_http.JWSRequestContainer, createNewAccount *api_http.CreateNewAccountRequest, otherRequest types.AccountAuthenticatedRequest) error {
+	var err error
+
 	if createNewAccount != nil {
 		// must have the JWK
 		if message.Key == nil {
-			return ctxerr.New(ctx, "missing JWK in JWS message")
+			err = types.UnauthorizedError("missing JWK in JWS message for new account creation")
+			return ctxerr.Wrap(ctx, err)
 		}
 		// For Apple ACME purposes we only support ECDSA hardware-bound keys so validate the key is of the correct type
 		// and the algorithm is of a proper type for the key (which also ensures it isn't none)
 		_, ok := message.Key.Key.(*ecdsa.PublicKey)
 		if !ok {
-			return ctxerr.New(ctx, "JWK in JWS message is not an ECDSA public key")
+			err = types.BadPublicKeyError("JWK in JWS message for new account creation is not an ECDSA public key")
+			return ctxerr.Wrap(ctx, err)
 		}
 	}
 
 	if otherRequest != nil {
 		// must have the kid
 		if message.KeyID == nil || *message.KeyID == "" {
-			return ctxerr.New(ctx, "missing kid in JWS message")
+			err = types.UnauthorizedError("missing kid in JWS message for account-authenticated request")
+			return ctxerr.Wrap(ctx, err)
 		}
 	}
 
 	if !slices.Contains(acceptableSignatureAlgorithms[:], message.JWS.Signatures[0].Protected.Algorithm) {
-		return ctxerr.New(ctx, "unsupported signature algorithm in JWS message")
+		err = types.BadSignatureAlgorithmError(fmt.Sprintf("unsupported signature algorithm %s in JWS message", message.JWS.Signatures[0].Protected.Algorithm))
+		return ctxerr.Wrap(ctx, err)
 	}
 
 	// "url" field validation: https://datatracker.ietf.org/doc/html/rfc8555/#section-6.4.1
@@ -72,7 +78,8 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 		return ctxerr.New(ctx, "get expected ACME URL")
 	}
 	if message.JWSHeaderURL != expectedURL {
-		return ctxerr.New(ctx, "invalid url in JWS protected header")
+		err = types.UnauthorizedError("invalid url in JWS protected header")
+		return ctxerr.Wrap(ctx, err)
 	}
 
 	// consume the nonce
@@ -109,7 +116,8 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 
 	payload, err := message.JWS.Verify(webKeyToVerify)
 	if err != nil {
-		return ctxerr.Wrapf(ctx, err, "verifying JWS message for identifier: %s", message.Identifier)
+		err = types.UnauthorizedError(err.Error()) // I think it's safe to return the error as details here?
+		return ctxerr.Wrap(ctx, err)
 	}
 
 	var requestPayload any
@@ -133,12 +141,10 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 }
 
 func (s *Service) AuthenticateNewAccountMessage(ctx context.Context, message *api_http.JWSRequestContainer, request *api_http.CreateNewAccountRequest) error {
-	// TODO: return proper ACME errors for those validations...
 	return s.commonAuthenticateMessage(ctx, message, request, nil)
 }
 
 func (s *Service) AuthenticateMessageFromAccount(ctx context.Context, message *api_http.JWSRequestContainer, request types.AccountAuthenticatedRequest) error {
-	// TODO: return proper ACME errors for those validations...
 	return s.commonAuthenticateMessage(ctx, message, nil, request)
 }
 

--- a/server/mdm/acme/internal/service/directory_nonce.go
+++ b/server/mdm/acme/internal/service/directory_nonce.go
@@ -22,12 +22,11 @@ func (s *Service) GetDirectory(ctx context.Context, identifier string) (*types.D
 		return nil, err
 	}
 
-	appConfig, err := s.providers.AppConfig(ctx)
+	baseURL, err := s.getACMEBaseURL(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	baseURL := appConfig.MDMUrl()
 	suffixes := []string{"new_nonce", "new_account", "new_order"}
 	urls := make(map[string]string, len(suffixes))
 	for _, suffix := range suffixes {

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -35,8 +35,11 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter, enc *json.Encoder, jsonErr *eu.JsonError) (handled bool) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
-		return false
+		// if it's not already an ACME error, it is because it is an internal server
+		// error (or an dev error, for 4xx we should always return ACMEError).
+		acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details
 	}
+
 	statusCode := acmeErr.StatusCode
 	if statusCode == 0 {
 		statusCode = http.StatusInternalServerError

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -59,8 +59,12 @@ func makeDecoder(iface any, requestBodySizeLimit int64) kithttp.DecodeRequestFun
 
 // parseCustomTags handles custom URL tag values for activity requests.
 func parseCustomTags(urlTagValue string, r *http.Request, field reflect.Value) (bool, error) {
-	if urlTagValue == "http_method" {
+	switch urlTagValue {
+	case "http_method":
 		field.Set(reflect.ValueOf(r.Method))
+		return true, nil
+	case "http_path":
+		field.Set(reflect.ValueOf(r.URL.Path))
 		return true, nil
 	}
 	return false, nil

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -88,7 +88,7 @@ func createAccountEndpoint(ctx context.Context, request any, svc api.Service) pl
 		return &api_http.CreateNewAccountResponse{Err: err, Nonces: svc.NoncesStore()}
 	}
 
-	accountResp, err := svc.CreateAccount(ctx, newAccountRequest.Enrollment.ID, *newAccountRequest.JSONWebKey, newAccountRequest.OnlyReturnExisting)
+	accountResp, err := svc.CreateAccount(ctx, req.Identifier, newAccountRequest.Enrollment.ID, *newAccountRequest.JSONWebKey, newAccountRequest.OnlyReturnExisting)
 	if err != nil {
 		return &api_http.CreateNewAccountResponse{Err: err, Nonces: svc.NoncesStore()}
 	}

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -98,7 +98,7 @@ func createAccountEndpoint(ctx context.Context, request any, svc api.Service) pl
 	}
 }
 
-// createAccountEndpoint handles POST /api/mdm/acme/{identifier}/new_account requests.
+// createOrderEndpoint handles POST /api/mdm/acme/{identifier}/new_order requests.
 func createOrderEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
 	req := request.(*api_http.JWSRequestContainer)
 	newOrderRequest := &api_http.CreateNewOrderRequest{}

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -46,15 +46,23 @@ func (s *Service) NoncesStore() *redis_nonces_store.RedisNoncesStore {
 	return s.nonces
 }
 
-// TODO(mna): I'm assuming we'll need this at some point (when we need to resolve only 1 URL), but not used for now.
-// func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
-// 	appConfig, err := s.providers.AppConfig(ctx)
-// 	if err != nil {
-// 		return "", err
-// 	}
-//
-// 	return s.getACMEURLWithBaseURL(ctx, appConfig.MDMUrl(), pathIdentifier, suffixes...)
-// }
+func (s *Service) getACMEBaseURL(ctx context.Context) (string, error) {
+	appConfig, err := s.providers.AppConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return appConfig.MDMUrl(), nil
+}
+
+func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
+	baseURL, err := s.getACMEBaseURL(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, suffixes...)
+}
 
 func (s *Service) getACMEURLWithBaseURL(_ context.Context, baseURL, pathIdentifier string, suffixes ...string) (string, error) {
 	return commonmdm.ResolveURL(baseURL, fmt.Sprintf("/api/mdm/acme/%s/%s", pathIdentifier, strings.Join(suffixes, "/")), true)

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -55,14 +55,16 @@ func (s *Service) getACMEBaseURL(ctx context.Context) (string, error) {
 	return appConfig.MDMUrl(), nil
 }
 
-func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
-	baseURL, err := s.getACMEBaseURL(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	return s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, suffixes...)
-}
+// TODO(mna): currently unused, could be useful if there's just a single ACME URL to resolve.
+// Will remove at the end if it turns out to be unnecessary.
+// func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
+// 	baseURL, err := s.getACMEBaseURL(ctx)
+// 	if err != nil {
+// 		return "", err
+// 	}
+//
+// 	return s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, suffixes...)
+// }
 
 func (s *Service) getACMEURLWithBaseURL(_ context.Context, baseURL, pathIdentifier string, suffixes ...string) (string, error) {
 	return commonmdm.ResolveURL(baseURL, fmt.Sprintf("/api/mdm/acme/%s/%s", pathIdentifier, strings.Join(suffixes, "/")), true)

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -55,16 +55,14 @@ func (s *Service) getACMEBaseURL(ctx context.Context) (string, error) {
 	return appConfig.MDMUrl(), nil
 }
 
-// TODO(mna): currently unused, could be useful if there's just a single ACME URL to resolve.
-// Will remove at the end if it turns out to be unnecessary.
-// func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
-// 	baseURL, err := s.getACMEBaseURL(ctx)
-// 	if err != nil {
-// 		return "", err
-// 	}
-//
-// 	return s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, suffixes...)
-// }
+func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {
+	baseURL, err := s.getACMEBaseURL(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return s.getACMEURLWithBaseURL(ctx, baseURL, pathIdentifier, suffixes...)
+}
 
 func (s *Service) getACMEURLWithBaseURL(_ context.Context, baseURL, pathIdentifier string, suffixes ...string) (string, error) {
 	return commonmdm.ResolveURL(baseURL, fmt.Sprintf("/api/mdm/acme/%s/%s", pathIdentifier, strings.Join(suffixes, "/")), true)

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -277,9 +277,11 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Nil(t, acmeErr)
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 		require.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
+		require.NotEmpty(t, resp.Header.Get("Location"))
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+`, resp.Header.Get("Location"))
 
 		require.Equal(t, "valid", acctResp.Status)
-		require.Contains(t, acctResp.Orders, "/orders")
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+/orders$`, acctResp.Orders)
 	})
 
 	t.Run("return existing account with same JWK", func(t *testing.T) {
@@ -293,6 +295,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		acctResp1, _, resp1 := s.createAccount(t, enrollValid.PathIdentifier, jwsBody1)
 
 		require.Equal(t, http.StatusCreated, resp1.StatusCode)
+		require.NotEmpty(t, resp1.Header.Get("Location"))
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+`, resp1.Header.Get("Location"))
+		location1 := resp1.Header.Get("Location")
 
 		// create again with same key - should return existing (use the valid returned nonce)
 		nonce2 := resp1.Header.Get("Replay-Nonce")
@@ -304,6 +309,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Equal(t, "valid", acctResp2.Status)
 		// same account, same orders URL
 		require.Equal(t, acctResp1.Orders, acctResp2.Orders)
+		require.NotEmpty(t, resp2.Header.Get("Location"))
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+`, resp2.Header.Get("Location"))
+		require.Equal(t, location1, resp2.Header.Get("Location"))
 	})
 
 	t.Run("too many accounts", func(t *testing.T) {
@@ -329,6 +337,7 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 		require.Contains(t, acmeErr.Type, "error/tooManyAccounts")
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 
 	t.Run("revoked account", func(t *testing.T) {
@@ -341,8 +350,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		// create an account
 		nonce := s.getNonce(t, enrollForRevoke.PathIdentifier)
 		jwsBody := buildJWS(t, privateKey, nonce, s.newAccountURL(enrollForRevoke.PathIdentifier), nil)
-		_, _, resp := s.createAccount(t, enrollForRevoke.PathIdentifier, jwsBody)
-		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		_, _, resp1 := s.createAccount(t, enrollForRevoke.PathIdentifier, jwsBody)
+		require.Equal(t, http.StatusCreated, resp1.StatusCode)
 
 		// revoke it directly in the DB
 		var accountID uint
@@ -352,13 +361,14 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.NoError(t, err)
 
 		// try to create again with the same key — should get accountRevoked error
-		nonce2 := resp.Header.Get("Replay-Nonce")
+		nonce2 := resp1.Header.Get("Replay-Nonce")
 		jwsBody2 := buildJWS(t, privateKey, nonce2, s.newAccountURL(enrollForRevoke.PathIdentifier), nil)
 		_, acmeErr, resp2 := s.createAccount(t, enrollForRevoke.PathIdentifier, jwsBody2)
 
 		require.Equal(t, http.StatusBadRequest, resp2.StatusCode)
 		require.NotEmpty(t, resp2.Header.Get("Replay-Nonce"))
 		require.Contains(t, acmeErr.Type, "error/accountRevoked")
+		require.Empty(t, resp2.Header.Get("Location"))
 	})
 
 	t.Run("onlyReturnExisting account exists", func(t *testing.T) {
@@ -370,6 +380,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		nonce1 := s.getNonce(t, enrollValid.PathIdentifier)
 		jwsBody1 := buildJWS(t, privateKey, nonce1, s.newAccountURL(enrollValid.PathIdentifier), nil)
 		acctResp1, _, resp1 := s.createAccount(t, enrollValid.PathIdentifier, jwsBody1)
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+`, resp1.Header.Get("Location"))
+		location1 := resp1.Header.Get("Location")
 
 		require.Equal(t, http.StatusCreated, resp1.StatusCode)
 
@@ -382,6 +394,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 
 		require.Equal(t, "valid", acctResp2.Status)
 		require.Equal(t, acctResp1.Orders, acctResp2.Orders)
+		require.Regexp(t, "/api/mdm/acme/"+enrollValid.PathIdentifier+`/accounts/\d+`, resp2.Header.Get("Location"))
+		require.Equal(t, location1, resp2.Header.Get("Location"))
 	})
 
 	t.Run("onlyReturnExisting account does not exist", func(t *testing.T) {
@@ -397,6 +411,7 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 		require.Contains(t, acmeErr.Type, "error:accountDoesNotExist")
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 
 	t.Run("unknown identifier", func(t *testing.T) {
@@ -416,6 +431,7 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is unknown
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 
 	t.Run("revoked enrollment", func(t *testing.T) {
@@ -434,6 +450,7 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is invalid
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 
 	t.Run("expired enrollment", func(t *testing.T) {
@@ -451,6 +468,7 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is invalid
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 
 	t.Run("invalid nonce", func(t *testing.T) {
@@ -465,5 +483,6 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "error:badNonce")
 		// it does generate a new valid nonce
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
+		require.Empty(t, resp.Header.Get("Location"))
 	})
 }

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -412,7 +412,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 		require.Nil(t, acctResp)
-		require.Nil(t, acmeErr)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is unknown
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
 	})
@@ -429,7 +430,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 		require.Nil(t, acctResp)
-		require.Nil(t, acmeErr)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is invalid
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
 	})
@@ -445,7 +447,8 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 
 		require.Equal(t, http.StatusNotFound, resp.StatusCode)
 		require.Nil(t, acctResp)
-		require.Nil(t, acmeErr)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "error/enrollmentNotFound")
 		// no nonce generated when the identifier is invalid
 		require.Empty(t, resp.Header.Get("Replay-Nonce"))
 	})

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -258,9 +258,6 @@ func testGetDirectory(t *testing.T, s *integrationTestSuite) {
 
 func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	// create enrollments for testing
-	enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
-	s.InsertACMEEnrollment(t, enrollValid)
-
 	enrollRevoked := &types.Enrollment{Revoked: true, NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
 	s.InsertACMEEnrollment(t, enrollRevoked)
 
@@ -268,6 +265,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	s.InsertACMEEnrollment(t, enrollExpired)
 
 	t.Run("create new account", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		privateKey := generateTestKey(t)
 		nonce := s.getNonce(t, enrollValid.PathIdentifier)
 		jwsBody := buildJWS(t, privateKey, nonce, s.newAccountURL(enrollValid.PathIdentifier), nil)
@@ -283,9 +283,11 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("return existing account with same JWK", func(t *testing.T) {
-		privateKey := generateTestKey(t)
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
 
 		// create account
+		privateKey := generateTestKey(t)
 		nonce1 := s.getNonce(t, enrollValid.PathIdentifier)
 		jwsBody1 := buildJWS(t, privateKey, nonce1, s.newAccountURL(enrollValid.PathIdentifier), nil)
 		acctResp1, _, resp1 := s.createAccount(t, enrollValid.PathIdentifier, jwsBody1)
@@ -304,10 +306,67 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 		require.Equal(t, acctResp1.Orders, acctResp2.Orders)
 	})
 
-	t.Run("onlyReturnExisting account exists", func(t *testing.T) {
+	t.Run("too many accounts", func(t *testing.T) {
+		// use a dedicated enrollment so prior sub-tests don't affect the count
+		enrollForLimit := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollForLimit)
+
+		// create 3 accounts (the maximum allowed per enrollment)
+		nonce := s.getNonce(t, enrollForLimit.PathIdentifier)
+		for range 3 {
+			key := generateTestKey(t)
+			jwsBody := buildJWS(t, key, nonce, s.newAccountURL(enrollForLimit.PathIdentifier), nil)
+			_, _, resp := s.createAccount(t, enrollForLimit.PathIdentifier, jwsBody)
+			require.Equal(t, http.StatusCreated, resp.StatusCode)
+			nonce = resp.Header.Get("Replay-Nonce")
+		}
+
+		// 4th should fail
+		key := generateTestKey(t)
+		jwsBody := buildJWS(t, key, nonce, s.newAccountURL(enrollForLimit.PathIdentifier), nil)
+		_, acmeErr, resp := s.createAccount(t, enrollForLimit.PathIdentifier, jwsBody)
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
+		require.Contains(t, acmeErr.Type, "error/tooManyAccounts")
+	})
+
+	t.Run("revoked account", func(t *testing.T) {
+		// use a dedicated enrollment to avoid interference with other sub-tests
+		enrollForRevoke := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollForRevoke)
+
 		privateKey := generateTestKey(t)
 
+		// create an account
+		nonce := s.getNonce(t, enrollForRevoke.PathIdentifier)
+		jwsBody := buildJWS(t, privateKey, nonce, s.newAccountURL(enrollForRevoke.PathIdentifier), nil)
+		_, _, resp := s.createAccount(t, enrollForRevoke.PathIdentifier, jwsBody)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+
+		// revoke it directly in the DB
+		var accountID uint
+		err := s.DB.GetContext(t.Context(), &accountID, `SELECT id FROM acme_accounts WHERE acme_enrollment_id = ? ORDER BY id DESC LIMIT 1`, enrollForRevoke.ID)
+		require.NoError(t, err)
+		_, err = s.DB.ExecContext(t.Context(), `UPDATE acme_accounts SET revoked = 1 WHERE id = ?`, accountID)
+		require.NoError(t, err)
+
+		// try to create again with the same key — should get accountRevoked error
+		nonce2 := resp.Header.Get("Replay-Nonce")
+		jwsBody2 := buildJWS(t, privateKey, nonce2, s.newAccountURL(enrollForRevoke.PathIdentifier), nil)
+		_, acmeErr, resp2 := s.createAccount(t, enrollForRevoke.PathIdentifier, jwsBody2)
+
+		require.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+		require.NotEmpty(t, resp2.Header.Get("Replay-Nonce"))
+		require.Contains(t, acmeErr.Type, "error/accountRevoked")
+	})
+
+	t.Run("onlyReturnExisting account exists", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		// create account first
+		privateKey := generateTestKey(t)
 		nonce1 := s.getNonce(t, enrollValid.PathIdentifier)
 		jwsBody1 := buildJWS(t, privateKey, nonce1, s.newAccountURL(enrollValid.PathIdentifier), nil)
 		acctResp1, _, resp1 := s.createAccount(t, enrollValid.PathIdentifier, jwsBody1)
@@ -326,6 +385,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("onlyReturnExisting account does not exist", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		privateKey := generateTestKey(t)
 		nonce := s.getNonce(t, enrollValid.PathIdentifier)
 		payload := map[string]any{"onlyReturnExisting": true}
@@ -338,6 +400,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("unknown identifier", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		// we need a valid enrollment to get a nonce, then use a bad identifier for the account request
 		privateKey := generateTestKey(t)
 		nonce := s.getNonce(t, enrollValid.PathIdentifier)
@@ -353,6 +418,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("revoked enrollment", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		// get nonce from valid enrollment, then try to create account on revoked
 		privateKey := generateTestKey(t)
 		nonce := s.getNonce(t, enrollValid.PathIdentifier)
@@ -367,6 +435,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("expired enrollment", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		privateKey := generateTestKey(t)
 		nonce := s.getNonce(t, enrollValid.PathIdentifier)
 		jwsBody := buildJWS(t, privateKey, nonce, s.newAccountURL(enrollExpired.PathIdentifier), nil)
@@ -380,6 +451,9 @@ func testCreateAccount(t *testing.T, s *integrationTestSuite) {
 	})
 
 	t.Run("invalid nonce", func(t *testing.T) {
+		enrollValid := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enrollValid)
+
 		privateKey := generateTestKey(t)
 		jwsBody := buildJWS(t, privateKey, "bad-nonce-value", s.newAccountURL(enrollValid.PathIdentifier), nil)
 		_, acmeErr, resp := s.createAccount(t, enrollValid.PathIdentifier, jwsBody)

--- a/server/mdm/acme/internal/types/errors.go
+++ b/server/mdm/acme/internal/types/errors.go
@@ -99,6 +99,42 @@ func InternalServerError(detail string) *ACMEError {
 	}
 }
 
+func BadPublicKeyError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "badPublicKey",
+		Title:      "The JWS was signed by a public key the server does not support",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
+	}
+}
+
+func BadSignatureAlgorithmError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "badSignatureAlgorithm",
+		Title:      "The JWS was signed with an algorithm the server does not support",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
+	}
+}
+
+func UnauthorizedError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "unauthorized",
+		Title:      "The client lacks sufficient authorization",
+		Detail:     detail,
+		StatusCode: http.StatusUnauthorized,
+	}
+}
+
+func MalformedError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "malformed",
+		Title:      "The request message was malformed",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
+	}
+}
+
 func (e *ACMEError) Error() string {
 	s := e.Type
 	if e.Title != "" {

--- a/server/mdm/acme/internal/types/errors.go
+++ b/server/mdm/acme/internal/types/errors.go
@@ -28,6 +28,32 @@ type ACMEError struct {
 	StatusCode int    `json:"-"`
 }
 
+var (
+	enrollmentNotFound = EnrollmentNotFoundError("")
+	serverInternal     = InternalServerError("")
+)
+
+func (e *ACMEError) ShouldReturnNonce() bool {
+	if e == nil {
+		return false
+	}
+	switch e.Type {
+	case enrollmentNotFound.Type, serverInternal.Type:
+		return false
+	default:
+		return true
+	}
+}
+
+func EnrollmentNotFoundError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "enrollmentNotFound",
+		Title:      "The specified enrollment does not exist",
+		Detail:     detail,
+		StatusCode: http.StatusNotFound,
+	}
+}
+
 func AccountDoesNotExistError(detail string) *ACMEError {
 	return &ACMEError{
 		Type:       acmeErrorsURN + "accountDoesNotExist",
@@ -61,6 +87,15 @@ func BadNonceError(detail string) *ACMEError {
 		Title:      "The client sent an unacceptable anti-replay nonce",
 		Detail:     detail,
 		StatusCode: http.StatusBadRequest, // as per RFC https://datatracker.ietf.org/doc/html/rfc8555/#section-6.5
+	}
+}
+
+func InternalServerError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "serverInternal",
+		Title:      "The server experienced an internal error",
+		Detail:     detail,
+		StatusCode: http.StatusInternalServerError,
 	}
 }
 

--- a/server/mdm/acme/internal/types/errors.go
+++ b/server/mdm/acme/internal/types/errors.go
@@ -4,7 +4,12 @@ import (
 	"net/http"
 )
 
-const acmeErrorsURN = "urn:ietf:params:acme:error:"
+const (
+	acmeErrorsURN = "urn:ietf:params:acme:error:"
+	// NOTE: ideally this would be a valid, dereferenceable link to human-readable documentation,
+	// but it's ok if it's not too. See https://datatracker.ietf.org/doc/html/rfc8555/#section-6.7
+	fleetCustomErrorsURI = "https://fleetdm.com/acme/error/"
+)
 
 // ACMEError represents an error related to the ACME protocol,
 // see https://datatracker.ietf.org/doc/html/rfc8555/#section-6.7
@@ -29,6 +34,24 @@ func AccountDoesNotExistError(detail string) *ACMEError {
 		Title:      "The request specified an account that does not exist",
 		Detail:     detail,
 		StatusCode: http.StatusBadRequest, // as per RFC https://datatracker.ietf.org/doc/html/rfc8555/#section-7.3.1
+	}
+}
+
+func AccountRevokedError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "accountRevoked",
+		Title:      "The request specified an account that is revoked",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
+	}
+}
+
+func TooManyAccountsError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "tooManyAccounts",
+		Title:      "Too many accounts already exist for this enrollment",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
 	}
 }
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40983 

Still no Create Order implementation, but lots of cleanups and proper error messages.

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
