### PR TITLE
OSV delta generation fix

### DIFF
--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -33,13 +33,28 @@ if [ -d "$REPO_DIR/.git" ]; then
     git fetch origin main
 
     NEW_SHA=$(git rev-parse origin/main)
+    git reset --hard origin/main
 
     echo ""
     if [ "$OLD_SHA" = "$NEW_SHA" ]; then
         echo "No new commits (already at $NEW_SHA)"
+
+        > "../changed_files_today.txt"
+        > "../changed_files_yesterday.txt"
     else
         echo "Updating: $OLD_SHA -> $NEW_SHA"
-        git reset --hard origin/main
+
+        # Use time-based approach to find files changed today and yesterday
+        TODAY_UTC=$(date -u +%Y-%m-%d)
+        YESTERDAY_UTC=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "yesterday" +%Y-%m-%d)
+
+        # Get files changed today (since midnight UTC today)
+        git log --since="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
+            | sed '/^$/d' | sort -u > "../changed_files_today.txt"
+
+        # Get files changed yesterday (from midnight yesterday to midnight today UTC)
+        git log --since="${YESTERDAY_UTC}T00:00:00Z" --until="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
+            | sed '/^$/d' | sort -u > "../changed_files_yesterday.txt"
     fi
 
     NEW_COUNT=$(git log --oneline | wc -l | xargs)
@@ -70,13 +85,14 @@ fi
 
 cd "$REPO_DIR"
 
-# Get files changed today (since midnight UTC today)
 TODAY_UTC=$(date -u +%Y-%m-%d)
+YESTERDAY_UTC=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "yesterday" +%Y-%m-%d)
+
+# Get files changed today (since midnight UTC today)
 git log --since="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
     | sed '/^$/d' | sort -u > "../changed_files_today.txt"
 
 # Get files changed yesterday (from midnight yesterday to midnight today UTC)
-YESTERDAY_UTC=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "yesterday" +%Y-%m-%d)
 git log --since="${YESTERDAY_UTC}T00:00:00Z" --until="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
     | sed '/^$/d' | sort -u > "../changed_files_yesterday.txt"
 

--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -38,23 +38,8 @@ if [ -d "$REPO_DIR/.git" ]; then
     echo ""
     if [ "$OLD_SHA" = "$NEW_SHA" ]; then
         echo "No new commits (already at $NEW_SHA)"
-
-        > "../changed_files_today.txt"
-        > "../changed_files_yesterday.txt"
     else
         echo "Updating: $OLD_SHA -> $NEW_SHA"
-
-        # Use time-based approach to find files changed today and yesterday
-        TODAY_UTC=$(date -u +%Y-%m-%d)
-        YESTERDAY_UTC=$(date -u -v-1d +%Y-%m-%d 2>/dev/null || date -u -d "yesterday" +%Y-%m-%d)
-
-        # Get files changed today (since midnight UTC today)
-        git log --since="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
-            | sed '/^$/d' | sort -u > "../changed_files_today.txt"
-
-        # Get files changed yesterday (from midnight yesterday to midnight today UTC)
-        git log --since="${YESTERDAY_UTC}T00:00:00Z" --until="${TODAY_UTC}T00:00:00Z" --name-only --pretty="" -- osv/cve \
-            | sed '/^$/d' | sort -u > "../changed_files_yesterday.txt"
     fi
 
     NEW_COUNT=$(git log --oneline | wc -l | xargs)


### PR DESCRIPTION
**Related issue:** Resolves #41571

Changing the way delta artifacts are generated.
`changed_files_today.txt` and `changed_files_yesterday.txt` will always look back into git history for any commits added yesterday and today. 

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved repository synchronization to ensure local state accurately reflects the remote main branch.
  * Enhanced file change detection logic for more reliable identification of modified files.
  * Refined output file handling to maintain consistency across synchronization cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->