### PR TITLE
Use display name when applicable for Android config change updates

### DIFF
--- a/changes/42383-android-display-name
+++ b/changes/42383-android-display-name
@@ -1,0 +1,1 @@
+* Fixed success message on Android software configuration to reference software display name when applicable.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
@@ -14,6 +14,7 @@ import CustomLink from "components/CustomLink";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 import InstallerDetailsWidget from "../SoftwareInstallerCard/InstallerDetailsWidget";
 import { getErrorMessage } from "./helpers";
+import { getDisplayedSoftwareName } from "../../helpers";
 
 const baseClass = "edit-configuration-modal";
 
@@ -93,7 +94,13 @@ const EditConfigurationModal = ({
       renderFlash(
         "success",
         <>
-          <strong>{softwareInstaller.name}</strong> configuration updated.
+          <strong>
+            {getDisplayedSoftwareName(
+              softwareInstaller.name,
+              softwareInstaller.display_name
+            )}
+          </strong>{" "}
+          configuration updated.
         </>
       );
 


### PR DESCRIPTION
Resolves #42383. Re-roll of #42384 using the relevant helper function.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Android software configuration success notifications to dynamically display the actual software display name, replacing previously static messaging. This improvement provides users with more specific and personalized feedback when confirming successful software configurations, improving clarity and reducing potential confusion when managing multiple software installations or updates on their Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->