### PR TITLE
Website: Update generated trial license keys for users who don't have an organization set.

### DIFF
--- a/website/api/controllers/view-fleet-premium-trial-or-redirect.js
+++ b/website/api/controllers/view-fleet-premium-trial-or-redirect.js
@@ -52,7 +52,7 @@ module.exports = {
       let thirtyDaysFromNowAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
       let trialLicenseKeyForThisUser = await sails.helpers.createLicenseKey.with({
         numberOfHosts: 10,
-        organization: this.req.me.organization,
+        organization: this.req.me.organization ? this.req.me.organization : 'Fleet premium trial',
         expiresAt: thirtyDaysFromNowAt,
       });
       // Save the trial license key to the DB record for this user.

--- a/website/api/controllers/view-fleet-premium-trial-or-redirect.js
+++ b/website/api/controllers/view-fleet-premium-trial-or-redirect.js
@@ -52,7 +52,7 @@ module.exports = {
       let thirtyDaysFromNowAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
       let trialLicenseKeyForThisUser = await sails.helpers.createLicenseKey.with({
         numberOfHosts: 10,
-        organization: this.req.me.organization ? this.req.me.organization : 'Fleet premium trial',
+        organization: this.req.me.organization ? this.req.me.organization : 'Fleet Premium trial',
         expiresAt: thirtyDaysFromNowAt,
       });
       // Save the trial license key to the DB record for this user.

--- a/website/api/controllers/view-fleetctl-preview.js
+++ b/website/api/controllers/view-fleetctl-preview.js
@@ -42,7 +42,7 @@ module.exports = {
         let thirtyDaysFromNowAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
         let trialLicenseKeyForThisUser = await sails.helpers.createLicenseKey.with({
           numberOfHosts: 10,
-          organization: this.req.me.organization ? this.req.me.organization : 'Fleet premium trial',
+          organization: this.req.me.organization ? this.req.me.organization : 'Fleet Premium trial',
           expiresAt: thirtyDaysFromNowAt,
         });
         // Save the trial license key to the DB record for this user.

--- a/website/api/controllers/view-fleetctl-preview.js
+++ b/website/api/controllers/view-fleetctl-preview.js
@@ -42,7 +42,7 @@ module.exports = {
         let thirtyDaysFromNowAt = Date.now() + (1000 * 60 * 60 * 24 * 30);
         let trialLicenseKeyForThisUser = await sails.helpers.createLicenseKey.with({
           numberOfHosts: 10,
-          organization: this.req.me.organization,
+          organization: this.req.me.organization ? this.req.me.organization : 'Fleet premium trial',
           expiresAt: thirtyDaysFromNowAt,
         });
         // Save the trial license key to the DB record for this user.


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/42829

Changes:
- Updated the trial licenses generated for users in view-fleet-premium-trial-or-redirect and view-fleetctl-preview to use "Fleet Premium trial" as the organization if a user does not have an organization set (older accounts created for Fleet sandbox)