### PR TITLE
Better error handling in Windows PS1 installer (#33555)

### DIFF
--- a/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
+++ b/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
@@ -1,0 +1,1 @@
+* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of  aborting.

--- a/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
+++ b/orbit/changes/33555-better-error-handling-of-win-pre-install-setup
@@ -1,1 +1,1 @@
-* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of  aborting.
+* Wrapped Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of aborting.

--- a/orbit/pkg/packaging/windows_templates.go
+++ b/orbit/pkg/packaging/windows_templates.go
@@ -580,7 +580,8 @@ function Force-Remove-Orbit {
     Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse  -ErrorAction "SilentlyContinue" |  Where-Object {($_.ValueCount -gt 0)} | ForEach-Object {
 
       # Filter for osquery entries
-      $properties = Get-ItemProperty -LiteralPath $_.PSPath  -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "Fleet osquery")}
+      $entryPath = $_.PSPath
+      $properties = try { Get-ItemProperty -LiteralPath $entryPath -ErrorAction "SilentlyContinue" | Where-Object {($_.DisplayName -eq "Fleet osquery")} } catch { Write-Host "Skipping invalid registry entry at ${entryPath}: $_"; $null }
       if ($properties) {
 
         #Remove Registry Entries
@@ -622,7 +623,8 @@ function Force-Remove-Osquery {
     Get-ChildItem "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall" -Recurse -ErrorAction "SilentlyContinue" |  Where-Object {($_.ValueCount -gt 0)} | ForEach-Object {
 
       # Filter for osquery entries
-      $properties = Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction "SilentlyContinue" |  Where-Object {($_.DisplayName -eq "osquery")}
+      $entryPath = $_.PSPath
+      $properties = try { Get-ItemProperty -LiteralPath $entryPath -ErrorAction "SilentlyContinue" | Where-Object {($_.DisplayName -eq "osquery")} } catch { Write-Host "Skipping invalid registry entry at ${entryPath}: $_"; $null }
       if ($properties) {
 
         #Remove files from osquery location


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33555 

Wrap Get-ItemProperty calls in try/catch blocks during registry enumeration to gracefully handle terminating exceptions (e.g. System.InvalidCastException) from malformed registry entries, logging the offending path instead of aborting.

# Testing

I recommend testing this inside a VM, since we will be doing some modifications to the registry.

1. Create two installers, one pre-fix the other post fix.
2. Run this to insert an invalid reg value: 
[bad_reg.ps1.zip](https://github.com/user-attachments/files/26441105/bad_reg.ps1.zip)

3. Run the pre-fix installer, using `msiexec.exe /i "pre-fleet-osquery.msi" /L*V "pre-fleet-install.log", it should fail: 
[pre-fleet-install-log.txt](https://github.com/user-attachments/files/26441002/pre-fleet-install-log.txt)
4. Run the post-fix installer, using `msiexec.exe /i "post-fleet-osquery.msi" /L*V "post-fleet-install.log", it should be OK and warn the user about the bad key: 
[post-fleet-install-log.txt](https://github.com/user-attachments/files/26441029/post-fleet-install-log.txt)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [X] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [X] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [X] Verified that fleetd runs on macOS, Linux and Windows