### PR TITLE
Website: add script to delete older HistoricalUsageSnapshot records

### DIFF
--- a/website/scripts/cleanup-old-usage-statistics.js
+++ b/website/scripts/cleanup-old-usage-statistics.js
@@ -1,0 +1,33 @@
+module.exports = {
+
+
+  friendlyName: 'Cleanup old usage statistics',
+
+
+  description: 'Deletes HistoricalUsageSnapshot records stored in the database that are over 60 days old.',
+
+
+  fn: async function () {
+
+    sails.log('Running custom shell script... (`sails run cleanup-old-usage-statistics`)');
+
+    let nowAt = Date.now();
+    let sixtyDaysAgoAt = nowAt - (1000 * 60 * 60 * 24 * 60);
+
+    let nativeQueryToDeleteRecords = `
+    DELETE FROM "historicalusagesnapshot"
+    WHERE "createdAt" < ${sixtyDaysAgoAt}`;
+
+    let queryResult = await sails.sendNativeQuery(nativeQueryToDeleteRecords);
+    let numberOfRecordsDeleted = queryResult.rowCount;
+
+
+    sails.log(`Successfully deleted ${numberOfRecordsDeleted} old HistoricalUsageSnapshot records.`);
+
+
+
+  }
+
+
+};
+


### PR DESCRIPTION
Changes:
- Added a new script to the website: `cleanup-old-usage-statistics`, a script that deletes `HistoricalUsageSnapshot` records stored in the website's database that are older than 60 days.