### PR TITLE
Add retry considerations to PR template and design/qa considerations

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ If some of the following don't apply, delete the relevant line.
   See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
 
 - [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
+- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
 - [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes
 
 ## Testing

--- a/docs/Contributing/guides/ui/design-qa-considerations.md
+++ b/docs/Contributing/guides/ui/design-qa-considerations.md
@@ -162,5 +162,8 @@ This is meant to be a helpful checklist of 'events' or 'transactions' to help ca
 - Global user (Admin, Maintainer, Observer, Observer+, API only)
 - Fleet-level user (Admin, Maintainer, Observer, Observer+, API only)
 
+## Retries
+- Operations with retries have defined limits(time, number of attempts, etc) to avoid infinite loops and unbounded retrying
+
 <meta name="pageOrderInSection" value="3300">
 <meta name="description" value="A helpful checklist of 'events' or 'transactions' to think about while designing or testing new features or bugs.">

--- a/docs/Contributing/guides/ui/design-qa-considerations.md
+++ b/docs/Contributing/guides/ui/design-qa-considerations.md
@@ -163,7 +163,7 @@ This is meant to be a helpful checklist of 'events' or 'transactions' to help ca
 - Fleet-level user (Admin, Maintainer, Observer, Observer+, API only)
 
 ## Retries
-- Operations with retries have defined limits(time, number of attempts, etc) to avoid infinite loops and unbounded retrying
+- Operations with retries have defined limits (time, number of attempts, etc.) to avoid infinite loops and unbounded retrying
 
 <meta name="pageOrderInSection" value="3300">
 <meta name="description" value="A helpful checklist of 'events' or 'transactions' to think about while designing or testing new features or bugs.">


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Action items for #40725 postmortem

Added in both places because we should consider these things both when working on bugs and drafting new features. #40725 happened because what was thought to be a temporary state had no limits on retries