### PR TITLE
Fleet UI: Fix icon color and other styling nits

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -187,7 +187,7 @@ const ActionsDropdown = ({
       width: "max-content",
       // Need minHeight to override default
       minHeight: variant === "small-button" ? "20px" : "32px", // Match button height
-      padding: variant === "small-button" ? "2px 4px" : "8px", // Match button padding
+      padding: variant === "small-button" ? "4px" : "8px", // Match button padding
       backgroundColor: state.isFocused ? COLORS["ui-fleet-black-5"] : "initial",
       border: 0,
       boxShadow: "none",
@@ -227,7 +227,7 @@ const ActionsDropdown = ({
         state.isFocused || variant === "button" || variant === "small-button"
           ? COLORS["ui-fleet-black-75"]
           : COLORS["core-fleet-black"],
-      fontSize: "13px",
+      fontSize: "14px",
       fontWeight:
         variant === "button" || variant === "small-button" ? "600" : undefined,
       lineHeight: "normal",

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
@@ -53,7 +53,7 @@
   }
 
   &__item-action {
-    min-width: 94px; // Fits the "Reinstall" button without shifting
+    min-width: 94px; // Fits the "Reinstall" button without shifting second item action
 
     .component__tooltip-wrapper {
       margin: 0; // Override 10px vertical margin

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -259,12 +259,14 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
   failed_install_update_available: {
     iconName: "error-outline", // Match update available icon and not failed install icon
+    iconColor: "ui-fleet-black-75",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedInstallTooltip,
   },
   failed_uninstall_update_available: {
     iconName: "error-outline", // Match update available icon and not failed uninstall icon
+    iconColor: "ui-fleet-black-75",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed (uninstall)" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedUninstallTooltip,

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -91,7 +91,7 @@
 
   .data-table-block .data-table tbody {
     .self-service-table__item-action {
-      min-width: 90px; // Second action buttons align between rows
+      min-width: 94px; // Fits the "Reinstall" button without shifting second item action
 
       .component__tooltip-wrapper {
         margin: 0; // Override 10px vertical margin


### PR DESCRIPTION
## Issue
Closes #42328 

## Description
- Update icon to be grey instead of red after error

### While testing noticed a few other nits
- FIXED: Self service page doesn't fit 94px reinstall button so it pushes the more dropdown over 
- FIXED: More dropdown height is not 28px like the install button next to it, confirmed on Figma design system that the Actions/More dropdowns are suppose to indeed be 28px height like the buttons https://www.figma.com/design/gxvU745LfOdkE9AuRg64wi/%F0%9F%A7%A9-Product-design-system?node-id=5626-25382&t=b35fluQASnxTBVa5-0
- FIXED: Font size 13px for More dropdown looks awkward next to font size 14px Install button, no where else do we have font size 13px, so I changed it to 14px

## Screenshot of fix


<img width="1040" height="805" alt="Screenshot 2026-03-26 at 11 17 34 AM" src="https://github.com/user-attachments/assets/d0c815bd-c051-4702-b7f7-34967b0a4a91" />


## Testing

- [x] QA'd all new/changed functionality manually
