### PR TITLE
Fix loadtest/infra docker_image resource

### DIFF
--- a/infrastructure/loadtesting/terraform/infra/docker.tf
+++ b/infrastructure/loadtesting/terraform/infra/docker.tf
@@ -28,6 +28,7 @@ resource "aws_ecr_repository" "fleet" {
 
 resource "docker_image" "dockerhub" {
   name = "fleetdm/fleet:${var.tag}"
+  pull_triggers = [data.docker_registry_image.dockerhub.sha256_digest]
 }
 
 data "docker_registry_image" "dockerhub" {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves # N/A

- Resolves an issue that prevents some locally pulled docker images from being pushed to ECR.