### PR TITLE
Website: Update case study links on customers page.

### DIFF
--- a/website/api/controllers/view-customers.js
+++ b/website/api/controllers/view-customers.js
@@ -1,16 +1,16 @@
 module.exports = {
 
 
-  friendlyName: 'View testimonials',
+  friendlyName: 'View customers',
 
 
-  description: 'Display "Testimonials" page.',
+  description: 'Display "Customers" page.',
 
 
   exits: {
 
     success: {
-      viewTemplatePath: 'pages/testimonials'
+      viewTemplatePath: 'pages/customers'
     }
 
   },
@@ -83,7 +83,6 @@ module.exports = {
         return article;
       }
     });
-
     // Sort the case study articles by the lowercase cardTitleForCustomersPage meta tag value.
     caseStudiesToCreateLinksFor = _.sortBy(caseStudiesToCreateLinksFor, (article)=>{
       return article.meta.cardTitleForCustomersPage.toLowerCase();

--- a/website/api/controllers/view-customers.js
+++ b/website/api/controllers/view-customers.js
@@ -88,10 +88,20 @@ module.exports = {
       return article.meta.cardTitleForCustomersPage.toLowerCase();
     });
 
+    // We want to show 12 links to case studies initially, so we'll find out how many cards we need to show when the page loads
+    let sizeOfFristBlockOfCaseStudyCards = 12 - (caseStudies.length - caseStudiesToCreateLinksFor.length);
+    // And remove that many case studies from the array of case studies to create links for.
+    let initalCaseStudyLinksToShow = caseStudiesToCreateLinksFor.splice(0, sizeOfFristBlockOfCaseStudyCards);
+    // And we'll break the rest of the array into smaller arrays of 12 case studies.
+    let blocksOfCaseStudies = _.chunk(caseStudiesToCreateLinksFor, 12);
+    let numberOfPagesOfCaseStudies = blocksOfCaseStudies.length + 1;
     return {
       testimonials: filteredTestimonialsForThisPage,
       testimonialsWithVideoLinks,
       caseStudiesToCreateLinksFor,
+      initalCaseStudyLinksToShow,
+      blocksOfCaseStudies,
+      numberOfPagesOfCaseStudies
     };
 
   }

--- a/website/assets/js/pages/customers.page.js
+++ b/website/assets/js/pages/customers.page.js
@@ -5,6 +5,7 @@ parasails.registerPage('customers', {
   data: {
     modal: '',
     quotesWithVideoLinks: [],
+    pageOfCaseStudiesVisible: -1,
   },
 
   //  ╦  ╦╔═╗╔═╗╔═╗╦ ╦╔═╗╦  ╔═╗
@@ -34,6 +35,20 @@ parasails.registerPage('customers', {
     clickOpenVideoModal: function(modalName) {
       console.log(modalName);
       this.modal = _.kebabCase(modalName);
+    },
+
+    clickGotoCaseStudyLink: function(url, event) {
+      if (event.ctrlKey || event.metaKey) {
+        window.open(url, '_blank');
+        return;
+      } else {
+        this.goto(url);
+      }
+
+    },
+
+    clickShowMoreCaseStudies: function() {
+      this.pageOfCaseStudiesVisible++;
     },
 
     closeModal: function() {

--- a/website/assets/js/pages/customers.page.js
+++ b/website/assets/js/pages/customers.page.js
@@ -1,4 +1,4 @@
-parasails.registerPage('testimonials', {
+parasails.registerPage('customers', {
   //  ╦╔╗╔╦╔╦╗╦╔═╗╦    ╔═╗╔╦╗╔═╗╔╦╗╔═╗
   //  ║║║║║ ║ ║╠═╣║    ╚═╗ ║ ╠═╣ ║ ║╣
   //  ╩╝╚╝╩ ╩ ╩╩ ╩╩═╝  ╚═╝ ╩ ╩ ╩ ╩ ╚═╝

--- a/website/assets/styles/importer.less
+++ b/website/assets/styles/importer.less
@@ -79,7 +79,7 @@
 @import 'pages/integrations.less';
 @import 'pages/start.less';
 @import 'pages/deals.less';
-@import 'pages/testimonials.less';
+@import 'pages/customers.less';
 @import 'pages/docs/app-library.less';
 @import 'pages/docs/app-details.less';
 @import 'pages/meetups.less';

--- a/website/assets/styles/pages/customers.less
+++ b/website/assets/styles/pages/customers.less
@@ -329,6 +329,10 @@
     background: linear-gradient(180deg, #FFFFFF 0%, #E9F4F4 100%);
   }
 
+  [purpose='button-container'] {
+    margin-top: 48px;
+  }
+
   [purpose='bottom-cta'] {
 
     display: flex;
@@ -349,65 +353,66 @@
       font-weight: 800;
       line-height: 120%;
     }
-    [purpose='button-row'] {
-      a {
-        font-weight: 700;
-        font-size: 16px;
-        text-decoration: none;
-      }
-      [purpose='cta-button'] {
-        display: flex;
-        height: 36px;
-        padding: 16px;
-        justify-content: center;
-        align-items: center;
-        gap: 4px;
-        border-radius: 8px;
-        background: @core-vibrant-green;
-        color: #FFF;
+  }
+  [purpose='button-row'] {
+    a {
+      font-weight: 700;
+      font-size: 16px;
+      text-decoration: none;
+    }
+    [purpose='cta-button'] {
+      display: flex;
+      height: 36px;
+      padding: 16px;
+      justify-content: center;
+      align-items: center;
+      gap: 4px;
+      border-radius: 8px;
+      background: @core-vibrant-green;
+      color: #FFF;
+      text-align: center;
+      width: 140px;
+      /* Body MD (bold) */
+      font-family: Inter;
+      font-size: 16px;
+      font-style: normal;
+      font-weight: 700;
+      line-height: 150%;
+      margin-right: 24px;
+      position: relative;
+      cursor: pointer;
+    }
+    [purpose='cta-button']::before {
+      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
+      opacity: 1;
+      content: '';
+      position: absolute;
+      top: 0;
+      left: -5px;
+      width: 50%;
+      height: 100%;
+      transform: skew(-10deg);
+      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
+    }
+    [purpose='cta-button']:hover:before {
+      left: 160px;
+      width: 110%;
+    }
+    [parasails-component='animated-arrow-button'] {
+      width: fit-content;
+      display: flex;
+      align-items: center;
+      padding: 6px 0px;
+      text-decoration: none;
+      font-weight: 700;
+      [purpose='button-text'] {
+        color: #192147;
         text-align: center;
-        width: 140px;
-        /* Body MD (bold) */
         font-family: Inter;
-        font-size: 16px;
+        font-size: 15px;
         font-style: normal;
-        font-weight: 700;
-        line-height: 150%;
-        margin-right: 24px;
-        position: relative;
-      }
-      [purpose='cta-button']::before {
-        background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-        opacity: 1;
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -5px;
-        width: 50%;
-        height: 100%;
-        transform: skew(-10deg);
-        transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-      }
-      [purpose='cta-button']:hover:before {
-        left: 160px;
-        width: 110%;
-      }
-      [parasails-component='animated-arrow-button'] {
-        width: fit-content;
-        display: flex;
-        align-items: center;
-        padding: 6px 0px;
-        text-decoration: none;
-        font-weight: 700;
-        [purpose='button-text'] {
-          color: #192147;
-          text-align: center;
-          font-family: Inter;
-          font-size: 15px;
-          font-style: normal;
-          font-weight: 600;
-          line-height: 160%;
-        }
+        font-weight: 600;
+        line-height: 160%;
       }
     }
   }

--- a/website/assets/styles/pages/customers.less
+++ b/website/assets/styles/pages/customers.less
@@ -1,4 +1,4 @@
-#testimonials {
+#customers {
 
   h4 {
     color: #515774;

--- a/website/config/policies.js
+++ b/website/config/policies.js
@@ -57,7 +57,7 @@ module.exports.policies = {
   'view-deals': true,
   'deliver-deal-registration-submission': true,
   'get-est-device-certificate': true,
-  'view-testimonials': true,
+  'view-customers': true,
   'view-meetups': true,
   'view-fleetctl-preview': true,
   'get-llm-generated-configuration-profile': true,

--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -469,7 +469,7 @@ module.exports.routes = {
   },
 
   'GET /customers': {
-    action: 'view-testimonials',
+    action: 'view-customers',
     locals: {
       pageTitleForMeta: 'What people are saying',
       pageDescriptionForMeta: 'See what people are saying about Fleet.',

--- a/website/views/layouts/layout.ejs
+++ b/website/views/layouts/layout.ejs
@@ -878,6 +878,7 @@
     <script src="/js/pages/configuration-builder.page.js"></script>
     <script src="/js/pages/connect-vanta.page.js"></script>
     <script src="/js/pages/contact.page.js"></script>
+    <script src="/js/pages/customers.page.js"></script>
     <script src="/js/pages/customers/dashboard.page.js"></script>
     <script src="/js/pages/customers/new-license.page.js"></script>
     <script src="/js/pages/deals.page.js"></script>
@@ -926,7 +927,6 @@
     <script src="/js/pages/software-management.page.js"></script>
     <script src="/js/pages/start.page.js"></script>
     <script src="/js/pages/support.page.js"></script>
-    <script src="/js/pages/testimonials.page.js"></script>
     <script src="/js/pages/transparency.page.js"></script>
     <script src="/js/pages/try-fleet/sandbox-expired.page.js"></script>
     <script src="/js/pages/try-fleet/sandbox-teleporter.page.js"></script>

--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -119,7 +119,7 @@
       <div>
         <div purpose="case-study-cards">
 
-          <div purpose="article-card" @click="goto('/case-study/foursquare', $event)">
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/foursquare', $event)">
             <img alt="Foursquare logo" src="/images/foursquare-logo-212x40@2x.png">
             <p>Foursquare cut costs and gained 114% ROI with Fleet.</p>
             <a href="/case-study/foursquare">Read their story</a>

--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -116,47 +116,66 @@
         </div><%// End of [purpose="hero-slides"]%>
       </div>
       <div purpose="page-body">
-      <div purpose="case-study-cards">
+      <div>
+        <div purpose="case-study-cards">
 
-        <div purpose="article-card" @click="goto('/case-study/foursquare')">
-          <img alt="Foursquare logo" src="/images/foursquare-logo-212x40@2x.png">
-          <p>Foursquare cut costs and gained 114% ROI with Fleet.</p>
-          <a href="/case-study/foursquare">Read their story</a>
-        </div>
-        <div purpose="article-card" @click="goto('/case-study/fastly')">
-          <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
-          <p>Fastly gains visibility into all endpoints and critical infrastructure around the world.</p>
-          <a href="/case-study/fastly">Read their story</a>
-        </div>
-        <div purpose="article-card" @click="goto('/case-study/faire')">
-          <img alt="Faire logo" src="/images/faire-logo-192x40@2x.png">
-          <p>Faire secures Macs with CIS benchmarks and Fleet.</p>
-          <a href="/case-study/faire">Read their story</a>
-        </div>
-        <div purpose="article-card" @click="goto('/case-study/stripe')">
-          <img alt="Stripe logo" src="/images/stripe-logo-96x40@2x.png">
-          <p>Stripe moved 10,000 Macs to Fleet, saving hundreds of thousands annually.</p>
-          <a href="/case-study/stripe">Read their story</a>
-        </div>
-        <div purpose="article-card" @click="goto('/case-study/thumbtack')">
-          <img alt="Thumbtack logo" src="/images/thumbtack-logo-197x40@2x.png">
-          <p>Thumbtack migrates more than 90% of Macs with no IT intervention.</p>
-          <a href="/case-study/thumbtack">Read their story</a>
-        </div>
-        <% /*  Automatically created cards for anonymous case studies  */%>
-        <% for(let article of caseStudiesToCreateLinksFor) { %>
-          <div purpose="article-card" @click="goto('<%- article.url %>')">
-            <p><strong><%- article.meta.cardTitleForCustomersPage %></strong></p>
-            <% if(article.meta.cardBodyForCustomersPage){ %>
-              <p><%- article.meta.cardBodyForCustomersPage %></p>
-            <% } else {%>
-              <p><%- article.meta.articleTitle %>.</p>
-            <% }%>
-            <a href="<%- article.url %>">Read their story</a>
+          <div purpose="article-card" @click="goto('/case-study/foursquare', $event)">
+            <img alt="Foursquare logo" src="/images/foursquare-logo-212x40@2x.png">
+            <p>Foursquare cut costs and gained 114% ROI with Fleet.</p>
+            <a href="/case-study/foursquare">Read their story</a>
           </div>
-        <% } %>
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/fastly', $event)">
+            <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
+            <p>Fastly gains visibility into all endpoints and critical infrastructure around the world.</p>
+            <a href="/case-study/fastly">Read their story</a>
+          </div>
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/faire', $event)">
+            <img alt="Faire logo" src="/images/faire-logo-192x40@2x.png">
+            <p>Faire secures Macs with CIS benchmarks and Fleet.</p>
+            <a href="/case-study/faire">Read their story</a>
+          </div>
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/stripe', $event)">
+            <img alt="Stripe logo" src="/images/stripe-logo-96x40@2x.png">
+            <p>Stripe moved 10,000 Macs to Fleet, saving hundreds of thousands annually.</p>
+            <a href="/case-study/stripe">Read their story</a>
+          </div>
+          <div purpose="article-card" @click="clickGotoCaseStudyLink('/case-study/thumbtack', $event)">
+            <img alt="Thumbtack logo" src="/images/thumbtack-logo-197x40@2x.png">
+            <p>Thumbtack migrates more than 90% of Macs with no IT intervention.</p>
+            <a href="/case-study/thumbtack">Read their story</a>
+          </div>
+          <% /*  Automatically created cards for anonymous case studies  */%>
+          <% for(let article of initalCaseStudyLinksToShow) { %>
+            <div purpose="article-card" @click="clickGotoCaseStudyLink('<%- article.url %>', $event)">
+              <p><strong><%- article.meta.cardTitleForCustomersPage %></strong></p>
+              <% if(article.meta.cardBodyForCustomersPage){ %>
+                <p><%- article.meta.cardBodyForCustomersPage %></p>
+              <% } else {%>
+                <p><%- article.meta.articleTitle %>.</p>
+              <% }%>
+              <a href="<%- article.url %>">Read their story</a>
+            </div>
+          <% } %>
+          <% for(let batch of blocksOfCaseStudies) { %>
+            <% for(let article of batch) { %>
+              <div purpose="article-card" @click="clickGotoCaseStudyLink('<%- article.url %>', $event)" v-if="pageOfCaseStudiesVisible >= <%- blocksOfCaseStudies.indexOf(batch) %>">
+                <p><strong><%- article.meta.cardTitleForCustomersPage %></strong></p>
+                <% if(article.meta.cardBodyForCustomersPage){ %>
+                  <p><%- article.meta.cardBodyForCustomersPage %></p>
+                <% } else {%>
+                  <p><%- article.meta.articleTitle %>.</p>
+                <% }%>
+                <a href="<%- article.url %>">Read their story</a>
+              </div>
+            <% } %>
+          <% } %>
+        </div>
+        <div purpose="button-container">
+          <div purpose="button-row" class="d-flex flex-row align-items-center justify-content-center w-100" v-if="pageOfCaseStudiesVisible !== (numberOfPagesOfCaseStudies - 2)">
+            <a purpose="cta-button" @click="clickShowMoreCaseStudies()">Load more</a>
+          </div>
+        </div>
       </div>
-
       <div purpose="logo-container">
       <logo-carousel display-bottom-row="true"></logo-carousel>
       </div>

--- a/website/views/pages/customers.ejs
+++ b/website/views/pages/customers.ejs
@@ -1,4 +1,4 @@
-<div id="testimonials" v-cloak>
+<div id="customers" v-cloak>
   <div purpose="page-container">
     <div purpose="page-content">
       <div purpose="page-hero">


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/42043

Changes:
- Updated the customers page to only show 12 case study links by default, and to include a "Load more" button that shows 12 more case study card links when clicked.
- Renamed the files for the customers page (testimonials » customers)