### PR TITLE
Add note about server private key

### DIFF
--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -15,6 +15,8 @@ Currently, these are supported platforms for each certificate authority:
 - **Custom SCEP server**: macOS, Windows, iOS, iPadOS, and Android
 - **Custom EST**: Linux
 
+NOTE - if hosting Fleet yourself, you must have a [server private key](https://fleetdm.com/docs/configuration/fleet-server-configuration#server-private-key) configured to deploy certificates.
+
 ## Okta
 
 The following steps show how to deploy SCEP certificates from Okta's certificate authority (CA). 

--- a/articles/connect-end-user-to-wifi-with-certificate.md
+++ b/articles/connect-end-user-to-wifi-with-certificate.md
@@ -6,6 +6,8 @@ Fleet can help your end users connect to third-party tools like Wi-Fi or VPN by 
 
 Fleet will automatically renew certificates on Apple (macOS, iOS, iPadOS), Windows, and Android hosts before expiration. Learn more in the [Renewal section](#renewal).
 
+To deploy certificates on a self-hosted Fleet instance, you'll need to configure a [server private key](https://fleetdm.com/docs/configuration/fleet-server-configuration#server-private-key).
+
 Currently, these are supported platforms for each certificate authority:
 - **Okta**: macOS, iOS, and iPadOS
 - **DigiCert**: macOS, iOS, and iPadOS
@@ -14,8 +16,6 @@ Currently, these are supported platforms for each certificate authority:
 - **Hydrant**: Linux
 - **Custom SCEP server**: macOS, Windows, iOS, iPadOS, and Android
 - **Custom EST**: Linux
-
-NOTE - if hosting Fleet yourself, you must have a [server private key](https://fleetdm.com/docs/configuration/fleet-server-configuration#server-private-key) configured to deploy certificates.
 
 ## Okta
 


### PR DESCRIPTION
To deploy certificates, you must have a server private key setup or GitOps errors with 'Error: applying certificate authorities: POST /api/latest/fleet/spec/certificate_authorities received status 500 crypto/aes: invalid key size 0: crypto/aes: invalid key size 0'

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
