### PR TITLE
🤖 Fix VPP handling, activity type for setup experience failures

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -904,6 +904,7 @@ func newAppleMDMWorkerSchedule(
 	commander *apple_mdm.MDMAppleCommander,
 	bootstrapPackageStore fleet.MDMBootstrapPackageStore,
 	vppInstaller fleet.AppleMDMVPPInstaller,
+	newActivityFn fleet.NewActivityFunc,
 ) (*schedule.Schedule, error) {
 	const (
 		name             = string(fleet.CronAppleMDMWorker)
@@ -921,6 +922,7 @@ func newAppleMDMWorkerSchedule(
 		Commander:             commander,
 		BootstrapPackageStore: bootstrapPackageStore,
 		VPPInstaller:          vppInstaller,
+		NewActivityFn:         newActivityFn,
 	}
 
 	w.Register(appleMDM)

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1235,7 +1235,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 	if err := cronSchedules.StartCronSchedule(func() (fleet.CronSchedule, error) {
 		commander := apple_mdm.NewMDMAppleCommander(mdmStorage, mdmPushService)
 		vppInstaller := svc.(fleet.AppleMDMVPPInstaller)
-		return newAppleMDMWorkerSchedule(ctx, instanceID, ds, logger, commander, bootstrapPackageStore, vppInstaller)
+		return newAppleMDMWorkerSchedule(ctx, instanceID, ds, logger, commander, bootstrapPackageStore, vppInstaller, svc.NewActivity)
 	}); err != nil {
 		initFatal(err, "failed to register apple_mdm_worker schedule")
 	}

--- a/ee/server/service/orbit.go
+++ b/ee/server/service/orbit.go
@@ -250,42 +250,39 @@ func (svc *Service) failCancelledSetupExperienceInstalls(
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "failing cancelled setup experience software install")
 		}
-		// TODO -- support recording activity for failed VPP apps as well.
-		// https://github.com/fleetdm/fleet/issues/34288
 		if r.IsForSoftwarePackage() {
-			softwarePackage := ""
-			var source *string
+			var softwareTitleID uint
 			installerMeta, err := svc.ds.GetSoftwareInstallerMetadataByID(ctx, *r.SoftwareInstallerID)
 			if err != nil && !fleet.IsNotFound(err) {
 				return ctxerr.Wrap(ctx, err, "getting software installer metadata for cancelled setup experience software install")
 			}
-			if installerMeta != nil {
-				softwarePackage = installerMeta.Name
-				// Get the software title to retrieve the source
-				if installerMeta.TitleID != nil {
-					title, err := svc.ds.SoftwareTitleByID(ctx, *installerMeta.TitleID, nil, fleet.TeamFilter{})
-					if err != nil && !fleet.IsNotFound(err) {
-						return ctxerr.Wrap(ctx, err, "getting software title for cancelled setup experience software install")
-					}
-					if title != nil {
-						source = &title.Source
-					}
-				}
+			if installerMeta != nil && installerMeta.TitleID != nil {
+				softwareTitleID = *installerMeta.TitleID
 			}
-			activity := fleet.ActivityTypeInstalledSoftware{
+			activity := fleet.ActivityTypeCanceledInstallSoftware{
 				HostID:              hostID,
 				HostDisplayName:     hostDisplayName,
 				SoftwareTitle:       r.Name,
-				SoftwarePackage:     softwarePackage,
-				InstallUUID:         *r.HostSoftwareInstallsExecutionID,
-				Status:              "failed",
-				SelfService:         false,
-				Source:              source,
+				SoftwareTitleID:     softwareTitleID,
 				FromSetupExperience: true,
 			}
-			err = svc.NewActivity(ctx, nil, activity)
-			if err != nil {
+			if err := svc.NewActivity(ctx, nil, activity); err != nil {
 				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience software install")
+			}
+		} else if r.VPPAppTeamID != nil {
+			var softwareTitleID uint
+			if r.SoftwareTitleID != nil {
+				softwareTitleID = *r.SoftwareTitleID
+			}
+			activity := fleet.ActivityTypeCanceledInstallAppStoreApp{
+				HostID:              hostID,
+				HostDisplayName:     hostDisplayName,
+				SoftwareTitle:       r.Name,
+				SoftwareTitleID:     softwareTitleID,
+				FromSetupExperience: true,
+			}
+			if err := svc.NewActivity(ctx, nil, activity); err != nil {
+				return ctxerr.Wrap(ctx, err, "creating activity for cancelled setup experience VPP app install")
 			}
 		}
 		continue

--- a/ee/server/service/orbit_test.go
+++ b/ee/server/service/orbit_test.go
@@ -1,0 +1,423 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	svcmock "github.com/fleetdm/fleet/v4/server/mock/service"
+	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFailCancelledSetupExperienceInstalls(t *testing.T) {
+	ctx := context.Background()
+	ds := new(mock.Store)
+	baseSvc := new(svcmock.Service)
+
+	svc := &Service{
+		Service: baseSvc,
+		ds:      ds,
+		logger:  slog.Default(),
+	}
+
+	hostID := uint(42)
+	hostUUID := "host-uuid-1"
+	hostDisplayName := "Test Host"
+
+	t.Run("skips non-cancelled results", func(t *testing.T) {
+		var activityCreated bool
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activityCreated = true
+			return nil
+		}
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:            hostUUID,
+				Status:              fleet.SetupExperienceStatusPending,
+				SoftwareInstallerID: ptr.Uint(1),
+			},
+			{
+				HostUUID:     hostUUID,
+				Status:       fleet.SetupExperienceStatusSuccess,
+				VPPAppTeamID: ptr.Uint(2),
+			},
+			{
+				HostUUID:     hostUUID,
+				Status:       fleet.SetupExperienceStatusRunning,
+				VPPAppTeamID: ptr.Uint(3),
+			},
+			{
+				HostUUID:     hostUUID,
+				Status:       fleet.SetupExperienceStatusFailure,
+				VPPAppTeamID: ptr.Uint(4),
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+		assert.False(t, activityCreated, "no activity should be created for non-cancelled results")
+		assert.False(t, ds.UpdateSetupExperienceStatusResultFuncInvoked, "no update should be called for non-cancelled results")
+	})
+
+	t.Run("software package cancelled emits canceled_install_software activity with FromSetupExperience", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		installerID := uint(10)
+		titleID := uint(100)
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+			require.Equal(t, installerID, id)
+			return &fleet.SoftwareInstaller{
+				Name:    "installer.pkg",
+				TitleID: &titleID,
+			}, nil
+		}
+
+		var createdActivity fleet.ActivityDetails
+		var createdUser *fleet.User
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			createdUser = user
+			createdActivity = activity
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:                        hostUUID,
+				Name:                            "DummyApp",
+				Status:                          fleet.SetupExperienceStatusCancelled,
+				SoftwareInstallerID:             &installerID,
+				HostSoftwareInstallsExecutionID: ptr.String("exec-uuid-1"),
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		// Status should have been changed to failure
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+
+		// Update should have been called
+		assert.True(t, ds.UpdateSetupExperienceStatusResultFuncInvoked)
+
+		// Activity should be a canceled install software type
+		require.NotNil(t, createdActivity)
+		canceledAct, ok := createdActivity.(fleet.ActivityTypeCanceledInstallSoftware)
+		require.True(t, ok, "expected ActivityTypeCanceledInstallSoftware, got %T", createdActivity)
+		assert.Equal(t, hostID, canceledAct.HostID)
+		assert.Equal(t, hostDisplayName, canceledAct.HostDisplayName)
+		assert.Equal(t, "DummyApp", canceledAct.SoftwareTitle)
+		assert.Equal(t, titleID, canceledAct.SoftwareTitleID)
+		assert.True(t, canceledAct.FromSetupExperience, "FromSetupExperience should be true")
+
+		// WasFromAutomation should return true
+		assert.True(t, canceledAct.WasFromAutomation(), "WasFromAutomation should be true for setup experience cancellations")
+
+		// Should be created with nil user (Fleet-initiated)
+		assert.Nil(t, createdUser)
+	})
+
+	t.Run("software package cancelled with missing metadata still works", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		installerID := uint(11)
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+			return nil, &notFoundError{}
+		}
+
+		var createdActivity fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			createdActivity = activity
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:                        hostUUID,
+				Name:                            "MissingApp",
+				Status:                          fleet.SetupExperienceStatusCancelled,
+				SoftwareInstallerID:             &installerID,
+				HostSoftwareInstallsExecutionID: ptr.String("exec-uuid-2"),
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		require.NotNil(t, createdActivity)
+		canceledAct, ok := createdActivity.(fleet.ActivityTypeCanceledInstallSoftware)
+		require.True(t, ok)
+		assert.Equal(t, uint(0), canceledAct.SoftwareTitleID, "SoftwareTitleID should be 0 when metadata not found")
+		assert.True(t, canceledAct.FromSetupExperience)
+	})
+
+	t.Run("VPP app cancelled emits canceled_install_app_store_app activity with FromSetupExperience", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		vppTeamID := uint(20)
+		adamID := "12345"
+		platform := "darwin"
+		softwareTitleID := uint(200)
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		var createdActivity fleet.ActivityDetails
+		var createdUser *fleet.User
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			createdUser = user
+			createdActivity = activity
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:        hostUUID,
+				Name:            "VPPApp",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				VPPAppPlatform:  &platform,
+				SoftwareTitleID: &softwareTitleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		// Status should have been changed to failure
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+
+		// Activity should be a canceled install app store app type
+		require.NotNil(t, createdActivity)
+		canceledAct, ok := createdActivity.(fleet.ActivityTypeCanceledInstallAppStoreApp)
+		require.True(t, ok, "expected ActivityTypeCanceledInstallAppStoreApp, got %T", createdActivity)
+		assert.Equal(t, hostID, canceledAct.HostID)
+		assert.Equal(t, hostDisplayName, canceledAct.HostDisplayName)
+		assert.Equal(t, "VPPApp", canceledAct.SoftwareTitle)
+		assert.Equal(t, softwareTitleID, canceledAct.SoftwareTitleID)
+		assert.True(t, canceledAct.FromSetupExperience, "FromSetupExperience should be true")
+
+		// WasFromAutomation should return true
+		assert.True(t, canceledAct.WasFromAutomation(), "WasFromAutomation should be true for setup experience cancellations")
+
+		// Should be created with nil user (Fleet-initiated)
+		assert.Nil(t, createdUser)
+	})
+
+	t.Run("VPP app cancelled without SoftwareTitleID defaults to 0", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		vppTeamID := uint(21)
+		adamID := "99999"
+		platform := "ios"
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		var createdActivity fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			createdActivity = activity
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:       hostUUID,
+				Name:           "VPPAppNoTitle",
+				Status:         fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:   &vppTeamID,
+				VPPAppAdamID:   &adamID,
+				VPPAppPlatform: &platform,
+				// SoftwareTitleID is nil
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		require.NotNil(t, createdActivity)
+		canceledAct, ok := createdActivity.(fleet.ActivityTypeCanceledInstallAppStoreApp)
+		require.True(t, ok)
+		assert.Equal(t, uint(0), canceledAct.SoftwareTitleID, "SoftwareTitleID should default to 0 when nil")
+		assert.True(t, canceledAct.FromSetupExperience)
+	})
+
+	t.Run("mixed cancelled and non-cancelled results", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		installerID := uint(30)
+		titleID := uint(300)
+		vppTeamID := uint(40)
+		adamID := "67890"
+		platform := "darwin"
+		vppTitleID := uint(400)
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+			return &fleet.SoftwareInstaller{
+				Name:    "installer.pkg",
+				TitleID: &titleID,
+			}, nil
+		}
+
+		var activities []fleet.ActivityDetails
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activities = append(activities, activity)
+			return nil
+		}
+
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:            hostUUID,
+				Name:                "SuccessApp",
+				Status:              fleet.SetupExperienceStatusSuccess,
+				SoftwareInstallerID: ptr.Uint(50),
+			},
+			{
+				HostUUID:                        hostUUID,
+				Name:                            "CancelledSW",
+				Status:                          fleet.SetupExperienceStatusCancelled,
+				SoftwareInstallerID:             &installerID,
+				HostSoftwareInstallsExecutionID: ptr.String("exec-uuid-3"),
+			},
+			{
+				HostUUID:     hostUUID,
+				Name:         "PendingVPP",
+				Status:       fleet.SetupExperienceStatusPending,
+				VPPAppTeamID: ptr.Uint(60),
+			},
+			{
+				HostUUID:        hostUUID,
+				Name:            "CancelledVPP",
+				Status:          fleet.SetupExperienceStatusCancelled,
+				VPPAppTeamID:    &vppTeamID,
+				VPPAppAdamID:    &adamID,
+				VPPAppPlatform:  &platform,
+				SoftwareTitleID: &vppTitleID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		// Only the two cancelled results should have their status changed
+		assert.Equal(t, fleet.SetupExperienceStatusSuccess, results[0].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[1].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusPending, results[2].Status)
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[3].Status)
+
+		// Two activities should have been created
+		require.Len(t, activities, 2)
+
+		// First: canceled install software
+		swAct, ok := activities[0].(fleet.ActivityTypeCanceledInstallSoftware)
+		require.True(t, ok, "expected ActivityTypeCanceledInstallSoftware, got %T", activities[0])
+		assert.Equal(t, "CancelledSW", swAct.SoftwareTitle)
+		assert.Equal(t, titleID, swAct.SoftwareTitleID)
+		assert.True(t, swAct.FromSetupExperience)
+
+		// Second: canceled install app store app
+		vppAct, ok := activities[1].(fleet.ActivityTypeCanceledInstallAppStoreApp)
+		require.True(t, ok, "expected ActivityTypeCanceledInstallAppStoreApp, got %T", activities[1])
+		assert.Equal(t, "CancelledVPP", vppAct.SoftwareTitle)
+		assert.Equal(t, vppTitleID, vppAct.SoftwareTitleID)
+		assert.True(t, vppAct.FromSetupExperience)
+	})
+
+	t.Run("script result is skipped (no activity created)", func(t *testing.T) {
+		ds.UpdateSetupExperienceStatusResultFuncInvoked = false
+
+		ds.UpdateSetupExperienceStatusResultFunc = func(ctx context.Context, status *fleet.SetupExperienceStatusResult) error {
+			return nil
+		}
+
+		var activityCreated bool
+		baseSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			activityCreated = true
+			return nil
+		}
+
+		scriptID := uint(70)
+		results := []*fleet.SetupExperienceStatusResult{
+			{
+				HostUUID:                hostUUID,
+				Name:                    "setup.sh",
+				Status:                  fleet.SetupExperienceStatusCancelled,
+				SetupExperienceScriptID: &scriptID,
+			},
+		}
+
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, results)
+		require.NoError(t, err)
+
+		// Status should still be changed to failure
+		assert.Equal(t, fleet.SetupExperienceStatusFailure, results[0].Status)
+		// But no activity should be created for script cancellations (only software)
+		assert.False(t, activityCreated)
+	})
+
+	t.Run("empty results returns nil", func(t *testing.T) {
+		err := svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, nil)
+		require.NoError(t, err)
+
+		err = svc.failCancelledSetupExperienceInstalls(ctx, hostID, hostUUID, hostDisplayName, []*fleet.SetupExperienceStatusResult{})
+		require.NoError(t, err)
+	})
+}
+
+func TestCanceledActivityWasFromAutomation(t *testing.T) {
+	t.Run("CanceledInstallSoftware", func(t *testing.T) {
+		// FromSetupExperience = false -> WasFromAutomation returns false
+		act := fleet.ActivityTypeCanceledInstallSoftware{
+			HostID:              1,
+			HostDisplayName:     "host",
+			SoftwareTitle:       "title",
+			SoftwareTitleID:     1,
+			FromSetupExperience: false,
+		}
+		assert.False(t, act.WasFromAutomation())
+
+		// FromSetupExperience = true -> WasFromAutomation returns true
+		act.FromSetupExperience = true
+		assert.True(t, act.WasFromAutomation())
+	})
+
+	t.Run("CanceledInstallAppStoreApp", func(t *testing.T) {
+		// FromSetupExperience = false -> WasFromAutomation returns false
+		act := fleet.ActivityTypeCanceledInstallAppStoreApp{
+			HostID:              1,
+			HostDisplayName:     "host",
+			SoftwareTitle:       "title",
+			SoftwareTitleID:     1,
+			FromSetupExperience: false,
+		}
+		assert.False(t, act.WasFromAutomation())
+
+		// FromSetupExperience = true -> WasFromAutomation returns true
+		act.FromSetupExperience = true
+		assert.True(t, act.WasFromAutomation())
+	})
+}

--- a/ee/server/service/setup_experience.go
+++ b/ee/server/service/setup_experience.go
@@ -277,6 +277,18 @@ func (svc *Service) SetupExperienceNextStep(ctx context.Context, host *fleet.Hos
 				svc.logger.WarnContext(ctx, "got an error when attempting to enqueue VPP app install", "err", err, "adam_id", app.VPPAppAdamID)
 				app.Status = fleet.SetupExperienceStatusFailure
 				app.Error = ptr.String(err.Error())
+				failActivity := fleet.ActivityInstalledAppStoreApp{
+					HostID:              host.ID,
+					HostDisplayName:     host.DisplayName(),
+					SoftwareTitle:       app.Name,
+					AppStoreID:          ptr.ValOrZero(app.VPPAppAdamID),
+					Status:              string(fleet.SoftwareInstallFailed),
+					HostPlatform:        host.Platform,
+					FromSetupExperience: true,
+				}
+				if actErr := svc.NewActivity(ctx, nil, failActivity); actErr != nil {
+					svc.logger.WarnContext(ctx, "failed to create activity for VPP app install failure during setup experience", "err", actErr)
+				}
 				// At this point we need to check whether the "cancel if software install fails" setting is active,
 				// in which case we'll cancel the remaining pending items.
 				requireAllSoftware, err := svc.IsAllSetupExperienceSoftwareRequired(ctx, host)

--- a/frontend/interfaces/activity.ts
+++ b/frontend/interfaces/activity.ts
@@ -279,6 +279,7 @@ export interface IActivityDetails {
   team_name?: string | null;
   teams?: ITeamSummary[];
   triggered_by?: string;
+  from_setup_experience?: boolean;
   user_email?: string;
   user_id?: number;
   webhook_url?: string;

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -1488,12 +1488,16 @@ const TAGGED_TEMPLATES = {
     );
   },
   canceledInstallSoftware: (activity: IActivity) => {
-    const { software_title: title, host_display_name: hostName } =
-      activity.details || {};
+    const {
+      software_title: title,
+      host_display_name: hostName,
+      from_setup_experience: fromSetupExperience,
+    } = activity.details || {};
     return (
       <>
         {" "}
-        canceled <b>{title}</b> install on <b>{hostName}</b>.
+        canceled <b>{title}</b> install on <b>{hostName}</b>
+        {fromSetupExperience ? " during setup experience" : ""}.
       </>
     );
   },

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tests.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tests.tsx
@@ -38,4 +38,62 @@ describe("CanceledInstallSoftwareActivityItem", () => {
 
     expect(screen.queryByTestId("info-outline-icon")).not.toBeInTheDocument();
   });
+
+  it("renders setup experience text when from_setup_experience is true", () => {
+    const setupExpActivity = createMockHostPastActivity({
+      type: ActivityType.CanceledInstallSoftware,
+      details: { software_title: "test.app", from_setup_experience: true },
+    });
+
+    render(
+      <CanceledInstallSoftwareActivityItem
+        tab="past"
+        activity={setupExpActivity}
+      />
+    );
+
+    expect(screen.getByText(/canceled/i)).toBeVisible();
+    expect(screen.getByText(/test.app/i)).toBeVisible();
+    expect(
+      screen.getByText(/install on this host during setup experience/i)
+    ).toBeVisible();
+  });
+
+  it("does not render setup experience text when from_setup_experience is false", () => {
+    const noSetupExpActivity = createMockHostPastActivity({
+      type: ActivityType.CanceledInstallSoftware,
+      details: { software_title: "test.app", from_setup_experience: false },
+    });
+
+    render(
+      <CanceledInstallSoftwareActivityItem
+        tab="past"
+        activity={noSetupExpActivity}
+      />
+    );
+
+    expect(
+      screen.queryByText(/during setup experience/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders setup experience text for canceled App Store app", () => {
+    const appStoreActivity = createMockHostPastActivity({
+      type: ActivityType.CanceledInstallAppStoreApp,
+      details: { software_title: "VPPApp.app", from_setup_experience: true },
+    });
+
+    render(
+      <CanceledInstallSoftwareActivityItem
+        tab="past"
+        activity={appStoreActivity}
+      />
+    );
+
+    expect(screen.getByText(/canceled/i)).toBeVisible();
+    expect(screen.getByText(/VPPApp.app/i)).toBeVisible();
+    expect(
+      screen.getByText(/install on this host during setup experience/i)
+    ).toBeVisible();
+  });
 });

--- a/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/ActivityItems/CanceledInstallSoftwareActivityItem/CanceledInstallSoftwareActivityItem.tsx
@@ -9,6 +9,8 @@ const baseClass = "canceled-install-software-activity-item";
 const CanceledInstallSoftwareActivityItem = ({
   activity,
 }: IHostActivityItemComponentProps) => {
+  const fromSetupExperience = activity.details?.from_setup_experience;
+
   return (
     <ActivityItem
       className={baseClass}
@@ -24,7 +26,8 @@ const CanceledInstallSoftwareActivityItem = ({
             activity.details.software_display_name
           )}
         </b>{" "}
-        install on this host.
+        install on this host
+        {fromSetupExperience ? " during setup experience" : ""}.
       </>
     </ActivityItem>
   );

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -1533,10 +1533,11 @@ func (a ActivityTypeCanceledRunScript) HostIDs() []uint {
 }
 
 type ActivityTypeCanceledInstallSoftware struct {
-	HostID          uint   `json:"host_id"`
-	HostDisplayName string `json:"host_display_name"`
-	SoftwareTitle   string `json:"software_title"`
-	SoftwareTitleID uint   `json:"software_title_id"`
+	HostID              uint   `json:"host_id"`
+	HostDisplayName     string `json:"host_display_name"`
+	SoftwareTitle       string `json:"software_title"`
+	SoftwareTitleID     uint   `json:"software_title_id"`
+	FromSetupExperience bool   `json:"from_setup_experience"`
 }
 
 func (a ActivityTypeCanceledInstallSoftware) ActivityName() string {
@@ -1545,6 +1546,10 @@ func (a ActivityTypeCanceledInstallSoftware) ActivityName() string {
 
 func (a ActivityTypeCanceledInstallSoftware) HostIDs() []uint {
 	return []uint{a.HostID}
+}
+
+func (a ActivityTypeCanceledInstallSoftware) WasFromAutomation() bool {
+	return a.FromSetupExperience
 }
 
 type ActivityTypeCanceledUninstallSoftware struct {
@@ -1563,10 +1568,11 @@ func (a ActivityTypeCanceledUninstallSoftware) HostIDs() []uint {
 }
 
 type ActivityTypeCanceledInstallAppStoreApp struct {
-	HostID          uint   `json:"host_id"`
-	HostDisplayName string `json:"host_display_name"`
-	SoftwareTitle   string `json:"software_title"`
-	SoftwareTitleID uint   `json:"software_title_id"`
+	HostID              uint   `json:"host_id"`
+	HostDisplayName     string `json:"host_display_name"`
+	SoftwareTitle       string `json:"software_title"`
+	SoftwareTitleID     uint   `json:"software_title_id"`
+	FromSetupExperience bool   `json:"from_setup_experience"`
 }
 
 func (a ActivityTypeCanceledInstallAppStoreApp) HostIDs() []uint {
@@ -1575,6 +1581,10 @@ func (a ActivityTypeCanceledInstallAppStoreApp) HostIDs() []uint {
 
 func (a ActivityTypeCanceledInstallAppStoreApp) ActivityName() string {
 	return "canceled_install_app_store_app"
+}
+
+func (a ActivityTypeCanceledInstallAppStoreApp) WasFromAutomation() bool {
+	return a.FromSetupExperience
 }
 
 type ActivityTypeRanScriptBatch struct {

--- a/server/worker/apple_mdm.go
+++ b/server/worker/apple_mdm.go
@@ -46,6 +46,7 @@ type AppleMDM struct {
 	Commander             *apple_mdm.MDMAppleCommander
 	BootstrapPackageStore fleet.MDMBootstrapPackageStore
 	VPPInstaller          fleet.AppleMDMVPPInstaller
+	NewActivityFn         fleet.NewActivityFunc
 }
 
 // Name returns the name of the job.
@@ -586,6 +587,21 @@ func (a *AppleMDM) installSetupExperienceVPPAppsOnIosIpadOS(ctx context.Context,
 				a.Log.ErrorContext(ctx, "got an error when attempting to enqueue VPP app install", "err", err, "adam_id", app.VPPAppAdamID)
 				app.Status = fleet.SetupExperienceStatusFailure
 				app.Error = ptr.String(err.Error())
+				// Emit activity for the VPP app install failure
+				if a.NewActivityFn != nil {
+					failActivity := fleet.ActivityInstalledAppStoreApp{
+						HostID:              host.ID,
+						HostDisplayName:     host.DisplayName(),
+						SoftwareTitle:       app.Name,
+						AppStoreID:          ptr.ValOrZero(app.VPPAppAdamID),
+						Status:              string(fleet.SoftwareInstallFailed),
+						HostPlatform:        host.Platform,
+						FromSetupExperience: true,
+					}
+					if actErr := a.NewActivityFn(ctx, nil, failActivity); actErr != nil {
+						a.Log.WarnContext(ctx, "failed to create activity for VPP app install failure during setup experience", "err", actErr)
+					}
+				}
 			} else {
 				commandUUIDs = append(commandUUIDs, cmdUUID)
 			}


### PR DESCRIPTION
Zed + Opus 4.6; prompt:

In Setup Experience, perform the following fixes:

1. Add a boolean flag to install cancelled activities. Skip Markdown changes. Update activity display in the frontend to indicate when cancellations came from setup experience.
2. Switch setup experience mark-as-failed logic to mark as cancelled using the new event. The code for this is near the TODO for #34288 in the code.
3. Implement the missing handling for VPP apps in the same area, using the cancelled VPP install activity. See PR #42358 for inspiration.
4. When VPP application installs fail during setup experience prior to sending the MDM command, emit a VPP app install failure activity.

Make sure changes are covered by automated tests when you're done.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
