### PR TITLE
Fleet UI: Hide host details reports when not supported

### DIFF
--- a/changes/38929-reports-tab
+++ b/changes/38929-reports-tab
@@ -1,0 +1,1 @@
+- Fleet UI: Hide host details > reports from platforms that do not support scheduled reporting

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1064,6 +1064,16 @@ const HostDetailsPage = ({
   }
   const failingPoliciesCount = host?.issues.failing_policies_count || 0;
 
+  const isMacOSHost = isMacOS(host.platform);
+  const isIosOrIpadosHost = isIPadOrIPhone(host.platform);
+  const isAndroidHost = isAndroid(host.platform);
+  const isWindowsHost = isWindows(host.platform);
+  const isAppleDeviceHost = isAppleDevice(host.platform);
+  const isChromeOsHost = host?.platform === "chrome";
+
+  const showReportsTab =
+    !isIosOrIpadosHost && !isAndroidHost && !isChromeOsHost;
+
   const hostDetailsSubNav: IHostDetailsSubNavItem[] = [
     {
       name: "Details",
@@ -1075,11 +1085,16 @@ const HostDetailsPage = ({
       title: "software",
       pathname: PATHS.HOST_SOFTWARE(hostIdFromURL),
     },
-    {
-      name: "Reports",
-      title: "reports",
-      pathname: PATHS.HOST_REPORTS(hostIdFromURL),
-    },
+    // Only include Reports for supported platforms
+    ...(showReportsTab
+      ? [
+          {
+            name: "Reports",
+            title: "reports",
+            pathname: PATHS.HOST_REPORTS(hostIdFromURL),
+          },
+        ]
+      : []),
     {
       name: "Policies",
       title: "policies",
@@ -1150,12 +1165,6 @@ const HostDetailsPage = ({
     name: host?.mdm.setup_experience?.bootstrap_package_name,
   };
 
-  const isMacOSHost = isMacOS(host.platform);
-  const isIosOrIpadosHost = isIPadOrIPhone(host.platform);
-  const isAndroidHost = isAndroid(host.platform);
-  const isWindowsHost = isWindows(host.platform);
-  const isAppleDeviceHost = isAppleDevice(host.platform);
-
   const canResendProfiles =
     (isAppleDeviceHost || isWindowsHost || isAndroidHost) &&
     (isGlobalAdmin ||
@@ -1166,7 +1175,7 @@ const HostDetailsPage = ({
       isHostTeamTechnician);
 
   const showSoftwareLibraryTab = isPremiumTier;
-  const showReportsTab = mdm?.enrollment_status !== "Pending";
+  const showReportsCard = mdm?.enrollment_status !== "Pending";
   const showAgentOptionsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showLocalUserAccountsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showCertificatesCard =
@@ -1494,20 +1503,20 @@ const HostDetailsPage = ({
                   </Tabs>
                 </TabNav>
               </TabPanel>
-
-              <TabPanel>
-                <HostReportsTab
-                  hostId={host.id}
-                  hostName={host.display_name}
-                  router={router}
-                  location={location}
-                  saveReportsDisabledInConfig={
-                    config?.server_settings?.query_reports_disabled
-                  }
-                  showReportsTab={showReportsTab}
-                />
-              </TabPanel>
-
+              {showReportsTab && (
+                <TabPanel>
+                  <HostReportsTab
+                    hostId={host.id}
+                    hostName={host.display_name}
+                    router={router}
+                    location={location}
+                    saveReportsDisabledInConfig={
+                      config?.server_settings?.query_reports_disabled
+                    }
+                    showReportsCard={showReportsCard}
+                  />
+                </TabPanel>
+              )}
               <TabPanel>
                 <PoliciesCard
                   policies={host?.policies || []}

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1175,7 +1175,7 @@ const HostDetailsPage = ({
       isHostTeamTechnician);
 
   const showSoftwareLibraryTab = isPremiumTier;
-  const showReportsCard = mdm?.enrollment_status !== "Pending";
+  const showReportsEmptyState = mdm?.enrollment_status === "Pending";
   const showAgentOptionsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showLocalUserAccountsCard = !isIosOrIpadosHost && !isAndroidHost;
   const showCertificatesCard =
@@ -1513,7 +1513,7 @@ const HostDetailsPage = ({
                     saveReportsDisabledInConfig={
                       config?.server_settings?.query_reports_disabled
                     }
-                    showReportsCard={showReportsCard}
+                    showReportsEmptyState={showReportsEmptyState}
                   />
                 </TabPanel>
               )}

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -70,7 +70,7 @@ interface IHostReportsTabProps {
     };
   };
   saveReportsDisabledInConfig?: boolean;
-  showReportsCard?: boolean;
+  showReportsEmptyState?: boolean;
 }
 
 const HostReportsTab = ({
@@ -79,7 +79,7 @@ const HostReportsTab = ({
   router,
   location,
   saveReportsDisabledInConfig,
-  showReportsCard = true,
+  showReportsEmptyState = false,
 }: IHostReportsTabProps): JSX.Element => {
   const searchQuery = location.query.query ?? "";
   const sortOption: SortOption =
@@ -199,7 +199,7 @@ const HostReportsTab = ({
 
   // No reports should be available if MDM enrollment is pending so hide any previous reports
   // that may be associated with the host to prevent confusion while pending
-  if ((totalCount === 0 && !searchQuery) || !showReportsCard) {
+  if ((totalCount === 0 && !searchQuery) || showReportsEmptyState) {
     return <EmptyReports isSearching={false} />;
   }
 

--- a/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
+++ b/frontend/pages/hosts/details/HostReportsTab/HostReportsTab.tsx
@@ -70,7 +70,7 @@ interface IHostReportsTabProps {
     };
   };
   saveReportsDisabledInConfig?: boolean;
-  showReportsTab?: boolean;
+  showReportsCard?: boolean;
 }
 
 const HostReportsTab = ({
@@ -79,7 +79,7 @@ const HostReportsTab = ({
   router,
   location,
   saveReportsDisabledInConfig,
-  showReportsTab = true,
+  showReportsCard = true,
 }: IHostReportsTabProps): JSX.Element => {
   const searchQuery = location.query.query ?? "";
   const sortOption: SortOption =
@@ -199,7 +199,7 @@ const HostReportsTab = ({
 
   // No reports should be available if MDM enrollment is pending so hide any previous reports
   // that may be associated with the host to prevent confusion while pending
-  if ((totalCount === 0 && !searchQuery) || !showReportsTab) {
+  if ((totalCount === 0 && !searchQuery) || !showReportsCard) {
     return <EmptyReports isSearching={false} />;
   }
 


### PR DESCRIPTION
## Issue
Closes #38929 

## Description
- Hide  Reports section all together for platforms that do not support scheduled queries

## Screenrecording of fix

Recording TLDR: Flagged platforms will hide the tab all together

https://github.com/user-attachments/assets/c760e5c2-e77b-46b7-9c09-96ae4a66a6a6


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
- [x] QA'd all new/changed functionality manually
