### PR TITLE
Editing a Windows profile to remove LocURIs now deletes those LocURIs

### DIFF
--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1,6 +1,7 @@
 package mysql
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"encoding/xml"
@@ -1083,14 +1084,8 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 				var activeProfiles [][]byte
 				if err := sqlx.SelectContext(ctx, tx, &activeProfiles, apStmt, apArgs...); err == nil {
 					for _, syncML := range activeProfiles {
-						cmds, err := fleet.UnmarshallMultiTopLevelXMLProfile(syncML)
-						if err != nil {
-							continue
-						}
-						for _, cmd := range cmds {
-							if uri := cmd.GetTargetURI(); uri != "" {
-								activeLocURIs[uri] = true
-							}
+						for _, uri := range fleet.ExtractLocURIsFromProfileBytes(syncML) {
+							activeLocURIs[uri] = true
 						}
 					}
 				}
@@ -2419,6 +2414,61 @@ ON DUPLICATE KEY UPDATE
 	if len(deletedProfileUUIDs) > 0 {
 		if err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, deletedProfileUUIDs, deletedProfileContents); err != nil {
 			return false, ctxerr.Wrap(ctx, err, "cancel installs of deleted profiles")
+		}
+	}
+
+	// For profiles being updated (same name, different content), diff the old
+	// and new LocURIs. Generate <Delete> commands for LocURIs that were removed
+	// so the device reverts those settings.
+	//
+	// This is an edge case (most edits change values, not remove LocURIs).
+	// The delete commands are best-effort and currently not visible to the
+	// IT admin in the UI or API. They are fire-and-forget MDM commands
+	// with no corresponding host_mdm_windows_profiles status entry.
+	for _, existing := range existingProfiles {
+		incoming := incomingProfs[existing.Name]
+		if incoming == nil || bytes.Equal(existing.SyncML, incoming.SyncML) {
+			continue
+		}
+
+		oldURIs := fleet.ExtractLocURIsFromProfileBytes(existing.SyncML)
+		newURIs := fleet.ExtractLocURIsFromProfileBytes(incoming.SyncML)
+
+		newSet := make(map[string]bool, len(newURIs))
+		for _, u := range newURIs {
+			newSet[u] = true
+		}
+
+		var removedURIs []string
+		for _, u := range oldURIs {
+			if !newSet[u] {
+				removedURIs = append(removedURIs, u)
+			}
+		}
+
+		if len(removedURIs) == 0 {
+			continue
+		}
+
+		cmdUUID := uuid.NewString()
+		deleteCmd, err := fleet.BuildDeleteCommandFromLocURIs(removedURIs, cmdUUID)
+		if err != nil || deleteCmd == nil {
+			continue
+		}
+
+		// Find hosts that have this profile installed (non-NULL status = was delivered at some point).
+		var hostUUIDs []string
+		if err := sqlx.SelectContext(ctx, tx, &hostUUIDs,
+			`SELECT host_uuid FROM host_mdm_windows_profiles WHERE profile_uuid = ? AND status IS NOT NULL`,
+			existing.ProfileUUID); err != nil {
+			return false, ctxerr.Wrap(ctx, err, "selecting hosts for edited profile LocURI cleanup")
+		}
+		if len(hostUUIDs) > 0 {
+			ds.logger.InfoContext(ctx, "sending delete commands for LocURIs removed from edited profile",
+				"profile.name", existing.Name, "profile.uuid", existing.ProfileUUID, "removed_loc_uris", len(removedURIs))
+			if err := ds.mdmWindowsInsertCommandForHostsDB(ctx, tx, hostUUIDs, deleteCmd); err != nil {
+				return false, ctxerr.Wrap(ctx, err, "inserting delete commands for removed LocURIs")
+			}
 		}
 	}
 

--- a/server/fleet/microsoft_mdm.go
+++ b/server/fleet/microsoft_mdm.go
@@ -1754,90 +1754,49 @@ func BuildDeleteCommandFromProfileBytes(profileBytes []byte, commandUUID string,
 		normalized = fmt.Appendf([]byte{}, "<Atomic>%s</Atomic>", normalized)
 	}
 
-	cmds, err := UnmarshallMultiTopLevelXMLProfile(normalized)
-	if err != nil {
-		return nil, fmt.Errorf("unmarshalling profile bytes for delete: %w", err)
-	}
-	if len(cmds) == 0 {
-		return nil, errors.New("no commands found in profile")
+	allURIs := ExtractLocURIsFromProfileBytes(normalized)
+	if len(allURIs) == 0 {
+		return nil, nil
 	}
 
-	// extractLocURIs collects all Target LocURIs from Replace and Add commands. Exec commands are intentionally excluded.
-	extractLocURIs := func(cmd *SyncMLCmd) []string {
-		var uris []string
-		for _, nested := range cmd.ReplaceCommands {
-			if uri := nested.GetTargetURI(); uri != "" {
-				uris = append(uris, uri)
-			}
-		}
-		for _, nested := range cmd.AddCommands {
-			if uri := nested.GetTargetURI(); uri != "" {
-				uris = append(uris, uri)
-			}
-		}
-		return uris
-	}
-
-	// makeDeleteCmd creates a single <Delete> SyncMLCmd for the given LocURI.
-	makeDeleteCmd := func(locURI string, cmdID string) SyncMLCmd {
-		target := locURI
-		return SyncMLCmd{
-			XMLName: xml.Name{Local: CmdDelete},
-			CmdID:   CmdID{Value: cmdID, IncludeFleetComment: true},
-			Items:   []CmdItem{{Target: &target}},
-		}
-	}
-
-	// Build the set of protected LocURIs from the variadic parameter.
+	// Filter out LocURIs that are still targeted by other active profiles.
 	inUse := make(map[string]bool)
 	if len(locURIsInUseByOtherProfiles) > 0 && locURIsInUseByOtherProfiles[0] != nil {
 		inUse = locURIsInUseByOtherProfiles[0]
 	}
 
-	// safeToDelete returns true if the LocURI is safe to delete (no other
-	// active profile targets it).
-	safeToDelete := func(uri string) bool {
-		return !inUse[uri]
-	}
-
-	var rawCommand []byte
-
-	// Collect all LocURIs to delete. For Atomic profiles, extract from nested
-	// commands; for non-atomic, extract from top-level commands.
-	var allURIs []string
-	switch {
-	case len(cmds) == 1 && cmds[0].XMLName.Local == CmdAtomic:
-		allURIs = extractLocURIs(&cmds[0])
-	default:
-		for _, cmd := range cmds {
-			if cmd.XMLName.Local == CmdExec {
-				continue
-			}
-			if uri := cmd.GetTargetURI(); uri != "" {
-				allURIs = append(allURIs, uri)
-			}
-		}
-	}
-
-	// Filter out protected URIs and build individual <Delete> commands.
-	// Never wrap in <Atomic> — removal is best-effort, and <Atomic> would
-	// cause all deletes to roll back (507) if any single one fails.
-	var deleteCmds []SyncMLCmd
+	var safeURIs []string
 	for _, uri := range allURIs {
-		if !safeToDelete(uri) {
-			continue
+		if !inUse[uri] {
+			safeURIs = append(safeURIs, uri)
 		}
+	}
+
+	return BuildDeleteCommandFromLocURIs(safeURIs, commandUUID)
+}
+
+// BuildDeleteCommandFromLocURIs generates individual <Delete> commands for
+// the given LocURIs. Returns nil if locURIs is empty.
+func BuildDeleteCommandFromLocURIs(locURIs []string, commandUUID string) (*MDMWindowsCommand, error) {
+	if len(locURIs) == 0 {
+		return nil, nil
+	}
+
+	var deleteCmds []SyncMLCmd
+	for _, uri := range locURIs {
 		cmdID := uuid.NewString()
 		if len(deleteCmds) == 0 {
 			cmdID = commandUUID
 		}
-		deleteCmds = append(deleteCmds, makeDeleteCmd(uri, cmdID))
-	}
-	if len(deleteCmds) == 0 {
-		return nil, nil
+		target := uri
+		deleteCmds = append(deleteCmds, SyncMLCmd{
+			XMLName: xml.Name{Local: CmdDelete},
+			CmdID:   CmdID{Value: cmdID, IncludeFleetComment: true},
+			Items:   []CmdItem{{Target: &target}},
+		})
 	}
 
-	rawCommand, err = xml.Marshal(deleteCmds)
+	rawCommand, err := xml.Marshal(deleteCmds)
 	if err != nil {
 		return nil, fmt.Errorf("marshalling delete commands: %w", err)
 	}
@@ -1869,4 +1828,42 @@ func UnmarshallMultiTopLevelXMLProfile(profileBytes []byte) ([]SyncMLCmd, error)
 	}
 
 	return root.Commands, nil
+}
+
+// ExtractLocURIsFromProfileBytes returns all Target LocURIs found in the
+// profile's Replace and Add commands. Exec commands are excluded (they
+// trigger one-time actions, not persistent settings). For Atomic profiles,
+// nested commands are inspected.
+func ExtractLocURIsFromProfileBytes(profileBytes []byte) []string {
+	// Mirror the install-side SCEP normalization.
+	normalized := profileBytes
+	if strings.Contains(string(normalized), WINDOWS_SCEP_LOC_URI_PART) && !strings.Contains(string(normalized), "<Atomic>") {
+		normalized = fmt.Appendf([]byte{}, "<Atomic>%s</Atomic>", normalized)
+	}
+
+	cmds, err := UnmarshallMultiTopLevelXMLProfile(normalized)
+	if err != nil || len(cmds) == 0 {
+		return nil
+	}
+
+	var uris []string
+	for _, cmd := range cmds {
+		if cmd.XMLName.Local == CmdAtomic {
+			for _, nested := range cmd.ReplaceCommands {
+				if uri := nested.GetTargetURI(); uri != "" {
+					uris = append(uris, uri)
+				}
+			}
+			for _, nested := range cmd.AddCommands {
+				if uri := nested.GetTargetURI(); uri != "" {
+					uris = append(uris, uri)
+				}
+			}
+		} else if cmd.XMLName.Local != CmdExec {
+			if uri := cmd.GetTargetURI(); uri != "" {
+				uris = append(uris, uri)
+			}
+		}
+	}
+	return uris
 }

--- a/server/fleet/microsoft_mdm_test.go
+++ b/server/fleet/microsoft_mdm_test.go
@@ -540,9 +540,9 @@ func TestBuildDeleteCommandFromProfileBytes(t *testing.T) {
 			expectNil: true,
 		},
 		{
-			name:        "empty profile",
-			profileXML:  "",
-			expectError: "no commands found in profile",
+			name:       "empty profile returns nil",
+			profileXML: "",
+			expectNil:  true,
 		},
 	}
 
@@ -778,5 +778,31 @@ func TestBuildMDMWindowsProfilePayloadFromMDMResponseRemoveOperation(t *testing.
 		payload, err := BuildMDMWindowsProfilePayloadFromMDMResponse(cmd, statuses, "host-1", true)
 		require.NoError(t, err)
 		require.Equal(t, MDMDeliveryVerified, *payload.Status)
+	})
+}
+
+func TestExtractLocURIsFromProfileBytes(t *testing.T) {
+	t.Parallel()
+	t.Run("atomic profile", func(t *testing.T) {
+		xml := `<Atomic><Replace><Item><Target><LocURI>./Device/A</LocURI></Target></Item></Replace><Replace><Item><Target><LocURI>./Device/B</LocURI></Target></Item></Replace></Atomic>`
+		uris := ExtractLocURIsFromProfileBytes([]byte(xml))
+		require.Equal(t, []string{"./Device/A", "./Device/B"}, uris)
+	})
+
+	t.Run("non-atomic profile", func(t *testing.T) {
+		xml := `<Replace><Item><Target><LocURI>./Device/X</LocURI></Target></Item></Replace><Replace><Item><Target><LocURI>./Device/Y</LocURI></Target></Item></Replace>`
+		uris := ExtractLocURIsFromProfileBytes([]byte(xml))
+		require.Equal(t, []string{"./Device/X", "./Device/Y"}, uris)
+	})
+
+	t.Run("exec commands excluded", func(t *testing.T) {
+		xml := `<Replace><Item><Target><LocURI>./Device/A</LocURI></Target></Item></Replace><Exec><Item><Target><LocURI>./Device/Enroll</LocURI></Target></Item></Exec>`
+		uris := ExtractLocURIsFromProfileBytes([]byte(xml))
+		require.Equal(t, []string{"./Device/A"}, uris)
+	})
+
+	t.Run("empty profile", func(t *testing.T) {
+		uris := ExtractLocURIsFromProfileBytes([]byte(""))
+		require.Nil(t, uris)
 	})
 }

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -4395,6 +4395,104 @@ func (s *integrationMDMTestSuite) TestWindowsProfileManagement() {
 	res = s.DoRaw("POST", fmt.Sprintf("/api/latest/fleet/hosts/%d/configuration_profiles/%s/resend", host.ID, mcUUID), nil, http.StatusUnprocessableEntity)
 	errMsg = extractServerErrorText(res.Body)
 	require.Contains(t, errMsg, "Profile is not compatible with host platform")
+
+	t.Run("edit_profile_removes_locuri_sends_delete", func(t *testing.T) {
+		// Editing a profile to remove a LocURI should send a <Delete> for the removed LocURI.
+		// Create a profile with two LocURIs via batch-set, then edit it to have only one.
+		// The device should receive a <Delete> for the removed LocURI plus an install for the updated profile.
+
+		// First, clean up: use batch-set with only our new test profile to remove all
+		// existing team profiles cleanly (this goes through the proper deletion path).
+		twoLocURIProfile := `<Atomic><Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Camera/AllowCamera</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace><Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Experience/AllowCortana</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace></Atomic>`
+		// Also disable OS updates to simplify
+		tmResp := teamResponse{}
+		s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm.ID), json.RawMessage(`{"mdm": { "windows_updates": {"deadline_days": null, "grace_period_days": null} }}`), http.StatusOK, &tmResp)
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "edit-locuri-test", Contents: []byte(twoLocURIProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		// Trigger profile sync: device gets the new profile + delete commands for old profiles.
+		// Drain all commands from the device without asserting exact counts (cleanup varies).
+		s.awaitTriggerProfileSchedule(t)
+		cmds, err := mdmDevice.StartManagementSession()
+		require.NoError(t, err)
+		msgID, err := mdmDevice.GetCurrentMsgID()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			cmdID := c.Cmd.CmdID
+			status := syncml.CmdStatusOK
+			mdmDevice.AppendResponse(fleet.SyncMLCmd{
+				XMLName: xml.Name{Local: fleet.CmdStatus},
+				MsgRef:  &msgID,
+				CmdRef:  &cmdID.Value,
+				Cmd:     ptr.String(c.Verb),
+				Data:    &status,
+				CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			})
+		}
+		cmds, err = mdmDevice.SendResponse()
+		require.NoError(t, err)
+
+		// Drain any remaining commands until the device is clean.
+		verifyProfiles(mdmDevice, 0, false)
+
+		// Now edit the profile to remove AllowCortana, keeping only AllowCamera.
+		oneLocURIProfile := `<Atomic><Replace><Item><Target><LocURI>./Device/Vendor/MSFT/Policy/Config/Camera/AllowCamera</LocURI></Target><Meta><Format xmlns="syncml:metinf">int</Format></Meta><Data>0</Data></Item></Replace></Atomic>`
+		s.Do("POST", "/api/v1/fleet/mdm/profiles/batch",
+			batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
+				{Name: "edit-locuri-test", Contents: []byte(oneLocURIProfile)},
+			}}, http.StatusNoContent, "team_id", fmt.Sprint(tm.ID))
+
+		// Trigger profile sync: device should get:
+		// - 1 <Delete> for the removed AllowCortana LocURI (from batchSet edit diff)
+		// - 1 Atomic install for the updated profile (from reconciler checksum mismatch)
+		// Total: 2 Status + 1 Delete + 1 Atomic = 4 commands
+		s.awaitTriggerProfileSchedule(t)
+		cmds, err = mdmDevice.StartManagementSession()
+		require.NoError(t, err)
+		require.Len(t, cmds, 4, "expected 2 status + 1 delete + 1 install")
+
+		var gotDelete, gotInstall bool
+		msgID, err = mdmDevice.GetCurrentMsgID()
+		require.NoError(t, err)
+		for _, c := range cmds {
+			cmdID := c.Cmd.CmdID
+			status := syncml.CmdStatusOK
+			switch c.Verb {
+			case "Delete":
+				gotDelete = true
+				require.Contains(t, c.Cmd.GetTargetURI(), "AllowCortana",
+					"Delete should target the removed LocURI")
+			case "Atomic":
+				if len(c.Cmd.ReplaceCommands) > 0 {
+					gotInstall = true
+					// Verify the install only has AllowCamera, not AllowCortana
+					var installURIs []string
+					for _, rc := range c.Cmd.ReplaceCommands {
+						installURIs = append(installURIs, rc.GetTargetURI())
+					}
+					require.Len(t, installURIs, 1)
+					require.Contains(t, installURIs[0], "AllowCamera")
+				}
+			}
+			mdmDevice.AppendResponse(fleet.SyncMLCmd{
+				XMLName: xml.Name{Local: fleet.CmdStatus},
+				MsgRef:  &msgID,
+				CmdRef:  &cmdID.Value,
+				Cmd:     ptr.String(c.Verb),
+				Data:    &status,
+				Items:   nil,
+				CmdID:   fleet.CmdID{Value: uuid.NewString()},
+			})
+		}
+		require.True(t, gotDelete, "expected a Delete command for the removed LocURI")
+		require.True(t, gotInstall, "expected an install command for the updated profile")
+
+		cmds, err = mdmDevice.SendResponse()
+		require.NoError(t, err)
+		require.Len(t, cmds, 1) // just the ack
+	})
 }
 
 func (s *integrationMDMTestSuite) TestApplyTeamsMDMWindowsProfiles() {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2746,14 +2746,8 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 			if _, isBeingRemoved := removeTargets[otherUUID]; isBeingRemoved {
 				continue // also being removed, don't protect its URIs
 			}
-			otherCmds, err := fleet.UnmarshallMultiTopLevelXMLProfile(otherContent.SyncML)
-			if err != nil {
-				continue
-			}
-			for _, cmd := range otherCmds {
-				if uri := cmd.GetTargetURI(); uri != "" {
-					activeLocURIs[uri] = true
-				}
+			for _, uri := range fleet.ExtractLocURIsFromProfileBytes(otherContent.SyncML) {
+				activeLocURIs[uri] = true
 			}
 		}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42452 

Fixed bug. Also did a little refactoring to use shared functions.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
