### PR TITLE
Prevent thundering herd from osquery_perf

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -19,6 +19,7 @@ import (
 	"log"
 	"maps"
 	"math/rand"
+	randv2 "math/rand/v2"
 	"net/http"
 	_ "net/http/pprof"
 	"os"
@@ -704,7 +705,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 
 	// (1) distributed thread:
 	go func() {
-		time.Sleep(time.Duration(rand.Int63n(int64(a.QueryInterval))))
+		time.Sleep(randv2.N(a.QueryInterval))
 		liveQueryTicker := time.NewTicker(a.QueryInterval)
 		defer liveQueryTicker.Stop()
 
@@ -717,7 +718,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 
 	// (2) config thread:
 	go func() {
-		time.Sleep(time.Duration(rand.Int63n(int64(a.ConfigInterval))))
+		time.Sleep(randv2.N(a.ConfigInterval))
 		configTicker := time.NewTicker(a.ConfigInterval)
 		defer configTicker.Stop()
 
@@ -727,7 +728,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 	}()
 
 	// (3) logger thread:
-	time.Sleep(time.Duration(rand.Int63n(int64(a.LogInterval))))
+	time.Sleep(randv2.N(a.LogInterval))
 	logTicker := time.NewTicker(a.LogInterval)
 	defer logTicker.Stop()
 	for range logTicker.C {

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -704,6 +704,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 
 	// (1) distributed thread:
 	go func() {
+		time.Sleep(time.Duration(rand.Int63n(int64(a.QueryInterval))))
 		liveQueryTicker := time.NewTicker(a.QueryInterval)
 		defer liveQueryTicker.Stop()
 
@@ -716,6 +717,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 
 	// (2) config thread:
 	go func() {
+		time.Sleep(time.Duration(rand.Int63n(int64(a.ConfigInterval))))
 		configTicker := time.NewTicker(a.ConfigInterval)
 		defer configTicker.Stop()
 
@@ -725,6 +727,7 @@ func (a *agent) runLoop(i int, onlyAlreadyEnrolled bool) {
 	}()
 
 	// (3) logger thread:
+	time.Sleep(time.Duration(rand.Int63n(int64(a.LogInterval))))
 	logTicker := time.NewTicker(a.LogInterval)
 	defer logTicker.Stop()
 	for range logTicker.C {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42808

Added some jitter to prevent all osquery perf agents from checking in at the same time. This seems like a more realistic access pattern for the loadtest.

# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually

