### PR TITLE
ACME: device attestation validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -256,6 +256,7 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
+	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect
@@ -345,6 +346,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/trivago/tgo v1.0.7 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/facebookincubator/flog v0.0.0-20190930132826-d2511d0ce33c
 	github.com/fatih/color v1.16.0
 	github.com/foxboron/go-tpm-keyfiles v0.0.0-20250520203025-c3c3a4ec1653
+	github.com/fxamacker/cbor/v2 v2.9.1
 	github.com/getsentry/sentry-go v0.18.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-git/go-git/v5 v5.16.5
@@ -256,7 +257,6 @@ require (
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
-	github.com/fxamacker/cbor/v2 v2.9.1 // indirect
 	github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 // indirect
 	github.com/go-git/gcfg v1.5.1-0.20230307220236-3a3c6141e376 // indirect
 	github.com/go-git/go-billy/v5 v5.6.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -341,6 +341,8 @@ github.com/freddierice/go-losetup/v2 v2.0.1/go.mod h1:TEyBrvlOelsPEhfWD5rutNXDmU
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
 github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
+github.com/fxamacker/cbor/v2 v2.9.1 h1:2rWm8B193Ll4VdjsJY28jxs70IdDsHRWgQYAI80+rMQ=
+github.com/fxamacker/cbor/v2 v2.9.1/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17 h1:GOfMz6cRgTJ9jWV0qAezv642OhPnKEG7gtUjJSdStHE=
 github.com/garyburd/go-oauth v0.0.0-20180319155456-bca2e7f09a17/go.mod h1:HfkOCN6fkKKaPSAeNq/er3xObxTW4VLeY6UUK895gLQ=
 github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
@@ -881,6 +883,8 @@ github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0o
 github.com/urfave/cli/v2 v2.27.7 h1:bH59vdhbjLv3LAvIu6gd0usJHgoTTPhCFib8qqOwXYU=
 github.com/urfave/cli/v2 v2.27.7/go.mod h1:CyNAG/xg+iAOg0N4MPGZqVmv2rCoP267496AOXUZjA4=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=

--- a/go.sum
+++ b/go.sum
@@ -1147,8 +1147,6 @@ google.golang.org/genproto v0.0.0-20260128011058-8636f8732409 h1:VQZ/yAbAtjkHgH8
 google.golang.org/genproto v0.0.0-20260128011058-8636f8732409/go.mod h1:rxKD3IEILWEu3P44seeNOAwZN4SaoKaQ/2eTg4mM6EM=
 google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20 h1:7ei4lp52gK1uSejlA8AZl5AJjeLUOHBQscRQZUgAcu0=
 google.golang.org/genproto/googleapis/api v0.0.0-20260203192932-546029d2fa20/go.mod h1:ZdbssH/1SOVnjnDlXzxDHK2MCidiqXtbYccJNzNYPEE=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d h1:t/LOSXPJ9R0B6fnZNyALBRfZBH0Uy0gT+uR+SJ6syqQ=
-google.golang.org/genproto/googleapis/rpc v0.0.0-20260217215200-42d3e9bedb6d/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 h1:ndE4FoJqsIceKP2oYSnUZqhTdYufCYYkqwtFzfrhI7w=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
@@ -1157,8 +1155,6 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.2/go.mod h1:JMHMWHQWaTccqQQlmk3MJZS+GWXOdAesneDmEnv2fbc=
-google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
-google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=

--- a/server/mdm/acme/api/challenge.go
+++ b/server/mdm/acme/api/challenge.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+)
+
+type ChallengeService interface {
+	ValidateChallenge(ctx context.Context, enrollment *types.Enrollment, account *types.Account, challengeID uint, payload string) (*types.ChallengeResponse, error)
+}

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -211,7 +211,8 @@ type GetAuthorizationResponse struct {
 }
 
 func (r *GetAuthorizationResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error
+	// only generate a new nonce if there is no error or the error is due to a client error
+	// other than "enrollment not found" (in which case the client has no reason to retry).
 	if r.Err != nil {
 		var acmeErr *types.ACMEError
 		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
@@ -246,7 +247,8 @@ type ListOrdersResponse struct {
 }
 
 func (r *ListOrdersResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error
+	// only generate a new nonce if there is no error or the error is due to a client error
+	// other than "enrollment not found" (in which case the client has no reason to retry).
 	if r.Err != nil {
 		var acmeErr *types.ACMEError
 		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
@@ -281,7 +283,8 @@ type DoChallengeResponse struct {
 }
 
 func (r *DoChallengeResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error
+	// only generate a new nonce if there is no error or the error is due to a client error
+	// other than "enrollment not found" (in which case the client has no reason to retry).
 	if r.Err != nil {
 		var acmeErr *types.ACMEError
 		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -196,7 +196,7 @@ func (r *GetOrderResponse) Error() error { return r.Err }
 
 type GetAuthorizationRequest struct {
 	JWSRequestContainer
-	AuthorizationID uint `url:"authorization"`
+	AuthorizationID uint `url:"authorization_id"`
 }
 
 type GetAuthorizationDecodedRequest struct {
@@ -264,7 +264,7 @@ func (r ListOrdersResponse) Error() error { return r.Err }
 
 type DoChallengeRequest struct {
 	JWSRequestContainer
-	ChallengeID uint `url:"challenge"`
+	ChallengeID uint `url:"challenge_id"`
 }
 
 type DoChallengeDecodedRequest struct {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -259,6 +259,7 @@ func (r *ListOrdersResponse) BeforeRender(ctx context.Context, w http.ResponseWr
 	}
 }
 
+// Error implements the platform_http.Errorer interface.
 func (r ListOrdersResponse) Error() error { return r.Err }
 
 type DoChallengeRequest struct {

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -246,8 +246,7 @@ type ListOrdersResponse struct {
 }
 
 func (r *ListOrdersResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
-	// only generate a new nonce if there is no error or the error is due to a client error
-	// other than "enrollment not found" (in which case the client has no reason to retry).
+	// only generate a new nonce if there is no error
 	if r.Err != nil {
 		var acmeErr *types.ACMEError
 		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
@@ -260,8 +259,44 @@ func (r *ListOrdersResponse) BeforeRender(ctx context.Context, w http.ResponseWr
 	}
 }
 
-// Error implements the platform_http.Errorer interface.
-func (r *ListOrdersResponse) Error() error { return r.Err }
+func (r ListOrdersResponse) Error() error { return r.Err }
+
+type DoChallengeRequest struct {
+	JWSRequestContainer
+	ChallengeID uint `url:"challenge"`
+}
+
+type DoChallengeDecodedRequest struct {
+	types.AccountAuthenticatedRequestBase
+	AttestationObject string `json:"attObj"`
+	AttestError       string `json:"error"`
+	ChallengeID       uint   `json:"-"`
+}
+
+type DoChallengeResponse struct {
+	*types.ChallengeResponse
+	Err    error                                `json:"error,omitempty"`
+	Nonces *redis_nonces_store.RedisNoncesStore `json:"-"`
+}
+
+func (r *DoChallengeResponse) BeforeRender(ctx context.Context, w http.ResponseWriter) {
+	// only generate a new nonce if there is no error
+	if r.Err != nil {
+		var acmeErr *types.ACMEError
+		if !errors.As(r.Err, &acmeErr) || !acmeErr.ShouldReturnNonce() {
+			return
+		}
+	}
+	if err := generateAndRenderNonce(ctx, r.Nonces, w); err != nil {
+		r.Err = err
+		return
+	}
+	if r.ChallengeResponse != nil && r.ChallengeResponse.Location != "" {
+		w.Header().Set("Location", r.ChallengeResponse.Location)
+	}
+}
+
+func (r DoChallengeResponse) Error() error { return r.Err }
 
 // JWS Request container is a container for doing basic decoding and validation operations common to all
 // authenticated ACME requests, which come in the form of a JWS in flattened serialization syntax. This is

--- a/server/mdm/acme/api/service.go
+++ b/server/mdm/acme/api/service.go
@@ -11,5 +11,6 @@ type Service interface {
 	AccountService
 	EnrollmentService
 	AuthorizationService
+	ChallengeService
 	NoncesStore() *redis_nonces_store.RedisNoncesStore
 }

--- a/server/mdm/acme/internal/mysql/account_order.go
+++ b/server/mdm/acme/internal/mysql/account_order.go
@@ -186,6 +186,7 @@ func (ds *Datastore) CreateOrder(ctx context.Context, order *types.Order, author
 		}
 		lastInsertID, _ = res.LastInsertId() // can never fail for mysql
 		challenge.ID = uint(lastInsertID)
+		challenge.ACMEAuthorizationID = authorization.ID
 
 		return nil
 	}, ds.logger)

--- a/server/mdm/acme/internal/mysql/authorization_test.go
+++ b/server/mdm/acme/internal/mysql/authorization_test.go
@@ -80,23 +80,7 @@ func testGetAuthorizationWithInvalidInputs(t *testing.T, env *testEnv) {
 }
 
 func createTestOrderForAccount(t *testing.T, account *types.Account, env *testEnv) (*types.Order, *types.Authorization, *types.Challenge) {
-	order := &types.Order{
-		ACMEAccountID: account.ID,
-		Status:        "pending",
-		Identifiers: []types.Identifier{
-			{Type: types.IdentifierTypePermanentIdentifier, Value: "serial-123"},
-		},
-	}
-	authorization := &types.Authorization{
-		Identifier: types.Identifier{Type: types.IdentifierTypePermanentIdentifier, Value: "serial-123"},
-		Status:     "pending",
-	}
-	challenge := &types.Challenge{
-		ChallengeType: types.DeviceAttestationChallengeType,
-		Token:         "test-token-123",
-		Status:        "pending",
-	}
-
+	order, authorization, challenge := buildTestOrder(account.ID, "serial-123")
 	result, err := env.ds.CreateOrder(t.Context(), order, authorization, challenge)
 	require.NoError(t, err)
 

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -18,8 +18,7 @@ func (ds *Datastore) GetChallengesByAuthorizationID(ctx context.Context, authori
 		return nil, types.MalformedError("invalid authorization ID")
 	}
 
-	// TODO: Should we get validated from here, via the updated_at if status=valid?
-	const query = `SELECT id, acme_authorization_id, challenge_type, status, token FROM acme_challenges WHERE acme_authorization_id = ?`
+	const query = `SELECT id, acme_authorization_id, challenge_type, status, token, updated_at FROM acme_challenges WHERE acme_authorization_id = ?`
 
 	var challenges []*types.Challenge
 	err := sqlx.SelectContext(ctx, ds.reader(ctx), &challenges, query, authorizationID)

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -33,7 +33,7 @@ func (ds *Datastore) GetChallengesByAuthorizationID(ctx context.Context, authori
 	return challenges, nil
 }
 
-// We rquire the accountID to validate the challenge belongs to the account trying to validate it
+// We require the accountID to validate the challenge belongs to the account trying to validate it
 func (ds *Datastore) GetChallengeByID(ctx context.Context, accountID, challengeID uint) (*types.Challenge, error) {
 	if challengeID == 0 {
 		return nil, types.MalformedError("invalid challenge ID")
@@ -47,7 +47,7 @@ func (ds *Datastore) GetChallengeByID(ctx context.Context, accountID, challengeI
 	var challenge types.Challenge
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &challenge, query, challengeID, accountID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			return nil, types.ChallengeDoesNotExistError(fmt.Sprintf("Challenge with ID %d not found for account ID %d", challengeID, accountID))
 		}
 		return nil, ctxerr.Wrap(ctx, err, "getting challenge by ID")

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -42,8 +42,7 @@ func (ds *Datastore) GetChallengeByID(ctx context.Context, accountID, challengeI
 	const query = `SELECT ac.id, ac.acme_authorization_id, ac.challenge_type, ac.status, ac.token, ac.updated_at FROM acme_challenges ac
 	INNER JOIN acme_authorizations a ON ac.acme_authorization_id = a.id
 	INNER JOIN acme_orders o ON a.acme_order_id = o.id
-	INNER JOIN acme_accounts acnt ON o.acme_account_id = acnt.id
-	WHERE ac.id = ? AND acnt.id = ?`
+	WHERE ac.id = ? AND o.acme_account_id = ?`
 	var challenge types.Challenge
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &challenge, query, challengeID, accountID)
 	if err != nil {

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -2,7 +2,11 @@ package mysql
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
+
+	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
@@ -27,4 +31,76 @@ func (ds *Datastore) GetChallengesByAuthorizationID(ctx context.Context, authori
 	}
 
 	return challenges, nil
+}
+
+// We rquire the accountID to validate the challenge belongs to the account trying to validate it
+func (ds *Datastore) GetChallengeByID(ctx context.Context, accountID, challengeID uint) (*types.Challenge, error) {
+	if challengeID == 0 {
+		return nil, types.MalformedError("invalid challenge ID")
+	}
+
+	const query = `SELECT ac.id, ac.acme_authorization_id, ac.challenge_type, ac.status, ac.token, ac.updated_at FROM acme_challenges ac
+	INNER JOIN acme_authorizations a ON ac.acme_authorization_id = a.id
+	INNER JOIN acme_orders o ON a.acme_order_id = o.id
+	INNER JOIN acme_accounts acnt ON o.acme_account_id = acnt.id
+	WHERE ac.id = ? AND acnt.id = ?`
+	var challenge types.Challenge
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &challenge, query, challengeID, accountID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, types.ChallengeDoesNotExistError(fmt.Sprintf("Challenge with ID %d not found for account ID %d", challengeID, accountID))
+		}
+		return nil, ctxerr.Wrap(ctx, err, "getting challenge by ID")
+	}
+	return &challenge, nil
+}
+
+// UpdateChallenge handles updating the challenge status, and the authorization status as well as moving the order status.
+func (ds *Datastore) UpdateChallenge(ctx context.Context, challenge *types.Challenge) (*types.Challenge, error) {
+	if challenge == nil {
+		return nil, errors.New("Challenge can not be nil for update")
+	}
+
+	err := platform_mysql.WithRetryTxx(ctx, ds.writer(ctx), func(tx sqlx.ExtContext) error {
+		const updateChallengeStmt = `UPDATE acme_challenges SET status = ? WHERE id = ?`
+		_, err := tx.ExecContext(ctx, updateChallengeStmt, challenge.Status, challenge.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "updating challenge")
+		}
+
+		const updateAuthorizationStatusStmt = `UPDATE acme_authorizations a INNER JOIN acme_challenges c ON a.id = c.acme_authorization_id
+		SET a.status = CASE
+			WHEN c.status = 'valid' THEN 'valid'
+			ELSE 'invalid'
+		END
+		WHERE c.id = ?`
+		_, err = tx.ExecContext(ctx, updateAuthorizationStatusStmt, challenge.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "updating authorization status based on challenge status")
+		}
+
+		const updateOrderStatusStmt = `UPDATE acme_orders o INNER JOIN acme_authorizations a ON o.id = a.acme_order_id
+		SET o.status = CASE
+			WHEN ? = 'valid' THEN 'ready'
+			WHEN ? = 'invalid' THEN 'invalid'
+			ELSE o.status
+		END
+		WHERE a.id = ? AND o.status != 'invalid'`
+		_, err = tx.ExecContext(ctx, updateOrderStatusStmt, challenge.Status, challenge.Status, challenge.ACMEAuthorizationID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "updating order status based on challenge status")
+		}
+
+		const selectQuery = `SELECT id, acme_authorization_id, challenge_type, status, token, updated_at FROM acme_challenges WHERE id = ?`
+		err = sqlx.GetContext(ctx, tx, challenge, selectQuery, challenge.ID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting updated challenge")
+		}
+
+		return nil
+	}, ds.logger)
+	if err != nil {
+		return nil, err
+	}
+	return challenge, nil
 }

--- a/server/mdm/acme/internal/mysql/challenge.go
+++ b/server/mdm/acme/internal/mysql/challenge.go
@@ -77,6 +77,9 @@ func (ds *Datastore) UpdateChallenge(ctx context.Context, challenge *types.Chall
 			return ctxerr.Wrap(ctx, err, "updating authorization status based on challenge status")
 		}
 
+		// We can confidently update the order status here based on the challenge and authorization status
+		// since we currently only have one, if we ever add more the state machine should account for all authorizations
+		// to be valid before moving the order to ready
 		const updateOrderStatusStmt = `UPDATE acme_orders o INNER JOIN acme_authorizations a ON o.id = a.acme_order_id
 		SET o.status = CASE
 			WHEN ? = 'valid' THEN 'ready'

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -82,14 +82,14 @@ func testGetChallengesWithZeroAuthorizationID(t *testing.T, env *testEnv) {
 
 func testGetChallengeByIDWithValidID(t *testing.T, env *testEnv) {
 	account, _ := createTestAccountForOrder(t, env)
-	_, _, challenge := createTestOrderForAccount(t, account, env)
+	_, authorization, challenge := createTestOrderForAccount(t, account, env)
 
 	challenge, err := env.ds.GetChallengeByID(t.Context(), account.ID, challenge.ID)
 	require.NoError(t, err)
 	require.NotNil(t, challenge)
 	require.Equal(t, "pending", challenge.Status)
 	require.Equal(t, types.DeviceAttestationChallengeType, challenge.ChallengeType)
-	require.Equal(t, account.ID, challenge.ACMEAuthorizationID)
+	require.Equal(t, authorization.ID, challenge.ACMEAuthorizationID)
 }
 
 func testGetChallengeByIDWithInvalidID(t *testing.T, env *testEnv) {

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -115,7 +115,7 @@ func testGetChallengeByIDWithInvalidAccountID(t *testing.T, env *testEnv) {
 
 func testUpdateChallengeHappyPath(t *testing.T, env *testEnv) {
 	account, _ := createTestAccountForOrder(t, env)
-	_, _, challenge := createTestOrderForAccount(t, account, env)
+	order, _, challenge := createTestOrderForAccount(t, account, env)
 
 	challenge.Status = "valid"
 	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
@@ -124,16 +124,12 @@ func testUpdateChallengeHappyPath(t *testing.T, env *testEnv) {
 	require.Equal(t, "valid", updatedChallenge.Status)
 	require.Equal(t, challenge.ID, updatedChallenge.ID)
 
-	// Verify that the authorization and order status were updated as well
-	var authStatus string
-	err = env.TestDB.DB.GetContext(t.Context(), &authStatus, "SELECT status FROM acme_authorizations WHERE id = ?", challenge.ACMEAuthorizationID)
+	order, auhtz, err := env.ds.GetOrderByID(t.Context(), account.ID, order.ID)
 	require.NoError(t, err)
-	require.Equal(t, "valid", authStatus)
+	require.NotNil(t, auhtz)
+	for _, auth := range auhtz {
+		require.Equal(t, "valid", auth.Status)
+	}
 
-	var orderStatus string
-	err = env.TestDB.DB.GetContext(t.Context(), &orderStatus, `SELECT o.status FROM acme_orders o
-	INNER JOIN acme_authorizations a ON o.id = a.acme_order_id
-	WHERE a.id = ?`, challenge.ACMEAuthorizationID)
-	require.NoError(t, err)
-	require.Equal(t, "ready", orderStatus)
+	require.Equal(t, "ready", order.Status)
 }

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -21,6 +21,12 @@ func TestACMEChallenge(t *testing.T) {
 		{"NoChallengesForAuthorization", testGetChallengesWithNoChallengesForAuthorization},
 		{"GetChallengesWithInvalidAuthorizationID", testGetChallengesWithInvalidAuthorizationID},
 		{"GetChallengesWithZeroAuthorizationID", testGetChallengesWithZeroAuthorizationID},
+
+		{"GetChallengeByIDWithValidID", testGetChallengeByIDWithValidID},
+		{"GetChallengeByIDWithInvalidID", testGetChallengeByIDWithInvalidID},
+		{"GetChallengeByIDWithInvalidAccountID", testGetChallengeByIDWithInvalidAccountID},
+
+		{"UpdateChallengeHappyPath", testUpdateChallengeHappyPath},
 	}
 
 	for _, c := range cases {
@@ -72,4 +78,62 @@ func testGetChallengesWithZeroAuthorizationID(t *testing.T, env *testEnv) {
 	require.ErrorAs(t, err, &acmeError)
 	require.Contains(t, acmeError.Type, "malformed") //nolint:nilaway // cannot be null due to previous require
 	require.Nil(t, challenges)
+}
+
+func testGetChallengeByIDWithValidID(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, _, challenge := createTestOrderForAccount(t, account, env)
+
+	challenge, err := env.ds.GetChallengeByID(t.Context(), account.ID, challenge.ID)
+	require.NoError(t, err)
+	require.NotNil(t, challenge)
+	require.Equal(t, "pending", challenge.Status)
+	require.Equal(t, types.DeviceAttestationChallengeType, challenge.ChallengeType)
+	require.Equal(t, account.ID, challenge.ACMEAuthorizationID)
+}
+
+func testGetChallengeByIDWithInvalidID(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+
+	challenge, err := env.ds.GetChallengeByID(t.Context(), account.ID, 9999) // non-existent ID
+	var acmeError *types.ACMEError
+	require.ErrorAs(t, err, &acmeError)
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist") //nolint:nilaway // cannot be null due to previous require
+	require.Nil(t, challenge)
+}
+
+func testGetChallengeByIDWithInvalidAccountID(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, _, challenge := createTestOrderForAccount(t, account, env)
+
+	challenge, err := env.ds.GetChallengeByID(t.Context(), 9999, challenge.ID) // non-existent account ID
+	var acmeError *types.ACMEError
+	require.ErrorAs(t, err, &acmeError)
+	require.Contains(t, acmeError.Type, "error/challengeDoesNotExist") //nolint:nilaway // cannot be null due to previous require
+	require.Nil(t, challenge)
+}
+
+func testUpdateChallengeHappyPath(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	_, _, challenge := createTestOrderForAccount(t, account, env)
+
+	challenge.Status = "valid"
+	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
+	require.NoError(t, err)
+	require.NotNil(t, updatedChallenge)
+	require.Equal(t, "valid", updatedChallenge.Status)
+	require.Equal(t, challenge.ID, updatedChallenge.ID)
+
+	// Verify that the authorization and order status were updated as well
+	var authStatus string
+	err = env.TestDB.DB.GetContext(t.Context(), &authStatus, "SELECT status FROM acme_authorizations WHERE id = ?", challenge.ACMEAuthorizationID)
+	require.NoError(t, err)
+	require.Equal(t, "valid", authStatus)
+
+	var orderStatus string
+	err = env.TestDB.DB.GetContext(t.Context(), &orderStatus, `SELECT o.status FROM acme_orders o
+	INNER JOIN acme_authorizations a ON o.id = a.acme_order_id
+	WHERE a.id = ?`, challenge.ACMEAuthorizationID)
+	require.NoError(t, err)
+	require.Equal(t, "ready", orderStatus)
 }

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -27,6 +27,9 @@ func TestACMEChallenge(t *testing.T) {
 		{"GetChallengeByIDWithInvalidAccountID", testGetChallengeByIDWithInvalidAccountID},
 
 		{"UpdateChallengeHappyPath", testUpdateChallengeHappyPath},
+		{"UpdateChallengeInvalidStatus", testUpdateChallengeInvalidStatus},
+		{"UpdateChallengeNilChallenge", testUpdateChallengeNilChallenge},
+		{"UpdateChallengeNonExistentID", testUpdateChallengeNonExistentID},
 	}
 
 	for _, c := range cases {
@@ -132,4 +135,44 @@ func testUpdateChallengeHappyPath(t *testing.T, env *testEnv) {
 	}
 
 	require.Equal(t, "ready", order.Status)
+}
+
+func testUpdateChallengeInvalidStatus(t *testing.T, env *testEnv) {
+	account, _ := createTestAccountForOrder(t, env)
+	order, _, challenge := createTestOrderForAccount(t, account, env)
+
+	challenge.Status = "invalid"
+	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
+	require.NoError(t, err)
+	require.NotNil(t, updatedChallenge)
+	require.Equal(t, "invalid", updatedChallenge.Status)
+
+	order, auhtz, err := env.ds.GetOrderByID(t.Context(), account.ID, order.ID)
+	require.NoError(t, err)
+	require.NotNil(t, auhtz)
+	for _, auth := range auhtz {
+		require.Equal(t, "invalid", auth.Status)
+	}
+
+	require.Equal(t, "invalid", order.Status)
+}
+
+func testUpdateChallengeNilChallenge(t *testing.T, env *testEnv) {
+	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Challenge can not be nil for update")
+	require.Nil(t, updatedChallenge)
+}
+
+func testUpdateChallengeNonExistentID(t *testing.T, env *testEnv) {
+	challenge := &types.Challenge{
+		ID:                  999999,
+		ACMEAuthorizationID: 999999,
+		Status:              "valid",
+		ChallengeType:       types.DeviceAttestationChallengeType,
+	}
+
+	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
+	require.Error(t, err)
+	require.Nil(t, updatedChallenge)
 }

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -20,8 +20,6 @@ func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enroll
 		return nil, ctxerr.Wrap(ctx, err, "getting authorization by ID")
 	}
 
-	// TODO: Should we check the auth status here? Or will that happen when we validate a challenge for an auth?
-
 	challenges, err := s.store.GetChallengesByAuthorizationID(ctx, authz.ID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting challenges by authorization ID")
@@ -39,12 +37,18 @@ func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enroll
 			return nil, ctxerr.Wrap(ctx, err, "constructing challenge URL")
 		}
 
-		challengeResponses = append(challengeResponses, types.ChallengeResponse{
+		challengeResponse := types.ChallengeResponse{
 			ChallengeType: c.ChallengeType,
 			Status:        c.Status,
 			Token:         c.Token,
 			URL:           challengeURL,
-		})
+		}
+
+		if c.Status == "valid" {
+			challengeResponse.Validated = &c.UpdatedAt
+		}
+
+		challengeResponses = append(challengeResponses, challengeResponse)
 	}
 
 	authzURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "authorizations", fmt.Sprint(authz.ID))

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -32,8 +32,8 @@ ZwFEh9bhKjJ+5VQ9/Do1os0u3LEkgN/r
 -----END CERTIFICATE-----`
 
 var (
-	oidAppleSerialNumber = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 1}
-	oidAppleNonce        = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 11, 1}
+	OIDAppleSerialNumber = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 1}
+	OIDAppleNonce        = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 11, 1}
 )
 
 func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrollment, account *types.Account, challengeID uint, payload string) (*types.ChallengeResponse, error) {
@@ -49,7 +49,11 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 	var validationErr error
 	switch challenge.ChallengeType {
 	case types.DeviceAttestationChallengeType:
-		challenge, validationErr = s.validateDeviceAttestationChallenge(ctx, enrollment, challenge, payload)
+		updatedChallenge, err := s.validateDeviceAttestationChallenge(ctx, enrollment, challenge, payload)
+		if updatedChallenge != nil {
+			challenge = updatedChallenge
+		}
+		validationErr = err
 	default:
 		return nil, types.InternalServerError(fmt.Sprintf("unsupported challenge type %s", challenge.ChallengeType))
 	}
@@ -124,16 +128,19 @@ func (s *Service) validateDeviceAttestationChallenge(ctx context.Context, enroll
 
 // Challenge status is updated by reference
 func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, enrollment *types.Enrollment, challenge *types.Challenge, attStmt types.AppleDeviceAttestationStatement) error {
-	roots := x509.NewCertPool()
-	rootCABlock, _ := pem.Decode([]byte(appleEnterpriseAttestationRootCA))
-	if rootCABlock == nil {
-		return types.BadAttestationStatementError("Failed to parse Apple Enterprise Attestation Root CA certificate")
+	roots := s.appleRootCAs
+	if roots == nil {
+		roots = x509.NewCertPool()
+		rootCABlock, _ := pem.Decode([]byte(appleEnterpriseAttestationRootCA))
+		if rootCABlock == nil {
+			return types.BadAttestationStatementError("Failed to parse Apple Enterprise Attestation Root CA certificate")
+		}
+		rootCA, err := x509.ParseCertificate(rootCABlock.Bytes)
+		if err != nil {
+			return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse Apple Enterprise Attestation Root CA certificate: %s", err.Error()))
+		}
+		roots.AddCert(rootCA)
 	}
-	rootCA, err := x509.ParseCertificate(rootCABlock.Bytes)
-	if err != nil {
-		return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse Apple Enterprise Attestation Root CA certificate: %s", err.Error()))
-	}
-	roots.AddCert(rootCA)
 
 	leaf, err := x509.ParseCertificate(attStmt.X5C[0])
 	if err != nil {
@@ -166,9 +173,9 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 	}{}
 
 	for _, ext := range leaf.Extensions {
-		if ext.Id.Equal(oidAppleSerialNumber) {
+		if ext.Id.Equal(OIDAppleSerialNumber) {
 			appleData.SerialNumber = string(ext.Value)
-		} else if ext.Id.Equal(oidAppleNonce) {
+		} else if ext.Id.Equal(OIDAppleNonce) {
 			appleData.Nonce = ext.Value
 		}
 	}
@@ -176,7 +183,7 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 	sha256Token := sha256.Sum256([]byte(challenge.Token))
 	if subtle.ConstantTimeCompare(appleData.Nonce, sha256Token[:]) != 1 {
 		challenge.Status = "invalid"
-		return types.BadAttestationStatementError("Nonce does not match challenge token")
+		return types.BadAttestationStatementError("Apple freshness nonce does not match challenge token")
 	}
 
 	if appleData.SerialNumber != enrollment.HostIdentifier {

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -142,6 +142,10 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 		roots.AddCert(rootCA)
 	}
 
+	if len(attStmt.X5C) < 1 {
+		return types.BadAttestationStatementError("Apple device attestation statement must contain at least one certificate in x5c field")
+	}
+
 	leaf, err := x509.ParseCertificate(attStmt.X5C[0])
 	if err != nil {
 		return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse leaf certificate in Apple device attestation statement: %s", err.Error()))
@@ -193,7 +197,6 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 
 	depAssignments, err := s.providers.GetHostDEPAssignmentsBySerial(ctx, appleData.SerialNumber)
 	if err != nil {
-		challenge.Status = "invalid"
 		return ctxerr.Wrap(ctx, err, "getting DEP assignments for serial number in attestation certificate")
 	}
 

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -90,6 +90,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		return nil, ctxerr.Wrap(ctx, err, "constructing challenge URL")
 	}
 	challengeResponse.URL = challengeURL
+	challengeResponse.Location = challengeURL
 
 	return challengeResponse, nil
 }

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -47,33 +47,29 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 	}
 
 	var validationErr error
+	var updatedChallenge *types.Challenge
 	switch challenge.ChallengeType {
 	case types.DeviceAttestationChallengeType:
-		updatedChallenge, err := s.validateDeviceAttestationChallenge(ctx, enrollment, challenge, payload)
-		if updatedChallenge != nil {
-			challenge = updatedChallenge
-		}
-		validationErr = err
+		updatedChallenge, validationErr = s.validateDeviceAttestationChallenge(ctx, enrollment, challenge, payload)
 	default:
 		return nil, types.InternalServerError(fmt.Sprintf("unsupported challenge type %s", challenge.ChallengeType))
 	}
 
-	if challenge.Status == "pending" && validationErr != nil {
+	if updatedChallenge.Status == "pending" && validationErr != nil {
 		// Don't update to invalid if we failed on other causes
-		// TODO: Is this correct, or should we always mark it invalid on any failures?
 		return nil, validationErr
 	}
 
 	challengeResponse := &types.ChallengeResponse{
-		ChallengeType: challenge.ChallengeType,
-		Status:        challenge.Status,
-		Token:         challenge.Token,
+		ChallengeType: updatedChallenge.ChallengeType,
+		Status:        updatedChallenge.Status,
+		Token:         updatedChallenge.Token,
 	}
 
 	// We always call UpdateChallenge here since we update it's validity by reference
 	// this internally updates challenge status, authorization status and order status, which we can
 	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
-	if updatedChallenge, err := s.store.UpdateChallenge(ctx, challenge); err != nil {
+	if updatedChallenge, err := s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
 	} else if updatedChallenge != nil && updatedChallenge.Status == "valid" {
 		challengeResponse.Validated = &updatedChallenge.UpdatedAt
@@ -88,7 +84,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		return nil, ctxerr.Wrap(ctx, err, "getting base URL")
 	}
 
-	challengeURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "challenges", fmt.Sprint(challenge.ID))
+	challengeURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "challenges", fmt.Sprint(updatedChallenge.ID))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "constructing challenge URL")
 	}
@@ -128,7 +124,7 @@ func (s *Service) validateDeviceAttestationChallenge(ctx context.Context, enroll
 
 // Challenge status is updated by reference
 func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, enrollment *types.Enrollment, challenge *types.Challenge, attStmt types.AppleDeviceAttestationStatement) error {
-	roots := s.appleRootCAs
+	roots := s.testAppleRootCAs
 	if roots == nil {
 		roots = x509.NewCertPool()
 		rootCABlock, _ := pem.Decode([]byte(appleEnterpriseAttestationRootCA))

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/fxamacker/cbor/v2"
+)
+
+const appleEnterpriseAttestationRootCA = `-----BEGIN CERTIFICATE-----
+MIICJDCCAamgAwIBAgIUQsDCuyxyfFxeq/bxpm8frF15hzcwCgYIKoZIzj0EAwMw
+UTEtMCsGA1UEAwwkQXBwbGUgRW50ZXJwcmlzZSBBdHRlc3RhdGlvbiBSb290IENB
+MRMwEQYDVQQKDApBcHBsZSBJbmMuMQswCQYDVQQGEwJVUzAeFw0yMjAyMTYxOTAx
+MjRaFw00NzAyMjAwMDAwMDBaMFExLTArBgNVBAMMJEFwcGxlIEVudGVycHJpc2Ug
+QXR0ZXN0YXRpb24gUm9vdCBDQTETMBEGA1UECgwKQXBwbGUgSW5jLjELMAkGA1UE
+BhMCVVMwdjAQBgcqhkjOPQIBBgUrgQQAIgNiAAT6Jigq+Ps9Q4CoT8t8q+UnOe2p
+oT9nRaUfGhBTbgvqSGXPjVkbYlIWYO+1zPk2Sz9hQ5ozzmLrPmTBgEWRcHjA2/y7
+7GEicps9wn2tj+G89l3INNDKETdxSPPIZpPj8VmjQjBAMA8GA1UdEwEB/wQFMAMB
+Af8wHQYDVR0OBBYEFPNqTQGd8muBpV5du+UIbVbi+d66MA4GA1UdDwEB/wQEAwIB
+BjAKBggqhkjOPQQDAwNpADBmAjEA1xpWmTLSpr1VH4f8Ypk8f3jMUKYz4QPG8mL5
+8m9sX/b2+eXpTv2pH4RZgJjucnbcAjEA4ZSB6S45FlPuS/u4pTnzoz632rA+xW/T
+ZwFEh9bhKjJ+5VQ9/Do1os0u3LEkgN/r
+-----END CERTIFICATE-----`
+
+var (
+	oidAppleSerialNumber = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 9, 1}
+	oidAppleNonce        = asn1.ObjectIdentifier{1, 2, 840, 113635, 100, 8, 11, 1}
+)
+
+func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrollment, account *types.Account, challengeID uint, payload string) (*types.ChallengeResponse, error) {
+	challenge, err := s.store.GetChallengeByID(ctx, account.ID, challengeID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting challenge by ID")
+	}
+
+	if challenge.Status != "pending" {
+		return nil, types.InvalidChallengeStatusError(fmt.Sprintf("Challenge with ID %d is not pending and can not be validated", challengeID))
+	}
+
+	var validationErr error
+	switch challenge.ChallengeType {
+	case types.DeviceAttestationChallengeType:
+		challenge, validationErr = s.validateDeviceAttestationChallenge(ctx, enrollment, challenge, payload)
+	default:
+		return nil, types.InternalServerError(fmt.Sprintf("unsupported challenge type %s", challenge.ChallengeType))
+	}
+
+	if challenge.Status == "pending" && validationErr != nil {
+		// Don't update to invalid if we failed on other causes
+		// TODO: Is this correct, or should we always mark it invalid on any failures?
+		return nil, validationErr
+	}
+
+	challengeResponse := &types.ChallengeResponse{
+		ChallengeType: challenge.ChallengeType,
+		Status:        challenge.Status,
+		Token:         challenge.Token,
+	}
+
+	// We always call UpdateChallenge here since we update it's validity by reference
+	// this internally updates challenge status, authorization status and order status, which we can
+	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
+	if updatedChallenge, err := s.store.UpdateChallenge(ctx, challenge); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
+	} else if updatedChallenge != nil && updatedChallenge.Status == "valid" {
+		challengeResponse.Validated = &updatedChallenge.UpdatedAt
+	}
+
+	if validationErr != nil {
+		return nil, validationErr
+	}
+
+	baseURL, err := s.getACMEBaseURL(ctx)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "getting base URL")
+	}
+
+	challengeURL, err := s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "challenges", fmt.Sprint(challenge.ID))
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "constructing challenge URL")
+	}
+	challengeResponse.URL = challengeURL
+
+	return challengeResponse, nil
+}
+
+func (s *Service) validateDeviceAttestationChallenge(ctx context.Context, enrollment *types.Enrollment, challenge *types.Challenge, payload string) (*types.Challenge, error) {
+	base64Decoded, err := base64.RawURLEncoding.DecodeString(payload)
+	if err != nil {
+		return nil, types.MalformedError(fmt.Sprintf("Failed to base64 decode payload: %v", err))
+	}
+
+	// Verify the CBOR structure
+	if err := cbor.Wellformed(base64Decoded); err != nil {
+		return nil, types.BadAttestationStatementError(fmt.Sprintf("Device attestation statement is not correctly CBOR formatted: %s", err.Error()))
+	}
+
+	var attestationObject types.AttestationObject
+	if err := cbor.Unmarshal(base64Decoded, &attestationObject); err != nil {
+		return nil, types.BadAttestationStatementError(fmt.Sprintf("Failed to unmarshal CBOR payload into attestation object: %s", err.Error()))
+	}
+
+	switch attestationObject.Format {
+	case "apple":
+		var appleStmt types.AppleDeviceAttestationStatement
+		if err := cbor.Unmarshal(attestationObject.AttestationStatement, &appleStmt); err != nil {
+			return nil, types.BadAttestationStatementError(fmt.Sprintf("Failed to unmarshal CBOR attestation statement into Apple format: %s", err.Error()))
+		}
+
+		return challenge, s.validateAppleDeviceAttestationStatement(ctx, enrollment, challenge, appleStmt)
+	default:
+		return nil, types.BadAttestationStatementError(fmt.Sprintf("Unsupported device attestation format: %s", attestationObject.Format))
+	}
+}
+
+// Challenge status is updated by reference
+func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, enrollment *types.Enrollment, challenge *types.Challenge, attStmt types.AppleDeviceAttestationStatement) error {
+	roots := x509.NewCertPool()
+	rootCABlock, _ := pem.Decode([]byte(appleEnterpriseAttestationRootCA))
+	if rootCABlock == nil {
+		return types.BadAttestationStatementError("Failed to parse Apple Enterprise Attestation Root CA certificate")
+	}
+	rootCA, err := x509.ParseCertificate(rootCABlock.Bytes)
+	if err != nil {
+		return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse Apple Enterprise Attestation Root CA certificate: %s", err.Error()))
+	}
+	roots.AddCert(rootCA)
+
+	leaf, err := x509.ParseCertificate(attStmt.X5C[0])
+	if err != nil {
+		return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse leaf certificate in Apple device attestation statement: %s", err.Error()))
+	}
+
+	intermediates := x509.NewCertPool()
+	for _, certBytes := range attStmt.X5C[1:] {
+		cert, err := x509.ParseCertificate(certBytes)
+		if err != nil {
+			return types.BadAttestationStatementError(fmt.Sprintf("Failed to parse intermediate certificate in Apple device attestation statement: %s", err.Error()))
+		}
+		intermediates.AddCert(cert)
+	}
+
+	if _, err := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		CurrentTime:   time.Now().Truncate(time.Second),
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); err != nil {
+		return types.BadAttestationStatementError(fmt.Sprintf("Failed to verify Apple Root CA is part of certificate chain: %s", err.Error()))
+	}
+
+	// TODO: Should we do any validation on leaf.PublicKey? Apple docs on validation calls out "Retain the public key in the attestation leaf certificate for a later validation."
+	// So unsure if we should persist it, or what the later validation might be.
+	appleData := struct {
+		SerialNumber string
+		Nonce        []byte
+	}{}
+
+	for _, ext := range leaf.Extensions {
+		if ext.Id.Equal(oidAppleSerialNumber) {
+			appleData.SerialNumber = string(ext.Value)
+		} else if ext.Id.Equal(oidAppleNonce) {
+			appleData.Nonce = ext.Value
+		}
+	}
+
+	sha256Token := sha256.Sum256([]byte(challenge.Token))
+	if subtle.ConstantTimeCompare(appleData.Nonce, sha256Token[:]) != 1 {
+		challenge.Status = "invalid"
+		return types.BadAttestationStatementError("Nonce does not match challenge token")
+	}
+
+	if appleData.SerialNumber != enrollment.HostIdentifier {
+		challenge.Status = "invalid"
+		return types.BadAttestationStatementError("Serial number in certificate does not match enrollment's host identifier")
+	}
+
+	depAssignments, err := s.providers.GetHostDEPAssignmentsBySerial(ctx, appleData.SerialNumber)
+	if err != nil {
+		challenge.Status = "invalid"
+		return ctxerr.Wrap(ctx, err, "getting DEP assignments for serial number in attestation certificate")
+	}
+
+	if len(depAssignments) < 1 {
+		challenge.Status = "invalid"
+		return types.BadAttestationStatementError("No DEP assignments found for serial number in certificate")
+	}
+
+	challenge.Status = "valid"
+	return nil
+}

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -55,8 +55,21 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		return nil, types.InternalServerError(fmt.Sprintf("unsupported challenge type %s", challenge.ChallengeType))
 	}
 
-	if updatedChallenge.Status == "pending" && validationErr != nil {
-		// Don't update to invalid if we failed on other causes
+	if validationErr != nil && updatedChallenge == nil {
+		return nil, validationErr
+	}
+
+	var validatedAt *time.Time
+	// We always call UpdateChallenge here since we update it's validity by reference
+	// this internally updates challenge status, authorization status and order status, which we can
+	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
+	if updatedChallenge, err := s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
+	} else if updatedChallenge != nil && updatedChallenge.Status == "valid" {
+		validatedAt = &updatedChallenge.UpdatedAt
+	}
+
+	if validationErr != nil {
 		return nil, validationErr
 	}
 
@@ -64,19 +77,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		ChallengeType: updatedChallenge.ChallengeType,
 		Status:        updatedChallenge.Status,
 		Token:         updatedChallenge.Token,
-	}
-
-	// We always call UpdateChallenge here since we update it's validity by reference
-	// this internally updates challenge status, authorization status and order status, which we can
-	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
-	if updatedChallenge, err := s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
-	} else if updatedChallenge != nil && updatedChallenge.Status == "valid" {
-		challengeResponse.Validated = &updatedChallenge.UpdatedAt
-	}
-
-	if validationErr != nil {
-		return nil, validationErr
+		Validated:     validatedAt,
 	}
 
 	baseURL, err := s.getACMEBaseURL(ctx)

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -5,7 +5,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -36,7 +35,6 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
-		fmt.Printf("Interlnal error in ACME service: %v\n", err)
 		// TODO: If we can get access to a logger, we can log the details here, to help troubleshoot service errors.
 		// if it's not already an ACME error, it is because it is an internal server
 		// error (or a dev error, for 4xx we should always return ACMEError).

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -35,6 +36,7 @@ func encodeResponse(ctx context.Context, w http.ResponseWriter, response any) er
 func acmeErrorEncoder(ctx context.Context, err error, w http.ResponseWriter) {
 	var acmeErr *types.ACMEError
 	if !errors.As(err, &acmeErr) {
+		fmt.Printf("Interlnal error in ACME service: %v\n", err)
 		// TODO: If we can get access to a logger, we can log the details here, to help troubleshoot service errors.
 		// if it's not already an ACME error, it is because it is an internal server
 		// error (or a dev error, for 4xx we should always return ACMEError).

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 
 	authz_ctx "github.com/fleetdm/fleet/v4/server/contexts/authz"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
@@ -176,16 +177,7 @@ func listOrdersEndpoint(ctx context.Context, request any, svc api.Service) platf
 // getAuthorizationEndpoint handles POST /api/mdm/acme/{identifier}/authz/{authorization} requests.
 func getAuthorizationEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
 	req := request.(*api_http.GetAuthorizationRequest)
-
-	// TODO: Uncomment once test changes with "" has been made
-	/* payload := req.JWS.UnsafePayloadWithoutVerification()
-	isPostAsGet := string(payload) == "" // POST-as-GET requests MUST have an empty payload
-	if !isPostAsGet {
-		return &api_http.GetAuthorizationResponse{
-			Err:    types.MalformedError("Payload was not empty for POST-as-GET request to authorization endpoint"),
-			Nonces: svc.NoncesStore(),
-		}
-	} */
+	req.PostAsGet = true
 	authzReq := &api_http.GetAuthorizationDecodedRequest{AuthorizationID: req.AuthorizationID}
 	err := svc.AuthenticateMessageFromAccount(ctx, &req.JWSRequestContainer, authzReq)
 	if err != nil {
@@ -204,7 +196,29 @@ func getAuthorizationEndpoint(ctx context.Context, request any, svc api.Service)
 }
 
 func getChallengeEndpoint(ctx context.Context, request any, svc api.Service) platform_http.Errorer {
-	panic("not implemented")
+	req := request.(*api_http.DoChallengeRequest)
+	decodedReq := &api_http.DoChallengeDecodedRequest{ChallengeID: req.ChallengeID}
+	err := svc.AuthenticateMessageFromAccount(ctx, &req.JWSRequestContainer, decodedReq)
+	if err != nil {
+		return &api_http.DoChallengeResponse{Err: err, Nonces: svc.NoncesStore()}
+	}
+
+	if decodedReq.AttestError != "" {
+		return &api_http.DoChallengeResponse{
+			Err:    types.UnauthorizedError(fmt.Sprintf("Attestation failure: %s", decodedReq.AttestError)),
+			Nonces: svc.NoncesStore(),
+		}
+	}
+
+	challengeResp, err := svc.ValidateChallenge(ctx, decodedReq.Enrollment, decodedReq.Account, decodedReq.ChallengeID, decodedReq.AttestationObject)
+	if err != nil {
+		return &api_http.DoChallengeResponse{Err: err, Nonces: svc.NoncesStore()}
+	}
+
+	return &api_http.DoChallengeResponse{
+		ChallengeResponse: challengeResp,
+		Nonces:            svc.NoncesStore(),
+	}
 }
 
 // finalizeOrderEndpoint handles POST /api/mdm/acme/{identifier}/orders/{order_id}/finalize requests.

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -52,8 +52,8 @@ func attachFleetAPIRoutes(r *mux.Router, svc api.Service, opts []kithttp.ServerO
 	// POST-as-GET for list orders endpoint, as per RFC.
 	ae.POST("/api/mdm/acme/{identifier}/accounts/{account_id}/orders", listOrdersEndpoint, api_http.ListOrdersRequest{})
 
-	ae.POST("/api/mdm/acme/{identifier}/authorizations/{authorization}", getAuthorizationEndpoint, api_http.GetAuthorizationRequest{})
-	ae.POST("/api/mdm/acme/{identifier}/challenges/{challenge}", getChallengeEndpoint, api_http.JWSRequestContainer{})
+	ae.POST("/api/mdm/acme/{identifier}/authorizations/{authorization_id}", getAuthorizationEndpoint, api_http.GetAuthorizationRequest{})
+	ae.POST("/api/mdm/acme/{identifier}/challenges/{challenge_id}", getChallengeEndpoint, api_http.DoChallengeRequest{})
 	ae.POST("/api/mdm/acme/{identifier}/orders/{order_id}/finalize", finalizeOrderEndpoint, api_http.FinalizeOrderRequestContainer{})
 }
 

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -3,6 +3,7 @@ package service
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -21,7 +22,12 @@ type Service struct {
 	nonces    *redis_nonces_store.RedisNoncesStore
 	providers acme.DataProviders
 	logger    *slog.Logger
+
+	// Field to set for testing, if not set it will use the hardcoded Apple Enterprise Attestation Root CA
+	appleRootCAs *x509.CertPool
 }
+
+type ServiceOption func(*Service)
 
 // NewService creates a new activity service.
 func NewService(
@@ -29,13 +35,24 @@ func NewService(
 	redisPool fleet.RedisPool,
 	providers acme.DataProviders,
 	logger *slog.Logger,
+	opts ...ServiceOption,
 ) *Service {
 	noncesStore := redis_nonces_store.New(redisPool)
-	return &Service{
+	svc := &Service{
 		store:     store,
 		nonces:    noncesStore,
 		providers: providers,
 		logger:    logger,
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
+}
+
+func WithAppleRootCAs(rootCAs *x509.CertPool) ServiceOption {
+	return func(svc *Service) {
+		svc.appleRootCAs = rootCAs
 	}
 }
 

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -24,7 +24,7 @@ type Service struct {
 	logger    *slog.Logger
 
 	// Field to set for testing, if not set it will use the hardcoded Apple Enterprise Attestation Root CA
-	appleRootCAs *x509.CertPool
+	testAppleRootCAs *x509.CertPool
 }
 
 type ServiceOption func(*Service)
@@ -50,9 +50,9 @@ func NewService(
 	return svc
 }
 
-func WithAppleRootCAs(rootCAs *x509.CertPool) ServiceOption {
+func WithTestAppleRootCAs(rootCAs *x509.CertPool) ServiceOption {
 	return func(svc *Service) {
-		svc.appleRootCAs = rootCAs
+		svc.testAppleRootCAs = rootCAs
 	}
 }
 

--- a/server/mdm/acme/internal/tests/attestation_test.go
+++ b/server/mdm/acme/internal/tests/attestation_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/service"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
+	"github.com/fxamacker/cbor/v2"
+)
+
+// Attestation test helpers
+
+func generateTestAttestationCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
+	key := generateTestKey(t)
+	template := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "Test Attestation CA"},
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("Failed to create test attestation CA certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse test attestation CA certificate: %v", err)
+	}
+	return cert, key
+}
+
+func buildAttestationLeafCert(t *testing.T, ca *x509.Certificate, caKey *ecdsa.PrivateKey, serial, token string) *x509.Certificate {
+	template := &x509.Certificate{
+		Subject:               pkix.Name{CommonName: "Test Attestation Leaf"},
+		KeyUsage:              x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+
+	hashedNonce := sha256.Sum256([]byte(token))
+
+	template.ExtraExtensions = []pkix.Extension{
+		{
+			Id:    service.OIDAppleSerialNumber,
+			Value: []byte(serial),
+		},
+		{
+			Id:    service.OIDAppleNonce,
+			Value: hashedNonce[:],
+		},
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, template, ca, generateTestKey(t).Public(), caKey)
+	if err != nil {
+		t.Fatalf("Failed to create attestation leaf certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("Failed to parse attestation leaf certificate: %v", err)
+	}
+	return cert
+}
+
+// The leaf cert should always be the first
+func buildAppleDeviceAttestationPayload(t *testing.T, certs ...*x509.Certificate) any {
+	x5c := make([][]byte, len(certs))
+	for i, cert := range certs {
+		x5c[i] = cert.Raw
+	}
+
+	appleAttest := types.AppleDeviceAttestationStatement{
+		X5C: x5c,
+	}
+
+	appleAttestCbor, err := cbor.Marshal(appleAttest)
+	if err != nil {
+		t.Fatalf("Failed to marshal Apple device attestation statement to CBOR: %v", err)
+	}
+
+	attObj := types.AttestationObject{
+		Format:               "apple",
+		AttestationStatement: appleAttestCbor,
+	}
+	attObjCbor, err := cbor.Marshal(attObj)
+	if err != nil {
+		t.Fatalf("Failed to marshal attestation object to CBOR: %v", err)
+	}
+
+	base64Encoded := base64.RawURLEncoding.EncodeToString(attObjCbor)
+
+	// finally embed in the top-level json payload
+	return struct {
+		AttObj string `json:"attObj"`
+	}{
+		AttObj: base64Encoded,
+	}
+}

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"testing"
@@ -8,6 +9,7 @@ import (
 
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fxamacker/cbor/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,6 +33,7 @@ func TestIntegration(t *testing.T) {
 		{"ListAccountOrders", testListAccountOrders},
 		{"GetAuthorization", testGetAuthorization},
 		{"FinalizeOrder", testFinalizeOrder},
+		{"DoChallengeDeviceAttestation", testDoChallengeDeviceAttestation},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -1383,5 +1386,221 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		require.NotNil(t, acmeErr)
 		require.Contains(t, acmeErr.Type, "badNonce")
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
+	})
+}
+
+func testDoChallengeDeviceAttestation(t *testing.T, s *integrationTestSuite) {
+	t.Run("successful device attestation", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour)), HostIdentifier: "valid-serial"}
+		s.InsertACMEEnrollment(t, enroll)
+
+		privateKey, accountURL, challengeURL, challengeToken, nonce := s.createOrderForChallenge(t, enroll)
+		leafCert := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, enroll.HostIdentifier, challengeToken)
+		payload := buildAppleDeviceAttestationPayload(t, leafCert, s.attestCA)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		challengeResp, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.Nil(t, acmeErr)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, challengeResp)
+		require.Equal(t, "valid", challengeResp.Status)
+	})
+
+	t.Run("challenge not pending", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour)), HostIdentifier: "valid-serial"}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, challengeToken, nonce := s.createOrderForChallenge(t, enroll)
+
+		// first do a successful challenge to move it out of pending state
+		leafCert := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, enroll.HostIdentifier, challengeToken)
+		payload := buildAppleDeviceAttestationPayload(t, leafCert, s.attestCA)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		challengeResp, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+		require.Nil(t, acmeErr)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		require.NotNil(t, challengeResp)
+		require.Equal(t, "valid", challengeResp.Status)
+		nonce = resp.Header.Get("Replay-Nonce")
+
+		// try to do the challenge again with the same JWS body
+		jwsBody = buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		challengeResp2, acmeErr2, resp2 := s.doChallenge(t, challengeURL, jwsBody)
+		require.NotNil(t, acmeErr2)
+		require.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+		require.Nil(t, challengeResp2)
+		require.Contains(t, acmeErr2.Type, "invalidChallengeStatus")
+		require.Contains(t, acmeErr2.Detail, "not pending and can not be validated")
+	})
+
+	t.Run("device attestation error", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, _, nonce := s.createOrderForChallenge(t, enroll)
+		payload := map[string]any{
+			"error": "device attestation failed",
+		}
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Type, "unauthorized")
+	})
+
+	t.Run("bad base64 payload", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, _, nonce := s.createOrderForChallenge(t, enroll)
+		// JWS with invalid base64 payload
+		body := map[string]any{
+			"attObj": "not a valid base64 string",
+		}
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, body)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Detail, "illegal base64 data")
+		require.Contains(t, acmeErr.Type, "malformed")
+	})
+
+	t.Run("bad CBOR payload", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, _, nonce := s.createOrderForChallenge(t, enroll)
+		// JWS with base64 that decodes but is not valid CBOR
+		body := map[string]any{
+			"attObj": base64.RawURLEncoding.EncodeToString([]byte("not valid CBOR data")),
+		}
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, body)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Detail, "not correctly CBOR formatted")
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+	})
+
+	t.Run("unsupported format", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, _, nonce := s.createOrderForChallenge(t, enroll)
+		// JWS with base64 that decodes to CBOR but has an unsupported format
+		cborData, err := cbor.Marshal(map[string]any{"fmt": "unsupported-format"})
+		require.NoError(t, err)
+		body := map[string]any{
+			"attObj": base64.RawURLEncoding.EncodeToString(cborData),
+		}
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, body)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.NotNil(t, acmeErr)
+		require.Contains(t, acmeErr.Detail, "Unsupported device attestation format")
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+	})
+
+	t.Run("invalid cert chain", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, challengeToken, nonce := s.createOrderForChallenge(t, enroll)
+
+		// build a cert chain that is not valid (leaf signed by unknown CA)
+		cert, key := generateTestAttestationCA(t)
+		leafCert := buildAttestationLeafCert(t, cert, key, enroll.HostIdentifier, challengeToken)
+		payload := buildAppleDeviceAttestationPayload(t, leafCert, cert)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+		require.Contains(t, acmeErr.Detail, "Failed to verify Apple Root CA is part of certificate chain")
+	})
+
+	t.Run("freshness nonce mismatch", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, _, nonce := s.createOrderForChallenge(t, enroll)
+
+		leaf := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, enroll.HostIdentifier, "dummy-challenge-token")
+		payload := buildAppleDeviceAttestationPayload(t, leaf, s.attestCA)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+		require.Contains(t, acmeErr.Detail, "Apple freshness nonce does not match challenge token")
+	})
+
+	t.Run("device serial mismatch", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, challengeToken, nonce := s.createOrderForChallenge(t, enroll)
+
+		leaf := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, "some-other-serial", challengeToken)
+		payload := buildAppleDeviceAttestationPayload(t, leaf, s.attestCA)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+		require.Contains(t, acmeErr.Detail, "Serial number in certificate does not match enrollment's host identifier")
+	})
+
+	t.Run("missing DEP assignment", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour)), HostIdentifier: "serial-without-dep"}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, challengeURL, challengeToken, nonce := s.createOrderForChallenge(t, enroll)
+
+		leaf := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, enroll.HostIdentifier, challengeToken)
+		payload := buildAppleDeviceAttestationPayload(t, leaf, s.attestCA)
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+		require.Contains(t, acmeErr.Detail, "No DEP assignments found for serial number in certificate")
+	})
+
+	t.Run("non existing challenge", func(t *testing.T) {
+		enroll := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour))}
+		s.InsertACMEEnrollment(t, enroll)
+		privateKey, accountURL, nonce := s.createAccountForOrder(t, enroll)
+
+		challengeURL := s.server.URL + "/api/mdm/acme/" + enroll.PathIdentifier + "/challenges/99999"
+		payload := map[string]any{
+			"attObj": "fake",
+		}
+		jwsBody := buildJWS(t, privateKey, nonce, accountURL, challengeURL, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "challengeDoesNotExist")
+		require.Contains(t, acmeErr.Detail, "Challenge with ID 99999 not found")
+	})
+
+	t.Run("challenge for different enrollment fails", func(t *testing.T) {
+		enroll1 := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour)), HostIdentifier: "serial1"}
+		enroll2 := &types.Enrollment{NotValidAfter: ptr.T(time.Now().Add(24 * time.Hour)), HostIdentifier: "serial2"}
+		s.InsertACMEEnrollment(t, enroll1)
+		s.InsertACMEEnrollment(t, enroll2)
+
+		privateKey1, accountURL1, challengeURL1, challengeToken1, nonce := s.createOrderForChallenge(t, enroll1)
+
+		// try to do enroll1's challenge with a payload built from enroll2's device cert
+		leaf := buildAttestationLeafCert(t, s.attestCA, s.attestCAKey, enroll2.HostIdentifier, challengeToken1)
+		payload := buildAppleDeviceAttestationPayload(t, leaf, s.attestCA)
+		jwsBody := buildJWS(t, privateKey1, nonce, accountURL1, challengeURL1, payload)
+		_, acmeErr, resp := s.doChallenge(t, challengeURL1, jwsBody)
+
+		require.NotNil(t, acmeErr)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		require.Contains(t, acmeErr.Type, "badAttestationStatement")
+		require.Contains(t, acmeErr.Detail, "Serial number in certificate does not match enrollment's host identifier")
 	})
 }

--- a/server/mdm/acme/internal/tests/mocks_test.go
+++ b/server/mdm/acme/internal/tests/mocks_test.go
@@ -2,6 +2,7 @@ package tests
 
 import (
 	"context"
+	"errors"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
@@ -25,4 +26,19 @@ func (m *mockDataProviders) AppConfig(ctx context.Context) (*fleet.AppConfig, er
 
 func (m *mockDataProviders) CSRSigner(ctx context.Context) (acme.CSRSigner, error) {
 	return m.signer, nil
+}
+
+// Returns a valid row with `valid-serial` else no row
+func (m *mockDataProviders) GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
+	// For testing, we can return a fixed response or an empty slice based on the serial number
+	if serial == "valid-serial" {
+		return []*fleet.HostDEPAssignment{
+			{
+				HostID: 1,
+			},
+		}, nil
+	} else if serial == "error-serial" {
+		return nil, errors.New("Mocked error for GetHostDEPAssignmentsBySerial")
+	}
+	return []*fleet.HostDEPAssignment{}, nil
 }

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -75,7 +75,7 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 		}),
 	)
 
-	opts := service.WithAppleRootCAs(rootPool)
+	opts := service.WithTestAppleRootCAs(rootPool)
 	// Create service
 	svc := service.NewService(ds, pool, providers, tdb.Logger, opts)
 

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -39,6 +39,9 @@ type integrationTestSuite struct {
 	*testutils.TestDB
 	ds     *mysql.Datastore
 	server *httptest.Server
+
+	attestCA    *x509.Certificate
+	attestCAKey *ecdsa.PrivateKey
 }
 
 // setupIntegrationTest creates a new test suite with a real database and HTTP server.
@@ -48,6 +51,9 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 	tdb := testutils.SetupTestDB(t, "acme_integration")
 	pool := redistest.SetupRedis(t, "acme_integration", false, false, false)
 	ds := mysql.NewDatastore(tdb.Conns(), tdb.Logger)
+	cert, key := generateTestAttestationCA(t)
+	rootPool := x509.NewCertPool()
+	rootPool.AddCert(cert)
 
 	// Create mocks
 	providers := newMockDataProviders(&fleet.AppConfig{
@@ -69,8 +75,9 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 		}),
 	)
 
+	opts := service.WithAppleRootCAs(rootPool)
 	// Create service
-	svc := service.NewService(ds, pool, providers, tdb.Logger)
+	svc := service.NewService(ds, pool, providers, tdb.Logger, opts)
 
 	// Create router with routes
 	router := mux.NewRouter()
@@ -85,9 +92,11 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 	ac.ServerSettings.ServerURL = server.URL
 
 	return &integrationTestSuite{
-		TestDB: tdb,
-		ds:     ds,
-		server: server,
+		TestDB:      tdb,
+		ds:          ds,
+		server:      server,
+		attestCA:    cert,
+		attestCAKey: key,
 	}
 }
 
@@ -276,6 +285,24 @@ func (s *integrationTestSuite) createOrderForGet(t *testing.T, enroll *types.Enr
 	return privateKey, accountURL, orderResp, nextNonce
 }
 
+// createOrderForChallenge is a convenience helper that creates account+order+fetches
+// authorization, returning: privateKey, accountURL, challengeURL, challengeToken, nonce.
+func (s *integrationTestSuite) createOrderForChallenge(t *testing.T, enroll *types.Enrollment) (privateKey *ecdsa.PrivateKey, accountURL, challengeURL, challengeToken, nonce string) {
+	t.Helper()
+	privateKey, accountURL, orderResp, nonce := s.createOrderForGet(t, enroll)
+
+	require.Len(t, orderResp.Authorizations, 1)
+	authURL := orderResp.Authorizations[0]
+
+	authResp, _, resp := s.getAuthorization(t, authURL, buildJWS(t, privateKey, nonce, accountURL, authURL, nil))
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Len(t, authResp.Challenges, 1)
+	challenge := authResp.Challenges[0]
+	nonce = resp.Header.Get("Replay-Nonce")
+	require.NotEmpty(t, nonce)
+	return privateKey, accountURL, challenge.URL, challenge.Token, nonce
+}
+
 // getOrderURL returns the full URL for the get order endpoint.
 func (s *integrationTestSuite) getOrderURL(pathIdentifier string, orderID uint) string {
 	return fmt.Sprintf("%s/api/mdm/acme/%s/orders/%d", s.server.URL, pathIdentifier, orderID)
@@ -401,25 +428,12 @@ func generateCSRPEM(t *testing.T, commonName string) string {
 	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}))
 }
 
-func (s *integrationTestSuite) getAuthorization(t *testing.T, authUrl string, jwsBody []byte) (*types.AuthorizationResponse, *types.ACMEError, *http.Response) {
+func (s *integrationTestSuite) getAuthorization(t *testing.T, authUrl string, jwsBody []byte) (*api_http.GetAuthorizationResponse, *types.ACMEError, *http.Response) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, authUrl, bytes.NewReader(jwsBody))
-	require.NoError(t, err)
+	return doACMERequest[api_http.GetAuthorizationResponse](t, http.MethodPost, authUrl, jwsBody)
+}
 
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer drainAndCloseBody(resp)
-
-	if resp.StatusCode >= 300 {
-		var acmeErr types.ACMEError
-		if err := json.NewDecoder(resp.Body).Decode(&acmeErr); err == nil && acmeErr.Type != "" {
-			return nil, &acmeErr, resp
-		}
-		return nil, nil, resp
-	}
-
-	var result types.AuthorizationResponse
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	require.NoError(t, err)
-	return &result, nil, resp
+func (s *integrationTestSuite) doChallenge(t *testing.T, challengeURL string, jwsBody []byte) (*api_http.DoChallengeResponse, *types.ACMEError, *http.Response) {
+	t.Helper()
+	return doACMERequest[api_http.DoChallengeResponse](t, http.MethodPost, challengeURL, jwsBody)
 }

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
 	"go.step.sm/crypto/jose"
 )
 
@@ -125,6 +126,8 @@ type Challenge struct {
 	ChallengeType       string `db:"challenge_type"`
 	Token               string `db:"token"`
 	Status              string `db:"status"`
+	// UpdatedAt is used as validated timestamp if the challenge is valid
+	UpdatedAt time.Time `db:"updated_at"`
 }
 
 type ChallengeResponse struct {
@@ -135,6 +138,20 @@ type ChallengeResponse struct {
 
 	// Validated is only set in the response when the challenge is valid and has been validated.
 	Validated *time.Time `json:"validated,omitempty"`
+
+	// Location is set in the header, pointing to the requested challenge's URL.
+	Location string `json:"-"`
+}
+
+// https://www.w3.org/TR/webauthn-2/#sctn-attestation, but we don't use authData as per the ACME RFC.
+type AttestationObject struct {
+	Format               string          `cbor:"fmt"`
+	AttestationStatement cbor.RawMessage `cbor:"attStmt"`
+}
+
+// https://www.w3.org/TR/webauthn-2/#sctn-apple-anonymous-attestation
+type AppleDeviceAttestationStatement struct {
+	X5C [][]byte `cbor:"x5c"`
 }
 
 const (
@@ -177,4 +194,7 @@ type Datastore interface {
 	GetAuthorizationByID(ctx context.Context, accountID uint, authorizationID uint) (*Authorization, error)
 	FinalizeOrder(ctx context.Context, orderID uint, csrPEM string, certSerial int64) error
 	GetChallengesByAuthorizationID(ctx context.Context, authorizationID uint) ([]*Challenge, error)
+	GetChallengeByID(ctx context.Context, accountID, challengeID uint) (*Challenge, error)
+	// Update challenge handles updating the challenge status, and the authorization status as well as moving the order status.
+	UpdateChallenge(ctx context.Context, challenge *Challenge) (*Challenge, error)
 }

--- a/server/mdm/acme/internal/types/errors.go
+++ b/server/mdm/acme/internal/types/errors.go
@@ -193,6 +193,7 @@ func AuthorizationDoesNotExistError(detail string) *ACMEError {
 	}
 }
 
+// Custom Fleet error code, as RFC does not document what to return.
 func ChallengeDoesNotExistError(detail string) *ACMEError {
 	return &ACMEError{
 		Type:       fleetCustomErrorsURI + "challengeDoesNotExist",
@@ -208,6 +209,25 @@ func OrderNotReadyError(detail string) *ACMEError {
 		Title:      "The request attempted to finalize an order that is not ready to be finalized",
 		Detail:     detail,
 		StatusCode: http.StatusForbidden, // as per RFC https://datatracker.ietf.org/doc/html/rfc8555/#section-6.7
+	}
+}
+
+func InvalidChallengeStatusError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       fleetCustomErrorsURI + "invalidChallengeStatus",
+		Title:      "The challenge is not in a valid status for the attempted operation",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
+	}
+}
+
+// Draft ACME device attest RFC https://datatracker.ietf.org/doc/html/draft-acme-device-attest-01#name-new-error-types
+func BadAttestationStatementError(detail string) *ACMEError {
+	return &ACMEError{
+		Type:       acmeErrorsURN + "badAttestationStatement",
+		Title:      "The attestation statement provided by the client was unacceptable",
+		Detail:     detail,
+		StatusCode: http.StatusBadRequest,
 	}
 }
 

--- a/server/mdm/acme/providers.go
+++ b/server/mdm/acme/providers.go
@@ -25,4 +25,5 @@ func (f CSRSignerFunc) SignCSR(ctx context.Context, csr *x509.CertificateRequest
 type DataProviders interface {
 	AppConfig(ctx context.Context) (*fleet.AppConfig, error)
 	CSRSigner(ctx context.Context) (CSRSigner, error)
+	GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error)
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40984  with the challenge and device attestation code piece.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Should have one for the entire ACME feature

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.


## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented ACME challenge validation with Apple device attestation support, enabling secure device verification during certificate enrollment.

* **Bug Fixes**
  * Fixed nonce generation in challenge responses to only occur on successful validations.

* **Chores**
  * Added CBOR module dependencies for attestation data serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->