### PR TITLE
Check osascript output instead of exit status

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -535,7 +535,9 @@ const quitApplicationFunc = `quit_application() {
   local timeout_duration=10
 
   # check if the application is running
-  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+  local app_running
+  app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
+  if [[ "$app_running" != "true" ]]; then
     return
   fi
 
@@ -576,7 +578,9 @@ const quitAndTrackApplicationFunc = `quit_and_track_application() {
   local timeout_duration=10
 
   # check if the application is running
-  if ! osascript -e "application id \"$bundle_id\" is running" 2>/dev/null; then
+  local app_running
+  app_running=$(osascript -e "application id \"$bundle_id\" is running" 2>/dev/null)
+  if [[ "$app_running" != "true" ]]; then
     eval "export $var_name=0"
     return
   fi


### PR DESCRIPTION
Capture osascript output into a variable and compare it to "true" when checking if an app is running. Updated quit_application and quit_and_track_application to use app_running=$(osascript ...) and [[ "$app_running" != "true" ]] rather than relying on the command's exit status. This makes the running check more reliable across osascript behaviors and avoids depending on its exit code.