### PR TITLE
The fix skips nodes where type === "column_ref", since those aren't table references

### DIFF
--- a/changes/40117-fix-sql-table-alias-platform-detection
+++ b/changes/40117-fix-sql-table-alias-platform-detection
@@ -1,0 +1,1 @@
+- Fixed a bug where SQL queries using table aliases (e.g., `FROM mounts m`) incorrectly reported no compatible platforms.

--- a/frontend/utilities/sql_tools.tests.ts
+++ b/frontend/utilities/sql_tools.tests.ts
@@ -60,11 +60,19 @@ WHERE triggering_extension IS NOT NULL AND username NOT LIKE '\\_%' ESCAPE '\\';
     expect(tables).toEqual([
       "file",
       "parse_json",
-      "chrome_preferences",
       "extension_safety_hub_menu_notifications",
       "extension_details",
       "problematic_extensions",
     ]);
+  });
+
+  // from https://github.com/fleetdm/fleet/issues/40117
+  it("should not include table aliases from column references", () => {
+    const sql =
+      "SELECT * FROM mounts m, disk_encryption d WHERE m.device_alias = d.name";
+    const { tables, error } = checkTable(sql);
+    expect(error).toBeNull();
+    expect(tables).toEqual(["mounts", "disk_encryption"]);
   });
 
   it("should return an error if SQL is invalid", () => {

--- a/frontend/utilities/sql_tools.ts
+++ b/frontend/utilities/sql_tools.ts
@@ -130,7 +130,7 @@ export const parseSqlTables = (
       }
 
       // Plain ol' tables.
-      if (node.table) {
+      if (node.table && node.type !== "column_ref") {
         results.push(node.table as string);
       }
     }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40117 

Fix:
<img width="1033" height="320" alt="image" src="https://github.com/user-attachments/assets/a6a642ef-d174-4ca7-b89b-8bb127c5c961" />

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.


## Testing

- [x] QA'd all new/changed functionality manually




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect platform detection for SQL queries that use table aliases (e.g., `FROM mounts m`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->