### PR TITLE
Fleet UI: Fix extra top border

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyAutomations/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyAutomations/_styles.scss
@@ -34,6 +34,10 @@
     padding: 0 $pad-large;
     height: 40px;
     border-top: 1px solid $ui-fleet-black-10;
+
+    &:first-child {
+      border-top: none;
+    }
   }
 
   &__row-graphic {


### PR DESCRIPTION
## Issue
Part of #31914 
Closes #42321 

## Description
- Only put border top on subsequent rows

## Screenshot of fix
<img width="872" height="251" alt="Screenshot 2026-03-25 at 5 22 03 PM" src="https://github.com/user-attachments/assets/7c351d2e-9b40-4e47-9a86-62fbdca057ba" />
