### PR TITLE
Add `API time` on GitOps errors to ease troubleshooting

### DIFF
--- a/changes/add-api-time-on-gitops-errors
+++ b/changes/add-api-time-on-gitops-errors
@@ -1,0 +1,1 @@
+* Added "API time" to GitOps output on API errors.

--- a/cmd/fleetctl/fleetctl/apply_test.go
+++ b/cmd/fleetctl/fleetctl/apply_test.go
@@ -2042,7 +2042,7 @@ spec:
 
 	_, err := RunAppNoChecks([]string{"apply", "-f", interval})
 	assert.Error(t, err)
-	require.Equal(t, expectedErrMsg, err.Error())
+	require.Contains(t, err.Error(), expectedErrMsg)
 }
 
 func TestApplyQueries(t *testing.T) {

--- a/cmd/fleetctl/fleetctl/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils.go
@@ -18,7 +18,7 @@ func RunAppForTest(t *testing.T, args []string) string {
 func RunAppCheckErr(t *testing.T, args []string, errorMsg string) string {
 	w, err := RunAppNoChecks(args)
 	require.Error(t, err)
-	require.Equal(t, errorMsg, err.Error())
+	require.Contains(t, err.Error(), errorMsg)
 	return w.String()
 }
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -282,7 +282,8 @@ func (c *Client) authenticatedRequestWithQuery(params interface{}, verb string, 
 		return fmt.Errorf("%s %s: %w (API time: %s)", verb, path, err, time.Since(start).Truncate(time.Millisecond))
 	}
 	if err := c.ParseResponse(verb, path, response, responseDest); err != nil {
-		return fmt.Errorf("%s %s: %w (API time: %s)", verb, path, err, time.Since(start).Truncate(time.Millisecond))
+		// ParseResponse already adds verb and path to the err.
+		return fmt.Errorf("%w (API time: %s)", err, time.Since(start).Truncate(time.Millisecond))
 	}
 	return nil
 }

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -276,11 +276,15 @@ func (l *logRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (c *Client) authenticatedRequestWithQuery(params interface{}, verb string, path string, responseDest interface{}, query string) error {
+	start := time.Now()
 	response, err := c.AuthenticatedDo(verb, path, query, params)
 	if err != nil {
-		return fmt.Errorf("%s %s: %w", verb, path, err)
+		return fmt.Errorf("%s %s: %w (API time: %s)", verb, path, err, time.Since(start).Truncate(time.Millisecond))
 	}
-	return c.ParseResponse(verb, path, response, responseDest)
+	if err := c.ParseResponse(verb, path, response, responseDest); err != nil {
+		return fmt.Errorf("%s %s: %w (API time: %s)", verb, path, err, time.Since(start).Truncate(time.Millisecond))
+	}
+	return nil
 }
 
 func (c *Client) authenticatedRequest(params interface{}, verb string, path string, responseDest interface{}) error {


### PR DESCRIPTION
This would have helped some troubleshooting on customer workflows failing due to long response times.
(We had a long running `spec/fleets` API request for customer-numa.)

Sample of logging after I added a `300s` sleep to `/api/latest/fleet/config`:
```
[+] would've applied EULA
[+] would've applied certificate authorities
Error: applying fleet config: PATCH /api/latest/fleet/config: do request: Patch "https://localhost:8080/api/latest/fleet/config?dry_run=true&overwrite=true": stream error: stream ID 49; INTERNAL_ERROR; received from peer (API time: 1m40.002s)
```
Another sample error after bringing Fleet down during a GitOps run:
```
[+] would've applied 4 software packages for fleet Conditional access FTW
Error: applying software installers for fleet "Conditional access FTW": GET /api/latest/fleet/software/batch/395942cc-69c9-49f9-93d3-f1120e0b9e34: do request: Get "https://localhost:8080/api/latest/fleet/software/batch/395942cc-69c9-49f9-93d3-f1120e0b9e34?dry_run=true&fleet_name=Conditional+access+test+team&overwrite=true": dial tcp [::1]:8080: connect: connection refused (API time: 2ms)
```