### PR TITLE
Update instances of "team" -> "fleet" introduced in 4.83 docs

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -451,7 +451,7 @@ Currently, using the Smallstep-Jamf connector is the best practice. Fleet is tes
 
 2. In the modal, select **Smallstep** from the dropdown and enter a name for your certificate authority (CA). Best practice is all caps snake case (for example, "WIFI_AUTHENTICATION"). This name is used later as a variable name in a configuration profile.
 
-3. For the **Challenge URL**, **Username**, and **Password**, enter the values noted in step 1. For the **SCEP URL**, you'll need to modify the URL provided by Smallstep to use the public proxy route instead. For example, `https://agents.SMALLSTEP_TEAM_NAME.ca.smallstep.com/scep/INTEGRATION_ID` becomes `https://<SMALLSTEP_TEAM_NAME>.scep.smallstep.com/p/agents/<INTEGRATION_ID>`
+3. For the **Challenge URL**, **Username**, and **Password**, enter the values noted in step 1. For the **SCEP URL**, you'll need to modify the URL provided by Smallstep to use the public proxy route instead. For example, `https://agents.SMALLSTEP_FLEET_NAME.ca.smallstep.com/scep/INTEGRATION_ID` becomes `https://<SMALLSTEP_FLEET_NAME>.scep.smallstep.com/p/agents/<INTEGRATION_ID>`
 
 ### Step 3: Add SCEP configuration profile to Fleet
 
@@ -1015,7 +1015,7 @@ fetch_cert -ca <EST-CA-ID> -fleeturl "<Fleet-server-URL>" -csr CustomerUserNetwo
 * On **Windows**, SCEP challenge strings should NOT include `base64` encoding or special characters such as `! @ # $ % ^ & * _`, and Common Names (CN) should NOT include `+` characters.
 * The Windows SCEP client adds ⁠/pkiclient.exe to the SCEP server URL. When using Fleet's custom SCEP proxy to deploy certificates, Fleet removes it, allowing you to use non-NDES SCEP servers.
 * On **Windows** hosts, Fleet will not verify the SCEP profile via osquery. Fleet will mark it as verified, if a successful request went through, even if the certificate is not present.
-* On **Windows** hosts, Fleet will not remove deployed certificates when configuration profiles are removed from Fleet or when host is transfered to another team.
+* On **Windows** hosts, Fleet will not remove deployed certificates when configuration profiles are removed from Fleet or when host is transfered to another fleet.
 
 ### Troubleshooting NDES on Windows
 

--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -451,7 +451,7 @@ Currently, using the Smallstep-Jamf connector is the best practice. Fleet is tes
 
 2. In the modal, select **Smallstep** from the dropdown and enter a name for your certificate authority (CA). Best practice is all caps snake case (for example, "WIFI_AUTHENTICATION"). This name is used later as a variable name in a configuration profile.
 
-3. For the **Challenge URL**, **Username**, and **Password**, enter the values noted in step 1. For the **SCEP URL**, you'll need to modify the URL provided by Smallstep to use the public proxy route instead. For example, `https://agents.SMALLSTEP_FLEET_NAME.ca.smallstep.com/scep/INTEGRATION_ID` becomes `https://<SMALLSTEP_FLEET_NAME>.scep.smallstep.com/p/agents/<INTEGRATION_ID>`
+3. For the **Challenge URL**, **Username**, and **Password**, enter the values noted in step 1. For the **SCEP URL**, you'll need to modify the URL provided by Smallstep to use the public proxy route instead. For example, `https://agents.SMALLSTEP_TEAM_NAME.ca.smallstep.com/scep/INTEGRATION_ID` becomes `https://<SMALLSTEP_TEAM_NAME>.scep.smallstep.com/p/agents/<INTEGRATION_ID>`
 
 ### Step 3: Add SCEP configuration profile to Fleet
 

--- a/articles/deploying-entra-platform-sso-with-fleet.md
+++ b/articles/deploying-entra-platform-sso-with-fleet.md
@@ -122,7 +122,7 @@ Save the profile to your computer so you can upload it to Fleet in the next sect
 ### Deploy the configuration profile to your hosts
 Now that we have a configuration profile with our desired settings, we can upload it to Fleet to deploy it to our hosts and activate the Platform SSO extension.
 
-On your Fleet server, select the team you want to deploy Platform SSO to. Navigate to Controls > OS Settings > Custom settings. Click the Add profile button, then find the `platform-sso-settings.mobileconfig` profile on your computer and upload it to Fleet.
+On your Fleet server, select the fleet you want to deploy Platform SSO to. Navigate to Controls > OS Settings > Custom settings. Click the Add profile button, then find the `platform-sso-settings.mobileconfig` profile on your computer and upload it to Fleet.
 
 Uploading the profile to a fleet will automatically deliver it to all macOS hosts enrolled in that fleet. If you wish to have more control over which hosts on the fleet receive the profile, you can use labels to target or exclude specific hosts.
 

--- a/articles/how-to-use-policies-for-patch-management-in-fleet.md
+++ b/articles/how-to-use-policies-for-patch-management-in-fleet.md
@@ -34,7 +34,7 @@ Key benefits:
 
 ### In the Fleet UI
 
-1. Navigate to **Software** and select your team.
+1. Navigate to **Software** and select your fleet.
 2. Click on a Fleet-maintained app to open its details.
 3. From the **Actions** dropdown, select **Patch**.
 4. Click **Add** in the confirmation modal.
@@ -59,7 +59,7 @@ For all available options, see the [GitOps reference documentation](https://flee
 
 ### Via the API
 
-Set `type` to `"patch"` and provide `patch_software_title_id` when [adding a team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy).
+Set `type` to `"patch"` and provide `patch_software_title_id` when [adding a fleet policy](https://fleetdm.com/docs/rest-api/rest-api#create-fleet-policy).
 
 ## Manual policies for custom packages
 
@@ -119,10 +119,10 @@ would deploy Slack to your endpoints the moment it comes out of the box, ensurin
 
 Fleet Premium customers can leverage the REST API for both approaches:
 
-- **Patch policies**: Set `type` to `"patch"` with `patch_software_title_id` when [adding a team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy).
+- **Patch policies**: Set `type` to `"patch"` with `patch_software_title_id` when [adding a fleet policy](https://fleetdm.com/docs/rest-api/rest-api#create-fleet-policy).
 - **Manual policies**: Use `software_title_id` to link a policy to software that installs on failure.
 
-See the [Upload software](https://fleetdm.com/docs/rest-api/rest-api#add-package) and [Team policy](https://fleetdm.com/docs/rest-api/rest-api#add-team-policy) API docs.
+See the [Upload software](https://fleetdm.com/docs/rest-api/rest-api#add-package) and [Create fleet policy](https://fleetdm.com/docs/rest-api/rest-api#create-fleet-policy) API docs.
 
 ## Curious about GitOps?
 


### PR DESCRIPTION
Missed checking the 4.83 docs branch for the word "teams"; a lot of the doc PRs for 4.83 were merged before the rename.