### PR TITLE
FE 🧹✨: Remove purple banner code and default to grey 

### DIFF
--- a/frontend/components/Card/Card.tsx
+++ b/frontend/components/Card/Card.tsx
@@ -8,7 +8,7 @@ import { Link } from "react-router";
 const baseClass = "card";
 
 type BorderRadiusSize = "small" | "medium" | "large" | "xlarge" | "xxlarge";
-type CardColor = "white" | "grey" | "purple" | "yellow";
+type CardColor = "white" | "grey" | "yellow";
 type PaddingSize =
   | "small"
   | "medium"

--- a/frontend/components/Card/_styles.scss
+++ b/frontend/components/Card/_styles.scss
@@ -71,11 +71,6 @@
     background-color: $ui-off-white;
   }
 
-  &__purple {
-    background-color: $ui-vibrant-blue-10;
-    border-color: $ui-vibrant-blue-50;
-  }
-
   &__yellow {
     background-color: $ui-yellow-banner;
     border-color: $ui-yellow-banner-outline;

--- a/frontend/components/InfoBanner/InfoBanner.stories.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.stories.tsx
@@ -10,7 +10,7 @@ const meta: Meta<typeof InfoBanner> = {
   argTypes: {
     color: {
       control: { type: "select" },
-      options: ["purple", "yellow", "grey"],
+      options: ["yellow", "grey"],
     },
     borderRadius: {
       control: { type: "select" },
@@ -59,7 +59,7 @@ export const Playground: Story = {
   args: {
     children: defaultChildren,
     cta: sampleCta,
-    color: "purple",
+    color: "grey",
     borderRadius: "medium",
     pageLevel: false,
     closable: true,

--- a/frontend/components/InfoBanner/InfoBanner.tsx
+++ b/frontend/components/InfoBanner/InfoBanner.tsx
@@ -11,8 +11,8 @@ const baseClass = "info-banner";
 export interface IInfoBannerProps {
   children?: React.ReactNode;
   className?: string;
-  /** default light purple */
-  color?: "purple" | "yellow" | "grey";
+  /** default grey */
+  color?: "grey" | "yellow";
   /** default 4px  */
   borderRadius?: "medium" | "xlarge";
   pageLevel?: boolean;
@@ -26,7 +26,7 @@ export interface IInfoBannerProps {
 const InfoBanner = ({
   children,
   className,
-  color = "purple",
+  color = "grey",
   borderRadius,
   pageLevel,
   cta,

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareCustomPackage/SoftwareCustomPackage.tsx
@@ -177,7 +177,7 @@ const SoftwareCustomPackage = ({
     return (
       <>
         {gitOpsModeEnabled && (
-          <InfoBanner color="grey" borderRadius="medium">
+          <InfoBanner borderRadius="medium">
             Add custom packages in GitOps mode so Fleet can host your software.
             After adding, copy its SHA-256 hash into your YAML so the next
             GitOps workflow doesn&apos;t delete it.

--- a/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Agents/Agents.tsx
@@ -99,7 +99,7 @@ const Agents = ({
       />
       <form onSubmit={onFormSubmit} autoComplete="off">
         {isPremiumTier ? (
-          <InfoBanner color="grey">
+          <InfoBanner>
             <div>
               These options are not applied to hosts in a fleet. To update agent
               options for hosts in a fleet, head to the&nbsp;
@@ -107,7 +107,7 @@ const Agents = ({
             </div>
           </InfoBanner>
         ) : (
-          <InfoBanner color="grey">
+          <InfoBanner>
             Want some hosts to have different options?&nbsp;
             <CustomLink
               url="https://fleetdm.com/docs/using-fleet/teams"

--- a/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
+++ b/frontend/pages/admin/UserManagementPage/components/UserForm/UserForm.tsx
@@ -344,10 +344,7 @@ const UserForm = ({
     return (
       <>
         {isPremiumTier && (
-          <InfoBanner
-            color="grey"
-            className={`${baseClass}__user-permissions-info`}
-          >
+          <InfoBanner className={`${baseClass}__user-permissions-info`}>
             <p>
               Global users can manage or observe all users, entities, and
               settings in Fleet.

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportCard.tsx
@@ -31,7 +31,7 @@ const ReportBanner = ({
   message: ReactNode;
   children?: ReactNode;
 }) => (
-  <InfoBanner color="grey" borderRadius="xlarge">
+  <InfoBanner borderRadius="xlarge">
     <div className={`${baseClass}__banner-content`}>
       <div className={`${baseClass}__banner-text`}>
         <Icon name={iconName} color={ICON_COLOR} />

--- a/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPolicies.tsx
@@ -68,7 +68,7 @@ const Policies = ({
     }
     if (conditionalAccessBypassed) {
       return (
-        <InfoBanner color="grey" borderRadius="xlarge">
+        <InfoBanner borderRadius="xlarge">
           <IconStatusMessage
             iconName="clock"
             iconColor="ui-fleet-black-50"

--- a/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyFailingCount/PolicyFailingCount.tsx
+++ b/frontend/pages/hosts/details/cards/Policies/HostPoliciesTable/PolicyFailingCount/PolicyFailingCount.tsx
@@ -54,7 +54,7 @@ const PolicyFailingCount = ({
     );
 
   return failCount ? (
-    <InfoBanner className={baseClass} color="grey" borderRadius="xlarge">
+    <InfoBanner className={baseClass} borderRadius="xlarge">
       <IconStatusMessage
         iconName="error-outline"
         iconColor="ui-fleet-black-50"

--- a/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyResults/PolicyResults.tsx
@@ -181,7 +181,7 @@ const PolicyResults = ({
 
     return (
       <div className={`${baseClass}__results-table-container`}>
-        <InfoBanner color="grey">
+        <InfoBanner>
           Hosts that responded with results are marked <strong>Pass</strong>.
           Hosts that responded with no results are marked <strong>Fail</strong>.
         </InfoBanner>

--- a/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
+++ b/frontend/pages/queries/edit/components/DiscardDataOption/DiscardDataOption.tsx
@@ -78,7 +78,7 @@ const DiscardDataOption = ({
   return (
     <div className={baseClass}>
       {isReportsLoggingIgnored && (
-        <InfoBanner color="grey">
+        <InfoBanner>
           The <b>Discard data</b> setting is ignored when differential logging
           is enabled. This report&apos;s results will not be saved in Fleet.
         </InfoBanner>


### PR DESCRIPTION
## Issue
Closes #41032 

## Description
- Combing through code, looks like Noah already updated all the banners to be grey
- Since we removed purple banners all together, I switched the code to default to grey


## Testing

- [x] Added/updated automated tests (storybook)
- [x] QA'd all new/changed functionality manually
