### PR TITLE
Add missing $FLEET_VAR_SCEP_RENEWAL_ID to Okta Platform SSO guide

### DIFF
--- a/articles/deploying-okta-platform-sso-with-fleet.md
+++ b/articles/deploying-okta-platform-sso-with-fleet.md
@@ -98,13 +98,32 @@ Open [iMazing Profile Editor](https://imazing.com/profile-editor), create a new 
 - **URL:** `$FLEET_VAR_NDES_SCEP_PROXY_URL`
 - **Challenge:** `$FLEET_VAR_NDES_SCEP_CHALLENGE`
 - **Subject:** `CN=managementAttestation %HardwareUUID%`
+- **Subject Alt Names:** Add an OU field with value `$FLEET_VAR_SCEP_RENEWAL_ID`
 - **Key Size:** 2048
 - **Key Usage:** Signing
 - **Key is Extractable:** Unchecked
 - **Allow All Apps Access:** Checked
 - **Certificate Expiration Notification:** Set to 14 days before expiration
 
-Fleet replaces `$FLEET_VAR_NDES_SCEP_PROXY_URL` and `$FLEET_VAR_NDES_SCEP_CHALLENGE` with fresh values each time the profile is delivered to a host. Each host receives a unique, short-lived challenge rather than a shared static secret.
+**Important:** The Subject must include both the CN and an OU field with `$FLEET_VAR_SCEP_RENEWAL_ID`. In raw XML, the Subject array should look like this:
+
+```xml
+<key>Subject</key>
+<array>
+    <array>
+        <array>
+            <string>CN</string>
+            <string>managementAttestation %HardwareUUID%</string>
+        </array>
+        <array>
+            <string>OU</string>
+            <string>$FLEET_VAR_SCEP_RENEWAL_ID</string>
+        </array>
+    </array>
+</array>
+```
+
+Fleet replaces `$FLEET_VAR_NDES_SCEP_PROXY_URL`, `$FLEET_VAR_NDES_SCEP_CHALLENGE`, and `$FLEET_VAR_SCEP_RENEWAL_ID` with the appropriate values each time the profile is delivered to a host. Each host receives a unique, short-lived challenge rather than a shared static secret.
 
 **Important:** Okta doesn't support automatic certificate renewal. You must redeploy the profile before the certificate expires to replace it. Use the osquery policy below to identify hosts with certificates expiring within 14 days.
 

--- a/docs/solutions/macos/configuration-profiles/okta-device-access-scep-dynamic-example.mobileconfig
+++ b/docs/solutions/macos/configuration-profiles/okta-device-access-scep-dynamic-example.mobileconfig
@@ -24,6 +24,10 @@
 							<string>CN</string>
 							<string>managementAttestation %HardwareUUID%</string>
 						</array>
+						<array>
+							<string>OU</string>
+							<string>$FLEET_VAR_SCEP_RENEWAL_ID</string>
+						</array>
 					</array>
 				</array>
 				<key>URL</key>


### PR DESCRIPTION
The SCEP profile for NDES certificate authority requires the $FLEET_VAR_SCEP_RENEWAL_ID variable in the Subject OU field. Without this, GitOps runs fail with an error about missing variables.

https://claude.ai/code/session_01DW2rrUmrxsTaD3t5J66Xz4

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
