### PR TITLE
Loadtest internal alb logging and osquery-perf scaling updates

### DIFF
--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -32,9 +32,9 @@ on:
         default: 300
         required: true
       extra_flags:
-        description: "Extra flags for osquery-perf. Example: [\"--orbit_prob\", \"0.0\", \"--host-count\", \"2000\", \"--start-period\", \"20m\"]"
+        description: "Extra flags for osquery-perf. Example: [\"--orbit_prob\", \"0.0\", \"--host_count\", \"2000\", \"--start_period\", \"20m\"]"
         type: string
-        default: "[\"--orbit_prob\", \"0.0\", \"--host-count\", \"2000\", \"--start-period\", \"20m\"]"
+        default: "[\"--orbit_prob\", \"0.0\", \"--host_count\", \"2000\", \"--start_period\", \"20m\"]"
         required: false
       terraform_action:
         description: Dry run only? No "terraform apply"

--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -21,15 +21,20 @@ on:
         type: string
         default: 0
         required: true
+      task_size:
+        description: "CPU and Memory setting for osquery-perf containers. Example: {\"cpu\":\"4098\",\"memory\":\"8192\"}"
+        type: string
+        default: "{\"cpu\":\"4096\",\"memory\":\"8192\"}"
+        required: true
       sleep_time:
         description: "Sleep time (in seconds) between batched osquery container deployments"
         type: string
-        default: 60
+        default: 300
         required: true
       extra_flags:
-        description: "Extra flags for osquery-perf. Example: [\"--orbit_prob\", \"0.0\"]"
+        description: "Extra flags for osquery-perf. Example: [\"--orbit_prob\", \"0.0\", \"--host-count\", \"2000\", \"--start-period\", \"20m\"]"
         type: string
-        default: "[\"--orbit_prob\", \"0.0\"]"
+        default: "[\"--orbit_prob\", \"0.0\", \"--host-count\", \"2000\", \"--start-period\", \"20m\"]"
         required: false
       terraform_action:
         description: Dry run only? No "terraform apply"
@@ -58,6 +63,7 @@ env:
   TF_VAR_extra_flags: "${{ inputs.extra_flags || '[]' }}"
   TF_VAR_loadtest_containers: "${{ inputs.loadtest_containers }}"
   TF_VAR_git_tag_branch: "${{ inputs.git_tag_branch }}"
+  TF_VAR_task_size: "${{ inputs.task_size }}"
 
 permissions:
   id-token: write
@@ -150,7 +156,7 @@ jobs:
           if [[ `terraform workspace show` = "${{ inputs.terraform_workspace }}" ]];
           then
             echo "TERRAFORM WORKSPACE: MATCHES - ${{ inputs.terraform_workspace }}"
-            ./enroll.sh ${{ inputs.git_tag_branch }} ${{ inputs.loadtest_containers_starting_index}} ${{ inputs.loadtest_containers }} ${{ inputs.sleep_time }} 
+            ./enroll.sh ${{ inputs.git_tag_branch }} "${{ inputs.task_size }}" ${{ inputs.loadtest_containers_starting_index}} ${{ inputs.loadtest_containers }} ${{ inputs.sleep_time }} 
           else
             echo "TERRAFORM WORKSPACE: DOES NOT MATCH INPUT - ${{ inputs.terraform_workspace }}"
           fi

--- a/infrastructure/loadtesting/terraform/infra/internal_alb.tf
+++ b/infrastructure/loadtesting/terraform/infra/internal_alb.tf
@@ -26,6 +26,11 @@ resource "aws_lb" "internal" {
   subnets                    = data.terraform_remote_state.shared.outputs.vpc.private_subnets
   idle_timeout               = 905
   drop_invalid_header_fields = true
+  access_logs {
+      bucket  = module.logging_alb.log_s3_bucket_id
+      prefix  = local.customer
+      enabled = true
+  }
 }
 
 resource "aws_lb_listener" "internal" {

--- a/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
+++ b/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
@@ -7,10 +7,11 @@ set -e
 # ./enroll.sh my-branch 8 240
 
 BRANCH_NAME=$1
-START_INDEX=$2
-END_INDEX=$3
-INCREMENT=${5:-8}
-SLEEP_TIME_SECONDS=${4:-60}
+TASK_SIZE=${2:?}
+START_INDEX=$3
+END_INDEX=$4
+SLEEP_TIME_SECONDS=${5:-60}
+INCREMENT=${6:-8}
 
 if [ -z "$BRANCH_NAME" ]; then
 	echo "Missing BRANCH_NAME"
@@ -21,6 +22,9 @@ fi
 if [ -z "$END_INDEX" ]; then
 	echo "Missing END_INDEX"
 fi
+if [ -z "$TASK_SIZE" ]; then
+	echo "Missing TASK_SIZE"
+fi
 
 # We add this check to avoid terraform (error-prone) locking in case of typos.
 # read -p "You will use BRANCH_NAME=$BRANCH_NAME. Continue? "
@@ -28,6 +32,6 @@ fi
 set -x
 
 for (( c=$START_INDEX; c<=$END_INDEX; c+=$INCREMENT )); do
-        terraform apply -var git_tag_branch=$BRANCH_NAME -var loadtest_containers=$c -auto-approve
+        terraform apply -var git_tag_branch=$BRANCH_NAME -var task_size="$TASK_SIZE" -var loadtest_containers=$c -auto-approve
 	sleep $SLEEP_TIME_SECONDS
 done

--- a/infrastructure/loadtesting/terraform/osquery_perf/variables.tf
+++ b/infrastructure/loadtesting/terraform/osquery_perf/variables.tf
@@ -17,12 +17,12 @@ variable "extra_flags" {
 
 variable "task_size" {
   type = object({
-    cpu    = optional(number, 256)
-    memory = optional(number, 1024)
+    cpu    = optional(number, 4096)
+    memory = optional(number, 8192)
   })
 
   default = {
-    cpu    = 256
-    memory = 1024
+    cpu    = 4096
+    memory = 8192
   }
 }


### PR DESCRIPTION
- Configures internal alb to log to the same bucket as the public alb
- Adds support for osquery-perf task size (cpu/memory) configuration
- Updates defaults for osquery-perf extra_flags
- Updates default enroll.sh loop sleep_time from 60s -> 300s