### PR TITLE
For R.C. - Fleet UI: Fix icon color and other styling nits (#42457)

### DIFF
--- a/frontend/components/ActionsDropdown/ActionsDropdown.tsx
+++ b/frontend/components/ActionsDropdown/ActionsDropdown.tsx
@@ -187,7 +187,7 @@ const ActionsDropdown = ({
       width: "max-content",
       // Need minHeight to override default
       minHeight: variant === "small-button" ? "20px" : "32px", // Match button height
-      padding: variant === "small-button" ? "2px 4px" : "8px", // Match button padding
+      padding: variant === "small-button" ? "4px" : "8px", // Match button padding
       backgroundColor: state.isFocused ? COLORS["ui-fleet-black-5"] : "initial",
       border: 0,
       boxShadow: "none",
@@ -227,7 +227,7 @@ const ActionsDropdown = ({
         state.isFocused || variant === "button" || variant === "small-button"
           ? COLORS["ui-fleet-black-75"]
           : COLORS["core-fleet-black"],
-      fontSize: "13px",
+      fontSize: "14px",
       fontWeight:
         variant === "button" || variant === "small-button" ? "600" : undefined,
       lineHeight: "normal",

--- a/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
+++ b/frontend/pages/hosts/details/cards/HostSoftwareLibrary/_styles.scss
@@ -53,7 +53,7 @@
   }
 
   &__item-action {
-    min-width: 94px; // Fits the "Reinstall" button without shifting
+    min-width: 94px; // Fits the "Reinstall" button without shifting second item action
 
     .component__tooltip-wrapper {
       margin: 0; // Override 10px vertical margin

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/InstallStatusCell.tsx
@@ -259,12 +259,14 @@ export const INSTALL_STATUS_DISPLAY_OPTIONS: Record<
   },
   failed_install_update_available: {
     iconName: "error-outline", // Match update available icon and not failed install icon
+    iconColor: "ui-fleet-black-75",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedInstallTooltip,
   },
   failed_uninstall_update_available: {
     iconName: "error-outline", // Match update available icon and not failed uninstall icon
+    iconColor: "ui-fleet-black-75",
     displayText: "Update available", // Shows "Update available" modal instead of "Failed (uninstall)" modal as of 4.82 #31663
     // Tooltip indicates failure info in host activity logs
     tooltip: failedUninstallTooltip,

--- a/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/_styles.scss
@@ -91,7 +91,7 @@
 
   .data-table-block .data-table tbody {
     .self-service-table__item-action {
-      min-width: 90px; // Second action buttons align between rows
+      min-width: 94px; // Fits the "Reinstall" button without shifting second item action
 
       .component__tooltip-wrapper {
         margin: 0; // Override 10px vertical margin


### PR DESCRIPTION
## Issue
Closes #42328 

## Description
Previously merged into `main` with #42457 
This is for the 4.83.0 RC

```
 1018  git checkout fleetdm/rc-minor-fleet-v4.83.0
 1019  git branch
 1020  git checkout -b 42328-fix-icon
 1021  git checkout -b 42328-fix-icon-rc
 1022  git log main
 1023  git cherry-pick ad2dcd47fe7551eaf936d959e9edd58429f570ea
 1024  git push -u fleetdm 42328-fix-icon-rc
```