### PR TITLE
[Guide] Update deploy-software-packages (#31914)

### DIFF
--- a/articles/deploy-software-packages.md
+++ b/articles/deploy-software-packages.md
@@ -24,13 +24,9 @@ Learn more about automatically installing software [the Automatically install so
 * Click the **Add software** button in the top right corner.
 * Select the **Custom package** tab.
 * Choose a file to upload. `.pkg`, `.msi`, `.exe`, `.rpm`, `.deb`, `.ipa`, `.tar.gz`, `.sh`, and `.ps1` files are supported.
-* If you check the **Automatic install** box, Fleet will create a policy that checks for the existence of the software and will automatically trigger an install on hosts where the software does not exist. 
-
-> **Note:** Automatic install is not supported for script-only packages (`.sh` and `.ps1` files).
-* To allow users to install the software from Fleet Desktop, check the **Self-service** checkbox.
 * To customize installer behavior, click on **Advanced options**.
 
-> After the initial package upload, all options, except for automatic install, can be modified. This includes the self-service setting, pre-install query, scripts, and the software package file. However, if the installer package needs to be replaced, the new package must be of the same file type (such as .pkg, .msi, .exe, .deb, .rpm, or .ipa) and for the same software as the original. Files in .dmg or .zip formats cannot be edited or uploaded for replacement. If you want to enable automatic installs after initial package upload, follow the steps in our [automatic software install guide](https://fleetdm.com/guides/automatic-software-install-in-fleet) to add an automatic install policy.
+> After the initial package upload, all options can be modified by editing the software. This includes self-service, targets, advanced options (pre-install query, scripts), and the software package file. However, if the installer package needs to be replaced, the new package must be of the same file type (such as .pkg, .msi, .exe, .deb, .rpm, or .ipa) and for the same software as the original. Files in .dmg or .zip formats cannot be edited or uploaded for replacement. To enable automatic installs, follow the steps in our [automatic software install guide](https://fleetdm.com/guides/automatic-software-install-in-fleet).
 
 ### Package metadata extraction
 
@@ -149,6 +145,6 @@ Please refer to the documentation for [managing software with GitOps](https://fl
 <meta name="authorFullName" value="Roberto Dip">
 <meta name="authorGitHubUsername" value="roperzh">
 <meta name="category" value="guides">
-<meta name="publishedOn" value="2025-05-05">
+<meta name="publishedOn" value="2026-03-26">
 <meta name="articleImageUrl" value="../website/assets/images/articles/deploy-security-agents-1600x900@2x.png">
 <meta name="description" value="This guide will walk you through adding and editing software packages in Fleet.">

--- a/articles/fleet-maintained-apps.md
+++ b/articles/fleet-maintained-apps.md
@@ -47,6 +47,8 @@ You can install a Fleet-maintained app three ways:
 
 You can track the installation process in the **Activities** section on the **Details** tab of this **Host Details** page.
 
+To keep the app up to date automatically, add a [patch policy](https://fleetdm.com/guides/how-to-use-policies-for-patch-management-in-fleet).
+
 ## Uninstall the app
 
 To remove the app, navigate to the **Host Details** page for the appropriate host, then to the **Software** tab. Find the app, then click on the **Actions** drop-down, then **Uninstall**.
@@ -64,6 +66,18 @@ To get the latest version of a Fleet-maintained app,
 3. Install the new version of the app via one of the three methods above.
 
 A streamlined flow for pulling the latest version of a Fleet-maintained app is [coming soon](https://github.com/fleetdm/fleet/issues/32993).
+
+With a [patch policy](https://fleetdm.com/guides/how-to-use-policies-for-patch-management-in-fleet) and [GitOps](https://fleetdm.com/docs/configuration/yaml-files#patch-policy), the query automatically updates to include the latest version each time specs are applied. Combined with install automation, outdated hosts receive the update automatically.
+
+## Keep apps up to date with patch policies
+
+You can create a **patch policy** for a Fleet-maintained app to automatically detect hosts running outdated versions. With [GitOps](https://fleetdm.com/docs/configuration/yaml-files#patch-policy), the patch policy query automatically updates to include the latest version each time specs are applied.
+
+To add a patch policy, open the app's details page under **Software**, then select **Actions > Patch**.
+
+To automatically install updates when the policy fails, enable the automation at **Policies > Manage automations > Install software**.
+
+For a detailed walkthrough, see the [patch management guide](https://fleetdm.com/guides/how-to-use-policies-for-patch-management-in-fleet).
 
 ## Manage apps with GitOps
 

--- a/articles/how-to-use-policies-for-patch-management-in-fleet.md
+++ b/articles/how-to-use-policies-for-patch-management-in-fleet.md
@@ -2,7 +2,7 @@
 
 ![How to use policies for patch management in Fleet](../website/assets/images/articles/sysadmin-diaries-1600x900@2x.png)
 
-Policies in Fleet enable IT admins to report on devices and get quick yes or no answers about the status of their endpoints. Powered by the flexibility of osquery, the policies engine has become an invaluable part of the IT toolkit, simplifying the management of devices at scale.
+Policies in Fleet enable IT admins to report on devices and get quick yes or no answers about the status of their endpoints. Powered by the flexibility of osquery, the policies engine has become an invaluable part of the IT toolkit, simplifying the management of devices at scale. This guide covers two approaches: **patch policies**, which automate everything for Fleet-maintained apps, and **manual policies** for custom packages.
 
 Initially, Fleet’s policies allowed for automated responses, like firing a webhook on a policy failure or creating a ticket in your ITSM system. While effective, these actions were limited by the capabilities of your existing tools to process and act on these notifications.
 
@@ -10,7 +10,9 @@ Initially, Fleet’s policies allowed for automated responses, like firing a web
 
 Fleet’s policy capabilities have evolved beyond notification-based responses. With the release of Fleet v4.57, the policies engine now supports a game-changing feature: automated software installation on a policy failure. This addition transforms the policies engine into a dynamic tool for streamlined patch management.
 
-In this article, we’ll explore how to leverage this new feature to automate patching across your environment. This will free up valuable IT resources to focus on high-impact tasks while enhancing end-user support.
+With Fleet v4.83, patch management gets even simpler with **patch policies** for [Fleet-maintained apps](https://fleetdm.com/guides/fleet-maintained-apps). Patch policies eliminate the need to write osquery queries — Fleet auto-generates the correct query for each app. When managed via GitOps, the query automatically updates to include the latest version each time specs are applied.
+
+In this article, we’ll explore how to leverage these features to automate patching across your environment. This will free up valuable IT resources to focus on high-impact tasks while enhancing end-user support.
 
 ## Why it matters
 
@@ -20,9 +22,50 @@ Regular updates often include bug fixes that improve stability and enhance user 
 
 Additionally, updated software often includes new features that can ultimately help teams work more efficiently and effectively.
 
-## Let’s get started 
+## Patch policies for Fleet-maintained apps
 
-In this article, we will be using Google Chrome to demonstrate the functionality, and I already have the latest version’s .pkg downloaded locally.
+_Available in Fleet Premium_
+
+A patch policy automatically checks whether a Fleet-maintained app is up to date on your hosts. Unlike manual policies, you don’t need to write or update osquery queries — Fleet handles it for you.
+
+Key benefits:
+- **Automatic query generation** — Fleet creates the correct query for the app and platform.
+- **Fail only if outdated** — The policy only fails if the app IS installed AND running an older version. Hosts without the app installed pass the policy.
+
+### In the Fleet UI
+
+1. Navigate to **Software** and select your team.
+2. Click on a Fleet-maintained app to open its details.
+3. From the **Actions** dropdown, select **Patch**.
+4. Click **Add** in the confirmation modal.
+
+To automatically install updates when the policy fails, navigate to **Policies > Manage automations > Install software** and enable the automation for the new patch policy.
+
+### Via GitOps
+
+Add a policy with `type: patch` and specify the `fleet_maintained_app_slug`. With GitOps, the patch policy query automatically updates to include the latest version each time specs are applied:
+
+```yaml
+policies:
+  - name: Zoom up to date
+    description: Outdated software might introduce security vulnerabilities or compatibility issues.
+    resolution: Install the latest version from self-service.
+    type: patch
+    fleet_maintained_app_slug: zoom/darwin
+    install_software: true
+```
+
+For all available options, see the [GitOps reference documentation](https://fleetdm.com/docs/configuration/yaml-files#patch-policy).
+
+### Via the API
+
+Set `type` to `"patch"` and provide `patch_software_title_id` when [adding a team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy).
+
+## Manual policies for custom packages
+
+If you’re deploying custom software packages (not Fleet-maintained apps), you can write your own policy query and pair it with install automation.
+
+In this example, we will be using Google Chrome to demonstrate the functionality, and I already have the latest version’s .pkg downloaded locally.
 
 Select the fleet you want the policy to run on. Navigate to **Software > Add Software**. Here you can use one of Fleet’s maintained apps, add from VPP or Custom Package. We will use Custom Package in this example and upload the Google Chrome.pkg mentioned previously. After upload, there are a couple of options for pre/post-install queries and scripts - you can read more about those options in our [guide on deploying software](https://fleetdm.com/guides/deploy-software-packages).
 
@@ -48,9 +91,19 @@ The module will show the policies available for that fleet. Check the box to tur
 
 And that’s it! Policies are evaluated across all online hosts every hour, or when a device is refetched manually. Any machine that fails this policy will install the Chrome version that was set in the policy.
 
+## When to use each approach
+
+| | Patch policies | Manual policies |
+| --- | --- | --- |
+| **Best for** | Fleet-maintained apps | Custom packages, VPP apps |
+| **Query management** | Automatic | You write and maintain the query |
+| **Version updates** | Automatic with GitOps; re-create via UI for new versions | Manual |
+| **Behavior when app is missing** | Policy passes | Depends on your query |
+| **Platforms** | macOS, Windows | macOS, Windows, Linux |
+
 ## What else can we do?
 
-This functionality unlocks many use cases for an IT admin to help manage their fleet. Another use case for this feature is to support a zero-touch deployment of devices and ensure that critical business and productivity software is installed from the first boot. 
+This functionality unlocks many use cases for an IT admin to help manage their fleet. Another use case for this feature is to support a zero-touch deployment of devices and ensure that critical business and productivity software is installed from the first boot.
 
 A simple query like such: 
 
@@ -60,17 +113,22 @@ SELECT 1 FROM apps WHERE bundle_identifier = ‘com.tinyspeck.slackmacgap’
 
 would deploy Slack to your endpoints the moment it comes out of the box, ensuring your users are ready to hit the ground running from day 1.
 
+> If the app is available as a Fleet-maintained app (like Slack), you can also add a [patch policy](#patch-policies-for-fleet-maintained-apps) to keep it updated automatically — no query maintenance required.
+
 ## Via the API
 
-Fleet Premium customers can leverage the REST API to upload software packages and set policy automations using the software_title_id field. 
+Fleet Premium customers can leverage the REST API for both approaches:
 
-Info about the [Upload software](https://fleetdm.com/docs/rest-api/rest-api#add-package) and [Team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy) API docs are available in the documentation. 
+- **Patch policies**: Set `type` to `"patch"` with `patch_software_title_id` when [adding a team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy).
+- **Manual policies**: Use `software_title_id` to link a policy to software that installs on failure.
+
+See the [Upload software](https://fleetdm.com/docs/rest-api/rest-api#add-package) and [Team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy) API docs.
 
 ## Curious about GitOps?
 
 Fleet's flexible API and support for a GitOps life cycle means this entire process can be stored and managed in code, further unlocking audibility, collaboration, and security. Know who made changes, when, and why—without being tied to vendor-specific methods. 
 
-Nest an **install_software** block in the policy you want to automate and ensure the path to the software matches the same path referenced in the fleet configuration file under the software block. Check out the [GitOps reference documentation](https://fleetdm.com/docs/configuration/yaml-files#policies) for more details.
+For manual policies, nest an **install_software** block in the policy you want to automate and ensure the path to the software matches the same path referenced in the fleet configuration file under the software block. For patch policies, set `type` to `patch` and specify `fleet_maintained_app_slug`. Check out the [GitOps reference documentation](https://fleetdm.com/docs/configuration/yaml-files#policies) for more details.
 
 ## Want to know more?
 
@@ -81,6 +139,6 @@ Reach out for more information and a demo, or explore Fleet's detailed [document
 <meta name="authorFullName" value="Harrison Ravazzolo">
 <meta name="authorGitHubUsername" value="harrisonravazzolo">
 <meta name="category" value="guides">
-<meta name="publishedOn" value="2024-11-07">
+<meta name="publishedOn" value="2026-03-27">
 <meta name="articleImageUrl" value="../website/assets/images/articles/sysadmin-diaries-1600x900@2x.png">
-<meta name="description" value="This guide explores automating patching across your environment.">
+<meta name="description" value="This guide explores automating patching using patch policies for Fleet-maintained apps and manual policies for custom packages.">


### PR DESCRIPTION
## Summary

  - Remove references to Automatic Install, Self-service, and Targets from the "Add a custom package" section of the Deploy software guide
  - These options were removed from the Add software page in #41518 (patch policy feature)
  - Update post-upload note to reflect that these options are now configured via Edit

For the "Update Deploy software guide" checklist item in #31914