### PR TITLE
ACME: Base64 decode and use DER and non-PEM format

### DIFF
--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -3,8 +3,8 @@ package service
 import (
 	"context"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/pem"
-	"errors"
 	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
@@ -184,9 +184,10 @@ func (s *Service) FinalizeOrder(ctx context.Context, enrollment *types.Enrollmen
 		}
 	}
 
-	parsedCSR, err := parsePEMCSR(csr)
+	// The RFC 7.4 calls out that for the CSR it sends a base64url-encoded DER (so not a full PEM block)
+	parsedCSR, err := parseDERCSR(csr)
 	if err != nil {
-		return nil, types.BadCSRError(fmt.Sprintf("Error parsing PEM CSR: %s", err))
+		return nil, types.BadCSRError(fmt.Sprintf("Error parsing DER CSR: %s", err))
 	}
 	if parsedCSR.Subject.CommonName != order.Identifiers[0].Value {
 		return nil, types.BadCSRError("CSR common name does not match identifier value")
@@ -224,21 +225,19 @@ func (s *Service) FinalizeOrder(ctx context.Context, enrollment *types.Enrollmen
 	return s.createOrderResponse(ctx, enrollment, order, authorizations)
 }
 
-func parsePEMCSR(pemCSR string) (*x509.CertificateRequest, error) {
-	block, _ := pem.Decode([]byte(pemCSR))
-	if block == nil {
-		return nil, errors.New("no PEM blocks found")
-	}
-	if block.Type != "CERTIFICATE REQUEST" {
-		return nil, fmt.Errorf("unexpected PEM block type: %s", block.Type)
+func parseDERCSR(csr string) (*x509.CertificateRequest, error) {
+	// The CSR is base64 url encoded
+	base64DecodedCSR, err := base64.RawURLEncoding.DecodeString(csr)
+	if err != nil {
+		return nil, types.BadCSRError(fmt.Sprintf("Error decoding base64 CSR: %s", err))
 	}
 
-	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	parsedCSR, err := x509.ParseCertificateRequest(base64DecodedCSR)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing certificate request: %w", err)
 	}
 
-	return csr, nil
+	return parsedCSR, nil
 }
 
 func (s *Service) GetOrder(ctx context.Context, enrollment *types.Enrollment, account *types.Account, orderID uint) (*types.OrderResponse, error) {

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -1454,7 +1454,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		enroll, privateKey, accountURL, orderResp, nonce := s.createOrderForFinalize(t)
 		s.makeOrderReady(t, orderResp.ID)
 
-		csrPEM := generateCSRPEM(t, enroll.HostIdentifier)
+		csrPEM := generateCSRDER(t, enroll.HostIdentifier)
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, orderResp.ID)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, nonce, accountURL, finalizeURL, payload)
@@ -1474,7 +1474,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		enroll, privateKey, accountURL, orderResp, nonce := s.createOrderForFinalize(t)
 		// order is still in "pending" status (not made ready)
 
-		csrPEM := generateCSRPEM(t, enroll.HostIdentifier)
+		csrPEM := generateCSRDER(t, enroll.HostIdentifier)
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, orderResp.ID)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, nonce, accountURL, finalizeURL, payload)
@@ -1491,7 +1491,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		s.makeOrderReady(t, orderResp.ID)
 
 		// finalize the order first
-		csrPEM := generateCSRPEM(t, enroll.HostIdentifier)
+		csrPEM := generateCSRDER(t, enroll.HostIdentifier)
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, orderResp.ID)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, nonce, accountURL, finalizeURL, payload)
@@ -1513,7 +1513,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		enroll, privateKey, accountURL, orderResp, nonce := s.createOrderForFinalize(t)
 		s.makeOrderReady(t, orderResp.ID)
 
-		csrPEM := generateCSRPEM(t, "wrong-common-name")
+		csrPEM := generateCSRDER(t, "wrong-common-name")
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, orderResp.ID)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, nonce, accountURL, finalizeURL, payload)
@@ -1543,7 +1543,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 	t.Run("non-existing order", func(t *testing.T) {
 		enroll, privateKey, accountURL, _, nonce := s.createOrderForFinalize(t)
 
-		csrPEM := generateCSRPEM(t, enroll.HostIdentifier)
+		csrPEM := generateCSRDER(t, enroll.HostIdentifier)
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, 99999)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, nonce, accountURL, finalizeURL, payload)
@@ -1559,7 +1559,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		enroll, privateKey, accountURL, orderResp, _ := s.createOrderForFinalize(t)
 		s.makeOrderReady(t, orderResp.ID)
 
-		csrPEM := generateCSRPEM(t, enroll.HostIdentifier)
+		csrPEM := generateCSRDER(t, enroll.HostIdentifier)
 		finalizeURL := s.finalizeOrderURL(enroll.PathIdentifier, orderResp.ID)
 		payload := map[string]any{"csr": csrPEM}
 		jwsBody := buildJWS(t, privateKey, "bad-nonce", accountURL, finalizeURL, payload)

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -8,8 +8,8 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/base64"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"math/big"
@@ -479,8 +479,8 @@ func (s *integrationTestSuite) makeOrderReady(t *testing.T, orderID uint) {
 	require.NoError(t, err)
 }
 
-// generateCSRPEM creates a PEM-encoded ECDSA CSR with the given common name.
-func generateCSRPEM(t *testing.T, commonName string) string {
+// generateCSRDER creates a base64 URL encoded DER-encoded ECDSA CSR with the given common name.
+func generateCSRDER(t *testing.T, commonName string) string {
 	t.Helper()
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)
@@ -491,7 +491,10 @@ func generateCSRPEM(t *testing.T, commonName string) string {
 	}
 	csrDER, err := x509.CreateCertificateRequest(rand.Reader, template, key)
 	require.NoError(t, err)
-	return string(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER}))
+
+	// base64 URL encode the DER csr as per the RFC 7.4 spec
+	encoded := base64.RawURLEncoding.EncodeToString(csrDER)
+	return encoded
 }
 
 func (s *integrationTestSuite) getAuthorization(t *testing.T, authUrl string, jwsBody []byte) (*api_http.GetAuthorizationResponse, *types.ACMEError, *http.Response) {


### PR DESCRIPTION
Found as part of testing the full ACME delivery flow.

RFC 7.4 calls out:
> csr (required, string):  A CSR encoding the parameters for the
      certificate being requested [[RFC2986](https://datatracker.ietf.org/doc/html/rfc2986)].  The CSR is sent in the
      base64url-encoded version of the DER format.  (Note: Because this
      field uses base64url, and does not include headers, it is
      different from PEM.)