### PR TITLE
Add lock semantics around dev_mode.IsEnabled to avoid data races

### DIFF
--- a/server/dev_mode/dev_mode.go
+++ b/server/dev_mode/dev_mode.go
@@ -3,7 +3,6 @@ package dev_mode
 import (
 	"os"
 	"sync"
-	"sync/atomic"
 	"testing"
 )
 
@@ -11,9 +10,9 @@ import (
 // It must not be written from concurrent goroutines; SetOverride only affects enabledViaOverride/env overrides.
 var IsEnabled bool
 
-// enabledViaOverride is set atomically by SetOverride so that background goroutines
-// calling Env() do not race with test code that calls SetOverride().
-var enabledViaOverride atomic.Bool
+// enabledViaOverride is set by SetOverride and protected by mu so that it is
+// always observed consistently with envOverrides.
+var enabledViaOverride bool
 
 var mu sync.RWMutex
 
@@ -22,12 +21,12 @@ var envOverrides = map[string]string{}
 type GetEnv func(name string) string
 
 func Env(name string) string {
-	if !IsEnabled && !enabledViaOverride.Load() {
-		return ""
-	}
-
 	mu.RLock()
 	defer mu.RUnlock()
+
+	if !IsEnabled && !enabledViaOverride {
+		return ""
+	}
 
 	if override, ok := envOverrides[name]; ok {
 		return override
@@ -44,10 +43,10 @@ func SetOverride(name string, value string, cleanup ...*testing.T) { // optional
 		})
 	}
 
-	enabledViaOverride.Store(true) // if we're setting overrides, we're in a test environment, so allow Env() lookups via enabledViaOverride (without changing IsEnabled)
 	mu.Lock()
 	defer mu.Unlock()
 
+	enabledViaOverride = true // if we're setting overrides, we're in a test environment so want to turn dev mode on
 	envOverrides[name] = value
 }
 

--- a/server/dev_mode/dev_mode.go
+++ b/server/dev_mode/dev_mode.go
@@ -2,19 +2,32 @@ package dev_mode
 
 import (
 	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
+// Do not write this variable from concurrent goroutines; use SetOverride instead.
 var IsEnabled bool
+
+// enabledViaOverride is set atomically by SetOverride so that background goroutines
+// calling Env() do not race with test code that calls SetOverride().
+var enabledViaOverride atomic.Bool
+
+var mu sync.RWMutex
 
 var envOverrides = map[string]string{}
 
 type GetEnv func(name string) string
 
 func Env(name string) string {
-	if !IsEnabled {
+	if !IsEnabled && !enabledViaOverride.Load() {
 		return ""
 	}
+
+	mu.RLock()
+	defer mu.RUnlock()
+
 	if override, ok := envOverrides[name]; ok {
 		return override
 	}
@@ -30,14 +43,23 @@ func SetOverride(name string, value string, cleanup ...*testing.T) { // optional
 		})
 	}
 
-	IsEnabled = true // if we're setting overrides, we're in a test environment so want to turn dev mode on
+	enabledViaOverride.Store(true) // if we're setting overrides, we're in a test environment so want to turn dev mode on
+	mu.Lock()
+	defer mu.Unlock()
+
 	envOverrides[name] = value
 }
 
 func ClearOverride(name string) {
+	mu.Lock()
+	defer mu.Unlock()
+
 	delete(envOverrides, name)
 }
 
 func ClearAllOverrides() {
+	mu.Lock()
+	defer mu.Unlock()
+
 	envOverrides = map[string]string{}
 }

--- a/server/dev_mode/dev_mode.go
+++ b/server/dev_mode/dev_mode.go
@@ -61,5 +61,6 @@ func ClearAllOverrides() {
 	mu.Lock()
 	defer mu.Unlock()
 
+	enabledViaOverride = false
 	envOverrides = map[string]string{}
 }

--- a/server/dev_mode/dev_mode.go
+++ b/server/dev_mode/dev_mode.go
@@ -44,7 +44,7 @@ func SetOverride(name string, value string, cleanup ...*testing.T) { // optional
 		})
 	}
 
-	enabledViaOverride.Store(true) // if we're setting overrides, we're in a test environment so want to turn dev mode on
+	enabledViaOverride.Store(true) // if we're setting overrides, we're in a test environment, so allow Env() lookups via enabledViaOverride (without changing IsEnabled)
 	mu.Lock()
 	defer mu.Unlock()
 

--- a/server/dev_mode/dev_mode.go
+++ b/server/dev_mode/dev_mode.go
@@ -7,7 +7,8 @@ import (
 	"testing"
 )
 
-// Do not write this variable from concurrent goroutines; use SetOverride instead.
+// IsEnabled should be configured once at process startup (e.g., via flags) and then treated as read-only.
+// It must not be written from concurrent goroutines; SetOverride only affects enabledViaOverride/env overrides.
 var IsEnabled bool
 
 // enabledViaOverride is set atomically by SetOverride so that background goroutines


### PR DESCRIPTION
Fix for [this](https://github.com/fleetdm/fleet/actions/runs/23728512273) data race

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety and concurrency handling for dev-mode environment overrides to prevent potential data races.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->