### PR TITLE
Recovery Lock password: Update copy

### DIFF
--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RecoveryLockPasswordModal/RecoveryLockPasswordModal.tsx
@@ -132,7 +132,7 @@ const RecoveryLockPasswordModal = ({
             </p>
             {recoveryLockData?.auto_rotate_at && (
               <InfoBanner color="yellow">
-                Password rotates automatically by{" "}
+                Password rotates automatically at{" "}
                 {monthDayTimeFormat(recoveryLockData.auto_rotate_at)}.
               </InfoBanner>
             )}


### PR DESCRIPTION
- @noahtalerman: "at" is more accurate than "by" because my understanding is that the password will never be rotated before the shown time. That's when the command goes out.