### PR TITLE
For R.C. - Fix missing margin on GitOps info banner in Add Custom Packages page (#41819)

### DIFF
--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/_styles.scss
@@ -1,4 +1,6 @@
 .software-custom-package {
+  @include vertical-page-layout;
+
   &__premium-message {
     margin-top: $pad-xxxlarge;
   }

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -489,23 +489,25 @@ const PackageForm = ({
           gitopsCompatible={gitopsCompatible}
           gitOpsModeEnabled={gitOpsModeEnabled}
         />
-        <div
-          // including `form` class here keeps the children fields subject to the global form
-          // children styles
-          className={
-            gitopsCompatible && gitOpsModeEnabled
-              ? `${baseClass}__form-fields--gitops-disabled form`
-              : "form"
-          }
-        >
-          {showDeploySoftwareSlider && renderSoftwareDeploySlider()}
-          {showOptionsTargetsSelectors && (
-            <div className={`${baseClass}__form-frame`}>
-              {renderSoftwareOptionsSelector()}
-              {renderTargetLabelSelector()}
-            </div>
-          )}
-        </div>
+        {(showDeploySoftwareSlider || showOptionsTargetsSelectors) && ( // Only show container if one of the two components will be rendered to avoid extra gap spacing
+          <div
+            // including `form` class here keeps the children fields subject to the global form
+            // children styles
+            className={
+              gitopsCompatible && gitOpsModeEnabled
+                ? `${baseClass}__form-fields--gitops-disabled form`
+                : "form"
+            }
+          >
+            {showDeploySoftwareSlider && renderSoftwareDeploySlider()}
+            {showOptionsTargetsSelectors && (
+              <div className={`${baseClass}__form-frame`}>
+                {renderSoftwareOptionsSelector()}
+                {renderTargetLabelSelector()}
+              </div>
+            )}
+          </div>
+        )}
         {showAdvancedOptions && (
           <PackageAdvancedOptions
             showSchemaButton={showSchemaButton}


### PR DESCRIPTION
## Issue
Closes #41820 

## Description
- This is for the 4.83.0 RC
- This was merged into main with #41819

```
 1068  git checkout fleetdm/rc-minor-fleet-v4.83.0
 1069  git checkout -b marko-kilo-margin-rc
 1070  git cherry-pick 9715ee9
 1071  git branch
 1072  git status
 1073  git push -u fleetdm marko-kilo-margin-rc
```