### PR TITLE
fix policy software vpp automations

### DIFF
--- a/changes/42399-support-vpp-policy-automations-in-generate-gitops
+++ b/changes/42399-support-vpp-policy-automations-in-generate-gitops
@@ -1,0 +1,1 @@
+- Support outputting VPP policy automations in `fleetctl generate-gitops`

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1531,11 +1531,11 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 		if policy.InstallSoftware != nil {
 			if software, ok := cmd.SoftwareList[policy.InstallSoftware.SoftwareTitleID]; ok {
 				if software.Hash != "" {
-					policySpec["install_software"] = map[string]interface{}{
+					policySpec["install_software"] = map[string]any{
 						"hash_sha256": software.Hash + " " + software.Comment,
 					}
 				} else if software.AppStoreId != "" {
-					policySpec["install_software"] = map[string]interface{}{
+					policySpec["install_software"] = map[string]any{
 						"app_store_id": software.AppStoreId,
 					}
 				}

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -587,7 +587,7 @@ func (cmd *GenerateGitopsCommand) Run() error {
 		}
 
 		// Generate policies.
-		policies, err := cmd.generatePolicies(teamToProcess.ID, teamFileName, failingPolicyIDs)
+		policies, err := cmd.generatePolicies(teamToProcess.ID, fileName, failingPolicyIDs)
 		if err != nil {
 			teamName := "global"
 			if team != nil {
@@ -1530,8 +1530,14 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 		// Handle software automation.
 		if policy.InstallSoftware != nil {
 			if software, ok := cmd.SoftwareList[policy.InstallSoftware.SoftwareTitleID]; ok {
-				policySpec["install_software"] = map[string]interface{}{
-					"hash_sha256": software.Hash + " " + software.Comment,
+				if software.Hash != "" {
+					policySpec["install_software"] = map[string]interface{}{
+						"hash_sha256": software.Hash + " " + software.Comment,
+					}
+				} else if software.AppStoreId != "" {
+					policySpec["install_software"] = map[string]interface{}{
+						"app_store_id": software.AppStoreId,
+					}
 				}
 			} else {
 				policySpec["install_software"] = map[string]interface{}{
@@ -1725,6 +1731,9 @@ func (cmd *GenerateGitopsCommand) generateSoftware(filePath string, teamID uint,
 			}
 		case sw.AppStoreApp != nil:
 			softwareSpec["app_store_id"] = sw.AppStoreApp.AppStoreID
+			cmd.SoftwareList[sw.ID] = Software{
+				AppStoreId: sw.AppStoreApp.AppStoreID,
+			}
 		default:
 			fmt.Fprintf(cmd.CLI.App.ErrWriter, "Error: software %s has no software package or app store app\n", sw.Name)
 			continue

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -284,7 +284,7 @@ func (MockClient) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListRes
 				ID:   7,
 				Name: "My iOS Auto Update App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{
-					AppStoreID: "com.example.ios-auto-update",
+					AppStoreID: "9999888877",
 					Platform:   string(fleet.IOSPlatform),
 				},
 				HashSHA256: ptr.String("ios-auto-update-hash"),
@@ -506,7 +506,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 		return &fleet.SoftwareTitle{
 			ID: 7,
 			AppStoreApp: &fleet.VPPAppStoreApp{
-				VPPAppID:    fleet.VPPAppID{AdamID: "com.example.ios-auto-update", Platform: fleet.IOSPlatform},
+				VPPAppID:    fleet.VPPAppID{AdamID: "9999888877", Platform: fleet.IOSPlatform},
 				SelfService: false,
 				LabelsIncludeAll: []fleet.SoftwareScopeLabel{
 					{
@@ -1113,7 +1113,7 @@ func TestGenerateSoftwareAutoUpdateSchedule(t *testing.T) {
 
 	var found bool
 	for _, a := range appsList {
-		if a["app_store_id"] == "com.example.ios-auto-update" {
+		if a["app_store_id"] == "9999888877" {
 			found = true
 			// auto update keys should be present
 			val, ok := a["auto_update_enabled"]

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -380,6 +380,20 @@ func (MockClient) GetPolicies(teamID *uint) ([]*fleet.Policy, error) {
 				SoftwareTitleID: 8,
 			},
 		},
+		{
+			PolicyData: fleet.PolicyData{
+				ID:          3,
+				Name:        "Team VPP policy",
+				Query:       "SELECT * FROM team_policy WHERE id = 3",
+				Resolution:  ptr.String("Install the app"),
+				Description: "This is a team policy with VPP app automation",
+				Platform:    "darwin",
+				Type:        fleet.PolicyTypeDynamic,
+			},
+			InstallSoftware: &fleet.PolicySoftwareTitle{
+				SoftwareTitleID: 2,
+			},
+		},
 	}, nil
 }
 
@@ -1759,6 +1773,9 @@ func TestGeneratePolicies(t *testing.T) {
 			1: {
 				Hash:    "team-software-hash",
 				Comment: "__TEAM_SOFTWARE_COMMENT_TOKEN__",
+			},
+			2: {
+				AppStoreId: "com.example.team-software",
 			},
 		},
 		ScriptList: map[uint]string{

--- a/cmd/fleetctl/fleetctl/generate_gitops_test.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops_test.go
@@ -265,7 +265,7 @@ func (MockClient) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListRes
 				ID:   2,
 				Name: "My App Store App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{
-					AppStoreID: "com.example.team-software",
+					AppStoreID: "1234567890",
 					Platform:   string(fleet.MacOSPlatform),
 				},
 				HashSHA256: ptr.String("app-store-app-hash"),
@@ -274,7 +274,7 @@ func (MockClient) ListSoftwareTitles(query string) ([]fleet.SoftwareTitleListRes
 				ID:   6,
 				Name: "My Setup Experience App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{
-					AppStoreID:         "com.example.setup-experience-software",
+					AppStoreID:         "55566677778",
 					Platform:           string(fleet.AndroidPlatform),
 					InstallDuringSetup: ptr.Bool(true),
 				},
@@ -487,7 +487,7 @@ func (MockClient) GetSoftwareTitleByID(ID uint, teamID *uint) (*fleet.SoftwareTi
 		return &fleet.SoftwareTitle{
 			ID: 6,
 			AppStoreApp: &fleet.VPPAppStoreApp{
-				VPPAppID: fleet.VPPAppID{AdamID: "com.example.setup-experience-software", Platform: fleet.AndroidPlatform},
+				VPPAppID: fleet.VPPAppID{AdamID: "55566677778", Platform: fleet.AndroidPlatform},
 				LabelsIncludeAll: []fleet.SoftwareScopeLabel{
 					{
 						LabelName: "Label C",
@@ -638,7 +638,7 @@ func (MockClient) GetSetupExperienceSoftware(platform string, teamID uint) ([]fl
 				ID:   6,
 				Name: "My Setup Experience App",
 				AppStoreApp: &fleet.SoftwarePackageOrApp{
-					AppStoreID:         "com.example.setup-experience-software",
+					AppStoreID:         "55566677778",
 					Platform:           string(fleet.AndroidPlatform),
 					InstallDuringSetup: ptr.Bool(true),
 				},
@@ -1775,7 +1775,7 @@ func TestGeneratePolicies(t *testing.T) {
 				Comment: "__TEAM_SOFTWARE_COMMENT_TOKEN__",
 			},
 			2: {
-				AppStoreId: "com.example.team-software",
+				AppStoreId: "1234567890",
 			},
 		},
 		ScriptList: map[uint]string{

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -28,7 +28,7 @@
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: 1234567890
+    app_store_id: "1234567890"
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -23,3 +23,15 @@
   conditional_access_enabled: true
   conditional_access_bypass_enabled: false
   webhooks_and_tickets_enabled: false
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a team policy with VPP app automation
+  install_software:
+    app_store_id: com.example.team-software
+  name: Team VPP policy
+  platform: darwin
+  query: SELECT * FROM team_policy WHERE id = 3
+  resolution: Install the app
+  type: dynamic
+  webhooks_and_tickets_enabled: false

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamPolicies.yaml
@@ -28,7 +28,7 @@
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: com.example.team-software
+    app_store_id: 1234567890
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -35,7 +35,7 @@ fleet_maintained_apps:
       - Label B
     self_service: true
 app_store_apps:
-  - app_store_id: com.example.team-software
+  - app_store_id: 1234567890
     labels_exclude_any:
       - Label C
       - Label D
@@ -44,7 +44,7 @@ app_store_apps:
       - Utilities
     self_service: true
     platform: darwin
-  - app_store_id: com.example.setup-experience-software
+  - app_store_id: 55566677778
     labels_include_all:
       - Label C
       - Label D

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/expectedTeamSoftware.yaml
@@ -35,7 +35,7 @@ fleet_maintained_apps:
       - Label B
     self_service: true
 app_store_apps:
-  - app_store_id: 1234567890
+  - app_store_id: "1234567890"
     labels_exclude_any:
       - Label C
       - Label D
@@ -44,14 +44,14 @@ app_store_apps:
       - Utilities
     self_service: true
     platform: darwin
-  - app_store_id: 55566677778
+  - app_store_id: "55566677778"
     labels_include_all:
       - Label C
       - Label D
     platform: android
     self_service: true
     setup_experience: true
-  - app_store_id: com.example.ios-auto-update
+  - app_store_id: "9999888877"
     labels_include_all:
       - Label C
       - Label D

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_free/default.yml
@@ -181,7 +181,7 @@ policies:
   critical: false
   description: This is a global policy
   install_software:
-    hash_sha256: ___GITOPS_COMMENT_15___
+    hash_sha256: # TODO: Add your hash_sha256 here
   labels_include_any:
   - Label A
   - Label B

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -70,6 +70,18 @@ policies:
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a team policy with VPP app automation
+  install_software:
+    app_store_id: com.example.team-software
+  name: Team VPP policy
+  platform: darwin
+  query: SELECT * FROM team_policy WHERE id = 3
+  resolution: Install the app
+  type: dynamic
+  webhooks_and_tickets_enabled: true
 reports:
 - automations_enabled: true
   description: This is a team query

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -75,7 +75,7 @@ policies:
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: com.example.team-software
+    app_store_id: 1234567890
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3
@@ -119,7 +119,7 @@ settings:
       host_percentage: 2
 software:
   app_store_apps:
-  - app_store_id: com.example.team-software
+  - app_store_id: 1234567890
     categories:
     - Productivity
     - Utilities
@@ -130,7 +130,7 @@ software:
     - Label D
     platform: darwin
     self_service: true
-  - app_store_id: com.example.setup-experience-software
+  - app_store_id: 55566677778
     icon:
       path: "../lib/team-a-👍/icons/my-setup-experience-app-android-icon.png"
     labels_include_all:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/team-a-thumbsup.yml
@@ -75,7 +75,7 @@ policies:
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: 1234567890
+    app_store_id: "1234567890"
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3
@@ -119,7 +119,7 @@ settings:
       host_percentage: 2
 software:
   app_store_apps:
-  - app_store_id: 1234567890
+  - app_store_id: "1234567890"
     categories:
     - Productivity
     - Utilities
@@ -130,7 +130,7 @@ software:
     - Label D
     platform: darwin
     self_service: true
-  - app_store_id: 55566677778
+  - app_store_id: "55566677778"
     icon:
       path: "../lib/team-a-👍/icons/my-setup-experience-app-android-icon.png"
     labels_include_all:
@@ -139,7 +139,7 @@ software:
     platform: android
     self_service: true
     setup_experience: true
-  - app_store_id: com.example.ios-auto-update
+  - app_store_id: "9999888877"
     auto_update_enabled: true
     auto_update_window_end: "03:00"
     auto_update_window_start: "01:00"

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -53,6 +53,18 @@ policies:
   resolution: Do a team thing
   type: patch
   webhooks_and_tickets_enabled: true
+- calendar_events_enabled: false
+  conditional_access_enabled: false
+  critical: false
+  description: This is a team policy with VPP app automation
+  install_software:
+    app_store_id: com.example.team-software
+  name: Team VPP policy
+  platform: darwin
+  query: SELECT * FROM team_policy WHERE id = 3
+  resolution: Install the app
+  type: dynamic
+  webhooks_and_tickets_enabled: true
 settings:
   webhook_settings:
     failing_policies_webhook:

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -58,7 +58,7 @@ policies:
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: 1234567890
+    app_store_id: "1234567890"
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3

--- a/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
+++ b/cmd/fleetctl/fleetctl/testdata/generateGitops/test_dir_premium/fleets/unassigned.yml
@@ -58,7 +58,7 @@ policies:
   critical: false
   description: This is a team policy with VPP app automation
   install_software:
-    app_store_id: com.example.team-software
+    app_store_id: 1234567890
   name: Team VPP policy
   platform: darwin
   query: SELECT * FROM team_policy WHERE id = 3


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42399

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [X] Added a policy with a VPP software automation, confirmed that `generate-gitops` output an `app_store_id` for the policy
  - [X] Verified that FMA and custom package automations still output correctly from `generate-gitops`
  - [X] Verified that `fleetctl gitops` ingested the policies + automations correctly.
