### PR TITLE
ACME: implement get authorization endpoint

### DIFF
--- a/server/mdm/acme/api/authorization.go
+++ b/server/mdm/acme/api/authorization.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+)
+
+type AuthorizationService interface {
+	GetAuthorization(ctx context.Context, enrollment *types.Enrollment, account *types.Account, authorizationID uint) (*types.AuthorizationResponse, error)
+}

--- a/server/mdm/acme/api/authorization.go
+++ b/server/mdm/acme/api/authorization.go
@@ -6,6 +6,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 )
 
+// AuthorizationService does not handle normal authentication, but the ACME concept of authorization as part of the protocol.
 type AuthorizationService interface {
 	GetAuthorization(ctx context.Context, enrollment *types.Enrollment, account *types.Account, authorizationID uint) (*types.AuthorizationResponse, error)
 }

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -203,11 +203,10 @@ type JWSRequestContainer struct {
 	JWS          jose.JSONWebSignature
 	JWSHeaderURL string
 
-	Key             *jose.JSONWebKey
-	KeyID           *string
-	Identifier      string `url:"identifier"`
-	AuthorizationID uint   `url:"authorization,optional"`
-	HTTPPath        string `url:"http_path"`
+	Key        *jose.JSONWebKey
+	KeyID      *string
+	Identifier string `url:"identifier"`
+	HTTPPath   string `url:"http_path"`
 }
 
 func (req *JWSRequestContainer) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -160,6 +160,36 @@ func (r *CreateNewOrderResponse) Error() error { return r.Err }
 // Status implements the statuser interface.
 func (r *CreateNewOrderResponse) Status() int { return http.StatusCreated }
 
+type GetAuthorizationRequest struct {
+	types.AccountAuthenticatedRequestBase
+	AuthorizationID uint
+}
+
+type GetAuthorizationResponse struct {
+	*types.AuthorizationResponse
+	Err    error                                `json:"error,omitempty"`
+	Nonces *redis_nonces_store.RedisNoncesStore `json:"-"`
+}
+
+func (r *GetAuthorizationResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
+	// only generate a new nonce if there is no error
+	if r.Err != nil {
+		var acmeErr *types.ACMEError
+		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
+			return
+		}
+	}
+	if err := generateAndRenderNonce(ctx, r.Nonces, w); err != nil {
+		r.Err = err
+		return
+	}
+	if r.AuthorizationResponse != nil && r.AuthorizationResponse.Location != "" {
+		w.Header().Set("Location", r.AuthorizationResponse.Location)
+	}
+}
+
+func (r GetAuthorizationResponse) Error() error { return r.Err }
+
 // JWS Request container is a container for doing basic decoding and validation operations common to all
 // authenticated ACME requests, which come in the form of a JWS in flattened serialization syntax. This is
 // parsed into a jose.JSONWebSignature with some basic validation done on it and then the downstream
@@ -168,10 +198,11 @@ type JWSRequestContainer struct {
 	JWS          jose.JSONWebSignature
 	JWSHeaderURL string
 
-	Key        *jose.JSONWebKey
-	KeyID      *string
-	Identifier string `url:"identifier"`
-	HTTPPath   string `url:"http_path"`
+	Key             *jose.JSONWebKey
+	KeyID           *string
+	Identifier      string `url:"identifier"`
+	AuthorizationID uint   `url:"authorization,optional"`
+	HTTPPath        string `url:"http_path"`
 }
 
 func (req *JWSRequestContainer) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -161,8 +161,13 @@ func (r *CreateNewOrderResponse) Error() error { return r.Err }
 func (r *CreateNewOrderResponse) Status() int { return http.StatusCreated }
 
 type GetAuthorizationRequest struct {
+	JWSRequestContainer
+	AuthorizationID uint `url:"authorization"`
+}
+
+type GetAuthorizationDecodedRequest struct {
 	types.AccountAuthenticatedRequestBase
-	AuthorizationID uint
+	AuthorizationID uint `json:"-"`
 }
 
 type GetAuthorizationResponse struct {

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -10,5 +10,6 @@ type Service interface {
 	DirectoryNonceService
 	AccountService
 	EnrollmentService
+	AuthorizationService
 	NoncesStore() *redis_nonces_store.RedisNoncesStore
 }

--- a/server/mdm/acme/internal/mysql/account_order_test.go
+++ b/server/mdm/acme/internal/mysql/account_order_test.go
@@ -289,7 +289,7 @@ func testCreateNewOrder(t *testing.T, env *testEnv) {
 		Status:     "pending",
 	}
 	challenge := &types.Challenge{
-		ChallengeType: "device-attest-01",
+		ChallengeType: types.DeviceAttestationChallengeType,
 		Token:         "test-token-123",
 		Status:        "pending",
 	}
@@ -322,7 +322,7 @@ func testOrderCreationLimit(t *testing.T, env *testEnv) {
 			Status:     "pending",
 		}
 		challenge := &types.Challenge{
-			ChallengeType: "device-attest-01",
+			ChallengeType: types.DeviceAttestationChallengeType,
 			Token:         "test-token",
 			Status:        "pending",
 		}
@@ -343,7 +343,7 @@ func testOrderCreationLimit(t *testing.T, env *testEnv) {
 		Status:     "pending",
 	}
 	challenge := &types.Challenge{
-		ChallengeType: "device-attest-01",
+		ChallengeType: types.DeviceAttestationChallengeType,
 		Token:         "test-token",
 		Status:        "pending",
 	}
@@ -368,7 +368,7 @@ func testInvalidAccountID(t *testing.T, env *testEnv) {
 		Status:     "pending",
 	}
 	challenge := &types.Challenge{
-		ChallengeType: "device-attest-01",
+		ChallengeType: types.DeviceAttestationChallengeType,
 		Token:         "test-token",
 		Status:        "pending",
 	}
@@ -396,7 +396,7 @@ func testMultipleOrdersDifferentAccounts(t *testing.T, env *testEnv) {
 			Status:     "pending",
 		}
 		challenge := &types.Challenge{
-			ChallengeType: "device-attest-01",
+			ChallengeType: types.DeviceAttestationChallengeType,
 			Token:         "test-token",
 			Status:        "pending",
 		}
@@ -417,7 +417,7 @@ func testMultipleOrdersDifferentAccounts(t *testing.T, env *testEnv) {
 		Status:     "pending",
 	}
 	challenge := &types.Challenge{
-		ChallengeType: "device-attest-01",
+		ChallengeType: types.DeviceAttestationChallengeType,
 		Token:         "test-token-2",
 		Status:        "pending",
 	}

--- a/server/mdm/acme/internal/mysql/authorization.go
+++ b/server/mdm/acme/internal/mysql/authorization.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"github.com/jmoiron/sqlx"
@@ -30,8 +31,7 @@ func (ds *Datastore) GetAuthorizationByID(ctx context.Context, accountID uint, a
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &dbAuthz, query, authorizationID, accountID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			// TODO: What should we return here to avoid authorization enumeration and not leak details?
-			return nil, types.UnauthorizedError("")
+			return nil, types.AuthorizationDoesNotExistError(fmt.Sprintf("ACME authorization with ID %d not found for account ID %d", authorizationID, accountID))
 		}
 		return nil, err
 	}

--- a/server/mdm/acme/internal/mysql/authorization.go
+++ b/server/mdm/acme/internal/mysql/authorization.go
@@ -1,0 +1,48 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+func (ds *Datastore) GetAuthorizationByID(ctx context.Context, accountID uint, authorizationID uint) (*types.Authorization, error) {
+	if accountID == 0 {
+		return nil, types.MalformedError("invalid account ID")
+	}
+	if authorizationID == 0 {
+		return nil, types.MalformedError("invalid authorization ID")
+	}
+
+	var dbAuthz struct {
+		types.Authorization
+		IdentifierType  string `db:"identifier_type"`
+		IdentifierValue string `db:"identifier_value"`
+	}
+
+	const query = `SELECT a.id, a.acme_order_id, a.identifier_type, a.identifier_value, a.status FROM acme_authorizations a
+	INNER JOIN acme_orders o ON a.acme_order_id = o.id
+	INNER JOIN acme_accounts ac ON o.acme_account_id = ac.id
+	WHERE a.id = ? AND ac.id = ?`
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &dbAuthz, query, authorizationID, accountID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			// TODO: What should we return here to avoid authorization enumeration and not leak details?
+			return nil, types.UnauthorizedError("")
+		}
+		return nil, err
+	}
+
+	return &types.Authorization{
+		ID:      dbAuthz.ID,
+		OrderID: dbAuthz.OrderID,
+		Identifier: types.Identifier{
+			Type:  dbAuthz.IdentifierType,
+			Value: dbAuthz.IdentifierValue,
+		},
+		Status: dbAuthz.Status,
+	}, nil
+}

--- a/server/mdm/acme/internal/mysql/authorization.go
+++ b/server/mdm/acme/internal/mysql/authorization.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+// This file does not handle normal authentication, but the ACME concept of authorization as part of the protocol.
+
 func (ds *Datastore) GetAuthorizationByID(ctx context.Context, accountID uint, authorizationID uint) (*types.Authorization, error) {
 	if accountID == 0 {
 		return nil, types.MalformedError("invalid account ID")

--- a/server/mdm/acme/internal/mysql/authorization_test.go
+++ b/server/mdm/acme/internal/mysql/authorization_test.go
@@ -51,7 +51,7 @@ func testGetAuthorizationWithInvalidID(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), account.ID, 9999) // non-existent ID
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist")
+	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, authResp)
 }
 
@@ -62,7 +62,7 @@ func testGetAuthorizationWithInvalidAccountID(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), 9999, authorization.ID) // non-existent account ID
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist")
+	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, authResp)
 }
 
@@ -70,12 +70,12 @@ func testGetAuthorizationWithInvalidInputs(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), 0, 0) // zero account ID
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "malformed")
+	require.Contains(t, acmeErr.Type, "malformed") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, authResp)
 
 	authResp, err = env.ds.GetAuthorizationByID(t.Context(), 1, 0) // zero authorization ID
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "malformed")
+	require.Contains(t, acmeErr.Type, "malformed") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, authResp)
 }
 

--- a/server/mdm/acme/internal/mysql/authorization_test.go
+++ b/server/mdm/acme/internal/mysql/authorization_test.go
@@ -51,7 +51,7 @@ func testGetAuthorizationWithInvalidID(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), account.ID, 9999) // non-existent ID
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "unauthorized")
+	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist")
 	require.Nil(t, authResp)
 }
 
@@ -62,7 +62,7 @@ func testGetAuthorizationWithInvalidAccountID(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), 9999, authorization.ID) // non-existent account ID
 	var acmeErr *types.ACMEError
 	require.ErrorAs(t, err, &acmeErr)
-	require.Contains(t, acmeErr.Type, "unauthorized")
+	require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist")
 	require.Nil(t, authResp)
 }
 

--- a/server/mdm/acme/internal/mysql/authorization_test.go
+++ b/server/mdm/acme/internal/mysql/authorization_test.go
@@ -1,0 +1,104 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/testutils"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestACMEAuthorization(t *testing.T) {
+	tdb := testutils.SetupTestDB(t, "acme_authorization")
+	ds := NewDatastore(tdb.Conns(), tdb.Logger)
+	env := &testEnv{TestDB: tdb, ds: ds}
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, env *testEnv)
+	}{
+		{"GetValidAuthorization", testGetValidAuthorization},
+		{"GetAuthorizationWithInvalidID", testGetAuthorizationWithInvalidID},
+		{"GetAuthorizationWithInvalidAccountID", testGetAuthorizationWithInvalidAccountID},
+		{"GetAuthorizationWithInvalidInputs", testGetAuthorizationWithInvalidInputs},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer env.TruncateTables(t)
+			c.fn(t, env)
+		})
+	}
+}
+
+func testGetValidAuthorization(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	order, authorization, _ := createTestOrderForAccount(t, account, env)
+
+	authResp, err := env.ds.GetAuthorizationByID(t.Context(), account.ID, authorization.ID)
+	require.NoError(t, err)
+	require.NotNil(t, authResp)
+	require.Equal(t, "pending", authResp.Status)
+	require.Equal(t, "permanent-identifier", authResp.Identifier.Type)
+	require.Equal(t, "serial-123", authResp.Identifier.Value)
+	require.Equal(t, order.ID, authResp.OrderID)
+	require.Equal(t, authorization.ID, authResp.ID)
+}
+
+func testGetAuthorizationWithInvalidID(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+
+	authResp, err := env.ds.GetAuthorizationByID(t.Context(), account.ID, 9999) // non-existent ID
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "unauthorized")
+	require.Nil(t, authResp)
+}
+
+func testGetAuthorizationWithInvalidAccountID(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, authorization, _ := createTestOrderForAccount(t, account, env)
+
+	authResp, err := env.ds.GetAuthorizationByID(t.Context(), 9999, authorization.ID) // non-existent account ID
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "unauthorized")
+	require.Nil(t, authResp)
+}
+
+func testGetAuthorizationWithInvalidInputs(t *testing.T, env *testEnv) {
+	authResp, err := env.ds.GetAuthorizationByID(t.Context(), 0, 0) // zero account ID
+	var acmeErr *types.ACMEError
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "malformed")
+	require.Nil(t, authResp)
+
+	authResp, err = env.ds.GetAuthorizationByID(t.Context(), 1, 0) // zero authorization ID
+	require.ErrorAs(t, err, &acmeErr)
+	require.Contains(t, acmeErr.Type, "malformed")
+	require.Nil(t, authResp)
+}
+
+func createTestOrderForAccount(t *testing.T, account *types.Account, env *testEnv) (*types.Order, *types.Authorization, *types.Challenge) {
+	order := &types.Order{
+		ACMEAccountID: account.ID,
+		Status:        "pending",
+		Identifiers: []types.Identifier{
+			{Type: types.IdentifierTypePermanentIdentifier, Value: "serial-123"},
+		},
+	}
+	authorization := &types.Authorization{
+		Identifier: types.Identifier{Type: types.IdentifierTypePermanentIdentifier, Value: "serial-123"},
+		Status:     "pending",
+	}
+	challenge := &types.Challenge{
+		ChallengeType: types.DeviceAttestationChallengeType,
+		Token:         "test-token-123",
+		Status:        "pending",
+	}
+
+	result, err := env.ds.CreateOrder(t.Context(), order, authorization, challenge)
+	require.NoError(t, err)
+
+	return result, authorization, challenge
+}

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -1,0 +1,33 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+func (ds *Datastore) GetChallengesByAuthorizationID(ctx context.Context, authorizationID uint) ([]*types.Challenge, error) {
+	if authorizationID == 0 {
+		return nil, types.MalformedError("invalid authorization ID")
+	}
+
+	// TODO: Should we get validated from here, via the updated_at if status=valid?
+	const query = `SELECT id, acme_authorization_id, challenge_type, status, token FROM acme_challenges WHERE acme_authorization_id = ?`
+
+	var challenges []*types.Challenge
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &challenges, query, authorizationID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting challenges by authorization ID")
+	}
+	// TODO: What if we have no rows? That shouldn't happen since we validated the authorization, so probably fine to return service error
+	if len(challenges) == 0 {
+		return nil, ctxerr.New(ctx, "no challenges found for authorization ID")
+	}
+
+	fmt.Printf("%#v\n", challenges)
+
+	return challenges, nil
+}

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -22,12 +22,9 @@ func (ds *Datastore) GetChallengesByAuthorizationID(ctx context.Context, authori
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting challenges by authorization ID")
 	}
-	// TODO: What if we have no rows? That shouldn't happen since we validated the authorization, so probably fine to return service error
 	if len(challenges) == 0 {
-		return nil, ctxerr.New(ctx, "no challenges found for authorization ID")
+		return nil, types.ChallengeDoesNotExistError(fmt.Sprintf("No challenges found for authorization ID %d", authorizationID))
 	}
-
-	fmt.Printf("%#v\n", challenges)
 
 	return challenges, nil
 }

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -1,0 +1,55 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/testutils"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestACMEChallenge(t *testing.T) {
+	tdb := testutils.SetupTestDB(t, "acme_challenge")
+	ds := NewDatastore(tdb.Conns(), tdb.Logger)
+	env := &testEnv{TestDB: tdb, ds: ds}
+
+	cases := []struct {
+		name string
+		fn   func(t *testing.T, env *testEnv)
+	}{
+		{"GetValidChallengesForAuthorization", testGetValidChallengesForAuthorization},
+		{"GetChallengesWithInvalidAuthorizationID", testGetChallengesWithInvalidAuthorizationID},
+		{"GetChallengesWithZeroAuthorizationID", testGetChallengesWithZeroAuthorizationID},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			defer env.TruncateTables(t)
+			c.fn(t, env)
+		})
+	}
+}
+
+func testGetValidChallengesForAuthorization(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, authorization, _ := createTestOrderForAccount(t, account, env)
+
+	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), authorization.ID)
+	require.NoError(t, err)
+	require.Len(t, challenges, 1)
+	require.Equal(t, "pending", challenges[0].Status)
+	require.Equal(t, types.DeviceAttestationChallengeType, challenges[0].ChallengeType)
+	require.Equal(t, authorization.ID, challenges[0].ACMEAuthorizationID)
+}
+
+func testGetChallengesWithInvalidAuthorizationID(t *testing.T, env *testEnv) {
+	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 999999) // non-existent ID
+	require.Error(t, err)
+	require.Nil(t, challenges)
+}
+
+func testGetChallengesWithZeroAuthorizationID(t *testing.T, env *testEnv) {
+	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 0)
+	require.Error(t, err)
+	require.Nil(t, challenges)
+}

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -18,6 +18,7 @@ func TestACMEChallenge(t *testing.T) {
 		fn   func(t *testing.T, env *testEnv)
 	}{
 		{"GetValidChallengesForAuthorization", testGetValidChallengesForAuthorization},
+		{"NoChallengesForAuthorization", testGetChallengesWithNoChallengesForAuthorization},
 		{"GetChallengesWithInvalidAuthorizationID", testGetChallengesWithInvalidAuthorizationID},
 		{"GetChallengesWithZeroAuthorizationID", testGetChallengesWithZeroAuthorizationID},
 	}
@@ -42,14 +43,33 @@ func testGetValidChallengesForAuthorization(t *testing.T, env *testEnv) {
 	require.Equal(t, authorization.ID, challenges[0].ACMEAuthorizationID)
 }
 
+func testGetChallengesWithNoChallengesForAuthorization(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, authorization, _ := createTestOrderForAccount(t, account, env)
+
+	// Delete the challenge to simulate no challenges for the authorization
+	_, err := env.TestDB.DB.ExecContext(t.Context(), "DELETE FROM acme_challenges WHERE acme_authorization_id = ?", authorization.ID)
+	require.NoError(t, err)
+
+	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), authorization.ID)
+	var acmeError *types.ACMEError
+	require.ErrorAs(t, err, &acmeError)
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist")
+	require.Nil(t, challenges)
+}
+
 func testGetChallengesWithInvalidAuthorizationID(t *testing.T, env *testEnv) {
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 999999) // non-existent ID
-	require.Error(t, err)
+	var acmeError *types.ACMEError
+	require.ErrorAs(t, err, &acmeError)
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist")
 	require.Nil(t, challenges)
 }
 
 func testGetChallengesWithZeroAuthorizationID(t *testing.T, env *testEnv) {
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 0)
-	require.Error(t, err)
+	var acmeError *types.ACMEError
+	require.ErrorAs(t, err, &acmeError)
+	require.Contains(t, acmeError.Type, "malformed")
 	require.Nil(t, challenges)
 }

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -54,7 +54,7 @@ func testGetChallengesWithNoChallengesForAuthorization(t *testing.T, env *testEn
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), authorization.ID)
 	var acmeError *types.ACMEError
 	require.ErrorAs(t, err, &acmeError)
-	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist")
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, challenges)
 }
 
@@ -62,7 +62,7 @@ func testGetChallengesWithInvalidAuthorizationID(t *testing.T, env *testEnv) {
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 999999) // non-existent ID
 	var acmeError *types.ACMEError
 	require.ErrorAs(t, err, &acmeError)
-	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist")
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, challenges)
 }
 
@@ -70,6 +70,6 @@ func testGetChallengesWithZeroAuthorizationID(t *testing.T, env *testEnv) {
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), 0)
 	var acmeError *types.ACMEError
 	require.ErrorAs(t, err, &acmeError)
-	require.Contains(t, acmeError.Type, "malformed")
+	require.Contains(t, acmeError.Type, "malformed") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, challenges)
 }

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -77,7 +77,7 @@ func (s *Service) CreateOrder(ctx context.Context, enrollment *types.Enrollment,
 		Status:     "pending", // always pending at creation
 	}
 	challenge := &types.Challenge{
-		ChallengeType: "device-attest-01", // only supported challenge for now
+		ChallengeType: types.DeviceAttestationChallengeType, // only supported challenge for now
 		Token:         types.CreateNonceEncodedForHeader(),
 		Status:        "pending", // always pending at creation
 	}

--- a/server/mdm/acme/internal/service/auth.go
+++ b/server/mdm/acme/internal/service/auth.go
@@ -124,10 +124,14 @@ func (s *Service) commonAuthenticateMessage(ctx context.Context, message *api_ht
 	if otherRequest != nil {
 		requestPayload = otherRequest
 	}
-	err = json.Unmarshal(payload, requestPayload)
-	if err != nil {
-		err = types.MalformedError(fmt.Sprintf("Failed to unmarshal JWS payload: %v", err))
-		return ctxerr.Wrap(ctx, err)
+	// From the RFC, for a POST-as-GET request, the payload is an empty JSON string,
+	// which would fail to unmarshal into an object, so we check it explicitly.
+	if string(payload) != `` {
+		err = json.Unmarshal(payload, requestPayload)
+		if err != nil {
+			err = types.MalformedError(fmt.Sprintf("Failed to unmarshal JWS payload: %v", err))
+			return ctxerr.Wrap(ctx, err)
+		}
 	}
 
 	if createNewAccount != nil {

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+)
+
+func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enrollment, account *types.Account, authorizationID uint) (*types.AuthorizationResponse, error) {
+	if account == nil {
+		return nil, types.UnauthorizedError("account information missing from context")
+	}
+
+	if enrollment == nil {
+		return nil, types.UnauthorizedError("enrollment information missing from context")
+	}
+
+	if authorizationID == 0 {
+		return nil, types.MalformedError("invalid authorization ID")
+	}
+
+	authz, err := s.store.GetAuthorizationByID(ctx, account.ID, authorizationID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting authorization by ID")
+	}
+
+	// TODO: Should we check the auth status here? Or will that happen when we validate a challenge for an auth?
+
+	challenges, err := s.store.GetChallengesByAuthorizationID(ctx, authz.ID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting challenges by authorization ID")
+	}
+
+	baseURL, err := s.getACMEBaseURL(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting base URL")
+	}
+
+	var challengeResponses []types.ChallengeResponse
+	for _, c := range challenges {
+		challengeURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "challenges", fmt.Sprint(c.ID))
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "constructing challenge URL")
+		}
+
+		challengeResponses = append(challengeResponses, types.ChallengeResponse{
+			ChallengeType: c.ChallengeType,
+			Status:        c.Status,
+			Token:         c.Token,
+			URL:           challengeURL,
+		})
+	}
+
+	authzURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "authorizations", fmt.Sprint(authz.ID))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "constructing authorization URL")
+	}
+
+	return &types.AuthorizationResponse{
+		Status:     authz.Status,
+		Expires:    enrollment.NotValidAfter,
+		Identifier: authz.Identifier,
+		Challenges: challengeResponses,
+		Location:   authzURL,
+	}, nil
+}

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -8,6 +8,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 )
 
+// This file does not handle normal authentication, but the ACME concept of authorization as part of the protocol.
+
 func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enrollment, account *types.Account, authorizationID uint) (*types.AuthorizationResponse, error) {
 	if authorizationID == 0 {
 		return nil, types.MalformedError("invalid authorization ID")

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -9,14 +9,6 @@ import (
 )
 
 func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enrollment, account *types.Account, authorizationID uint) (*types.AuthorizationResponse, error) {
-	if account == nil {
-		return nil, types.UnauthorizedError("account information missing from context")
-	}
-
-	if enrollment == nil {
-		return nil, types.UnauthorizedError("enrollment information missing from context")
-	}
-
 	if authorizationID == 0 {
 		return nil, types.MalformedError("invalid authorization ID")
 	}

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -36,7 +35,6 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
-		fmt.Println(err)
 		// if it's not already an ACME error, it is because it is an internal server
 		// error (or a dev error, for 4xx we should always return ACMEError).
 		acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -35,6 +36,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
+		fmt.Println(err)
 		// if it's not already an ACME error, it is because it is an internal server
 		// error (or a dev error, for 4xx we should always return ACMEError).
 		acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -35,6 +35,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
+		// TODO: If we can get access to a logger, we can log the details here, to help troubleshoot service errors.
 		// if it's not already an ACME error, it is because it is an internal server
 		// error (or a dev error, for 4xx we should always return ACMEError).
 		acmeErr = types.InternalServerError("") // not passing err.Error() as we don't want to leak internal details

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -46,7 +46,7 @@ func attachFleetAPIRoutes(r *mux.Router, svc api.Service, opts []kithttp.ServerO
 	ae.POST("/api/mdm/acme/{identifier}/new_account", createAccountEndpoint, api_http.JWSRequestContainer{})
 	ae.POST("/api/mdm/acme/{identifier}/new_order", createOrderEndpoint, api_http.JWSRequestContainer{})
 
-	ae.POST("/api/mdm/acme/{identifier}/authorizations/{authorization}", getAuthorizationEndpoint, api_http.JWSRequestContainer{})
+	ae.POST("/api/mdm/acme/{identifier}/authorizations/{authorization}", getAuthorizationEndpoint, api_http.GetAuthorizationRequest{})
 	ae.POST("/api/mdm/acme/{identifier}/challenges/{challenge}", getChallengeEndpoint, api_http.JWSRequestContainer{})
 }
 
@@ -129,7 +129,7 @@ func createOrderEndpoint(ctx context.Context, request any, svc api.Service) plat
 
 // getAuthorizationEndpoint handles POST /api/mdm/acme/{identifier}/authz/{authorization} requests.
 func getAuthorizationEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
-	req := request.(*api_http.JWSRequestContainer)
+	req := request.(*api_http.GetAuthorizationRequest)
 
 	// TODO: Uncomment once test changes with "" has been made
 	/* payload := req.JWS.UnsafePayloadWithoutVerification()
@@ -140,8 +140,8 @@ func getAuthorizationEndpoint(ctx context.Context, request any, svc api.Service)
 			Nonces: svc.NoncesStore(),
 		}
 	} */
-	authzReq := &api_http.GetAuthorizationRequest{AuthorizationID: req.AuthorizationID}
-	err := svc.AuthenticateMessageFromAccount(ctx, req, authzReq)
+	authzReq := &api_http.GetAuthorizationDecodedRequest{AuthorizationID: req.AuthorizationID}
+	err := svc.AuthenticateMessageFromAccount(ctx, &req.JWSRequestContainer, authzReq)
 	if err != nil {
 		return &api_http.GetAuthorizationResponse{Err: err, Nonces: svc.NoncesStore()}
 	}

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -45,6 +45,9 @@ func attachFleetAPIRoutes(r *mux.Router, svc api.Service, opts []kithttp.ServerO
 
 	ae.POST("/api/mdm/acme/{identifier}/new_account", createAccountEndpoint, api_http.JWSRequestContainer{})
 	ae.POST("/api/mdm/acme/{identifier}/new_order", createOrderEndpoint, api_http.JWSRequestContainer{})
+
+	ae.POST("/api/mdm/acme/{identifier}/authorizations/{authorization}", getAuthorizationEndpoint, api_http.JWSRequestContainer{})
+	ae.POST("/api/mdm/acme/{identifier}/challenges/{challenge}", getChallengeEndpoint, api_http.JWSRequestContainer{})
 }
 
 func skipStandardFleetAuth() endpoint.Middleware {
@@ -122,4 +125,38 @@ func createOrderEndpoint(ctx context.Context, request any, svc api.Service) plat
 		Nonces:        svc.NoncesStore(),
 		OrderResponse: orderResp,
 	}
+}
+
+// getAuthorizationEndpoint handles POST /api/mdm/acme/{identifier}/authz/{authorization} requests.
+func getAuthorizationEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
+	req := request.(*api_http.JWSRequestContainer)
+
+	// TODO: Uncomment once test changes with "" has been made
+	/* payload := req.JWS.UnsafePayloadWithoutVerification()
+	isPostAsGet := string(payload) == "" // POST-as-GET requests MUST have an empty payload
+	if !isPostAsGet {
+		return &api_http.GetAuthorizationResponse{
+			Err:    types.MalformedError("Payload was not empty for POST-as-GET request to authorization endpoint"),
+			Nonces: svc.NoncesStore(),
+		}
+	} */
+	authzReq := &api_http.GetAuthorizationRequest{AuthorizationID: req.AuthorizationID}
+	err := svc.AuthenticateMessageFromAccount(ctx, req, authzReq)
+	if err != nil {
+		return &api_http.GetAuthorizationResponse{Err: err, Nonces: svc.NoncesStore()}
+	}
+
+	authzResp, err := svc.GetAuthorization(ctx, authzReq.Enrollment, authzReq.Account, authzReq.AuthorizationID)
+	if err != nil {
+		return &api_http.GetAuthorizationResponse{Err: err, Nonces: svc.NoncesStore()}
+	}
+
+	return &api_http.GetAuthorizationResponse{
+		AuthorizationResponse: authzResp,
+		Nonces:                svc.NoncesStore(),
+	}
+}
+
+func getChallengeEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
+	panic("not implemented")
 }

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -27,6 +27,7 @@ func TestIntegration(t *testing.T) {
 		{"GetDirectory", testGetDirectory},
 		{"CreateAccount", testCreateAccount},
 		{"CreateOrder", testCreateOrder},
+		{"GetAuthorization", testGetAuthorization},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -797,5 +798,74 @@ func testCreateOrder(t *testing.T, s *integrationTestSuite) {
 		require.Contains(t, acmeErr.Type, "badNonce")
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 		require.Empty(t, resp.Header.Get("Location"))
+	})
+}
+
+func testGetAuthorization(t *testing.T, s *integrationTestSuite) {
+	enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+	s.InsertACMEEnrollment(t, enroll)
+	payload := map[string]any{
+		"identifiers": []map[string]string{
+			{"type": "permanent-identifier", "value": enroll.HostIdentifier},
+		},
+	}
+	privateKey, accountURL, nonce := s.createAccountForOrder(t, enroll)
+	jwsBody := buildJWS(t, privateKey, nonce, accountURL, s.newOrderURL(enroll.PathIdentifier), payload)
+	orderResp, acmeErr, resp := s.createOrder(t, enroll.PathIdentifier, jwsBody)
+	require.Nil(t, acmeErr)
+	require.NotNil(t, orderResp)
+	require.Len(t, orderResp.Authorizations, 1) // We only expect one authorization for any given order
+	nextNonce := resp.Header.Get("Replay-Nonce")
+
+	t.Run("successful authorization retrieval", func(t *testing.T) {
+		authURL := orderResp.Authorizations[0]
+		jws := buildJWS(t, privateKey, nextNonce, accountURL, authURL, nil)
+		authResp, acmeErr, _ := s.getAuthorization(t, authURL, jws)
+		require.Nil(t, acmeErr)
+		require.NotNil(t, authResp)
+		require.Equal(t, "pending", authResp.Status)
+		require.Equal(t, "permanent-identifier", authResp.Identifier.Type)
+		require.Equal(t, enroll.HostIdentifier, authResp.Identifier.Value)
+		require.Len(t, authResp.Challenges, 1)
+		require.Regexp(t, "/api/mdm/acme/"+enroll.PathIdentifier+`/challenges/\d+`, authResp.Challenges[0].URL)
+		require.Equal(t, types.DeviceAttestationChallengeType, authResp.Challenges[0].ChallengeType)
+	})
+
+	t.Run("valid auth but for a different enrollment", func(t *testing.T) {
+		// create a second enrollment and order to get a different auth URL
+		enroll2 := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll2)
+		privateKey2, accountURL2, nonce2 := s.createAccountForOrder(t, enroll2)
+		payload2 := map[string]any{
+			"identifiers": []map[string]string{
+				{"type": "permanent-identifier", "value": enroll2.HostIdentifier},
+			},
+		}
+		jwsBody2 := buildJWS(t, privateKey2, nonce2, accountURL2, s.newOrderURL(enroll2.PathIdentifier), payload2)
+		orderResp2, acmeErr2, resp2 := s.createOrder(t, enroll2.PathIdentifier, jwsBody2)
+		require.Nil(t, acmeErr2)
+		require.NotNil(t, orderResp2)
+		require.Len(t, orderResp2.Authorizations, 1)
+		authURL2 := orderResp2.Authorizations[0]
+		nextNonce2 := resp2.Header.Get("Replay-Nonce")
+
+		// try to use the auth URL from enroll2's order with enroll1's account/key
+		jws := buildJWS(t, privateKey, nextNonce2, accountURL, authURL2, nil)
+		authResp, acmeErr, resp := s.getAuthorization(t, authURL2, jws)
+		nextNonce = resp.Header.Get("Replay-Nonce")
+
+		require.Nil(t, authResp)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "unauthorized")
+	})
+
+	t.Run("non existing auth", func(t *testing.T) {
+		authURL := s.server.URL + "/api/mdm/acme/" + enroll.PathIdentifier + "/authorizations/99999"
+		jws := buildJWS(t, privateKey, nextNonce, accountURL, authURL, nil)
+		authResp, acmeErr, _ := s.getAuthorization(t, authURL, jws)
+
+		require.Nil(t, authResp)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "unauthorized")
 	})
 }

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -866,6 +866,6 @@ func testGetAuthorization(t *testing.T, s *integrationTestSuite) {
 
 		require.Nil(t, authResp)
 		require.NotNil(t, acmeErr)
-		require.Contains(t, acmeErr.Type, "unauthorized")
+		require.Contains(t, acmeErr.Type, "error/authorizationDoesNotExist")
 	})
 }

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -255,3 +255,26 @@ func (s *integrationTestSuite) createOrder(t *testing.T, pathIdentifier string, 
 	require.NoError(t, err)
 	return &result, nil, resp
 }
+
+func (s *integrationTestSuite) getAuthorization(t *testing.T, authUrl string, jwsBody []byte) (*types.AuthorizationResponse, *types.ACMEError, *http.Response) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, authUrl, bytes.NewReader(jwsBody))
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer drainAndCloseBody(resp)
+
+	if resp.StatusCode >= 300 {
+		var acmeErr types.ACMEError
+		if err := json.NewDecoder(resp.Body).Decode(&acmeErr); err == nil && acmeErr.Type != "" {
+			return nil, &acmeErr, resp
+		}
+		return nil, nil, resp
+	}
+
+	var result types.AuthorizationResponse
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+	return &result, nil, resp
+}

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -89,10 +89,24 @@ type OrderResponse struct {
 
 type Authorization struct {
 	ID         uint       `db:"id"`
-	OrderID    uint       `db:"order_id"`
+	OrderID    uint       `db:"acme_order_id"`
 	Identifier Identifier `db:"-"`
 	Status     string     `db:"status"`
 }
+
+type AuthorizationResponse struct {
+	Status     string              `json:"status"`
+	Expires    *time.Time          `json:"expires,omitempty"`
+	Identifier Identifier          `json:"identifier"`
+	Challenges []ChallengeResponse `json:"challenges"`
+
+	// Location is set in the header, pointing to the requested authorization's URL.
+	Location string `json:"-"`
+}
+
+const (
+	DeviceAttestationChallengeType string = "device-attest-01"
+)
 
 type Challenge struct {
 	ID                  uint   `db:"id"`
@@ -100,6 +114,16 @@ type Challenge struct {
 	ChallengeType       string `db:"challenge_type"`
 	Token               string `db:"token"`
 	Status              string `db:"status"`
+}
+
+type ChallengeResponse struct {
+	ChallengeType string `json:"type"`
+	Status        string `json:"status"`
+	Token         string `json:"token"`
+	URL           string `json:"url"`
+
+	// Validated is only set in the response when the challenge is valid and has been validated.
+	Validated *time.Time `json:"validated,omitempty"`
 }
 
 const (
@@ -137,4 +161,6 @@ type Datastore interface {
 	GetAccountByID(ctx context.Context, enrollmentID uint, accountID uint) (*Account, error)
 	CreateAccount(ctx context.Context, account *Account, onlyReturnExisting bool) (*Account, bool, error)
 	CreateOrder(ctx context.Context, order *Order, authorization *Authorization, challenge *Challenge) (*Order, error)
+	GetAuthorizationByID(ctx context.Context, accountID uint, authorizationID uint) (*Authorization, error)
+	GetChallengesByAuthorizationID(ctx context.Context, authorizationID uint) ([]*Challenge, error)
 }

--- a/server/mdm/acme/internal/types/errors.go
+++ b/server/mdm/acme/internal/types/errors.go
@@ -171,6 +171,25 @@ func MalformedError(detail string) *ACMEError {
 	}
 }
 
+// Custom Fleet error code, as RFC does not document what to return.
+func AuthorizationDoesNotExistError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "authorizationDoesNotExist",
+		Title:      "The specified authorization does not exist for the account",
+		Detail:     detail,
+		StatusCode: http.StatusNotFound,
+	}
+}
+
+func ChallengeDoesNotExistError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "challengeDoesNotExist",
+		Title:      "The specified challenge does not exist for the authorization",
+		Detail:     detail,
+		StatusCode: http.StatusNotFound,
+	}
+}
+
 func (e *ACMEError) Error() string {
 	s := e.Type
 	if e.Title != "" {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40984 partly, it handles the authorization endpoint, and then I'll follow up with a PR for the challenge/attestation.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. We should just have one for the entire story.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually