### PR TITLE
Website: update comparison template

### DIFF
--- a/articles/compare-fleet-and-jamf.md
+++ b/articles/compare-fleet-and-jamf.md
@@ -86,8 +86,7 @@ Implementation and migration timelines vary based on fleet size and organization
 
 
 
-<meta name="articleTitle" value="Fleet vs. Jamf"> 
-<meta name="articleSubtitle" value="How to choose the right MDM">
+<meta name="articleTitle" value="Fleet vs. Jamf">
 <meta name="authorFullName" value="Brock Walters">
 <meta name="authorGitHubUsername" value="nonpunctual">
 <meta name="articleSlugInCategory" value="jamf-vs-fleet"> 

--- a/articles/fleet-management-software.md
+++ b/articles/fleet-management-software.md
@@ -124,6 +124,5 @@ Timelines depends on fleet size and configuration complexity. Fleet supports zer
 <meta name="publishedOn" value="2026-02-26">
 <meta name="description" value="Compare the Fleet, Jamf Pro, and Microsoft Intune product offerings.">
 
-<meta name="articleSubtitle" value="How to choose the right fleet management software">
 <meta name="articleSlugInCategory" value="jamf-vs-intune-vs-fleet"> 
 <meta name="introductionTextBlockOne" value="This guide compares Fleet, Jamf Pro, and Microsoft Intune as device management software options, covering platform support, security capabilities, and automation features."> 

--- a/articles/fleet-vs-jamf-pro-ninjaone-mdm-comparison.md
+++ b/articles/fleet-vs-jamf-pro-ninjaone-mdm-comparison.md
@@ -118,7 +118,6 @@ Jamf Pro only supports Apple and Android devices, so organizations with Windows 
 Migration timeframes vary based on fleet size and complexity. Fleet supports gradual migration alongside existing MDM tools, allowing you to transition devices incrementally while maintaining visibility across your entire fleet during the transition. [Talk to Fleet](https://fleetdm.com/contact) to discuss your specific migration requirements and timeline.
 
 <meta name="articleTitle" value="Fleet vs. Jamf Pro and NinjaOne">
-<meta name="articleSubtitle" value="How do they compare?">
 <meta name="authorFullName" value="Brock Walters">
 <meta name="authorGitHubUsername" value="nonpunctual">
 <meta name="publishedOn" value="2026-03-09">

--- a/articles/mdm-providers-compared.md
+++ b/articles/mdm-providers-compared.md
@@ -102,7 +102,6 @@ Fleet and Workspace ONE each provide MDM enrollment, configuration management, a
 Fleet supports MDM migration without requiring device wipes, allowing organizations to transition devices from an existing MDM with minimal disruption. The migration process preserves device enrollment and user data while transferring management to Fleet. Organizations can migrate gradually, running Fleet alongside an existing tool during the transition period.
 
 <meta name="articleTitle" value="MDM Providers Compared: Fleet vs Workspace ONE">
-<meta name="articleSubtitle" value="Choosing the right MDM solution">
 <meta name="authorFullName" value="Brock Walters">
 <meta name="authorGitHubUsername" value="nonpunctual">
 <meta name="category" value="comparison">

--- a/website/assets/styles/pages/landing-pages/basic-comparison.less
+++ b/website/assets/styles/pages/landing-pages/basic-comparison.less
@@ -158,9 +158,30 @@
       margin-bottom: 0px;
       margin-top: 0px;
     }
+    [purpose='demo-button'] {
+      margin-top: 42px;
+
+    }
   }
 
-
+  [purpose='demo-button'] {
+    display: flex;
+    min-height: 36px;
+    width: 140px;
+    padding: 8px var(--Space-space_200, 16px);
+    justify-content: center;
+    align-items: center;
+    gap: 4px;
+    color: var(--White, #FFF);
+    text-align: center;
+    border-radius: 8px;
+    /* Body/Emphasis/SM */
+    font-family: Inter;
+    font-size: 14px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: 21px; /* 150% */
+  }
 
   [purpose='article-container'] {
     margin-top: 64px;
@@ -232,6 +253,22 @@
       &:last-of-type {
         margin-bottom: 0px;
       }
+    }
+  }
+
+  [purpose='bottom-cta'] {
+    margin-top: 64px;
+    hr {
+      margin-bottom: 48px;
+    }
+    h2 {
+      margin-bottom: 10px;
+    }
+    p {
+      margin-bottom: 10px;
+    }
+    [purpose='demo-button'] {
+      margin-top: 32px;
     }
   }
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -752,10 +752,6 @@ module.exports = {
                 }
                 // If this is a comparison article, we will require a different set of meta tags and will determine the URL of the page using the articleSlugInCategory meta tag.
                 if(embeddedMetadata.category === 'comparison') {
-                  if(!embeddedMetadata.articleSubtitle){
-                    throw new Error(`Failed compiling markdown content: A comparison article is missing a "articleSubtitle" meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a articleSubtitle meta tag and try running this script again.`);
-                  }
-
                   if(!embeddedMetadata.articleSlugInCategory){
                     throw new Error(`Failed compiling markdown content: A comparison article is missing a "articleSlugInCategory" meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a articleSlugInCategory meta tag and try running this script again.`);
                   }

--- a/website/views/pages/landing-pages/basic-comparison.ejs
+++ b/website/views/pages/landing-pages/basic-comparison.ejs
@@ -2,10 +2,13 @@
   <div purpose="page-container" class="container-fluid">
     <div purpose="article-title-and-image">
       <div purpose="article-title">
-        <h4><%= thisPage.meta.articleSubtitle%></h4>
+        <div>
+        <h4>How to choose the right MDM</h4>
         <h1><%=thisPage.meta.articleTitle %></h1>
+        </div>
         <p><%= thisPage.meta.introductionTextBlockOne%></p>
         <%if(thisPage.meta.introductionTextBlockTwo){%><p class="mb-0"><%= thisPage.meta.introductionTextBlockTwo%></p><% } %>
+        <div><a purpose="demo-button" class="btn btn-primary" href="/contact">Get a demo</a></div>
       </div>
       <div purpose="hero-image">
         <img alt="Hero image" src="/images/comparison-page-hero-504x349@2x.png">
@@ -26,6 +29,12 @@
       <div purpose="article-container">
         <div purpose="article-content" parasails-has-no-page-script>
           <%- partial(path.relative(path.dirname(__filename), path.resolve( sails.config.appPath, path.join(sails.config.builtStaticContent.compiledPagePartialsAppPath, thisPage.htmlId)))) %>
+        </div>
+        <div purpose="bottom-cta">
+          <hr>
+          <h2>See Fleet in action</h2>
+          <p>Compare your current setup and plan your move to Fleet</p>
+          <div><a purpose="demo-button" class="btn btn-primary" href="/contact">Get a demo</a></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes: https://github.com/fleetdm/confidential/issues/14799

Changes:
- Updated the comparison page template to have a hardcoded subtitle and removed the requirement for a `articleSubtitle` meta tag for comparison articles
- Added two calls to action to the comparison page template.