### PR TITLE
Insert hmwp and windows command entries at once

### DIFF
--- a/changes/42544-windows-profiles
+++ b/changes/42544-windows-profiles
@@ -1,0 +1,1 @@
+* Fixed an issue where Windows MDM profiles could remain in pending if hosts acknowledged them too quickly after upload

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -230,11 +230,12 @@ func (ds *Datastore) MDMWindowsDeleteEnrolledDeviceWithDeviceID(ctx context.Cont
 	return ctxerr.Wrap(ctx, notFound("MDMWindowsDeleteEnrolledDeviceWithDeviceID"))
 }
 
-// this function inserts both the host_mdm_windows_profile entries and the actual mdm_windows_command and queue entries for a given command and list of hosts.
-// We do this in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries, which would cause issues
-// when processing responses from the device. It is done in batches for performance reasons, the first batch being the one that inserts the actual command entry.
-// It need not be one big tranasaction as long as a given host's command queue entry and host profile entry are inserted in the same transaction
-// Note that unlike the insert command function below this does not work with device IDs, only host UUIDs
+// this function inserts both the host_mdm_windows_profile entries and the actual mdm_windows_command_queue entries for a given command and list of hosts.
+// We do the host-targeting pieces in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries,
+// which would previously cause issues when processing responses from the device if there was a long delay between enqueing the command and the host profile
+// entry insertion. It is done in batches for performance reasons and the command itself is inserted before the batches begin. It need not be one big tranasaction
+// as long as a given host's command queue entry and host profile entry are inserted in the same transaction. Note that unlike the insert command function below
+// this does not work with device IDs, only host UUIDs
 func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
 	if len(hostUUIDs) == 0 {
 		return nil
@@ -290,6 +291,11 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 					return ctxerr.Wrap(ctx, alreadyExists("MDMWindowsCommandQueue", cmd.CommandUUID))
 				}
 				return ctxerr.Wrap(ctx, err, "batch inserting MDMWindowsCommandQueue")
+			}
+
+			// Should never happen but could in the case of a bug in the batching logic or if the caller supplied bad args(we warn in the logs for this case)
+			if len(profileArgs) == 0 {
+				return nil
 			}
 
 			// Upsert host profile entries.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -325,6 +325,16 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 	}
 
 	for _, hostUUID := range hostUUIDs {
+		// This may seem odd running the batch up front but it helps ensure we don't run oversized batches if for instance a caller
+		// makes an error leading to the warning below about mismatch host profile/command entries
+		if batchCount >= batchSize {
+			if err := executeBatch(); err != nil {
+				return err
+			}
+			resetBatch()
+		}
+
+		batchCount++
 		// Command queue entry: resolve enrollment_id via subquery.
 		queueSB.WriteString(
 			"((SELECT id FROM mdm_windows_enrollments WHERE host_uuid = ? ORDER BY created_at DESC LIMIT 1), ?),",
@@ -333,17 +343,14 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 
 		// Host profile entry.
 		p := payloadByHostUUID[hostUUID]
+
+		if p == nil {
+			ds.logger.WarnContext(ctx, "windows MDM profile Command enqueued without corresponding host profile", "host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
+			continue
+		}
 		profileSB.WriteString("(?, ?, ?, ?, ?, ?, ?, ?),")
 		profileArgs = append(profileArgs, p.ProfileUUID, p.HostUUID, p.Status, p.OperationType, p.Detail, p.CommandUUID, p.ProfileName, p.Checksum)
 
-		batchCount++
-
-		if batchCount >= batchSize {
-			if err := executeBatch(); err != nil {
-				return err
-			}
-			resetBatch()
-		}
 	}
 
 	if batchCount > 0 {

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -234,8 +234,9 @@ func (ds *Datastore) MDMWindowsDeleteEnrolledDeviceWithDeviceID(ctx context.Cont
 // We do this in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries, which would cause issues
 // when processing responses from the device. It is done in batches for performance reasons, the first batch being the one that inserts the actual command entry.
 // It need not be one big tranasaction as long as a given host's command queue entry and host profile entry are inserted in the same transaction
-func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDsOrDeviceIDs []string, cmd *fleet.MDMWindowsCommand, payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
-	if len(hostUUIDsOrDeviceIDs) == 0 {
+// Note that unlike the insert command function below this does not work with device IDs, only host UUIDs
+func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+	if len(hostUUIDs) == 0 {
 		return nil
 	}
 
@@ -266,7 +267,8 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 	// Insert command queue entries and host profile entries in batches, each
 	// batch in its own transaction to limit lock contention. Each host gets
 	// one command queue row and one host_mdm_windows_profiles row, inserted
-	// together so they stay consistent within the batch.
+	// together so they stay consistent within the batch and so we don't end\
+	// up with queued commands that don't have corresponding host profile entries.
 	var (
 		queueArgs   []any
 		queueSB     strings.Builder
@@ -322,15 +324,15 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 		profileSB.Reset()
 	}
 
-	for _, hostUUIDOrDeviceID := range hostUUIDsOrDeviceIDs {
+	for _, hostUUID := range hostUUIDs {
 		// Command queue entry: resolve enrollment_id via subquery.
 		queueSB.WriteString(
-			"((SELECT id FROM mdm_windows_enrollments WHERE host_uuid = ? OR mdm_device_id = ? ORDER BY created_at DESC LIMIT 1), ?),",
+			"((SELECT id FROM mdm_windows_enrollments WHERE host_uuid = ? ORDER BY created_at DESC LIMIT 1), ?),",
 		)
-		queueArgs = append(queueArgs, hostUUIDOrDeviceID, hostUUIDOrDeviceID, cmd.CommandUUID)
+		queueArgs = append(queueArgs, hostUUID, cmd.CommandUUID)
 
 		// Host profile entry.
-		p := payloadByHostUUID[hostUUIDOrDeviceID]
+		p := payloadByHostUUID[hostUUID]
 		profileSB.WriteString("(?, ?, ?, ?, ?, ?, ?, ?),")
 		profileArgs = append(profileArgs, p.ProfileUUID, p.HostUUID, p.Status, p.OperationType, p.Detail, p.CommandUUID, p.ProfileName, p.Checksum)
 

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -230,6 +230,129 @@ func (ds *Datastore) MDMWindowsDeleteEnrolledDeviceWithDeviceID(ctx context.Cont
 	return ctxerr.Wrap(ctx, notFound("MDMWindowsDeleteEnrolledDeviceWithDeviceID"))
 }
 
+// this function inserts both the host_mdm_windows_profile entries and the actual mdm_windows_command and queue entries for a given command and list of hosts.
+// We do this in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries, which would cause issues
+// when processing responses from the device. It is done in batches for performance reasons, the first batch being the one that inserts the actual command entry.
+// It need not be one big tranasaction as long as a given host's command queue entry and host profile entry are inserted in the same transaction
+func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDsOrDeviceIDs []string, cmd *fleet.MDMWindowsCommand, payload []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+	if len(hostUUIDsOrDeviceIDs) == 0 {
+		return nil
+	}
+
+	const defaultBatchSize = 1000
+	batchSize := defaultBatchSize
+	if ds.testUpsertMDMDesiredProfilesBatchSize > 0 {
+		batchSize = ds.testUpsertMDMDesiredProfilesBatchSize
+	}
+
+	// Insert the command once, outside of the batched transactions.
+	cmdStmt := `
+		INSERT INTO windows_mdm_commands (command_uuid, raw_command, target_loc_uri)
+		VALUES (?, ?, ?)
+	`
+	if _, err := ds.writer(ctx).ExecContext(ctx, cmdStmt, cmd.CommandUUID, cmd.RawCommand, cmd.TargetLocURI); err != nil {
+		if IsDuplicate(err) {
+			return ctxerr.Wrap(ctx, alreadyExists("MDMWindowsCommand", cmd.CommandUUID))
+		}
+		return ctxerr.Wrap(ctx, err, "inserting MDMWindowsCommand")
+	}
+
+	// Build a map from host UUID to its corresponding profile payload for quick lookup.
+	payloadByHostUUID := make(map[string]*fleet.MDMWindowsBulkUpsertHostProfilePayload, len(payload))
+	for _, p := range payload {
+		payloadByHostUUID[p.HostUUID] = p
+	}
+
+	// Insert command queue entries and host profile entries in batches, each
+	// batch in its own transaction to limit lock contention. Each host gets
+	// one command queue row and one host_mdm_windows_profiles row, inserted
+	// together so they stay consistent within the batch.
+	var (
+		queueArgs   []any
+		queueSB     strings.Builder
+		profileArgs []any
+		profileSB   strings.Builder
+		batchCount  int
+	)
+
+	executeBatch := func() error {
+		return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+			// Insert command queue entries.
+			queueStmt := fmt.Sprintf(`
+				INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid)
+				VALUES %s`,
+				strings.TrimSuffix(queueSB.String(), ","),
+			)
+			if _, err := tx.ExecContext(ctx, queueStmt, queueArgs...); err != nil {
+				if IsDuplicate(err) {
+					return ctxerr.Wrap(ctx, alreadyExists("MDMWindowsCommandQueue", cmd.CommandUUID))
+				}
+				return ctxerr.Wrap(ctx, err, "batch inserting MDMWindowsCommandQueue")
+			}
+
+			// Upsert host profile entries.
+			profileStmt := fmt.Sprintf(`
+				INSERT INTO host_mdm_windows_profiles (
+					profile_uuid, host_uuid, status, operation_type,
+					detail, command_uuid, profile_name, checksum
+				)
+				VALUES %s
+				ON DUPLICATE KEY UPDATE
+					status = VALUES(status),
+					operation_type = VALUES(operation_type),
+					detail = VALUES(detail),
+					profile_name = VALUES(profile_name),
+					checksum = VALUES(checksum),
+					command_uuid = VALUES(command_uuid)`,
+				strings.TrimSuffix(profileSB.String(), ","),
+			)
+			if _, err := tx.ExecContext(ctx, profileStmt, profileArgs...); err != nil {
+				return ctxerr.Wrap(ctx, err, "batch upserting host_mdm_windows_profiles")
+			}
+
+			return nil
+		})
+	}
+
+	resetBatch := func() {
+		batchCount = 0
+		queueArgs = queueArgs[:0]
+		queueSB.Reset()
+		profileArgs = profileArgs[:0]
+		profileSB.Reset()
+	}
+
+	for _, hostUUIDOrDeviceID := range hostUUIDsOrDeviceIDs {
+		// Command queue entry: resolve enrollment_id via subquery.
+		queueSB.WriteString(
+			"((SELECT id FROM mdm_windows_enrollments WHERE host_uuid = ? OR mdm_device_id = ? ORDER BY created_at DESC LIMIT 1), ?),",
+		)
+		queueArgs = append(queueArgs, hostUUIDOrDeviceID, hostUUIDOrDeviceID, cmd.CommandUUID)
+
+		// Host profile entry.
+		p := payloadByHostUUID[hostUUIDOrDeviceID]
+		profileSB.WriteString("(?, ?, ?, ?, ?, ?, ?, ?),")
+		profileArgs = append(profileArgs, p.ProfileUUID, p.HostUUID, p.Status, p.OperationType, p.Detail, p.CommandUUID, p.ProfileName, p.Checksum)
+
+		batchCount++
+
+		if batchCount >= batchSize {
+			if err := executeBatch(); err != nil {
+				return err
+			}
+			resetBatch()
+		}
+	}
+
+	if batchCount > 0 {
+		if err := executeBatch(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (ds *Datastore) MDMWindowsInsertCommandForHosts(ctx context.Context, hostUUIDsOrDeviceIDs []string, cmd *fleet.MDMWindowsCommand) error {
 	if len(hostUUIDsOrDeviceIDs) == 0 {
 		return nil

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -1526,44 +1526,6 @@ func testMDMWindowsInsertCommandAndUpsertHostProfilesForHosts(t *testing.T, ds *
 		require.Equal(t, "prof-upsert-updated", profiles[0].ProfileName)
 	})
 
-	t.Run("works with device IDs", func(t *testing.T) {
-		profUUID := InsertWindowsProfileForTest(t, ds, 0)
-		cmdUUID := uuid.NewString()
-		cmd := &fleet.MDMWindowsCommand{
-			CommandUUID:  cmdUUID,
-			RawCommand:   []byte("<Exec></Exec>"),
-			TargetLocURI: "./test/uri",
-		}
-		payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
-			{
-				ProfileUUID:   profUUID,
-				ProfileName:   "prof-devid",
-				HostUUID:      d1.HostUUID,
-				CommandUUID:   cmdUUID,
-				OperationType: fleet.MDMOperationTypeInstall,
-				Status:        &fleet.MDMDeliveryPending,
-				Checksum:      []byte("checksum-devid"),
-			},
-		}
-
-		// Use device ID instead of host UUID
-		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.MDMDeviceID}, cmd, payload)
-		require.NoError(t, err)
-
-		// Verify command was enqueued
-		cmds, err := ds.MDMWindowsGetPendingCommands(ctx, d1.MDMDeviceID)
-		require.NoError(t, err)
-		// Should have at least 1 pending command for this device
-		found := false
-		for _, c := range cmds {
-			if c.CommandUUID == cmdUUID {
-				found = true
-				break
-			}
-		}
-		require.True(t, found, "expected to find command %s in pending commands", cmdUUID)
-	})
-
 	t.Run("batching works correctly", func(t *testing.T) {
 		// Set a small batch size to force multiple batches
 		ds.testUpsertMDMDesiredProfilesBatchSize = 1

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -31,6 +31,7 @@ func TestMDMWindows(t *testing.T) {
 	}{
 		{"TestMDMWindowsEnrolledDevices", testMDMWindowsEnrolledDevice},
 		{"TestMDMWindowsInsertCommandForHosts", testMDMWindowsInsertCommandForHosts},
+		{"TestMDMWindowsInsertCommandAndUpsertHostProfilesForHosts", testMDMWindowsInsertCommandAndUpsertHostProfilesForHosts},
 		{"TestMDMWindowsGetPendingCommands", testMDMWindowsGetPendingCommands},
 		{"TestMDMWindowsCommandResults", testMDMWindowsCommandResults},
 		{"TestMDMWindowsCommandResultsWithPendingResult", testMDMWindowsCommandResultsWithPendingResult},
@@ -1337,6 +1338,294 @@ func testMDMWindowsInsertCommandForHosts(t *testing.T, ds *Datastore) {
 	cmds, err = ds.MDMWindowsGetPendingCommands(ctx, d3.MDMDeviceID)
 	require.NoError(t, err)
 	require.Len(t, cmds, 3)
+}
+
+func testMDMWindowsInsertCommandAndUpsertHostProfilesForHosts(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	newEnrolledDevice := func() *fleet.MDMWindowsEnrolledDevice {
+		return &fleet.MDMWindowsEnrolledDevice{
+			MDMDeviceID:            uuid.New().String(),
+			MDMHardwareID:          uuid.New().String() + uuid.New().String(),
+			MDMDeviceState:         microsoft_mdm.MDMDeviceStateEnrolled,
+			MDMDeviceType:          "CIMClient_Windows",
+			MDMDeviceName:          "DESKTOP-1C3ARC1",
+			MDMEnrollType:          "ProgrammaticEnrollment",
+			MDMEnrollUserID:        "",
+			MDMEnrollProtoVersion:  "5.0",
+			MDMEnrollClientVersion: "10.0.19045.2965",
+			MDMNotInOOBE:           false,
+			HostUUID:               uuid.NewString(),
+		}
+	}
+
+	d1 := newEnrolledDevice()
+	d2 := newEnrolledDevice()
+	err := ds.MDMWindowsInsertEnrolledDevice(ctx, d1)
+	require.NoError(t, err)
+	err = ds.MDMWindowsInsertEnrolledDevice(ctx, d2)
+	require.NoError(t, err)
+
+	getAllHostProfiles := func() []*fleet.MDMWindowsProfilePayload {
+		var hostProfiles []*fleet.MDMWindowsProfilePayload
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := `SELECT profile_uuid, host_uuid, status, operation_type, command_uuid, profile_name FROM host_mdm_windows_profiles ORDER BY host_uuid, profile_name`
+			return sqlx.SelectContext(ctx, q, &hostProfiles, stmt)
+		})
+		return hostProfiles
+	}
+
+	t.Run("empty host list is a noop", func(t *testing.T) {
+		cmd := &fleet.MDMWindowsCommand{
+			CommandUUID:  uuid.NewString(),
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{}, cmd, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("inserts command and profiles for multiple hosts", func(t *testing.T) {
+		profUUID1 := InsertWindowsProfileForTest(t, ds, 0)
+		profUUID2 := InsertWindowsProfileForTest(t, ds, 0)
+
+		cmdUUID := uuid.NewString()
+		cmd := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+
+		payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID1,
+				ProfileName:   "prof1",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum1"),
+			},
+			{
+				ProfileUUID:   profUUID2,
+				ProfileName:   "prof2",
+				HostUUID:      d2.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum2"),
+			},
+		}
+
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID, d2.HostUUID}, cmd, payload)
+		require.NoError(t, err)
+
+		// Verify commands were enqueued
+		cmds, err := ds.MDMWindowsGetPendingCommands(ctx, d1.MDMDeviceID)
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+		cmds, err = ds.MDMWindowsGetPendingCommands(ctx, d2.MDMDeviceID)
+		require.NoError(t, err)
+		require.Len(t, cmds, 1)
+
+		// Verify host profiles were upserted
+		hostProfs := getAllHostProfiles()
+		require.Len(t, hostProfs, 2)
+		// Verify both profiles are present with expected values
+		for _, hp := range hostProfs {
+			require.Equal(t, fleet.MDMOperationTypeInstall, hp.OperationType)
+			require.Equal(t, &fleet.MDMDeliveryPending, hp.Status)
+			require.Equal(t, cmdUUID, hp.CommandUUID)
+		}
+	})
+
+	t.Run("duplicate command uuid returns already exists", func(t *testing.T) {
+		profUUID := InsertWindowsProfileForTest(t, ds, 0)
+		cmdUUID := uuid.NewString()
+		cmd := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID,
+				ProfileName:   "prof-dup",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum-dup"),
+			},
+		}
+
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID}, cmd, payload)
+		require.NoError(t, err)
+
+		// Same command UUID again should fail with already exists
+		err = ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID}, cmd, payload)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "already exists")
+	})
+
+	t.Run("upserts update existing host profiles", func(t *testing.T) {
+		profUUID := InsertWindowsProfileForTest(t, ds, 0)
+		cmdUUID1 := uuid.NewString()
+		cmd1 := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID1,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		payload1 := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID,
+				ProfileName:   "prof-upsert",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID1,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum-v1"),
+			},
+		}
+
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID}, cmd1, payload1)
+		require.NoError(t, err)
+
+		// Now upsert with a new command and updated status
+		cmdUUID2 := uuid.NewString()
+		cmd2 := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID2,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		payload2 := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID,
+				ProfileName:   "prof-upsert-updated",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID2,
+				OperationType: fleet.MDMOperationTypeRemove,
+				Status:        &fleet.MDMDeliveryVerifying,
+				Checksum:      []byte("checksum-v2"),
+			},
+		}
+
+		err = ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID}, cmd2, payload2)
+		require.NoError(t, err)
+
+		// Verify the profile was updated (not duplicated)
+		var profiles []*fleet.MDMWindowsProfilePayload
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			stmt := `SELECT profile_uuid, host_uuid, status, operation_type, command_uuid, profile_name FROM host_mdm_windows_profiles WHERE profile_uuid = ? AND host_uuid = ?`
+			return sqlx.SelectContext(ctx, q, &profiles, stmt, profUUID, d1.HostUUID)
+		})
+		require.Len(t, profiles, 1)
+		require.Equal(t, cmdUUID2, profiles[0].CommandUUID)
+		require.Equal(t, fleet.MDMOperationTypeRemove, profiles[0].OperationType)
+		require.Equal(t, &fleet.MDMDeliveryVerifying, profiles[0].Status)
+		require.Equal(t, "prof-upsert-updated", profiles[0].ProfileName)
+	})
+
+	t.Run("works with device IDs", func(t *testing.T) {
+		profUUID := InsertWindowsProfileForTest(t, ds, 0)
+		cmdUUID := uuid.NewString()
+		cmd := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID,
+				ProfileName:   "prof-devid",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum-devid"),
+			},
+		}
+
+		// Use device ID instead of host UUID
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.MDMDeviceID}, cmd, payload)
+		require.NoError(t, err)
+
+		// Verify command was enqueued
+		cmds, err := ds.MDMWindowsGetPendingCommands(ctx, d1.MDMDeviceID)
+		require.NoError(t, err)
+		// Should have at least 1 pending command for this device
+		found := false
+		for _, c := range cmds {
+			if c.CommandUUID == cmdUUID {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected to find command %s in pending commands", cmdUUID)
+	})
+
+	t.Run("batching works correctly", func(t *testing.T) {
+		// Set a small batch size to force multiple batches
+		ds.testUpsertMDMDesiredProfilesBatchSize = 1
+
+		profUUID1 := InsertWindowsProfileForTest(t, ds, 0)
+		profUUID2 := InsertWindowsProfileForTest(t, ds, 0)
+		cmdUUID := uuid.NewString()
+		cmd := &fleet.MDMWindowsCommand{
+			CommandUUID:  cmdUUID,
+			RawCommand:   []byte("<Exec></Exec>"),
+			TargetLocURI: "./test/uri",
+		}
+		payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{
+				ProfileUUID:   profUUID1,
+				ProfileName:   "prof-batch1",
+				HostUUID:      d1.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum-batch1"),
+			},
+			{
+				ProfileUUID:   profUUID2,
+				ProfileName:   "prof-batch2",
+				HostUUID:      d2.HostUUID,
+				CommandUUID:   cmdUUID,
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &fleet.MDMDeliveryPending,
+				Checksum:      []byte("checksum-batch2"),
+			},
+		}
+
+		err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID, d2.HostUUID}, cmd, payload)
+		require.NoError(t, err)
+
+		// Verify both hosts got their commands despite batching
+		cmds, err := ds.MDMWindowsGetPendingCommands(ctx, d1.MDMDeviceID)
+		require.NoError(t, err)
+		found := false
+		for _, c := range cmds {
+			if c.CommandUUID == cmdUUID {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected command for d1")
+
+		cmds, err = ds.MDMWindowsGetPendingCommands(ctx, d2.MDMDeviceID)
+		require.NoError(t, err)
+		found = false
+		for _, c := range cmds {
+			if c.CommandUUID == cmdUUID {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected command for d2")
+
+		// Reset batch size
+		ds.testUpsertMDMDesiredProfilesBatchSize = 0
+	})
 }
 
 func testMDMWindowsGetPendingCommands(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -1852,6 +1852,8 @@ type Datastore interface {
 	// for each device.
 	MDMWindowsInsertCommandForHosts(ctx context.Context, hostUUIDs []string, cmd *MDMWindowsCommand) error
 
+	MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDs []string, cmd *MDMWindowsCommand, profilePayloads []*MDMWindowsBulkUpsertHostProfilePayload) error
+
 	// MDMWindowsGetPendingCommands returns all the pending commands for a device
 	MDMWindowsGetPendingCommands(ctx context.Context, deviceID string) ([]*MDMWindowsCommand, error)
 

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1225,6 +1225,8 @@ type MDMWindowsDeleteEnrolledDeviceWithDeviceIDFunc func(ctx context.Context, md
 
 type MDMWindowsInsertCommandForHostsFunc func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand) error
 
+type MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, profilePayloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error
+
 type MDMWindowsGetPendingCommandsFunc func(ctx context.Context, deviceID string) ([]*fleet.MDMWindowsCommand, error)
 
 type MDMWindowsSaveResponseFunc func(ctx context.Context, deviceID string, enrichedSyncML fleet.EnrichedSyncML, commandIDsBeingResent []string) error
@@ -3638,6 +3640,9 @@ type DataStore struct {
 
 	MDMWindowsInsertCommandForHostsFunc        MDMWindowsInsertCommandForHostsFunc
 	MDMWindowsInsertCommandForHostsFuncInvoked bool
+
+	MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc        MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc
+	MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFuncInvoked bool
 
 	MDMWindowsGetPendingCommandsFunc        MDMWindowsGetPendingCommandsFunc
 	MDMWindowsGetPendingCommandsFuncInvoked bool
@@ -8762,6 +8767,13 @@ func (s *DataStore) MDMWindowsInsertCommandForHosts(ctx context.Context, hostUUI
 	s.MDMWindowsInsertCommandForHostsFuncInvoked = true
 	s.mu.Unlock()
 	return s.MDMWindowsInsertCommandForHostsFunc(ctx, hostUUIDs, cmd)
+}
+
+func (s *DataStore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, profilePayloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+	s.mu.Lock()
+	s.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFuncInvoked = true
+	s.mu.Unlock()
+	return s.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc(ctx, hostUUIDs, cmd, profilePayloads)
 }
 
 func (s *DataStore) MDMWindowsGetPendingCommands(ctx context.Context, deviceID string) ([]*fleet.MDMWindowsCommand, error) {

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2555,6 +2555,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	// hostProfilesMap provides O(1) lookup for host profiles by host UUID and profile UUID
 	// Key format: "hostUUID|profileUUID"
 	hostProfilesMap := make(map[string]*fleet.MDMWindowsBulkUpsertHostProfilePayload, len(toInstall))
+	batchProfilesMap := make(map[string][]*fleet.MDMWindowsBulkUpsertHostProfilePayload) // profileUUID -> host profiles, used for batch updates during command creation
 
 	// install are maps from profileUUID -> command uuid and host
 	// UUIDs as the underlying MDM services are optimized to send one command to
@@ -2592,6 +2593,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		hostProfilesToUpdate = append(hostProfilesToUpdate, hp)
 		// Add to map for fast lookup
 		hostProfilesMap[p.HostUUID+"|"+p.ProfileUUID] = hp
+		batchProfilesMap[target.cmdUUID] = append(batchProfilesMap[target.cmdUUID], hp)
 		logger.DebugContext(ctx, "installing profile", "profile_uuid", p.ProfileUUID, "host_id", p.HostUUID, "name", p.ProfileName)
 	}
 
@@ -2657,7 +2659,17 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 				logger.InfoContext(ctx, "error building command from profile", "err", err, "profile_uuid", profUUID)
 				continue
 			}
-			if err := ds.MDMWindowsInsertCommandForHosts(ctx, target.hostUUIDs, command); err != nil {
+			payloads, ok := batchProfilesMap[command.CommandUUID]
+			if !ok {
+				logger.ErrorContext(ctx, "no host profiles found for command UUID", "command_uuid", command.CommandUUID)
+				continue
+			}
+			// Since we are not using DB transactions here, there is a small chance that the profile contents don't match
+			// the checksum we retrieved earlier. Update the checksums if needed.
+			for _, payload := range payloads {
+				payload.Checksum = p.Checksum
+			}
+			if err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, target.hostUUIDs, command, payloads); err != nil {
 				return ctxerr.Wrap(ctx, err, "inserting commands for hosts")
 			}
 		} else {
@@ -2699,33 +2711,20 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 					continue
 				}
 
+				// Update the command UUID for this specific host
+				hp.CommandUUID = hostCmdUUID
+				// Since we are not using DB transactions here, there is a small chance that the profile contents don't match
+				// the checksum we retrieved earlier. Update the checksum if needed.
+				hp.Checksum = p.Checksum
 				// Insert the command for this specific host
-				if err := ds.MDMWindowsInsertCommandForHosts(ctx, []string{hostUUID}, command); err != nil {
+				if err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{hostUUID}, command, []*fleet.MDMWindowsBulkUpsertHostProfilePayload{hp}); err != nil {
 					logger.ErrorContext(ctx, "inserting command for host", "err", err, "host_uuid", hostUUID)
 					// Mark this host's profile as failed
 					hp.Status = &fleet.MDMDeliveryFailed
 					hp.Detail = fmt.Sprintf("Failed to insert command for host: %s", err.Error())
 					continue
 				}
-
-				// Update the command UUID for this specific host
-				hp.CommandUUID = hostCmdUUID
 			}
-		}
-	}
-
-	// Store list of failed profiles (profile UUID + host UUID to create uniqueness) to avoid updating other stuff for that, such as managed certs.
-	failedProfileHostUUIDs := make(map[string]bool)
-
-	// Since we are not using DB transactions here, there is a small chance that the profile contents don't match
-	// the checksum we retrieved earlier. Update the checksums if needed.
-	for _, p := range hostProfilesToUpdate {
-		if _, ok := profileContents[p.ProfileUUID]; ok {
-			p.Checksum = profileContents[p.ProfileUUID].Checksum
-		}
-
-		if p.Status != nil && *p.Status == fleet.MDMDeliveryFailed {
-			failedProfileHostUUIDs[p.ProfileUUID+p.HostUUID] = true
 		}
 	}
 
@@ -2766,11 +2765,8 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 			// All LocURIs are protected by other active profiles; skip.
 			continue
 		}
-		if err := ds.MDMWindowsInsertCommandForHosts(ctx, target.hostUUIDs, command); err != nil {
-			return ctxerr.Wrap(ctx, err, "inserting remove commands for hosts")
-		}
 
-		// Only create host profile entries after the command was successfully enqueued.
+		removePayloadsForCommand := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{}
 		for _, rp := range removePayloadData[profUUID] {
 			// Remove operations don't need a checksum; use a zero value if none exists (defensive coding).
 			checksum := rp.Checksum
@@ -2786,13 +2782,27 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 				Status:        &fleet.MDMDeliveryPending,
 				Checksum:      checksum,
 			}
-			hostProfilesToUpdate = append(hostProfilesToUpdate, hp)
+			removePayloadsForCommand = append(removePayloadsForCommand, hp)
 			logger.DebugContext(ctx, "removing profile", "profile.uuid", rp.ProfileUUID, "host.uuid", rp.HostUUID, "profile.name", rp.ProfileName)
+		}
+		if err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, target.hostUUIDs, command, removePayloadsForCommand); err != nil {
+			return ctxerr.Wrap(ctx, err, "inserting remove commands for hosts")
 		}
 	}
 
 	// Upsert the host profiles we need to track.
-	if err := ds.BulkUpsertMDMWindowsHostProfiles(ctx, hostProfilesToUpdate); err != nil {
+	// Store list of failed profiles (profile UUID + host UUID to create uniqueness) to avoid updating other stuff for that, such as managed certs.
+	failedProfileHostUUIDs := make(map[string]bool)
+	// Create a final pass list of the failed profiles to update at the end. We already updated the pending ones during command processing
+	hostProfilesForFinalUpdate := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{}
+
+	for _, p := range hostProfilesToUpdate {
+		if p.Status != nil && *p.Status == fleet.MDMDeliveryFailed {
+			failedProfileHostUUIDs[p.ProfileUUID+p.HostUUID] = true
+			hostProfilesForFinalUpdate = append(hostProfilesForFinalUpdate, p)
+		}
+	}
+	if err := ds.BulkUpsertMDMWindowsHostProfiles(ctx, hostProfilesForFinalUpdate); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating host profiles")
 	}
 

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2555,7 +2555,11 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	// hostProfilesMap provides O(1) lookup for host profiles by host UUID and profile UUID
 	// Key format: "hostUUID|profileUUID"
 	hostProfilesMap := make(map[string]*fleet.MDMWindowsBulkUpsertHostProfilePayload, len(toInstall))
-	batchProfilesMap := make(map[string][]*fleet.MDMWindowsBulkUpsertHostProfilePayload) // profileUUID -> host profiles, used for batch updates during command creation
+
+	// batchProfileCmdsMap maps command UUID -> host profiles, used to fetch all host profiles associated
+	// with a given command UUID so all host_mdm_windows_profiles entries can be updated as the command
+	// is enqueued for hosts
+	batchProfileCmdsMap := make(map[string][]*fleet.MDMWindowsBulkUpsertHostProfilePayload)
 
 	// install are maps from profileUUID -> command uuid and host
 	// UUIDs as the underlying MDM services are optimized to send one command to
@@ -2593,7 +2597,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		hostProfilesToUpdate = append(hostProfilesToUpdate, hp)
 		// Add to map for fast lookup
 		hostProfilesMap[p.HostUUID+"|"+p.ProfileUUID] = hp
-		batchProfilesMap[target.cmdUUID] = append(batchProfilesMap[target.cmdUUID], hp)
+		batchProfileCmdsMap[target.cmdUUID] = append(batchProfileCmdsMap[target.cmdUUID], hp)
 		logger.DebugContext(ctx, "installing profile", "profile_uuid", p.ProfileUUID, "host_id", p.HostUUID, "name", p.ProfileName)
 	}
 
@@ -2654,7 +2658,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 
 		if !variables.ContainsBytes(p.SyncML) {
 			// No Fleet variables, send the same command to all hosts
-			payloads, ok := batchProfilesMap[target.cmdUUID]
+			payloads, ok := batchProfileCmdsMap[target.cmdUUID]
 			if !ok {
 				logger.ErrorContext(ctx, "no host profiles found for command UUID", "command_uuid", target.cmdUUID)
 				continue

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2654,16 +2654,21 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 
 		if !variables.ContainsBytes(p.SyncML) {
 			// No Fleet variables, send the same command to all hosts
+			payloads, ok := batchProfilesMap[target.cmdUUID]
+			if !ok {
+				logger.ErrorContext(ctx, "no host profiles found for command UUID", "command_uuid", target.cmdUUID)
+				continue
+			}
 			command, err := buildCommandFromProfileBytes(p.SyncML, target.cmdUUID)
 			if err != nil {
 				logger.InfoContext(ctx, "error building command from profile", "err", err, "profile_uuid", profUUID)
+				for _, payload := range payloads {
+					payload.Status = &fleet.MDMDeliveryFailed
+					payload.Detail = fmt.Sprintf("Failed to build command from profile: %s", err.Error())
+				}
 				continue
 			}
-			payloads, ok := batchProfilesMap[command.CommandUUID]
-			if !ok {
-				logger.ErrorContext(ctx, "no host profiles found for command UUID", "command_uuid", command.CommandUUID)
-				continue
-			}
+
 			// Since we are not using DB transactions here, there is a small chance that the profile contents don't match
 			// the checksum we retrieved earlier. Update the checksums if needed.
 			for _, payload := range payloads {
@@ -2798,7 +2803,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 
 	for _, p := range hostProfilesToUpdate {
 		if p.Status != nil && *p.Status == fleet.MDMDeliveryFailed {
-			failedProfileHostUUIDs[p.ProfileUUID+p.HostUUID] = true
+			failedProfileHostUUIDs[p.HostUUID+"|"+p.ProfileUUID] = true
 			hostProfilesForFinalUpdate = append(hostProfilesForFinalUpdate, p)
 		}
 	}
@@ -2809,7 +2814,7 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	// Run through managed certs and remove all those that belong to failed profiles
 	filteredManagedCerts := []*fleet.MDMManagedCertificate{}
 	for _, mc := range *managedCertificatePayloads {
-		if _, failed := failedProfileHostUUIDs[mc.ProfileUUID+mc.HostUUID]; !failed {
+		if _, failed := failedProfileHostUUIDs[mc.HostUUID+"|"+mc.ProfileUUID]; !failed {
 			filteredManagedCerts = append(filteredManagedCerts, mc)
 		}
 	}

--- a/server/service/microsoft_mdm_test.go
+++ b/server/service/microsoft_mdm_test.go
@@ -728,12 +728,13 @@ func TestReconcileWindowsProfilesWithFleetVariableError(t *testing.T) {
 	capturedUpdates, managedCerts := setupReconcilerTest(ds, hostToProfile)
 
 	var receivedCommand *fleet.MDMWindowsCommand
-	ds.MDMWindowsInsertCommandForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand) error {
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
 		receivedCommand = cmd
 		// Simulate error only for commands with substituted UUID (to test error handling)
 		if strings.Contains(string(cmd.RawCommand), testHostUUID) {
 			return errors.New("command insert failed after preprocessing")
 		}
+		*capturedUpdates = append(*capturedUpdates, updates...)
 		return nil
 	}
 
@@ -750,7 +751,7 @@ func TestReconcileWindowsProfilesWithFleetVariableError(t *testing.T) {
 	require.Empty(t, managedCerts, "No managed certificates should have been added")
 
 	// Verify that the error was captured and the profile was marked as failed
-	require.True(t, ds.MDMWindowsInsertCommandForHostsFuncInvoked, "MDMWindowsInsertCommandForHosts should have been called")
+	require.True(t, ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFuncInvoked, "MDMWindowsInsertCommandAndUpsertHostProfilesForHosts should have been called")
 	require.True(t, ds.BulkUpsertMDMWindowsHostProfilesFuncInvoked, "BulkUpsertMDMWindowsHostProfiles should have been called")
 
 	// Find the error status update
@@ -804,7 +805,7 @@ func TestReconcileWindowsProfileWithCertificateFailureDoesNotAddManagedCertifica
 		return "secret", nil
 	}
 
-	ds.MDMWindowsInsertCommandForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand) error {
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
 		return errors.New("fake error to check managed certificate")
 	}
 
@@ -871,7 +872,8 @@ func TestReconcileWindowsProfilesWithOneHostFailingStillAddsManagedCertificate(t
 		return "secret", nil
 	}
 
-	ds.MDMWindowsInsertCommandForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand) error {
+	ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHostsFunc = func(ctx context.Context, hostUUIDs []string, cmd *fleet.MDMWindowsCommand, updates []*fleet.MDMWindowsBulkUpsertHostProfilePayload) error {
+		*capturedUpdates = append(*capturedUpdates, updates...)
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42544 

This inserts the commands into the windows command queue in batches along with the host_mdm_windows_profile entries. corresponding host profile entries are inserted in the same batch as the command queue entry so that if a host checks in very quickly after, its profile doesn't get overwritten by the reconciler during the "update" pass at the end.

This isn't easily reproducible locally, but will run a loadtest as soon as possible

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Windows MDM device profile management with more efficient batch processing for command delivery and profile updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->