### PR TITLE
Add quarterly access review ritual for IT

### DIFF
--- a/handbook/it/it.rituals.yml
+++ b/handbook/it/it.rituals.yml
@@ -17,6 +17,15 @@
   autoIssue:
     labels: [":help-it"]
     repo: "confidential"
+- task: "Quarterly access review"
+  startedOn: "2026-04-01"
+  frequency: "Quarterly"
+  description: "This is a compliance requirement. Create a new issue using the quarterly access review template."
+  moreInfoUrl: "https://github.com/fleetdm/confidential/issues/new?template=compliance-quarterly-access-review.md"
+  dri: "lppepper2"
+  autoIssue:
+    labels: [":help-it"]
+    repo: "confidential"
 - task: "Review active eval instances"
   startedOn: "2025-08-25"
   frequency: "Monthly"


### PR DESCRIPTION
## Changes

- Added new quarterly access review ritual to IT rituals configuration
- Task is scheduled to start on 2026-04-01 with quarterly frequency
- Configured to automatically create issues using the compliance-quarterly-access-review template
- Assigned to lppepper2 as DRI
- Tagged with `:help-it` label in confidential repo