### PR TITLE
fixing shallow clone boundary error

### DIFF
--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -15,13 +15,13 @@ set -euo pipefail
 # Configuration
 REPO_URL="https://github.com/canonical/ubuntu-security-notices.git"
 REPO_DIR="ubuntu-security-notices"
-DAYS_TO_KEEP=3 # how much git history to keep
+DAYS_TO_KEEP=3 # how much git history to get for initial clone
 
 echo "=== OSV Repository Sync ==="
 echo ""
 
 if [ -d "$REPO_DIR/.git" ]; then
-    echo "Repository exists, updating with rolling window..."
+    echo "Repository exists, fetching new commits..."
     cd "$REPO_DIR"
 
     git config core.sparseCheckout true
@@ -30,7 +30,7 @@ if [ -d "$REPO_DIR/.git" ]; then
     OLD_SHA=$(git rev-parse HEAD)
     OLD_COUNT=$(git log --oneline | wc -l | xargs)
 
-    git fetch --update-shallow --shallow-since="${DAYS_TO_KEEP} days ago" origin main
+    git fetch origin main
 
     NEW_SHA=$(git rev-parse origin/main)
 


### PR DESCRIPTION
Related issue: Resolves https://github.com/fleetdm/fleet/issues/41571

It appears that there is some sort of error with shallow cloning.
```
Run echo "=== Generating OSV Artifacts for Ubuntu ===" 
=== Generating OSV Artifacts for Ubuntu ===
=== OSV Repository Sync ===

Repository exists, updating with rolling window...
fatal: error processing shallow info: 4
Error: Process completed with exit code 128.
```

Since we are only keeping a limited history of the repository via cache before re-clone, fall back to doing a regular `git pull`. This avoids the complicated shallow cloning / Git having to reconcile the overlapping but different shallow boundaries, which can cause "error processing shallow info: 4".


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified repository synchronization to use full fetches instead of rolling-window shallow fetches.
  * Updated sync status messaging for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->