### PR TITLE
Bugfix: User management table has row key collision when user and invite share the same ID (#42396)

### DIFF
--- a/changes/42311-fix-users-table-duplicates-and-count
+++ b/changes/42311-fix-users-table-duplicates-and-count
@@ -1,0 +1,1 @@
+* Fixed an issue where users with the same ID as an invited user would be hidden from the users table, and fixed the users count to include invited users.

--- a/frontend/pages/admin/UserManagementPage/components/ResetPasswordModal/ResetPasswordModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/ResetPasswordModal/ResetPasswordModal.tsx
@@ -1,18 +1,15 @@
 import React from "react";
-import { IUser } from "interfaces/user";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
 const baseClass = "reset-password-modal";
 
 interface IResetPasswordModal {
-  user: IUser;
-  onResetConfirm: (user: IUser) => void;
+  onResetConfirm: () => void;
   onResetCancel: () => void;
 }
 
 const ResetPasswordModal = ({
-  user,
   onResetConfirm,
   onResetCancel,
 }: IResetPasswordModal): JSX.Element => {
@@ -20,7 +17,7 @@ const ResetPasswordModal = ({
     <Modal
       title="Require password reset"
       onExit={onResetCancel}
-      onEnter={() => onResetConfirm(user)}
+      onEnter={onResetConfirm}
     >
       <div className={baseClass}>
         <p>
@@ -30,7 +27,7 @@ const ResetPasswordModal = ({
           This will revoke all active Fleet API tokens for this user.
         </p>
         <div className="modal-cta-wrap">
-          <Button type="button" onClick={() => onResetConfirm(user)}>
+          <Button type="button" onClick={onResetConfirm}>
             Confirm
           </Button>
           <Button onClick={onResetCancel} variant="inverse">

--- a/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/ResetSessionsModal/ResetSessionsModal.tsx
@@ -1,18 +1,15 @@
 import React from "react";
-import { IUser } from "interfaces/user";
 import Modal from "components/Modal";
 import Button from "components/buttons/Button";
 
 const baseClass = "reset-sessions-modal";
 
 interface IResetSessionsModal {
-  user: IUser;
-  onResetConfirm: (user: IUser) => void;
+  onResetConfirm: () => void;
   onResetCancel: () => void;
 }
 
 const ResetSessionsModal = ({
-  user,
   onResetConfirm,
   onResetCancel,
 }: IResetSessionsModal): JSX.Element => {
@@ -20,7 +17,7 @@ const ResetSessionsModal = ({
     <Modal
       title="Reset sessions"
       onExit={onResetCancel}
-      onEnter={() => onResetConfirm(user)}
+      onEnter={onResetConfirm}
     >
       <div className={baseClass}>
         <p>
@@ -29,7 +26,7 @@ const ResetSessionsModal = ({
           This will revoke all active Fleet API tokens for this user.
         </p>
         <div className="modal-cta-wrap">
-          <Button type="button" onClick={() => onResetConfirm(user)}>
+          <Button type="button" onClick={onResetConfirm}>
             Confirm
           </Button>
           <Button onClick={onResetCancel} variant="inverse">

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTable.tsx
@@ -20,7 +20,11 @@ import { ITableQueryData } from "components/TableContainer/TableContainer";
 import TableCount from "components/TableContainer/TableCount";
 import TableDataError from "components/DataError";
 import EmptyTable from "components/EmptyTable";
-import { generateTableHeaders, combineDataSets } from "./UsersTableConfig";
+import {
+  generateTableHeaders,
+  combineDataSets,
+  IUserTableData,
+} from "./UsersTableConfig";
 import DeleteUserModal from "../DeleteUserModal";
 import ResetPasswordModal from "../ResetPasswordModal";
 import ResetSessionsModal from "../ResetSessionsModal";
@@ -49,7 +53,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   const [showResetPasswordModal, setShowResetPasswordModal] = useState(false);
   const [showResetSessionsModal, setShowResetSessionsModal] = useState(false);
   const [isUpdatingUsers, setIsUpdatingUsers] = useState(false);
-  const [userEditing, setUserEditing] = useState<any>(null);
+  const [userEditing, setUserEditing] = useState<IUserTableData | null>(null);
   const [addUserErrors, setAddUserErrors] = useState<IUserFormErrors>({});
   const [editUserErrors, setEditUserErrors] = useState<IUserFormErrors>({});
   const [querySearchText, setQuerySearchText] = useState("");
@@ -112,34 +116,34 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   }, [showAddUserModal, setShowAddUserModal]);
 
   const toggleDeleteUserModal = useCallback(
-    (user?: IUser | IInvite) => {
+    (user?: IUserTableData) => {
       setShowDeleteUserModal(!showDeleteUserModal);
-      setUserEditing(!showDeleteUserModal ? user : null);
+      setUserEditing(!showDeleteUserModal ? user ?? null : null);
     },
     [showDeleteUserModal, setShowDeleteUserModal, setUserEditing]
   );
 
   const toggleEditUserModal = useCallback(
-    (user?: IUser | IInvite) => {
+    (user?: IUserTableData) => {
       setShowEditUserModal(!showEditUserModal);
-      setUserEditing(!showEditUserModal ? user : null);
+      setUserEditing(!showEditUserModal ? user ?? null : null);
       setEditUserErrors({});
     },
     [showEditUserModal, setShowEditUserModal, setUserEditing]
   );
 
   const toggleResetPasswordUserModal = useCallback(
-    (user?: IUser | IInvite) => {
+    (user?: IUserTableData) => {
       setShowResetPasswordModal(!showResetPasswordModal);
-      setUserEditing(!showResetPasswordModal ? user : null);
+      setUserEditing(!showResetPasswordModal ? user ?? null : null);
     },
     [showResetPasswordModal, setShowResetPasswordModal, setUserEditing]
   );
 
   const toggleResetSessionsUserModal = useCallback(
-    (user?: IUser | IInvite) => {
+    (user?: IUserTableData) => {
       setShowResetSessionsModal(!showResetSessionsModal);
-      setUserEditing(!showResetSessionsModal ? user : null);
+      setUserEditing(!showResetSessionsModal ? user ?? null : null);
     },
     [showResetSessionsModal, setShowResetSessionsModal, setUserEditing]
   );
@@ -152,7 +156,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   }, [router]);
 
   const onActionSelect = useCallback(
-    (value: string, user: IUser | IInvite) => {
+    (value: string, user: IUserTableData) => {
       switch (value) {
         case "edit":
           toggleEditUserModal(user);
@@ -290,7 +294,8 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   };
 
   const onEditUser = (formData: IUserFormData) => {
-    const userData = getUser(userEditing.type, userEditing.id);
+    if (!userEditing) return;
+    const userData = getUser(userEditing.type, userEditing.apiId);
 
     let userUpdatedFlashMessage = `Successfully edited ${formData.name}`;
     if (userData?.email !== formData.email) {
@@ -307,40 +312,36 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
       requestData.new_password = null;
     }
 
+    if (!userData) return;
+
     setIsUpdatingUsers(true);
     if (userEditing.type === "invite") {
-      return (
-        userData &&
-        invitesAPI
-          .update(userData.id, requestData as IEditInviteFormData)
-          .then(() => {
-            renderFlash("success", userUpdatedFlashMessage);
-            toggleEditUserModal();
-            refetchInvites();
-          })
-          .catch((userErrors: { data: IApiError }) => {
-            if (userErrors.data.errors[0].reason.includes("already exists")) {
-              setEditUserErrors({
-                email: userUpdatedEmailError,
-              });
-            } else if (
-              userErrors.data.errors[0].reason.includes("required criteria")
-            ) {
-              setEditUserErrors({
-                password: userUpdatedPasswordError,
-              });
-            } else {
-              renderFlash("error", userUpdatedError);
-            }
-          })
-          .finally(() => {
-            setIsUpdatingUsers(false);
-          })
-      );
-    }
-
-    return (
-      userData &&
+      invitesAPI
+        .update(userData.id, requestData as IEditInviteFormData)
+        .then(() => {
+          renderFlash("success", userUpdatedFlashMessage);
+          toggleEditUserModal();
+          refetchInvites();
+        })
+        .catch((userErrors: { data: IApiError }) => {
+          if (userErrors.data.errors[0].reason.includes("already exists")) {
+            setEditUserErrors({
+              email: userUpdatedEmailError,
+            });
+          } else if (
+            userErrors.data.errors[0].reason.includes("required criteria")
+          ) {
+            setEditUserErrors({
+              password: userUpdatedPasswordError,
+            });
+          } else {
+            renderFlash("error", userUpdatedError);
+          }
+        })
+        .finally(() => {
+          setIsUpdatingUsers(false);
+        });
+    } else {
       usersAPI
         .update(userData.id, requestData)
         .then(() => {
@@ -365,15 +366,16 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         })
         .finally(() => {
           setIsUpdatingUsers(false);
-        })
-    );
+        });
+    }
   };
 
   const onDeleteUser = () => {
+    if (!userEditing) return;
     setIsUpdatingUsers(true);
     if (userEditing.type === "invite") {
       invitesAPI
-        .destroy(userEditing.id)
+        .destroy(userEditing.apiId)
         .then(() => {
           renderFlash("success", `Successfully deleted ${userEditing?.name}.`);
         })
@@ -390,7 +392,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
         });
     } else {
       usersAPI
-        .destroy(userEditing.id)
+        .destroy(userEditing.apiId)
         .then(() => {
           renderFlash("success", `Successfully deleted ${userEditing?.name}.`);
         })
@@ -409,10 +411,12 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   };
 
   const onResetSessions = () => {
-    const isResettingCurrentUser = currentUser?.id === userEditing.id;
+    if (!userEditing) return;
+    const isResettingCurrentUser =
+      userEditing.type === "user" && currentUser?.id === userEditing.apiId;
 
     usersAPI
-      .deleteSessions(userEditing.id)
+      .deleteSessions(userEditing.apiId)
       .then(() => {
         if (isResettingCurrentUser) {
           authToken.remove();
@@ -431,9 +435,10 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
       });
   };
 
-  const resetPassword = (user: IUser) => {
-    return usersAPI
-      .requirePasswordReset(user.id, { require: true })
+  const resetPassword = () => {
+    if (!userEditing) return;
+    usersAPI
+      .requirePasswordReset(userEditing.apiId, { require: true })
       .then(() => {
         renderFlash("success", "Successfully required a password reset.");
       })
@@ -449,7 +454,8 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   };
 
   const renderEditUserModal = () => {
-    const userData = getUser(userEditing.type, userEditing.id);
+    if (!userEditing) return null;
+    const userData = getUser(userEditing.type, userEditing.apiId);
 
     return (
       <EditUserModal
@@ -495,6 +501,7 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   };
 
   const renderDeleteUserModal = () => {
+    if (!userEditing) return null;
     return (
       <DeleteUserModal
         name={userEditing.name}
@@ -508,7 +515,6 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   const renderResetPasswordModal = () => {
     return (
       <ResetPasswordModal
-        user={userEditing}
         onResetConfirm={resetPassword}
         onResetCancel={toggleResetPasswordUserModal}
       />
@@ -518,7 +524,6 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   const renderResetSessionsModal = () => {
     return (
       <ResetSessionsModal
-        user={userEditing}
         onResetConfirm={onResetSessions}
         onResetCancel={toggleResetSessionsUserModal}
       />
@@ -548,8 +553,8 @@ const UsersTable = ({ router }: IUsersTableProps): JSX.Element => {
   );
 
   const renderUsersCount = useCallback(() => {
-    return <TableCount name="users" count={users?.length} />;
-  }, [users?.length]);
+    return <TableCount name="users" count={tableData?.length} />;
+  }, [tableData?.length]);
 
   return (
     <>

--- a/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UsersTable/UsersTableConfig.tsx
@@ -22,7 +22,7 @@ interface IHeaderProps {
 
 interface IRowProps {
   row: {
-    original: IUser | IInvite;
+    original: IUserTableData;
   };
 }
 
@@ -56,7 +56,10 @@ export interface IUserTableData {
   teams: string;
   role: UserRole;
   actions: IDropdownOption[];
-  id: number;
+  /** Prefixed ID used as a unique react-table row key (e.g. "user-3", "invite-1") */
+  id: string;
+  /** Numeric ID used for API calls */
+  apiId: number;
   type: string;
   api_only: boolean;
 }
@@ -64,7 +67,7 @@ export interface IUserTableData {
 // NOTE: cellProps come from react-table
 // more info here https://react-table.tanstack.com/docs/api/useTable#cell-properties
 const generateTableHeaders = (
-  actionSelectHandler: (value: string, user: IUser | IInvite) => void,
+  actionSelectHandler: (value: string, user: IUserTableData) => void,
   isPremiumTier: boolean | undefined
 ): IDataColumn[] => {
   const tableHeaders: IDataColumn[] = [
@@ -276,7 +279,8 @@ const enhanceUserData = (
         false,
         user.sso_enabled
       ),
-      id: user.id,
+      id: `user-${user.id}`,
+      apiId: user.id,
       type: "user",
       api_only: user.api_only,
     };
@@ -292,7 +296,8 @@ const enhanceInviteData = (invites: IInvite[]): IUserTableData[] => {
       teams: generateTeam(invite.teams, invite.global_role),
       role: generateRole(invite.teams, invite.global_role),
       actions: generateActionDropdownOptions(false, true, invite.sso_enabled),
-      id: invite.id,
+      id: `invite-${invite.id}`,
+      apiId: invite.id,
       type: "invite",
       api_only: false, // api only users are created through fleetctl and not invites
     };


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42311

- Fixes ID collision on Users table (causing users to not be rendered when an existing user's ID matches an invited user's ID).
- Fixes total users count.
- Fixes `isResettingCurrentUser` check.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
See [Changes
files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

#### Before

- ID collision caused the admin user to not be rendered on the table (see the user with Invite pending which has id=1 as the admin does).
- Notice that we have a total of 3 users counting the response from `users` and `invites` endpoints.

<img width="2557" height="477" alt="Screenshot 2026-03-25 at 2 46 31 PM" src="https://github.com/user-attachments/assets/833b07f5-a0ce-4f15-94bf-79040bd03dba" />
<img width="2555" height="722" alt="Screenshot 2026-03-25 at 2 46 26 PM" src="https://github.com/user-attachments/assets/5707ab37-b060-40b4-913f-864b2254076d" />

#### After

- All users showing.
- Updated count to reflect the sum of users + invited users above the table.

<img width="1358" height="432" alt="Screenshot 2026-03-25 at 2 53 24 PM" src="https://github.com/user-attachments/assets/2a995e78-0ae8-4846-a8b1-b35edd61cb02" />
