### PR TITLE
POC: Recovery lock bounded context module pattern

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -27,6 +27,7 @@ import (
 	android_svc "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/recoverylock"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/vpp"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
 	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
@@ -2046,7 +2047,7 @@ func newRecoveryLockPasswordSchedule(
 		ctx, name, instanceID, defaultInterval, ds, ds,
 		schedule.WithLogger(logger),
 		schedule.WithJob("send_recovery_lock_commands", func(ctx context.Context) error {
-			return apple_mdm.SendRecoveryLockCommands(ctx, ds, commander, logger, newActivityFn)
+			return recoverylock.SendCommands(ctx, ds, commander, logger, newActivityFn)
 		}),
 	)
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -62,6 +62,7 @@ import (
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/recoverylock"
 	"github.com/fleetdm/fleet/v4/server/mdm/cryptoutil"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push"
@@ -1547,7 +1548,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 
 		mdmCheckinAndCommandService.RegisterResultsHandler("InstalledApplicationList", service.NewInstalledApplicationListResultsHandler(ds, commander, logger, config.Server.VPPVerifyTimeout, config.Server.VPPVerifyRequestDelay, svc.NewActivity))
 		mdmCheckinAndCommandService.RegisterResultsHandler(fleet.DeviceLocationCmdName, service.NewDeviceLocationResultsHandler(ds, commander, logger))
-		mdmCheckinAndCommandService.RegisterResultsHandler(fleet.SetRecoveryLockCmdName, service.NewSetRecoveryLockResultsHandler(ds, logger, svc.NewActivity))
+		mdmCheckinAndCommandService.RegisterResultsHandler(fleet.SetRecoveryLockCmdName, recoverylock.NewResultsHandler(ds, logger, svc.NewActivity))
 
 		hasSCEPChallenge, err := checkMDMAssets([]fleet.MDMAssetName{fleet.MDMAssetSCEPChallenge})
 		if err != nil {

--- a/server/acl/recoverylockacl/fleet_adapter.go
+++ b/server/acl/recoverylockacl/fleet_adapter.go
@@ -1,0 +1,128 @@
+// Package recoverylockacl provides an Anti-Corruption Layer (ACL) adapter
+// that implements the recoverylock.DataProviders interface using legacy Fleet services.
+//
+// This adapter bridges the gap between the recovery lock bounded context and
+// the existing Fleet codebase, allowing the bounded context to remain isolated
+// while still integrating with the rest of the system.
+package recoverylockacl
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/recoverylock"
+)
+
+// FleetAdapter implements recoverylock.DataProviders using Fleet services.
+type FleetAdapter struct {
+	ds        fleet.Datastore
+	svc       fleet.Service
+	commander recoverylock.CommanderProvider
+}
+
+// New creates a new FleetAdapter.
+func New(ds fleet.Datastore, svc fleet.Service, commander recoverylock.CommanderProvider) *FleetAdapter {
+	return &FleetAdapter{
+		ds:        ds,
+		svc:       svc,
+		commander: commander,
+	}
+}
+
+// GetHostLite returns minimal host information by host ID.
+func (a *FleetAdapter) GetHostLite(ctx context.Context, hostID uint) (*recoverylock.Host, error) {
+	host, err := a.ds.HostLite(ctx, hostID)
+	if err != nil {
+		return nil, err
+	}
+	return toRecoveryLockHost(host), nil
+}
+
+// GetHostByUUID returns minimal host information by host UUID.
+func (a *FleetAdapter) GetHostByUUID(ctx context.Context, uuid string) (*recoverylock.Host, error) {
+	host, err := a.ds.HostByIdentifier(ctx, uuid)
+	if err != nil {
+		return nil, err
+	}
+	return toRecoveryLockHost(host), nil
+}
+
+// GetEligibleHostUUIDs returns UUIDs of hosts eligible for recovery lock operations.
+func (a *FleetAdapter) GetEligibleHostUUIDs(ctx context.Context, filter recoverylock.EligibilityFilter) ([]string, error) {
+	// For now, delegate to the legacy datastore method
+	// In a full implementation, this would use the filter parameters
+	// to query hosts that meet the eligibility criteria
+	return a.ds.GetHostsForRecoveryLockAction(ctx)
+}
+
+// IsRecoveryLockEnabled returns whether recovery lock is enabled for a team.
+func (a *FleetAdapter) IsRecoveryLockEnabled(ctx context.Context, teamID *uint) (bool, error) {
+	if teamID != nil {
+		team, err := a.ds.TeamWithExtras(ctx, *teamID)
+		if err != nil {
+			return false, err
+		}
+		return team.Config.MDM.EnableRecoveryLockPassword, nil
+	}
+
+	// Check global config
+	config, err := a.ds.AppConfig(ctx)
+	if err != nil {
+		return false, err
+	}
+	return config.MDM.EnableRecoveryLockPassword.Value, nil
+}
+
+// GetAutoRotationDuration returns the duration after which viewed passwords
+// should be automatically rotated. Returns 0 if auto-rotation is disabled.
+func (a *FleetAdapter) GetAutoRotationDuration(ctx context.Context) (int, error) {
+	// Auto-rotation is currently hardcoded to 1 hour (3600 seconds)
+	// In a full implementation, this could be configurable
+	return 3600, nil
+}
+
+// SetRecoveryLock sends a SetRecoveryLock MDM command to the specified hosts.
+func (a *FleetAdapter) SetRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string, password string) error {
+	return a.commander.SetRecoveryLock(ctx, hostUUIDs, cmdUUID, password)
+}
+
+// ClearRecoveryLock sends a ClearRecoveryLock MDM command to the specified hosts.
+func (a *FleetAdapter) ClearRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string, password string) error {
+	return a.commander.ClearRecoveryLock(ctx, hostUUIDs, cmdUUID, password)
+}
+
+// RotateRecoveryLock sends commands to clear and set a new recovery lock password.
+func (a *FleetAdapter) RotateRecoveryLock(ctx context.Context, hostUUID string, cmdUUID string, oldPassword string, newPassword string) error {
+	return a.commander.RotateRecoveryLock(ctx, hostUUID, cmdUUID, oldPassword, newPassword)
+}
+
+// LogRecoveryLockViewed logs that a user viewed a recovery lock password.
+func (a *FleetAdapter) LogRecoveryLockViewed(ctx context.Context, hostID uint, hostDisplayName string) error {
+	// Activity logging would go here
+	// For now, this is a no-op as activity logging requires the service layer
+	return nil
+}
+
+// LogRecoveryLockRotated logs that a recovery lock password was rotated.
+func (a *FleetAdapter) LogRecoveryLockRotated(ctx context.Context, hostID uint, hostDisplayName string) error {
+	// Activity logging would go here
+	// For now, this is a no-op as activity logging requires the service layer
+	return nil
+}
+
+// toRecoveryLockHost converts a Fleet host to a recoverylock.Host.
+func toRecoveryLockHost(host *fleet.Host) *recoverylock.Host {
+	if host == nil {
+		return nil
+	}
+	return &recoverylock.Host{
+		ID:            host.ID,
+		UUID:          host.UUID,
+		TeamID:        host.TeamID,
+		Platform:      host.Platform,
+		HardwareModel: host.HardwareModel,
+	}
+}
+
+// Verify interface compliance
+var _ recoverylock.DataProviders = (*FleetAdapter)(nil)

--- a/server/mdm/apple/apple_mdm.go
+++ b/server/mdm/apple/apple_mdm.go
@@ -1660,6 +1660,8 @@ func ValidateMDMSettingsAppleSupportedOSVersion[T fleet.MDM | fleet.TeamMDM](set
 
 // RecoveryLockCommander defines the interface for sending recovery lock commands.
 // This interface is implemented by MDMAppleCommander and allows for testing.
+//
+// Deprecated: Use recoverylock.Commander instead.
 type RecoveryLockCommander interface {
 	SetRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string) error
 	ClearRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string) error
@@ -1670,7 +1672,10 @@ type RecoveryLockCommander interface {
 // to hosts that need a recovery lock password.
 //
 // Note: SetRecoveryLock command results are handled in the MDM results handler
-// (server/service/apple_mdm.go), which sends VerifyRecoveryLock immediately upon acknowledgment.
+// (server/service/apple_mdm.go), which marks the password as verified upon acknowledgment.
+//
+// Deprecated: Use recoverylock.SendCommands instead. This function is kept for backward
+// compatibility and will be removed in a future version.
 func SendRecoveryLockCommands(
 	ctx context.Context,
 	ds fleet.Datastore,
@@ -1977,10 +1982,14 @@ func logAutoRotationActivity(
 }
 
 // RecoveryLockPasswordCharset excludes confusing characters (0/O, 1/I/l)
+//
+// Deprecated: Use recoverylock.PasswordCharset instead.
 const RecoveryLockPasswordCharset = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 
 // GenerateRecoveryLockPassword generates a password in format: 5ADZ-HTZ8-LJJ4-B2F8-JWH3-YPBT
 // (6 groups of 4 alphanumeric characters separated by dashes)
+//
+// Deprecated: Use recoverylock.GeneratePassword instead.
 func GenerateRecoveryLockPassword() string {
 	const (
 		groupCount = 6

--- a/server/mdm/apple/recoverylock/cron.go
+++ b/server/mdm/apple/recoverylock/cron.go
@@ -1,0 +1,323 @@
+package recoverylock
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/google/uuid"
+	"github.com/hashicorp/go-multierror"
+)
+
+// SendCommands is the cron job function that sends SetRecoveryLock MDM commands
+// to hosts that need a recovery lock password.
+//
+// Note: SetRecoveryLock command results are handled in the MDM results handler
+// (server/service/apple_mdm.go), which marks the password as verified upon acknowledgment.
+func SendCommands(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander *apple_mdm.MDMAppleCommander,
+	logger *slog.Logger,
+	newActivityFn fleet.NewActivityFunc,
+) error {
+	return sendCommandsWithCommander(ctx, ds, commander, logger, newActivityFn)
+}
+
+func sendCommandsWithCommander(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander Commander,
+	logger *slog.Logger,
+	newActivityFn fleet.NewActivityFunc,
+) error {
+	var result *multierror.Error
+
+	// Restore hosts that were in "pending remove" state but feature was re-enabled.
+	// This transitions them back to "verified install" to preserve the existing password.
+	restored, err := ds.RestoreRecoveryLockForReenabledHosts(ctx)
+	if err != nil {
+		result = multierror.Append(result, ctxerr.Wrap(ctx, err, "restore recovery lock for re-enabled hosts"))
+	} else if restored > 0 {
+		logger.InfoContext(ctx, "restored recovery lock for re-enabled hosts", "count", restored)
+	}
+
+	// Handle SET password operations (hosts that need a recovery lock password)
+	if err := sendSetCommands(ctx, ds, commander, logger); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	// Handle CLEAR password operations (hosts that need their recovery lock cleared)
+	if err := sendClearCommands(ctx, ds, commander, logger); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	// Handle AUTO-ROTATION for viewed passwords (password viewed 1+ hour ago)
+	if err := sendAutoRotationCommands(ctx, ds, commander, logger, newActivityFn); err != nil {
+		result = multierror.Append(result, err)
+	}
+
+	return result.ErrorOrNil()
+}
+
+func sendSetCommands(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander Commander,
+	logger *slog.Logger,
+) error {
+	hosts, err := ds.GetHostsForRecoveryLockAction(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get hosts for recovery lock action")
+	}
+
+	if len(hosts) == 0 {
+		logger.DebugContext(ctx, "no hosts need SetRecoveryLock")
+		return nil
+	}
+
+	logger.InfoContext(ctx, "sending SetRecoveryLock commands", "count", len(hosts))
+
+	// Generate passwords for all hosts upfront.
+	// Passwords must be stored BEFORE enqueuing commands because they are injected
+	// at delivery time by ExpandHostSecrets (which looks up by host UUID).
+	passwords := make([]fleet.HostRecoveryLockPasswordPayload, 0, len(hosts))
+	for _, hostUUID := range hosts {
+		passwords = append(passwords, fleet.HostRecoveryLockPasswordPayload{
+			HostUUID: hostUUID,
+			Password: GeneratePassword(),
+		})
+	}
+
+	// Store passwords with status='pending' atomically. This prevents the host from
+	// being picked up again by the next cron run while we're enqueuing the command.
+	// If enqueue fails, we reset the status to NULL so the host can be retried.
+	if err := ds.SetHostsRecoveryLockPasswords(ctx, passwords); err != nil {
+		return ctxerr.Wrap(ctx, err, "bulk set recovery lock passwords")
+	}
+
+	// Collect host UUIDs for enqueue.
+	// The password is not in the command - a placeholder is used that will be
+	// expanded at delivery time by ExpandHostSecrets.
+	hostUUIDs := make([]string, 0, len(passwords))
+	for _, p := range passwords {
+		hostUUIDs = append(hostUUIDs, p.HostUUID)
+	}
+
+	// Enqueue a single command for all hosts. Each host gets their own queue entry
+	// pointing to the same command, and ExpandHostSecrets injects the per-host
+	// password at delivery time.
+	cmdUUID := uuid.NewString()
+	if err := commander.SetRecoveryLock(ctx, hostUUIDs, cmdUUID); err != nil {
+		// Check if this is an APNs delivery error (command was persisted but push failed).
+		// In this case, the command is already queued and will be delivered when the device
+		// checks in, so we should NOT clear the pending status (which would cause duplicates).
+		var apnsErr *apple_mdm.APNSDeliveryError
+		if errors.As(err, &apnsErr) {
+			// Command was persisted but push notification failed - log warning but don't fail.
+			// The command will be delivered when the device next checks in.
+			logger.WarnContext(ctx, "SetRecoveryLock commands enqueued but APNs push failed",
+				"host_count", len(hostUUIDs),
+				"command_uuid", cmdUUID,
+				"error", err,
+			)
+			// Don't clear pending status - command is queued and will be processed
+			return nil
+		}
+
+		// Persistence failed - reset status to NULL so hosts will be picked up again on next cron run.
+		// The password is already stored, but a new one will be generated on retry (overwrites old).
+		logger.ErrorContext(ctx, "failed to enqueue SetRecoveryLock commands",
+			"host_count", len(hostUUIDs),
+			"error", err,
+		)
+		if clearErr := ds.ClearRecoveryLockPendingStatus(ctx, hostUUIDs); clearErr != nil {
+			logger.ErrorContext(ctx, "failed to clear recovery lock pending status after enqueue failure",
+				"host_count", len(hostUUIDs),
+				"error", clearErr,
+			)
+			err = multierror.Append(err, clearErr)
+		}
+		return ctxerr.Wrap(ctx, err, "enqueue SetRecoveryLock commands")
+	}
+
+	logger.InfoContext(ctx, "sent SetRecoveryLock commands",
+		"host_count", len(hostUUIDs),
+		"command_uuid", cmdUUID,
+	)
+
+	return nil
+}
+
+func sendClearCommands(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander Commander,
+	logger *slog.Logger,
+) error {
+	hosts, err := ds.ClaimHostsForRecoveryLockClear(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get hosts for recovery lock clear action")
+	}
+
+	if len(hosts) == 0 {
+		logger.DebugContext(ctx, "no hosts need ClearRecoveryLock")
+		return nil
+	}
+
+	logger.InfoContext(ctx, "sending ClearRecoveryLock commands", "count", len(hosts))
+
+	// Enqueue clear command. The CurrentPassword placeholder will be expanded at
+	// delivery time by ExpandHostSecrets (which looks up by host UUID).
+	cmdUUID := uuid.NewString()
+	if err := commander.ClearRecoveryLock(ctx, hosts, cmdUUID); err != nil {
+		var apnsErr *apple_mdm.APNSDeliveryError
+		if errors.As(err, &apnsErr) {
+			// Command was persisted but push notification failed - log warning but don't fail.
+			logger.WarnContext(ctx, "ClearRecoveryLock commands enqueued but APNs push failed",
+				"host_count", len(hosts),
+				"command_uuid", cmdUUID,
+				"error", err,
+			)
+			return nil
+		}
+
+		// Persistence failed - reset status to NULL so hosts will be picked up again.
+		logger.ErrorContext(ctx, "failed to enqueue ClearRecoveryLock commands",
+			"host_count", len(hosts),
+			"error", err,
+		)
+		if clearErr := ds.ClearRecoveryLockPendingStatus(ctx, hosts); clearErr != nil {
+			logger.ErrorContext(ctx, "failed to clear recovery lock pending status after enqueue failure",
+				"host_count", len(hosts),
+				"error", clearErr,
+			)
+			err = multierror.Append(err, clearErr)
+		}
+		return ctxerr.Wrap(ctx, err, "enqueue ClearRecoveryLock commands")
+	}
+
+	logger.InfoContext(ctx, "sent ClearRecoveryLock commands",
+		"host_count", len(hosts),
+		"command_uuid", cmdUUID,
+	)
+
+	return nil
+}
+
+func sendAutoRotationCommands(
+	ctx context.Context,
+	ds fleet.Datastore,
+	commander Commander,
+	logger *slog.Logger,
+	newActivityFn fleet.NewActivityFunc,
+) error {
+	hosts, err := ds.GetHostsForAutoRotation(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get hosts for auto rotation")
+	}
+
+	if len(hosts) == 0 {
+		logger.DebugContext(ctx, "no hosts need auto-rotation")
+		return nil
+	}
+
+	logger.InfoContext(ctx, "performing auto-rotation for viewed passwords", "count", len(hosts))
+
+	var result *multierror.Error
+	for _, host := range hosts {
+		newPassword := GeneratePassword()
+
+		// Initiate rotation - stores pending password and validates eligibility
+		if err := ds.InitiateRecoveryLockRotation(ctx, host.HostUUID, newPassword); err != nil {
+			// Check for benign race conditions where host state changed between
+			// GetHostsForAutoRotation and now (e.g., manual rotation started,
+			// password removed, host deleted, etc.)
+			if fleet.IsNotFound(err) ||
+				errors.Is(err, fleet.ErrRecoveryLockRotationPending) ||
+				errors.Is(err, fleet.ErrRecoveryLockNotEligible) {
+				logger.DebugContext(ctx, "host lost eligibility for auto-rotation",
+					"host_uuid", host.HostUUID,
+					"error", err,
+				)
+				continue
+			}
+
+			logger.ErrorContext(ctx, "failed to initiate auto-rotation",
+				"host_uuid", host.HostUUID,
+				"error", err,
+			)
+			result = multierror.Append(result, err)
+			continue
+		}
+
+		// Enqueue RotateRecoveryLock command
+		cmdUUID := uuid.NewString()
+		if err := commander.RotateRecoveryLock(ctx, host.HostUUID, cmdUUID); err != nil {
+			var apnsErr *apple_mdm.APNSDeliveryError
+			if errors.As(err, &apnsErr) {
+				// Command was persisted but push notification failed - log activity and continue.
+				// The command will be retried when the device checks in.
+				logAutoRotationActivity(ctx, logger, newActivityFn, host)
+				logger.WarnContext(ctx, "auto-rotation command enqueued but APNs push failed",
+					"host_uuid", host.HostUUID,
+					"command_uuid", cmdUUID,
+					"error", err,
+				)
+				continue
+			}
+
+			// Persistence failed - clear pending rotation so host can be retried
+			logger.ErrorContext(ctx, "failed to enqueue auto-rotation command",
+				"host_uuid", host.HostUUID,
+				"error", err,
+			)
+			if clearErr := ds.ClearRecoveryLockRotation(ctx, host.HostUUID); clearErr != nil {
+				logger.ErrorContext(ctx, "failed to clear pending rotation after enqueue failure",
+					"host_uuid", host.HostUUID,
+					"error", clearErr,
+				)
+				result = multierror.Append(result, clearErr)
+			}
+			result = multierror.Append(result, err)
+			continue
+		}
+
+		// Log activity for auto-rotation (Fleet-initiated)
+		logAutoRotationActivity(ctx, logger, newActivityFn, host)
+
+		logger.DebugContext(ctx, "sent auto-rotation command",
+			"host_uuid", host.HostUUID,
+			"command_uuid", cmdUUID,
+		)
+	}
+
+	return result.ErrorOrNil()
+}
+
+// logAutoRotationActivity logs the rotation activity for auto-rotations.
+// It uses the same activity type as manual rotations but marks it as Fleet-initiated.
+func logAutoRotationActivity(
+	ctx context.Context,
+	logger *slog.Logger,
+	newActivityFn fleet.NewActivityFunc,
+	host fleet.HostAutoRotationInfo,
+) {
+	if newActivityFn == nil {
+		return
+	}
+
+	if err := newActivityFn(ctx, nil, fleet.ActivityTypeRotatedHostRecoveryLockPassword{
+		HostID:          host.HostID,
+		HostDisplayName: host.DisplayName,
+		FleetInitiated:  true,
+	}); err != nil {
+		logger.WarnContext(ctx, "auto-rotation: failed to create activity",
+			"host_uuid", host.HostUUID,
+			"err", err,
+		)
+	}
+}

--- a/server/mdm/apple/recoverylock/password.go
+++ b/server/mdm/apple/recoverylock/password.go
@@ -1,0 +1,34 @@
+package recoverylock
+
+import (
+	"crypto/rand"
+	"strings"
+)
+
+// PasswordCharset excludes confusing characters (0/O, 1/I/l)
+const PasswordCharset = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
+
+// GeneratePassword generates a password in format: 5ADZ-HTZ8-LJJ4-B2F8-JWH3-YPBT
+// (6 groups of 4 alphanumeric characters separated by dashes)
+func GeneratePassword() string {
+	const (
+		groupCount = 6
+		groupLen   = 4
+	)
+
+	groups := make([]string, groupCount)
+	charsetLen := len(PasswordCharset)
+
+	for i := range groupCount {
+		randBytes := make([]byte, groupLen)
+		_, _ = rand.Read(randBytes) // rand.Read never returns an error; it panics on failure
+
+		group := make([]byte, groupLen)
+		for j := range groupLen {
+			group[j] = PasswordCharset[int(randBytes[j])%charsetLen]
+		}
+		groups[i] = string(group)
+	}
+
+	return strings.Join(groups, "-")
+}

--- a/server/mdm/apple/recoverylock/result_handler.go
+++ b/server/mdm/apple/recoverylock/result_handler.go
@@ -1,0 +1,204 @@
+package recoverylock
+
+import (
+	"context"
+	"log/slog"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
+)
+
+// Result wraps mdm.CommandResults to implement fleet.MDMCommandResults
+type Result struct {
+	CmdResult *mdm.CommandResults
+}
+
+func (r *Result) Raw() []byte      { return r.CmdResult.Raw }
+func (r *Result) UUID() string     { return r.CmdResult.CommandUUID }
+func (r *Result) HostUUID() string { return r.CmdResult.UDID } // SetRecoveryLock is device-only, UDID is always present
+
+// NewResult wraps an mdm.CommandResults to implement fleet.MDMCommandResults
+func NewResult(cmdResult *mdm.CommandResults) fleet.MDMCommandResults {
+	return &Result{CmdResult: cmdResult}
+}
+
+// NewResultsHandler processes SetRecoveryLock command results.
+// It handles SET (install), CLEAR (remove), and ROTATE operations:
+// - SET: When acknowledged, marks the recovery lock as verified. On error, marks as failed.
+// - CLEAR: When acknowledged, deletes the recovery lock password record. On error, marks as failed.
+// - ROTATE: When acknowledged, moves pending password to active. On error, marks rotation as failed.
+func NewResultsHandler(
+	ds fleet.Datastore,
+	logger *slog.Logger,
+	newActivityFn fleet.NewActivityFunc,
+) fleet.MDMCommandResultsHandler {
+	return func(ctx context.Context, results fleet.MDMCommandResults) error {
+		// Get the underlying result to access status and error chain
+		rlResult, ok := results.(*Result)
+		if !ok {
+			return ctxerr.New(ctx, "SetRecoveryLock handler: unexpected results type")
+		}
+
+		hostUUID := results.HostUUID()
+		status := rlResult.CmdResult.Status
+
+		// Check if this is a rotation (has pending password)
+		hasPendingRotation, err := ds.HasPendingRecoveryLockRotation(ctx, hostUUID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: check pending rotation")
+		}
+
+		if hasPendingRotation {
+			// This is a rotation result
+			logger.DebugContext(ctx, "SetRecoveryLock rotation result received",
+				"host_uuid", hostUUID,
+				"command_uuid", results.UUID(),
+				"status", status,
+			)
+
+			switch status {
+			case fleet.MDMAppleStatusAcknowledged:
+				// Rotation succeeded - move pending password to active
+				if err := ds.CompleteRecoveryLockRotation(ctx, hostUUID); err != nil {
+					return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: complete rotation")
+				}
+
+				logger.InfoContext(ctx, "RotateRecoveryLock acknowledged, password rotated",
+					"host_uuid", hostUUID,
+				)
+
+			case fleet.MDMAppleStatusError, fleet.MDMAppleStatusCommandFormatError:
+				errorMsg := apple_mdm.FmtErrorChain(rlResult.CmdResult.ErrorChain)
+				if errorMsg == "" {
+					errorMsg = "RotateRecoveryLock command failed"
+				}
+				if err := ds.FailRecoveryLockRotation(ctx, hostUUID, errorMsg); err != nil {
+					return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: fail rotation")
+				}
+				logger.WarnContext(ctx, "RotateRecoveryLock command failed",
+					"host_uuid", hostUUID,
+					"error", errorMsg,
+				)
+			}
+
+			return nil
+		}
+
+		// Get the operation type to determine if this was a SET or CLEAR operation
+		opType, err := ds.GetRecoveryLockOperationType(ctx, hostUUID)
+		if err != nil {
+			// If the record doesn't exist, it may have been deleted already - nothing to do
+			if fleet.IsNotFound(err) {
+				logger.DebugContext(ctx, "SetRecoveryLock result received but no password record exists",
+					"host_uuid", hostUUID,
+					"status", status,
+				)
+				return nil
+			}
+			return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: get operation type")
+		}
+
+		logger.DebugContext(ctx, "SetRecoveryLock command result received",
+			"host_uuid", hostUUID,
+			"command_uuid", results.UUID(),
+			"status", status,
+			"operation_type", opType,
+		)
+
+		switch status {
+		case fleet.MDMAppleStatusAcknowledged:
+			if opType == fleet.MDMOperationTypeRemove {
+				// CLEAR succeeded - delete the password record
+				if err := ds.DeleteHostRecoveryLockPassword(ctx, hostUUID); err != nil {
+					return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: delete recovery lock password")
+				}
+				logger.InfoContext(ctx, "ClearRecoveryLock acknowledged, password record deleted",
+					"host_uuid", hostUUID,
+				)
+			} else {
+				// SET succeeded - mark as verified
+				if err := ds.SetRecoveryLockVerified(ctx, hostUUID); err != nil {
+					return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: set recovery lock verified")
+				}
+
+				// Get host info for activity logging - don't fail the operation if this fails
+				var hostID uint
+				var displayName string
+				host, err := ds.HostLiteByIdentifier(ctx, hostUUID)
+				if err != nil {
+					logger.WarnContext(ctx, "SetRecoveryLock handler: failed to get host for activity logging",
+						"host_uuid", hostUUID,
+						"err", err,
+					)
+				} else {
+					hostID = host.ID
+					displayName = host.Hostname
+
+					// Log the activity only if we could identify the host (fleet-initiated via WasFromAutomation)
+					if err := newActivityFn(ctx, nil, fleet.ActivityTypeSetHostRecoveryLockPassword{
+						HostID:          hostID,
+						HostDisplayName: displayName,
+					}); err != nil {
+						logger.WarnContext(ctx, "SetRecoveryLock handler: failed to create activity",
+							"host_uuid", hostUUID,
+							"err", err,
+						)
+					}
+				}
+
+				logger.InfoContext(ctx, "SetRecoveryLock acknowledged, marked verified",
+					"host_uuid", hostUUID,
+					"host_id", hostID,
+				)
+			}
+
+		case fleet.MDMAppleStatusError, fleet.MDMAppleStatusCommandFormatError:
+			errorMsg := apple_mdm.FmtErrorChain(rlResult.CmdResult.ErrorChain)
+			if errorMsg == "" {
+				if opType == fleet.MDMOperationTypeRemove {
+					errorMsg = "ClearRecoveryLock command failed"
+				} else {
+					errorMsg = "SetRecoveryLock command failed"
+				}
+			}
+
+			if opType == fleet.MDMOperationTypeRemove {
+				// CLEAR operation failed
+				// Command format errors are terminal - command is malformed and won't succeed on retry.
+				// Password mismatch errors are also terminal - requires admin intervention.
+				if rlResult.CmdResult.Status == fleet.MDMAppleStatusCommandFormatError ||
+					apple_mdm.IsRecoveryLockPasswordMismatchError(rlResult.CmdResult.ErrorChain) {
+					if err := ds.SetRecoveryLockFailed(ctx, hostUUID, errorMsg); err != nil {
+						return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: set recovery lock failed")
+					}
+					logger.WarnContext(ctx, "ClearRecoveryLock failed with terminal error",
+						"host_uuid", hostUUID,
+						"error", errorMsg,
+					)
+				} else {
+					// Transient error - reset to install/verified for retry on next cron cycle
+					if err := ds.ResetRecoveryLockForRetry(ctx, hostUUID); err != nil {
+						return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: reset recovery lock for retry")
+					}
+					logger.InfoContext(ctx, "ClearRecoveryLock failed with transient error, will retry",
+						"host_uuid", hostUUID,
+						"error", errorMsg,
+					)
+				}
+			} else {
+				// SET operation failed - mark as failed
+				if err := ds.SetRecoveryLockFailed(ctx, hostUUID, errorMsg); err != nil {
+					return ctxerr.Wrap(ctx, err, "SetRecoveryLock handler: set recovery lock failed")
+				}
+				logger.WarnContext(ctx, "SetRecoveryLock command failed",
+					"host_uuid", hostUUID,
+					"error", errorMsg,
+				)
+			}
+		}
+
+		return nil
+	}
+}

--- a/server/mdm/apple/recoverylock/types.go
+++ b/server/mdm/apple/recoverylock/types.go
@@ -1,0 +1,58 @@
+// Package recoverylock provides recovery lock password management for macOS devices.
+//
+// This package consolidates all recovery lock password functionality including:
+// - Password generation (GeneratePassword)
+// - Cron job processing for SET/CLEAR/ROTATE operations (SendCommands)
+// - Result handling from MDM command acknowledgments (NewResultsHandler)
+//
+// Note: This is a domain module within the MDM structure, not a fully isolated
+// bounded context. It has dependencies on MDM infrastructure components.
+//
+// # Types
+//
+// The following types from the fleet package are part of this module's API:
+//
+//   - fleet.HostRecoveryLockPassword - password record for a host
+//   - fleet.HostRecoveryLockPasswordPayload - payload for storing passwords
+//   - fleet.HostRecoveryLockRotationStatus - rotation state for a host
+//   - fleet.HostAutoRotationInfo - minimal host data for auto-rotation logging
+//   - fleet.HostMDMRecoveryLockPassword - status representation for API responses
+//   - fleet.RecoveryLockStatus - enum for status values
+//   - fleet.ErrRecoveryLockRotationPending - rotation already in progress
+//   - fleet.ErrRecoveryLockNotEligible - host not eligible for rotation
+//
+// # Datastore Methods
+//
+// The following fleet.Datastore methods are part of this module's contract:
+//
+//   - SetHostsRecoveryLockPasswords
+//   - GetHostRecoveryLockPassword
+//   - GetHostRecoveryLockPasswordStatus
+//   - GetHostsForRecoveryLockAction
+//   - RestoreRecoveryLockForReenabledHosts
+//   - SetRecoveryLockVerified
+//   - SetRecoveryLockFailed
+//   - ClearRecoveryLockPendingStatus
+//   - ClaimHostsForRecoveryLockClear
+//   - DeleteHostRecoveryLockPassword
+//   - GetRecoveryLockOperationType
+//   - InitiateRecoveryLockRotation
+//   - CompleteRecoveryLockRotation
+//   - FailRecoveryLockRotation
+//   - ClearRecoveryLockRotation
+//   - GetRecoveryLockRotationStatus
+//   - HasPendingRecoveryLockRotation
+//   - ResetRecoveryLockForRetry
+//   - MarkRecoveryLockPasswordViewed
+//   - GetHostsForAutoRotation
+package recoverylock
+
+import "context"
+
+// Commander defines the interface for sending recovery lock commands.
+// This interface is implemented by MDMAppleCommander and allows for testing.
+type Commander interface {
+	SetRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string) error
+	ClearRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string) error
+	RotateRecoveryLock(ctx context.Context, hostUUID string, cmdUUID string) error
+}

--- a/server/mdmsettingsstatus/api/service.go
+++ b/server/mdmsettingsstatus/api/service.go
@@ -1,0 +1,21 @@
+// Package api defines the public service interface for the MDM settings status aggregator.
+package api
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus"
+)
+
+// Service is the interface for the MDM settings status aggregator.
+type Service interface {
+	// GetHostsOverallStatus returns the computed overall MDM status for hosts.
+	// This combines status from all 4 components (profiles, declarations, FileVault, recovery lock)
+	// using hierarchical logic: failed > pending > verifying > verified.
+	GetHostsOverallStatus(ctx context.Context, hostUUIDs []string) (map[string]mdmsettingsstatus.Status, error)
+
+	// FilterHostsByOverallStatus returns host UUIDs matching an overall status.
+	// This is used for filtering before the main host query.
+	// If candidateUUIDs is nil, considers all hosts.
+	FilterHostsByOverallStatus(ctx context.Context, status mdmsettingsstatus.Status, candidateUUIDs []string) ([]string, error)
+}

--- a/server/mdmsettingsstatus/bootstrap/bootstrap.go
+++ b/server/mdmsettingsstatus/bootstrap/bootstrap.go
@@ -1,0 +1,18 @@
+// Package bootstrap provides dependency injection for the MDM settings status aggregator.
+package bootstrap
+
+import (
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus"
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus/api"
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus/internal/service"
+)
+
+// New creates a new MDM settings status aggregator service with all dependencies wired up.
+func New(
+	recoveryLock mdmsettingsstatus.RecoveryLockStatusProvider,
+	profiles mdmsettingsstatus.ProfilesStatusProvider,
+	declarations mdmsettingsstatus.DeclarationsStatusProvider,
+	fileVault mdmsettingsstatus.FileVaultStatusProvider,
+) api.Service {
+	return service.New(recoveryLock, profiles, declarations, fileVault)
+}

--- a/server/mdmsettingsstatus/internal/service/service.go
+++ b/server/mdmsettingsstatus/internal/service/service.go
@@ -1,0 +1,271 @@
+// Package service implements the MDM settings status aggregator.
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus"
+	"github.com/fleetdm/fleet/v4/server/mdmsettingsstatus/api"
+	rlapi "github.com/fleetdm/fleet/v4/server/recoverylock/api"
+)
+
+// Service implements the api.Service interface.
+type Service struct {
+	recoveryLock mdmsettingsstatus.RecoveryLockStatusProvider
+	profiles     mdmsettingsstatus.ProfilesStatusProvider
+	declarations mdmsettingsstatus.DeclarationsStatusProvider
+	fileVault    mdmsettingsstatus.FileVaultStatusProvider
+}
+
+// New creates a new MDM settings status aggregator service.
+func New(
+	recoveryLock mdmsettingsstatus.RecoveryLockStatusProvider,
+	profiles mdmsettingsstatus.ProfilesStatusProvider,
+	declarations mdmsettingsstatus.DeclarationsStatusProvider,
+	fileVault mdmsettingsstatus.FileVaultStatusProvider,
+) *Service {
+	return &Service{
+		recoveryLock: recoveryLock,
+		profiles:     profiles,
+		declarations: declarations,
+		fileVault:    fileVault,
+	}
+}
+
+// GetHostsOverallStatus returns the computed overall MDM status for hosts.
+func (s *Service) GetHostsOverallStatus(ctx context.Context, hostUUIDs []string) (map[string]mdmsettingsstatus.Status, error) {
+	if len(hostUUIDs) == 0 {
+		return make(map[string]mdmsettingsstatus.Status), nil
+	}
+
+	// Get status from all components
+	rlStatus, err := s.recoveryLock.GetHostsStatusBulk(ctx, hostUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	profStatus, err := s.profiles.GetProfilesStatusBulk(ctx, hostUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	declStatus, err := s.declarations.GetDeclarationsStatusBulk(ctx, hostUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	fvStatus, err := s.fileVault.GetFileVaultStatusBulk(ctx, hostUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Aggregate using hierarchical logic
+	result := make(map[string]mdmsettingsstatus.Status, len(hostUUIDs))
+	for _, uuid := range hostUUIDs {
+		result[uuid] = aggregateStatus(
+			toStatus(rlStatus[uuid]),
+			profStatus[uuid],
+			declStatus[uuid],
+			fvStatus[uuid],
+		)
+	}
+
+	return result, nil
+}
+
+// FilterHostsByOverallStatus returns host UUIDs matching an overall status.
+func (s *Service) FilterHostsByOverallStatus(ctx context.Context, targetStatus mdmsettingsstatus.Status, candidateUUIDs []string) ([]string, error) {
+	// Get hosts matching the target status from each component
+	rlMatches, err := s.recoveryLock.FilterHostsByStatus(ctx, toRLStatus(targetStatus), candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	profMatches, err := s.profiles.FilterHostsByProfileStatus(ctx, targetStatus, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	declMatches, err := s.declarations.FilterHostsByDeclarationStatus(ctx, targetStatus, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	fvMatches, err := s.fileVault.FilterHostsByFileVaultStatus(ctx, targetStatus, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Combine based on hierarchical logic
+	return combineFilters(ctx, s, targetStatus, rlMatches, profMatches, declMatches, fvMatches, candidateUUIDs)
+}
+
+// aggregateStatus computes the overall status using hierarchical logic:
+// failed > pending > verifying > verified
+func aggregateStatus(statuses ...mdmsettingsstatus.Status) mdmsettingsstatus.Status {
+	hasPending := false
+	hasVerifying := false
+	allVerified := true
+
+	for _, status := range statuses {
+		switch status {
+		case mdmsettingsstatus.StatusFailed:
+			// If any component is failed, overall is failed
+			return mdmsettingsstatus.StatusFailed
+		case mdmsettingsstatus.StatusPending:
+			hasPending = true
+			allVerified = false
+		case mdmsettingsstatus.StatusVerifying:
+			hasVerifying = true
+			allVerified = false
+		case mdmsettingsstatus.StatusVerified:
+			// Continue checking
+		default:
+			// Unknown status, treat as pending
+			hasPending = true
+			allVerified = false
+		}
+	}
+
+	if hasPending {
+		return mdmsettingsstatus.StatusPending
+	}
+	if hasVerifying {
+		return mdmsettingsstatus.StatusVerifying
+	}
+	if allVerified && len(statuses) > 0 {
+		return mdmsettingsstatus.StatusVerified
+	}
+
+	// Default to pending if no status
+	return mdmsettingsstatus.StatusPending
+}
+
+// combineFilters combines filter results based on hierarchical logic.
+func combineFilters(
+	ctx context.Context,
+	s *Service,
+	targetStatus mdmsettingsstatus.Status,
+	rl, prof, decl, fv []string,
+	candidateUUIDs []string,
+) ([]string, error) {
+	switch targetStatus {
+	case mdmsettingsstatus.StatusFailed:
+		// ANY component failed → host is "failed"
+		// UNION of all failed hosts
+		return union(rl, prof, decl, fv), nil
+
+	case mdmsettingsstatus.StatusPending:
+		// ANY component pending AND no component failed → host is "pending"
+		pending := union(rl, prof, decl, fv)
+		// Get failed hosts to subtract
+		failed, err := s.getFailedHosts(ctx, candidateUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		return subtract(pending, failed), nil
+
+	case mdmsettingsstatus.StatusVerifying:
+		// ANY component verifying AND no failed/pending → host is "verifying"
+		verifying := union(rl, prof, decl, fv)
+		failedOrPending, err := s.getFailedOrPendingHosts(ctx, candidateUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		return subtract(verifying, failedOrPending), nil
+
+	case mdmsettingsstatus.StatusVerified:
+		// ALL components must be verified → INTERSECTION
+		return intersection(rl, prof, decl, fv), nil
+
+	default:
+		return nil, nil
+	}
+}
+
+// getFailedHosts returns hosts with any component in failed status.
+func (s *Service) getFailedHosts(ctx context.Context, candidateUUIDs []string) ([]string, error) {
+	rl, err := s.recoveryLock.FilterHostsByStatus(ctx, rlapi.StatusFailed, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	prof, err := s.profiles.FilterHostsByProfileStatus(ctx, mdmsettingsstatus.StatusFailed, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	decl, err := s.declarations.FilterHostsByDeclarationStatus(ctx, mdmsettingsstatus.StatusFailed, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	fv, err := s.fileVault.FilterHostsByFileVaultStatus(ctx, mdmsettingsstatus.StatusFailed, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	return union(rl, prof, decl, fv), nil
+}
+
+// getFailedOrPendingHosts returns hosts with any component in failed or pending status.
+func (s *Service) getFailedOrPendingHosts(ctx context.Context, candidateUUIDs []string) ([]string, error) {
+	failed, err := s.getFailedHosts(ctx, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	rl, err := s.recoveryLock.FilterHostsByStatus(ctx, rlapi.StatusPending, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	prof, err := s.profiles.FilterHostsByProfileStatus(ctx, mdmsettingsstatus.StatusPending, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	decl, err := s.declarations.FilterHostsByDeclarationStatus(ctx, mdmsettingsstatus.StatusPending, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+	fv, err := s.fileVault.FilterHostsByFileVaultStatus(ctx, mdmsettingsstatus.StatusPending, candidateUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	pending := union(rl, prof, decl, fv)
+	return union(failed, pending), nil
+}
+
+// toStatus converts a recovery lock HostStatus to an aggregator Status.
+func toStatus(s *rlapi.HostStatus) mdmsettingsstatus.Status {
+	if s == nil {
+		return mdmsettingsstatus.StatusVerified // No recovery lock = verified
+	}
+	switch s.Status {
+	case rlapi.StatusPending:
+		return mdmsettingsstatus.StatusPending
+	case rlapi.StatusFailed:
+		return mdmsettingsstatus.StatusFailed
+	case rlapi.StatusVerifying:
+		return mdmsettingsstatus.StatusVerifying
+	case rlapi.StatusVerified:
+		return mdmsettingsstatus.StatusVerified
+	default:
+		return mdmsettingsstatus.StatusPending
+	}
+}
+
+// toRLStatus converts an aggregator Status to a recovery lock Status.
+func toRLStatus(s mdmsettingsstatus.Status) rlapi.Status {
+	switch s {
+	case mdmsettingsstatus.StatusPending:
+		return rlapi.StatusPending
+	case mdmsettingsstatus.StatusFailed:
+		return rlapi.StatusFailed
+	case mdmsettingsstatus.StatusVerifying:
+		return rlapi.StatusVerifying
+	case mdmsettingsstatus.StatusVerified:
+		return rlapi.StatusVerified
+	default:
+		return rlapi.StatusPending
+	}
+}
+
+// Verify interface compliance
+var _ api.Service = (*Service)(nil)

--- a/server/mdmsettingsstatus/internal/service/setops.go
+++ b/server/mdmsettingsstatus/internal/service/setops.go
@@ -1,0 +1,86 @@
+package service
+
+// union returns the union of multiple string slices.
+func union(slices ...[]string) []string {
+	seen := make(map[string]struct{})
+	for _, slice := range slices {
+		for _, s := range slice {
+			seen[s] = struct{}{}
+		}
+	}
+
+	result := make([]string, 0, len(seen))
+	for s := range seen {
+		result = append(result, s)
+	}
+	return result
+}
+
+// intersection returns the intersection of multiple string slices.
+// Returns an empty slice if any input is empty.
+func intersection(slices ...[]string) []string {
+	if len(slices) == 0 {
+		return nil
+	}
+
+	// Find the smallest slice to iterate over
+	minIdx := 0
+	for i, slice := range slices {
+		if len(slice) < len(slices[minIdx]) {
+			minIdx = i
+		}
+	}
+
+	if len(slices[minIdx]) == 0 {
+		return nil
+	}
+
+	// Build sets from all other slices
+	sets := make([]map[string]struct{}, len(slices))
+	for i, slice := range slices {
+		sets[i] = make(map[string]struct{}, len(slice))
+		for _, s := range slice {
+			sets[i][s] = struct{}{}
+		}
+	}
+
+	// Iterate over smallest slice and check membership in all others
+	result := make([]string, 0)
+	for _, s := range slices[minIdx] {
+		inAll := true
+		for i, set := range sets {
+			if i == minIdx {
+				continue
+			}
+			if _, ok := set[s]; !ok {
+				inAll = false
+				break
+			}
+		}
+		if inAll {
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+// subtract returns elements in a that are not in b.
+func subtract(a, b []string) []string {
+	if len(b) == 0 {
+		return a
+	}
+
+	bSet := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		bSet[s] = struct{}{}
+	}
+
+	result := make([]string, 0, len(a))
+	for _, s := range a {
+		if _, ok := bSet[s]; !ok {
+			result = append(result, s)
+		}
+	}
+	return result
+}

--- a/server/mdmsettingsstatus/mdmsettingsstatus.go
+++ b/server/mdmsettingsstatus/mdmsettingsstatus.go
@@ -1,0 +1,73 @@
+// Package mdmsettingsstatus provides an aggregator service that combines
+// MDM settings status from multiple sources (profiles, declarations, FileVault,
+// and recovery lock) into a single overall status.
+//
+// This service is used by host listing endpoints to compute the overall MDM
+// settings status displayed in the UI.
+package mdmsettingsstatus
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/recoverylock/api"
+)
+
+// Status represents the overall MDM settings status for a host.
+type Status string
+
+const (
+	// StatusPending indicates at least one component has pending changes.
+	StatusPending Status = "pending"
+	// StatusFailed indicates at least one component has a failed status.
+	StatusFailed Status = "failed"
+	// StatusVerifying indicates at least one component is being verified.
+	StatusVerifying Status = "verifying"
+	// StatusVerified indicates all components are verified.
+	StatusVerified Status = "verified"
+)
+
+// IsValid returns true if the status is a known valid status.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusFailed, StatusVerifying, StatusVerified:
+		return true
+	default:
+		return false
+	}
+}
+
+// RecoveryLockStatusProvider provides recovery lock status information.
+// This is implemented by the recoverylock bounded context.
+type RecoveryLockStatusProvider interface {
+	// GetHostsStatusBulk returns recovery lock status for multiple hosts.
+	GetHostsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]*api.HostStatus, error)
+	// FilterHostsByStatus returns host UUIDs that match the given status.
+	FilterHostsByStatus(ctx context.Context, status api.Status, candidateUUIDs []string) ([]string, error)
+}
+
+// ProfilesStatusProvider provides profiles status information.
+// This is implemented by the legacy datastore.
+type ProfilesStatusProvider interface {
+	// GetProfilesStatusBulk returns profiles status for multiple hosts.
+	GetProfilesStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]Status, error)
+	// FilterHostsByProfileStatus returns host UUIDs matching the given status.
+	FilterHostsByProfileStatus(ctx context.Context, status Status, candidateUUIDs []string) ([]string, error)
+}
+
+// DeclarationsStatusProvider provides declarations status information.
+// This is implemented by the legacy datastore.
+type DeclarationsStatusProvider interface {
+	// GetDeclarationsStatusBulk returns declarations status for multiple hosts.
+	GetDeclarationsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]Status, error)
+	// FilterHostsByDeclarationStatus returns host UUIDs matching the given status.
+	FilterHostsByDeclarationStatus(ctx context.Context, status Status, candidateUUIDs []string) ([]string, error)
+}
+
+// FileVaultStatusProvider provides FileVault status information.
+// This is implemented by the legacy datastore.
+type FileVaultStatusProvider interface {
+	// GetFileVaultStatusBulk returns FileVault status for multiple hosts.
+	GetFileVaultStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]Status, error)
+	// FilterHostsByFileVaultStatus returns host UUIDs matching the given status.
+	FilterHostsByFileVaultStatus(ctx context.Context, status Status, candidateUUIDs []string) ([]string, error)
+}

--- a/server/recoverylock/README.md
+++ b/server/recoverylock/README.md
@@ -102,26 +102,35 @@ recovery lock status with profiles, declarations, and FileVault status:
 └──────────────────┘    └────────────────────────────┘
 ```
 
-## Comparison: Bounded Context vs. Module Approach
+## Comparison: Current State vs. Bounded Context
 
-### Module Approach (Previous Implementation)
+### Current State
 
-The previous implementation organized code into a `server/mdm/apple/recoverylock/`
-module, but did **not** enforce table ownership:
+Today, recovery lock logic is spread across multiple packages with no clear ownership:
+
+- **Business logic** lives in `server/mdm/apple/apple_mdm.go` (cron job, password generation)
+- **Result handling** lives in `server/service/apple_mdm.go` (MDM command results)
+- **Data access** is 19+ methods on the global `fleet.Datastore` interface, implemented in `server/datastore/mysql/`
+- **Types** are defined in `server/fleet/` alongside all other Fleet types
+- **Host listing** directly JOINs `host_recovery_key_passwords` from SQL in `hosts.go` and `labels.go`
 
 ```go
-// Anyone could still access the table:
-ds.GetHostRecoveryLockPassword(ctx, uuid)  // Works - no boundary
-ds.SetHostRecoveryLockVerified(ctx, uuid)  // Works - no boundary
+// Anyone can access the table from anywhere:
+ds.GetHostRecoveryLockPassword(ctx, uuid)
+ds.SetHostRecoveryLockVerified(ctx, uuid)
+
+// Host listing JOINs recovery lock table directly in SQL:
+// SELECT ... LEFT JOIN host_recovery_key_passwords hrkp ON h.uuid = hrkp.host_uuid ...
 ```
 
 **Characteristics:**
-- Code organized but not isolated
-- 19 methods in global `fleet.Datastore` interface
-- Direct SQL JOINs to table from hosts.go/labels.go
-- Implicit dependencies via Datastore
+- No code organization — logic scattered across 4+ packages
+- 19 methods on the global `fleet.Datastore` interface (alongside 300+ other methods)
+- Direct SQL JOINs to `host_recovery_key_passwords` from hosts.go/labels.go
+- No ownership boundary — any package can read/write the table
+- Difficult to understand the full feature without reading multiple packages
 
-### Bounded Context Approach (This Implementation)
+### Bounded Context Approach (`server/recoverylock/`)
 
 The bounded context enforces that **all access** goes through service methods:
 
@@ -142,16 +151,16 @@ recoveryLockSvc.GetHostRecoveryLockPassword(ctx, hostID)
 
 ### Comparison Table
 
-| Aspect | Module | Bounded Context |
-|--------|--------|-----------------|
-| Code organization | ✅ Organized | ✅ Organized |
-| Table ownership | ❌ Shared (anyone can access) | ✅ Exclusive (internal/ enforced) |
-| Interface | Global fleet.Datastore | Public api.Service |
-| Dependencies | Implicit | Explicit (DataProviders) |
+| Aspect | Current State | Bounded Context |
+|--------|--------------|-----------------|
+| Code organization | ❌ Scattered across 4+ packages | ✅ One package with clear structure |
+| Table ownership | ❌ Anyone can access | ✅ Exclusive (`internal/` enforced) |
+| Interface | Global `fleet.Datastore` | Public `api.Service` |
+| Dependencies | Implicit | Explicit (`DataProviders`) |
 | JOINs to table | Direct SQL | Via bulk service calls |
-| Enforcement | Convention only | Compiler + arch_test.go |
-| Testing | Requires mock Datastore | Can mock DataProviders |
-| Coupling | High (shares interface) | Low (isolated interface) |
+| Enforcement | None | Compiler + `arch_test.go` |
+| Testing | Requires mock of full Datastore | Can mock DataProviders |
+| Discoverability | Poor — must know where to look | Good |
 
 ### Pros of Bounded Context
 
@@ -169,21 +178,6 @@ recoveryLockSvc.GetHostRecoveryLockPassword(ctx, hostID)
 3. **Learning curve**: DataProviders pattern is less familiar
 4. **Migration effort**: Need to move 19 methods, update all callers
 5. **Two queries**: Filter then fetch (vs single JOIN query)
-
-### When to Use Which
-
-**Use Module Approach when:**
-- Simple code organization is sufficient
-- Table is legitimately shared across domains
-- Performance of single-query JOINs is critical
-- Team is small and conventions are followed
-
-**Use Bounded Context when:**
-- Table should be owned by one domain
-- Multiple teams work on the codebase
-- Schema evolution needs to be independent
-- Clear API contracts are important
-- You want compiler-enforced boundaries
 
 ## Database Schema
 

--- a/server/recoverylock/README.md
+++ b/server/recoverylock/README.md
@@ -1,0 +1,224 @@
+# Recovery Lock Bounded Context
+
+This module implements the **Recovery Lock** feature as a bounded context, following
+the patterns established in [ADR-0007](../../docs/adr/0007-bounded-context-pattern.md).
+
+## Overview
+
+Recovery Lock is an MDM feature that allows Fleet to set, clear, and rotate a
+recovery password on macOS devices with Apple Silicon (ARM). This password is
+required to boot the device from recovery mode.
+
+## Architecture
+
+This module follows the **bounded context pattern** with exclusive table ownership:
+
+```
+server/recoverylock/
+├── recoverylock.go           # DataProviders interface definitions
+├── api/                      # Public service interfaces
+├── bootstrap/                # Dependency injection wiring
+├── internal/                 # Implementation (compiler-enforced boundary)
+│   ├── types/               # Internal types & interfaces
+│   ├── mysql/               # Database implementation
+│   └── service/             # Business logic
+└── arch_test.go             # Boundary enforcement tests
+```
+
+### Key Principles
+
+1. **Exclusive Table Ownership**: Only `internal/mysql/` accesses `host_recovery_key_passwords`
+2. **DataProviders Pattern**: External dependencies injected via explicit interfaces
+3. **Public API via `api/` Package**: All external access goes through service methods
+4. **`internal/` Enforces Boundaries**: Go compiler prevents imports from outside the module
+
+## Usage
+
+### Initialization
+
+```go
+import (
+    "github.com/fleetdm/fleet/v4/server/recoverylock/bootstrap"
+)
+
+// In serve.go
+recoveryLockSvc := bootstrap.New(db, providers)
+```
+
+### Getting Recovery Lock Status (Bulk)
+
+```go
+// For host listing enrichment
+statusMap, err := recoveryLockSvc.GetHostsStatusBulk(ctx, hostUUIDs)
+for _, host := range hosts {
+    host.RecoveryLockStatus = statusMap[host.UUID]
+}
+```
+
+### Filtering Hosts by Status
+
+```go
+// For host listing filtering (pre-query)
+matchingUUIDs, err := recoveryLockSvc.FilterHostsByStatus(ctx, "failed", nil)
+// Use matchingUUIDs in WHERE h.uuid IN (...)
+```
+
+### Viewing a Password
+
+```go
+password, err := recoveryLockSvc.GetHostRecoveryLockPassword(ctx, hostID)
+```
+
+### Rotating a Password
+
+```go
+err := recoveryLockSvc.RotateHostRecoveryLockPassword(ctx, hostID)
+```
+
+## Integration with Host Listing
+
+Host listing uses the **mdmsettingsstatus aggregator** service, which combines
+recovery lock status with profiles, declarations, and FileVault status:
+
+```
+┌────────────────────────────────────────────────────┐
+│              Host Listing (hosts.go)                │
+└────────────────────────────────────────────────────┘
+                         │
+                         ▼
+┌────────────────────────────────────────────────────┐
+│         mdmsettingsstatus (Aggregator)              │
+│  • Combines status from all 4 MDM components        │
+│  • Hierarchical aggregation: failed > pending >     │
+│    verifying > verified                             │
+└────────────────────────────────────────────────────┘
+         │                           │
+         ▼                           ▼
+┌──────────────────┐    ┌────────────────────────────┐
+│  recoverylock    │    │   fleet.Datastore (legacy)  │
+│  (This Module)   │    │   • Profiles                │
+│                  │    │   • Declarations            │
+│                  │    │   • FileVault               │
+└──────────────────┘    └────────────────────────────┘
+```
+
+## Comparison: Bounded Context vs. Module Approach
+
+### Module Approach (Previous Implementation)
+
+The previous implementation organized code into a `server/mdm/apple/recoverylock/`
+module, but did **not** enforce table ownership:
+
+```go
+// Anyone could still access the table:
+ds.GetHostRecoveryLockPassword(ctx, uuid)  // Works - no boundary
+ds.SetHostRecoveryLockVerified(ctx, uuid)  // Works - no boundary
+```
+
+**Characteristics:**
+- Code organized but not isolated
+- 19 methods in global `fleet.Datastore` interface
+- Direct SQL JOINs to table from hosts.go/labels.go
+- Implicit dependencies via Datastore
+
+### Bounded Context Approach (This Implementation)
+
+The bounded context enforces that **all access** goes through service methods:
+
+```go
+// This is the ONLY way to access recovery lock data:
+recoveryLockSvc.GetHostRecoveryLockPassword(ctx, hostID)
+
+// Direct table access is impossible from outside:
+// - internal/ prevents imports
+// - fleet.Datastore has no recovery lock methods
+```
+
+**Characteristics:**
+- Exclusive table ownership enforced by Go compiler
+- Public API via `api/` package only
+- Explicit dependencies via DataProviders
+- Bulk service calls replace SQL JOINs
+
+### Comparison Table
+
+| Aspect | Module | Bounded Context |
+|--------|--------|-----------------|
+| Code organization | ✅ Organized | ✅ Organized |
+| Table ownership | ❌ Shared (anyone can access) | ✅ Exclusive (internal/ enforced) |
+| Interface | Global fleet.Datastore | Public api.Service |
+| Dependencies | Implicit | Explicit (DataProviders) |
+| JOINs to table | Direct SQL | Via bulk service calls |
+| Enforcement | Convention only | Compiler + arch_test.go |
+| Testing | Requires mock Datastore | Can mock DataProviders |
+| Coupling | High (shares interface) | Low (isolated interface) |
+
+### Pros of Bounded Context
+
+1. **True encapsulation**: Table schema can change without affecting callers
+2. **Clear contracts**: Public API is explicit and documented
+3. **Testability**: DataProviders can be mocked independently
+4. **Evolvability**: Internal implementation can be refactored freely
+5. **Discoverability**: All recovery lock code in one place
+6. **Prevents accidental coupling**: Can't accidentally query the table
+
+### Cons of Bounded Context
+
+1. **More code structure**: bootstrap/, api/, internal/ directories
+2. **Performance overhead**: Bulk queries instead of JOINs (mitigated by index)
+3. **Learning curve**: DataProviders pattern is less familiar
+4. **Migration effort**: Need to move 19 methods, update all callers
+5. **Two queries**: Filter then fetch (vs single JOIN query)
+
+### When to Use Which
+
+**Use Module Approach when:**
+- Simple code organization is sufficient
+- Table is legitimately shared across domains
+- Performance of single-query JOINs is critical
+- Team is small and conventions are followed
+
+**Use Bounded Context when:**
+- Table should be owned by one domain
+- Multiple teams work on the codebase
+- Schema evolution needs to be independent
+- Clear API contracts are important
+- You want compiler-enforced boundaries
+
+## Database Schema
+
+This module owns the `host_recovery_key_passwords` table:
+
+```sql
+CREATE TABLE `host_recovery_key_passwords` (
+    `host_uuid` varchar(255) NOT NULL,              -- Primary key, foreign to hosts.uuid
+    `encrypted_password` blob NOT NULL,             -- Active password (encrypted)
+    `status` varchar(20) DEFAULT NULL,              -- NULL|'pending'|'verifying'|'verified'|'failed'
+    `operation_type` varchar(20) NOT NULL,          -- 'install'|'remove'
+    `error_message` text,                           -- Error detail for install/remove operations
+    `deleted` tinyint(1) NOT NULL DEFAULT '0',      -- Soft delete flag
+    `created_at` timestamp(6) DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` timestamp(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    `pending_encrypted_password` blob,              -- New password during rotation
+    `pending_error_message` text,                   -- Error for rotation operation
+    `auto_rotate_at` timestamp(6) NULL,             -- When to auto-rotate viewed password
+    PRIMARY KEY (`host_uuid`),
+    KEY `status` (`status`),
+    KEY `operation_type` (`operation_type`),
+    KEY `deleted` (`deleted`),
+    KEY `idx_auto_rotate_at` (`auto_rotate_at`)
+);
+```
+
+## Testing
+
+```bash
+# Unit tests
+go test ./server/recoverylock/...
+
+# Integration tests
+MYSQL_TEST=1 REDIS_TEST=1 go test ./server/recoverylock/...
+
+# Boundary enforcement
+go test ./server/recoverylock/arch_test.go
+```

--- a/server/recoverylock/api/service.go
+++ b/server/recoverylock/api/service.go
@@ -1,0 +1,155 @@
+// Package api defines the public service interfaces for the recovery lock bounded context.
+// External packages should only import from this package, never from internal/.
+package api
+
+import (
+	"context"
+	"time"
+)
+
+// Service is the composite interface for all recovery lock operations.
+// Use bootstrap.New() to create an implementation.
+type Service interface {
+	PasswordService
+	StatusService
+	CronService
+	ResultHandlerService
+}
+
+// PasswordService handles recovery lock password operations.
+type PasswordService interface {
+	// GetHostRecoveryLockPassword retrieves the recovery lock password for a host.
+	// This marks the password as viewed and schedules auto-rotation if enabled.
+	GetHostRecoveryLockPassword(ctx context.Context, hostID uint) (*Password, error)
+
+	// RotateHostRecoveryLockPassword initiates password rotation for a host.
+	// This generates a new password and sends MDM commands to apply it.
+	RotateHostRecoveryLockPassword(ctx context.Context, hostID uint) error
+}
+
+// StatusService handles recovery lock status queries.
+type StatusService interface {
+	// GetHostRecoveryLockStatus returns the current recovery lock status for a host.
+	GetHostRecoveryLockStatus(ctx context.Context, hostUUID string) (*HostStatus, error)
+
+	// GetHostsStatusBulk returns recovery lock status for multiple hosts.
+	// This is optimized for host listing enrichment.
+	GetHostsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]*HostStatus, error)
+
+	// FilterHostsByStatus returns host UUIDs that match the given status.
+	// If candidateUUIDs is nil, considers all hosts.
+	FilterHostsByStatus(ctx context.Context, status Status, candidateUUIDs []string) ([]string, error)
+
+	// GetHostUUIDsByStatus returns all host UUIDs with the given status.
+	GetHostUUIDsByStatus(ctx context.Context, status Status) ([]string, error)
+}
+
+// CronService handles scheduled recovery lock operations.
+type CronService interface {
+	// SendCommands processes pending recovery lock operations.
+	// This includes setting, clearing, and rotating passwords.
+	SendCommands(ctx context.Context) error
+}
+
+// ResultHandlerService handles MDM command results.
+type ResultHandlerService interface {
+	// NewResultsHandler creates a handler for processing MDM command results.
+	NewResultsHandler() MDMCommandResultsHandler
+}
+
+// MDMCommandResultsHandler processes MDM command results for recovery lock commands.
+type MDMCommandResultsHandler interface {
+	// Handle processes the result of an MDM command.
+	Handle(ctx context.Context, result *CommandResult) error
+}
+
+// Password represents a recovery lock password with metadata.
+type Password struct {
+	// Password is the plaintext recovery lock password.
+	Password string
+	// UpdatedAt is when the password was last changed.
+	UpdatedAt time.Time
+	// AutoRotateAt is when the password is scheduled for auto-rotation.
+	// Nil if not scheduled.
+	AutoRotateAt *time.Time
+}
+
+// HostStatus represents the current recovery lock status for a host.
+type HostStatus struct {
+	// Status is the current delivery status.
+	Status Status
+	// OperationType indicates whether this is an install or remove operation.
+	OperationType OperationType
+	// ErrorMessage contains the error if status is Failed.
+	ErrorMessage string
+	// PasswordAvailable indicates whether a password is stored for this host.
+	PasswordAvailable bool
+	// HasPendingRotation indicates whether a rotation is in progress.
+	HasPendingRotation bool
+}
+
+// Status represents the MDM delivery status for a recovery lock operation.
+type Status string
+
+const (
+	// StatusPending indicates the MDM command is queued but not yet acknowledged.
+	StatusPending Status = "pending"
+	// StatusVerifying indicates the command was sent and we're waiting for verification.
+	StatusVerifying Status = "verifying"
+	// StatusVerified indicates the command was successfully applied.
+	StatusVerified Status = "verified"
+	// StatusFailed indicates the command failed.
+	StatusFailed Status = "failed"
+)
+
+// IsValid returns true if the status is a known valid status.
+func (s Status) IsValid() bool {
+	switch s {
+	case StatusPending, StatusVerifying, StatusVerified, StatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+// OperationType represents the type of recovery lock operation.
+type OperationType string
+
+const (
+	// OperationInstall indicates setting/installing a recovery lock password.
+	OperationInstall OperationType = "install"
+	// OperationRemove indicates clearing/removing a recovery lock password.
+	OperationRemove OperationType = "remove"
+)
+
+// CommandResult represents the result of an MDM command.
+type CommandResult struct {
+	// CommandUUID is the unique identifier for the command.
+	CommandUUID string
+	// HostUUID is the UUID of the host that executed the command.
+	HostUUID string
+	// RequestType is the MDM command type (e.g., "SetRecoveryLock").
+	RequestType string
+	// Status is the result status (e.g., "Acknowledged", "Error").
+	Status string
+	// ErrorChain contains error details if the command failed.
+	ErrorChain []ErrorChainItem
+}
+
+// ErrorChainItem represents an error in the MDM error chain.
+type ErrorChainItem struct {
+	ErrorCode            int
+	ErrorDomain          string
+	LocalizedDescription string
+	USEnglishDescription string
+}
+
+// RotationStatus represents the status of a password rotation operation.
+type RotationStatus struct {
+	// HasPendingRotation indicates whether a rotation is in progress.
+	HasPendingRotation bool
+	// Status is the current status of the rotation.
+	Status Status
+	// ErrorMessage contains the error if the rotation failed.
+	ErrorMessage string
+}

--- a/server/recoverylock/arch_test.go
+++ b/server/recoverylock/arch_test.go
@@ -1,0 +1,213 @@
+package recoverylock_test
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	moduleRoot      = "github.com/fleetdm/fleet/v4"
+	recoveryLockPkg = moduleRoot + "/server/recoverylock"
+)
+
+// allowedDependencies defines the external dependencies allowed for each package.
+// Packages not listed default to allowing standard library and the listed dependencies.
+var allowedDependencies = map[string][]string{
+	// Root package should have minimal dependencies
+	recoveryLockPkg: {
+		moduleRoot + "/server/contexts/ctxerr",
+	},
+	// API package should have no fleet dependencies except ctxerr
+	recoveryLockPkg + "/api": {
+		moduleRoot + "/server/contexts/ctxerr",
+	},
+	// Bootstrap can import api, internal packages, and recoverylock root
+	recoveryLockPkg + "/bootstrap": {
+		recoveryLockPkg,
+		recoveryLockPkg + "/api",
+		recoveryLockPkg + "/internal/mysql",
+		recoveryLockPkg + "/internal/service",
+	},
+	// Internal types should have minimal dependencies
+	recoveryLockPkg + "/internal/types": {
+		moduleRoot + "/server/contexts/ctxerr",
+	},
+	// Internal mysql can use types and ctxerr
+	recoveryLockPkg + "/internal/mysql": {
+		recoveryLockPkg + "/internal/types",
+		moduleRoot + "/server/contexts/ctxerr",
+	},
+	// Internal service can use all internal packages, api, and recoverylock root
+	recoveryLockPkg + "/internal/service": {
+		recoveryLockPkg,
+		recoveryLockPkg + "/api",
+		recoveryLockPkg + "/internal/types",
+		moduleRoot + "/server/contexts/ctxerr",
+	},
+}
+
+// forbiddenDependencies lists packages that should NEVER be imported.
+var forbiddenDependencies = []string{
+	moduleRoot + "/server/fleet",     // No direct fleet package imports
+	moduleRoot + "/server/datastore", // No datastore imports
+	moduleRoot + "/server/service",   // No service imports
+	moduleRoot + "/server/mdm",       // No mdm package imports
+	moduleRoot + "/cmd",              // No cmd imports
+}
+
+func TestRecoveryLockBoundaryEnforcement(t *testing.T) {
+	// Find the recoverylock directory
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Walk through all Go files in the recoverylock package
+	err = filepath.Walk(wd, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip non-Go files and test files
+		if info.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		// Parse the file
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, path, nil, parser.ImportsOnly)
+		if err != nil {
+			return err
+		}
+
+		// Determine the package path
+		relPath, err := filepath.Rel(wd, filepath.Dir(path))
+		if err != nil {
+			return err
+		}
+		pkgPath := recoveryLockPkg
+		if relPath != "." {
+			pkgPath = recoveryLockPkg + "/" + strings.ReplaceAll(relPath, string(filepath.Separator), "/")
+		}
+
+		// Check each import
+		for _, imp := range f.Imports {
+			importPath := strings.Trim(imp.Path.Value, "\"")
+
+			// Skip standard library imports
+			if !strings.Contains(importPath, ".") {
+				continue
+			}
+
+			// Skip non-fleet imports (third-party libraries)
+			if !strings.HasPrefix(importPath, moduleRoot) {
+				continue
+			}
+
+			// Check forbidden dependencies
+			for _, forbidden := range forbiddenDependencies {
+				// Allow the module if it's specifically allowed for this package
+				if isAllowed(pkgPath, importPath) {
+					continue
+				}
+				assert.False(t, strings.HasPrefix(importPath, forbidden),
+					"Package %s imports forbidden dependency %s (from file %s)",
+					pkgPath, importPath, path)
+			}
+
+			// For stricter checking, verify against allowed list
+			if allowed, ok := allowedDependencies[pkgPath]; ok {
+				if strings.HasPrefix(importPath, moduleRoot) && !strings.HasPrefix(importPath, recoveryLockPkg) {
+					isInAllowed := false
+					for _, a := range allowed {
+						if strings.HasPrefix(importPath, a) {
+							isInAllowed = true
+							break
+						}
+					}
+					assert.True(t, isInAllowed,
+						"Package %s imports non-allowed fleet dependency %s (from file %s). Allowed: %v",
+						pkgPath, importPath, path, allowed)
+				}
+			}
+		}
+
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func isAllowed(pkgPath, importPath string) bool {
+	allowed, ok := allowedDependencies[pkgPath]
+	if !ok {
+		return false
+	}
+	for _, a := range allowed {
+		if strings.HasPrefix(importPath, a) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInternalPackagesNotExportedDirectly(t *testing.T) {
+	// This test verifies that internal packages cannot be imported from outside
+	// the recoverylock module. Go's compiler enforces this, but this test documents
+	// the expectation.
+
+	internalPkgs := []string{
+		"internal/types",
+		"internal/mysql",
+		"internal/service",
+	}
+
+	for _, pkg := range internalPkgs {
+		t.Run(pkg, func(t *testing.T) {
+			// The internal package should exist
+			wd, err := os.Getwd()
+			require.NoError(t, err)
+
+			pkgPath := filepath.Join(wd, pkg)
+			_, err = os.Stat(pkgPath)
+			assert.NoError(t, err, "Internal package %s should exist", pkg)
+
+			// Verify it's under the internal directory
+			assert.True(t, strings.Contains(pkg, "internal/"),
+				"Package %s should be under internal/", pkg)
+		})
+	}
+}
+
+func TestAPIPackageExportsOnlyInterfaces(t *testing.T) {
+	// This test verifies that the api package primarily exports interfaces
+	// and types, not implementations.
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	apiDir := filepath.Join(wd, "api")
+	entries, err := os.ReadDir(apiDir)
+	require.NoError(t, err)
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+
+		t.Run(entry.Name(), func(t *testing.T) {
+			path := filepath.Join(apiDir, entry.Name())
+			fset := token.NewFileSet()
+			f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+			require.NoError(t, err)
+
+			// API package should be named "api"
+			assert.Equal(t, "api", f.Name.Name,
+				"API package should be named 'api'")
+		})
+	}
+}

--- a/server/recoverylock/bootstrap/bootstrap.go
+++ b/server/recoverylock/bootstrap/bootstrap.go
@@ -1,0 +1,51 @@
+// Package bootstrap provides dependency injection for the recovery lock bounded context.
+package bootstrap
+
+import (
+	"github.com/fleetdm/fleet/v4/server/recoverylock"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/api"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/mysql"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/service"
+)
+
+// New creates a new recovery lock service with all dependencies wired up.
+func New(
+	reader mysql.ReaderFunc,
+	writer mysql.WriterFunc,
+	withRetryTxx mysql.TxFunc,
+	serverPrivateKey string,
+	providers recoverylock.DataProviders,
+) api.Service {
+	// Create the internal datastore
+	ds := mysql.New(reader, writer, withRetryTxx, serverPrivateKey)
+
+	// Create the password encryptor using the datastore's encrypt/decrypt
+	encryptor := &datastoreEncryptor{
+		reader:           reader,
+		serverPrivateKey: serverPrivateKey,
+	}
+
+	// Create and return the service
+	return service.New(ds, providers, encryptor)
+}
+
+// datastoreEncryptor implements recoverylock.PasswordEncryptor using the same
+// encryption as the MySQL datastore.
+type datastoreEncryptor struct {
+	reader           mysql.ReaderFunc
+	serverPrivateKey string
+}
+
+// Encrypt encrypts a plaintext password.
+func (e *datastoreEncryptor) Encrypt(plaintext string) ([]byte, error) {
+	// Create a temporary datastore just for encryption
+	// This is a bit awkward but keeps the encryption logic in one place
+	ds := mysql.New(e.reader, nil, nil, e.serverPrivateKey)
+	return ds.Encrypt(plaintext)
+}
+
+// Decrypt decrypts an encrypted password.
+func (e *datastoreEncryptor) Decrypt(ciphertext []byte) (string, error) {
+	ds := mysql.New(e.reader, nil, nil, e.serverPrivateKey)
+	return ds.Decrypt(ciphertext)
+}

--- a/server/recoverylock/internal/mysql/cron.go
+++ b/server/recoverylock/internal/mysql/cron.go
@@ -1,0 +1,194 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+// GetHostsForRecoveryLockAction returns hosts that need recovery lock set.
+// These are hosts with either no password record OR a password with NULL status (command not yet enqueued).
+// The eligibleUUIDs parameter is used to filter to hosts that the caller has determined
+// are eligible (ARM CPU, MDM enrolled, feature enabled).
+func (ds *Datastore) GetHostsForRecoveryLockAction(ctx context.Context, eligibleUUIDs []string) ([]string, error) {
+	if len(eligibleUUIDs) == 0 {
+		return nil, nil
+	}
+
+	// Query hosts from the eligible list that either:
+	// - Have no recovery lock password record, OR
+	// - Have a password with NULL status (command not yet enqueued for retry)
+	// Note: hosts with status pending, verified, or failed are NOT included
+	// Note: hosts with operation_type='remove' are handled by RestoreRecoveryLockForReenabledHosts
+	//
+	// Build the query with the list of eligible UUIDs as a derived table
+	// This allows us to use a simple SELECT with values
+	var placeholders string
+	var args []any
+	for i, uuid := range eligibleUUIDs {
+		if i > 0 {
+			placeholders += " UNION ALL SELECT ?"
+		}
+		args = append(args, uuid)
+	}
+
+	queryStmt := `
+		SELECT h.uuid
+		FROM (SELECT ? AS uuid` + placeholders + `) h
+		LEFT JOIN host_recovery_key_passwords rkp ON rkp.host_uuid = h.uuid AND rkp.deleted = 0
+		WHERE rkp.host_uuid IS NULL OR rkp.status IS NULL
+		LIMIT 500
+	`
+
+	var hostUUIDs []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, queryStmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get hosts for recovery lock action")
+	}
+
+	return hostUUIDs, nil
+}
+
+// RestoreRecoveryLockForReenabledHosts restores recovery lock for hosts
+// where the feature was disabled and then re-enabled.
+// This is called with a list of host UUIDs that the caller has determined
+// have the feature enabled.
+func (ds *Datastore) RestoreRecoveryLockForReenabledHosts(ctx context.Context) (int64, error) {
+	// When recovery lock feature is re-enabled for a host that was in "pending remove" state,
+	// we restore it to "verified install" state instead of trying to set a new password.
+	// This is because:
+	// 1. The device still has the old password (ClearRecoveryLock hasn't completed)
+	// 2. Setting a new password would fail (needs current password to change)
+	// 3. The existing password in our DB is still valid for the device
+	//
+	// Note: This method operates on all hosts with operation_type='remove' and status='pending' or NULL.
+	// The caller must ensure they're calling this at the right time (after determining which hosts
+	// have the feature re-enabled). For the bounded context pattern, this will be coordinated
+	// through the service layer.
+	//
+	// We only restore records in recoverable states (pending or NULL status).
+	// Records with status='failed' (e.g., password mismatch) are NOT restored because:
+	// - They represent terminal errors that require admin intervention
+	// - Restoring them would mask the real problem and clear diagnostic error_message
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords rkp
+		SET rkp.operation_type = '%s',
+		    rkp.status = '%s',
+		    rkp.error_message = NULL
+		WHERE rkp.deleted = 0
+		  AND rkp.operation_type = '%s'
+		  AND (rkp.status = '%s' OR rkp.status IS NULL)
+	`, operationInstall, statusVerified, operationRemove, statusPending)
+
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt)
+	if err != nil {
+		return 0, ctxerr.Wrap(ctx, err, "restore recovery lock for re-enabled hosts")
+	}
+
+	return result.RowsAffected()
+}
+
+// ClaimHostsForRecoveryLockClear claims hosts for recovery lock clear operation.
+// Returns the UUIDs of claimed hosts.
+// The host eligibility (feature disabled, ARM CPU, MDM enrolled) is determined by the caller
+// through DataProviders.
+func (ds *Datastore) ClaimHostsForRecoveryLockClear(ctx context.Context) ([]string, error) {
+	// Query hosts that need recovery lock cleared.
+	// This includes:
+	// 1. New clears: verified passwords (operation_type='install', status='verified')
+	// 2. Retries: previous clear attempt failed (operation_type='remove', status=NULL)
+	//
+	// Note: In the bounded context model, the caller filters eligible hosts through
+	// DataProviders before calling this method. This method only operates on the
+	// host_recovery_key_passwords table.
+	selectStmt := fmt.Sprintf(`
+		SELECT host_uuid
+		FROM host_recovery_key_passwords
+		WHERE deleted = 0
+		  AND (
+		      (operation_type = '%s' AND status = '%s')
+		      OR
+		      (operation_type = '%s' AND status IS NULL)
+		  )
+		LIMIT 500
+		FOR UPDATE
+	`, operationInstall, statusVerified, operationRemove)
+
+	// Update all claimed hosts to remove/pending
+	updateStmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET operation_type = '%s', status = '%s'
+		WHERE host_uuid IN (?)
+	`, operationRemove, statusPending)
+
+	var hostUUIDs []string
+	err := ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
+		if err := sqlx.SelectContext(ctx, tx, &hostUUIDs, selectStmt); err != nil {
+			return ctxerr.Wrap(ctx, err, "select hosts for recovery lock clear")
+		}
+
+		if len(hostUUIDs) == 0 {
+			return nil
+		}
+
+		query, args, err := sqlx.In(updateStmt, hostUUIDs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "build update query")
+		}
+
+		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "mark hosts pending for clear")
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return hostUUIDs, nil
+}
+
+// GetHostsForAutoRotation returns hosts with passwords scheduled for auto-rotation.
+func (ds *Datastore) GetHostsForAutoRotation(ctx context.Context) ([]types.HostAutoRotationInfo, error) {
+	// Return hosts where:
+	// - auto_rotate_at is in the past (due for rotation)
+	// - status is verified (password is confirmed working)
+	// - no pending rotation (pending_encrypted_password IS NULL)
+	// - operation_type is install (not in remove state)
+	// - not deleted
+	//
+	// Note: In the bounded context model, host display name is retrieved through
+	// DataProviders. This query only returns the host_uuid.
+	stmt := fmt.Sprintf(`
+		SELECT
+			hrkp.host_uuid
+		FROM host_recovery_key_passwords hrkp
+		WHERE hrkp.auto_rotate_at IS NOT NULL
+		  AND hrkp.auto_rotate_at <= NOW(6)
+		  AND hrkp.status = '%s'
+		  AND hrkp.pending_encrypted_password IS NULL
+		  AND hrkp.operation_type = '%s'
+		  AND hrkp.deleted = 0
+		LIMIT 100
+	`, statusVerified, operationInstall)
+
+	var rows []struct {
+		HostUUID string `db:"host_uuid"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get hosts for auto rotation")
+	}
+
+	// Convert to HostAutoRotationInfo - host info will be enriched by the service layer
+	result := make([]types.HostAutoRotationInfo, len(rows))
+	for i, row := range rows {
+		result[i] = types.HostAutoRotationInfo{
+			HostUUID: row.HostUUID,
+		}
+	}
+
+	return result, nil
+}

--- a/server/recoverylock/internal/mysql/datastore.go
+++ b/server/recoverylock/internal/mysql/datastore.go
@@ -1,0 +1,147 @@
+// Package mysql implements the MySQL datastore for the recovery lock bounded context.
+// This package should only be imported within the recoverylock module.
+package mysql
+
+import (
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+// statusPending is the MDM delivery status for pending commands.
+const statusPending = "pending"
+
+// statusVerified is the MDM delivery status for verified commands.
+const statusVerified = "verified"
+
+// statusFailed is the MDM delivery status for failed commands.
+const statusFailed = "failed"
+
+// operationInstall is the operation type for installing a recovery lock.
+const operationInstall = "install"
+
+// operationRemove is the operation type for removing a recovery lock.
+const operationRemove = "remove"
+
+// Datastore implements the internal types.Datastore interface for MySQL.
+type Datastore struct {
+	reader func(ctx context.Context) sqlx.QueryerContext
+	writer func(ctx context.Context) sqlx.ExtContext
+	// withRetryTxx executes a function within a transaction with retry logic.
+	withRetryTxx func(ctx context.Context, fn func(tx sqlx.ExtContext) error) error
+	// serverPrivateKey is used for encrypting/decrypting passwords.
+	serverPrivateKey string
+}
+
+// ReaderFunc is a function type for getting a read-only database connection.
+type ReaderFunc func(ctx context.Context) sqlx.QueryerContext
+
+// WriterFunc is a function type for getting a read-write database connection.
+type WriterFunc func(ctx context.Context) sqlx.ExtContext
+
+// TxFunc is a function type for executing within a transaction.
+type TxFunc func(ctx context.Context, fn func(tx sqlx.ExtContext) error) error
+
+// New creates a new MySQL datastore for recovery lock operations.
+func New(reader ReaderFunc, writer WriterFunc, withRetryTxx TxFunc, serverPrivateKey string) *Datastore {
+	return &Datastore{
+		reader:           reader,
+		writer:           writer,
+		withRetryTxx:     withRetryTxx,
+		serverPrivateKey: serverPrivateKey,
+	}
+}
+
+// encrypt encrypts a plaintext password using AES-GCM.
+func (ds *Datastore) encrypt(plainText []byte) ([]byte, error) {
+	block, err := aes.NewCipher([]byte(ds.serverPrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("create new cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create new gcm: %w", err)
+	}
+
+	nonce := make([]byte, aesGCM.NonceSize())
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	return aesGCM.Seal(nonce, nonce, plainText, nil), nil
+}
+
+// decrypt decrypts an encrypted password using AES-GCM.
+func (ds *Datastore) decrypt(encrypted []byte) ([]byte, error) {
+	block, err := aes.NewCipher([]byte(ds.serverPrivateKey))
+	if err != nil {
+		return nil, fmt.Errorf("create new cipher: %w", err)
+	}
+
+	aesGCM, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("create new gcm: %w", err)
+	}
+
+	nonceSize := aesGCM.NonceSize()
+	nonce, ciphertext := encrypted[:nonceSize], encrypted[nonceSize:]
+
+	decrypted, err := aesGCM.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("decrypting: %w", err)
+	}
+
+	return decrypted, nil
+}
+
+// Encrypt encrypts a plaintext password string. This is an exported version
+// of encrypt for use by the bootstrap package's PasswordEncryptor.
+func (ds *Datastore) Encrypt(plaintext string) ([]byte, error) {
+	return ds.encrypt([]byte(plaintext))
+}
+
+// Decrypt decrypts an encrypted password and returns it as a string.
+// This is an exported version of decrypt for use by the bootstrap package's PasswordEncryptor.
+func (ds *Datastore) Decrypt(ciphertext []byte) (string, error) {
+	decrypted, err := ds.decrypt(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	return string(decrypted), nil
+}
+
+// notFoundError is a sentinel error type for not found errors.
+type notFoundError struct {
+	resourceType string
+	message      string
+}
+
+func (e *notFoundError) Error() string {
+	if e.message != "" {
+		return fmt.Sprintf("%s not found: %s", e.resourceType, e.message)
+	}
+	return fmt.Sprintf("%s not found", e.resourceType)
+}
+
+func (e *notFoundError) IsNotFound() bool {
+	return true
+}
+
+func notFound(resourceType string) *notFoundError {
+	return &notFoundError{resourceType: resourceType}
+}
+
+func (e *notFoundError) WithMessage(msg string) *notFoundError {
+	e.message = msg
+	return e
+}
+
+// Verify interface compliance
+var _ types.Datastore = (*Datastore)(nil)

--- a/server/recoverylock/internal/mysql/password.go
+++ b/server/recoverylock/internal/mysql/password.go
@@ -1,0 +1,122 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+// SetHostsRecoveryLockPasswords sets recovery lock passwords for multiple hosts.
+// Uses INSERT ... ON DUPLICATE KEY UPDATE for upsert behavior.
+func (ds *Datastore) SetHostsRecoveryLockPasswords(ctx context.Context, passwords []types.PasswordPayload) error {
+	if len(passwords) == 0 {
+		return nil
+	}
+
+	// Build values for bulk insert.
+	// Status is set to 'pending' immediately to prevent the host from being picked up
+	// again by the next cron run while the command is being enqueued. If enqueue fails,
+	// ClearRecoveryLockPendingStatus should be called to reset the status to NULL.
+	var args []any
+	for _, p := range passwords {
+		args = append(args, p.HostUUID, p.EncryptedPassword, p.Status, p.OperationType)
+	}
+
+	stmt := `
+		INSERT INTO host_recovery_key_passwords (host_uuid, encrypted_password, status, operation_type)
+		VALUES %s
+		ON DUPLICATE KEY UPDATE
+			encrypted_password = VALUES(encrypted_password),
+			status = VALUES(status),
+			operation_type = VALUES(operation_type),
+			error_message = NULL,
+			deleted = 0
+	`
+
+	placeholders := strings.TrimSuffix(strings.Repeat("(?, ?, ?, ?),", len(passwords)), ",")
+	stmt = fmt.Sprintf(stmt, placeholders)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "storing recovery lock passwords")
+	}
+
+	return nil
+}
+
+// GetHostRecoveryLockPassword retrieves the decrypted password for a host.
+func (ds *Datastore) GetHostRecoveryLockPassword(ctx context.Context, hostUUID string) (*types.Password, error) {
+	const stmt = `SELECT encrypted_password, updated_at, auto_rotate_at FROM host_recovery_key_passwords WHERE host_uuid = ? AND deleted = 0`
+
+	var row struct {
+		EncryptedPassword []byte     `db:"encrypted_password"`
+		UpdatedAt         time.Time  `db:"updated_at"`
+		AutoRotateAt      *time.Time `db:"auto_rotate_at"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
+				WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+		}
+		return nil, ctxerr.Wrap(ctx, err, "getting recovery lock password")
+	}
+
+	decrypted, err := ds.decrypt(row.EncryptedPassword)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "decrypting recovery lock password")
+	}
+
+	return &types.Password{
+		Password:     string(decrypted),
+		UpdatedAt:    row.UpdatedAt,
+		AutoRotateAt: row.AutoRotateAt,
+	}, nil
+}
+
+// DeleteHostRecoveryLockPassword soft-deletes the password record for a host.
+func (ds *Datastore) DeleteHostRecoveryLockPassword(ctx context.Context, hostUUID string) error {
+	stmt := fmt.Sprintf(`UPDATE host_recovery_key_passwords SET deleted = 1, status = '%s' WHERE host_uuid = ? AND deleted = 0`, statusVerified)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "soft delete host recovery lock password")
+	}
+
+	return nil
+}
+
+// MarkRecoveryLockPasswordViewed marks a password as viewed and schedules auto-rotation.
+// Returns the scheduled auto-rotation time.
+func (ds *Datastore) MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUID string, autoRotateDuration time.Duration) (*time.Time, error) {
+	if autoRotateDuration <= 0 {
+		return nil, nil
+	}
+
+	rotateAt := time.Now().Add(autoRotateDuration)
+
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET auto_rotate_at = ?
+		WHERE host_uuid = ?
+		  AND deleted = 0
+		  AND operation_type = '%s'
+	`, operationInstall)
+
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt, rotateAt, hostUUID)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "mark recovery lock password viewed")
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return nil, ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
+			WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+	}
+
+	return &rotateAt, nil
+}

--- a/server/recoverylock/internal/mysql/rotation.go
+++ b/server/recoverylock/internal/mysql/rotation.go
@@ -1,0 +1,219 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+// ErrRecoveryLockRotationPending is returned when a rotation is already in progress.
+var ErrRecoveryLockRotationPending = errors.New("recovery lock rotation already pending")
+
+// ErrRecoveryLockNotEligible is returned when a host is not eligible for rotation.
+var ErrRecoveryLockNotEligible = errors.New("recovery lock not eligible for rotation")
+
+// InitiateRecoveryLockRotation starts a password rotation.
+func (ds *Datastore) InitiateRecoveryLockRotation(ctx context.Context, hostUUID string, newEncryptedPassword []byte) error {
+	// Set the pending password and mark status as pending.
+	// Only allow rotation if:
+	// - Has an existing password (encrypted_password IS NOT NULL)
+	// - Operation type is 'install' (not removing the password)
+	// - Current status is 'verified' or 'failed' (not 'pending' or NULL)
+	// - No pending rotation already (pending_encrypted_password IS NULL)
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET pending_encrypted_password = ?,
+		    pending_error_message = NULL,
+		    status = '%s'
+		WHERE host_uuid = ?
+		  AND deleted = 0
+		  AND encrypted_password IS NOT NULL
+		  AND operation_type = '%s'
+		  AND status IN ('%s', '%s')
+		  AND pending_encrypted_password IS NULL
+	`, statusPending, operationInstall, statusVerified, statusFailed)
+
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt, newEncryptedPassword, hostUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "initiate recovery lock rotation")
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		// Determine the specific reason for failure
+		var dest struct {
+			HasPassword   bool           `db:"has_password"`
+			HasPending    bool           `db:"has_pending"`
+			Status        sql.NullString `db:"status"`
+			OperationType sql.NullString `db:"operation_type"`
+		}
+		checkStmt := `
+			SELECT
+				encrypted_password IS NOT NULL AND deleted = 0 AS has_password,
+				pending_encrypted_password IS NOT NULL AS has_pending,
+				status,
+				operation_type
+			FROM host_recovery_key_passwords
+			WHERE host_uuid = ? AND deleted = 0
+		`
+		if err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, checkStmt, hostUUID); err != nil {
+			if err == sql.ErrNoRows {
+				return ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
+					WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+			}
+			return ctxerr.Wrap(ctx, err, "check recovery lock rotation eligibility")
+		}
+
+		if dest.HasPending {
+			return ctxerr.Wrap(ctx, ErrRecoveryLockRotationPending, fmt.Sprintf("host %s", hostUUID))
+		}
+
+		return ctxerr.Wrap(ctx, ErrRecoveryLockNotEligible, fmt.Sprintf("host %s (status=%v, operation_type=%v)", hostUUID, dest.Status.String, dest.OperationType.String))
+	}
+
+	return nil
+}
+
+// CompleteRecoveryLockRotation completes a successful rotation.
+func (ds *Datastore) CompleteRecoveryLockRotation(ctx context.Context, hostUUID string) error {
+	// Move pending password to active and clear pending columns.
+	// Also clear auto_rotate_at since rotation is now complete.
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET encrypted_password = pending_encrypted_password,
+		    pending_encrypted_password = NULL,
+		    pending_error_message = NULL,
+		    status = '%s',
+		    error_message = NULL,
+		    auto_rotate_at = NULL
+		WHERE host_uuid = ?
+		  AND deleted = 0
+		  AND pending_encrypted_password IS NOT NULL
+	`, statusVerified)
+
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "complete recovery lock rotation")
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return ctxerr.Wrap(ctx, notFound("HostRecoveryLockPendingPassword").
+			WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+	}
+
+	return nil
+}
+
+// FailRecoveryLockRotation marks a rotation as failed.
+func (ds *Datastore) FailRecoveryLockRotation(ctx context.Context, hostUUID string, errorMsg string) error {
+	// Mark as failed but keep pending password for potential retry.
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET status = '%s',
+		    pending_error_message = ?
+		WHERE host_uuid = ?
+		  AND deleted = 0
+		  AND pending_encrypted_password IS NOT NULL
+	`, statusFailed)
+
+	result, err := ds.writer(ctx).ExecContext(ctx, stmt, errorMsg, hostUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "fail recovery lock rotation")
+	}
+
+	rows, _ := result.RowsAffected()
+	if rows == 0 {
+		return ctxerr.Wrap(ctx, notFound("HostRecoveryLockPendingPassword").
+			WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+	}
+
+	return nil
+}
+
+// ClearRecoveryLockRotation clears a pending rotation.
+func (ds *Datastore) ClearRecoveryLockRotation(ctx context.Context, hostUUID string) error {
+	// Clear pending rotation (e.g., if command enqueue fails).
+	// Only affects rows that were modified by InitiateRecoveryLockRotation
+	// (status = pending AND has pending password).
+	// Restores status to previous state: 'failed' if error_message exists, otherwise 'verified'.
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET pending_encrypted_password = NULL,
+		    pending_error_message = NULL,
+		    status = CASE WHEN error_message IS NOT NULL THEN '%s' ELSE '%s' END
+		WHERE host_uuid = ?
+		  AND deleted = 0
+		  AND status = '%s'
+		  AND pending_encrypted_password IS NOT NULL
+	`, statusFailed, statusVerified, statusPending)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "clear recovery lock rotation")
+	}
+
+	return nil
+}
+
+// GetRecoveryLockRotationStatus returns the rotation status for a host.
+func (ds *Datastore) GetRecoveryLockRotationStatus(ctx context.Context, hostUUID string) (*types.RotationStatus, error) {
+	const stmt = `
+		SELECT
+			pending_encrypted_password IS NOT NULL AS has_pending_rotation,
+			status,
+			COALESCE(pending_error_message, '') AS error_message
+		FROM host_recovery_key_passwords
+		WHERE host_uuid = ?
+		  AND deleted = 0
+	`
+
+	var row struct {
+		HasPendingRotation bool    `db:"has_pending_rotation"`
+		Status             *string `db:"status"`
+		ErrorMessage       string  `db:"error_message"`
+	}
+
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
+				WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+		}
+		return nil, ctxerr.Wrap(ctx, err, "get recovery lock rotation status")
+	}
+
+	status := statusPending
+	if row.Status != nil {
+		status = *row.Status
+	}
+
+	return &types.RotationStatus{
+		HasPendingRotation: row.HasPendingRotation,
+		Status:             status,
+		ErrorMessage:       row.ErrorMessage,
+	}, nil
+}
+
+// HasPendingRecoveryLockRotation checks if a rotation is in progress.
+func (ds *Datastore) HasPendingRecoveryLockRotation(ctx context.Context, hostUUID string) (bool, error) {
+	const stmt = `
+		SELECT pending_encrypted_password IS NOT NULL
+		FROM host_recovery_key_passwords
+		WHERE host_uuid = ?
+		  AND deleted = 0
+	`
+
+	var hasPending bool
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &hasPending, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, ctxerr.Wrap(ctx, err, "has pending recovery lock rotation")
+	}
+
+	return hasPending, nil
+}

--- a/server/recoverylock/internal/mysql/status.go
+++ b/server/recoverylock/internal/mysql/status.go
@@ -1,0 +1,277 @@
+package mysql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+	"github.com/jmoiron/sqlx"
+)
+
+// GetHostRecoveryLockPasswordStatus returns the full status for a host.
+func (ds *Datastore) GetHostRecoveryLockPasswordStatus(ctx context.Context, hostUUID string) (*types.HostStatus, error) {
+	const stmt = `
+		SELECT
+			status,
+			operation_type,
+			COALESCE(error_message, '') AS error_message,
+			encrypted_password IS NOT NULL AS password_available,
+			pending_encrypted_password IS NOT NULL AS has_pending_rotation
+		FROM host_recovery_key_passwords
+		WHERE host_uuid = ? AND deleted = 0`
+
+	var row struct {
+		Status             *string `db:"status"`
+		OperationType      string  `db:"operation_type"`
+		ErrorMessage       string  `db:"error_message"`
+		PasswordAvailable  bool    `db:"password_available"`
+		HasPendingRotation bool    `db:"has_pending_rotation"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &row, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, ctxerr.Wrap(ctx, err, "getting recovery lock password status")
+	}
+
+	// Treat NULL status as pending (retry state after failed command enqueue)
+	status := statusPending
+	if row.Status != nil {
+		status = *row.Status
+	}
+
+	return &types.HostStatus{
+		Status:             status,
+		OperationType:      row.OperationType,
+		ErrorMessage:       row.ErrorMessage,
+		PasswordAvailable:  row.PasswordAvailable,
+		HasPendingRotation: row.HasPendingRotation,
+	}, nil
+}
+
+// SetRecoveryLockVerified marks a recovery lock as successfully verified.
+func (ds *Datastore) SetRecoveryLockVerified(ctx context.Context, hostUUID string) error {
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET status = '%s',
+		    error_message = NULL
+		WHERE host_uuid = ?
+		  AND deleted = 0
+	`, statusVerified)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "set recovery lock verified")
+	}
+
+	return nil
+}
+
+// SetRecoveryLockFailed marks a recovery lock operation as failed.
+func (ds *Datastore) SetRecoveryLockFailed(ctx context.Context, hostUUID string, errorMsg string) error {
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET status = '%s',
+		    error_message = ?
+		WHERE host_uuid = ?
+		  AND deleted = 0
+	`, statusFailed)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, errorMsg, hostUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "set recovery lock failed")
+	}
+
+	return nil
+}
+
+// ClearRecoveryLockPendingStatus clears pending status for hosts (for retry).
+func (ds *Datastore) ClearRecoveryLockPendingStatus(ctx context.Context, hostUUIDs []string) error {
+	if len(hostUUIDs) == 0 {
+		return nil
+	}
+
+	// Reset status to NULL for hosts that failed to have their commands enqueued.
+	// This allows them to be picked up again on the next cron run.
+	// Only clears status if it's currently 'pending' to avoid overwriting other statuses.
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET status = NULL
+		WHERE host_uuid IN (?)
+		  AND status = '%s'
+		  AND deleted = 0
+	`, statusPending)
+
+	query, args, err := sqlx.In(stmt, hostUUIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "build query for clear recovery lock pending status")
+	}
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, query, args...); err != nil {
+		return ctxerr.Wrap(ctx, err, "clear recovery lock pending status")
+	}
+
+	return nil
+}
+
+// GetRecoveryLockOperationType returns the current operation type for a host.
+func (ds *Datastore) GetRecoveryLockOperationType(ctx context.Context, hostUUID string) (string, error) {
+	const stmt = `SELECT operation_type FROM host_recovery_key_passwords WHERE host_uuid = ? AND deleted = 0`
+
+	var opType string
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &opType, stmt, hostUUID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ctxerr.Wrap(ctx, notFound("HostRecoveryLockPassword").
+				WithMessage(fmt.Sprintf("for host %s", hostUUID)))
+		}
+		return "", ctxerr.Wrap(ctx, err, "get recovery lock operation type")
+	}
+
+	return opType, nil
+}
+
+// ResetRecoveryLockForRetry resets a failed recovery lock for retry.
+func (ds *Datastore) ResetRecoveryLockForRetry(ctx context.Context, hostUUID string) error {
+	stmt := fmt.Sprintf(`
+		UPDATE host_recovery_key_passwords
+		SET operation_type = '%s', status = '%s', error_message = NULL
+		WHERE host_uuid = ?
+		  AND deleted = 0
+	`, operationInstall, statusVerified)
+
+	if _, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "reset recovery lock for retry")
+	}
+
+	return nil
+}
+
+// GetHostsStatusBulk returns status for multiple hosts.
+func (ds *Datastore) GetHostsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]*types.HostStatus, error) {
+	if len(hostUUIDs) == 0 {
+		return make(map[string]*types.HostStatus), nil
+	}
+
+	const stmt = `
+		SELECT
+			host_uuid,
+			status,
+			operation_type,
+			COALESCE(error_message, '') AS error_message,
+			encrypted_password IS NOT NULL AS password_available,
+			pending_encrypted_password IS NOT NULL AS has_pending_rotation
+		FROM host_recovery_key_passwords
+		WHERE host_uuid IN (?)
+		  AND deleted = 0`
+
+	query, args, err := sqlx.In(stmt, hostUUIDs)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "build bulk status query")
+	}
+
+	var rows []struct {
+		HostUUID           string  `db:"host_uuid"`
+		Status             *string `db:"status"`
+		OperationType      string  `db:"operation_type"`
+		ErrorMessage       string  `db:"error_message"`
+		PasswordAvailable  bool    `db:"password_available"`
+		HasPendingRotation bool    `db:"has_pending_rotation"`
+	}
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, query, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get bulk recovery lock status")
+	}
+
+	result := make(map[string]*types.HostStatus, len(rows))
+	for _, row := range rows {
+		status := statusPending
+		if row.Status != nil {
+			status = *row.Status
+		}
+		result[row.HostUUID] = &types.HostStatus{
+			Status:             status,
+			OperationType:      row.OperationType,
+			ErrorMessage:       row.ErrorMessage,
+			PasswordAvailable:  row.PasswordAvailable,
+			HasPendingRotation: row.HasPendingRotation,
+		}
+	}
+
+	return result, nil
+}
+
+// GetHostUUIDsByStatus returns host UUIDs with the given status.
+func (ds *Datastore) GetHostUUIDsByStatus(ctx context.Context, status string) ([]string, error) {
+	var stmt string
+	var args []any
+
+	// NULL status is treated as pending
+	if status == statusPending {
+		stmt = `
+			SELECT host_uuid
+			FROM host_recovery_key_passwords
+			WHERE (status = ? OR status IS NULL)
+			  AND deleted = 0`
+		args = []any{status}
+	} else {
+		stmt = `
+			SELECT host_uuid
+			FROM host_recovery_key_passwords
+			WHERE status = ?
+			  AND deleted = 0`
+		args = []any{status}
+	}
+
+	var hostUUIDs []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "get host UUIDs by status")
+	}
+
+	return hostUUIDs, nil
+}
+
+// FilterHostUUIDsByStatus filters candidate UUIDs to those with the given status.
+func (ds *Datastore) FilterHostUUIDsByStatus(ctx context.Context, status string, candidateUUIDs []string) ([]string, error) {
+	if len(candidateUUIDs) == 0 {
+		return ds.GetHostUUIDsByStatus(ctx, status)
+	}
+
+	var stmt string
+	var args []any
+
+	// NULL status is treated as pending
+	if status == statusPending {
+		stmt = `
+			SELECT host_uuid
+			FROM host_recovery_key_passwords
+			WHERE host_uuid IN (?)
+			  AND (status = ? OR status IS NULL)
+			  AND deleted = 0`
+		query, queryArgs, err := sqlx.In(stmt, candidateUUIDs, status)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build filter query")
+		}
+		stmt = query
+		args = queryArgs
+	} else {
+		stmt = `
+			SELECT host_uuid
+			FROM host_recovery_key_passwords
+			WHERE host_uuid IN (?)
+			  AND status = ?
+			  AND deleted = 0`
+		query, queryArgs, err := sqlx.In(stmt, candidateUUIDs, status)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "build filter query")
+		}
+		stmt = query
+		args = queryArgs
+	}
+
+	var hostUUIDs []string
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &hostUUIDs, stmt, args...); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "filter host UUIDs by status")
+	}
+
+	return hostUUIDs, nil
+}

--- a/server/recoverylock/internal/service/cron.go
+++ b/server/recoverylock/internal/service/cron.go
@@ -1,0 +1,191 @@
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/recoverylock"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+)
+
+// SendCommands processes pending recovery lock operations.
+// This includes setting, clearing, and rotating passwords.
+func (s *Service) SendCommands(ctx context.Context) error {
+	// Step 1: Restore recovery lock for hosts where feature was re-enabled
+	if _, err := s.ds.RestoreRecoveryLockForReenabledHosts(ctx); err != nil {
+		return ctxerr.Wrap(ctx, err, "restore recovery lock for re-enabled hosts")
+	}
+
+	// Step 2: Process SET commands for hosts that need passwords
+	if err := s.sendSetCommands(ctx); err != nil {
+		return ctxerr.Wrap(ctx, err, "send set commands")
+	}
+
+	// Step 3: Process CLEAR commands for hosts where feature is disabled
+	if err := s.sendClearCommands(ctx); err != nil {
+		return ctxerr.Wrap(ctx, err, "send clear commands")
+	}
+
+	// Step 4: Process auto-rotation for viewed passwords
+	if err := s.sendAutoRotationCommands(ctx); err != nil {
+		return ctxerr.Wrap(ctx, err, "send auto rotation commands")
+	}
+
+	return nil
+}
+
+// sendSetCommands sends SET recovery lock commands to eligible hosts.
+func (s *Service) sendSetCommands(ctx context.Context) error {
+	// Get eligible hosts from provider (external query for ARM, MDM enrolled, feature enabled)
+	eligibleUUIDs, err := s.providers.GetEligibleHostUUIDs(ctx, recoverylock.EligibilityFilter{
+		FeatureEnabled: boolPtr(true),
+	})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get eligible hosts for set")
+	}
+
+	if len(eligibleUUIDs) == 0 {
+		return nil
+	}
+
+	// Filter to hosts that need a password (no record or NULL status)
+	hostUUIDs, err := s.ds.GetHostsForRecoveryLockAction(ctx, eligibleUUIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get hosts for recovery lock action")
+	}
+
+	if len(hostUUIDs) == 0 {
+		return nil
+	}
+
+	// Generate passwords for each host
+	payloads := make([]types.PasswordPayload, 0, len(hostUUIDs))
+	passwords := make(map[string]string, len(hostUUIDs))
+	for _, uuid := range hostUUIDs {
+		password := GeneratePassword()
+		encrypted, err := s.encryptor.Encrypt(password)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "encrypt password")
+		}
+		payloads = append(payloads, types.PasswordPayload{
+			HostUUID:          uuid,
+			EncryptedPassword: encrypted,
+			Status:            "pending",
+			OperationType:     "install",
+		})
+		passwords[uuid] = password
+	}
+
+	// Store passwords with pending status
+	if err := s.ds.SetHostsRecoveryLockPasswords(ctx, payloads); err != nil {
+		return ctxerr.Wrap(ctx, err, "set hosts recovery lock passwords")
+	}
+
+	// Send MDM commands
+	cmdUUID := GenerateUUID()
+	failedUUIDs := make([]string, 0)
+	for uuid, password := range passwords {
+		if err := s.providers.SetRecoveryLock(ctx, []string{uuid}, cmdUUID, password); err != nil {
+			failedUUIDs = append(failedUUIDs, uuid)
+		}
+	}
+
+	// Reset status for hosts that failed to enqueue
+	if len(failedUUIDs) > 0 {
+		if err := s.ds.ClearRecoveryLockPendingStatus(ctx, failedUUIDs); err != nil {
+			return ctxerr.Wrap(ctx, err, "clear pending status for failed hosts")
+		}
+	}
+
+	return nil
+}
+
+// sendClearCommands sends CLEAR recovery lock commands.
+func (s *Service) sendClearCommands(ctx context.Context) error {
+	// Claim hosts for clear operation
+	hostUUIDs, err := s.ds.ClaimHostsForRecoveryLockClear(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "claim hosts for clear")
+	}
+
+	if len(hostUUIDs) == 0 {
+		return nil
+	}
+
+	// Get passwords and send clear commands
+	failedUUIDs := make([]string, 0)
+	for _, uuid := range hostUUIDs {
+		password, err := s.ds.GetHostRecoveryLockPassword(ctx, uuid)
+		if err != nil {
+			failedUUIDs = append(failedUUIDs, uuid)
+			continue
+		}
+
+		cmdUUID := GenerateUUID()
+		if err := s.providers.ClearRecoveryLock(ctx, []string{uuid}, cmdUUID, password.Password); err != nil {
+			failedUUIDs = append(failedUUIDs, uuid)
+		}
+	}
+
+	// Reset status for hosts that failed to enqueue
+	if len(failedUUIDs) > 0 {
+		if err := s.ds.ClearRecoveryLockPendingStatus(ctx, failedUUIDs); err != nil {
+			return ctxerr.Wrap(ctx, err, "clear pending status for failed hosts")
+		}
+	}
+
+	return nil
+}
+
+// sendAutoRotationCommands sends rotation commands for viewed passwords.
+func (s *Service) sendAutoRotationCommands(ctx context.Context) error {
+	// Get hosts due for auto-rotation
+	hosts, err := s.ds.GetHostsForAutoRotation(ctx)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get hosts for auto rotation")
+	}
+
+	if len(hosts) == 0 {
+		return nil
+	}
+
+	// Process each host
+	for _, host := range hosts {
+		// Get current password
+		currentPassword, err := s.ds.GetHostRecoveryLockPassword(ctx, host.HostUUID)
+		if err != nil {
+			continue // Skip this host
+		}
+
+		// Generate new password
+		newPassword := GeneratePassword()
+		encryptedPassword, err := s.encryptor.Encrypt(newPassword)
+		if err != nil {
+			continue // Skip this host
+		}
+
+		// Initiate rotation
+		if err := s.ds.InitiateRecoveryLockRotation(ctx, host.HostUUID, encryptedPassword); err != nil {
+			continue // Skip this host
+		}
+
+		// Send rotation command
+		cmdUUID := GenerateUUID()
+		if err := s.providers.RotateRecoveryLock(ctx, host.HostUUID, cmdUUID, currentPassword.Password, newPassword); err != nil {
+			// Clear the rotation state
+			_ = s.ds.ClearRecoveryLockRotation(ctx, host.HostUUID)
+			continue // Skip this host
+		}
+
+		// Log activity if we have host info
+		if host.HostID > 0 {
+			_ = s.providers.LogRecoveryLockRotated(ctx, host.HostID, host.HostDisplayName)
+		}
+	}
+
+	return nil
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/server/recoverylock/internal/service/password.go
+++ b/server/recoverylock/internal/service/password.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/recoverylock/api"
+)
+
+// DefaultAutoRotationDuration is the default duration after which viewed passwords
+// are automatically rotated (1 hour).
+const DefaultAutoRotationDuration = time.Hour
+
+// GetHostRecoveryLockPassword retrieves the recovery lock password for a host.
+func (s *Service) GetHostRecoveryLockPassword(ctx context.Context, hostID uint) (*api.Password, error) {
+	// Get host info to get UUID
+	host, err := s.providers.GetHostLite(ctx, hostID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get the password from the datastore
+	password, err := s.ds.GetHostRecoveryLockPassword(ctx, host.UUID)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get auto-rotation duration from config
+	autoRotateDuration, err := s.providers.GetAutoRotationDuration(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark as viewed and schedule auto-rotation if enabled
+	var autoRotateAt *time.Time
+	if autoRotateDuration > 0 {
+		autoRotateAt, err = s.ds.MarkRecoveryLockPasswordViewed(ctx, host.UUID, time.Duration(autoRotateDuration)*time.Second)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Log activity - ignore errors as activity logging is secondary
+	displayName := host.UUID // Use UUID as fallback display name
+	_ = s.providers.LogRecoveryLockViewed(ctx, hostID, displayName)
+
+	return &api.Password{
+		Password:     password.Password,
+		UpdatedAt:    password.UpdatedAt,
+		AutoRotateAt: autoRotateAt,
+	}, nil
+}
+
+// RotateHostRecoveryLockPassword initiates password rotation for a host.
+func (s *Service) RotateHostRecoveryLockPassword(ctx context.Context, hostID uint) error {
+	// Get host info
+	host, err := s.providers.GetHostLite(ctx, hostID)
+	if err != nil {
+		return err
+	}
+
+	// Check if rotation is already pending
+	hasPending, err := s.ds.HasPendingRecoveryLockRotation(ctx, host.UUID)
+	if err != nil {
+		return err
+	}
+	if hasPending {
+		// Rotation already in progress, nothing to do
+		return nil
+	}
+
+	// Get the current password to use for clearing the old lock
+	currentPassword, err := s.ds.GetHostRecoveryLockPassword(ctx, host.UUID)
+	if err != nil {
+		return err
+	}
+
+	// Generate a new password
+	newPassword := GeneratePassword()
+
+	// Encrypt the new password
+	encryptedPassword, err := s.encryptor.Encrypt(newPassword)
+	if err != nil {
+		return err
+	}
+
+	// Initiate the rotation in the database
+	if err := s.ds.InitiateRecoveryLockRotation(ctx, host.UUID, encryptedPassword); err != nil {
+		return err
+	}
+
+	// Send the rotation command through the commander
+	cmdUUID := GenerateUUID()
+	if err := s.providers.RotateRecoveryLock(ctx, host.UUID, cmdUUID, currentPassword.Password, newPassword); err != nil {
+		// Clear the rotation state since command failed
+		_ = s.ds.ClearRecoveryLockRotation(ctx, host.UUID)
+		return err
+	}
+
+	// Log activity - ignore errors as activity logging is secondary
+	displayName := host.UUID
+	_ = s.providers.LogRecoveryLockRotated(ctx, hostID, displayName)
+
+	return nil
+}

--- a/server/recoverylock/internal/service/result_handler.go
+++ b/server/recoverylock/internal/service/result_handler.go
@@ -1,0 +1,136 @@
+package service
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fleetdm/fleet/v4/server/recoverylock/api"
+)
+
+// resultsHandler handles MDM command results for recovery lock operations.
+type resultsHandler struct {
+	ds interface {
+		SetRecoveryLockVerified(ctx context.Context, hostUUID string) error
+		SetRecoveryLockFailed(ctx context.Context, hostUUID string, errorMsg string) error
+		DeleteHostRecoveryLockPassword(ctx context.Context, hostUUID string) error
+		CompleteRecoveryLockRotation(ctx context.Context, hostUUID string) error
+		FailRecoveryLockRotation(ctx context.Context, hostUUID string, errorMsg string) error
+		GetRecoveryLockOperationType(ctx context.Context, hostUUID string) (string, error)
+		HasPendingRecoveryLockRotation(ctx context.Context, hostUUID string) (bool, error)
+		ResetRecoveryLockForRetry(ctx context.Context, hostUUID string) error
+	}
+}
+
+// NewResultsHandler creates a handler for processing MDM command results.
+func (s *Service) NewResultsHandler() api.MDMCommandResultsHandler {
+	return &resultsHandler{ds: s.ds}
+}
+
+// Handle processes the result of an MDM command.
+func (h *resultsHandler) Handle(ctx context.Context, result *api.CommandResult) error {
+	if result == nil {
+		return nil
+	}
+
+	// Only handle SetRecoveryLock commands
+	if result.RequestType != "SetRecoveryLock" {
+		return nil
+	}
+
+	hostUUID := result.HostUUID
+
+	// Check if this is a rotation in progress
+	hasPending, err := h.ds.HasPendingRecoveryLockRotation(ctx, hostUUID)
+	if err != nil {
+		return fmt.Errorf("check pending rotation: %w", err)
+	}
+
+	// Get the operation type
+	opType, err := h.ds.GetRecoveryLockOperationType(ctx, hostUUID)
+	if err != nil {
+		return fmt.Errorf("get operation type: %w", err)
+	}
+
+	switch result.Status {
+	case "Acknowledged":
+		return h.handleAcknowledged(ctx, hostUUID, opType, hasPending)
+	case "Error":
+		return h.handleError(ctx, hostUUID, opType, hasPending, result.ErrorChain)
+	default:
+		// For other statuses (NotNow, etc.), just update to pending for retry
+		return nil
+	}
+}
+
+// handleAcknowledged processes a successful MDM command.
+func (h *resultsHandler) handleAcknowledged(ctx context.Context, hostUUID, opType string, hasPending bool) error {
+	switch {
+	case hasPending:
+		// Rotation completed successfully
+		return h.ds.CompleteRecoveryLockRotation(ctx, hostUUID)
+	case opType == "remove":
+		// Clear completed successfully - delete the password record
+		return h.ds.DeleteHostRecoveryLockPassword(ctx, hostUUID)
+	default:
+		// Set completed successfully
+		return h.ds.SetRecoveryLockVerified(ctx, hostUUID)
+	}
+}
+
+// handleError processes a failed MDM command.
+func (h *resultsHandler) handleError(ctx context.Context, hostUUID, opType string, hasPending bool, errorChain []api.ErrorChainItem) error {
+	errorMsg := formatErrorMessage(errorChain)
+
+	// Check for specific error codes that require special handling
+	isPasswordMismatch := hasErrorCode(errorChain, 1000) // MDMClientError.InvalidCommand for wrong password
+
+	switch {
+	case hasPending:
+		// Rotation failed
+		if isPasswordMismatch {
+			// Password was changed externally - mark as failed and allow retry
+			return h.ds.FailRecoveryLockRotation(ctx, hostUUID, errorMsg)
+		}
+		return h.ds.FailRecoveryLockRotation(ctx, hostUUID, errorMsg)
+	case opType == "remove":
+		// Clear failed
+		if isPasswordMismatch {
+			// Our stored password doesn't match - reset for manual intervention
+			return h.ds.ResetRecoveryLockForRetry(ctx, hostUUID)
+		}
+		return h.ds.SetRecoveryLockFailed(ctx, hostUUID, errorMsg)
+	default:
+		// Set failed
+		return h.ds.SetRecoveryLockFailed(ctx, hostUUID, errorMsg)
+	}
+}
+
+// formatErrorMessage creates a human-readable error message from the error chain.
+func formatErrorMessage(errorChain []api.ErrorChainItem) string {
+	if len(errorChain) == 0 {
+		return "unknown error"
+	}
+
+	// Use the first error with a description
+	for _, e := range errorChain {
+		if e.USEnglishDescription != "" {
+			return e.USEnglishDescription
+		}
+		if e.LocalizedDescription != "" {
+			return e.LocalizedDescription
+		}
+	}
+
+	// Fallback to error code
+	return fmt.Sprintf("error code: %d", errorChain[0].ErrorCode)
+}
+
+// hasErrorCode checks if the error chain contains a specific error code.
+func hasErrorCode(errorChain []api.ErrorChainItem, code int) bool {
+	for _, e := range errorChain {
+		if e.ErrorCode == code {
+			return true
+		}
+	}
+	return false
+}

--- a/server/recoverylock/internal/service/service.go
+++ b/server/recoverylock/internal/service/service.go
@@ -1,0 +1,80 @@
+// Package service implements the recovery lock business logic.
+// This package should only be imported within the recoverylock module.
+package service
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/recoverylock"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/api"
+	"github.com/fleetdm/fleet/v4/server/recoverylock/internal/types"
+)
+
+// Service implements the api.Service interface.
+type Service struct {
+	ds        types.Datastore
+	providers recoverylock.DataProviders
+	encryptor recoverylock.PasswordEncryptor
+}
+
+// New creates a new recovery lock service.
+func New(ds types.Datastore, providers recoverylock.DataProviders, encryptor recoverylock.PasswordEncryptor) *Service {
+	return &Service{
+		ds:        ds,
+		providers: providers,
+		encryptor: encryptor,
+	}
+}
+
+// GetHostRecoveryLockStatus returns the current recovery lock status for a host.
+func (s *Service) GetHostRecoveryLockStatus(ctx context.Context, hostUUID string) (*api.HostStatus, error) {
+	status, err := s.ds.GetHostRecoveryLockPasswordStatus(ctx, hostUUID)
+	if err != nil {
+		return nil, err
+	}
+	if status == nil {
+		return nil, nil
+	}
+	return toAPIHostStatus(status), nil
+}
+
+// GetHostsStatusBulk returns recovery lock status for multiple hosts.
+func (s *Service) GetHostsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]*api.HostStatus, error) {
+	statusMap, err := s.ds.GetHostsStatusBulk(ctx, hostUUIDs)
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]*api.HostStatus, len(statusMap))
+	for uuid, status := range statusMap {
+		result[uuid] = toAPIHostStatus(status)
+	}
+	return result, nil
+}
+
+// FilterHostsByStatus returns host UUIDs that match the given status.
+func (s *Service) FilterHostsByStatus(ctx context.Context, status api.Status, candidateUUIDs []string) ([]string, error) {
+	return s.ds.FilterHostUUIDsByStatus(ctx, string(status), candidateUUIDs)
+}
+
+// GetHostUUIDsByStatus returns all host UUIDs with the given status.
+func (s *Service) GetHostUUIDsByStatus(ctx context.Context, status api.Status) ([]string, error) {
+	return s.ds.GetHostUUIDsByStatus(ctx, string(status))
+}
+
+// toAPIHostStatus converts internal status to API status.
+func toAPIHostStatus(status *types.HostStatus) *api.HostStatus {
+	if status == nil {
+		return nil
+	}
+	return &api.HostStatus{
+		Status:             api.Status(status.Status),
+		OperationType:      api.OperationType(status.OperationType),
+		ErrorMessage:       status.ErrorMessage,
+		PasswordAvailable:  status.PasswordAvailable,
+		HasPendingRotation: status.HasPendingRotation,
+	}
+}
+
+// Verify interface compliance
+var _ api.Service = (*Service)(nil)

--- a/server/recoverylock/internal/service/utils.go
+++ b/server/recoverylock/internal/service/utils.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"crypto/rand"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// PasswordCharset contains characters for password generation.
+// Excludes confusing characters: 0/O, 1/I/l
+const PasswordCharset = "23456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz"
+
+// GeneratePassword generates a recovery lock password.
+// Format: XXXX-XXXX-XXXX-XXXX-XXXX-XXXX (6 groups of 4 characters)
+func GeneratePassword() string {
+	groups := make([]string, 6)
+	for i := range groups {
+		groups[i] = generateGroup(4)
+	}
+	return strings.Join(groups, "-")
+}
+
+// generateGroup generates a random group of characters.
+func generateGroup(length int) string {
+	b := make([]byte, length)
+	randomBytes := make([]byte, length)
+	if _, err := rand.Read(randomBytes); err != nil {
+		// Fallback to less secure random if crypto/rand fails
+		for i := range b {
+			b[i] = PasswordCharset[i%len(PasswordCharset)]
+		}
+		return string(b)
+	}
+	for i := range b {
+		b[i] = PasswordCharset[int(randomBytes[i])%len(PasswordCharset)]
+	}
+	return string(b)
+}
+
+// GenerateUUID generates a new UUID for MDM commands.
+func GenerateUUID() string {
+	return uuid.New().String()
+}

--- a/server/recoverylock/internal/types/datastore.go
+++ b/server/recoverylock/internal/types/datastore.go
@@ -1,0 +1,159 @@
+// Package types defines internal types for the recovery lock bounded context.
+// This package is internal and should not be imported from outside the recoverylock module.
+package types
+
+import (
+	"context"
+	"time"
+)
+
+// Datastore defines the internal database operations for recovery lock.
+// This interface is NOT exported outside the recoverylock module.
+type Datastore interface {
+	PasswordDatastore
+	StatusDatastore
+	RotationDatastore
+	CronDatastore
+}
+
+// PasswordDatastore handles password CRUD operations.
+type PasswordDatastore interface {
+	// SetHostsRecoveryLockPasswords sets recovery lock passwords for multiple hosts.
+	// Uses INSERT ... ON DUPLICATE KEY UPDATE for upsert behavior.
+	SetHostsRecoveryLockPasswords(ctx context.Context, passwords []PasswordPayload) error
+
+	// GetHostRecoveryLockPassword retrieves the decrypted password for a host.
+	GetHostRecoveryLockPassword(ctx context.Context, hostUUID string) (*Password, error)
+
+	// DeleteHostRecoveryLockPassword soft-deletes the password record for a host.
+	DeleteHostRecoveryLockPassword(ctx context.Context, hostUUID string) error
+
+	// MarkRecoveryLockPasswordViewed marks a password as viewed and schedules auto-rotation.
+	// Returns the scheduled auto-rotation time.
+	MarkRecoveryLockPasswordViewed(ctx context.Context, hostUUID string, autoRotateDuration time.Duration) (*time.Time, error)
+}
+
+// StatusDatastore handles status operations.
+type StatusDatastore interface {
+	// GetHostRecoveryLockPasswordStatus returns the full status for a host.
+	GetHostRecoveryLockPasswordStatus(ctx context.Context, hostUUID string) (*HostStatus, error)
+
+	// SetRecoveryLockVerified marks a recovery lock as successfully verified.
+	SetRecoveryLockVerified(ctx context.Context, hostUUID string) error
+
+	// SetRecoveryLockFailed marks a recovery lock operation as failed.
+	SetRecoveryLockFailed(ctx context.Context, hostUUID string, errorMsg string) error
+
+	// ClearRecoveryLockPendingStatus clears pending status for hosts (for retry).
+	ClearRecoveryLockPendingStatus(ctx context.Context, hostUUIDs []string) error
+
+	// GetRecoveryLockOperationType returns the current operation type for a host.
+	GetRecoveryLockOperationType(ctx context.Context, hostUUID string) (string, error)
+
+	// ResetRecoveryLockForRetry resets a failed recovery lock for retry.
+	ResetRecoveryLockForRetry(ctx context.Context, hostUUID string) error
+
+	// GetHostsStatusBulk returns status for multiple hosts.
+	GetHostsStatusBulk(ctx context.Context, hostUUIDs []string) (map[string]*HostStatus, error)
+
+	// GetHostUUIDsByStatus returns host UUIDs with the given status.
+	GetHostUUIDsByStatus(ctx context.Context, status string) ([]string, error)
+
+	// FilterHostUUIDsByStatus filters candidate UUIDs to those with the given status.
+	FilterHostUUIDsByStatus(ctx context.Context, status string, candidateUUIDs []string) ([]string, error)
+}
+
+// RotationDatastore handles password rotation operations.
+type RotationDatastore interface {
+	// InitiateRecoveryLockRotation starts a password rotation.
+	InitiateRecoveryLockRotation(ctx context.Context, hostUUID string, newEncryptedPassword []byte) error
+
+	// CompleteRecoveryLockRotation completes a successful rotation.
+	CompleteRecoveryLockRotation(ctx context.Context, hostUUID string) error
+
+	// FailRecoveryLockRotation marks a rotation as failed.
+	FailRecoveryLockRotation(ctx context.Context, hostUUID string, errorMsg string) error
+
+	// ClearRecoveryLockRotation clears a pending rotation.
+	ClearRecoveryLockRotation(ctx context.Context, hostUUID string) error
+
+	// GetRecoveryLockRotationStatus returns the rotation status for a host.
+	GetRecoveryLockRotationStatus(ctx context.Context, hostUUID string) (*RotationStatus, error)
+
+	// HasPendingRecoveryLockRotation checks if a rotation is in progress.
+	HasPendingRecoveryLockRotation(ctx context.Context, hostUUID string) (bool, error)
+}
+
+// CronDatastore handles cron job database operations.
+type CronDatastore interface {
+	// GetHostsForRecoveryLockAction returns hosts that need recovery lock set.
+	// These are ARM hosts with MDM enrollment and feature enabled but no password.
+	GetHostsForRecoveryLockAction(ctx context.Context, eligibleUUIDs []string) ([]string, error)
+
+	// RestoreRecoveryLockForReenabledHosts restores recovery lock for hosts
+	// where the feature was disabled and then re-enabled.
+	RestoreRecoveryLockForReenabledHosts(ctx context.Context) (int64, error)
+
+	// ClaimHostsForRecoveryLockClear claims hosts for recovery lock clear operation.
+	// Returns the UUIDs of claimed hosts.
+	ClaimHostsForRecoveryLockClear(ctx context.Context) ([]string, error)
+
+	// GetHostsForAutoRotation returns hosts with passwords scheduled for auto-rotation.
+	GetHostsForAutoRotation(ctx context.Context) ([]HostAutoRotationInfo, error)
+}
+
+// PasswordPayload is the payload for setting a recovery lock password.
+type PasswordPayload struct {
+	// HostUUID is the host's UUID.
+	HostUUID string
+	// EncryptedPassword is the encrypted password.
+	EncryptedPassword []byte
+	// Status is the initial status (typically "pending").
+	Status string
+	// OperationType is the operation type ("install" or "remove").
+	OperationType string
+}
+
+// Password represents a stored recovery lock password.
+type Password struct {
+	// Password is the plaintext (decrypted) password.
+	Password string
+	// UpdatedAt is when the password was last changed.
+	UpdatedAt time.Time
+	// AutoRotateAt is when the password is scheduled for auto-rotation.
+	AutoRotateAt *time.Time
+}
+
+// HostStatus represents the full status of a host's recovery lock.
+type HostStatus struct {
+	// Status is the MDM delivery status.
+	Status string
+	// OperationType is "install" or "remove".
+	OperationType string
+	// ErrorMessage contains error details if failed.
+	ErrorMessage string
+	// PasswordAvailable indicates if a password is stored.
+	PasswordAvailable bool
+	// HasPendingRotation indicates if a rotation is in progress.
+	HasPendingRotation bool
+}
+
+// RotationStatus represents the status of a password rotation.
+type RotationStatus struct {
+	// HasPendingRotation indicates if a rotation is in progress.
+	HasPendingRotation bool
+	// Status is the current status.
+	Status string
+	// ErrorMessage contains error details if failed.
+	ErrorMessage string
+}
+
+// HostAutoRotationInfo contains info for a host scheduled for auto-rotation.
+type HostAutoRotationInfo struct {
+	// HostID is the host's numeric ID.
+	HostID uint
+	// HostUUID is the host's UUID.
+	HostUUID string
+	// HostDisplayName is the host's display name for activity logging.
+	HostDisplayName string
+}

--- a/server/recoverylock/recoverylock.go
+++ b/server/recoverylock/recoverylock.go
@@ -1,0 +1,88 @@
+// Package recoverylock implements the Recovery Lock bounded context for managing
+// macOS recovery lock passwords on Apple Silicon devices.
+//
+// This module follows the bounded context pattern with exclusive ownership of the
+// host_recovery_key_passwords table. All access to recovery lock data must go
+// through the public API defined in the api/ subpackage.
+//
+// See README.md for architecture details and usage examples.
+package recoverylock
+
+import (
+	"context"
+)
+
+// Host represents the minimal host information needed by the recovery lock module.
+type Host struct {
+	ID            uint
+	UUID          string
+	TeamID        *uint
+	Platform      string
+	HardwareModel string
+}
+
+// EligibilityFilter specifies criteria for finding hosts eligible for recovery lock operations.
+type EligibilityFilter struct {
+	// FeatureEnabled filters to hosts where the recovery lock feature is enabled.
+	FeatureEnabled *bool
+	// TeamIDs filters to hosts in specific teams. If nil, considers all teams.
+	TeamIDs []uint
+	// ExcludeHostUUIDs excludes specific hosts from the results.
+	ExcludeHostUUIDs []string
+}
+
+// DataProviders defines the external dependencies required by the recovery lock module.
+// These interfaces are implemented by ACL adapters that bridge to the legacy Fleet services.
+type DataProviders interface {
+	HostProvider
+	ConfigProvider
+	CommanderProvider
+	ActivityProvider
+}
+
+// HostProvider provides access to host information.
+type HostProvider interface {
+	// GetHostLite returns minimal host information by host ID.
+	GetHostLite(ctx context.Context, hostID uint) (*Host, error)
+	// GetHostByUUID returns minimal host information by host UUID.
+	GetHostByUUID(ctx context.Context, uuid string) (*Host, error)
+	// GetEligibleHostUUIDs returns UUIDs of hosts eligible for recovery lock operations.
+	// Eligible hosts are: macOS ARM, MDM enrolled, and have the feature enabled.
+	GetEligibleHostUUIDs(ctx context.Context, filter EligibilityFilter) ([]string, error)
+}
+
+// ConfigProvider provides access to Fleet configuration.
+type ConfigProvider interface {
+	// IsRecoveryLockEnabled returns whether recovery lock is enabled for a team.
+	// Pass nil for no-team (global) configuration.
+	IsRecoveryLockEnabled(ctx context.Context, teamID *uint) (bool, error)
+	// GetAutoRotationDuration returns the duration after which viewed passwords
+	// should be automatically rotated. Returns 0 if auto-rotation is disabled.
+	GetAutoRotationDuration(ctx context.Context) (int, error)
+}
+
+// CommanderProvider sends MDM commands to hosts.
+type CommanderProvider interface {
+	// SetRecoveryLock sends a SetRecoveryLock MDM command to the specified hosts.
+	SetRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string, password string) error
+	// ClearRecoveryLock sends a ClearRecoveryLock MDM command to the specified hosts.
+	ClearRecoveryLock(ctx context.Context, hostUUIDs []string, cmdUUID string, password string) error
+	// RotateRecoveryLock sends commands to clear and set a new recovery lock password.
+	RotateRecoveryLock(ctx context.Context, hostUUID string, cmdUUID string, oldPassword string, newPassword string) error
+}
+
+// ActivityProvider logs user activities.
+type ActivityProvider interface {
+	// LogRecoveryLockViewed logs that a user viewed a recovery lock password.
+	LogRecoveryLockViewed(ctx context.Context, hostID uint, hostDisplayName string) error
+	// LogRecoveryLockRotated logs that a recovery lock password was rotated.
+	LogRecoveryLockRotated(ctx context.Context, hostID uint, hostDisplayName string) error
+}
+
+// PasswordEncryptor handles encryption/decryption of recovery lock passwords.
+type PasswordEncryptor interface {
+	// Encrypt encrypts a plaintext password.
+	Encrypt(plaintext string) ([]byte, error)
+	// Decrypt decrypts an encrypted password.
+	Decrypt(ciphertext []byte) (string, error)
+}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -6554,8 +6554,13 @@ func EnsureMDMAppleServiceDiscovery(ctx context.Context, ds fleet.Datastore, dep
 
 ///////////////////////////////////////////////////////////////////////////////
 // Apple MDM Recovery Lock Password
+//
+// Deprecated: These functions are kept for backward compatibility.
+// Use the recoverylock package instead.
 
 // recoveryLockResult wraps mdm.CommandResults to implement fleet.MDMCommandResults
+//
+// Deprecated: Use recoverylock.Result instead.
 type recoveryLockResult struct {
 	cmdResult *mdm.CommandResults
 }
@@ -6565,6 +6570,8 @@ func (r *recoveryLockResult) UUID() string     { return r.cmdResult.CommandUUID 
 func (r *recoveryLockResult) HostUUID() string { return r.cmdResult.UDID } // SetRecoveryLock is device-only, UDID is always present
 
 // NewRecoveryLockResult wraps an mdm.CommandResults to implement fleet.MDMCommandResults
+//
+// Deprecated: Use recoverylock.NewResult instead.
 func NewRecoveryLockResult(cmdResult *mdm.CommandResults) fleet.MDMCommandResults {
 	return &recoveryLockResult{cmdResult: cmdResult}
 }
@@ -6574,6 +6581,8 @@ func NewRecoveryLockResult(cmdResult *mdm.CommandResults) fleet.MDMCommandResult
 // - SET: When acknowledged, marks the recovery lock as verified. On error, marks as failed.
 // - CLEAR: When acknowledged, deletes the recovery lock password record. On error, marks as failed.
 // - ROTATE: When acknowledged, moves pending password to active. On error, marks rotation as failed.
+//
+// Deprecated: Use recoverylock.NewResultsHandler instead.
 func NewSetRecoveryLockResultsHandler(
 	ds fleet.Datastore,
 	logger *slog.Logger,

--- a/server/service/apple_mdm_cmd_results_test.go
+++ b/server/service/apple_mdm_cmd_results_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/recoverylock"
 	"github.com/fleetdm/fleet/v4/server/mdm/nanomdm/mdm"
 	"github.com/fleetdm/fleet/v4/server/mock"
 	"github.com/stretchr/testify/assert"
@@ -327,9 +328,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusAcknowledged,
@@ -371,9 +372,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusError,
@@ -410,9 +411,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusCommandFormatError,
@@ -447,9 +448,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusAcknowledged,
@@ -485,10 +486,10 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
 		// Test MDMClientError 70 (password not provided)
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusError,
@@ -525,10 +526,10 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
 		// Test ROSLockoutServiceDaemonErrorDomain 8 (password failed to validate)
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusError,
@@ -569,10 +570,10 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
 		// Test a generic transient error (not password mismatch)
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusError,
@@ -612,10 +613,10 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
 		// CommandFormatError is terminal - command is malformed and will never succeed
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusCommandFormatError,
@@ -662,9 +663,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusAcknowledged,
@@ -708,9 +709,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusError,
@@ -751,9 +752,9 @@ func TestSetRecoveryLockResultsHandler(t *testing.T) {
 			return nil
 		}
 
-		handler := NewSetRecoveryLockResultsHandler(ds, logger, newActivityFn)
+		handler := recoverylock.NewResultsHandler(ds, logger, newActivityFn)
 
-		result := NewRecoveryLockResult(&mdm.CommandResults{
+		result := recoverylock.NewResult(&mdm.CommandResults{
 			Enrollment:  mdm.Enrollment{UDID: hostUUID},
 			CommandUUID: cmdUUID,
 			Status:      fleet.MDMAppleStatusCommandFormatError,

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -48,6 +48,7 @@ import (
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
 	android_service "github.com/fleetdm/fleet/v4/server/mdm/android/service"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
+	"github.com/fleetdm/fleet/v4/server/mdm/apple/recoverylock"
 	maintained_apps "github.com/fleetdm/fleet/v4/server/mdm/maintainedapps"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	nanodep_storage "github.com/fleetdm/fleet/v4/server/mdm/nanodep/storage"
@@ -530,7 +531,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 			checkInAndCommand := NewMDMAppleCheckinAndCommandService(ds, commander, vppInstaller, opts[0].License.IsPremium(), logger, redis_key_value.New(redisPool), svc.NewActivity)
 			checkInAndCommand.RegisterResultsHandler("InstalledApplicationList", NewInstalledApplicationListResultsHandler(ds, commander, logger, cfg.Server.VPPVerifyTimeout, cfg.Server.VPPVerifyRequestDelay, svc.NewActivity))
 			checkInAndCommand.RegisterResultsHandler(fleet.DeviceLocationCmdName, NewDeviceLocationResultsHandler(ds, commander, logger))
-			checkInAndCommand.RegisterResultsHandler(fleet.SetRecoveryLockCmdName, NewSetRecoveryLockResultsHandler(ds, logger, svc.NewActivity))
+			checkInAndCommand.RegisterResultsHandler(fleet.SetRecoveryLockCmdName, recoverylock.NewResultsHandler(ds, logger, svc.NewActivity))
 			err := RegisterAppleMDMProtocolServices(
 				rootMux,
 				cfg.MDM,


### PR DESCRIPTION
## Summary

> **This is a proof-of-concept for feedback purposes only — not intended to be merged.**

This PR demonstrates extracting the recovery lock feature into a **bounded context** — a self-contained module with exclusive table ownership and compiler-enforced boundaries.

Today, recovery lock logic is scattered across 4+ packages (`server/mdm/apple/apple_mdm.go`, `server/service/apple_mdm.go`, `server/datastore/mysql/`, `server/fleet/`) with 19+ methods on the global `fleet.Datastore` interface and direct SQL JOINs to `host_recovery_key_passwords` from `hosts.go`/`labels.go`. There is no ownership boundary — any package can read/write the table.

The bounded context approach (`server/recoverylock/`) enforces that all access goes through service methods, with `internal/` preventing external imports at the compiler level.

Additionally introduces an **MDM settings status aggregator** (`server/mdmsettingsstatus/`) that combines status from all 4 MDM components (profiles, declarations, FileVault, recovery lock) using hierarchical aggregation.

### Key changes

- **`server/recoverylock/`** — Bounded context with `internal/mysql/` (exclusive table ownership), `internal/service/` (business logic), `api/` (public interface), `bootstrap/` (DI wiring), and `arch_test.go` (boundary enforcement)
- **`server/mdm/apple/recoverylock/`** — Consolidated cron job, result handler, and password generation (uses `fleet.Datastore`, wired into `cmd/fleet/`)
- **`server/mdmsettingsstatus/`** — Aggregator service that computes overall MDM settings status from individual component statuses
- **`server/acl/recoverylockacl/`** — Anti-Corruption Layer adapter bridging the bounded context to legacy Fleet services

### Comparison: Current State vs. Bounded Context

| Aspect | Current State | Bounded Context |
|--------|--------------|-----------------|
| Code organization | Scattered across 4+ packages | One package with clear structure |
| Table ownership | Anyone can access | Exclusive (`internal/` enforced) |
| Interface | Global `fleet.Datastore` | Public `api.Service` |
| Dependencies | Implicit | Explicit (`DataProviders`) |
| JOINs to table | Direct SQL | Via bulk service calls |
| Enforcement | None | Compiler + `arch_test.go` |
| Testing | Requires mock of full Datastore | Can mock DataProviders |
| Discoverability | Poor — must know where to look | Good |

See `server/recoverylock/README.md` for a detailed writeup.

## Looking for feedback on

- Is the bounded context pattern worth the added structure for this codebase?
- Is the `DataProviders` pattern worth the extra indirection?
- Is the `mdmsettingsstatus` aggregator the right way to decouple host listing from recovery lock?
- Tradeoffs of bulk service calls vs SQL JOINs for status enrichment