### PR TITLE
Claude, use math/rand/v2 instead of math/rand

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -23,3 +23,4 @@ MYSQL_TEST=1 go test -run TestFunctionName ./server/datastore/mysql/...
 - Use `require` and `assert` from `github.com/stretchr/testify` in tests.
 - Use `t.Context()` in tests instead of `context.Background()`.
 - Use `any` instead of `interface{}`
+- Use `math/rand/v2` instead of `math/rand`.

--- a/.golangci-incremental.yml
+++ b/.golangci-incremental.yml
@@ -15,6 +15,7 @@ linters:
     - testifylint
     - nilaway
     - setboolcheck
+    - depguard
   settings:
     gosec:
       # Only enable rules that are too noisy on existing code but valuable for new code.
@@ -31,6 +32,13 @@ linters:
         - G704 # SSRF via taint analysis.
         - G705 # XSS via taint analysis.
         - G706 # Log injection via taint analysis.
+    depguard:
+      rules:
+        no-old-rand:
+          list-mode: lax
+          deny:
+            - pkg: math/rand$
+              desc: Use math/rand/v2 instead
     custom:
       nilaway:
         type: module


### PR DESCRIPTION
This will only fire if Claude adds `math/rand` as an import.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code style guidelines and enhanced linting configuration to enforce stricter code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->