### PR TITLE
Remove generate-gitops warning about categories

### DIFF
--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -725,12 +725,6 @@ func (cmd *GenerateGitopsCommand) Run() error {
 		})
 	}
 
-	if cmd.CLI.String(fleetFlagName) != "global" {
-		cmd.Messages.Notes = append(cmd.Messages.Notes, Note{
-			Note: "Warning: Software categories are not supported by this tool yet. If you have added any categories to software items, add them to the appropriate fleet .yml file.",
-		})
-	}
-
 	if len(cmd.Messages.Notes) > 0 {
 		fmt.Fprintf(cmd.CLI.App.Writer, "Other notes:\n")
 		for _, note := range cmd.Messages.Notes {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #30453

All the work for this was already done in https://github.com/fleetdm/fleet/pull/32492. I verified that `generate-gitops` outputs the expected categories, and that `gitops` reads them back in correctly. This PR just removes the warning