### PR TITLE
Fleet UI: Center empty/error states

### DIFF
--- a/frontend/components/DataError/DataError.tsx
+++ b/frontend/components/DataError/DataError.tsx
@@ -51,8 +51,10 @@ const DataError = ({
             `${baseClass}__vertical-${verticalPaddingSize}`
           }`}
         >
-          <div className="info">
-            <span className="info__header-single-line">
+          <div className={`${baseClass}__content`}>
+            <span
+              className={`${baseClass}__header ${baseClass}__header--single-line`}
+            >
               <Icon name="error" />
               {description}
             </span>
@@ -77,9 +79,11 @@ const DataError = ({
           </div>
           {children || (
             <>
-              <div className={`${baseClass}__data`}>Refresh to try again.</div>
+              <div className={`${baseClass}__description`}>
+                Refresh to try again.
+              </div>
               {!excludeIssueLink && (
-                <div className={`${baseClass}__data`}>
+                <div className={`${baseClass}__file-issue`}>
                   If this keeps happening please&nbsp;
                   <CustomLink
                     url="https://github.com/fleetdm/fleet/issues/new/choose"
@@ -102,8 +106,8 @@ const DataError = ({
           verticalPaddingSize && `${baseClass}__vertical-${verticalPaddingSize}`
         }`}
       >
-        <div className="info">
-          <span className="info__header">
+        <div className={`${baseClass}__content`}>
+          <span className={`${baseClass}__header`}>
             <Icon name="error" />
             Something&apos;s gone wrong.
           </span>
@@ -112,10 +116,12 @@ const DataError = ({
             {children || (
               <>
                 {description && (
-                  <span className="info__data">{description}</span>
+                  <span className={`${baseClass}__description`}>
+                    {description}
+                  </span>
                 )}
                 {!excludeIssueLink && (
-                  <span className="info__data">
+                  <span className={`${baseClass}__file-issue`}>
                     If this keeps happening, please&nbsp;
                     <CustomLink
                       url="https://github.com/fleetdm/fleet/issues/new/choose"

--- a/frontend/components/DataError/_styles.scss
+++ b/frontend/components/DataError/_styles.scss
@@ -32,36 +32,33 @@
     flex-direction: row;
   }
 
-  .info {
+  &__content {
     display: flex;
     flex-direction: column;
     gap: $pad-small;
+  }
 
-    &__header {
-      display: flex;
-      color: $core-fleet-black;
-      font-weight: $bold;
-      font-size: $x-small;
-      text-align: left;
-      gap: $pad-small;
-      margin-bottom: $pad-small;
-    }
+  &__header {
+    display: flex;
+    color: $core-fleet-black;
+    font-weight: $bold;
+    font-size: $x-small;
+    text-align: left;
+    gap: $pad-small;
+    margin-bottom: $pad-small;
+  }
 
-    &__header-single-line {
-      display: flex;
-      color: $core-fleet-black;
-      font-size: $x-small;
-      gap: $pad-small;
-      padding: $pad-large;
-    }
+  &__header--single-line {
+    margin-bottom: 0;
+  }
 
-    &__data {
-      display: block;
-      color: $core-fleet-black;
-      font-weight: normal;
-      font-size: $x-small;
-      text-align: left;
-    }
+  &__description,
+  &__file-issue {
+    display: block;
+    color: $core-fleet-black;
+    font-weight: normal;
+    font-size: $x-small;
+    text-align: left;
   }
 
   //  // // // // // // // // // // //

--- a/frontend/components/DeviceUserError/DeviceUserError.tsx
+++ b/frontend/components/DeviceUserError/DeviceUserError.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import Icon from "components/Icon/Icon";
+
 import classNames from "classnames";
+import Icon from "components/Icon/Icon";
+import DataError from "components/DataError";
 
 const baseClass = "device-user-error";
 
@@ -10,20 +12,18 @@ interface IDeviceUserErrorProps {
   /** Modifies error message for iPhone/iPad/Android */
   isMobileDevice?: boolean;
   isAuthenticationError?: boolean;
-  platform?: string;
+  isErrorSetupSteps?: boolean;
 }
 
 const DeviceUserError = ({
   isMobileView = false,
   isMobileDevice = false,
   isAuthenticationError = false,
-  platform,
+  isErrorSetupSteps = false,
 }: IDeviceUserErrorProps): JSX.Element => {
   const wrapperClassnames = classNames(baseClass, {
     [`${baseClass}__mobile-view`]: isMobileView,
   });
-
-  const isIOSIPadOS = platform === "ios" || platform === "ipados";
 
   // Default: "Something went wrong"
   let headerContent: React.ReactNode = (
@@ -31,7 +31,19 @@ const DeviceUserError = ({
       <Icon name="error" /> Something went wrong
     </>
   );
-  let bodyContent: React.ReactNode = <>Please contact your IT admin.</>;
+
+  let descriptionContent: React.ReactNode = <>Please contact your IT admin.</>;
+
+  if (isErrorSetupSteps) {
+    // Use generic UI error component
+    return (
+      <div className={wrapperClassnames}>
+        <div className={`${baseClass}__inner`}>
+          <DataError description="Could not get software setup status." />
+        </div>
+      </div>
+    );
+  }
 
   if (isAuthenticationError) {
     headerContent = (
@@ -42,7 +54,7 @@ const DeviceUserError = ({
           : "This URL is invalid or expired."}
       </>
     );
-    bodyContent = isMobileDevice ? (
+    descriptionContent = isMobileDevice ? (
       "Couldn't authenticate this device. Please contact your IT admin."
     ) : (
       <>
@@ -55,9 +67,11 @@ const DeviceUserError = ({
   return (
     <div className={wrapperClassnames}>
       <div className={`${baseClass}__inner`}>
-        <div className="info">
-          <span className="info__header">{headerContent}</span>
-          <span className="info__data">{bodyContent}</span>
+        <div className={`${baseClass}__content`}>
+          <span className={`${baseClass}__header`}>{headerContent}</span>
+          <span className={`${baseClass}__description`}>
+            {descriptionContent}
+          </span>
         </div>
       </div>
     </div>

--- a/frontend/components/DeviceUserError/_styles.scss
+++ b/frontend/components/DeviceUserError/_styles.scss
@@ -16,35 +16,34 @@
     margin: $pad-xxxlarge 0;
   }
 
-  .info {
+  &__content {
     display: flex;
     flex-direction: column;
     gap: $pad-large;
     max-width: 333px;
     padding: $pad-small;
+  }
+  &__header {
+    display: block;
+    gap: $pad-large;
+    color: $core-fleet-black;
+    font-weight: $bold;
+    font-size: $x-small;
+    text-align: center;
 
-    &__header {
-      display: block;
-      gap: $pad-large;
-      color: $core-fleet-black;
-      font-weight: $bold;
-      font-size: $x-small;
-      text-align: center;
-
-      .icon {
-        vertical-align: sub;
-        margin-right: $pad-small;
-        position: relative;
-        bottom: 1px;
-      }
+    .icon {
+      vertical-align: sub;
+      margin-right: $pad-small;
+      position: relative;
+      bottom: 1px;
     }
-    &__data {
-      display: block;
-      color: $core-fleet-black;
-      font-weight: normal;
-      font-size: $x-small;
-      text-align: center;
-      line-height: 21px; // Matches design
-    }
+  }
+  &__description {
+    display: block;
+    color: $core-fleet-black;
+    font-weight: normal;
+    font-size: $x-small;
+    text-align: center;
+    line-height: 21px; // Matches design
   }
 }

--- a/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
+++ b/frontend/pages/hosts/details/DeviceUserPage/DeviceUserPage.tsx
@@ -42,7 +42,6 @@ import Spinner from "components/Spinner";
 import TabNav from "components/TabNav";
 import TabText from "components/TabText";
 import FlashMessage from "components/FlashMessage";
-import DataError from "components/DataError";
 import CustomLink from "components/CustomLink";
 
 import { normalizeEmptyValues } from "utilities/helpers";
@@ -616,7 +615,15 @@ const DeviceUserPage = ({
       return <Spinner {...(isMobileView && { variant: "mobile" })} />;
     }
     if (isErrorSetupSteps) {
-      return <DataError description="Could not get software setup status." />;
+      return (
+        <div className={`${baseClass} main-content`}>
+          <DeviceUserError
+            isMobileView={isMobileView}
+            isMobileDevice={isMobileDevice}
+            isErrorSetupSteps={isErrorSetupSteps}
+          />
+        </div>
+      );
     }
     if (
       checkForSetupExperienceSoftware &&
@@ -949,7 +956,6 @@ const DeviceUserPage = ({
           isMobileView={isMobileView}
           isMobileDevice={isMobileDevice}
           isAuthenticationError={!!isAuthenticationError}
-          platform={host?.platform}
         />
       ) : (
         <div className={coreWrapperClassnames}>{renderDeviceUserPage()}</div>

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/_styles.scss
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/RunScriptModal/_styles.scss
@@ -8,12 +8,6 @@
     gap: $pad-xlarge;
     width: 729px; // Fixes cut off table border
     margin-bottom: 9px; // Fixes cut off dropdown
-
-    .empty-table__container {
-      max-width: none;
-      margin: 0 0 20px 0;
-      align-self: center;
-    }
   }
 
   .modal-cta-wrap {


### PR DESCRIPTION
## Issue
Closes #34930 

## Description
- Move error state into DeviceUserError so it has some kind of wrapper that centers it
- Remove unnecessary styling around empty state within modal

### Other
- Update some classnames to follow block element modifier (BEM) styling
-  Confirm matches current Figma (Note: Figma doesn't consistently align text) https://www.figma.com/design/gxvU745LfOdkE9AuRg64wi/%F0%9F%A7%A9-Product-design-system?node-id=1375-4511&p=f&t=9k3yQGJ64JyIRmGj-0

## Screenshots of fixes

<img width="1120" height="364" alt="Screenshot 2026-03-30 at 11 58 26 AM" src="https://github.com/user-attachments/assets/4f750f9f-0c0d-47ea-974a-d19df726c575" />
<img width="1224" height="549" alt="Screenshot 2026-03-31 at 12 46 20 PM" src="https://github.com/user-attachments/assets/341ec08e-5f1b-4abf-829b-0d00e08f9b6d" />
<img width="1226" height="556" alt="Screenshot 2026-03-31 at 12 45 44 PM" src="https://github.com/user-attachments/assets/8c885b5e-3d29-4bbd-b4f6-66b448a853a0" />


## Testing

- [x] QA'd all new/changed functionality manually
