### PR TITLE
ACME: DEP enrollment changes (Part 2)

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1046,9 +1046,9 @@ the way that the Fleet server works.
 			// Inject the activity bounded context into the main service
 			svc.SetActivityService(activitySvc)
 
-			// Bootstrap ACME service modiule
+			// Bootstrap ACME service module
 			acmeSvc, acmeRoutes := createACMEServiceModule(ds, dbConns, redisPool, logger)
-			// Inject the ACME service modiule into the main service
+			// Inject the ACME service module into the main service
 			svc.SetACMEService(acmeSvc)
 
 			// Perform a cleanup of cron_stats outside of the cronSchedules because the

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1046,9 +1046,9 @@ the way that the Fleet server works.
 			// Inject the activity bounded context into the main service
 			svc.SetActivityService(activitySvc)
 
-			// Bootstrap ACME bounded context
+			// Bootstrap ACME service modiule
 			acmeSvc, acmeRoutes := createACMEServiceModule(ds, dbConns, redisPool, logger)
-			// Inject the ACME bounded context into the main service
+			// Inject the ACME service modiule into the main service
 			svc.SetACMEService(acmeSvc)
 
 			// Perform a cleanup of cron_stats outside of the cronSchedules because the

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -58,6 +58,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/live_query"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
+	acme_api "github.com/fleetdm/fleet/v4/server/mdm/acme/api"
+	acme_bootstrap "github.com/fleetdm/fleet/v4/server/mdm/acme/bootstrap"
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
@@ -1044,6 +1046,11 @@ the way that the Fleet server works.
 			// Inject the activity bounded context into the main service
 			svc.SetActivityService(activitySvc)
 
+			// Bootstrap ACME bounded context
+			acmeSvc, acmeRoutes := createACMEServiceModule(ds, dbConns, redisPool, logger)
+			// Inject the ACME bounded context into the main service
+			svc.SetACMEService(acmeSvc)
+
 			// Perform a cleanup of cron_stats outside of the cronSchedules because the
 			// schedule package uses cron_stats entries to decide whether a schedule will
 			// run or not (see https://github.com/fleetdm/fleet/issues/9486).
@@ -1405,7 +1412,7 @@ the way that the Fleet server works.
 				extra = append(extra, service.WithHTTPSigVerifier(httpSigVerifier))
 
 				apiHandler = service.MakeHandler(svc, config, httpLogger, limiterStore, redisPool, carveStore,
-					[]endpointer.HandlerRoutesFunc{android_service.GetRoutes(svc, androidSvc), activityRoutes}, extra...)
+					[]endpointer.HandlerRoutesFunc{android_service.GetRoutes(svc, androidSvc), activityRoutes, acmeRoutes}, extra...)
 
 				if serveCSP {
 					// Only injecting this if CSP is turned on since the default security headers add some overhead to each request
@@ -1815,6 +1822,12 @@ the way that the Fleet server works.
 	serveCmd.PersistentFlags().BoolVar(&devExpiredLicense, "dev_expired_license", false, "Enable expired development license")
 
 	return serveCmd
+}
+
+func createACMEServiceModule(ds fleet.Datastore, dbConns *common_mysql.DBConnections, redisPool fleet.RedisPool, logger *slog.Logger) (acme_api.Service, endpointer.HandlerRoutesFunc) {
+	acmeSvc, acmeRoutesFn := acme_bootstrap.New(dbConns, redisPool, ds, logger)
+	acmeRoutes := acmeRoutesFn()
+	return acmeSvc, acmeRoutes
 }
 
 func createActivityBoundedContext(svc fleet.Service, dbConns *common_mysql.DBConnections, logger *slog.Logger) (activity_api.Service, endpointer.HandlerRoutesFunc) {

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -48,6 +48,8 @@ type TestAppleMDMClient struct {
 	SerialNumber string
 	// Model is the model of the simulated device.
 	Model string
+	// OSVersion is the version of the operating system of the simulated device.
+	OSVersion string
 
 	// EnrollInfo holds the information necessary to enroll to an MDM server.
 	EnrollInfo AppleEnrollInfo
@@ -449,9 +451,10 @@ func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDesktopURL() error {
 
 func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURL() error {
 	di, err := EncodeDeviceInfo(fleet.MDMAppleMachineInfo{
-		Serial:  c.SerialNumber,
-		UDID:    c.UUID,
-		Product: c.Model,
+		Serial:    c.SerialNumber,
+		UDID:      c.UUID,
+		Product:   c.Model,
+		OSVersion: c.OSVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("test client: encoding device info: %w", err)
@@ -463,9 +466,10 @@ func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURL() error {
 
 func (c *TestAppleMDMClient) fetchEnrollmentProfileFromDEPURLUsingPost() error {
 	buf, err := MachineInfoAsPKCS7(fleet.MDMAppleMachineInfo{
-		Serial:  c.SerialNumber,
-		UDID:    c.UUID,
-		Product: c.Model,
+		Serial:    c.SerialNumber,
+		UDID:      c.UUID,
+		Product:   c.Model,
+		OSVersion: c.OSVersion,
 	})
 	if err != nil {
 		return fmt.Errorf("test client: encoding device info: %w", err)
@@ -534,6 +538,8 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 	if err != nil {
 		return fmt.Errorf("verifying OTA profile: %w", err)
 	}
+
+	fmt.Println("OTA profile content:", string(p7.Content))
 
 	var otaEnrollmentProfile struct {
 		PayloadContent struct {
@@ -629,6 +635,8 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		} `plist:"PayloadContent"`
 	}
 
+	fmt.Println("SCEP response content:", string(body))
+
 	err = plist.Unmarshal(body, &scepInfo)
 	if err != nil {
 		return fmt.Errorf("unmarshaling SCEP response: %w", err)
@@ -655,6 +663,7 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		c.EnrollInfo.RawProfile = p7.Content
 		return nil
 	}
+	fmt.Println("Enrollment profile content:", string(p7.Content))
 	enrollInfo, err := ParseEnrollmentProfile(p7.Content)
 	if err != nil {
 		return fmt.Errorf("parse OTA SCEP profile: %w", err)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -1278,12 +1278,12 @@ func (c *TestAppleMDMClient) request(contentType string, payload map[string]any)
 // ParseEnrollmentProfile parses the enrollment profile and returns the parsed information as EnrollInfo.
 func ParseEnrollmentProfile(mobileConfig []byte) (*AppleEnrollInfo, error) {
 	var enrollmentProfile struct {
-		PayloadContent []map[string]interface{} `plist:"PayloadContent"`
+		PayloadContent []map[string]any `plist:"PayloadContent"`
 	}
 	if err := plist.Unmarshal(mobileConfig, &enrollmentProfile); err != nil {
 		return nil, fmt.Errorf("unmarshal enrollment profile: %w", err)
 	}
-	payloadContent, ok := enrollmentProfile.PayloadContent[0]["PayloadContent"].(map[string]interface{})
+	payloadContent, ok := enrollmentProfile.PayloadContent[0]["PayloadContent"].(map[string]any)
 	if !ok {
 		return nil, errors.New("PayloadContent field not found")
 	}

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -539,8 +539,6 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		return fmt.Errorf("verifying OTA profile: %w", err)
 	}
 
-	fmt.Println("OTA profile content:", string(p7.Content))
-
 	var otaEnrollmentProfile struct {
 		PayloadContent struct {
 			URL string `plist:"URL"`
@@ -635,8 +633,6 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		} `plist:"PayloadContent"`
 	}
 
-	fmt.Println("SCEP response content:", string(body))
-
 	err = plist.Unmarshal(body, &scepInfo)
 	if err != nil {
 		return fmt.Errorf("unmarshaling SCEP response: %w", err)
@@ -663,7 +659,6 @@ func (c *TestAppleMDMClient) fetchOTAProfile(url string) error {
 		c.EnrollInfo.RawProfile = p7.Content
 		return nil
 	}
-	fmt.Println("Enrollment profile content:", string(p7.Content))
 	enrollInfo, err := ParseEnrollmentProfile(p7.Content)
 	if err != nil {
 		return fmt.Errorf("parse OTA SCEP profile: %w", err)

--- a/pkg/mdm/mdmtest/apple.go
+++ b/pkg/mdm/mdmtest/apple.go
@@ -1283,7 +1283,10 @@ func ParseEnrollmentProfile(mobileConfig []byte) (*AppleEnrollInfo, error) {
 	if err := plist.Unmarshal(mobileConfig, &enrollmentProfile); err != nil {
 		return nil, fmt.Errorf("unmarshal enrollment profile: %w", err)
 	}
-	payloadContent := enrollmentProfile.PayloadContent[0]["PayloadContent"].(map[string]interface{})
+	payloadContent, ok := enrollmentProfile.PayloadContent[0]["PayloadContent"].(map[string]interface{})
+	if !ok {
+		return nil, errors.New("PayloadContent field not found")
+	}
 
 	scepChallenge, ok := payloadContent["Challenge"].(string)
 	if !ok || scepChallenge == "" {

--- a/server/fleet/acme.go
+++ b/server/fleet/acme.go
@@ -1,0 +1,11 @@
+package fleet
+
+import "context"
+
+// ACMEWriteService is the subset of the ACME bounded context service
+// used by the legacy service layer for write operations.
+type ACMEWriteService interface {
+	// UpsertEnrollment upserts the acme_enrollments table with the specified
+	// host_uuid and returns a new path_identifier for the upserted row.
+	UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error)
+}

--- a/server/fleet/acme.go
+++ b/server/fleet/acme.go
@@ -2,7 +2,7 @@ package fleet
 
 import "context"
 
-// ACMEWriteService is the subset of the ACME bounded context service
+// ACMEWriteService is the subset of the ACME service modiule service
 // used by the legacy service layer for write operations.
 type ACMEWriteService interface {
 	// UpsertEnrollment upserts the acme_enrollments table with the specified

--- a/server/fleet/acme.go
+++ b/server/fleet/acme.go
@@ -5,7 +5,7 @@ import "context"
 // ACMEWriteService is the subset of the ACME service module service
 // used by the legacy service layer for write operations.
 type ACMEWriteService interface {
-	// UpsertEnrollment upserts the acme_enrollments table with the specified
-	// host_uuid and returns a new path_identifier for the upserted row.
-	UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error)
+	// NewEnrollment creates a new enrollment in the acme_enrollments table with the specified
+	// host_uuid and returns a new path_identifier for the created row.
+	NewEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 }

--- a/server/fleet/acme.go
+++ b/server/fleet/acme.go
@@ -2,7 +2,7 @@ package fleet
 
 import "context"
 
-// ACMEWriteService is the subset of the ACME service modiule service
+// ACMEWriteService is the subset of the ACME service module service
 // used by the legacy service layer for write operations.
 type ACMEWriteService interface {
 	// UpsertEnrollment upserts the acme_enrollments table with the specified

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -650,7 +650,7 @@ type Service interface {
 	// This should be called after service creation to inject the activity service dependency.
 	SetActivityService(activitySvc ActivityWriteService)
 
-	// SetACMEService sets the ACME bounded context service for write operations.
+	// SetACMEService sets the ACME service module for write operations.
 	// This should be called after service creation to inject the ACME service dependency.
 	SetACMEService(acmeSvc ACMEWriteService)
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -650,6 +650,10 @@ type Service interface {
 	// This should be called after service creation to inject the activity service dependency.
 	SetActivityService(activitySvc ActivityWriteService)
 
+	// SetACMEService sets the ACME bounded context service for write operations.
+	// This should be called after service creation to inject the ACME service dependency.
+	SetACMEService(acmeSvc ACMEWriteService)
+
 	// NewActivity creates the given activity on the datastore.
 	//
 	// What we call "Activities" are administrative operations,

--- a/server/mdm/acme/api/enrollment.go
+++ b/server/mdm/acme/api/enrollment.go
@@ -1,0 +1,10 @@
+package api
+
+import "context"
+
+// EnrollmentService upserts records in the acme_enrollments table.
+type EnrollmentService interface {
+	// UpsertEnrollment upserts the acme_enrollments table with the specified
+	// host_uuid and returns a new path_identifier for the upserted row.
+	UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error)
+}

--- a/server/mdm/acme/api/enrollment.go
+++ b/server/mdm/acme/api/enrollment.go
@@ -2,9 +2,9 @@ package api
 
 import "context"
 
-// EnrollmentService upserts records in the acme_enrollments table.
+// EnrollmentService stores records in the acme_enrollments table.
 type EnrollmentService interface {
-	// UpsertEnrollment upserts the acme_enrollments table with the specified
-	// host_uuid and returns a new path_identifier for the upserted row.
-	UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error)
+	// NewEnrollment creates a new enrollment in the acme_enrollments table with the specified
+	// host_uuid and returns a new path_identifier for the created row.
+	NewEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 }

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -1,4 +1,4 @@
-// Package http provides HTTP request and response types for the ACME service modiule.
+// Package http provides HTTP request and response types for the ACME service module.
 // These types are used exclusively by the ACME endpoint handler.
 package http
 
@@ -28,7 +28,7 @@ func generateAndRenderNonce(ctx context.Context, nonces *redis_nonces_store.Redi
 
 type GetNewNonceRequest struct {
 	// HTTPMethod used to make this request, populated by the parse custom URL
-	// tag function of the ACME service modiule, which is one of the only ways
+	// tag function of the ACME service module, which is one of the only ways
 	// with our framework to access the *http.Request value.
 	HTTPMethod string `url:"http_method"`
 	Identifier string `url:"identifier"`

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -1,4 +1,4 @@
-// Package http provides HTTP request and response types for the ACME bounded context.
+// Package http provides HTTP request and response types for the ACME service modiule.
 // These types are used exclusively by the ACME endpoint handler.
 package http
 
@@ -28,7 +28,7 @@ func generateAndRenderNonce(ctx context.Context, nonces *redis_nonces_store.Redi
 
 type GetNewNonceRequest struct {
 	// HTTPMethod used to make this request, populated by the parse custom URL
-	// tag function of the ACME bounded context, which is one of the only ways
+	// tag function of the ACME service modiule, which is one of the only ways
 	// with our framework to access the *http.Request value.
 	HTTPMethod string `url:"http_method"`
 	Identifier string `url:"identifier"`

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -1,10 +1,10 @@
-// Package api provides the public API for the ACME bounded context.
+// Package api provides the public API for the ACME service modiule.
 // External code should use this package to interact with ACME.
 package api
 
 import "github.com/fleetdm/fleet/v4/server/mdm/acme/internal/redis_nonces_store"
 
-// Service is the composite interface for the ACME bounded context.
+// Service is the composite interface for the ACME service modiule.
 // It embeds all method-specific interfaces. Bootstrap returns this type.
 type Service interface {
 	DirectoryNonceService

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -9,5 +9,6 @@ import "github.com/fleetdm/fleet/v4/server/mdm/acme/internal/redis_nonces_store"
 type Service interface {
 	DirectoryNonceService
 	AccountService
+	EnrollmentService
 	NoncesStore() *redis_nonces_store.RedisNoncesStore
 }

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -1,10 +1,10 @@
-// Package api provides the public API for the ACME service modiule.
+// Package api provides the public API for the ACME service module.
 // External code should use this package to interact with ACME.
 package api
 
 import "github.com/fleetdm/fleet/v4/server/mdm/acme/internal/redis_nonces_store"
 
-// Service is the composite interface for the ACME service modiule.
+// Service is the composite interface for the ACME service module.
 // It embeds all method-specific interfaces. Bootstrap returns this type.
 type Service interface {
 	DirectoryNonceService

--- a/server/mdm/acme/bootstrap/bootstrap.go
+++ b/server/mdm/acme/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-// Package bootstrap provides the public entry point for the ACME bounded context.
+// Package bootstrap provides the public entry point for the ACME service modiule.
 // It wires together internal components and exposes them for use in serve.go.
 package bootstrap
 
@@ -14,7 +14,7 @@ import (
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 )
 
-// New creates a new ACME bounded context and returns its service and route handler.
+// New creates a new ACME service modiule and returns its service and route handler.
 func New(
 	dbConns *platform_mysql.DBConnections,
 	redisPool fleet.RedisPool,

--- a/server/mdm/acme/bootstrap/bootstrap.go
+++ b/server/mdm/acme/bootstrap/bootstrap.go
@@ -1,4 +1,4 @@
-// Package bootstrap provides the public entry point for the ACME service modiule.
+// Package bootstrap provides the public entry point for the ACME service module.
 // It wires together internal components and exposes them for use in serve.go.
 package bootstrap
 
@@ -14,7 +14,7 @@ import (
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 )
 
-// New creates a new ACME service modiule and returns its service and route handler.
+// New creates a new ACME service module and returns its service and route handler.
 func New(
 	dbConns *platform_mysql.DBConnections,
 	redisPool fleet.RedisPool,

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -1,4 +1,4 @@
-// Package mysql provides the MySQL datastore implementation for the ACME bounded context.
+// Package mysql provides the MySQL datastore implementation for the ACME service modiule.
 package mysql
 
 import (

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -35,9 +35,9 @@ func (ds *Datastore) reader(ctx context.Context) fleet.DBReader {
 	return ds.replica
 }
 
-// func (ds *Datastore) writer(_ context.Context) *sqlx.DB {
-// 	return ds.primary
-// }
+func (ds *Datastore) writer(_ context.Context) *sqlx.DB {
+	return ds.primary
+}
 
 // Ensure Datastore implements types.Datastore
 var _ types.Datastore = (*Datastore)(nil)

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -1,4 +1,4 @@
-// Package mysql provides the MySQL datastore implementation for the ACME service modiule.
+// Package mysql provides the MySQL datastore implementation for the ACME service module.
 package mysql
 
 import (

--- a/server/mdm/acme/internal/mysql/enrollment.go
+++ b/server/mdm/acme/internal/mysql/enrollment.go
@@ -7,38 +7,21 @@ import (
 	"github.com/google/uuid"
 )
 
-// UpsertACMEEnrollment upserts the acme_enrollments table with the given
+// NewEnrollment creates a new row in the acme_enrollments table with the given
 // host_identifier. It generates a new path_identifier for the row and returns
-// it. If a row already exists for the host, its path_identifier is refreshed;
-// otherwise a new row is inserted.
-func (ds *Datastore) UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
-	ctx, span := tracer.Start(ctx, "acme.mysql.UpsertACMEEnrollment")
+// it.
+func (ds *Datastore) NewEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+	ctx, span := tracer.Start(ctx, "acme.mysql.NewEnrollment")
 	defer span.End()
 
 	pathIdentifier := uuid.NewString()
 
-	result, err := ds.writer(ctx).ExecContext(ctx, `
-UPDATE acme_enrollments
-SET path_identifier = ?
-WHERE host_identifier = ?
-`, pathIdentifier, hostIdentifier)
-	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "updating ACME enrollment path identifier")
-	}
-
-	rows, err := result.RowsAffected()
-	if err != nil {
-		return "", ctxerr.Wrap(ctx, err, "checking rows affected for ACME enrollment upsert")
-	}
-
-	if rows == 0 {
-		_, err = ds.writer(ctx).ExecContext(ctx, `
+	_, err := ds.writer(ctx).ExecContext(ctx, `
 INSERT INTO acme_enrollments (path_identifier, host_identifier)
 VALUES (?, ?)
 `, pathIdentifier, hostIdentifier)
-		if err != nil {
-			return "", ctxerr.Wrap(ctx, err, "inserting ACME enrollment")
-		}
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "inserting ACME enrollment")
 	}
 
 	return pathIdentifier, nil

--- a/server/mdm/acme/internal/mysql/enrollment.go
+++ b/server/mdm/acme/internal/mysql/enrollment.go
@@ -1,0 +1,45 @@
+package mysql
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/google/uuid"
+)
+
+// UpsertACMEEnrollment upserts the acme_enrollments table with the given
+// host_identifier. It generates a new path_identifier for the row and returns
+// it. If a row already exists for the host, its path_identifier is refreshed;
+// otherwise a new row is inserted.
+func (ds *Datastore) UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+	ctx, span := tracer.Start(ctx, "acme.mysql.UpsertACMEEnrollment")
+	defer span.End()
+
+	pathIdentifier := uuid.NewString()
+
+	result, err := ds.writer(ctx).ExecContext(ctx, `
+UPDATE acme_enrollments
+SET path_identifier = ?
+WHERE host_identifier = ?
+`, pathIdentifier, hostIdentifier)
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "updating ACME enrollment path identifier")
+	}
+
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return "", ctxerr.Wrap(ctx, err, "checking rows affected for ACME enrollment upsert")
+	}
+
+	if rows == 0 {
+		_, err = ds.writer(ctx).ExecContext(ctx, `
+INSERT INTO acme_enrollments (path_identifier, host_identifier)
+VALUES (?, ?)
+`, pathIdentifier, hostIdentifier)
+		if err != nil {
+			return "", ctxerr.Wrap(ctx, err, "inserting ACME enrollment")
+		}
+	}
+
+	return pathIdentifier, nil
+}

--- a/server/mdm/acme/internal/service/enrollment.go
+++ b/server/mdm/acme/internal/service/enrollment.go
@@ -6,12 +6,12 @@ import (
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 )
 
-func (s *Service) UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+func (s *Service) NewEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
 	// skipauth: No authorization check needed; caller is authenticated via DEP device identity.
 	// TODO: confirm this is how we want to handle auth for this method
 	if az, ok := authz_ctx.FromContext(ctx); ok {
 		az.SetChecked()
 	}
 
-	return s.store.UpsertACMEEnrollment(ctx, hostIdentifier)
+	return s.store.NewEnrollment(ctx, hostIdentifier)
 }

--- a/server/mdm/acme/internal/service/enrollment.go
+++ b/server/mdm/acme/internal/service/enrollment.go
@@ -1,0 +1,17 @@
+package service
+
+import (
+	"context"
+
+	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
+)
+
+func (s *Service) UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+	// skipauth: No authorization check needed; caller is authenticated via DEP device identity.
+	// TODO: confirm this is how we want to handle auth for this method
+	if az, ok := authz_ctx.FromContext(ctx); ok {
+		az.SetChecked()
+	}
+
+	return s.store.UpsertACMEEnrollment(ctx, hostIdentifier)
+}

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -1,4 +1,4 @@
-// Package service provides the service implementation for the ACME service modiule.
+// Package service provides the service implementation for the ACME service module.
 package service
 
 import (

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -1,4 +1,4 @@
-// Package service provides the service implementation for the ACME bounded context.
+// Package service provides the service implementation for the ACME service modiule.
 package service
 
 import (

--- a/server/mdm/acme/internal/testutils/testutils.go
+++ b/server/mdm/acme/internal/testutils/testutils.go
@@ -1,4 +1,4 @@
-// Package testutils provides shared test utilities for the ACME service modiule.
+// Package testutils provides shared test utilities for the ACME service module.
 package testutils
 
 import (

--- a/server/mdm/acme/internal/testutils/testutils.go
+++ b/server/mdm/acme/internal/testutils/testutils.go
@@ -1,4 +1,4 @@
-// Package testutils provides shared test utilities for the ACME bounded context.
+// Package testutils provides shared test utilities for the ACME service modiule.
 package testutils
 
 import (

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -125,7 +125,7 @@ type Identifier struct {
 	Value string `json:"value"`
 }
 
-// Datastore is the datastore interface for the ACME bounded context.
+// Datastore is the datastore interface for the ACME service modiule.
 type Datastore interface {
 	UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 	GetACMEEnrollment(ctx context.Context, pathIdentifier string) (*Enrollment, error)

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -125,7 +125,7 @@ type Identifier struct {
 	Value string `json:"value"`
 }
 
-// Datastore is the datastore interface for the ACME service modiule.
+// Datastore is the datastore interface for the ACME service module.
 type Datastore interface {
 	UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 	GetACMEEnrollment(ctx context.Context, pathIdentifier string) (*Enrollment, error)

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -127,7 +127,7 @@ type Identifier struct {
 
 // Datastore is the datastore interface for the ACME service module.
 type Datastore interface {
-	UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error)
+	NewEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 	GetACMEEnrollment(ctx context.Context, pathIdentifier string) (*Enrollment, error)
 	GetAccountByID(ctx context.Context, enrollmentID uint, accountID uint) (*Account, error)
 	CreateAccount(ctx context.Context, account *Account, onlyReturnExisting bool) (*Account, bool, error)

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -127,6 +127,7 @@ type Identifier struct {
 
 // Datastore is the datastore interface for the ACME bounded context.
 type Datastore interface {
+	UpsertACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 	GetACMEEnrollment(ctx context.Context, pathIdentifier string) (*Enrollment, error)
 	GetAccountByID(ctx context.Context, enrollmentID uint, accountID uint) (*Account, error)
 	CreateAccount(ctx context.Context, account *Account, onlyReturnExisting bool) (*Account, bool, error)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1461,9 +1461,12 @@ func GenerateACMEEnrollmentProfileMobileconfig(orgName, mdmURL, acmeIdent, devic
 		return nil, fmt.Errorf("execute template: %w", err)
 	}
 
-	// TODO: Figure out why the generated profile escaopes the left angle bracket in the opening
-	// `<?xml` tag and remove the need for this replacement.
-	return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
+	// TODO: In the PoC, the generated profile unexpectedly escaped the left angle bracket in the opening
+	// `<?xml` tag. If we see that again, the replacement below can be used as a workaround, but
+	// ideally we should figure out why that is happening in the first place.
+	// return bytes.Replace(buf.Bytes(), []byte("&lt;"), []byte("<"), 1), nil
+
+	return buf.Bytes(), nil
 }
 
 // ProfileBimap implements bidirectional mapping for profiles, and utility

--- a/server/mock/acme_mock.go
+++ b/server/mock/acme_mock.go
@@ -9,17 +9,17 @@ import (
 // MockACMEService is a mock implementation of fleet.ACMEWriteService
 // for unit tests that use mock.Store instead of real MySQL connections.
 type MockACMEService struct {
-	UpsertEnrollmentFunc        func(ctx context.Context, hostIdentifier string) (string, error)
-	UpsertEnrollmentFuncInvoked bool
+	NewEnrollmentFunc        func(ctx context.Context, hostIdentifier string) (string, error)
+	NewEnrollmentFuncInvoked bool
 }
 
 // Ensure MockACMEService implements fleet.ACMEWriteService.
 var _ fleet.ACMEWriteService = (*MockACMEService)(nil)
 
-func (m *MockACMEService) UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
-	m.UpsertEnrollmentFuncInvoked = true
-	if m.UpsertEnrollmentFunc != nil {
-		return m.UpsertEnrollmentFunc(ctx, hostIdentifier)
+func (m *MockACMEService) NewEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+	m.NewEnrollmentFuncInvoked = true
+	if m.NewEnrollmentFunc != nil {
+		return m.NewEnrollmentFunc(ctx, hostIdentifier)
 	}
 	return "", nil
 }

--- a/server/mock/acme_mock.go
+++ b/server/mock/acme_mock.go
@@ -1,0 +1,25 @@
+package mock
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+)
+
+// MockACMEService is a mock implementation of fleet.ACMEWriteService
+// for unit tests that use mock.Store instead of real MySQL connections.
+type MockACMEService struct {
+	UpsertEnrollmentFunc        func(ctx context.Context, hostIdentifier string) (string, error)
+	UpsertEnrollmentFuncInvoked bool
+}
+
+// Ensure MockACMEService implements fleet.ACMEWriteService.
+var _ fleet.ACMEWriteService = (*MockACMEService)(nil)
+
+func (m *MockACMEService) UpsertEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
+	m.UpsertEnrollmentFuncInvoked = true
+	if m.UpsertEnrollmentFunc != nil {
+		return m.UpsertEnrollmentFunc(ctx, hostIdentifier)
+	}
+	return "", nil
+}

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -395,6 +395,8 @@ type ApplyTeamSpecsFunc func(ctx context.Context, specs []*fleet.TeamSpec, apply
 
 type SetActivityServiceFunc func(activitySvc fleet.ActivityWriteService)
 
+type SetACMEServiceFunc func(acmeSvc fleet.ACMEWriteService)
+
 type NewActivityFunc func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error
 
 type ListHostUpcomingActivitiesFunc func(ctx context.Context, hostID uint, opt fleet.ListOptions) ([]*fleet.UpcomingActivity, *fleet.PaginationMetadata, error)
@@ -1455,6 +1457,9 @@ type Service struct {
 
 	SetActivityServiceFunc        SetActivityServiceFunc
 	SetActivityServiceFuncInvoked bool
+
+	SetACMEServiceFunc        SetACMEServiceFunc
+	SetACMEServiceFuncInvoked bool
 
 	NewActivityFunc        NewActivityFunc
 	NewActivityFuncInvoked bool
@@ -3517,6 +3522,13 @@ func (s *Service) SetActivityService(activitySvc fleet.ActivityWriteService) {
 	s.SetActivityServiceFuncInvoked = true
 	s.mu.Unlock()
 	s.SetActivityServiceFunc(activitySvc)
+}
+
+func (s *Service) SetACMEService(acmeSvc fleet.ACMEWriteService) {
+	s.mu.Lock()
+	s.SetACMEServiceFuncInvoked = true
+	s.mu.Unlock()
+	s.SetACMEServiceFunc(acmeSvc)
 }
 
 func (s *Service) NewActivity(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2099,7 +2099,10 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, appConfig *fleet
 }
 
 func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string) ([]byte, error) {
-	acmeIdent := "foobar" // TODO: replace this with call to upsert acme enrollments
+	acmeIdent, err := svc.acmeSvc.UpsertEnrollment(ctx, hardwareSerial)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "upserting ACME enrollment")
+	}
 
 	b, err := apple_mdm.GenerateACMEEnrollmentProfileMobileconfig(
 		orgName,

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2112,9 +2112,9 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, appConfig *fleet
 }
 
 func (svc *Service) generateMDMAppleACMEEnrollProfile(ctx context.Context, hardwareSerial string, orgName string, mdmURL string, topic string) ([]byte, error) {
-	acmeIdent, err := svc.acmeSvc.UpsertEnrollment(ctx, hardwareSerial)
+	acmeIdent, err := svc.acmeSvc.NewEnrollment(ctx, hardwareSerial)
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "upserting ACME enrollment")
+		return nil, ctxerr.Wrap(ctx, err, "creating ACME enrollment")
 	}
 
 	b, err := apple_mdm.GenerateACMEEnrollmentProfileMobileconfig(

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -2081,19 +2081,32 @@ func (svc *Service) isMDMAppleACMERequired(ctx context.Context, appConfig *fleet
 		return false, ctxerr.New(ctx, "machine info is nil")
 	}
 
-	// we only require ACME for Apple Silicon Macs, so check the product to see if it's an Apple Silicon Mac before doing any further checks
+	// account-driven user enrollment does not include a serial number in the device info, so we can't require ACME without a serial number
+	if machineInfo.Serial == "" {
+		svc.logger.InfoContext(ctx, "missing serial number in machine info, skipping ACME requirement check")
+		return false, nil
+	}
+
+	// we only require ACME for Apple Silicon Macs
 	if isMacAppleSilicon, err := fleet.IsMacAppleSilicon(machineInfo.Product); err != nil {
 		return false, ctxerr.Wrap(ctx, err, "checking if device is Apple Silicon")
 	} else if !isMacAppleSilicon {
 		return false, nil
 	}
 
-	// check dep assignment status, we only require ACME if the serial is DEP-assigned to Fleet
+	// we only require ACME for Apple Silicon Macs running macOS 14 or later
+	if isLessThanMacOS14, err := apple_mdm.IsLessThanVersion(machineInfo.OSVersion, "14.0"); err != nil {
+		return false, ctxerr.Wrap(ctx, err, "checking if device is less than macOS 14")
+	} else if isLessThanMacOS14 {
+		return false, nil
+	}
+
+	// we only require ACME if the serial is DEP-assigned to Fleet
 	assignments, err := svc.ds.GetHostDEPAssignmentsBySerial(ctx, machineInfo.Serial)
 	if err != nil {
 		return false, ctxerr.Wrap(ctx, err, "checking DEP assignment status")
 	}
-	svc.logger.InfoContext(ctx, "device is Apple Silicon, checking DEP assignment status for ACME requirement", "serial", machineInfo.Serial, "dep_assignments_count", len(assignments))
+	svc.logger.InfoContext(ctx, "checking DEP assignment status for ACME requirement", "serial", machineInfo.Serial, "dep_assignments_count", len(assignments))
 
 	return len(assignments) > 0, nil
 }
@@ -7286,6 +7299,7 @@ func (svc *Service) MDMAppleProcessOTAEnrollment(
 		return nil, ctxerr.Wrap(ctx, err, "extracting topic from APNs cert")
 	}
 
+	// NOTE: we don't offer ACME enrollment via OTA
 	enrollmentProf, err := apple_mdm.GenerateEnrollmentProfileMobileconfig(
 		appCfg.OrgInfo.OrgName,
 		mdmURL,

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -7113,11 +7113,32 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 		}{
 			{
 				name: "Apple Silicon Mac", mi: fleet.MDMAppleMachineInfo{
-					Product: "MacBookPro18,3", // major 18 >= threshold of 17 → Apple Silicon
-					Serial:  "MACSILSERIAL",
-					UDID:    "mac-sil-udid",
+					Product:   "MacBookPro18,3", // major 18 >= threshold of 17 → Apple Silicon
+					Serial:    "MACSILSERIAL",
+					UDID:      "mac-sil-udid",
+					OSVersion: "15.0", // macOS 15 >= 14 → eligible for ACME
 				},
 				expectACME: true,
+			},
+			{
+				// macOS < 14 disqualifies ACME even for Apple Silicon with DEP enrollment
+				name: "Apple Silicon Mac macOS 13", mi: fleet.MDMAppleMachineInfo{
+					Product:   "MacBookPro18,3", // Apple Silicon
+					Serial:    "MACSILSERIAL13",
+					UDID:      "mac-sil-13-udid",
+					OSVersion: "13.6.0", // macOS 13 < 14 → SCEP regardless of DEP assignment
+				},
+				expectACME: false,
+			},
+			{
+				// missing serial (account-driven user enrollment) disqualifies ACME regardless of device or DEP assignment
+				name: "Apple Silicon Mac without serial", mi: fleet.MDMAppleMachineInfo{
+					Product:   "MacBookPro18,3", // Apple Silicon
+					Serial:    "",               // no serial → SCEP without error
+					UDID:      "mac-sil-noserial-udid",
+					OSVersion: "15.0",
+				},
+				expectACME: false,
 			},
 			{
 				name: "Intel Mac",
@@ -7197,9 +7218,10 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 		// For these tests we can just use a single device type since we're not asserting on the
 		// profile content, just that errors are handled and returned properly.
 		machineInfo := fleet.MDMAppleMachineInfo{
-			Product: "MacBookPro18,3",
-			Serial:  "MACSILSERIAL",
-			UDID:    "mac-sil-udid",
+			Product:   "MacBookPro18,3",
+			Serial:    "MACSILSERIAL",
+			UDID:      "mac-sil-udid",
+			OSVersion: "15.0", // macOS 15 >= 14 so that the OSVersion check in isMDMAppleACMERequired passes through to the DEP check
 		}
 
 		t.Run("AppConfig error returns error", func(t *testing.T) {
@@ -7261,6 +7283,29 @@ func TestGetMDMAppleEnrollmentProfileByToken(t *testing.T) {
 						require.Contains(t, err.Error(), "checking DEP assignment")
 					} else {
 						// when hardware attestation is not required, DEP assignment is not relevant since we always return SCEP, so an error here should not be returned
+						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						require.NoError(t, err)
+					}
+				})
+
+				t.Run("invalid OS version for Apple Silicon Mac returns error", func(t *testing.T) {
+					// restore foundProfileFunc in case a previous sub-test left a different func
+					ds.GetMDMAppleEnrollmentProfileByTokenFunc = foundProfileFunc
+					ds.GetHostDEPAssignmentsBySerialFuncInvoked = false // reset invocation flag
+					invalidOSMI := fleet.MDMAppleMachineInfo{
+						Product:   "MacBookPro18,3", // Apple Silicon — reaches the OSVersion check
+						Serial:    "MACSILSERIAL",
+						UDID:      "mac-sil-udid",
+						OSVersion: "not-a-valid-version",
+					}
+					_, err := svc.GetMDMAppleEnrollmentProfileByToken(ctx, "valid-token", "", &invalidOSMI)
+					if hardwareAttestationRequired {
+						// isMDMAppleACMERequired is called and fails at the OSVersion check — DEP check is never reached
+						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
+						require.Error(t, err)
+						require.Contains(t, err.Error(), "checking if device is less than macOS 14")
+					} else {
+						// isMDMAppleACMERequired is never called, so OSVersion is irrelevant — SCEP is always returned
 						require.False(t, ds.GetHostDEPAssignmentsBySerialFuncInvoked)
 						require.NoError(t, err)
 					}

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3281,12 +3281,11 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	require.NoError(t, err)
 
 	var expectIdent string
-	// mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-	// 	stmt := `SELECT path_identifier FROM acme_enrollments WHERE host_identifier = ?`
-	// 	err := sqlx.GetContext(context.Background(), q, &expectIdent, stmt, appleSiliconDevice.SerialNumber)
-	// 	return err
-	// })
-	expectIdent = "foobar" // TODO: delete this and uncoment above
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		stmt := `SELECT path_identifier FROM acme_enrollments WHERE host_identifier = ?`
+		err := sqlx.GetContext(context.Background(), q, &expectIdent, stmt, appleSiliconDevice.SerialNumber)
+		return err
+	})
 
 	require.Contains(t, string(appleSiliconDevice.EnrollInfo.RawProfile), "/api/mdm/acme/"+expectIdent+"/directory", "enrollment profile should contain the ACME directory URL")
 

--- a/server/service/integration_mdm_dep_test.go
+++ b/server/service/integration_mdm_dep_test.go
@@ -3204,12 +3204,14 @@ func (s *integrationMDMTestSuite) TestSoftwareInventoryForADEMacOSAfterWipeAndRe
 func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	t := s.T()
 	s.enableABM(t.Name())
+	s.setSkipWorkerJobs(t)
 
-	// for our tests, we'll crete two devices: devices[0] will be enrolled with ACME and
-	// devices[1] will be enrolled with SCEP
+	// for our tests, we'll crete three DEP-assigned devices: devices[0] will be enrolled via DEP with ACME,
+	// devices[1] will be enrolled with SCEP, and devices[2] will be enrolled via OTA (no ACME).
 	devices := []godep.Device{
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
 		{SerialNumber: uuid.New().String(), Model: "MacBookPro16,1", OS: "osx", OpType: "added"},
+		{SerialNumber: uuid.New().String(), Model: "MacBookPro17,1", OS: "osx", OpType: "added"},
 	}
 	s.mockDEPResponse(t.Name(), http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -3252,10 +3254,14 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 
 	depURLToken := loadEnrollmentProfileDEPToken(t, s.ds)
 
+	enrollSecrets, err := s.ds.GetEnrollSecrets(context.Background(), nil)
+	require.NoError(t, err)
+	require.Len(t, enrollSecrets, 1)
+
 	// confirm that the devices were created
 	listHostsRes := listHostsResponse{}
 	s.DoJSON("GET", "/api/latest/fleet/hosts", nil, http.StatusOK, &listHostsRes)
-	require.Len(t, listHostsRes.Hosts, 2)
+	require.Len(t, listHostsRes.Hosts, 3)
 	bySerial := make(map[string]*fleet.Host, len(devices))
 	for _, h := range listHostsRes.Hosts {
 		bySerial[h.HardwareSerial] = h.Host
@@ -3277,7 +3283,8 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	appleSiliconDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken, mdmtest.WithSkipParseEnrollProf(true))
 	appleSiliconDevice.SerialNumber = devices[0].SerialNumber
 	appleSiliconDevice.Model = devices[0].Model
-	err := appleSiliconDevice.Enroll()
+	appleSiliconDevice.OSVersion = "14.0"
+	err = appleSiliconDevice.Enroll()
 	require.NoError(t, err)
 
 	var expectIdent string
@@ -3293,7 +3300,20 @@ func (s *integrationMDMTestSuite) TestDEPRequireACME() {
 	intelDevice := mdmtest.NewTestMDMClientAppleDEP(s.server.URL, depURLToken)
 	intelDevice.SerialNumber = devices[1].SerialNumber
 	intelDevice.Model = devices[1].Model
+	intelDevice.OSVersion = "14.0"
 	err = intelDevice.Enroll()
 	require.NoError(t, err)
 	require.NotContains(t, string(intelDevice.EnrollInfo.RawProfile), "/api/mdm/acme/"+expectIdent+"/directory", "enrollment profile should not contain the ACME directory URL")
+
+	// otaAppleSiliconDevice enrolls through OTA gets SCEP (not ACME) even though it would enroll
+	// via ACME if it enrolled through DEP, because OTA enrollments should not require hardware attestation and thus should not require ACME
+	otaAppleSiliconDevice := mdmtest.NewTestMDMClientAppleOTA(s.server.URL, enrollSecrets[0].Secret, devices[2].Model)
+	otaAppleSiliconDevice.SerialNumber = devices[2].SerialNumber
+	otaAppleSiliconDevice.Model = devices[2].Model
+	otaAppleSiliconDevice.OSVersion = "14.0"
+	err = otaAppleSiliconDevice.Enroll()
+	require.NoError(t, err)
+	// next assertion is superflous with checks that happen inside the test client, but we'll keep
+	// it here to be explicit about the expectation that OTA enrollments should not be ACME
+	require.NotContains(t, string(otaAppleSiliconDevice.EnrollInfo.RawProfile), "/api/mdm/acme/", "enrollment profile should not contain the ACME directory URL")
 }

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -204,7 +204,7 @@ func (svc *Service) SetActivityService(activitySvc fleet.ActivityWriteService) {
 	svc.activitySvc = activitySvc
 }
 
-// SetACMEService sets the ACME service modiule service for write operations.
+// SetACMEService sets the ACME service module service for write operations.
 // This should be called after NewService to inject the ACME service dependency.
 func (svc *Service) SetACMEService(acmeSvc fleet.ACMEWriteService) {
 	svc.acmeSvc = acmeSvc

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -204,7 +204,7 @@ func (svc *Service) SetActivityService(activitySvc fleet.ActivityWriteService) {
 	svc.activitySvc = activitySvc
 }
 
-// SetACMEService sets the ACME bounded context service for write operations.
+// SetACMEService sets the ACME service modiule service for write operations.
 // This should be called after NewService to inject the ACME service dependency.
 func (svc *Service) SetACMEService(acmeSvc fleet.ACMEWriteService) {
 	svc.acmeSvc = acmeSvc

--- a/server/service/service.go
+++ b/server/service/service.go
@@ -74,6 +74,9 @@ type Service struct {
 
 	// activitySvc is the activity bounded context service for write operations.
 	activitySvc fleet.ActivityWriteService
+
+	// acmeSvc is the ACME service module for write operations.
+	acmeSvc fleet.ACMEWriteService
 }
 
 // ConditionalAccessMicrosoftProxy is the interface of the Microsoft compliance proxy.
@@ -199,6 +202,12 @@ func (svc *Service) SendEmail(ctx context.Context, mail fleet.Email) error {
 // This should be called after NewService to inject the activity service dependency.
 func (svc *Service) SetActivityService(activitySvc fleet.ActivityWriteService) {
 	svc.activitySvc = activitySvc
+}
+
+// SetACMEService sets the ACME bounded context service for write operations.
+// This should be called after NewService to inject the ACME service dependency.
+func (svc *Service) SetACMEService(acmeSvc fleet.ACMEWriteService) {
+	svc.acmeSvc = acmeSvc
 }
 
 type validationMiddleware struct {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -304,7 +304,7 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 	}
 
 	// Set up mock ACME service for unit tests. When DBConns is provided,
-	// RunServerForTestsWithServiceWithDS will overwrite this with the real bounded context.
+	// RunServerForTestsWithServiceWithDS will overwrite this with the real service module.
 	svc.SetACMEService(&fleet_mock.MockACMEService{})
 
 	return svc, ctx
@@ -525,7 +525,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		redisPool = redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
 	}
 
-	// Wire real ACME bounded context if DBConns is provided (overrides the mock set in newTestServiceWithConfig).
+	// Wire real ACME service modiule if DBConns is provided (overrides the mock set in newTestServiceWithConfig).
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		acmeSvc, _ := acme_bootstrap.New(opts[0].DBConns, redisPool, ds, logger)
 		svc.SetACMEService(acmeSvc)

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -43,6 +43,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
+	acme_bootstrap "github.com/fleetdm/fleet/v4/server/mdm/acme/bootstrap"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
@@ -302,6 +303,10 @@ func newTestServiceWithConfig(t *testing.T, ds fleet.Datastore, fleetConfig conf
 		opts[0].ActivityMock = activityMock
 	}
 
+	// Set up mock ACME service for unit tests. When DBConns is provided,
+	// RunServerForTestsWithServiceWithDS will overwrite this with the real bounded context.
+	svc.SetACMEService(&fleet_mock.MockACMEService{})
+
 	return svc, ctx
 }
 
@@ -518,6 +523,12 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		}
 	} else {
 		redisPool = redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
+	}
+
+	// Wire real ACME bounded context if DBConns is provided (overrides the mock set in newTestServiceWithConfig).
+	if len(opts) > 0 && opts[0].DBConns != nil {
+		acmeSvc, _ := acme_bootstrap.New(opts[0].DBConns, redisPool, ds, logger)
+		svc.SetACMEService(acmeSvc)
 	}
 
 	if len(opts) > 0 {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -525,7 +525,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		redisPool = redistest.SetupRedis(t, t.Name(), false, false, false) // We are good to initalize a redis pool here as it is only called by integration tests
 	}
 
-	// Wire real ACME service modiule if DBConns is provided (overrides the mock set in newTestServiceWithConfig).
+	// Wire real ACME service module if DBConns is provided (overrides the mock set in newTestServiceWithConfig).
 	if len(opts) > 0 && opts[0].DBConns != nil {
 		acmeSvc, _ := acme_bootstrap.New(opts[0].DBConns, redisPool, ds, logger)
 		svc.SetACMEService(acmeSvc)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40991

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
