### PR TITLE
Fix OS versions not populated in vulnerability details

### DIFF
--- a/changes/40581-os-versions-vuln-details
+++ b/changes/40581-os-versions-vuln-details
@@ -1,0 +1,1 @@
+* Fixed a bug where OS versions were not populated in vulnerability details for OS-only vulnerabilities (e.g., macOS CVEs).

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -196,6 +196,14 @@ func getVulnFuncs(ds fleet.Datastore, logger *slog.Logger, config *config.Vulner
 			},
 		},
 		{
+			Name: "update_os_versions",
+			VulnFunc: func(ctx context.Context) error {
+				ctx, span := tracer.Start(ctx, "vuln.update_os_versions")
+				defer span.End()
+				return ds.UpdateOSVersions(ctx)
+			},
+		},
+		{
 			Name: "insert_kernel_software_mapping",
 			VulnFunc: func(ctx context.Context) error {
 				ctx, span := tracer.Start(ctx, "vuln.kernel_software_mapping")

--- a/cmd/fleet/vuln_process.go
+++ b/cmd/fleet/vuln_process.go
@@ -158,6 +158,16 @@ type NamedVulnFunc struct {
 func getVulnFuncs(ds fleet.Datastore, logger *slog.Logger, config *config.VulnerabilitiesConfig) []NamedVulnFunc {
 	vulnFuncs := []NamedVulnFunc{
 		{
+			// Run first to ensure aggregated_stats has fresh OS version data
+			// before cronVulnerabilities scans for OS vulnerabilities.
+			Name: "update_os_versions",
+			VulnFunc: func(ctx context.Context) error {
+				ctx, span := tracer.Start(ctx, "vuln.update_os_versions")
+				defer span.End()
+				return ds.UpdateOSVersions(ctx)
+			},
+		},
+		{
 			Name: "cron_vulnerabilities",
 			VulnFunc: func(ctx context.Context) error {
 				return cronVulnerabilities(ctx, ds, logger, config)
@@ -193,14 +203,6 @@ func getVulnFuncs(ds fleet.Datastore, logger *slog.Logger, config *config.Vulner
 				ctx, span := tracer.Start(ctx, "vuln.update_host_issues")
 				defer span.End()
 				return ds.UpdateHostIssuesVulnerabilities(ctx)
-			},
-		},
-		{
-			Name: "update_os_versions",
-			VulnFunc: func(ctx context.Context) error {
-				ctx, span := tracer.Start(ctx, "vuln.update_os_versions")
-				defer span.End()
-				return ds.UpdateOSVersions(ctx)
 			},
 		},
 		{


### PR DESCRIPTION
## Summary
- Adds `UpdateOSVersions` to the vulnerability cron so `aggregated_stats` is refreshed immediately after vulnerability scanning completes
- Fixes issue where `os_versions` array is empty when viewing OS-only vulnerabilities (e.g., macOS CVEs)

Resolves #40581

## Root Cause
`OSVersionsByCVE()` intersects `operating_system_vulnerabilities` (populated by vuln cron) with `aggregated_stats` (populated by `UpdateOSVersions` in cleanups cron). The cleanups cron runs hourly, creating up to 1 hour lag where `os_versions` data is stale/empty.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where OS versions were not populated in vulnerability details for OS-only vulnerabilities, such as macOS CVEs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->