### PR TITLE
Department IDP host vital not populating for some users

### DIFF
--- a/changes/41996-department-idp-vitals-not-synch-sometimes
+++ b/changes/41996-department-idp-vitals-not-synch-sometimes
@@ -1,0 +1,2 @@
+* Fixed bug where batched PATCH operations abort on unrecognized attributes.
+* Extended the parsing of the SCIM enterprise user extension (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User) to allow for no-path PATCH format: {"urn:...:User": {"department": "Sales"}}

--- a/ee/server/scim/groups.go
+++ b/ee/server/scim/groups.go
@@ -317,6 +317,7 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 		return scim.Resource{}, err
 	}
 
+	modified := false
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			g.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
@@ -328,7 +329,7 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 				g.logger.InfoContext(ctx, "the 'path' attribute is REQUIRED for 'remove' operations", "op", op.Op)
 				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
 			}
-			newValues, ok := op.Value.(map[string]interface{})
+			newValues, ok := op.Value.(map[string]any)
 			if !ok {
 				g.logger.InfoContext(ctx, "unsupported patch value", "value", op.Value)
 				return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
@@ -340,19 +341,23 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case displayNameAttr:
 					err = g.patchDisplayName(ctx, op.Op, v, group)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case membersAttr:
 					err = g.patchMembers(ctx, op.Op, v, group)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				default:
-					g.logger.InfoContext(ctx, "unsupported patch value field", "field", k)
-					return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+					// Skip unrecognized fields rather than failing — a single unknown attribute
+					// must not abort the entire batch and discard valid updates like members.
+					g.logger.WarnContext(ctx, "unsupported patch value field", "field", k)
 				}
 			}
 		case op.Path.String() == externalIdAttr:
@@ -360,28 +365,33 @@ func (g *GroupHandler) Patch(r *http.Request, id string, operations []scim.Patch
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == displayNameAttr:
 			err = g.patchDisplayName(ctx, op.Op, op.Value, group)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == membersAttr:
 			err = g.patchMembers(ctx, op.Op, op.Value, group)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.AttributePath.String() == membersAttr:
 			err = g.patchMembersWithPathFiltering(ctx, op, group)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		default:
-			g.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-			return scim.Resource{}, errors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			// Skip unrecognized paths rather than failing — a single unknown attribute
+			// must not abort the entire batch and discard valid updates like members.
+			g.logger.WarnContext(ctx, "unsupported patch path", "path", op.Path)
 		}
 	}
 
-	if len(operations) != 0 {
+	if modified {
 		err = g.ds.ReplaceScimGroup(ctx, group)
 		switch {
 		case fleet.IsNotFound(err):

--- a/ee/server/scim/groups_test.go
+++ b/ee/server/scim/groups_test.go
@@ -1,0 +1,186 @@
+package scim
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/elimity-com/scim"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mock"
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"github.com/scim2/filter-parser/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestGroupHandler(ds *mock.Store) *GroupHandler {
+	return NewGroupHandler(ds, slog.New(slog.DiscardHandler)).(*GroupHandler)
+}
+
+func newTestScimGroup(id uint, displayName string, memberIDs []uint) *fleet.ScimGroup {
+	return &fleet.ScimGroup{
+		ID:          id,
+		DisplayName: displayName,
+		ScimUsers:   memberIDs,
+	}
+}
+
+// TestGroupHandlerPatchUnrecognizedAttributes tests that unrecognized attributes in a PATCH
+// request are skipped rather than causing the entire operation to fail.
+func TestGroupHandlerPatchUnrecognizedAttributes(t *testing.T) {
+	setupMocks := func(t *testing.T, group *fleet.ScimGroup) (*mock.Store, **fleet.ScimGroup) {
+		t.Helper()
+		ds := new(mock.Store)
+		ds.ScimGroupByIDFunc = func(ctx context.Context, id uint, excludeUsers bool) (*fleet.ScimGroup, error) {
+			return group, nil
+		}
+		var saved *fleet.ScimGroup
+		ds.ReplaceScimGroupFunc = func(ctx context.Context, g *fleet.ScimGroup) error {
+			saved = g
+			return nil
+		}
+		return ds, &saved
+	}
+
+	t.Run("members update succeeds when batched with an unrecognized path attribute", func(t *testing.T) {
+		// When Okta (or another IdP) sends a PATCH with multiple Operations, an unrecognized
+		// attribute path must not abort the batch. The member update must still be applied.
+		group := newTestScimGroup(1, "Engineering", []uint{})
+		ds, saved := setupMocks(t, group)
+		ds.ScimUsersExistFunc = func(ctx context.Context, ids []uint) (bool, error) {
+			return true, nil
+		}
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+
+		membersPath, err := filter.ParsePath([]byte(membersAttr))
+		require.NoError(t, err)
+		unknownPath, err := filter.ParsePath([]byte("unknownAttribute"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "group-1", []scim.PatchOperation{
+			// Unrecognized attribute comes first.
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "ignored"},
+			// Member addition must still be applied.
+			{Op: scim.PatchOperationAdd, Path: &membersPath, Value: []any{
+				map[string]any{"value": "1"},
+			}},
+		})
+		require.NoError(t, err)
+		require.True(t, ds.ReplaceScimGroupFuncInvoked)
+		require.NotNil(t, *saved)
+		assert.Equal(t, []uint{1}, (*saved).ScimUsers)
+	})
+
+	t.Run("displayName update succeeds when batched with an unrecognized no-path field", func(t *testing.T) {
+		// Same issue in the no-path handler: when op.Path is nil, the code iterates over the
+		// value map keys. An unrecognized key must be skipped, not abort the request.
+		group := newTestScimGroup(1, "OldName", []uint{})
+		ds, saved := setupMocks(t, group)
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+
+		_, err := handler.Patch(req, "group-1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					"unknownField":  "ignored",
+					displayNameAttr: "NewName",
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, ds.ReplaceScimGroupFuncInvoked)
+		require.NotNil(t, *saved)
+		assert.Equal(t, "NewName", (*saved).DisplayName)
+	})
+
+	t.Run("members update still fails correctly for truly invalid member data", func(t *testing.T) {
+		// Skipping unknown attributes must not suppress errors for genuinely bad data
+		// (e.g. a member reference pointing to a non-existent user).
+		group := newTestScimGroup(1, "Engineering", []uint{})
+		ds, _ := setupMocks(t, group)
+		ds.ScimUsersExistFunc = func(ctx context.Context, ids []uint) (bool, error) {
+			return false, nil
+		}
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+
+		membersPath, err := filter.ParsePath([]byte(membersAttr))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "group-1", []scim.PatchOperation{
+			{Op: scim.PatchOperationAdd, Path: &membersPath, Value: []any{
+				map[string]any{"value": "999"},
+			}},
+		})
+		require.Error(t, err)
+		assert.False(t, ds.ReplaceScimGroupFuncInvoked)
+	})
+
+	t.Run("group not found returns 404, not affected by the skip-unknown change", func(t *testing.T) {
+		ds := new(mock.Store)
+		ds.ScimGroupByIDFunc = func(ctx context.Context, id uint, excludeUsers bool) (*fleet.ScimGroup, error) {
+			return nil, platform_mysql.NotFound("ScimGroup")
+		}
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-999", nil)
+
+		unknownPath, err := filter.ParsePath([]byte("unknownAttribute"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "group-999", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "ignored"},
+		})
+		require.Error(t, err)
+		assert.False(t, ds.ReplaceScimGroupFuncInvoked)
+	})
+
+	t.Run("Patch with only unrecognized path attributes does not write to database", func(t *testing.T) {
+		// When all operations contain only unrecognized attributes, there is nothing to persist.
+		// ReplaceScimGroup must not be called to avoid an unnecessary DB round-trip.
+		group := newTestScimGroup(1, "Engineering", []uint{})
+		ds, _ := setupMocks(t, group)
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte("unknownAttribute"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "group-1", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "ignored"},
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "also ignored"},
+		})
+		require.NoError(t, err)
+		assert.False(t, ds.ReplaceScimGroupFuncInvoked)
+	})
+
+	t.Run("no-path Patch with only unrecognized value fields does not write to database", func(t *testing.T) {
+		// Same guard for the nil-path code path: if all keys in the value map are unrecognized,
+		// ReplaceScimGroup must not be called.
+		group := newTestScimGroup(1, "Engineering", []uint{})
+		ds, _ := setupMocks(t, group)
+
+		handler := newTestGroupHandler(ds)
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Groups/group-1", nil)
+
+		_, err := handler.Patch(req, "group-1", []scim.PatchOperation{
+			{
+				Op:    scim.PatchOperationReplace,
+				Path:  nil,
+				Value: map[string]any{"unknownField": "ignored"},
+			},
+		})
+		require.NoError(t, err)
+		assert.False(t, ds.ReplaceScimGroupFuncInvoked)
+	})
+}

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -1258,8 +1258,9 @@ func (u *UserHandler) patchName(ctx context.Context, v any, op scim.PatchOperati
 			}
 			user.FamilyName = &familyName
 		default:
-			u.logger.InfoContext(ctx, "unsupported patch value field", "field", nameAttr+"."+nameKey)
-			return scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			// Skip unrecognized name subattributes (e.g. formatted, middleName) rather than
+			// aborting — a single unknown subattribute must not discard the entire name update.
+			u.logger.WarnContext(ctx, "unsupported name subattribute", "field", nameAttr+"."+nameKey)
 		}
 	}
 	return nil

--- a/ee/server/scim/users.go
+++ b/ee/server/scim/users.go
@@ -667,6 +667,7 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 	// Store previous active state before applying patches
 	previousActive := user.Active
 
+	modified := false
 	for _, op := range operations {
 		if op.Op != scim.PatchOperationAdd && op.Op != scim.PatchOperationReplace && op.Op != scim.PatchOperationRemove {
 			u.logger.InfoContext(ctx, "unsupported patch operation", "op", op.Op)
@@ -691,44 +692,81 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case userNameAttr:
 					err = u.patchUserName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case activeAttr:
 					err = u.patchActive(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr + "." + givenNameAttr:
 					err = u.patchGivenName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr + "." + familyNameAttr:
 					err = u.patchFamilyName(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case nameAttr:
 					err = u.patchName(ctx, v, op, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case emailsAttr:
 					err = u.patchEmails(ctx, v, op, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
 				case extensionEnterpriseUserAttributes + ":" + departmentAttr:
 					err = u.patchDepartment(ctx, op.Op, v, user)
 					if err != nil {
 						return scim.Resource{}, err
 					}
+					modified = true
+				case extensionEnterpriseUserAttributes:
+					// Some SCIM clients send enterprise extension attributes as a nested map with
+					// the schema URN as the key, e.g. {"urn:...:User": {"department": "Sales"}}.
+					// Ex:
+					//   "urn:ietf:params:scim:schemas:extension:{{CompanyName}}:2.0:User": {
+					// 	   "{{CustomAttributeName}}": "CustomValue",
+					// 	   "anotherCustomField": "AnotherValue"
+					//   }
+					extMap, ok := v.(map[string]any)
+					if !ok {
+						u.logger.ErrorContext(ctx,
+							fmt.Sprintf("unexpected type for %s: %T", extensionEnterpriseUserAttributes, v),
+							userNameAttr, user.UserName,
+						)
+						return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{extensionEnterpriseUserAttributes})
+					}
+					for key, val := range extMap {
+						switch key {
+						case departmentAttr:
+							err = u.patchDepartment(ctx, op.Op, val, user)
+							if err != nil {
+								return scim.Resource{}, err
+							}
+							modified = true
+						default:
+							u.logger.WarnContext(ctx, "unsupported enterprise extension attribute", "attribute", key)
+						}
+					}
 				default:
-					u.logger.InfoContext(ctx, "unsupported patch value field", "field", k)
-					return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+					// Skip unrecognized fields rather than failing — a single unknown attribute
+					// must not abort the entire batch and discard valid updates like department.
+					u.logger.WarnContext(ctx, "unsupported patch value field", "field", k)
 				}
 			}
 		case op.Path.String() == externalIdAttr:
@@ -736,53 +774,63 @@ func (u *UserHandler) Patch(r *http.Request, id string, operations []scim.PatchO
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == userNameAttr:
 			err = u.patchUserName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == activeAttr:
 			err = u.patchActive(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr+"."+givenNameAttr:
 			err = u.patchGivenName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr+"."+familyNameAttr:
 			err = u.patchFamilyName(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == nameAttr:
 			err = u.patchName(ctx, op.Value, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.String() == emailsAttr:
 			err = u.patchEmails(ctx, op.Value, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.AttributePath.String() == emailsAttr:
 			err = u.patchEmailsWithPathFiltering(ctx, op, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		case op.Path.AttributePath.String() == extensionEnterpriseUserAttributes+":"+departmentAttr:
 			err = u.patchDepartment(ctx, op.Op, op.Value, user)
 			if err != nil {
 				return scim.Resource{}, err
 			}
+			modified = true
 		default:
-			u.logger.InfoContext(ctx, "unsupported patch path", "path", op.Path)
-			return scim.Resource{}, scimerrors.ScimErrorBadParams([]string{fmt.Sprintf("%v", op)})
+			// Skip unrecognized paths rather than failing — a single unknown attribute must not
+			// abort the entire batch and discard valid updates (e.g. department alongside groups).
+			u.logger.WarnContext(ctx, "unsupported patch path", "path", op.Path)
 		}
 	}
 
-	if len(operations) != 0 {
+	if modified {
 		err = u.ds.ReplaceScimUser(ctx, user)
 		switch {
 		case fleet.IsNotFound(err):

--- a/ee/server/scim/users_test.go
+++ b/ee/server/scim/users_test.go
@@ -1032,3 +1032,234 @@ func TestUserHandlerCreateReactivation(t *testing.T) {
 		assert.False(t, mocks.ds.CreateScimUserFuncInvoked)
 	})
 }
+
+// TestUserHandlerPatchDepartment tests that department PATCH operations from Okta are handled
+// correctly.
+func TestUserHandlerPatchDepartment(t *testing.T) {
+	const enterpriseExtURN = "urn:ietf:params:scim:schemas:extension:enterprise:2.0:User"
+
+	setupMocks := func(t *testing.T) (*testMocks, *fleet.ScimUser, **fleet.ScimUser) {
+		t.Helper()
+		mocks := newTestMocks()
+		existingUser := newTestScimUser(&scimUserOpts{active: new(true), givenName: "John", familyName: "Doe"})
+		mocks.ds.ScimUserByIDFunc = func(ctx context.Context, id uint) (*fleet.ScimUser, error) {
+			return existingUser, nil
+		}
+		var saved *fleet.ScimUser
+		mocks.ds.ReplaceScimUserFunc = func(ctx context.Context, user *fleet.ScimUser) error {
+			saved = user
+			return nil
+		}
+		return mocks, existingUser, &saved
+	}
+
+	// Test {"op":"replace","path":"urn:...:User:department","value":"Sales"}
+	t.Run("Patch with path (confirmed Okta format) updates department", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		deptPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":department"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &deptPath, Value: "Sales"},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Sales", *(*saved).Department)
+	})
+
+	t.Run("Patch with path (confirmed Okta format) removes department", func(t *testing.T) {
+		// Okta sends: {"op":"remove","path":"urn:...:User:department"}
+		mocks, existingUser, saved := setupMocks(t)
+		existingUser.Department = ptr.String("Sales")
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		deptPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":department"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationRemove, Path: &deptPath, Value: nil},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		assert.Nil(t, (*saved).Department)
+	})
+
+	t.Run("Patch with path updates department even when batched with unrecognized attributes", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		deptPath, err := filter.ParsePath([]byte(enterpriseExtURN + ":department"))
+		require.NoError(t, err)
+
+		unknownPath, err := filter.ParsePath([]byte("unknownAttribute"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			// An unrecognized attribute operation comes first (simulates groups or other attrs).
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "ignored"},
+			// The department update must still be applied.
+			{Op: scim.PatchOperationReplace, Path: &deptPath, Value: "Engineering"},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Engineering", *(*saved).Department)
+	})
+
+	t.Run("no-path Patch with nested enterprise extension map updates department", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN: map[string]any{"department": "Sales"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Sales", *(*saved).Department)
+	})
+
+	t.Run("no-path Patch with nested enterprise extension map also works for add operation", func(t *testing.T) {
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationAdd,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN: map[string]any{"department": "Sales"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Sales", *(*saved).Department)
+	})
+
+	t.Run("no-path Patch with nested enterprise extension rejects non-string department", func(t *testing.T) {
+		// The enterprise extension value is a recognized attribute, so a malformed value type
+		// must return a 400 error rather than being silently skipped.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN: map[string]any{"department": 42},
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("no-path Patch with nested enterprise extension rejects non-map extension value", func(t *testing.T) {
+		// If the extension URN maps to a non-map value (e.g. a plain string), it is a client
+		// error and must return 400 — not be silently skipped like an unknown attribute.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN: "not-a-map",
+				},
+			},
+		})
+		require.Error(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("no-path Patch with nested enterprise extension ignores unrecognized extension keys", func(t *testing.T) {
+		// Keys inside the enterprise extension map that Fleet doesn't support (e.g. manager,
+		// costCenter) must be silently skipped so that supported keys like department still apply.
+		mocks, _, saved := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					enterpriseExtURN: map[string]any{
+						"department": "Engineering",
+						"manager":    map[string]any{"value": "some-manager-id"},
+						"costCenter": "CC-001",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		require.True(t, mocks.ds.ReplaceScimUserFuncInvoked)
+		require.NotNil(t, *saved)
+		require.NotNil(t, (*saved).Department)
+		assert.Equal(t, "Engineering", *(*saved).Department)
+	})
+
+	t.Run("Patch with only unrecognized path attributes does not write to database", func(t *testing.T) {
+		// When all operations in a PATCH contain only unrecognized attributes, there is nothing
+		// to persist. ReplaceScimUser must not be called to avoid an unnecessary DB round-trip.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		unknownPath, err := filter.ParsePath([]byte("unknownAttribute"))
+		require.NoError(t, err)
+
+		_, err = handler.Patch(req, "1", []scim.PatchOperation{
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "ignored"},
+			{Op: scim.PatchOperationReplace, Path: &unknownPath, Value: "also ignored"},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+
+	t.Run("no-path Patch with only unrecognized value fields does not write to database", func(t *testing.T) {
+		// Same guard for the nil-path code path: if all keys in the value map are unrecognized,
+		// ReplaceScimUser must not be called.
+		mocks, _, _ := setupMocks(t)
+		handler := mocks.newTestHandler()
+		req := httptest.NewRequest(http.MethodPatch, "/scim/v2/Users/1", nil)
+
+		_, err := handler.Patch(req, "1", []scim.PatchOperation{
+			{
+				Op:   scim.PatchOperationReplace,
+				Path: nil,
+				Value: map[string]any{
+					"groups":        []any{map[string]any{"value": "grp1"}},
+					"unknownField2": "ignored",
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.False(t, mocks.ds.ReplaceScimUserFuncInvoked)
+	})
+}


### PR DESCRIPTION
**Related issue:** Resolves #41996 

# Checklist for submitter

* Fixed bug where batched PATCH operations abort on unrecognized attributes.
* Extended the parsing of the SCIM enterprise user extension (urn:ietf:params:scim:schemas:extension:enterprise:2.0:User) to allow for no-path PATCH format: `{"urn:...:User": {"department": "Sales"}}`

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SCIM batch PATCH operations that previously aborted when encountering unrecognized attributes. Operations now skip unrecognized attributes and continue processing recognized updates.

* **New Features**
  * Added support for updating the `department` attribute through the SCIM enterprise user extension via no-path PATCH format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->