### PR TITLE
Enable FLEET_MDM_ALLOW_ALL_DECLARATIONS on dogfood

### DIFF
--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -80,6 +80,7 @@ locals {
     # Webhook Results & Status Logging Destination
     FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"
     FLEET_SERVER_GZIP_RESPONSES     = "true"
+    FLEET_MDM_ALLOW_ALL_DECLARATIONS = "true"
 
     # Load TLS Certificate for RDS Authentication
     FLEET_MYSQL_TLS_CA                  = local.cert_path

--- a/infrastructure/dogfood/terraform/aws-tf-module/main.tf
+++ b/infrastructure/dogfood/terraform/aws-tf-module/main.tf
@@ -80,6 +80,7 @@ locals {
     # Webhook Results & Status Logging Destination
     FLEET_SERVER_VPP_VERIFY_TIMEOUT = "20m"
     FLEET_SERVER_GZIP_RESPONSES     = "true"
+    # https://github.com/fleetdm/fleet/issues/38366
     FLEET_MDM_ALLOW_ALL_DECLARATIONS = "true"
 
     # Load TLS Certificate for RDS Authentication


### PR DESCRIPTION
### Changes

Enable the `FLEET_MDM_ALLOW_ALL_DECLARATIONS` environment variable on the dogfood infrastructure.

### Details

- Added `FLEET_MDM_ALLOW_ALL_DECLARATIONS = "true"` to the Terraform configuration in the AWS module
- This allows all MDM declarations to be processed in the dogfood environment for testing purposes