### PR TITLE
Website: add support for new usage statistics

### DIFF
--- a/website/api/controllers/webhooks/receive-usage-analytics.js
+++ b/website/api/controllers/webhooks/receive-usage-analytics.js
@@ -47,6 +47,10 @@ module.exports = {
     numHostsABMPending: {type: 'number', defaultsTo: 0 },
     fleetMaintainedAppsWindows: {type: ['string'], defaultsTo: [] },
     fleetMaintainedAppsMacOS: {type: ['string'], defaultsTo: [] },
+    oktaConditionalAccessConfigured: {type: 'boolean', defaultsTo: false},
+    entraConditionalAccessConfigured: {type: 'boolean', defaultsTo: false},
+    conditionalAccessBypassDisabled: {type: 'boolean', defaultsTo: false},
+    conditionalAccessEnabled: {type: 'boolean', defaultsTo: false},
   },
 
 

--- a/website/api/models/HistoricalUsageSnapshot.js
+++ b/website/api/models/HistoricalUsageSnapshot.js
@@ -51,6 +51,10 @@ module.exports = {
     numHostsABMPending: {required: true, type: 'number' },
     fleetMaintainedAppsMacOS: {required: true, type: 'json'},
     fleetMaintainedAppsWindows: {required: true, type: 'json'},
+    oktaConditionalAccessConfigured: {required: true, type: 'boolean'},
+    conditionalAccessEnabled: {required: true, type: 'boolean'},
+    conditionalAccessBypassDisabled: {required: true, type: 'boolean'},
+    entraConditionalAccessConfigured: {required: true, type: 'boolean'},
 
     //  ╔═╗╔╦╗╔╗ ╔═╗╔╦╗╔═╗
     //  ║╣ ║║║╠╩╗║╣  ║║╚═╗


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/42049

Changes:
- Added four attributes to the HistoricalUsageSnapshot model: `oktaConditionalAccessConfigured`, `conditionalAccessEnabled`, `conditionalAccessBypassDisabled`, and `entraConditionalAccessConfigured`
- Added the new usage statistics as inputs to the receive-usage-analytics webhook

> Note: Before this PR can be merged, the website's database needs to be migrated to add the new columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for conditional access configuration states across Okta and Entra platforms, including bypass and enablement status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->