### PR TITLE
Fleet UI: Host ABM assignment followups

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -62,44 +62,50 @@ export const DEFAULT_SORT_DIRECTION = "asc";
 export const DEFAULT_PAGE_SIZE = 50;
 export const DEFAULT_PAGE_INDEX = 0;
 
-export const hostSelectStatuses = [
-  {
-    disabled: false,
-    label: "All hosts",
-    value: "",
-    helpText: "All hosts added to Fleet.",
-  },
-  {
-    disabled: false,
-    label: "Online hosts",
-    value: "online",
-    helpText: "Hosts that will respond to a live report.",
-  },
-  {
-    disabled: false,
-    label: "Offline hosts",
-    value: "offline",
-    helpText: "Hosts that won't respond to a live report.",
-  },
-  {
-    disabled: false,
-    label: "Missing hosts",
-    value: "missing",
-    helpText: "Hosts that have been offline for 30 days or more.",
-  },
-  {
-    disabled: false,
-    label: "New hosts",
-    value: "new",
-    helpText: "Hosts added to Fleet in the last 24 hours.",
-  },
-  {
-    disabled: false,
-    label: "Pending",
-    value: "pending",
-    helpText: "Hosts pending enrollment.",
-  },
-];
+export const hostSelectStatuses = (isPremiumTier: boolean) => {
+  const baseStatuses = [
+    {
+      disabled: false,
+      label: "All hosts",
+      value: "",
+      helpText: "All hosts added to Fleet.",
+    },
+    {
+      disabled: false,
+      label: "Online hosts",
+      value: "online",
+      helpText: "Hosts that will respond to a live report.",
+    },
+    {
+      disabled: false,
+      label: "Offline hosts",
+      value: "offline",
+      helpText: "Hosts that won't respond to a live report.",
+    },
+    {
+      disabled: false,
+      label: "Missing hosts",
+      value: "missing",
+      helpText: "Hosts that have been offline for 30 days or more.",
+    },
+    {
+      disabled: false,
+      label: "New hosts",
+      value: "new",
+      helpText: "Hosts added to Fleet in the last 24 hours.",
+    },
+  ];
+
+  const premiumStatuses = [
+    {
+      disabled: false,
+      label: "Pending",
+      value: "pending",
+      helpText: "Hosts pending enrollment.",
+    },
+  ];
+  return [...baseStatuses, ...(isPremiumTier ? premiumStatuses : [])];
+};
 
 export const OS_SETTINGS_FILTER_OPTIONS = [
   {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -880,7 +880,10 @@ const ManageHostsPage = ({
         routeParams,
         queryParams: {
           ...queryParams,
-          status: statusName?.value,
+          ...(statusName?.value !== "pending" && { status: statusName?.value }),
+          ...(statusName?.value === "pending" && {
+            mdm_enrollment_status: statusName?.value,
+          }),
           page: 0, // resets page index
         },
       })

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1683,7 +1683,7 @@ const ManageHostsPage = ({
           name="status-filter"
           value={status || ""}
           className={`${baseClass}__status-filter`}
-          options={hostSelectStatuses}
+          options={hostSelectStatuses(isPremiumTier || false)}
           onChange={handleStatusDropdownChange}
           variant="table-filter"
         />

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -882,8 +882,14 @@ const ManageHostsPage = ({
         routeParams,
         queryParams: {
           ...queryParams,
-          ...(value !== "pending" && { status: value }),
-          ...(value === "pending" && { mdm_enrollment_status: value }),
+          ...(value !== "pending" && {
+            status: value,
+            mdm_enrollment_status: undefined,
+          }),
+          ...(value === "pending" && {
+            mdm_enrollment_status: value,
+            status: undefined,
+          }),
           page: 0, // resets page index
         },
       })
@@ -1684,7 +1690,7 @@ const ManageHostsPage = ({
       <div className={`${baseClass}__filter-dropdowns`}>
         <DropdownWrapper
           name="status-filter"
-          value={status || ""}
+          value={status || mdmEnrollmentStatus || ""}
           className={`${baseClass}__status-filter`}
           options={hostSelectStatuses(isPremiumTier || false)}
           onChange={handleStatusDropdownChange}

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -873,6 +873,8 @@ const ManageHostsPage = ({
   const handleStatusDropdownChange = (
     statusName: SingleValue<CustomOptionType>
   ) => {
+    const value = statusName?.value;
+
     router.replace(
       getNextLocationPath({
         pathPrefix: PATHS.MANAGE_HOSTS,
@@ -880,10 +882,8 @@ const ManageHostsPage = ({
         routeParams,
         queryParams: {
           ...queryParams,
-          ...(statusName?.value !== "pending" && { status: statusName?.value }),
-          ...(statusName?.value === "pending" && {
-            mdm_enrollment_status: statusName?.value,
-          }),
+          ...(value !== "pending" && { status: value }),
+          ...(value === "pending" && { mdm_enrollment_status: value }),
           page: 0, // resets page index
         },
       })

--- a/frontend/styles/var/mixins.scss
+++ b/frontend/styles/var/mixins.scss
@@ -155,6 +155,7 @@ $max-width: 2560px;
 
   &:hover {
     color: $ui-fleet-black-75-over;
+    cursor: pointer;
   }
 
   &:focus-visible {


### PR DESCRIPTION
## Issue
FE followups for #39063 

## Description
- Hide pending host option in dropdown from fleet free
- Show pointer cursor when hovering over custom link (as seen in host details page > mdm status > open mdm status modal new styling to look like a link)
- Update `status` dropdown to have a second key (`mdm_enrollment_status`) option used for one of the options (pending status)

## Screenshots of fixes

### no pending host option in Fleet Free
<img width="1652" height="714" alt="Screenshot 2026-04-02 at 12 20 37 PM" src="https://github.com/user-attachments/assets/60b1537c-3c8d-499e-aabf-aa547822605d" />

### shows pending on manage host table using dropdown status pending
<img width="1657" height="445" alt="Screenshot 2026-04-02 at 12 35 58 PM" src="https://github.com/user-attachments/assets/b4408c1c-69c3-40c0-a5b9-e0d3281e9004" />

# Checklist for submitter

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
