### PR TITLE
Cleanup temp installer files after download

### DIFF
--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -94,6 +94,11 @@ func run(cfg *Config) error {
 		cfg.logger.ErrorContext(ctx, fmt.Sprintf("Error creating temporary directory: %v", err))
 		return err
 	}
+	cfg.tmpDir, err = filepath.EvalSymlinks(cfg.tmpDir)
+	if err != nil {
+		cfg.logger.ErrorContext(ctx, fmt.Sprintf("Error resolving temporary directory path: %v", err))
+		return err
+	}
 	defer func() {
 		detachAllDMGs(ctx, cfg.logger, cfg.tmpDir)
 		if err := os.RemoveAll(cfg.tmpDir); err != nil {

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -63,6 +63,7 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 
 func run(cfg *Config) error {
 	ctx := context.Background()
+	skipFiles := make(map[string]bool)
 	cleanupAppFiles := func(_ string) {
 		detachAllDMGs(ctx, cfg.logger)
 
@@ -72,8 +73,12 @@ func run(cfg *Config) error {
 			return
 		}
 		for _, e := range entries {
+			if skipFiles[e.Name()] {
+				continue
+			}
 			if err := os.RemoveAll(filepath.Join(cfg.tmpDir, e.Name())); err != nil {
 				cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove %s: %v", e.Name(), err))
+				skipFiles[e.Name()] = true
 			}
 		}
 	}

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -52,6 +52,26 @@ func logDiskSpace(ctx context.Context, logger *slog.Logger, tmpDir string, label
 		logger.WarnContext(ctx, fmt.Sprintf("Failed to get disk space: %v", err))
 	}
 
+	if runtime.GOOS == "darwin" {
+		if output, err := exec.Command("hdiutil", "info").CombinedOutput(); err == nil {
+			mounted := parseMountedDMGInfo(string(output))
+			if len(mounted) > 0 {
+				logger.WarnContext(ctx, fmt.Sprintf("Mounted DMG volumes (%d):", len(mounted)))
+				for _, m := range mounted {
+					logger.WarnContext(ctx, fmt.Sprintf("  %s (from %s)", m.mountPoint, m.imagePath))
+				}
+			}
+		}
+
+		if entries, err := os.ReadDir("/Volumes"); err == nil {
+			var names []string
+			for _, e := range entries {
+				names = append(names, e.Name())
+			}
+			logger.InfoContext(ctx, fmt.Sprintf("/Volumes: %v", names))
+		}
+	}
+
 	if matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "fleet-temp-file-*")); len(matches) > 0 {
 		var totalSize int64
 		for _, m := range matches {
@@ -75,6 +95,44 @@ func logDiskSpace(ctx context.Context, logger *slog.Logger, tmpDir string, label
 	}
 }
 
+type mountedDMG struct {
+	imagePath  string
+	mountPoint string
+}
+
+func parseMountedDMGInfo(hdiutilOutput string) []mountedDMG {
+	var results []mountedDMG
+	var currentImage string
+	for _, line := range strings.Split(hdiutilOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "image-path") {
+			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
+		}
+		if strings.HasPrefix(line, "/dev/") && strings.Contains(line, "/Volumes/") {
+			mountPoint := line[strings.Index(line, "/Volumes/"):]
+			results = append(results, mountedDMG{imagePath: currentImage, mountPoint: mountPoint})
+		}
+	}
+	return results
+}
+
+func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
+	if runtime.GOOS != "darwin" {
+		return
+	}
+	output, err := exec.Command("hdiutil", "info").CombinedOutput()
+	if err != nil {
+		return
+	}
+	mounted := parseMountedDMGInfo(string(output))
+	for _, m := range mounted {
+		logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", m.mountPoint, m.imagePath))
+		if out, err := exec.Command("hdiutil", "detach", m.mountPoint, "-force").CombinedOutput(); err != nil {
+			logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", m.mountPoint, err, strings.TrimSpace(string(out))))
+		}
+	}
+}
+
 func run(cfg *Config) error {
 	ctx := context.Background()
 	cleanupInstaller := func(installerPath string) {
@@ -91,6 +149,7 @@ func run(cfg *Config) error {
 			return
 		}
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Deleted installer file: %s", installerPath))
+		detachAllDMGs(ctx, cfg.logger)
 	}
 
 	apps, err := getListOfApps(cfg.outputsPath)

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -38,6 +38,14 @@ type Config struct {
 
 func run(cfg *Config) error {
 	ctx := context.Background()
+	cleanupInstaller := func(installerPath string) {
+		if installerPath == "" {
+			return
+		}
+		if err := os.Remove(installerPath); err != nil && !os.IsNotExist(err) {
+			cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove installer file '%s': %v", installerPath, err))
+		}
+	}
 
 	apps, err := getListOfApps(cfg.outputsPath)
 	if err != nil {
@@ -72,6 +80,7 @@ func run(cfg *Config) error {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Validating app: %s (%s)", app.Name, app.Slug))
 		appLogger := cfg.logger.With("app", app.Name)
 		ac := &AppCommander{cfg: cfg, appLogger: appLogger}
+		installerPath := ""
 
 		appJson, err := getAppJson(cfg.outputsPath, app.Slug)
 		if err != nil {
@@ -101,12 +110,13 @@ func run(cfg *Config) error {
 			continue
 		}
 
-		installerTFR, err := DownloadMaintainedApp(cfg, maintainedApp)
+		installerTFR, downloadedInstallerPath, err := DownloadMaintainedApp(cfg, maintainedApp)
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error downloading maintained app: %v", err))
 			appWithError = append(appWithError, ac.Name)
 			continue
 		}
+		installerPath = downloadedInstallerPath
 
 		err = ac.extractAppVersion(installerTFR)
 		if err != nil {
@@ -119,11 +129,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if sha256 hash matches: %v", err))
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 		if hash != maintainedApp.SHA256 && maintainedApp.SHA256 != "no_check" {
 			appLogger.ErrorContext(ctx, "SHA256 hash in manifest does not match installer file hash")
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 
@@ -150,6 +162,7 @@ func run(cfg *Config) error {
 		}
 		if changerError != nil {
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 		ac.AppPath = appPath
@@ -167,11 +180,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if app exists: %v", err))
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 		if !existance {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("App version '%s' was not found by osquery", ac.Version))
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 
@@ -179,9 +194,11 @@ func run(cfg *Config) error {
 		uninstalled := ac.uninstallApp(ctx)
 		if !uninstalled {
 			appWithError = append(appWithError, ac.Name)
+			cleanupInstaller(installerPath)
 			continue
 		}
 
+		cleanupInstaller(installerPath)
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("All checks passed for app: %s (%s)", ac.Name, ac.Slug))
 		successfulApps++
 	}
@@ -306,14 +323,14 @@ func appFromJson(manifest *maintained_apps.FMAManifestFile) fleet.MaintainedApp 
 	return app
 }
 
-func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFileReader, error) {
+func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFileReader, string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
 
 	cfg.logger.InfoContext(ctx, "Downloading...")
 	installerTFR, filename, err := mdm_maintained_apps.DownloadInstaller(ctx, app.InstallerURL, http.DefaultClient)
 	if err != nil {
-		return nil, fmt.Errorf("downloading installer: %w", err)
+		return nil, "", fmt.Errorf("downloading installer: %w", err)
 	}
 
 	// Create a file in tmpDir for the installer
@@ -324,27 +341,27 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 	filePath := filepath.Join(cfg.tmpDir, cleanFilename)
 	out, err := os.Create(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("creating file: %w", err)
+		return nil, "", fmt.Errorf("creating file: %w", err)
 	}
 	defer out.Close()
 
 	// Copy from TempFileReader to our file
 	_, err = io.Copy(out, installerTFR)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save file: %w", err)
+		return nil, "", fmt.Errorf("failed to save file: %w", err)
 	}
 
 	// Rewind the TempFileReader for future use
 	err = installerTFR.Rewind()
 	if err != nil {
-		return nil, fmt.Errorf("rewinding temp file: %w", err)
+		return nil, "", fmt.Errorf("rewinding temp file: %w", err)
 	}
 
 	cfg.env = os.Environ()
 	installerPathEnv := fmt.Sprintf("INSTALLER_PATH=%s", filePath)
 	cfg.env = append(cfg.env, installerPathEnv)
 
-	return installerTFR, nil
+	return installerTFR, filePath, nil
 }
 
 func listDirectoryContents(dir string) (map[string]struct{}, error) {

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -85,12 +85,18 @@ func logDiskSpace(ctx context.Context, logger *slog.Logger, tmpDir string, label
 	if tmpDir != "" {
 		if entries, err := os.ReadDir(tmpDir); err == nil {
 			var totalSize int64
+			var fileDetails []string
 			for _, e := range entries {
 				if info, err := e.Info(); err == nil {
-					totalSize += info.Size()
+					size := info.Size()
+					totalSize += size
+					fileDetails = append(fileDetails, fmt.Sprintf("  %s (%.2f MB, dir=%v)", e.Name(), float64(size)/(1024*1024), e.IsDir()))
 				}
 			}
 			logger.InfoContext(ctx, fmt.Sprintf("Validation tmpDir (%s): %d entries, %.2f MB", tmpDir, len(entries), float64(totalSize)/(1024*1024)))
+			for _, detail := range fileDetails {
+				logger.InfoContext(ctx, detail)
+			}
 		}
 	}
 }
@@ -135,21 +141,26 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 
 func run(cfg *Config) error {
 	ctx := context.Background()
-	cleanupInstaller := func(installerPath string) {
-		if installerPath == "" {
-			return
-		}
-		var sizeBytes int64
-		if info, err := os.Stat(installerPath); err == nil {
-			sizeBytes = info.Size()
-		}
-		cfg.logger.InfoContext(ctx, fmt.Sprintf("Cleaning up installer file: %s (%d bytes)", installerPath, sizeBytes))
-		if err := os.Remove(installerPath); err != nil && !os.IsNotExist(err) {
-			cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove installer file '%s': %v", installerPath, err))
-			return
-		}
-		cfg.logger.InfoContext(ctx, fmt.Sprintf("Deleted installer file: %s", installerPath))
+	cleanupAppFiles := func(installerPath string) {
 		detachAllDMGs(ctx, cfg.logger)
+
+		entries, err := os.ReadDir(cfg.tmpDir)
+		if err != nil {
+			cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to read tmpDir for cleanup: %v", err))
+			return
+		}
+		for _, e := range entries {
+			p := filepath.Join(cfg.tmpDir, e.Name())
+			var sizeStr string
+			if info, err := e.Info(); err == nil {
+				sizeStr = fmt.Sprintf("%.2f MB", float64(info.Size())/(1024*1024))
+			}
+			if err := os.RemoveAll(p); err != nil {
+				cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove %s: %v", e.Name(), err))
+			} else {
+				cfg.logger.InfoContext(ctx, fmt.Sprintf("Cleaned up: %s (%s, dir=%v)", e.Name(), sizeStr, e.IsDir()))
+			}
+		}
 	}
 
 	apps, err := getListOfApps(cfg.outputsPath)
@@ -237,13 +248,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if sha256 hash matches: %v", err))
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 		if hash != maintainedApp.SHA256 && maintainedApp.SHA256 != "no_check" {
 			appLogger.ErrorContext(ctx, "SHA256 hash in manifest does not match installer file hash")
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 
@@ -270,7 +281,7 @@ func run(cfg *Config) error {
 		}
 		if changerError != nil {
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 		ac.AppPath = appPath
@@ -288,13 +299,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if app exists: %v", err))
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 		if !existance {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("App version '%s' was not found by osquery", ac.Version))
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 
@@ -302,11 +313,11 @@ func run(cfg *Config) error {
 		uninstalled := ac.uninstallApp(ctx)
 		if !uninstalled {
 			appWithError = append(appWithError, ac.Name)
-			cleanupInstaller(installerPath)
+			cleanupAppFiles(installerPath)
 			continue
 		}
 
-		cleanupInstaller(installerPath)
+		cleanupAppFiles(installerPath)
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("All checks passed for app: %s (%s)", ac.Name, ac.Slug))
 		successfulApps++
 	}

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -37,11 +37,11 @@ type Config struct {
 	outputsPath                 string
 }
 
-func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
+func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 	if runtime.GOOS != "darwin" {
 		return
 	}
-	output, err := exec.Command("hdiutil", "info").CombinedOutput()
+	output, err := exec.CommandContext(ctx, "hdiutil", "info").CombinedOutput()
 	if err != nil {
 		return
 	}
@@ -52,9 +52,12 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
 		}
 		if idx := strings.Index(line, "/Volumes/"); strings.HasPrefix(line, "/dev/") && idx >= 0 {
+			if tmpDir == "" || !strings.HasPrefix(currentImage, tmpDir) {
+				continue
+			}
 			mountPoint := line[idx:]
 			logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", mountPoint, currentImage))
-			if out, err := exec.Command("hdiutil", "detach", mountPoint, "-force").CombinedOutput(); err != nil {
+			if out, err := exec.CommandContext(ctx, "hdiutil", "detach", mountPoint, "-force").CombinedOutput(); err != nil {
 				logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", mountPoint, err, strings.TrimSpace(string(out))))
 			}
 		}
@@ -64,8 +67,8 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 func run(cfg *Config) error {
 	ctx := context.Background()
 	skipFiles := make(map[string]bool)
-	cleanupAppFiles := func(_ string) {
-		detachAllDMGs(ctx, cfg.logger)
+	cleanupTmpDir := func() {
+		detachAllDMGs(ctx, cfg.logger, cfg.tmpDir)
 
 		entries, err := os.ReadDir(cfg.tmpDir)
 		if err != nil {
@@ -116,7 +119,6 @@ func run(cfg *Config) error {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Validating app: %s (%s)", app.Name, app.Slug))
 		appLogger := cfg.logger.With("app", app.Name)
 		ac := &AppCommander{cfg: cfg, appLogger: appLogger}
-		installerPath := ""
 
 		appJson, err := getAppJson(cfg.outputsPath, app.Slug)
 		if err != nil {
@@ -146,13 +148,12 @@ func run(cfg *Config) error {
 			continue
 		}
 
-		installerTFR, downloadedInstallerPath, err := DownloadMaintainedApp(cfg, maintainedApp)
+		installerTFR, _, err := DownloadMaintainedApp(cfg, maintainedApp)
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error downloading maintained app: %v", err))
 			appWithError = append(appWithError, ac.Name)
 			continue
 		}
-		installerPath = downloadedInstallerPath
 
 		err = ac.extractAppVersion(installerTFR)
 		if err != nil {
@@ -165,13 +166,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if sha256 hash matches: %v", err))
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 		if hash != maintainedApp.SHA256 && maintainedApp.SHA256 != "no_check" {
 			appLogger.ErrorContext(ctx, "SHA256 hash in manifest does not match installer file hash")
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 
@@ -198,7 +199,7 @@ func run(cfg *Config) error {
 		}
 		if changerError != nil {
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 		ac.AppPath = appPath
@@ -216,13 +217,13 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error checking if app exists: %v", err))
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 		if !existance {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("App version '%s' was not found by osquery", ac.Version))
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 
@@ -230,11 +231,11 @@ func run(cfg *Config) error {
 		uninstalled := ac.uninstallApp(ctx)
 		if !uninstalled {
 			appWithError = append(appWithError, ac.Name)
-			cleanupAppFiles(installerPath)
+			cleanupTmpDir()
 			continue
 		}
 
-		cleanupAppFiles(installerPath)
+		cleanupTmpDir()
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("All checks passed for app: %s (%s)", ac.Name, ac.Slug))
 		successfulApps++
 	}
@@ -384,12 +385,14 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 	_, err = io.Copy(out, installerTFR)
 	if err != nil {
 		installerTFR.Close()
+		os.Remove(filePath)
 		return nil, "", fmt.Errorf("failed to save file: %w", err)
 	}
 
 	err = installerTFR.Rewind()
 	if err != nil {
 		installerTFR.Close()
+		os.Remove(filePath)
 		return nil, "", fmt.Errorf("rewinding temp file: %w", err)
 	}
 

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -54,7 +54,7 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 			}
 		}
 		if idx := strings.Index(line, "/Volumes/"); strings.HasPrefix(line, "/dev/") && idx >= 0 {
-			if tmpDir == "" || !strings.HasPrefix(currentImage, tmpDir) {
+			if tmpDir == "" || !strings.HasPrefix(currentImage, tmpDir+string(os.PathSeparator)) {
 				continue
 			}
 			mountPoint := line[idx:]
@@ -68,7 +68,6 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 
 func run(cfg *Config) error {
 	ctx := context.Background()
-	skipFiles := make(map[string]bool)
 	cleanupTmpDir := func() {
 		detachAllDMGs(ctx, cfg.logger, cfg.tmpDir)
 
@@ -78,12 +77,8 @@ func run(cfg *Config) error {
 			return
 		}
 		for _, e := range entries {
-			if skipFiles[e.Name()] {
-				continue
-			}
 			if err := os.RemoveAll(filepath.Join(cfg.tmpDir, e.Name())); err != nil {
 				cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove %s: %v", e.Name(), err))
-				skipFiles[e.Name()] = true
 			}
 		}
 	}
@@ -100,8 +95,8 @@ func run(cfg *Config) error {
 		return err
 	}
 	defer func() {
-		err := os.RemoveAll(cfg.tmpDir)
-		if err != nil {
+		detachAllDMGs(ctx, cfg.logger, cfg.tmpDir)
+		if err := os.RemoveAll(cfg.tmpDir); err != nil {
 			cfg.logger.ErrorContext(ctx, fmt.Sprintf("warning failed to remove temporary directory: %v", err))
 		}
 	}()
@@ -129,7 +124,12 @@ func run(cfg *Config) error {
 			continue
 		}
 
-		maintainedApp := appFromJson(appJson)
+		maintainedApp, err := appFromJson(appJson)
+		if err != nil {
+			appLogger.ErrorContext(ctx, fmt.Sprintf("Error parsing app manifest: %v", err))
+			appWithError = append(appWithError, app.Name)
+			continue
+		}
 		ac.Name = app.Name
 		ac.Slug = app.Slug
 		ac.UniqueIdentifier = app.UniqueIdentifier
@@ -159,8 +159,8 @@ func run(cfg *Config) error {
 
 		err = ac.extractAppVersion(installerTFR)
 		if err != nil {
-			appLogger.ErrorContext(ctx, fmt.Sprintf("Error extracting installer version: %v. Using '%s'", err, ac.Version))
-			appWithError = append(appWithError, ac.Name)
+			appLogger.WarnContext(ctx, fmt.Sprintf("Error extracting installer version: %v. Using '%s'", err, ac.Version))
+			appWithWarning = append(appWithWarning, ac.Name)
 		}
 
 		hash, err := file.SHA256FromTempFileReader(installerTFR)
@@ -348,18 +348,23 @@ func getAppJson(outputPath string, slug string) (*maintained_apps.FMAManifestFil
 	return &manifest, nil
 }
 
-func appFromJson(manifest *maintained_apps.FMAManifestFile) fleet.MaintainedApp {
-	var app fleet.MaintainedApp
-	app.Version = manifest.Versions[0].Version
-	app.Platform = manifest.Versions[0].Platform()
-	app.InstallerURL = manifest.Versions[0].InstallerURL
-	app.SHA256 = manifest.Versions[0].SHA256
-	app.InstallScript = manifest.Refs[manifest.Versions[0].InstallScriptRef]
-	app.UninstallScript = manifest.Refs[manifest.Versions[0].UninstallScriptRef]
-	app.AutomaticInstallQuery = manifest.Versions[0].Queries.Exists
-	app.Categories = manifest.Versions[0].DefaultCategories
+func appFromJson(manifest *maintained_apps.FMAManifestFile) (fleet.MaintainedApp, error) {
+	if len(manifest.Versions) == 0 {
+		return fleet.MaintainedApp{}, fmt.Errorf("manifest has no versions")
+	}
 
-	return app
+	v := manifest.Versions[0]
+	app := fleet.MaintainedApp{
+		Version:               v.Version,
+		Platform:              v.Platform(),
+		InstallerURL:          v.InstallerURL,
+		SHA256:                v.SHA256,
+		InstallScript:         manifest.Refs[v.InstallScriptRef],
+		UninstallScript:       manifest.Refs[v.UninstallScriptRef],
+		AutomaticInstallQuery: v.Queries.Exists,
+		Categories:            v.DefaultCategories,
+	}
+	return app, nil
 }
 
 func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFileReader, string, error) {

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -51,8 +51,8 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 		if strings.HasPrefix(line, "image-path") {
 			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
 		}
-		if strings.HasPrefix(line, "/dev/") && strings.Contains(line, "/Volumes/") {
-			mountPoint := line[strings.Index(line, "/Volumes/"):]
+		if idx := strings.Index(line, "/Volumes/"); strings.HasPrefix(line, "/dev/") && idx >= 0 {
+			mountPoint := line[idx:]
 			logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", mountPoint, currentImage))
 			if out, err := exec.Command("hdiutil", "detach", mountPoint, "-force").CombinedOutput(); err != nil {
 				logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", mountPoint, err, strings.TrimSpace(string(out))))

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -37,91 +37,6 @@ type Config struct {
 	outputsPath                 string
 }
 
-func logDiskSpace(ctx context.Context, logger *slog.Logger, tmpDir string, label string) {
-	logger.InfoContext(ctx, fmt.Sprintf("--- Disk space check: %s ---", label))
-
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("wmic", "logicaldisk", "get", "size,freespace,caption")
-	} else {
-		cmd = exec.Command("df", "-h", "/")
-	}
-	if output, err := cmd.CombinedOutput(); err == nil {
-		logger.InfoContext(ctx, strings.TrimSpace(string(output)))
-	} else {
-		logger.WarnContext(ctx, fmt.Sprintf("Failed to get disk space: %v", err))
-	}
-
-	if runtime.GOOS == "darwin" {
-		if output, err := exec.Command("hdiutil", "info").CombinedOutput(); err == nil {
-			mounted := parseMountedDMGInfo(string(output))
-			if len(mounted) > 0 {
-				logger.WarnContext(ctx, fmt.Sprintf("Mounted DMG volumes (%d):", len(mounted)))
-				for _, m := range mounted {
-					logger.WarnContext(ctx, fmt.Sprintf("  %s (from %s)", m.mountPoint, m.imagePath))
-				}
-			}
-		}
-
-		if entries, err := os.ReadDir("/Volumes"); err == nil {
-			var names []string
-			for _, e := range entries {
-				names = append(names, e.Name())
-			}
-			logger.InfoContext(ctx, fmt.Sprintf("/Volumes: %v", names))
-		}
-	}
-
-	if matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "fleet-temp-file-*")); len(matches) > 0 {
-		var totalSize int64
-		for _, m := range matches {
-			if info, err := os.Stat(m); err == nil {
-				totalSize += info.Size()
-			}
-		}
-		logger.WarnContext(ctx, fmt.Sprintf("Lingering fleet-temp-file-* in %s: %d files, %.2f MB", os.TempDir(), len(matches), float64(totalSize)/(1024*1024)))
-	}
-
-	if tmpDir != "" {
-		if entries, err := os.ReadDir(tmpDir); err == nil {
-			var totalSize int64
-			var fileDetails []string
-			for _, e := range entries {
-				if info, err := e.Info(); err == nil {
-					size := info.Size()
-					totalSize += size
-					fileDetails = append(fileDetails, fmt.Sprintf("  %s (%.2f MB, dir=%v)", e.Name(), float64(size)/(1024*1024), e.IsDir()))
-				}
-			}
-			logger.InfoContext(ctx, fmt.Sprintf("Validation tmpDir (%s): %d entries, %.2f MB", tmpDir, len(entries), float64(totalSize)/(1024*1024)))
-			for _, detail := range fileDetails {
-				logger.InfoContext(ctx, detail)
-			}
-		}
-	}
-}
-
-type mountedDMG struct {
-	imagePath  string
-	mountPoint string
-}
-
-func parseMountedDMGInfo(hdiutilOutput string) []mountedDMG {
-	var results []mountedDMG
-	var currentImage string
-	for _, line := range strings.Split(hdiutilOutput, "\n") {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "image-path") {
-			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
-		}
-		if strings.HasPrefix(line, "/dev/") && strings.Contains(line, "/Volumes/") {
-			mountPoint := line[strings.Index(line, "/Volumes/"):]
-			results = append(results, mountedDMG{imagePath: currentImage, mountPoint: mountPoint})
-		}
-	}
-	return results
-}
-
 func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 	if runtime.GOOS != "darwin" {
 		return
@@ -130,18 +45,25 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger) {
 	if err != nil {
 		return
 	}
-	mounted := parseMountedDMGInfo(string(output))
-	for _, m := range mounted {
-		logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", m.mountPoint, m.imagePath))
-		if out, err := exec.Command("hdiutil", "detach", m.mountPoint, "-force").CombinedOutput(); err != nil {
-			logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", m.mountPoint, err, strings.TrimSpace(string(out))))
+	var currentImage string
+	for line := range strings.SplitSeq(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "image-path") {
+			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
+		}
+		if strings.HasPrefix(line, "/dev/") && strings.Contains(line, "/Volumes/") {
+			mountPoint := line[strings.Index(line, "/Volumes/"):]
+			logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", mountPoint, currentImage))
+			if out, err := exec.Command("hdiutil", "detach", mountPoint, "-force").CombinedOutput(); err != nil {
+				logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", mountPoint, err, strings.TrimSpace(string(out))))
+			}
 		}
 	}
 }
 
 func run(cfg *Config) error {
 	ctx := context.Background()
-	cleanupAppFiles := func(installerPath string) {
+	cleanupAppFiles := func(_ string) {
 		detachAllDMGs(ctx, cfg.logger)
 
 		entries, err := os.ReadDir(cfg.tmpDir)
@@ -150,15 +72,8 @@ func run(cfg *Config) error {
 			return
 		}
 		for _, e := range entries {
-			p := filepath.Join(cfg.tmpDir, e.Name())
-			var sizeStr string
-			if info, err := e.Info(); err == nil {
-				sizeStr = fmt.Sprintf("%.2f MB", float64(info.Size())/(1024*1024))
-			}
-			if err := os.RemoveAll(p); err != nil {
+			if err := os.RemoveAll(filepath.Join(cfg.tmpDir, e.Name())); err != nil {
 				cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove %s: %v", e.Name(), err))
-			} else {
-				cfg.logger.InfoContext(ctx, fmt.Sprintf("Cleaned up: %s (%s, dir=%v)", e.Name(), sizeStr, e.IsDir()))
 			}
 		}
 	}
@@ -181,8 +96,6 @@ func run(cfg *Config) error {
 		}
 	}()
 
-	logDiskSpace(ctx, cfg.logger, cfg.tmpDir, "initial state")
-
 	totalApps := 0
 	successfulApps := 0
 	appWithError := []string{}
@@ -195,7 +108,6 @@ func run(cfg *Config) error {
 
 		totalApps++
 
-		logDiskSpace(ctx, cfg.logger, cfg.tmpDir, fmt.Sprintf("before %s (%s)", app.Name, app.Slug))
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Validating app: %s (%s)", app.Name, app.Slug))
 		appLogger := cfg.logger.With("app", app.Name)
 		ac := &AppCommander{cfg: cfg, appLogger: appLogger}
@@ -321,8 +233,6 @@ func run(cfg *Config) error {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("All checks passed for app: %s (%s)", ac.Name, ac.Slug))
 		successfulApps++
 	}
-
-	logDiskSpace(ctx, cfg.logger, cfg.tmpDir, "final state")
 
 	if len(frozenApps) > 0 {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Some apps were skipped: %v", frozenApps))

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -55,7 +55,7 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 		}
 		if strings.HasPrefix(line, "/dev/") {
 			var mountPoint string
-			for _, field := range strings.Fields(line) {
+			for field := range strings.FieldsSeq(line) {
 				if strings.HasPrefix(field, "/") && !strings.HasPrefix(field, "/dev/") {
 					mountPoint = field
 					break

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -42,9 +42,16 @@ func run(cfg *Config) error {
 		if installerPath == "" {
 			return
 		}
+		var sizeBytes int64
+		if info, err := os.Stat(installerPath); err == nil {
+			sizeBytes = info.Size()
+		}
+		cfg.logger.InfoContext(ctx, fmt.Sprintf("Cleaning up installer file: %s (%d bytes)", installerPath, sizeBytes))
 		if err := os.Remove(installerPath); err != nil && !os.IsNotExist(err) {
 			cfg.logger.WarnContext(ctx, fmt.Sprintf("failed to remove installer file '%s': %v", installerPath, err))
+			return
 		}
+		cfg.logger.InfoContext(ctx, fmt.Sprintf("Deleted installer file: %s", installerPath))
 	}
 
 	apps, err := getListOfApps(cfg.outputsPath)

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -350,7 +350,7 @@ func getAppJson(outputPath string, slug string) (*maintained_apps.FMAManifestFil
 
 func appFromJson(manifest *maintained_apps.FMAManifestFile) (fleet.MaintainedApp, error) {
 	if len(manifest.Versions) == 0 {
-		return fleet.MaintainedApp{}, fmt.Errorf("manifest has no versions")
+		return fleet.MaintainedApp{}, errors.New("manifest has no versions")
 	}
 
 	v := manifest.Versions[0]

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -53,11 +53,20 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 				currentImage = strings.TrimSpace(parts[1])
 			}
 		}
-		if idx := strings.Index(line, "/Volumes/"); strings.HasPrefix(line, "/dev/") && idx >= 0 {
+		if strings.HasPrefix(line, "/dev/") {
+			var mountPoint string
+			for _, field := range strings.Fields(line) {
+				if strings.HasPrefix(field, "/") && !strings.HasPrefix(field, "/dev/") {
+					mountPoint = field
+					break
+				}
+			}
+			if mountPoint == "" {
+				continue
+			}
 			if tmpDir == "" || !strings.HasPrefix(currentImage, tmpDir+string(os.PathSeparator)) {
 				continue
 			}
-			mountPoint := line[idx:]
 			logger.InfoContext(ctx, fmt.Sprintf("Force-detaching DMG: %s (image: %s)", mountPoint, currentImage))
 			if out, err := exec.CommandContext(ctx, "hdiutil", "detach", mountPoint, "-force").CombinedOutput(); err != nil {
 				logger.WarnContext(ctx, fmt.Sprintf("Failed to detach %s: %v (%s)", mountPoint, err, strings.TrimSpace(string(out))))
@@ -94,9 +103,11 @@ func run(cfg *Config) error {
 		cfg.logger.ErrorContext(ctx, fmt.Sprintf("Error creating temporary directory: %v", err))
 		return err
 	}
+	origTmpDir := cfg.tmpDir
 	cfg.tmpDir, err = filepath.EvalSymlinks(cfg.tmpDir)
 	if err != nil {
 		cfg.logger.ErrorContext(ctx, fmt.Sprintf("Error resolving temporary directory path: %v", err))
+		os.RemoveAll(origTmpDir)
 		return err
 	}
 	defer func() {
@@ -159,6 +170,7 @@ func run(cfg *Config) error {
 		if err != nil {
 			appLogger.ErrorContext(ctx, fmt.Sprintf("Error downloading maintained app: %v", err))
 			appWithError = append(appWithError, ac.Name)
+			cleanupTmpDir()
 			continue
 		}
 

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -34,6 +35,44 @@ type Config struct {
 	logLevel                    string
 	inputsPath                  string
 	outputsPath                 string
+}
+
+func logDiskSpace(ctx context.Context, logger *slog.Logger, tmpDir string, label string) {
+	logger.InfoContext(ctx, fmt.Sprintf("--- Disk space check: %s ---", label))
+
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("wmic", "logicaldisk", "get", "size,freespace,caption")
+	} else {
+		cmd = exec.Command("df", "-h", "/")
+	}
+	if output, err := cmd.CombinedOutput(); err == nil {
+		logger.InfoContext(ctx, strings.TrimSpace(string(output)))
+	} else {
+		logger.WarnContext(ctx, fmt.Sprintf("Failed to get disk space: %v", err))
+	}
+
+	if matches, _ := filepath.Glob(filepath.Join(os.TempDir(), "fleet-temp-file-*")); len(matches) > 0 {
+		var totalSize int64
+		for _, m := range matches {
+			if info, err := os.Stat(m); err == nil {
+				totalSize += info.Size()
+			}
+		}
+		logger.WarnContext(ctx, fmt.Sprintf("Lingering fleet-temp-file-* in %s: %d files, %.2f MB", os.TempDir(), len(matches), float64(totalSize)/(1024*1024)))
+	}
+
+	if tmpDir != "" {
+		if entries, err := os.ReadDir(tmpDir); err == nil {
+			var totalSize int64
+			for _, e := range entries {
+				if info, err := e.Info(); err == nil {
+					totalSize += info.Size()
+				}
+			}
+			logger.InfoContext(ctx, fmt.Sprintf("Validation tmpDir (%s): %d entries, %.2f MB", tmpDir, len(entries), float64(totalSize)/(1024*1024)))
+		}
+	}
 }
 
 func run(cfg *Config) error {
@@ -72,6 +111,8 @@ func run(cfg *Config) error {
 		}
 	}()
 
+	logDiskSpace(ctx, cfg.logger, cfg.tmpDir, "initial state")
+
 	totalApps := 0
 	successfulApps := 0
 	appWithError := []string{}
@@ -84,6 +125,7 @@ func run(cfg *Config) error {
 
 		totalApps++
 
+		logDiskSpace(ctx, cfg.logger, cfg.tmpDir, fmt.Sprintf("before %s (%s)", app.Name, app.Slug))
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Validating app: %s (%s)", app.Name, app.Slug))
 		appLogger := cfg.logger.With("app", app.Name)
 		ac := &AppCommander{cfg: cfg, appLogger: appLogger}
@@ -209,6 +251,8 @@ func run(cfg *Config) error {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("All checks passed for app: %s (%s)", ac.Name, ac.Slug))
 		successfulApps++
 	}
+
+	logDiskSpace(ctx, cfg.logger, cfg.tmpDir, "final state")
 
 	if len(frozenApps) > 0 {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Some apps were skipped: %v", frozenApps))
@@ -340,7 +384,6 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 		return nil, "", fmt.Errorf("downloading installer: %w", err)
 	}
 
-	// Create a file in tmpDir for the installer
 	cleanFilename := filepath.Base(filename)
 	if cleanFilename == "." || cleanFilename == ".." {
 		cleanFilename = fmt.Sprintf("installer_%d", time.Now().UnixNano())
@@ -348,19 +391,20 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 	filePath := filepath.Join(cfg.tmpDir, cleanFilename)
 	out, err := os.Create(filePath)
 	if err != nil {
+		installerTFR.Close()
 		return nil, "", fmt.Errorf("creating file: %w", err)
 	}
 	defer out.Close()
 
-	// Copy from TempFileReader to our file
 	_, err = io.Copy(out, installerTFR)
 	if err != nil {
+		installerTFR.Close()
 		return nil, "", fmt.Errorf("failed to save file: %w", err)
 	}
 
-	// Rewind the TempFileReader for future use
 	err = installerTFR.Rewind()
 	if err != nil {
+		installerTFR.Close()
 		return nil, "", fmt.Errorf("rewinding temp file: %w", err)
 	}
 

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -55,10 +55,10 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 		}
 		if strings.HasPrefix(line, "/dev/") {
 			var mountPoint string
-			for field := range strings.FieldsSeq(line) {
-				if strings.HasPrefix(field, "/") && !strings.HasPrefix(field, "/dev/") {
-					mountPoint = field
-					break
+			for part := range strings.SplitSeq(line, "\t") {
+				part = strings.TrimSpace(part)
+				if strings.HasPrefix(part, "/") && !strings.HasPrefix(part, "/dev/") {
+					mountPoint = part
 				}
 			}
 			if mountPoint == "" {
@@ -174,10 +174,18 @@ func run(cfg *Config) error {
 			continue
 		}
 
+		hadWarning := false
+		warnApp := func() {
+			if !hadWarning {
+				appWithWarning = append(appWithWarning, ac.Name)
+				hadWarning = true
+			}
+		}
+
 		err = ac.extractAppVersion(installerTFR)
 		if err != nil {
 			appLogger.WarnContext(ctx, fmt.Sprintf("Error extracting installer version: %v. Using '%s'", err, ac.Version))
-			appWithWarning = append(appWithWarning, ac.Name)
+			warnApp()
 		}
 
 		hash, err := file.SHA256FromTempFileReader(installerTFR)
@@ -223,13 +231,13 @@ func run(cfg *Config) error {
 		}
 		ac.AppPath = appPath
 		if ac.AppPath == "" {
-			appWithWarning = append(appWithWarning, ac.Name)
+			warnApp()
 		}
 
 		err = postApplicationInstall(ctx, appLogger, ac.AppPath)
 		if err != nil {
 			appLogger.WarnContext(ctx, fmt.Sprintf("Error detected in post-installation steps: %v", err))
-			appWithWarning = append(appWithWarning, ac.Name)
+			warnApp()
 		}
 
 		existance, err := appExists(ctx, appLogger, ac.Name, ac.UniqueIdentifier, ac.Version, ac.AppPath)
@@ -262,8 +270,18 @@ func run(cfg *Config) error {
 	if len(frozenApps) > 0 {
 		cfg.logger.InfoContext(ctx, fmt.Sprintf("Some apps were skipped: %v", frozenApps))
 	}
-	if len(appWithWarning) > 0 {
-		cfg.logger.WarnContext(ctx, fmt.Sprintf("Some apps were validated with warnings: %v", appWithWarning))
+	errorSet := make(map[string]bool, len(appWithError))
+	for _, name := range appWithError {
+		errorSet[name] = true
+	}
+	warningsOnly := appWithWarning[:0]
+	for _, name := range appWithWarning {
+		if !errorSet[name] {
+			warningsOnly = append(warningsOnly, name)
+		}
+	}
+	if len(warningsOnly) > 0 {
+		cfg.logger.WarnContext(ctx, fmt.Sprintf("Some apps were validated with warnings: %v", warningsOnly))
 	}
 
 	if successfulApps == totalApps-len(frozenApps) {

--- a/cmd/maintained-apps/validate/main.go
+++ b/cmd/maintained-apps/validate/main.go
@@ -49,7 +49,9 @@ func detachAllDMGs(ctx context.Context, logger *slog.Logger, tmpDir string) {
 	for line := range strings.SplitSeq(string(output), "\n") {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "image-path") {
-			currentImage = strings.TrimSpace(strings.TrimPrefix(line, "image-path      :"))
+			if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+				currentImage = strings.TrimSpace(parts[1])
+			}
 		}
 		if idx := strings.Index(line, "/Volumes/"); strings.HasPrefix(line, "/dev/") && idx >= 0 {
 			if tmpDir == "" || !strings.HasPrefix(currentImage, tmpDir) {
@@ -385,6 +387,7 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 	_, err = io.Copy(out, installerTFR)
 	if err != nil {
 		installerTFR.Close()
+		out.Close()
 		os.Remove(filePath)
 		return nil, "", fmt.Errorf("failed to save file: %w", err)
 	}
@@ -392,6 +395,7 @@ func DownloadMaintainedApp(cfg *Config, app fleet.MaintainedApp) (*fleet.TempFil
 	err = installerTFR.Rewind()
 	if err != nil {
 		installerTFR.Close()
+		out.Close()
 		os.Remove(filePath)
 		return nil, "", fmt.Errorf("rewinding temp file: %w", err)
 	}


### PR DESCRIPTION
Ensure downloaded installer files are removed after validation. Add cleanupInstaller to remove the installer file (ignoring missing files and logging failures). Propagate a downloaded installer path from DownloadMaintainedApp (signature now returns the TempFileReader, the saved file path, and error), write the installer into cfg.tmpDir and set INSTALLER_PATH in cfg.env. Call cleanupInstaller on error paths and after successful validation to avoid leftover temp files.
