### PR TITLE
Fix disk encryption key modal to not show stale key when switching between hosts

### DIFF
--- a/changes/42443-fix-show-disk-encryption-key-modal
+++ b/changes/42443-fix-show-disk-encryption-key-modal
@@ -1,0 +1,1 @@
+* Fixed disk encryption key modal to not show stale key when switching between hosts.

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/DiskEncryptionKeyModal/DiskEncryptionKeyModal.tsx
@@ -30,7 +30,7 @@ const DiskEncryptionKeyModal = ({
     IHostEncrpytionKeyResponse,
     unknown,
     string
-  >("hostEncrpytionKey", () => hostAPI.getEncryptionKey(hostId), {
+  >(["hostEncrpytionKey", hostId], () => hostAPI.getEncryptionKey(hostId), {
     refetchOnMount: false,
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,


### PR DESCRIPTION
Resolves: #42443

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually