### PR TITLE
Fleet UI: Fix margin on operating system dataset

### DIFF
--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -459,7 +459,6 @@ const Vitals = ({
     // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS, Android operating systems
     if (!osVersionRequirement?.minimum_version) {
       const version = vitalsData.os_version;
-      // Parent class contains styling
       const versionForRender = ROLLING_ARCH_LINUX_VERSIONS.includes(version) ? (
         <>
           {version.slice(0, -8)}

--- a/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
+++ b/frontend/pages/hosts/details/cards/Vitals/Vitals.tsx
@@ -459,6 +459,7 @@ const Vitals = ({
     // No tooltip if minimum version is not set, including all Windows, Linux, ChromeOS, Android operating systems
     if (!osVersionRequirement?.minimum_version) {
       const version = vitalsData.os_version;
+      // Parent class contains styling
       const versionForRender = ROLLING_ARCH_LINUX_VERSIONS.includes(version) ? (
         <>
           {version.slice(0, -8)}

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -83,9 +83,8 @@
   }
 
   &__os-data-set {
-    .component__tooltip-wrapper {
-      margin-left: $pad-xsmall;
-    }
+    display: flex;
+    gap: $pad-xsmall;
 
     .component__tooltip-wrapper__element {
       line-height: inherit;

--- a/frontend/pages/hosts/details/cards/Vitals/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Vitals/_styles.scss
@@ -82,7 +82,7 @@
     white-space: nowrap;
   }
 
-  &__os-data-set {
+  &__os-version {
     display: flex;
     gap: $pad-xsmall;
 


### PR DESCRIPTION
## Issue
Closes #42415 

## Description
- Use gaps between elements instead of a left margin that will always be present on an element even if another element is not present

## Screenshot of fix (with and without icon element left of text)
<img width="255" height="244" alt="Screenshot 2026-03-31 at 3 54 31 PM" src="https://github.com/user-attachments/assets/2f0c38f0-4432-4319-a68c-133f03b3f000" />
<img width="343" height="243" alt="Screenshot 2026-03-31 at 3 45 19 PM" src="https://github.com/user-attachments/assets/6e80a485-45f7-4635-b1f6-e44f02d1f2f5" />



- [x] QA'd all new/changed functionality manually
