### PR TITLE
Improve Windows Autopilot dev setup docs with custom domain

### DIFF
--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -1001,63 +1001,19 @@ a branch you're working on. Step 1 Option A below describes the former and B des
 You will also need to serve the `meta.json` for the fleetd-base.msi installer, creation of which is
 described below.
 
-For Autopilot, Microsoft Entra requires the Fleet server to have a **verified custom domain** for the MDM application URIs (see `/settings/integrations/automatic-enrollment/windows` on your Fleet instance). You cannot use a raw `*.ngrok.io` URL — Entra will reject it during domain verification. You can test this flow with Dogfood/QA (already configured) or set up your own custom domain as described below.
-
-#### Setting up a custom domain with ngrok
-
-1. **Register a domain** (e.g., a cheap `.xyz` domain from Namecheap). You don't need to purchase SSL — ngrok handles TLS termination.
-2. **Add the domain in ngrok's dashboard** (Domains section). ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
-3. **Configure DNS in your domain registrar:**
-   - Add a **CNAME record** pointing your domain to the ngrok CNAME target.
-   - Add the **TXT record** that Microsoft Entra provides for domain verification (see next step).
-4. **Verify the domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your domain, and verify it using the TXT record.
-5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your custom domain for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
-
-#### Required licenses
-
-Your Entra test user needs **both** of the following:
-- **Microsoft Intune Plan 1** — required for Autopilot device management.
-- **Microsoft Entra ID P1** (or a bundle that includes it, such as Microsoft 365 Business Premium, E3, or E5) — required for automatic MDM enrollment. Note: Microsoft 365 Business Standard does **not** include Entra P1.
-
-Assign licenses from the [Microsoft 365 Admin Center](https://admin.cloud.microsoft/?#/licenses). See the [Windows Autopilot guide](../../product-groups/mdm/windows-autopilot.md#assigning-an-intune-license-to-your-user) for details.
+For Autopilot, Azure requires the Fleet server instance to have a proper domain name with some TXT/MX records added (see `/settings/integrations/automatic-enrollment/windows` on your Fleet instance).
+For that reason, currently the only way to test this flow is to use Dogfood or the QA fleet server,
+which already have this configured, or to [configure an alternate server for this workflow](../../product-groups/mdm/windows-autopilot.md#setting-up-a-custom-domain-with-ngrok).
 
 #### Pre-requisites
 
-- The URL of your Fleet server (must be your verified custom domain for Autopilot)
+- The URL of your Fleet server
 - An ngrok tunnel URL pointed at your local TUF server. In the examples below this is
   https://tuf.fleetdm-example.ngrok.app and the TUF server is running on http://localhost:8081
 - An ngrok tunnel URL for serving the `fleetd-base.msi` installer and a properly formatted
   `meta.json` file under the `stable/` path. In the examples below this is
   https://installers.fleetdm-example.ngrok.app and the installers are served from http://localhost:8085
 - Perform a deployment with `FLEET_DEV_DOWNLOAD_FLEETDM_URL` set to the "installers" ngrok URL.
-
-Example ngrok config with a custom domain for the Fleet server:
-```yaml
-version: "3"
-agent:
-    authtoken: <your_ngrok_authtoken>
-tunnels:
-    fleet:
-        proto: http
-        schemes: [https]
-        hostname: yourdomain.xyz  # your verified custom domain
-        addr: https://localhost:8080
-        inspect: true
-    installers:
-        proto: http
-        schemes: [https]
-        hostname: installers.your-ngrok-subdomain.ngrok.io
-        addr: http://localhost:8085
-        inspect: true
-    tuf:
-        proto: http
-        schemes: [http]
-        hostname: tuf.your-ngrok-subdomain.ngrok.io
-        addr: http://localhost:8081
-        inspect: true
-```
-
-Only the Fleet server tunnel needs the custom domain. The installer and TUF tunnels can use regular ngrok subdomains.
 
 #### Step 1 Option A: Building a signed fleetd-base.msi installer from `edge`
 

--- a/docs/Contributing/getting-started/testing-and-local-development.md
+++ b/docs/Contributing/getting-started/testing-and-local-development.md
@@ -1001,19 +1001,63 @@ a branch you're working on. Step 1 Option A below describes the former and B des
 You will also need to serve the `meta.json` for the fleetd-base.msi installer, creation of which is
 described below.
 
-For Autopilot, Azure requires the Fleet server instance to have a proper domain name with some TXT/MX records added (see `/settings/integrations/automatic-enrollment/windows` on your Fleet instance).
-For that reason, currently the only way to test this flow is to use Dogfood or the QA fleet server,
-which already have this configured, or to configure an alternate server for this workflow.
+For Autopilot, Microsoft Entra requires the Fleet server to have a **verified custom domain** for the MDM application URIs (see `/settings/integrations/automatic-enrollment/windows` on your Fleet instance). You cannot use a raw `*.ngrok.io` URL — Entra will reject it during domain verification. You can test this flow with Dogfood/QA (already configured) or set up your own custom domain as described below.
+
+#### Setting up a custom domain with ngrok
+
+1. **Register a domain** (e.g., a cheap `.xyz` domain from Namecheap). You don't need to purchase SSL — ngrok handles TLS termination.
+2. **Add the domain in ngrok's dashboard** (Domains section). ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
+3. **Configure DNS in your domain registrar:**
+   - Add a **CNAME record** pointing your domain to the ngrok CNAME target.
+   - Add the **TXT record** that Microsoft Entra provides for domain verification (see next step).
+4. **Verify the domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your domain, and verify it using the TXT record.
+5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your custom domain for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
+
+#### Required licenses
+
+Your Entra test user needs **both** of the following:
+- **Microsoft Intune Plan 1** — required for Autopilot device management.
+- **Microsoft Entra ID P1** (or a bundle that includes it, such as Microsoft 365 Business Premium, E3, or E5) — required for automatic MDM enrollment. Note: Microsoft 365 Business Standard does **not** include Entra P1.
+
+Assign licenses from the [Microsoft 365 Admin Center](https://admin.cloud.microsoft/?#/licenses). See the [Windows Autopilot guide](../../product-groups/mdm/windows-autopilot.md#assigning-an-intune-license-to-your-user) for details.
 
 #### Pre-requisites
 
-- The URL of your Fleet server
+- The URL of your Fleet server (must be your verified custom domain for Autopilot)
 - An ngrok tunnel URL pointed at your local TUF server. In the examples below this is
   https://tuf.fleetdm-example.ngrok.app and the TUF server is running on http://localhost:8081
 - An ngrok tunnel URL for serving the `fleetd-base.msi` installer and a properly formatted
   `meta.json` file under the `stable/` path. In the examples below this is
   https://installers.fleetdm-example.ngrok.app and the installers are served from http://localhost:8085
 - Perform a deployment with `FLEET_DEV_DOWNLOAD_FLEETDM_URL` set to the "installers" ngrok URL.
+
+Example ngrok config with a custom domain for the Fleet server:
+```yaml
+version: "3"
+agent:
+    authtoken: <your_ngrok_authtoken>
+tunnels:
+    fleet:
+        proto: http
+        schemes: [https]
+        hostname: yourdomain.xyz  # your verified custom domain
+        addr: https://localhost:8080
+        inspect: true
+    installers:
+        proto: http
+        schemes: [https]
+        hostname: installers.your-ngrok-subdomain.ngrok.io
+        addr: http://localhost:8085
+        inspect: true
+    tuf:
+        proto: http
+        schemes: [http]
+        hostname: tuf.your-ngrok-subdomain.ngrok.io
+        addr: http://localhost:8081
+        inspect: true
+```
+
+Only the Fleet server tunnel needs the custom domain. The installer and TUF tunnels can use regular ngrok subdomains.
 
 #### Step 1 Option A: Building a signed fleetd-base.msi installer from `edge`
 
@@ -1071,11 +1115,11 @@ mkdir -p ./tmp/fleetd-base-dir/stable
 4. Start up an HTTP file server from the Fleet repo root directory using the [`tools/file-server`](../../tools/file-server/README.md) tool: `go run ./tools/file-server 8085 ./tmp/fleetd-base-dir`
 5. Start your "installers" ngrok tunnel and forward to http://localhost:8085.
 	- Example: `ngrok http --domain=installers.fleetdm-example.ngrok.app http://localhost:8085`
-6. Perform a Fleet deployment(to Dogfood, QA or your own instance) with
-   `FLEET_DEV_DOWNLOAD_FLEETDM_URL` set to the "installers" ngrok URL (if using Terraform, the environment variable is set on
-   `infrastructure/dogfood/terraform/aws-tf-module/main.tf`).
-	- Example: `FLEET_DEV_DOWNLOAD_FLEETDM_URL="https://installers.fleetdm-example.ngrok.app"`
-7. Enroll your Windows device with Autopilot. Tip: You can watch ngrok traffic via the inspect web interface url to ensure the two hosted packages are in the correct place and successfully reached by the host.
+6. Start your Fleet server with `FLEET_DEV_DOWNLOAD_FLEETDM_URL` set to the "installers" ngrok URL. For a local dev server:
+	- Example: `FLEET_DEV_DOWNLOAD_FLEETDM_URL="https://installers.fleetdm-example.ngrok.app" ./build/fleet serve --dev`
+	- For Dogfood/QA deployments using Terraform, set the environment variable on `infrastructure/dogfood/terraform/aws-tf-module/main.tf`.
+	- Note: This variable is only read when dev mode is enabled (`--dev` flag).
+7. Enroll your Windows device with Autopilot. See the [Windows Autopilot guide](../../product-groups/mdm/windows-autopilot.md#enrolling-the-device) for detailed enrollment steps, including prerequisites like custom domain setup and required licenses. Tip: You can watch ngrok traffic via the inspect web interface url to ensure the two hosted packages are in the correct place and successfully reached by the host.
 
 ## MDM setup and testing
 

--- a/docs/Contributing/product-groups/mdm/windows-autopilot.md
+++ b/docs/Contributing/product-groups/mdm/windows-autopilot.md
@@ -4,7 +4,7 @@
 - [Windows MDM Setup](https://fleetdm.com/guides/windows-mdm-setup#windows-autopilot)
 - [Autopilot add devices](https://learn.microsoft.com/en-us/autopilot/add-devices)
 - [Assigning Intune licenses](https://learn.microsoft.com/en-gb/intune/intune-service/fundamentals/licenses-assign)
-- [Serve locally built Fleetd during Autopilot](https://github.com/fleetdm/fleet/blob/docs-windows-autopilot-dev/docs/Contributing/getting-started/testing-and-local-development.md#building-and-serving-your-own-fleetd-basemsi-installer-for-windows)
+- [Serve locally built Fleetd during Autopilot](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/getting-started/testing-and-local-development.md#building-and-serving-your-own-fleetd-basemsi-installer-for-windows)
 
 ## Assigning an Intune license to your user
 To use Autopilot, your user needs to have an Intune license assigned. If you don't already have one assigned, follow these steps:
@@ -14,6 +14,7 @@ To use Autopilot, your user needs to have an Intune license assigned. If you don
 3. Click "Assign licenses"
 4. Select your user and click "Assign"
     1. If it says no license is available, you are good to buy a license, which will be charged on Noah Talerman's (As of 24th February 2026) brex card.
+
 
 ## Configuring Windows Autopilot for development
 To set up Windows Autopilot for development, follow these steps:
@@ -34,9 +35,49 @@ To add your Windows device (VM's work as well) to Autopilot, you need to get som
 
 Follow the steps [in the autopilot add devices guide](https://learn.microsoft.com/en-us/autopilot/add-devices#directly-upload-the-hardware-hash-to-an-mdm-service), to either get the information into a .csv or upload it directly.
 
+> **Important:** When uploading the hardware hash CSV, include the **group tag** that matches your dynamic security group query (e.g., `NameDev`). If you forget, you can edit the device in the [Autopilot devices list](https://intune.microsoft.com/#view/Microsoft_Intune_Enrollment/AutopilotDevices.ReactView/filterOnManualRemediationRequired~/false) and add it later.
 
 #### If using a VM
 If using a VM, make sure the VM is assigned a serial number. This is different on how to do for each VM provider, but for example on UTM, you can edit an instance, go to "Arguments" and add the following: `-smbios type=1,serial=<SERIAL_NUMBER>`, where <SERIAL_NUMBER> is a custom unique identifier.
 
+Once added, you should see the device with it's serial show up in [the Autopilot devices list](https://intune.microsoft.com/#view/Microsoft_Intune_Enrollment/AutopilotDevices.ReactView/filterOnManualRemediationRequired~/false), it is ready to be enrolled, once the "Profile status" is "Assigned" (which may take some minutes).
 
-Once added, you should see the device with it's serial show up in [the Autopilot devices list](https://intune.microsoft.com/#view/Microsoft_Intune_Enrollment/AutopilotDevices.ReactView/filterOnManualRemediationRequired~/false), it is ready to be enrolled, once the "Profile status" is "Assigned".
+## Setting up a custom domain with ngrok
+
+Microsoft Entra requires a **verified custom domain** for the MDM application URIs. You cannot use a raw `*.ngrok.io` URL — Entra will reject it during domain verification.
+
+1. **Register a domain** (e.g., a cheap `.xyz` domain from Namecheap). You don't need to purchase SSL — ngrok handles TLS termination.
+2. **Add the domain in ngrok's dashboard** (Domains section). ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
+3. **Configure DNS in your domain registrar:**
+   - Add a **CNAME record** pointing your domain to the ngrok CNAME target.
+   - Add the **TXT record** that Microsoft Entra provides for domain verification (see next step).
+4. **Verify the domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your domain, and verify it using the TXT record.
+5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your custom domain for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
+
+Example ngrok config with a custom domain for the Fleet server:
+```yaml
+version: "3"
+agent:
+    authtoken: <your_ngrok_authtoken>
+tunnels:
+    fleet:
+        proto: http
+        schemes: [https]
+        hostname: yourdomain.xyz  # your verified custom domain
+        addr: https://localhost:8080
+        inspect: true
+    installers:
+        proto: http
+        schemes: [https]
+        hostname: installers.your-ngrok-subdomain.ngrok.io
+        addr: http://localhost:8085
+        inspect: true
+    tuf:
+        proto: http
+        schemes: [http]
+        hostname: tuf.your-ngrok-subdomain.ngrok.io
+        addr: http://localhost:8081
+        inspect: true
+```
+
+Only the Fleet server tunnel needs the custom domain. The installer and TUF tunnels can use regular ngrok subdomains.

--- a/docs/Contributing/product-groups/mdm/windows-autopilot.md
+++ b/docs/Contributing/product-groups/mdm/windows-autopilot.md
@@ -50,7 +50,7 @@ Microsoft Entra requires a **verified custom domain** for the MDM application UR
 2. **Add the domain in ngrok's dashboard** (Domains section). ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
 3. **Configure DNS in your domain registrar:**
    - Add a **CNAME record** pointing your domain to the ngrok CNAME target.
-   - Add the **TXT record** that Microsoft Entra provides for domain verification (see next step).
+   - Add the **TXT record** that Microsoft Entra provides for domain verification.
 4. **Verify the domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your domain, and verify it using the TXT record.
 5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your custom domain for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
 

--- a/docs/Contributing/product-groups/mdm/windows-autopilot.md
+++ b/docs/Contributing/product-groups/mdm/windows-autopilot.md
@@ -47,12 +47,13 @@ Once added, you should see the device with it's serial show up in [the Autopilot
 Microsoft Entra requires a **verified custom domain** for the MDM application URIs. You cannot use a raw `*.ngrok.io` URL — Entra will reject it during domain verification.
 
 1. **Register a domain** (e.g., a cheap `.xyz` domain from Namecheap). You don't need to purchase SSL — ngrok handles TLS termination.
-2. **Add the domain in ngrok's dashboard** (Domains section). ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
+2. **Add a subdomain in ngrok's dashboard** (Domains section) — e.g., `mdm.yourdomain.xyz`. ngrok will provide a CNAME target (e.g., `xxx.ngrok-dns.com`).
 3. **Configure DNS in your domain registrar:**
-   - Add a **CNAME record** pointing your domain to the ngrok CNAME target.
-   - Add the **TXT record** that Microsoft Entra provides for domain verification.
-4. **Verify the domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your domain, and verify it using the TXT record.
-5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your custom domain for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
+   - Add a **CNAME record** for the subdomain (e.g., `mdm`) pointing to the ngrok CNAME target.
+   - Add the **TXT record** that Microsoft Entra provides on the **root domain** (e.g., `yourdomain.xyz`) for domain verification.
+   - Note: DNS standards don't allow CNAME records to coexist with other record types at the same name. Using a subdomain for the CNAME avoids this conflict — the root domain stays free for the Entra TXT verification record.
+4. **Verify the root domain in Entra:** go to [Entra > Domain names](https://entra.microsoft.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Domains) > Add custom domain, enter your root domain (e.g., `yourdomain.xyz`), and verify it using the TXT record.
+5. **Configure the MDM application in Entra** following the [Windows MDM Setup guide](https://fleetdm.com/guides/windows-mdm-setup#step-2-connect-fleet-to-microsoft-entra-id). Use your **subdomain** (e.g., `mdm.yourdomain.xyz`) for all MDM URLs (Application ID URI, discovery URL, terms of use URL).
 
 Example ngrok config with a custom domain for the Fleet server:
 ```yaml
@@ -63,7 +64,7 @@ tunnels:
     fleet:
         proto: http
         schemes: [https]
-        hostname: yourdomain.xyz  # your verified custom domain
+        hostname: mdm.yourdomain.xyz  # subdomain CNAME'd to ngrok
         addr: https://localhost:8080
         inspect: true
     installers:


### PR DESCRIPTION
- Added custom domain + ngrok setup instructions for local Autopilot testing (Entra requires a verified domain, not raw ngrok URLs).
- Clarified that `FLEET_DEV_DOWNLOAD_FLEETDM_URL` is a server runtime env var requiring `--dev` mode.