### PR TITLE
Improve 'Activities run as listed' tooltip wording

### DIFF
--- a/frontend/pages/hosts/details/cards/Activity/Activity.tsx
+++ b/frontend/pages/hosts/details/cards/Activity/Activity.tsx
@@ -33,7 +33,7 @@ const UpcomingTooltip = () => {
       tipContent={
         <>
           Software and scripts always run in order. Each waits until the
-          previous one runs successfully or fails.
+          previous one runs successfully or fails 3 times.
         </>
       }
       className={`${baseClass}__upcoming-tooltip`}


### PR DESCRIPTION
- @noahtalerman: Feedback from `cisneros` that it's not clear that Fleet retries 3 times for software and scripts.

For the following quick win:
- https://github.com/fleetdm/fleet/issues/41107

