### PR TITLE
ACME: Cleanup code, slight DDD-lite, and attempt arch_test with clearer isolated dependencies.

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -80,6 +80,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/service/async"
 	"github.com/fleetdm/fleet/v4/server/service/conditional_access_microsoft_proxy"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
+	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	otelmw "github.com/fleetdm/fleet/v4/server/service/middleware/otel"
 	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/service/redis_lock"
@@ -1851,7 +1852,7 @@ func (a *acmeCSRSigner) SignCSR(_ context.Context, csr *x509.CertificateRequest)
 func createACMEServiceModule(ds fleet.Datastore, dbConns *common_mysql.DBConnections, redisPool fleet.RedisPool, logger *slog.Logger, csrSigner acme.CSRSigner) (acme_api.Service, endpointer.HandlerRoutesFunc) {
 	providers := &acmeDataProviders{Datastore: ds, signer: csrSigner}
 	acmeSvc, acmeRoutesFn := acme_bootstrap.New(dbConns, redisPool, providers, logger)
-	acmeRoutes := acmeRoutesFn()
+	acmeRoutes := acmeRoutesFn(log.Logged)
 	return acmeSvc, acmeRoutes
 }
 

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -35,6 +35,7 @@ import (
 	"github.com/fleetdm/fleet/v4/pkg/scripts"
 	"github.com/fleetdm/fleet/v4/pkg/str"
 	"github.com/fleetdm/fleet/v4/server"
+	"github.com/fleetdm/fleet/v4/server/acl/acmeacl"
 	"github.com/fleetdm/fleet/v4/server/acl/activityacl"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	activity_bootstrap "github.com/fleetdm/fleet/v4/server/activity/bootstrap"
@@ -1829,16 +1830,6 @@ the way that the Fleet server works.
 	return serveCmd
 }
 
-// acmeDataProviders composes fleet.Datastore (which provides AppConfig) with
-// an ACME-specific CSR signer backed by the SCEP depot.
-type acmeDataProviders struct {
-	fleet.Datastore
-	signer acme.CSRSigner
-}
-
-func (a *acmeDataProviders) CSRSigner(_ context.Context) (acme.CSRSigner, error) {
-	return a.signer, nil
-}
 
 // acmeCSRSigner adapts a depot.Signer to the acme.CSRSigner interface.
 type acmeCSRSigner struct {
@@ -1850,7 +1841,7 @@ func (a *acmeCSRSigner) SignCSR(_ context.Context, csr *x509.CertificateRequest)
 }
 
 func createACMEServiceModule(ds fleet.Datastore, dbConns *common_mysql.DBConnections, redisPool fleet.RedisPool, logger *slog.Logger, csrSigner acme.CSRSigner) (acme_api.Service, endpointer.HandlerRoutesFunc) {
-	providers := &acmeDataProviders{Datastore: ds, signer: csrSigner}
+	providers := acmeacl.NewFleetDatastoreAdapter(ds, csrSigner)
 	acmeSvc, acmeRoutesFn := acme_bootstrap.New(dbConns, redisPool, providers, logger)
 	acmeRoutes := acmeRoutesFn(log.Logged)
 	return acmeSvc, acmeRoutes

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1830,7 +1830,6 @@ the way that the Fleet server works.
 	return serveCmd
 }
 
-
 // acmeCSRSigner adapts a depot.Signer to the acme.CSRSigner interface.
 type acmeCSRSigner struct {
 	signer *scepdepot.Signer

--- a/server/acl/acmeacl/fleet_adapter.go
+++ b/server/acl/acmeacl/fleet_adapter.go
@@ -1,0 +1,57 @@
+// Package acmeacl provides the anti-corruption layer between the ACME
+// bounded context and legacy Fleet code.
+//
+// This package is the ONLY place that imports both ACME types and fleet types.
+// It translates between them, allowing the ACME context to remain decoupled
+// from legacy code.
+package acmeacl
+
+import (
+	"context"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme"
+)
+
+// FleetDatastoreAdapter adapts fleet.Datastore to the narrow
+// acme.DataProviders interface that the ACME bounded context requires.
+type FleetDatastoreAdapter struct {
+	ds     fleet.Datastore
+	signer acme.CSRSigner
+}
+
+// NewFleetDatastoreAdapter creates a new adapter for the Fleet datastore.
+func NewFleetDatastoreAdapter(ds fleet.Datastore, signer acme.CSRSigner) *FleetDatastoreAdapter {
+	return &FleetDatastoreAdapter{ds: ds, signer: signer}
+}
+
+// Ensure FleetDatastoreAdapter implements acme.DataProviders
+var _ acme.DataProviders = (*FleetDatastoreAdapter)(nil)
+
+func (a *FleetDatastoreAdapter) ServerURL(ctx context.Context) (string, error) {
+	appCfg, err := a.ds.AppConfig(ctx)
+	if err != nil {
+		return "", err
+	}
+	return appCfg.MDMUrl(), nil
+}
+
+func (a *FleetDatastoreAdapter) GetCACertificatePEM(ctx context.Context) ([]byte, error) {
+	assets, err := a.ds.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetCACert}, nil)
+	if err != nil {
+		return nil, err
+	}
+	return assets[fleet.MDMAssetCACert].Value, nil
+}
+
+func (a *FleetDatastoreAdapter) CSRSigner(_ context.Context) (acme.CSRSigner, error) {
+	return a.signer, nil
+}
+
+func (a *FleetDatastoreAdapter) IsDEPEnrolled(ctx context.Context, serial string) (bool, error) {
+	assignments, err := a.ds.GetHostDEPAssignmentsBySerial(ctx, serial)
+	if err != nil {
+		return false, err
+	}
+	return len(assignments) > 0, nil
+}

--- a/server/datastore/redis/redis.go
+++ b/server/datastore/redis/redis.go
@@ -133,11 +133,16 @@ func ReadOnlyConn(pool fleet.RedisPool, conn redis.Conn) redis.Conn {
 	return conn
 }
 
+// Simplified interface for the ConfigureDoer function.
+type getPool interface {
+	Get() redis.Conn
+}
+
 // ConfigureDoer configures conn to follow redirections if the redis
 // configuration requested it and the pool is a Redis Cluster pool. If the conn
 // is already in error, or if it is not a redisc cluster connection, it is
 // returned unaltered.
-func ConfigureDoer(pool fleet.RedisPool, conn redis.Conn) redis.Conn {
+func ConfigureDoer(pool getPool, conn redis.Conn) redis.Conn {
 	if p, isCluster := pool.(*clusterPool); isCluster {
 		if err := conn.Err(); err == nil && p.followRedirs {
 			rc, err := redisc.RetryConn(conn, 3, 300*time.Millisecond)

--- a/server/mdm/acme/api/enrollment.go
+++ b/server/mdm/acme/api/enrollment.go
@@ -5,6 +5,6 @@ import "context"
 // EnrollmentService stores records in the acme_enrollments table.
 type EnrollmentService interface {
 	// NewACMEEnrollment creates a new enrollment in the acme_enrollments table with the specified
-	// host_uuid and returns a new path_identifier for the created row.
+	// host identifier and returns a new path_identifier for the created row.
 	NewACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error)
 }

--- a/server/mdm/acme/api/http/types.go
+++ b/server/mdm/acme/api/http/types.go
@@ -366,7 +366,7 @@ type JWSRequestContainer struct {
 func (req *JWSRequestContainer) DecodeBody(ctx context.Context, r io.Reader, u url.Values, c []*x509.Certificate) error {
 	jwsBytes, err := io.ReadAll(r)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "reading soap mdm request")
+		return ctxerr.Wrap(ctx, err, "reading ACME JWS request body")
 	}
 	// Note: req.Identifier is set from the mux path variable by the framework
 	// (via the `url:"identifier"` struct tag), so we don't set it here.

--- a/server/mdm/acme/arch_test.go
+++ b/server/mdm/acme/arch_test.go
@@ -1,0 +1,137 @@
+package acme_test
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/archtest"
+)
+
+const m = archtest.ModuleName
+
+var (
+	fleetDeps = regexp.MustCompile(`^github\.com/fleetdm/`)
+
+	// Common allowed dependencies across acme packages
+	acmePkgs = []string{
+		m + "/server/mdm/acme",
+		m + "/server/mdm/acme/api",
+		m + "/server/mdm/acme/api/http",
+		m + "/server/mdm/acme/internal/types",
+		// TODO: redis_nonces_store should not leak through the API layer.
+		// It's here because api.Service exposes NoncesStore() and the HTTP
+		// response types reference it for nonce generation in BeforeRender.
+		m + "/server/mdm/acme/internal/redis_nonces_store",
+	}
+
+	platformPkgs = []string{
+		m + "/server/ptr",
+		m + "/server/platform/...",
+		m + "/server/contexts/...",
+		m + "/server/mdm/internal/commonmdm",
+		m + "/pkg/fleethttp",
+	}
+)
+
+// TestACMEPackageDependencies runs architecture tests for all ACME packages.
+// Each package has specific rules about what dependencies are allowed.
+func TestACMEPackageDependencies(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name              string
+		pkg               string
+		shouldNotDepend   []string // defaults to m + "/..." if empty
+		ignoreDeps        []string
+		ignoreRecursively []string // for test infra packages whose transitive deps we don't control
+	}{
+		{
+			name: "root package has no Fleet dependencies",
+			pkg:  m + "/server/mdm/acme",
+		},
+		{
+			name:       "api package only depends on acme and platform packages",
+			pkg:        m + "/server/mdm/acme/api",
+			ignoreDeps: append(acmePkgs, platformPkgs...),
+		},
+		{
+			name: "api/http depends on api and platform",
+			pkg:  m + "/server/mdm/acme/api/http",
+			ignoreDeps: append(append([]string{
+				m + "/server/mdm/acme/api",
+			}, acmePkgs...), platformPkgs...),
+		},
+		{
+			name:       "internal/types only depends on api",
+			pkg:        m + "/server/mdm/acme/internal/types",
+			ignoreDeps: []string{m + "/server/mdm/acme/api"},
+		},
+		{
+			name: "internal/mysql depends on api, types, and platform",
+			pkg:  m + "/server/mdm/acme/internal/mysql",
+			ignoreDeps: append([]string{
+				m + "/server/mdm/acme/api",
+				m + "/server/mdm/acme/internal/types",
+				m + "/server/mdm/acme/internal/testutils",
+			}, platformPkgs...),
+		},
+		{
+			name: "internal/service depends on acme and platform packages",
+			pkg:  m + "/server/mdm/acme/internal/service",
+			ignoreDeps: append(append([]string{
+				m + "/server/ptr",
+				m + "/server/mdm/acme/internal/redis_nonces_store",
+			}, acmePkgs...), platformPkgs...),
+		},
+		{
+			name: "bootstrap depends on acme and platform packages",
+			pkg:  m + "/server/mdm/acme/bootstrap",
+			ignoreDeps: append(append([]string{
+				m + "/server/mdm/acme/internal/mysql",
+				m + "/server/mdm/acme/internal/service",
+				m + "/server/ptr",
+			}, acmePkgs...), platformPkgs...),
+		},
+		{
+			name: "all packages only depend on acme and platform",
+			pkg:  m + "/server/mdm/acme/...",
+			ignoreDeps: append(append([]string{
+				m + "/server/ptr",
+				m + "/server/mdm/acme/internal/mysql",
+				m + "/server/mdm/acme/internal/service",
+				m + "/server/mdm/acme/internal/testutils",
+				m + "/server/mdm/acme/testhelpers",
+			}, acmePkgs...), platformPkgs...),
+			// Test infrastructure packages whose transitive deps (fleet, etc.) we don't control.
+			ignoreRecursively: []string{
+				m + "/server/datastore/redis/redistest",
+				m + "/server/test",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			shouldNotDepend := tc.shouldNotDepend
+			if len(shouldNotDepend) == 0 {
+				shouldNotDepend = []string{m + "/..."}
+			}
+
+			test := archtest.NewPackageTest(t, tc.pkg).
+				OnlyInclude(fleetDeps).
+				ShouldNotDependOn(shouldNotDepend...).
+				WithTests()
+
+			if len(tc.ignoreDeps) > 0 {
+				test.IgnoreDeps(tc.ignoreDeps...)
+			}
+			if len(tc.ignoreRecursively) > 0 {
+				test.IgnoreRecursively(tc.ignoreRecursively...)
+			}
+
+			test.Check()
+		})
+	}
+}

--- a/server/mdm/acme/arch_test.go
+++ b/server/mdm/acme/arch_test.go
@@ -44,6 +44,7 @@ func TestACMEPackageDependencies(t *testing.T) {
 		shouldNotDepend   []string // defaults to m + "/..." if empty
 		ignoreDeps        []string
 		ignoreRecursively []string // for test infra packages whose transitive deps we don't control
+		skip              bool     // Temp flag to skip tests that will end up using the redis package, and therefore pull in all of server/fleet, we need to move the datastore redis package out, to enable these.
 	}{
 		{
 			name: "root package has no Fleet dependencies",
@@ -53,6 +54,7 @@ func TestACMEPackageDependencies(t *testing.T) {
 			name:       "api package only depends on acme and platform packages",
 			pkg:        m + "/server/mdm/acme/api",
 			ignoreDeps: append(acmePkgs, platformPkgs...),
+			skip:       true,
 		},
 		{
 			name: "api/http depends on api and platform",
@@ -60,6 +62,7 @@ func TestACMEPackageDependencies(t *testing.T) {
 			ignoreDeps: append(append([]string{
 				m + "/server/mdm/acme/api",
 			}, acmePkgs...), platformPkgs...),
+			skip: true,
 		},
 		{
 			name:       "internal/types only depends on api",
@@ -82,6 +85,7 @@ func TestACMEPackageDependencies(t *testing.T) {
 				m + "/server/ptr",
 				m + "/server/mdm/acme/internal/redis_nonces_store",
 			}, acmePkgs...), platformPkgs...),
+			skip: true,
 		},
 		{
 			name: "bootstrap depends on acme and platform packages",
@@ -91,6 +95,7 @@ func TestACMEPackageDependencies(t *testing.T) {
 				m + "/server/mdm/acme/internal/service",
 				m + "/server/ptr",
 			}, acmePkgs...), platformPkgs...),
+			skip: true,
 		},
 		{
 			name: "all packages only depend on acme and platform",
@@ -107,11 +112,15 @@ func TestACMEPackageDependencies(t *testing.T) {
 				m + "/server/datastore/redis/redistest",
 				m + "/server/test",
 			},
+			skip: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.skip {
+				t.Skip("Skipping test, due to pulling in server/datastore/redis, which pulls in server/fleet.")
+			}
 			t.Parallel()
 
 			shouldNotDepend := tc.shouldNotDepend

--- a/server/mdm/acme/bootstrap/bootstrap.go
+++ b/server/mdm/acme/bootstrap/bootstrap.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/service"
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
+	"github.com/go-kit/kit/endpoint"
 )
 
 type ServiceOption = service.ServiceOption
@@ -24,12 +25,12 @@ func New(
 	providers acme.DataProviders,
 	logger *slog.Logger,
 	opts ...ServiceOption,
-) (api.Service, func() eu.HandlerRoutesFunc) {
+) (api.Service, func(authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc) {
 	ds := mysql.NewDatastore(dbConns, logger)
 	svc := service.NewService(ds, redisPool, providers, logger, opts...)
 
-	routesFn := func() eu.HandlerRoutesFunc {
-		return service.GetRoutes(svc)
+	routesFn := func(authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc {
+		return service.GetRoutes(svc, authMiddleware)
 	}
 
 	return svc, routesFn

--- a/server/mdm/acme/bootstrap/bootstrap.go
+++ b/server/mdm/acme/bootstrap/bootstrap.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"log/slog"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/mysql"
@@ -21,7 +20,7 @@ type ServiceOption = service.ServiceOption
 // New creates a new ACME service module and returns its service and route handler.
 func New(
 	dbConns *platform_mysql.DBConnections,
-	redisPool fleet.RedisPool,
+	redisPool acme.RedisPool,
 	providers acme.DataProviders,
 	logger *slog.Logger,
 	opts ...ServiceOption,

--- a/server/mdm/acme/internal/mysql/account_order_test.go
+++ b/server/mdm/acme/internal/mysql/account_order_test.go
@@ -274,17 +274,17 @@ func createTestAccountForOrder(t *testing.T, env *testEnv) (*types.Account, *typ
 func buildTestOrder(accountID uint, identifierValue string) (*types.Order, *types.Authorization, *types.Challenge) {
 	return &types.Order{
 			ACMEAccountID: accountID,
-			Status:        "pending",
+			Status:        types.OrderStatusPending,
 			Identifiers: []types.Identifier{
 				{Type: types.IdentifierTypePermanentIdentifier, Value: identifierValue},
 			},
 		}, &types.Authorization{
 			Identifier: types.Identifier{Type: types.IdentifierTypePermanentIdentifier, Value: identifierValue},
-			Status:     "pending",
+			Status:     types.AuthorizationStatusPending,
 		}, &types.Challenge{
-			ChallengeType: "device-attest-01",
+			ChallengeType: types.DeviceAttestationChallengeType,
 			Token:         "test-token",
-			Status:        "pending",
+			Status:        types.ChallengeStatusPending,
 		}
 }
 
@@ -296,7 +296,7 @@ func testCreateNewOrder(t *testing.T, env *testEnv) {
 	require.NoError(t, err)
 	require.NotZero(t, result.ID)
 	require.Equal(t, account.ID, result.ACMEAccountID)
-	require.Equal(t, "pending", result.Status)
+	require.Equal(t, types.OrderStatusPending, result.Status)
 
 	// authorization and challenge IDs should be set by CreateOrder
 	require.NotZero(t, authorization.ID)
@@ -360,7 +360,7 @@ func testGetExistingOrder(t *testing.T, env *testEnv) {
 	require.NoError(t, err)
 	require.Equal(t, created.ID, gotOrder.ID)
 	require.Equal(t, account.ID, gotOrder.ACMEAccountID)
-	require.Equal(t, "pending", gotOrder.Status)
+	require.Equal(t, types.OrderStatusPending, gotOrder.Status)
 	require.False(t, gotOrder.Finalized)
 	require.Len(t, gotOrder.Identifiers, 1)
 	require.Equal(t, types.IdentifierTypePermanentIdentifier, gotOrder.Identifiers[0].Type)

--- a/server/mdm/acme/internal/mysql/acme.go
+++ b/server/mdm/acme/internal/mysql/acme.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	platform_mysql "github.com/fleetdm/fleet/v4/server/platform/mysql"
 	"github.com/jmoiron/sqlx"
@@ -28,7 +27,7 @@ func NewDatastore(conns *platform_mysql.DBConnections, logger *slog.Logger) *Dat
 	return &Datastore{primary: conns.Primary, replica: conns.Replica, logger: logger}
 }
 
-func (ds *Datastore) reader(ctx context.Context) fleet.DBReader {
+func (ds *Datastore) reader(ctx context.Context) sqlx.QueryerContext {
 	if ctxdb.IsPrimaryRequired(ctx) {
 		return ds.primary
 	}

--- a/server/mdm/acme/internal/mysql/authorization_test.go
+++ b/server/mdm/acme/internal/mysql/authorization_test.go
@@ -38,7 +38,7 @@ func testGetValidAuthorization(t *testing.T, env *testEnv) {
 	authResp, err := env.ds.GetAuthorizationByID(t.Context(), account.ID, authorization.ID)
 	require.NoError(t, err)
 	require.NotNil(t, authResp)
-	require.Equal(t, "pending", authResp.Status)
+	require.Equal(t, types.AuthorizationStatusPending, authResp.Status)
 	require.Equal(t, "permanent-identifier", authResp.Identifier.Type)
 	require.Equal(t, "serial-123", authResp.Identifier.Value)
 	require.Equal(t, order.ID, authResp.ACMEOrderID)

--- a/server/mdm/acme/internal/mysql/challenge_test.go
+++ b/server/mdm/acme/internal/mysql/challenge_test.go
@@ -47,7 +47,7 @@ func testGetValidChallengesForAuthorization(t *testing.T, env *testEnv) {
 	challenges, err := env.ds.GetChallengesByAuthorizationID(t.Context(), authorization.ID)
 	require.NoError(t, err)
 	require.Len(t, challenges, 1)
-	require.Equal(t, "pending", challenges[0].Status)
+	require.Equal(t, types.ChallengeStatusPending, challenges[0].Status)
 	require.Equal(t, types.DeviceAttestationChallengeType, challenges[0].ChallengeType)
 	require.Equal(t, authorization.ID, challenges[0].ACMEAuthorizationID)
 }
@@ -90,7 +90,7 @@ func testGetChallengeByIDWithValidID(t *testing.T, env *testEnv) {
 	challenge, err := env.ds.GetChallengeByID(t.Context(), account.ID, challenge.ID)
 	require.NoError(t, err)
 	require.NotNil(t, challenge)
-	require.Equal(t, "pending", challenge.Status)
+	require.Equal(t, types.ChallengeStatusPending, challenge.Status)
 	require.Equal(t, types.DeviceAttestationChallengeType, challenge.ChallengeType)
 	require.Equal(t, authorization.ID, challenge.ACMEAuthorizationID)
 }
@@ -120,41 +120,41 @@ func testUpdateChallengeHappyPath(t *testing.T, env *testEnv) {
 	account, _ := createTestAccountForOrder(t, env)
 	order, _, challenge := createTestOrderForAccount(t, account, env)
 
-	challenge.Status = "valid"
+	challenge.Status = types.ChallengeStatusValid
 	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
 	require.NoError(t, err)
 	require.NotNil(t, updatedChallenge)
-	require.Equal(t, "valid", updatedChallenge.Status)
+	require.Equal(t, types.ChallengeStatusValid, updatedChallenge.Status)
 	require.Equal(t, challenge.ID, updatedChallenge.ID)
 
 	order, auhtz, err := env.ds.GetOrderByID(t.Context(), account.ID, order.ID)
 	require.NoError(t, err)
 	require.NotNil(t, auhtz)
 	for _, auth := range auhtz {
-		require.Equal(t, "valid", auth.Status)
+		require.Equal(t, types.AuthorizationStatusValid, auth.Status)
 	}
 
-	require.Equal(t, "ready", order.Status)
+	require.Equal(t, types.OrderStatusReady, order.Status)
 }
 
 func testUpdateChallengeInvalidStatus(t *testing.T, env *testEnv) {
 	account, _ := createTestAccountForOrder(t, env)
 	order, _, challenge := createTestOrderForAccount(t, account, env)
 
-	challenge.Status = "invalid"
+	challenge.Status = types.ChallengeStatusInvalid
 	updatedChallenge, err := env.ds.UpdateChallenge(t.Context(), challenge)
 	require.NoError(t, err)
 	require.NotNil(t, updatedChallenge)
-	require.Equal(t, "invalid", updatedChallenge.Status)
+	require.Equal(t, types.ChallengeStatusInvalid, updatedChallenge.Status)
 
 	order, auhtz, err := env.ds.GetOrderByID(t.Context(), account.ID, order.ID)
 	require.NoError(t, err)
 	require.NotNil(t, auhtz)
 	for _, auth := range auhtz {
-		require.Equal(t, "invalid", auth.Status)
+		require.Equal(t, types.AuthorizationStatusInvalid, auth.Status)
 	}
 
-	require.Equal(t, "invalid", order.Status)
+	require.Equal(t, types.OrderStatusInvalid, order.Status)
 }
 
 func testUpdateChallengeNilChallenge(t *testing.T, env *testEnv) {
@@ -168,7 +168,7 @@ func testUpdateChallengeNonExistentID(t *testing.T, env *testEnv) {
 	challenge := &types.Challenge{
 		ID:                  999999,
 		ACMEAuthorizationID: 999999,
-		Status:              "valid",
+		Status:              types.ChallengeStatusValid,
 		ChallengeType:       types.DeviceAttestationChallengeType,
 	}
 

--- a/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store.go
+++ b/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store.go
@@ -5,8 +5,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/datastore/redis"
-	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	redigo "github.com/gomodule/redigo/redis"
 )
 
@@ -14,12 +13,12 @@ const DefaultNonceExpiration = 1 * time.Hour
 
 // RedisNoncesStore is a store for ACME nonces, implemented using Redis.
 type RedisNoncesStore struct {
-	pool       fleet.RedisPool
+	pool       acme.RedisPool
 	testPrefix string // for tests, the key prefix to use to avoid conflicts
 }
 
 // New creates a new RedisNoncesStore store.
-func New(pool fleet.RedisPool) *RedisNoncesStore {
+func New(pool acme.RedisPool) *RedisNoncesStore {
 	return &RedisNoncesStore{pool: pool}
 }
 
@@ -29,7 +28,7 @@ const prefix = "acmenonce:"
 // Store creates the key with the given nonce.
 // Argument expireTime is used to set the expiration of the item.
 func (r *RedisNoncesStore) Store(ctx context.Context, nonce string, expireTime time.Duration) error {
-	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
+	conn := r.pool.Get()
 	defer conn.Close()
 
 	// the value of the key is not really important, just that the key exists or not (indicates
@@ -48,7 +47,7 @@ func (r *RedisNoncesStore) Consume(ctx context.Context, nonce string) (ok bool, 
 		return false, nil
 	}
 
-	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
+	conn := r.pool.Get()
 	defer conn.Close()
 
 	n, err := redigo.Int(conn.Do("DEL", r.testPrefix+prefix+nonce))

--- a/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store.go
+++ b/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	redigo "github.com/gomodule/redigo/redis"
 )
@@ -28,7 +29,7 @@ const prefix = "acmenonce:"
 // Store creates the key with the given nonce.
 // Argument expireTime is used to set the expiration of the item.
 func (r *RedisNoncesStore) Store(ctx context.Context, nonce string, expireTime time.Duration) error {
-	conn := r.pool.Get()
+	conn := redis.ConfigureDoer(r.pool, r.pool.Get())
 	defer conn.Close()
 
 	// the value of the key is not really important, just that the key exists or not (indicates

--- a/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store_test.go
+++ b/server/mdm/acme/internal/redis_nonces_store/redis_nonces_store_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
-	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +37,7 @@ type testName interface {
 	Name() string
 }
 
-func newRedisNoncesStoreForTest(t testName, pool fleet.RedisPool) *RedisNoncesStore {
+func newRedisNoncesStoreForTest(t testName, pool acme.RedisPool) *RedisNoncesStore {
 	return &RedisNoncesStore{
 		pool:       pool,
 		testPrefix: t.Name() + ":",

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"go.step.sm/crypto/jose"
 )
@@ -280,11 +279,11 @@ func (s *Service) GetCertificate(ctx context.Context, accountID, orderID uint) (
 	}
 
 	// retrieve the root certificate
-	assets, err := s.providers.GetAllMDMConfigAssetsByName(ctx, []fleet.MDMAssetName{fleet.MDMAssetCACert}, nil)
+	rootPEMBytes, err := s.providers.GetCACertificatePEM(ctx)
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "getting Apple SCEP/ACME root certificate")
 	}
-	block, _ := pem.Decode(assets[fleet.MDMAssetCACert].Value)
+	block, _ := pem.Decode(rootPEMBytes)
 	if block == nil || block.Type != "CERTIFICATE" {
 		return "", ctxerr.New(ctx, "failed to parse PEM block from root SCEP/ACME certificate")
 	}

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -74,16 +74,16 @@ func (s *Service) CreateOrder(ctx context.Context, enrollment *types.Enrollment,
 		ACMEAccountID: account.ID,
 		Finalized:     false,
 		Identifiers:   identifiers,
-		Status:        "pending", // always pending at creation
+		Status:        types.OrderStatusPending, // always pending at creation
 	}
 	authz := &types.Authorization{
 		Identifier: identifiers[0],
-		Status:     "pending", // always pending at creation
+		Status:     types.AuthorizationStatusPending, // always pending at creation
 	}
 	challenge := &types.Challenge{
 		ChallengeType: types.DeviceAttestationChallengeType, // only supported challenge for now
 		Token:         types.CreateNonceEncodedForHeader(),
-		Status:        "pending", // always pending at creation
+		Status:        types.ChallengeStatusPending, // always pending at creation
 	}
 	order, err := s.store.CreateOrder(ctx, order, authz, challenge)
 	if err != nil {
@@ -284,8 +284,8 @@ func (s *Service) GetCertificate(ctx context.Context, accountID, orderID uint) (
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "get order from datastore")
 	}
-	if !order.Finalized || order.Status != "valid" {
-		if order.Status == "invalid" {
+	if !order.Finalized || order.Status != types.OrderStatusValid {
+		if order.Status == types.OrderStatusInvalid {
 			return "", types.OrderDoesNotExistError("Order is in invalid state, cannot get certificate")
 		}
 		return "", types.OrderNotFinalizedError("Order is not finalized/in valid state, cannot get certificate")

--- a/server/mdm/acme/internal/service/account_order.go
+++ b/server/mdm/acme/internal/service/account_order.go
@@ -51,20 +51,8 @@ func (s *Service) CreateAccount(ctx context.Context, pathIdentifier string, enro
 func (s *Service) CreateOrder(ctx context.Context, enrollment *types.Enrollment, account *types.Account, partialOrder *types.Order) (*types.OrderResponse, error) {
 	// authorization is checked in the endpoint implementation for JWS-protected endpoints
 
-	// The "identifiers" passed as part of the newOrder request must be an array with a
-	// single member of type "permanent-identifier" matching the serial specified in the
-	// acme_enrollment that this enrollment was created for.
-	if len(partialOrder.Identifiers) != 1 || partialOrder.Identifiers[0].Type != types.IdentifierTypePermanentIdentifier {
-		return nil, types.UnsupportedIdentifierError("A single identifier of type permanent-identifier must be provided in the order request")
-	}
-	if partialOrder.Identifiers[0].Value != enrollment.HostIdentifier {
-		return nil, types.RejectedIdentifierError("The identifier value does not match the host identifier for this enrollment")
-	}
-
-	// notBefore and notAfter, which are optional, must not be set because fleet is going
-	// to control these and the Apple payload doesn't allow specification of them.
-	if partialOrder.NotBefore != nil || partialOrder.NotAfter != nil {
-		return nil, types.MalformedError("notBefore and notAfter must not be set in the order request")
+	if err := partialOrder.ValidateOrderCreation(enrollment); err != nil {
+		return nil, err
 	}
 
 	identifiers := []types.Identifier{
@@ -122,7 +110,7 @@ func (s *Service) createOrderResponse(
 	}
 
 	var certURL string
-	if order.Finalized && order.Status == types.OrderStatusValid {
+	if err := order.IsCertificateReady(); err == nil {
 		certURL, err = s.getACMEURLWithBaseURL(ctx, baseURL, enrollment.PathIdentifier, "orders", fmt.Sprint(order.ID), "certificate")
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "constructing certificate URL for account")
@@ -146,12 +134,9 @@ func (s *Service) FinalizeOrder(ctx context.Context, enrollment *types.Enrollmen
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "getting order from datastore")
 	}
-	if order.Status != types.OrderStatusReady || order.Finalized {
-		extra := ""
-		if order.Finalized {
-			extra = " and order has already been finalized"
-		}
-		return nil, types.OrderNotReadyError(fmt.Sprintf("Order is in status %s%s.", order.Status, extra))
+
+	if err := order.IsReadyToFinalize(); err != nil {
+		return nil, err
 	}
 
 	baseURL, err := s.getACMEBaseURL(ctx)
@@ -284,11 +269,9 @@ func (s *Service) GetCertificate(ctx context.Context, accountID, orderID uint) (
 	if err != nil {
 		return "", ctxerr.Wrap(ctx, err, "get order from datastore")
 	}
-	if !order.Finalized || order.Status != types.OrderStatusValid {
-		if order.Status == types.OrderStatusInvalid {
-			return "", types.OrderDoesNotExistError("Order is in invalid state, cannot get certificate")
-		}
-		return "", types.OrderNotFinalizedError("Order is not finalized/in valid state, cannot get certificate")
+
+	if err := order.IsCertificateReady(); err != nil {
+		return "", err
 	}
 
 	certPEM, err := s.store.GetCertificatePEMByOrderID(ctx, accountID, orderID)

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -44,7 +44,7 @@ func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enroll
 			URL:           challengeURL,
 		}
 
-		if c.Status == "valid" {
+		if c.Status == types.ChallengeStatusValid {
 			challengeResponse.Validated = &c.UpdatedAt
 		}
 

--- a/server/mdm/acme/internal/service/authorization.go
+++ b/server/mdm/acme/internal/service/authorization.go
@@ -42,10 +42,7 @@ func (s *Service) GetAuthorization(ctx context.Context, enrollment *types.Enroll
 			Status:        c.Status,
 			Token:         c.Token,
 			URL:           challengeURL,
-		}
-
-		if c.Status == types.ChallengeStatusValid {
-			challengeResponse.Validated = &c.UpdatedAt
+			Validated:     c.ValidatedAt(),
 		}
 
 		challengeResponses = append(challengeResponses, challengeResponse)

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -59,14 +59,11 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		return nil, validationErr
 	}
 
-	var validatedAt *time.Time
 	// We always call UpdateChallenge here since we update it's validity by reference
 	// this internally updates challenge status, authorization status and order status, which we can
 	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
-	if updatedChallenge, err := s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
+	if updatedChallenge, err = s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
-	} else if updatedChallenge != nil && updatedChallenge.Status == types.ChallengeStatusValid {
-		validatedAt = &updatedChallenge.UpdatedAt
 	}
 
 	if validationErr != nil {
@@ -77,7 +74,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		ChallengeType: updatedChallenge.ChallengeType,
 		Status:        updatedChallenge.Status,
 		Token:         updatedChallenge.Token,
-		Validated:     validatedAt,
+		Validated:     updatedChallenge.ValidatedAt(),
 	}
 
 	baseURL, err := s.getACMEBaseURL(ctx)
@@ -184,12 +181,12 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 
 	sha256Token := sha256.Sum256([]byte(challenge.Token))
 	if subtle.ConstantTimeCompare(appleData.Nonce, sha256Token[:]) != 1 {
-		challenge.Status = types.ChallengeStatusInvalid
+		challenge.MarkInvalid()
 		return types.BadAttestationStatementError("Apple freshness nonce does not match challenge token")
 	}
 
 	if appleData.SerialNumber != enrollment.HostIdentifier {
-		challenge.Status = types.ChallengeStatusInvalid
+		challenge.MarkInvalid()
 		return types.BadAttestationStatementError("Serial number in certificate does not match enrollment's host identifier")
 	}
 
@@ -199,10 +196,10 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 	}
 
 	if len(depAssignments) < 1 {
-		challenge.Status = types.ChallengeStatusInvalid
+		challenge.MarkInvalid()
 		return types.BadAttestationStatementError("No DEP assignments found for serial number in certificate")
 	}
 
-	challenge.Status = types.ChallengeStatusValid
+	challenge.MarkValid()
 	return nil
 }

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -42,7 +42,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 		return nil, ctxerr.Wrap(ctx, err, "getting challenge by ID")
 	}
 
-	if challenge.Status != "pending" {
+	if challenge.Status != types.ChallengeStatusPending {
 		return nil, types.InvalidChallengeStatusError(fmt.Sprintf("Challenge with ID %d is not pending and can not be validated", challengeID))
 	}
 
@@ -65,7 +65,7 @@ func (s *Service) ValidateChallenge(ctx context.Context, enrollment *types.Enrol
 	// confidently do with only one authorization and one challenge per order, if we add more we need to re-work this.
 	if updatedChallenge, err := s.store.UpdateChallenge(ctx, updatedChallenge); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "updating challenge status")
-	} else if updatedChallenge != nil && updatedChallenge.Status == "valid" {
+	} else if updatedChallenge != nil && updatedChallenge.Status == types.ChallengeStatusValid {
 		validatedAt = &updatedChallenge.UpdatedAt
 	}
 
@@ -184,12 +184,12 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 
 	sha256Token := sha256.Sum256([]byte(challenge.Token))
 	if subtle.ConstantTimeCompare(appleData.Nonce, sha256Token[:]) != 1 {
-		challenge.Status = "invalid"
+		challenge.Status = types.ChallengeStatusInvalid
 		return types.BadAttestationStatementError("Apple freshness nonce does not match challenge token")
 	}
 
 	if appleData.SerialNumber != enrollment.HostIdentifier {
-		challenge.Status = "invalid"
+		challenge.Status = types.ChallengeStatusInvalid
 		return types.BadAttestationStatementError("Serial number in certificate does not match enrollment's host identifier")
 	}
 
@@ -199,10 +199,10 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 	}
 
 	if len(depAssignments) < 1 {
-		challenge.Status = "invalid"
+		challenge.Status = types.ChallengeStatusInvalid
 		return types.BadAttestationStatementError("No DEP assignments found for serial number in certificate")
 	}
 
-	challenge.Status = "valid"
+	challenge.Status = types.ChallengeStatusValid
 	return nil
 }

--- a/server/mdm/acme/internal/service/challenge.go
+++ b/server/mdm/acme/internal/service/challenge.go
@@ -190,12 +190,12 @@ func (s *Service) validateAppleDeviceAttestationStatement(ctx context.Context, e
 		return types.BadAttestationStatementError("Serial number in certificate does not match enrollment's host identifier")
 	}
 
-	depAssignments, err := s.providers.GetHostDEPAssignmentsBySerial(ctx, appleData.SerialNumber)
+	enrolled, err := s.providers.IsDEPEnrolled(ctx, appleData.SerialNumber)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "getting DEP assignments for serial number in attestation certificate")
+		return ctxerr.Wrap(ctx, err, "checking DEP enrollment for serial number in attestation certificate")
 	}
 
-	if len(depAssignments) < 1 {
+	if !enrolled {
 		challenge.MarkInvalid()
 		return types.BadAttestationStatementError("No DEP assignments found for serial number in certificate")
 	}

--- a/server/mdm/acme/internal/service/endpoint_utils.go
+++ b/server/mdm/acme/internal/service/endpoint_utils.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	eu "github.com/fleetdm/fleet/v4/server/platform/endpointer"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
-	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/go-kit/kit/endpoint"
 	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
@@ -119,7 +118,7 @@ func (e *endpointer) Service() any {
 // Compile-time check to ensure endpointer implements Endpointer.
 var _ eu.Endpointer[handlerFunc] = &endpointer{}
 
-func newEndpointerWithNoAuth(svc api.Service, opts []kithttp.ServerOption, r *mux.Router,
+func newEndpointerWithNoAuth(svc api.Service, authMiddleware endpoint.Middleware, opts []kithttp.ServerOption, r *mux.Router,
 	versions ...string,
 ) *eu.CommonEndpointer[handlerFunc] {
 	return &eu.CommonEndpointer[handlerFunc]{
@@ -129,12 +128,8 @@ func newEndpointerWithNoAuth(svc api.Service, opts []kithttp.ServerOption, r *mu
 		MakeDecoderFn:  makeDecoder,
 		EncodeFn:       encodeResponse,
 		Opts:           opts,
-		AuthMiddleware: unauthenticatedRequest,
+		AuthMiddleware: authMiddleware,
 		Router:         r,
 		Versions:       versions,
 	}
-}
-
-func unauthenticatedRequest(next endpoint.Endpoint) endpoint.Endpoint {
-	return log.Logged(next)
 }

--- a/server/mdm/acme/internal/service/enrollment.go
+++ b/server/mdm/acme/internal/service/enrollment.go
@@ -8,7 +8,6 @@ import (
 
 func (s *Service) NewACMEEnrollment(ctx context.Context, hostIdentifier string) (string, error) {
 	// skipauth: No authorization check needed; caller is authenticated via DEP device identity.
-	// TODO: confirm this is how we want to handle auth for this method
 	if az, ok := authz_ctx.FromContext(ctx); ok {
 		az.SetChecked()
 	}

--- a/server/mdm/acme/internal/service/handler.go
+++ b/server/mdm/acme/internal/service/handler.go
@@ -17,15 +17,15 @@ import (
 
 // GetRoutes returns a function that registers ACME routes on the router using the provided
 // authMiddleware.
-func GetRoutes(svc api.Service) eu.HandlerRoutesFunc {
+func GetRoutes(svc api.Service, authMiddleware endpoint.Middleware) eu.HandlerRoutesFunc {
 	return func(r *mux.Router, opts []kithttp.ServerOption) {
-		attachFleetAPIRoutes(r, svc, opts)
+		attachFleetAPIRoutes(r, svc, authMiddleware, opts)
 	}
 }
 
-func attachFleetAPIRoutes(r *mux.Router, svc api.Service, opts []kithttp.ServerOption) {
+func attachFleetAPIRoutes(r *mux.Router, svc api.Service, authMiddleware endpoint.Middleware, opts []kithttp.ServerOption) {
 	opts = append(opts, kithttp.ServerErrorEncoder(acmeErrorEncoder))
-	ae := newEndpointerWithNoAuth(svc, opts, r)
+	ae := newEndpointerWithNoAuth(svc, authMiddleware, opts, r)
 	// ACME endpoints use path identifier and JWS authn/z, so we use a middleware to mark
 	// the standard Fleet auth as skipped/done so the endpoints don't return a Forbidden
 	// error due to no standard auth done.

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/internal/commonmdm"
 )
 
-// Service is the activity bounded context service implementation.
+// Service is the ACME bounded context service implementation.
 type Service struct {
 	store     types.Datastore
 	nonces    *redis_nonces_store.RedisNoncesStore
@@ -29,7 +29,7 @@ type Service struct {
 
 type ServiceOption func(*Service)
 
-// NewService creates a new activity service.
+// NewService creates a new ACME service.
 func NewService(
 	store types.Datastore,
 	redisPool fleet.RedisPool,

--- a/server/mdm/acme/internal/service/service.go
+++ b/server/mdm/acme/internal/service/service.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"strings"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/api"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/redis_nonces_store"
@@ -32,7 +31,7 @@ type ServiceOption func(*Service)
 // NewService creates a new ACME service.
 func NewService(
 	store types.Datastore,
-	redisPool fleet.RedisPool,
+	redisPool acme.RedisPool,
 	providers acme.DataProviders,
 	logger *slog.Logger,
 	opts ...ServiceOption,
@@ -58,12 +57,7 @@ func (s *Service) NoncesStore() *redis_nonces_store.RedisNoncesStore {
 }
 
 func (s *Service) getACMEBaseURL(ctx context.Context) (string, error) {
-	appConfig, err := s.providers.AppConfig(ctx)
-	if err != nil {
-		return "", err
-	}
-
-	return appConfig.MDMUrl(), nil
+	return s.providers.ServerURL(ctx)
 }
 
 func (s *Service) getACMEURL(ctx context.Context, pathIdentifier string, suffixes ...string) (string, error) {

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -14,11 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newAccountURL returns the full URL for the new_account endpoint.
-func (s *integrationTestSuite) newAccountURL(pathIdentifier string) string {
-	return fmt.Sprintf("%s/api/mdm/acme/%s/new_account", s.server.URL, pathIdentifier)
-}
-
 func TestIntegration(t *testing.T) {
 	s := setupIntegrationTest(t)
 

--- a/server/mdm/acme/internal/tests/integration_test.go
+++ b/server/mdm/acme/internal/tests/integration_test.go
@@ -573,7 +573,7 @@ func testCreateOrder(t *testing.T, s *integrationTestSuite) {
 		require.NotEmpty(t, resp.Header.Get("Location"))
 		require.Regexp(t, "/api/mdm/acme/"+enroll.PathIdentifier+`/orders/\d+`, resp.Header.Get("Location"))
 
-		require.Equal(t, "pending", orderResp.Status)
+		require.Equal(t, types.OrderStatusPending, orderResp.Status)
 		require.Len(t, orderResp.Identifiers, 1)
 		require.Equal(t, "permanent-identifier", orderResp.Identifiers[0].Type)
 		require.Equal(t, enroll.HostIdentifier, orderResp.Identifiers[0].Value)
@@ -845,7 +845,7 @@ func testGetOrder(t *testing.T, s *integrationTestSuite) {
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
 		require.Equal(t, "no-store", resp.Header.Get("Cache-Control"))
 
-		require.Equal(t, "pending", gotOrder.Status)
+		require.Equal(t, types.OrderStatusPending, gotOrder.Status)
 		require.Len(t, gotOrder.Identifiers, 1)
 		require.Equal(t, "permanent-identifier", gotOrder.Identifiers[0].Type)
 		require.Equal(t, enroll.HostIdentifier, gotOrder.Identifiers[0].Value)
@@ -891,7 +891,7 @@ func testGetOrder(t *testing.T, s *integrationTestSuite) {
 
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Nil(t, acmeErr)
-		require.Equal(t, "valid", gotOrder.Status)
+		require.Equal(t, types.OrderStatusValid, gotOrder.Status)
 		require.Regexp(t, fmt.Sprintf("/api/mdm/acme/%s/orders/%d/certificate", enroll.PathIdentifier, orderResp.ID), gotOrder.Certificate)
 	})
 
@@ -1419,7 +1419,7 @@ func testGetAuthorization(t *testing.T, s *integrationTestSuite) {
 		authResp, acmeErr, _ := s.getAuthorization(t, authURL, jws)
 		require.Nil(t, acmeErr)
 		require.NotNil(t, authResp)
-		require.Equal(t, "pending", authResp.Status)
+		require.Equal(t, types.AuthorizationStatusPending, authResp.Status)
 		require.Equal(t, "permanent-identifier", authResp.Identifier.Type)
 		require.Equal(t, enroll.HostIdentifier, authResp.Identifier.Value)
 		require.Len(t, authResp.Challenges, 1)
@@ -1481,7 +1481,7 @@ func testFinalizeOrder(t *testing.T, s *integrationTestSuite) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.Nil(t, acmeErr)
 		require.NotNil(t, result)
-		require.Equal(t, "valid", result.Status)
+		require.Equal(t, types.OrderStatusValid, result.Status)
 		require.NotEmpty(t, result.Certificate)
 		require.Regexp(t, "/api/mdm/acme/"+enroll.PathIdentifier+`/orders/\d+/certificate`, result.Certificate)
 		require.NotEmpty(t, resp.Header.Get("Replay-Nonce"))
@@ -1611,7 +1611,7 @@ func testDoChallengeDeviceAttestation(t *testing.T, s *integrationTestSuite) {
 		require.Nil(t, acmeErr)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.NotNil(t, challengeResp)
-		require.Equal(t, "valid", challengeResp.Status)
+		require.Equal(t, types.ChallengeStatusValid, challengeResp.Status)
 	})
 
 	t.Run("challenge not pending", func(t *testing.T) {
@@ -1629,7 +1629,7 @@ func testDoChallengeDeviceAttestation(t *testing.T, s *integrationTestSuite) {
 		require.Nil(t, acmeErr)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		require.NotNil(t, challengeResp)
-		require.Equal(t, "valid", challengeResp.Status)
+		require.Equal(t, types.ChallengeStatusValid, challengeResp.Status)
 		nonce = resp.Header.Get("Replay-Nonce")
 
 		// try to do the challenge again with the same JWS body

--- a/server/mdm/acme/internal/tests/mocks_test.go
+++ b/server/mdm/acme/internal/tests/mocks_test.go
@@ -4,48 +4,47 @@ import (
 	"context"
 	"errors"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
-	"github.com/jmoiron/sqlx"
 )
 
 // Mock implementations for dependencies outside the bounded context
 
-// mockDataProviders combines all provider interfaces for testing.
+// mockDataProviders implements acme.DataProviders for testing.
 type mockDataProviders struct {
-	appCfg *fleet.AppConfig
-	assets map[fleet.MDMAssetName]fleet.MDMConfigAsset
-	signer acme.CSRSigner
+	serverURL string
+	assets    map[string][]byte // asset name → PEM bytes
+	signer    acme.CSRSigner
 }
 
-func newMockDataProviders(appCfg *fleet.AppConfig, signer acme.CSRSigner, assets map[fleet.MDMAssetName]fleet.MDMConfigAsset) *mockDataProviders {
-	return &mockDataProviders{appCfg: appCfg, signer: signer, assets: assets}
+func newMockDataProviders(serverURL string, signer acme.CSRSigner, caCertPEM []byte) *mockDataProviders {
+	return &mockDataProviders{
+		serverURL: serverURL,
+		signer:    signer,
+		assets:    map[string][]byte{"ca_cert": caCertPEM},
+	}
 }
 
-func (m *mockDataProviders) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
-	return m.appCfg, nil
+func (m *mockDataProviders) ServerURL(_ context.Context) (string, error) {
+	return m.serverURL, nil
 }
 
-func (m *mockDataProviders) GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []fleet.MDMAssetName,
-	queryerContext sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
-	return m.assets, nil
+func (m *mockDataProviders) GetCACertificatePEM(_ context.Context) ([]byte, error) {
+	if pem, ok := m.assets["ca_cert"]; ok {
+		return pem, nil
+	}
+	return nil, errors.New("ca_cert not found")
 }
 
-func (m *mockDataProviders) CSRSigner(ctx context.Context) (acme.CSRSigner, error) {
+func (m *mockDataProviders) CSRSigner(_ context.Context) (acme.CSRSigner, error) {
 	return m.signer, nil
 }
 
-// Returns a valid row with `valid-serial` else no row
-func (m *mockDataProviders) GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error) {
-	// For testing, we can return a fixed response or an empty slice based on the serial number
+// Returns true for "valid-serial", error for "error-serial", false otherwise
+func (m *mockDataProviders) IsDEPEnrolled(_ context.Context, serial string) (bool, error) {
 	if serial == "valid-serial" {
-		return []*fleet.HostDEPAssignment{
-			{
-				HostID: 1,
-			},
-		}, nil
+		return true, nil
 	} else if serial == "error-serial" {
-		return nil, errors.New("Mocked error for GetHostDEPAssignmentsBySerial")
+		return false, errors.New("Mocked error for IsDEPEnrolled")
 	}
-	return []*fleet.HostDEPAssignment{}, nil
+	return false, nil
 }

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	api_http "github.com/fleetdm/fleet/v4/server/mdm/acme/api/http"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/bootstrap"
@@ -56,11 +55,8 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 	rootPool.AddCert(cert)
 
 	// Create mocks
-	providers := newMockDataProviders(&fleet.AppConfig{
-		ServerSettings: fleet.ServerSettings{
-			ServerURL: "https://example.com", // will update with actual test server URL after it is started
-		},
-	},
+	providers := newMockDataProviders(
+		"https://example.com", // will update with actual test server URL after it is started
 		acme.CSRSignerFunc(func(ctx context.Context, csr *x509.CertificateRequest) (*x509.Certificate, error) {
 			res, err := tdb.DB.DB.Exec(`INSERT INTO identity_serials () VALUES ()`) // insert a row to get an auto-incremented ID for the cert serial number
 			require.NoError(t, err)
@@ -73,13 +69,8 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 				Raw:          []byte("mock-cert"),
 			}, nil
 		}),
-		map[fleet.MDMAssetName]fleet.MDMConfigAsset{
-			fleet.MDMAssetCACert: {
-				Name:        fleet.MDMAssetCACert,
-				Value:       []byte("-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----"),
-				MD5Checksum: "63a9f0ea7bb98050796b649e85481845", // md5 of "root"
-			},
-		})
+		[]byte("-----BEGIN CERTIFICATE-----\nroot\n-----END CERTIFICATE-----"),
+	)
 
 	opts := bootstrap.WithTestAppleRootCAs(rootPool)
 	// Create service
@@ -94,9 +85,7 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 	// Create test server
 	server := httptest.NewServer(router)
 	t.Cleanup(server.Close)
-	ac, err := providers.AppConfig(t.Context())
-	require.NoError(t, err)
-	ac.ServerSettings.ServerURL = server.URL
+	providers.serverURL = server.URL
 
 	return &integrationTestSuite{
 		TestDB:      tdb,

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/internal/types"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/testhelpers"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/go-kit/kit/endpoint"
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/require"
 	"go.step.sm/crypto/jose"
@@ -86,7 +87,8 @@ func setupIntegrationTest(t *testing.T) *integrationTestSuite {
 
 	// Create router with routes
 	router := mux.NewRouter()
-	routesFn := service.GetRoutes(svc)
+	authMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint { return next } // no-op auth middleware for testing
+	routesFn := service.GetRoutes(svc, authMiddleware)
 	routesFn(router, nil)
 
 	// Create test server

--- a/server/mdm/acme/internal/tests/suite_test.go
+++ b/server/mdm/acme/internal/tests/suite_test.go
@@ -242,6 +242,11 @@ func (s *integrationTestSuite) createAccount(t *testing.T, pathIdentifier string
 	return doACMERequest[types.AccountResponse](t, http.MethodPost, url, jwsBody)
 }
 
+// newAccountURL returns the full URL for the new_account endpoint.
+func (s *integrationTestSuite) newAccountURL(pathIdentifier string) string {
+	return fmt.Sprintf("%s/api/mdm/acme/%s/new_account", s.server.URL, pathIdentifier)
+}
+
 // newOrderURL returns the full URL for the new_order endpoint.
 func (s *integrationTestSuite) newOrderURL(pathIdentifier string) string {
 	return fmt.Sprintf("%s/api/mdm/acme/%s/new_order", s.server.URL, pathIdentifier)
@@ -417,25 +422,7 @@ func (s *integrationTestSuite) finalizeOrderURL(pathIdentifier string, orderID u
 // order response or acme error and the raw response.
 func (s *integrationTestSuite) finalizeOrder(t *testing.T, finalizeURL string, jwsBody []byte) (*types.OrderResponse, *types.ACMEError, *http.Response) {
 	t.Helper()
-	req, err := http.NewRequest(http.MethodPost, finalizeURL, bytes.NewReader(jwsBody))
-	require.NoError(t, err)
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-	defer drainAndCloseBody(resp)
-
-	if resp.StatusCode >= 300 {
-		var acmeErr types.ACMEError
-		if err := json.NewDecoder(resp.Body).Decode(&acmeErr); err == nil && acmeErr.Type != "" {
-			return nil, &acmeErr, resp
-		}
-		return nil, nil, resp
-	}
-
-	var result types.OrderResponse
-	err = json.NewDecoder(resp.Body).Decode(&result)
-	require.NoError(t, err)
-	return &result, nil, resp
+	return doACMERequest[types.OrderResponse](t, http.MethodPost, finalizeURL, jwsBody)
 }
 
 // createOrderForFinalize is a convenience helper that creates an enrollment, account, and order,

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fxamacker/cbor/v2"
@@ -91,6 +92,51 @@ type Order struct {
 	NotAfter  *time.Time `db:"-"`
 }
 
+// IsReadyToFinalize returns an error if the order is not in a state where it can be finalized.
+func (o Order) IsReadyToFinalize() error {
+	if o.Status != OrderStatusReady || o.Finalized {
+		extra := ""
+		if o.Finalized {
+			extra = " and order has already been finalized"
+		}
+		return OrderNotReadyError(fmt.Sprintf("Order is in status %s%s.", o.Status, extra))
+	}
+
+	return nil
+}
+
+// IsCertificateReady returns an error if the order is not in a state where the certificate can be retrieved.
+func (o Order) IsCertificateReady() error {
+	if !o.Finalized || o.Status != OrderStatusValid {
+		if o.Status == OrderStatusInvalid {
+			return OrderDoesNotExistError("Order is in invalid state, cannot get certificate")
+		}
+		return OrderNotFinalizedError("Order is not finalized/in valid state, cannot get certificate")
+	}
+	return nil
+}
+
+// ValidateOrderCreation validates that the order creation request is valid given the enrollment. It returns an error if the request is not valid.
+func (o Order) ValidateOrderCreation(enrollment *Enrollment) error {
+	// The "identifiers" passed as part of the newOrder request must be an array with a
+	// single member of type "permanent-identifier" matching the serial specified in the
+	// acme_enrollment that this enrollment was created for.
+	if len(o.Identifiers) != 1 || o.Identifiers[0].Type != IdentifierTypePermanentIdentifier {
+		return UnsupportedIdentifierError("A single identifier of type permanent-identifier must be provided in the order request")
+	}
+	if o.Identifiers[0].Value != enrollment.HostIdentifier {
+		return RejectedIdentifierError("The identifier value does not match the host identifier for this enrollment")
+	}
+
+	// notBefore and notAfter, which are optional, must not be set because fleet is going
+	// to control these and the Apple payload doesn't allow specification of them.
+	if o.NotBefore != nil || o.NotAfter != nil {
+		return MalformedError("notBefore and notAfter must not be set in the order request")
+	}
+
+	return nil
+}
+
 type OrderResponse struct {
 	ID             uint         `json:"id"`
 	Status         string       `json:"status"`
@@ -133,6 +179,22 @@ type Challenge struct {
 	Status              string `db:"status"`
 	// UpdatedAt is used as validated timestamp if the challenge is valid
 	UpdatedAt time.Time `db:"updated_at"`
+}
+
+// ValidatedAt returns the time that the challenge was validated if it is valid, or nil if it is not valid.
+func (c Challenge) ValidatedAt() *time.Time {
+	if c.Status == ChallengeStatusValid {
+		return &c.UpdatedAt
+	}
+	return nil
+}
+
+func (c *Challenge) MarkValid() {
+	c.Status = ChallengeStatusValid
+}
+
+func (c *Challenge) MarkInvalid() {
+	c.Status = ChallengeStatusInvalid
 }
 
 type ChallengeResponse struct {

--- a/server/mdm/acme/internal/types/acme.go
+++ b/server/mdm/acme/internal/types/acme.go
@@ -12,10 +12,15 @@ const (
 	OrderStatusPending = "pending"
 	OrderStatusReady   = "ready"
 	OrderStatusValid   = "valid"
+	OrderStatusInvalid = "invalid"
 
-	AuthorizationStatusValid = "valid"
+	AuthorizationStatusPending = "pending"
+	AuthorizationStatusValid   = "valid"
+	AuthorizationStatusInvalid = "invalid"
 
-	ChallengeStatusValid = "valid"
+	ChallengeStatusPending = "pending"
+	ChallengeStatusValid   = "valid"
+	ChallengeStatusInvalid = "invalid"
 )
 
 type Directory struct {

--- a/server/mdm/acme/providers.go
+++ b/server/mdm/acme/providers.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"crypto/x509"
 
-	"github.com/fleetdm/fleet/v4/server/fleet"
-	"github.com/jmoiron/sqlx"
+	redigo "github.com/gomodule/redigo/redis"
 )
+
+// RedisPool is the minimal Redis pool interface needed by the ACME bounded context.
+// fleet.RedisPool satisfies this implicitly via Go's structural typing.
+type RedisPool interface {
+	Get() redigo.Conn
+}
 
 // CSRSigner signs x509 certificate requests. This is the ACME-specific
 // interface for certificate signing, decoupled from the SCEP protocol types.
@@ -22,11 +27,21 @@ func (f CSRSignerFunc) SignCSR(ctx context.Context, csr *x509.CertificateRequest
 }
 
 // DataProviders combines all external dependency interfaces for the ACME
-// bounded context.
+// bounded context. Methods are narrowed to exactly what ACME needs,
+// keeping the bounded context decoupled from Fleet-internal types.
 type DataProviders interface {
-	AppConfig(ctx context.Context) (*fleet.AppConfig, error)
-	GetAllMDMConfigAssetsByName(ctx context.Context, assetNames []fleet.MDMAssetName,
-		queryerContext sqlx.QueryerContext) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error)
+	// ServerURL returns the base URL used to construct ACME endpoint URLs.
+	ServerURL(ctx context.Context) (string, error)
+
+	// GetCACertificatePEM returns the PEM-encoded root CA certificate
+	// used to build the certificate chain in download-certificate responses.
+	GetCACertificatePEM(ctx context.Context) ([]byte, error)
+
+	// CSRSigner returns the signer used to sign certificate requests
+	// during order finalization.
 	CSRSigner(ctx context.Context) (CSRSigner, error)
-	GetHostDEPAssignmentsBySerial(ctx context.Context, serial string) ([]*fleet.HostDEPAssignment, error)
+
+	// IsDEPEnrolled reports whether the given serial number has an active
+	// DEP assignment, used during device attestation challenge validation.
+	IsDEPEnrolled(ctx context.Context, serial string) (bool, error)
 }

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -29,6 +29,7 @@ import (
 	"github.com/fleetdm/fleet/v4/ee/server/service/est"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity"
 	"github.com/fleetdm/fleet/v4/ee/server/service/hostidentity/httpsig"
+	"github.com/fleetdm/fleet/v4/server/acl/acmeacl"
 	"github.com/fleetdm/fleet/v4/server/acl/activityacl"
 	activity_api "github.com/fleetdm/fleet/v4/server/activity/api"
 	activity_bootstrap "github.com/fleetdm/fleet/v4/server/activity/bootstrap"
@@ -45,7 +46,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/logging"
 	"github.com/fleetdm/fleet/v4/server/mail"
-	"github.com/fleetdm/fleet/v4/server/mdm/acme"
 	acme_bootstrap "github.com/fleetdm/fleet/v4/server/mdm/acme/bootstrap"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
@@ -542,7 +542,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 			acmeOpts = append(acmeOpts, acme_bootstrap.WithTestAppleRootCAs(rootCAPool))
 		}
 		acmeSigner := &acmeCSRSigner{signer: depot.NewSigner(opts[0].SCEPStorage, depot.WithValidityDays(365), depot.WithAllowRenewalDays(14))}
-		acmeSvc, acmeRoutes := acme_bootstrap.New(opts[0].DBConns, redisPool, &testACMEDataProviders{Datastore: ds, signer: acmeSigner}, logger, acmeOpts...)
+		acmeSvc, acmeRoutes := acme_bootstrap.New(opts[0].DBConns, redisPool, acmeacl.NewFleetDatastoreAdapter(ds, acmeSigner), logger, acmeOpts...)
 		svc.SetACMEService(acmeSvc)
 		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, acmeRoutes(log.Logged))
 	}
@@ -1528,15 +1528,6 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
 }
 
-// testACMEDataProviders wraps fleet.Datastore to satisfy acme.DataProviders in tests.
-type testACMEDataProviders struct {
-	fleet.Datastore
-	signer acme.CSRSigner
-}
-
-func (t *testACMEDataProviders) CSRSigner(_ context.Context) (acme.CSRSigner, error) {
-	return t.signer, nil
-}
 
 // acmeCSRSigner adapts a depot.Signer to the acme.CSRSigner interface.
 type acmeCSRSigner struct {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -1528,7 +1528,6 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
 }
 
-
 // acmeCSRSigner adapts a depot.Signer to the acme.CSRSigner interface.
 type acmeCSRSigner struct {
 	signer *depot.Signer

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -66,6 +66,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/async"
 	"github.com/fleetdm/fleet/v4/server/service/middleware/auth"
+	"github.com/fleetdm/fleet/v4/server/service/middleware/log"
 	"github.com/fleetdm/fleet/v4/server/service/mock"
 	"github.com/fleetdm/fleet/v4/server/service/redis_key_value"
 	"github.com/fleetdm/fleet/v4/server/service/redis_lock"
@@ -543,7 +544,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		acmeSigner := &acmeCSRSigner{signer: depot.NewSigner(opts[0].SCEPStorage, depot.WithValidityDays(365), depot.WithAllowRenewalDays(14))}
 		acmeSvc, acmeRoutes := acme_bootstrap.New(opts[0].DBConns, redisPool, &testACMEDataProviders{Datastore: ds, signer: acmeSigner}, logger, acmeOpts...)
 		svc.SetACMEService(acmeSvc)
-		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, acmeRoutes())
+		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, acmeRoutes(log.Logged))
 	}
 
 	if len(opts) > 0 {


### PR DESCRIPTION
I split this PR by commits. The first two are the ones I originally wanted to do, the last two are more an attempt and a potential idea, with the reason to make it act more as a truly bounded context isolated from outside dependencies (primarily server/fleet).

