### PR TITLE
Allow combination of inclusions and exclusions using labels

### DIFF
--- a/changes/allow-combined-include-exclude-labels
+++ b/changes/allow-combined-include-exclude-labels
@@ -1,0 +1,1 @@
+* Allowed combining `labels_include_any` (or `labels_include_all`) with `labels_exclude_any` when scoping policies, software installers, VPP apps, fleet-maintained apps, in-house apps, and MDM configuration profiles. For example, deploy software to all hosts labeled "Engineering" except those labeled "g-mdm".

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -831,22 +831,20 @@ func getLabelUsage(config *spec.GitOps) (map[string][]LabelUsage, error) {
 		if osSettings, ok := getCustomSettings(osSettingName); ok {
 			for _, setting := range osSettings {
 				var labels []string
-				err := fmt.Errorf("MDM profile '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_include_all` or `labels_exclude_any`.", setting.Path)
+
+				if len(setting.LabelsIncludeAny) > 0 && len(setting.LabelsIncludeAll) > 0 {
+					return nil, fmt.Errorf("MDM profile '%s': \"labels_include_any\" and \"labels_include_all\" cannot be combined.", setting.Path)
+				}
 
 				if len(setting.LabelsIncludeAny) > 0 {
 					labels = setting.LabelsIncludeAny
 				}
 				if len(setting.LabelsIncludeAll) > 0 {
-					if len(labels) > 0 {
-						return nil, err
-					}
 					labels = setting.LabelsIncludeAll
 				}
+				// Exclude labels can be combined with include labels
 				if len(setting.LabelsExcludeAny) > 0 {
-					if len(labels) > 0 {
-						return nil, err
-					}
-					labels = setting.LabelsExcludeAny
+					updateLabelUsage(setting.LabelsExcludeAny, setting.Path, "MDM Profile", result)
 				}
 
 				updateLabelUsage(labels, setting.Path, "MDM Profile", result)
@@ -856,64 +854,31 @@ func getLabelUsage(config *spec.GitOps) (map[string][]LabelUsage, error) {
 
 	// Get software package installer label usage
 	for _, softwarePackage := range config.Software.Packages {
-		var labels []string
-		if len(softwarePackage.LabelsIncludeAny) > 0 {
-			labels = softwarePackage.LabelsIncludeAny
+		if len(softwarePackage.LabelsIncludeAny) > 0 && len(softwarePackage.LabelsIncludeAll) > 0 {
+			return nil, fmt.Errorf("Software package '%s': \"labels_include_any\" and \"labels_include_all\" cannot be combined.", softwarePackage.URL)
 		}
-		if len(softwarePackage.LabelsExcludeAny) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Software package '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", softwarePackage.URL)
-			}
-			labels = softwarePackage.LabelsExcludeAny
-		}
-		if len(softwarePackage.LabelsIncludeAll) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Software package '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", softwarePackage.URL)
-			}
-			labels = softwarePackage.LabelsIncludeAll
-		}
-		updateLabelUsage(labels, softwarePackage.URL, "Software Package", result)
+		updateLabelUsage(softwarePackage.LabelsIncludeAny, softwarePackage.URL, "Software Package", result)
+		updateLabelUsage(softwarePackage.LabelsExcludeAny, softwarePackage.URL, "Software Package", result)
+		updateLabelUsage(softwarePackage.LabelsIncludeAll, softwarePackage.URL, "Software Package", result)
 	}
 
 	// Get app store app installer label usage
 	for _, vppApp := range config.Software.AppStoreApps {
-		var labels []string
-		if len(vppApp.LabelsIncludeAny) > 0 {
-			labels = vppApp.LabelsIncludeAny
+		if len(vppApp.LabelsIncludeAny) > 0 && len(vppApp.LabelsIncludeAll) > 0 {
+			return nil, fmt.Errorf("App Store App '%s': \"labels_include_any\" and \"labels_include_all\" cannot be combined.", vppApp.AppStoreID)
 		}
-		if len(vppApp.LabelsExcludeAny) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("App Store App '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", vppApp.AppStoreID)
-			}
-			labels = vppApp.LabelsExcludeAny
-		}
-		if len(vppApp.LabelsIncludeAll) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("App Store App '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", vppApp.AppStoreID)
-			}
-			labels = vppApp.LabelsIncludeAll
-		}
-		updateLabelUsage(labels, vppApp.AppStoreID, "App Store App", result)
+		updateLabelUsage(vppApp.LabelsIncludeAny, vppApp.AppStoreID, "App Store App", result)
+		updateLabelUsage(vppApp.LabelsExcludeAny, vppApp.AppStoreID, "App Store App", result)
+		updateLabelUsage(vppApp.LabelsIncludeAll, vppApp.AppStoreID, "App Store App", result)
 	}
 
 	for _, maintainedApp := range config.Software.FleetMaintainedApps {
-		var labels []string
-		if len(maintainedApp.LabelsIncludeAny) > 0 {
-			labels = maintainedApp.LabelsIncludeAny
+		if len(maintainedApp.LabelsIncludeAny) > 0 && len(maintainedApp.LabelsIncludeAll) > 0 {
+			return nil, fmt.Errorf("Fleet Maintained App '%s': \"labels_include_any\" and \"labels_include_all\" cannot be combined.", maintainedApp.Slug)
 		}
-		if len(maintainedApp.LabelsExcludeAny) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Fleet Maintained App '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", maintainedApp.Slug)
-			}
-			labels = maintainedApp.LabelsExcludeAny
-		}
-		if len(maintainedApp.LabelsIncludeAll) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Fleet Maintained App '%s' has multiple label keys; please choose one of `labels_include_all`, `labels_include_any`, `labels_exclude_any`.", maintainedApp.Slug)
-			}
-			labels = maintainedApp.LabelsIncludeAll
-		}
-		updateLabelUsage(labels, maintainedApp.Slug, "Fleet Maintained App", result)
+		updateLabelUsage(maintainedApp.LabelsIncludeAny, maintainedApp.Slug, "Fleet Maintained App", result)
+		updateLabelUsage(maintainedApp.LabelsExcludeAny, maintainedApp.Slug, "Fleet Maintained App", result)
+		updateLabelUsage(maintainedApp.LabelsIncludeAll, maintainedApp.Slug, "Fleet Maintained App", result)
 	}
 
 	// Get query label usage
@@ -923,17 +888,9 @@ func getLabelUsage(config *spec.GitOps) (map[string][]LabelUsage, error) {
 
 	// Get policy label usage
 	for _, policy := range config.Policies {
-		var labels []string
-		if len(policy.LabelsIncludeAny) > 0 {
-			labels = policy.LabelsIncludeAny
-		}
-		if len(policy.LabelsExcludeAny) > 0 {
-			if len(labels) > 0 {
-				return nil, fmt.Errorf("Policy '%s' has multiple label keys; please choose one of `labels_include_any`, `labels_exclude_any`.", policy.Name)
-			}
-			labels = policy.LabelsExcludeAny
-		}
-		updateLabelUsage(labels, policy.Name, "Policy", result)
+		// Policies support combining include_any + exclude_any
+		updateLabelUsage(policy.LabelsIncludeAny, policy.Name, "Policy", result)
+		updateLabelUsage(policy.LabelsExcludeAny, policy.Name, "Policy", result)
 	}
 
 	return result, nil

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3788,13 +3788,13 @@ func TestGitOpsCustomSettings(t *testing.T) {
 	}{
 		{"testdata/gitops/global_macos_windows_custom_settings_valid.yml", ""},
 		{"testdata/gitops/global_macos_custom_settings_valid_deprecated.yml", ""},
-		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml", ""},
+		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml", `"labels_include_any" and "labels_include_all" cannot be combined.`},
 		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix_2.yml", `"labels_include_any" and "labels_include_all" cannot be combined.`},
 		{"testdata/gitops/global_windows_custom_settings_unknown_label.yml", `Please create the missing labels, or update your settings to not refer to these labels.`},
 		{"testdata/gitops/team_macos_windows_custom_settings_valid.yml", ""},
 		{"testdata/gitops/team_macos_custom_settings_valid_deprecated.yml", ""},
-		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml", ""},
-		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml", ""},
+		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml", `"labels_include_any" and "labels_include_all" cannot be combined.`},
+		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml", `"labels_include_any" and "labels_include_all" cannot be combined.`},
 		{"testdata/gitops/team_macos_windows_custom_settings_unknown_label.yml", `Please create the missing labels, or update your settings to not refer to these labels.`},
 	}
 	for _, c := range cases {

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -3788,13 +3788,13 @@ func TestGitOpsCustomSettings(t *testing.T) {
 	}{
 		{"testdata/gitops/global_macos_windows_custom_settings_valid.yml", ""},
 		{"testdata/gitops/global_macos_custom_settings_valid_deprecated.yml", ""},
-		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml", "please choose one of `labels_include_any`, `labels_include_all` or `labels_exclude_any`"},
-		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix_2.yml", "please choose one of `labels_include_any`, `labels_include_all` or `labels_exclude_any`"},
+		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml", ""},
+		{"testdata/gitops/global_windows_custom_settings_invalid_label_mix_2.yml", `"labels_include_any" and "labels_include_all" cannot be combined.`},
 		{"testdata/gitops/global_windows_custom_settings_unknown_label.yml", `Please create the missing labels, or update your settings to not refer to these labels.`},
 		{"testdata/gitops/team_macos_windows_custom_settings_valid.yml", ""},
 		{"testdata/gitops/team_macos_custom_settings_valid_deprecated.yml", ""},
-		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml", "please choose one of `labels_include_any`, `labels_include_all` or `labels_exclude_any`"},
-		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml", "please choose one of `labels_include_any`, `labels_include_all` or `labels_exclude_any`"},
+		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml", ""},
+		{"testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml", ""},
 		{"testdata/gitops/team_macos_windows_custom_settings_unknown_label.yml", `Please create the missing labels, or update your settings to not refer to these labels.`},
 	}
 	for _, c := range cases {

--- a/cmd/fleetctl/fleetctl/testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/global_windows_custom_settings_invalid_label_mix.yml
@@ -4,7 +4,7 @@ controls:
       - path: ./lib/windows-screenlock.xml
         labels_include_all:
           - B
-        labels_exclude_any:
+        labels_include_any:
           - C
   scripts:
   enable_disk_encryption: false

--- a/cmd/fleetctl/fleetctl/testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml
@@ -14,7 +14,7 @@ software:
         path: lib/uninstall_ruby.sh
       labels_include_any:
         - a
-      labels_exclude_any:
+      labels_include_all:
         - b
     - url: ${SOFTWARE_INSTALLER_URL}/other.deb
       self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix.yml
@@ -22,7 +22,7 @@ controls:
       - path: ./lib/windows-screenlock.xml
         labels_include_all:
           - A
-        labels_exclude_any:
+        labels_include_any:
           - C
 policies:
 queries:

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_macos_windows_custom_settings_invalid_labels_mix_2.yml
@@ -22,7 +22,7 @@ controls:
       - path: ./lib/windows-screenlock.xml
         labels_include_any:
           - A
-        labels_exclude_any:
+        labels_include_all:
           - C
 policies:
 queries:

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_invalid_both_include_exclude.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_software_installer_invalid_both_include_exclude.yml
@@ -23,7 +23,7 @@ software:
         path: lib/post_install_ruby.sh
       labels_include_any:
         - a
-      labels_exclude_any:
+      labels_include_all:
         - b
     - url: ${SOFTWARE_INSTALLER_URL}/other.deb
       self_service: true

--- a/cmd/fleetctl/fleetctl/testdata/gitops/team_vpp_invalid_app_labels_both.yml
+++ b/cmd/fleetctl/fleetctl/testdata/gitops/team_vpp_invalid_app_labels_both.yml
@@ -15,7 +15,7 @@ queries:
 software:
   app_store_apps:
     - app_store_id: "1"
-      labels_exclude_any: 
+      labels_include_all: 
         - "label 1"
       labels_include_any:
         - "label 2"

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -52,10 +52,7 @@ func TestGitOpsTeamSoftwareInstallers(t *testing.T) {
 			"testdata/gitops/team_software_installer_invalid_self_service_value.yml",
 			"Couldn't edit \"../../fleetctl/testdata/gitops/team_software_installer_invalid_self_service_value.yml\" at \"software.packages.self_service\", expected type bool but got string",
 		},
-		{
-			"testdata/gitops/team_software_installer_invalid_both_include_exclude.yml",
-			`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified`,
-		},
+		{"testdata/gitops/team_software_installer_invalid_both_include_exclude.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_include.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_exclude.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_include_all.yml", ""},
@@ -359,10 +356,7 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 			"testdata/gitops/no_team_software_installer_invalid_self_service_value.yml",
 			"Couldn't edit \"../../fleetctl/testdata/gitops/no-team.yml\" at \"software.packages.self_service\", expected type bool but got string",
 		},
-		{
-			"testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml",
-			`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified`,
-		},
+		{"testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml", ""},
 		{"testdata/gitops/no_team_software_installer_valid_include.yml", ""},
 		{"testdata/gitops/no_team_software_installer_valid_exclude.yml", ""},
 		{"testdata/gitops/no_team_software_installer_valid_include_all.yml", ""},
@@ -523,8 +517,8 @@ func TestGitOpsTeamVPPApps(t *testing.T) {
 		},
 		{
 			"testdata/gitops/team_vpp_invalid_app_labels_both.yml",
-			`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified for app store app`, time.Now().Add(24 * time.Hour),
-			map[string]uint{},
+			"", time.Now().Add(24 * time.Hour),
+			map[string]uint{"label 1": 1, "label 2": 2},
 		},
 	}
 

--- a/cmd/fleetctl/integrationtest/gitops/software_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/software_test.go
@@ -52,7 +52,7 @@ func TestGitOpsTeamSoftwareInstallers(t *testing.T) {
 			"testdata/gitops/team_software_installer_invalid_self_service_value.yml",
 			"Couldn't edit \"../../fleetctl/testdata/gitops/team_software_installer_invalid_self_service_value.yml\" at \"software.packages.self_service\", expected type bool but got string",
 		},
-		{"testdata/gitops/team_software_installer_invalid_both_include_exclude.yml", ""},
+		{"testdata/gitops/team_software_installer_invalid_both_include_exclude.yml", `"labels_include_all" and "labels_include_any" cannot be combined`},
 		{"testdata/gitops/team_software_installer_valid_include.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_exclude.yml", ""},
 		{"testdata/gitops/team_software_installer_valid_include_all.yml", ""},
@@ -356,7 +356,7 @@ func TestGitOpsNoTeamSoftwareInstallers(t *testing.T) {
 			"testdata/gitops/no_team_software_installer_invalid_self_service_value.yml",
 			"Couldn't edit \"../../fleetctl/testdata/gitops/no-team.yml\" at \"software.packages.self_service\", expected type bool but got string",
 		},
-		{"testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml", ""},
+		{"testdata/gitops/no_team_software_installer_invalid_both_include_exclude.yml", `"labels_include_all" and "labels_include_any" cannot be combined`},
 		{"testdata/gitops/no_team_software_installer_valid_include.yml", ""},
 		{"testdata/gitops/no_team_software_installer_valid_exclude.yml", ""},
 		{"testdata/gitops/no_team_software_installer_valid_include_all.yml", ""},
@@ -517,8 +517,8 @@ func TestGitOpsTeamVPPApps(t *testing.T) {
 		},
 		{
 			"testdata/gitops/team_vpp_invalid_app_labels_both.yml",
-			"", time.Now().Add(24 * time.Hour),
-			map[string]uint{"label 1": 1, "label 2": 2},
+			`"labels_include_all" and "labels_include_any" cannot be combined`, time.Now().Add(24 * time.Hour),
+			nil,
 		},
 	}
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -448,13 +448,13 @@ controls:
 - `macos_settings.custom_settings` is a list of paths to macOS, iOS, and iPadOS configuration profiles (.mobileconfig) or declaration profiles (.json).
 - `windows_settings.custom_settings` is a list of paths to Windows configuration profiles (.xml).
 
-Use `labels_include_all` to target hosts that have all labels, `labels_include_any` to target hosts that have any label, or `labels_exclude_any` to target hosts that don't have any of the labels. Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
+Use `labels_include_all` to target hosts that have all labels, `labels_include_any` to target hosts that have any label, or `labels_exclude_any` to target hosts that don't have any of the labels. `labels_include_any` or `labels_include_all` can be combined with `labels_exclude_any` for inclusion+exclusion scoping. `labels_include_any` and `labels_include_all` cannot be combined with each other. If none are specified, all hosts are targeted.
 
 ### android_settings
 
 - `android_settings.custom_settings` is a list of paths to Android configuration profiles (.json).
 
-Use `labels_include_all` to target hosts that have all labels, `labels_include_any` to target hosts that have any label, or `labels_exclude_any` to target hosts that don't have any of the labels. Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
+Use `labels_include_all` to target hosts that have all labels, `labels_include_any` to target hosts that have any label, or `labels_exclude_any` to target hosts that don't have any of the labels. `labels_include_any` or `labels_include_all` can be combined with `labels_exclude_any` for inclusion+exclusion scoping. `labels_include_any` and `labels_include_all` cannot be combined with each other. If none are specified, all hosts are targeted.
 
 #### android_settings.certificates
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -6225,7 +6225,7 @@ Add a configuration profile to enforce custom settings on macOS and Windows host
 | labels_include_any      | array     | body | _Available in Fleet Premium_. Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | body | _Available in Fleet Premium_. Target hosts that that don’t have any label, specified by label name, in the array. |
 
-Only one of `labels_include_all`, `labels_include_any`, or `labels_exclude_any` can be specified. If none are specified, all hosts are targeted.
+`labels_include_any` or `labels_include_all` can be combined with `labels_exclude_any` for inclusion+exclusion scoping. `labels_include_any` and `labels_include_all` cannot be combined with each other. If none are specified, all hosts are targeted.
 
 If the response is `Status: 409 Conflict`, the body may include additional error details in the case
 of duplicate payload display name or duplicate payload identifier (macOS profiles).
@@ -8358,7 +8358,7 @@ _Available in Fleet Premium_
 | labels_include_any      | array     | form | _Available in Fleet Premium_. Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | form | _Available in Fleet Premium_. Target hosts that that don’t have any, specified by label name, label in the array. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither is set, all hosts on the specified `platform` are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither is set, all hosts on the specified `platform` are targeted.
 
 #### Example
 
@@ -8437,7 +8437,7 @@ The semantics for creating a fleet policy are the same as for global policies, s
 
 Either `query` or `query_id` must be provided.
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither is set, all hosts on the specified `platform` are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither is set, all hosts on the specified `platform` are targeted.
 
 #### Example
 
@@ -8585,7 +8585,7 @@ _Available in Fleet Premium_
 | labels_include_any      | array     | form | _Available in Fleet Premium_. Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | form | _Available in Fleet Premium_. Target hosts that that don’t have any label, specified by label name, in the array. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither is set, all hosts on the specified `platform` are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither is set, all hosts on the specified `platform` are targeted.
 
 #### Example
 
@@ -8661,7 +8661,7 @@ _Available in Fleet Premium_
 | labels_include_any      | array     | form | _Available in Fleet Premium_. Target hosts that have any label, specified by label name, in the array. |
 | labels_exclude_any | array | form | _Available in Fleet Premium_. Target hosts that that don’t have any label, specified by label name, in the array. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither is set, all hosts on the specified `platform` are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither is set, all hosts on the specified `platform` are targeted.
 
 #### Example
 
@@ -11015,7 +11015,7 @@ Add a package (.pkg, .msi, .exe, .deb, .rpm, .tar.gz, .ipa) to install on Apple 
 | labels_exclude_any | array | body | Target hosts that don't have any label, specified by label name, in the array. |
 | automatic_install | boolean | body | Specifies whether to create a policy that triggers a software install only on hosts missing the software. Not supported for iOS, iPadOS, Android, or for `.sh` and `.ps1`. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither are specified, all hosts are targeted.
 
 Add the `X-Fleet-Scripts-Encoded: base64` header line to parse `install_script`, `uninstall_script`, `post_install_script`, and `pre_install_query` fields as bas64-encoded rather than as-is.
 
@@ -11104,7 +11104,7 @@ Update a package to install on macOS, Windows, Linux, iOS, or iPadOS hosts.
 | labels_include_any        | array     | body | Target hosts that have any label, specified by label name, in the array. Only one of either `labels_include_any` or `labels_exclude_any` can be specified. |
 | labels_exclude_any | array | body | Target hosts that don't have any label, specified by label name, in the array. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither are specified, all hosts are targeted.
 
 > Changes to the installer package will reset installation counts. Changes to any field other than `self_service` will cancel pending installs for the old package.
 
@@ -11334,7 +11334,7 @@ Add Apple App Store or Google Play store app. Apple apps must be added in Apple 
 | labels_exclude_any | array | form | Target hosts that don't have any label, specified by label name, in the array. |
 | configuration | object | form | The Android Play Store app's managed configuration in JSON format. Currently only supported for Android. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither are specified, all hosts are targeted.
 
 
 #### Example
@@ -11399,7 +11399,7 @@ Modify an Apple App Store (VPP) or a Google Play app's options.
 | labels_exclude_any | array | body | Target hosts that don't have any label, specified by label name, in the array. |
 | configuration | object | body | The Android Play Store app's managed configuration in JSON format. Currently only supported for Android. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither are specified, all hosts are targeted.
 
 `configuration` only supports `managedConfiguration` and `workProfileWidgets` from [Android application policy](https://developers.google.com/android/management/reference/rest/v1/enterprises.policies#ApplicationPolicy). Configuration keys vary by app. Refer to the app vendor's documentation for available managed configuration options. For example, see [Zoom's Android managed configuration](https://support.zoom.com/hc/en/article?id=zm_kb&sysparm_article=KB0064790) or [GlobalProtect's Android configuration](https://docs.paloaltonetworks.com/globalprotect/10-1/globalprotect-admin/mobile-endpoint-management/manage-the-globalprotect-app-using-other-third-party-mdms/configure-the-globalprotect-app-for-android).
 
@@ -11587,7 +11587,7 @@ Add Fleet-maintained app so it's available for install.
 | labels_exclude_any | array | form | Target hosts that don't have any label, specified by label name, in the array. |
 | automatic_install | boolean | form | Create a policy that triggers a software install only on hosts missing the software. |
 
-Only one of `labels_include_any` or `labels_exclude_any` can be specified. If neither are specified, all hosts are targeted.
+Both `labels_include_any` and `labels_exclude_any` can be specified together to combine inclusion and exclusion scoping. If neither are specified, all hosts are targeted.
 
 Add the `X-Fleet-Scripts-Encoded: base64` header line to parse `install_script`, `uninstall_script`, `post_install_script`, and `pre_install_query` fields as bas64-encoded rather than as-is.
 

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -223,50 +223,91 @@ func ValidateSoftwareLabels(ctx context.Context, svc fleet.Service, teamID *uint
 		return nil, fleet.NewAuthRequiredError("validate software labels: method requires previous authorization")
 	}
 
-	var count int
-	for _, set := range [][]string{labelsIncludeAny, labelsExcludeAny, labelsIncludeAll} {
-		if len(set) > 0 {
-			count++
-		}
-	}
-	if count > 1 {
-		return nil, &fleet.BadRequestError{Message: `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included.`}
+	// Validate that include_any and include_all are not combined (they conflict),
+	// but allow combining either include scope with exclude_any.
+	hasIncludeAny := len(labelsIncludeAny) > 0
+	hasExcludeAny := len(labelsExcludeAny) > 0
+	hasIncludeAll := len(labelsIncludeAll) > 0
+
+	if hasIncludeAny && hasIncludeAll {
+		return nil, &fleet.BadRequestError{Message: `"labels_include_all" and "labels_include_any" cannot be combined.`}
 	}
 
-	var names []string
+	// Determine the primary include scope
+	var includeNames []string
 	var scope fleet.LabelScope
 	switch {
-	case len(labelsIncludeAny) > 0:
-		names = labelsIncludeAny
+	case hasIncludeAny:
+		includeNames = labelsIncludeAny
 		scope = fleet.LabelScopeIncludeAny
-	case len(labelsExcludeAny) > 0:
-		names = labelsExcludeAny
-		scope = fleet.LabelScopeExcludeAny
-	case len(labelsIncludeAll) > 0:
-		names = labelsIncludeAll
+	case hasIncludeAll:
+		includeNames = labelsIncludeAll
 		scope = fleet.LabelScopeIncludeAll
+	case hasExcludeAny:
+		// exclude-only (no include labels)
+		scope = fleet.LabelScopeExcludeAny
 	}
 
-	if len(names) == 0 {
+	if len(includeNames) == 0 && len(labelsExcludeAny) == 0 {
 		// nothing to validate, return empty result
 		return &fleet.LabelIdentsWithScope{}, nil
 	}
 
-	byName, err := svc.BatchValidateLabels(ctx, teamID, names)
-	if err != nil {
-		var missingLabelErr *fleet.MissingLabelError
-		if errors.As(err, &missingLabelErr) {
-			return nil, &fleet.BadRequestError{
-				InternalErr: missingLabelErr,
-				Message:     fmt.Sprintf("Couldn't update. Label %q doesn't exist. Please remove the label from the software.", missingLabelErr.MissingLabelName),
+	// Validate include labels
+	var includeByName map[string]fleet.LabelIdent
+	if len(includeNames) > 0 {
+		var err error
+		includeByName, err = svc.BatchValidateLabels(ctx, teamID, includeNames)
+		if err != nil {
+			var missingLabelErr *fleet.MissingLabelError
+			if errors.As(err, &missingLabelErr) {
+				return nil, &fleet.BadRequestError{
+					InternalErr: missingLabelErr,
+					Message:     fmt.Sprintf("Couldn't update. Label %q doesn't exist. Please remove the label from the software.", missingLabelErr.MissingLabelName),
+				}
+			}
+			return nil, err
+		}
+	}
+
+	// Validate exclude labels
+	var excludeByName map[string]fleet.LabelIdent
+	if hasExcludeAny {
+		if len(includeNames) > 0 {
+			// Combined include + exclude: validate exclude labels separately
+			var err error
+			excludeByName, err = svc.BatchValidateLabels(ctx, teamID, labelsExcludeAny)
+			if err != nil {
+				var missingLabelErr *fleet.MissingLabelError
+				if errors.As(err, &missingLabelErr) {
+					return nil, &fleet.BadRequestError{
+						InternalErr: missingLabelErr,
+						Message:     fmt.Sprintf("Couldn't update. Label %q doesn't exist. Please remove the label from the software.", missingLabelErr.MissingLabelName),
+					}
+				}
+				return nil, err
+			}
+		} else {
+			// Exclude-only: put exclude labels in ByName (backward compatible)
+			var err error
+			includeByName, err = svc.BatchValidateLabels(ctx, teamID, labelsExcludeAny)
+			if err != nil {
+				var missingLabelErr *fleet.MissingLabelError
+				if errors.As(err, &missingLabelErr) {
+					return nil, &fleet.BadRequestError{
+						InternalErr: missingLabelErr,
+						Message:     fmt.Sprintf("Couldn't update. Label %q doesn't exist. Please remove the label from the software.", missingLabelErr.MissingLabelName),
+					}
+				}
+				return nil, err
 			}
 		}
-		return nil, err
 	}
 
 	return &fleet.LabelIdentsWithScope{
-		LabelScope: scope,
-		ByName:     byName,
+		LabelScope:    scope,
+		ByName:        includeByName,
+		ExcludeByName: excludeByName,
 	}, nil
 }
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1852,17 +1852,23 @@ func (svc *Service) editTeamFromSpec(
 
 func validateTeamCustomSettings(invalid *fleet.InvalidArgumentError, prefix string, customSettings []fleet.MDMProfileSpec) {
 	for i, prof := range customSettings {
-		count := 0
-		for _, b := range []bool{len(prof.Labels) > 0, len(prof.LabelsIncludeAll) > 0, len(prof.LabelsIncludeAny) > 0, len(prof.LabelsExcludeAny) > 0} {
-			if b {
-				count++
-			}
-		}
-		if count > 1 {
+		hasLabels := len(prof.Labels) > 0
+		hasInclAll := len(prof.LabelsIncludeAll) > 0
+		hasInclAny := len(prof.LabelsIncludeAny) > 0
+		hasExclAny := len(prof.LabelsExcludeAny) > 0
+
+		// Allow combining an include scope with exclude_any, but disallow
+		// include_any + include_all and deprecated labels + anything else.
+		if hasLabels && (hasInclAll || hasInclAny || hasExclAny) {
 			invalid.Append(fmt.Sprintf("%s_settings.configuration_profiles", prefix),
-				fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`, prefix))
+				fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. Deprecated "labels" field cannot be combined with other label fields.`, prefix))
 		}
-		if len(prof.Labels) > 0 {
+		if hasInclAll && hasInclAny {
+			invalid.Append(fmt.Sprintf("%s_settings.configuration_profiles", prefix),
+				fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. "labels_include_all" and "labels_include_any" cannot be combined.`, prefix))
+		}
+		_ = hasExclAny // exclude_any can be combined with either include scope
+		if hasLabels {
 			customSettings[i].LabelsIncludeAll = customSettings[i].Labels
 			customSettings[i].Labels = nil
 		}

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -27,15 +27,28 @@ export const listNamesFromSelectedLabels = (dict: Record<string, boolean>) => {
 export const generateLabelKey = (
   target: string,
   customTargetOption: string,
-  selectedLabels: Record<string, boolean>
+  selectedLabels: Record<string, boolean>,
+  selectedExcludeLabels?: Record<string, boolean>
 ) => {
   if (target !== "Custom") {
     return {};
   }
 
-  return {
+  const result: Record<string, string[]> = {
     [customTargetOption]: listNamesFromSelectedLabels(selectedLabels),
   };
+
+  // When combining include + exclude, also add the exclude labels
+  if (
+    selectedExcludeLabels &&
+    customTargetOption !== "labelsExcludeAny" &&
+    listNamesFromSelectedLabels(selectedExcludeLabels).length > 0
+  ) {
+    result.labelsExcludeAny =
+      listNamesFromSelectedLabels(selectedExcludeLabels);
+  }
+
+  return result;
 };
 
 interface ITargetChooserProps {
@@ -186,6 +199,18 @@ interface ITargetLabelSelectorProps {
   title?: string;
   suppressTitle?: boolean;
   subTitle?: string;
+  /** Optional: enable combined include+exclude label selection.
+   * When true and an include mode is selected, an additional exclude label
+   * section is shown below the include labels. */
+  enableExcludeLabels?: boolean;
+  selectedExcludeLabels?: Record<string, boolean>;
+  onSelectExcludeLabel?: ({
+    name,
+    value,
+  }: {
+    name: string;
+    value: boolean;
+  }) => void;
 }
 
 const TargetLabelSelector = ({
@@ -206,8 +231,18 @@ const TargetLabelSelector = ({
   title = "Target",
   subTitle,
   suppressTitle = false,
+  enableExcludeLabels = false,
+  selectedExcludeLabels = {},
+  onSelectExcludeLabel,
 }: ITargetLabelSelectorProps) => {
   const classNames = classnames(baseClass, className, "form");
+
+  // Show the exclude section when an include mode is active (not "labelsExcludeAny")
+  const showExcludeSection =
+    enableExcludeLabels &&
+    selectedTargetType === "Custom" &&
+    selectedCustomTarget !== "labelsExcludeAny" &&
+    onSelectExcludeLabel;
 
   return (
     <div className={classNames}>
@@ -219,19 +254,44 @@ const TargetLabelSelector = ({
         subTitle={subTitle}
       />
       {selectedTargetType === "Custom" && (
-        <LabelChooser
-          selectedCustomTarget={selectedCustomTarget}
-          customTargetOptions={customTargetOptions}
-          isError={isErrorLabels}
-          isLoading={isLoadingLabels}
-          labels={labels || []}
-          selectedLabels={selectedLabels}
-          customHelpText={customHelpText}
-          dropdownHelpText={dropdownHelpText}
-          onSelectCustomTarget={onSelectCustomTarget}
-          onSelectLabel={onSelectLabel}
-          disableOptions={disableOptions}
-        />
+        <>
+          <LabelChooser
+            selectedCustomTarget={selectedCustomTarget}
+            customTargetOptions={customTargetOptions}
+            isError={isErrorLabels}
+            isLoading={isLoadingLabels}
+            labels={labels || []}
+            selectedLabels={selectedLabels}
+            customHelpText={customHelpText}
+            dropdownHelpText={dropdownHelpText}
+            onSelectCustomTarget={onSelectCustomTarget}
+            onSelectLabel={onSelectLabel}
+            disableOptions={disableOptions}
+          />
+          {showExcludeSection && labels.length > 0 && (
+            <div className={`${baseClass}__exclude-section`}>
+              <div className={`${baseClass}__exclude-header`}>
+                Additionally exclude hosts with any of these labels:
+              </div>
+              <div className={`${baseClass}__checkboxes`}>
+                {labels.map((label) => (
+                  <div className={`${baseClass}__label`} key={label.name}>
+                    <Checkbox
+                      className={`${baseClass}__checkbox`}
+                      name={label.name}
+                      value={!!selectedExcludeLabels[label.name]}
+                      onChange={onSelectExcludeLabel}
+                      parseTarget
+                    />
+                    <div className={`${baseClass}__label-name`}>
+                      {label.name}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -44,8 +44,9 @@ export const generateLabelKey = (
     customTargetOption !== "labelsExcludeAny" &&
     listNamesFromSelectedLabels(selectedExcludeLabels).length > 0
   ) {
-    result.labelsExcludeAny =
-      listNamesFromSelectedLabels(selectedExcludeLabels);
+    result.labelsExcludeAny = listNamesFromSelectedLabels(
+      selectedExcludeLabels
+    );
   }
 
   return result;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -109,6 +109,7 @@ const EditSoftwareModal = ({
     targetType: "",
     customTarget: "",
     labelTargets: {},
+    excludeLabelTargets: {},
     categories: [],
   });
   const [

--- a/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/PackageForm/PackageForm.tsx
@@ -23,6 +23,7 @@ import {
   CUSTOM_TARGET_OPTIONS,
   generateHelpText,
   generateSelectedLabels,
+  generateSelectedExcludeLabels,
   getCustomTarget,
   getTargetType,
 } from "pages/SoftwarePage/helpers";
@@ -53,6 +54,7 @@ export interface IPackageFormData {
   targetType: string;
   customTarget: string;
   labelTargets: Record<string, boolean>;
+  excludeLabelTargets: Record<string, boolean>;
   automaticInstall: boolean; // Used on add but not edit
   categories: string[];
 }
@@ -190,6 +192,7 @@ const PackageForm = ({
     targetType: getTargetType(defaultSoftware),
     customTarget: getCustomTarget(defaultSoftware),
     labelTargets: generateSelectedLabels(defaultSoftware),
+    excludeLabelTargets: generateSelectedExcludeLabels(defaultSoftware),
     automaticInstall: false,
     categories: defaultCategories || [],
   };
@@ -333,6 +336,24 @@ const PackageForm = ({
     setFormValidation(generateFormValidation(newData));
   };
 
+  const onSelectExcludeLabel = ({
+    name,
+    value,
+  }: {
+    name: string;
+    value: boolean;
+  }) => {
+    const newData = {
+      ...formData,
+      excludeLabelTargets: {
+        ...formData.excludeLabelTargets,
+        [name]: value,
+      },
+    };
+    setFormData(newData);
+    setFormValidation(generateFormValidation(newData));
+  };
+
   const onSelectVersion = (version: string) => {
     // For now we can only update version in GitOps
     // Selection is currently disabled in the UI
@@ -438,6 +459,9 @@ const PackageForm = ({
         formData.targetType === "Custom" &&
         generateHelpText(formData.automaticInstall, formData.customTarget)
       }
+      enableExcludeLabels
+      selectedExcludeLabels={formData.excludeLabelTargets}
+      onSelectExcludeLabel={onSelectExcludeLabel}
     />
   );
 

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -101,6 +101,8 @@ export const getCustomTarget = (
 };
 
 // Used in EditSoftwareModal and PackageForm
+// When both include and exclude labels exist, this returns only the include labels
+// for the primary label selection. Use generateSelectedExcludeLabels for the exclude set.
 export const generateSelectedLabels = (
   softwareInstaller: ISoftwarePackage | IAppStoreApp
 ) => {
@@ -113,6 +115,7 @@ export const generateSelectedLabels = (
     return {};
   }
 
+  // When both include and exclude exist, return only include labels
   let customTypeKey:
     | "labels_include_any"
     | "labels_include_all"
@@ -127,6 +130,30 @@ export const generateSelectedLabels = (
 
   return (
     softwareInstaller[customTypeKey]?.reduce<Record<string, boolean>>(
+      (acc, label) => {
+        acc[label.name] = true;
+        return acc;
+      },
+      {}
+    ) ?? {}
+  );
+};
+
+// Returns exclude labels when combined with an include scope.
+// Only populated when both include_any/include_all AND exclude_any are present.
+export const generateSelectedExcludeLabels = (
+  softwareInstaller: ISoftwarePackage | IAppStoreApp
+): Record<string, boolean> => {
+  if (!softwareInstaller) return {};
+
+  // Only return exclude labels when there's also an include scope
+  const hasInclude =
+    softwareInstaller.labels_include_any ||
+    softwareInstaller.labels_include_all;
+  if (!hasInclude || !softwareInstaller.labels_exclude_any) return {};
+
+  return (
+    softwareInstaller.labels_exclude_any.reduce<Record<string, boolean>>(
       (acc, label) => {
         acc[label.name] = true;
         return acc;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -360,7 +360,7 @@ describe("PolicyForm - component", () => {
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeDisabled();
 
-        const funButton = screen.getByLabelText("Fun");
+        const funButton = screen.getAllByLabelText("Fun")[0];
         expect(funButton).not.toBeChecked();
         await userEvent.click(funButton);
         await waitFor(() => {
@@ -378,7 +378,7 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(screen.getAllByLabelText("Fun")[0]);
 
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeEnabled();
@@ -398,7 +398,7 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(screen.getAllByLabelText("Fun")[0]);
 
         // Click "Include any" to open the dropdown.
         const includeAnyOption = screen.getByRole("option", {
@@ -433,7 +433,7 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(screen.getAllByLabelText("Fun")[0]);
 
         await userEvent.click(screen.getByLabelText("All hosts"));
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -123,6 +123,9 @@ const PolicyForm = ({
     "labelsIncludeAny"
   );
   const [selectedLabels, setSelectedLabels] = useState({});
+  const [selectedExcludeLabels, setSelectedExcludeLabels] = useState<
+    Record<string, boolean>
+  >({});
 
   const isPatchPolicy = storedPolicy?.type === "patch";
   const [isAddingAutomation, setIsAddingAutomation] = useState(false);
@@ -157,6 +160,19 @@ const PolicyForm = ({
   }) => {
     setSelectedLabels({
       ...selectedLabels,
+      [labelName]: value,
+    });
+  };
+
+  const onSelectExcludeLabel = ({
+    name: labelName,
+    value,
+  }: {
+    name: string;
+    value: boolean;
+  }) => {
+    setSelectedExcludeLabels({
+      ...selectedExcludeLabels,
       [labelName]: value,
     });
   };
@@ -246,27 +262,44 @@ const PolicyForm = ({
     DEFAULT_POLICIES.find((p) => p.name === lastEditedQueryName);
 
   useEffect(() => {
+    const hasInclude = lastEditedQueryLabelsIncludeAny.length > 0;
+    const hasExclude = lastEditedQueryLabelsExcludeAny.length > 0;
+
     setSelectedTargetType(
-      !lastEditedQueryLabelsIncludeAny.length &&
-        !lastEditedQueryLabelsExcludeAny.length
-        ? "All hosts"
-        : "Custom"
+      !hasInclude && !hasExclude ? "All hosts" : "Custom"
     );
-    setSelectedCustomTarget(
-      lastEditedQueryLabelsExcludeAny.length
-        ? "labelsExcludeAny"
-        : "labelsIncludeAny"
-    );
-    setSelectedLabels(
-      lastEditedQueryLabelsIncludeAny
-        .concat(lastEditedQueryLabelsExcludeAny)
-        .reduce((acc, label) => {
-          return {
-            ...acc,
-            [label.name]: true,
-          };
-        }, {}) || {}
-    );
+
+    // When both include and exclude exist, the primary mode is include
+    // and excludes are in the separate exclude section.
+    // When only exclude exists, the primary mode is exclude.
+    if (hasInclude) {
+      setSelectedCustomTarget("labelsIncludeAny");
+      setSelectedLabels(
+        lastEditedQueryLabelsIncludeAny.reduce(
+          (acc, label) => ({ ...acc, [label.name]: true }),
+          {} as Record<string, boolean>
+        )
+      );
+      setSelectedExcludeLabels(
+        lastEditedQueryLabelsExcludeAny.reduce(
+          (acc, label) => ({ ...acc, [label.name]: true }),
+          {} as Record<string, boolean>
+        )
+      );
+    } else if (hasExclude) {
+      setSelectedCustomTarget("labelsExcludeAny");
+      setSelectedLabels(
+        lastEditedQueryLabelsExcludeAny.reduce(
+          (acc, label) => ({ ...acc, [label.name]: true }),
+          {} as Record<string, boolean>
+        )
+      );
+      setSelectedExcludeLabels({});
+    } else {
+      setSelectedCustomTarget("labelsIncludeAny");
+      setSelectedLabels({});
+      setSelectedExcludeLabels({});
+    }
   }, [lastEditedQueryLabelsIncludeAny, lastEditedQueryLabelsExcludeAny]);
 
   useEffect(() => {
@@ -397,26 +430,34 @@ const PolicyForm = ({
     if (!isExistingPolicy) {
       setIsSaveNewPolicyModalOpen(true);
     } else {
+      // Build include/exclude label arrays based on the selected target mode
+      let includeAny: string[] = [];
+      let excludeAny: string[] = [];
+
+      if (selectedTargetType === "Custom") {
+        const primaryLabels = Object.entries(selectedLabels)
+          .filter(([, selected]) => selected)
+          .map(([labelName]) => labelName);
+
+        if (selectedCustomTarget === "labelsIncludeAny") {
+          includeAny = primaryLabels;
+          // Also include exclude labels from the separate section
+          excludeAny = Object.entries(selectedExcludeLabels)
+            .filter(([, selected]) => selected)
+            .map(([labelName]) => labelName);
+        } else if (selectedCustomTarget === "labelsExcludeAny") {
+          excludeAny = primaryLabels;
+        }
+      }
+
       const payload: IPolicyFormData = {
         name: lastEditedQueryName,
         description: lastEditedQueryDescription,
         query: lastEditedQueryBody,
         resolution: lastEditedQueryResolution,
         platform: newPlatformString,
-        labels_include_any:
-          selectedTargetType === "Custom" &&
-          selectedCustomTarget === "labelsIncludeAny"
-            ? Object.entries(selectedLabels)
-                .filter(([, selected]) => selected)
-                .map(([labelName]) => labelName)
-            : [],
-        labels_exclude_any:
-          selectedTargetType === "Custom" &&
-          selectedCustomTarget === "labelsExcludeAny"
-            ? Object.entries(selectedLabels)
-                .filter(([, selected]) => selected)
-                .map(([labelName]) => labelName)
-            : [],
+        labels_include_any: includeAny,
+        labels_exclude_any: excludeAny,
       };
       if (isPremiumTier) {
         payload.critical = lastEditedQueryCritical;
@@ -865,6 +906,9 @@ const PolicyForm = ({
                 </span>
               }
               suppressTitle
+              enableExcludeLabels
+              selectedExcludeLabels={selectedExcludeLabels}
+              onSelectExcludeLabel={onSelectExcludeLabel}
             />
           )}
           {isExistingPolicy && storedPolicy && (

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -265,9 +265,7 @@ const PolicyForm = ({
     const hasInclude = lastEditedQueryLabelsIncludeAny.length > 0;
     const hasExclude = lastEditedQueryLabelsExcludeAny.length > 0;
 
-    setSelectedTargetType(
-      !hasInclude && !hasExclude ? "All hosts" : "Custom"
-    );
+    setSelectedTargetType(!hasInclude && !hasExclude ? "All hosts" : "Custom");
 
     // When both include and exclude exist, the primary mode is include
     // and excludes are in the separate exclude section.

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -327,6 +327,19 @@ const handleEditPackageForm = (
     selectedLabels?.forEach((label) => {
       formData.append(labelKey, label);
     });
+
+    // Add exclude labels when combining include+exclude
+    if (
+      data.excludeLabelTargets &&
+      data.customTarget !== "labelsExcludeAny"
+    ) {
+      const excludeLabels = listNamesFromSelectedLabels(
+        data.excludeLabelTargets
+      );
+      excludeLabels?.forEach((label) => {
+        formData.append("labels_exclude_any", label);
+      });
+    }
   }
 };
 

--- a/frontend/services/entities/software.ts
+++ b/frontend/services/entities/software.ts
@@ -329,10 +329,7 @@ const handleEditPackageForm = (
     });
 
     // Add exclude labels when combining include+exclude
-    if (
-      data.excludeLabelTargets &&
-      data.customTarget !== "labelsExcludeAny"
-    ) {
+    if (data.excludeLabelTargets && data.customTarget !== "labelsExcludeAny") {
       const excludeLabels = listNamesFromSelectedLabels(
         data.excludeLabelTargets
       );

--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1792,14 +1792,8 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			continue
 		}
 
-		var count int
-		for _, set := range [][]string{item.LabelsExcludeAny, item.LabelsIncludeAny, item.LabelsIncludeAll} {
-			if len(set) > 0 {
-				count++
-			}
-		}
-		if count > 1 {
-			multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified for app store app %q`, item.AppStoreID))
+		if len(item.LabelsIncludeAny) > 0 && len(item.LabelsIncludeAll) > 0 {
+			multiError = multierror.Append(multiError, fmt.Errorf(`"labels_include_all" and "labels_include_any" cannot be combined for app store app %q`, item.AppStoreID))
 			continue
 		}
 
@@ -1819,14 +1813,8 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 			continue
 		}
 
-		var count int
-		for _, set := range [][]string{maintainedAppSpec.LabelsExcludeAny, maintainedAppSpec.LabelsIncludeAny, maintainedAppSpec.LabelsIncludeAll} {
-			if len(set) > 0 {
-				count++
-			}
-		}
-		if count > 1 {
-			multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified for fleet maintained app %q`, maintainedAppSpec.Slug))
+		if len(maintainedAppSpec.LabelsIncludeAny) > 0 && len(maintainedAppSpec.LabelsIncludeAll) > 0 {
+			multiError = multierror.Append(multiError, fmt.Errorf(`"labels_include_all" and "labels_include_any" cannot be combined for fleet maintained app %q`, maintainedAppSpec.Slug))
 			continue
 		}
 
@@ -1952,14 +1940,8 @@ func parseSoftware(top map[string]json.RawMessage, result *GitOps, baseDir strin
 				}
 			}
 
-			var count int
-			for _, set := range [][]string{softwarePackageSpec.LabelsExcludeAny, softwarePackageSpec.LabelsIncludeAny, softwarePackageSpec.LabelsIncludeAll} {
-				if len(set) > 0 {
-					count++
-				}
-			}
-			if count > 1 {
-				multiError = multierror.Append(multiError, fmt.Errorf(`only one of "labels_include_all", "labels_exclude_any" or "labels_include_any" can be specified for software URL %q`, softwarePackageSpec.URL))
+			if len(softwarePackageSpec.LabelsIncludeAny) > 0 && len(softwarePackageSpec.LabelsIncludeAll) > 0 {
+				multiError = multierror.Append(multiError, fmt.Errorf(`"labels_include_all" and "labels_include_any" cannot be combined for software URL %q`, softwarePackageSpec.URL))
 				continue
 			}
 

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2655,12 +2655,10 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 				toInstallStmt,
 				onlyProfileUUIDs, batchUUIDs,
 				onlyProfileUUIDs, batchUUIDs,
-				onlyProfileUUIDs, batchUUIDs,
-				onlyProfileUUIDs, batchUUIDs,
 				fleet.MDMOperationTypeRemove,
 			)
 		} else {
-			stmt, args, err = sqlx.In(toInstallStmt, batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs, fleet.MDMOperationTypeRemove)
+			stmt, args, err = sqlx.In(toInstallStmt, batchUUIDs, batchUUIDs, fleet.MDMOperationTypeRemove)
 		}
 
 		if err != nil {
@@ -2737,13 +2735,11 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 				toRemoveStmt,
 				onlyProfileUUIDs, batchUUIDs,
 				onlyProfileUUIDs, batchUUIDs,
-				onlyProfileUUIDs, batchUUIDs,
-				onlyProfileUUIDs, batchUUIDs,
 				batchUUIDs, onlyProfileUUIDs,
 				fleet.MDMOperationTypeRemove,
 			)
 		} else {
-			stmt, args, err = sqlx.In(toRemoveStmt, batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs, batchUUIDs, fleet.MDMOperationTypeRemove)
+			stmt, args, err = sqlx.In(toRemoveStmt, batchUUIDs, batchUUIDs, batchUUIDs, fleet.MDMOperationTypeRemove)
 		}
 
 		if err != nil {

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -2624,7 +2624,7 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 		( hmap.profile_uuid IS NULL AND hmap.host_uuid IS NULL ) OR
 		-- profiles in A and B but with operation type "remove"
 		( hmap.host_uuid IS NOT NULL AND ( hmap.operation_type = ? OR hmap.operation_type IS NULL ) )
-`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, profileHostIn, profileHostIn, profileHostIn, profileHostIn))
+`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, profileHostIn, profileHostIn))
 
 	// batches of 10K hosts because h.uuid appears three times in the
 	// query, and the max number of prepared statements is 65K, this was
@@ -2716,7 +2716,7 @@ func (ds *Datastore) bulkSetPendingMDMAppleHostProfilesDB(
 			mcpl.apple_profile_uuid = hmap.profile_uuid AND
 			mcpl.label_id IS NULL
 		)
-`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, profileHostIn, profileHostIn, profileHostIn, profileHostIn), narrowByProfiles)
+`, fmt.Sprintf(appleMDMProfilesDesiredStateQuery, profileHostIn, profileHostIn), narrowByProfiles)
 
 	var currentProfiles []*fleet.MDMAppleProfilePayload
 	for i := 0; i < selectProfilesTotalBatches; i++ {
@@ -2996,7 +2996,7 @@ func generateDesiredStateQuery(entityType string) string {
 	}
 
 	return os.Expand(`
-	-- non label-based entities
+	-- non label-based entities (apply to all hosts)
 	SELECT
 		mae.${entityUUIDColumn},
 		h.uuid as host_uuid,
@@ -3032,9 +3032,8 @@ func generateDesiredStateQuery(entityType string) string {
 
 	UNION
 
-	-- label-based entities where the host is a member of all the labels (include-all).
-	-- by design, "include" labels cannot match if they are broken (the host cannot be
-	-- a member of a deleted label).
+	-- label-based entities: all conditions (include-any, include-all, exclude-any) are AND-ed together.
+	-- This supports combined include+exclude scoping.
 	SELECT
 		mae.${entityUUIDColumn},
 		h.uuid as host_uuid,
@@ -3045,9 +3044,9 @@ func generateDesiredStateQuery(entityType string) string {
 		mae.secrets_updated_at as secrets_updated_at,
 		mae.scope as scope,
 		nd.authenticate_at as device_enrolled_at,
-		COUNT(*) as ${countEntityLabelsColumn},
-		COUNT(mel.label_id) as count_non_broken_labels,
-		COUNT(lm.label_id) as count_host_labels,
+		0 as ${countEntityLabelsColumn},
+		0 as count_non_broken_labels,
+		0 as count_host_labels,
 		0 as count_host_updated_after_labels
 	FROM
 		${mdmAppleEntityTable} mae
@@ -3057,113 +3056,83 @@ func generateDesiredStateQuery(entityType string) string {
 				ON ne.device_id = h.uuid
 			JOIN nano_devices nd
 				ON nd.id = ne.device_id
-			JOIN ${mdmEntityLabelsTable} mel
-				ON mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 1
-			LEFT OUTER JOIN label_membership lm
-				ON lm.label_id = mel.label_id AND lm.host_id = h.id
 	WHERE
 		(h.platform = 'darwin' OR h.platform = 'ios' OR h.platform = 'ipados') AND
 		ne.enabled = 1 AND
 		ne.type IN ('Device', 'User Enrollment (Device)') AND
-		( %s )
-	GROUP BY
-		mae.${entityUUIDColumn}, h.uuid, h.platform, mae.identifier, mae.name, mae.${checksumColumn}, mae.secrets_updated_at, mae.scope
-	HAVING
-		${countEntityLabelsColumn} > 0 AND count_host_labels = ${countEntityLabelsColumn}
-
-	UNION
-
-	-- label-based entities where the host is NOT a member of any of the labels (exclude-any).
-	-- explicitly ignore profiles with broken excluded labels so that they are never applied,
-	-- and ignore profiles that depend on labels created _after_ the label_updated_at timestamp
-	-- of the host (because we don't have results for that label yet, the host may or may not be
-	-- a member).
-	SELECT
-		mae.${entityUUIDColumn},
-		h.uuid as host_uuid,
-		h.platform as host_platform,
-		mae.identifier as ${entityIdentifierColumn},
-		mae.name as ${entityNameColumn},
-		mae.${checksumColumn} as ${checksumColumn},
-		mae.secrets_updated_at as secrets_updated_at,
-		mae.scope as scope,
-		nd.authenticate_at as device_enrolled_at,
-		COUNT(*) as ${countEntityLabelsColumn},
-		COUNT(mel.label_id) as count_non_broken_labels,
-		COUNT(lm.label_id) as count_host_labels,
-		-- this helps avoid the case where the host is not a member of a label
-		-- just because it hasn't reported results for that label yet. But we
-		-- only need consider this for dynamic labels - manual(type=1) can be
-		-- considered at any time
-		SUM(
-			CASE WHEN lbl.label_membership_type <> 1 AND lbl.created_at IS NOT NULL AND h.label_updated_at >= lbl.created_at THEN 1
-			WHEN lbl.label_membership_type = 1 AND lbl.created_at IS NOT NULL THEN 1
-			ELSE 0 END) as count_host_updated_after_labels
-	FROM
-		${mdmAppleEntityTable} mae
-			JOIN hosts h
-				ON h.team_id = mae.team_id OR (h.team_id IS NULL AND mae.team_id = 0)
-			JOIN nano_enrollments ne
-				ON ne.device_id = h.uuid
-			JOIN nano_devices nd
-				ON nd.id = ne.device_id
-			JOIN ${mdmEntityLabelsTable} mel
-				ON mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 1 AND mel.require_all = 0
-			LEFT OUTER JOIN labels lbl
-				ON lbl.id = mel.label_id
-			LEFT OUTER JOIN label_membership lm
-				ON lm.label_id = mel.label_id AND lm.host_id = h.id
-	WHERE
-		(h.platform = 'darwin' OR h.platform = 'ios' OR h.platform = 'ipados') AND
-		ne.enabled = 1 AND
-		ne.type IN ('Device', 'User Enrollment (Device)') AND
-		( %s )
-	GROUP BY
-		mae.${entityUUIDColumn}, h.uuid, h.platform, mae.identifier, mae.name, mae.${checksumColumn}, mae.secrets_updated_at, mae.scope
-	HAVING
-		-- considers only the profiles with labels, without any broken label, with results reported after all labels were created and with the host not in any label
-		${countEntityLabelsColumn} > 0 AND ${countEntityLabelsColumn} = count_non_broken_labels AND ${countEntityLabelsColumn} = count_host_updated_after_labels AND count_host_labels = 0
-
-	UNION
-
-	-- label-based entities where the host is a member of any the labels (include-any).
-	-- by design, "include" labels cannot match if they are broken (the host cannot be
-	-- a member of a deleted label).
-	SELECT
-		mae.${entityUUIDColumn},
-		h.uuid as host_uuid,
-		h.platform as host_platform,
-		mae.identifier as ${entityIdentifierColumn},
-		mae.name as ${entityNameColumn},
-		mae.${checksumColumn} as ${checksumColumn},
-		mae.secrets_updated_at as secrets_updated_at,
-		mae.scope as scope,
-		nd.authenticate_at as device_enrolled_at,
-		COUNT(*) as ${countEntityLabelsColumn},
-		COUNT(mel.label_id) as count_non_broken_labels,
-		COUNT(lm.label_id) as count_host_labels,
-		0 as count_host_updated_after_labels
-	FROM
-		${mdmAppleEntityTable} mae
-			JOIN hosts h
-				ON h.team_id = mae.team_id OR (h.team_id IS NULL AND mae.team_id = 0)
-			JOIN nano_enrollments ne
-				ON ne.device_id = h.uuid
-			JOIN nano_devices nd
-				ON nd.id = ne.device_id
-			JOIN ${mdmEntityLabelsTable} mel
-				ON mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 0
-			LEFT OUTER JOIN label_membership lm
-				ON lm.label_id = mel.label_id AND lm.host_id = h.id
-	WHERE
-		(h.platform = 'darwin' OR h.platform = 'ios' OR h.platform = 'ipados') AND
-		ne.enabled = 1 AND
-		ne.type IN ('Device', 'User Enrollment (Device)') AND
-		( %s )
-	GROUP BY
-		mae.${entityUUIDColumn}, h.uuid, h.platform, mae.identifier, mae.name, mae.${checksumColumn}, mae.secrets_updated_at, mae.scope
-	HAVING
-		${countEntityLabelsColumn} > 0 AND count_host_labels >= 1
+		-- entity has at least one label
+		EXISTS (
+			SELECT 1 FROM ${mdmEntityLabelsTable} mel
+			WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn}
+		)
+		-- include-any: no include-any labels, OR host is in at least one
+		AND (
+			NOT EXISTS (
+				SELECT 1 FROM ${mdmEntityLabelsTable} mel
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 0
+			)
+			OR EXISTS (
+				SELECT 1 FROM ${mdmEntityLabelsTable} mel
+				INNER JOIN label_membership lm ON lm.label_id = mel.label_id AND lm.host_id = h.id
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 0
+			)
+		)
+		-- include-all: no include-all labels, OR host is in ALL of them
+		AND (
+			NOT EXISTS (
+				SELECT 1 FROM ${mdmEntityLabelsTable} mel
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 1
+			)
+			OR (
+				SELECT COUNT(*) FROM ${mdmEntityLabelsTable} mel
+				INNER JOIN label_membership lm ON lm.label_id = mel.label_id AND lm.host_id = h.id
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 1
+			) = (
+				SELECT COUNT(*) FROM ${mdmEntityLabelsTable} mel
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 0 AND mel.require_all = 1
+			)
+		)
+		-- exclude-any: no exclude labels, OR (all non-broken, all evaluated, host not in any)
+		AND (
+			NOT EXISTS (
+				SELECT 1 FROM ${mdmEntityLabelsTable} mel
+				WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 1 AND mel.require_all = 0
+			)
+			OR (
+				-- all exclude labels must be non-broken
+				(SELECT COUNT(mel.label_id) FROM ${mdmEntityLabelsTable} mel
+				 WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 1 AND mel.require_all = 0
+				) = (SELECT COUNT(*) FROM ${mdmEntityLabelsTable} mel
+				     WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 1 AND mel.require_all = 0
+				)
+				-- all exclude labels must be evaluated (timing check for dynamic labels)
+				AND (
+					SELECT COUNT(*) FROM ${mdmEntityLabelsTable} mel
+					INNER JOIN labels lbl ON lbl.id = mel.label_id
+					WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn}
+						AND mel.exclude = 1 AND mel.require_all = 0
+						AND (
+							lbl.label_membership_type = 1
+							OR (lbl.label_membership_type <> 1 AND lbl.created_at IS NOT NULL AND h.label_updated_at >= lbl.created_at)
+						)
+				) = (SELECT COUNT(*) FROM ${mdmEntityLabelsTable} mel
+				     WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn} AND mel.exclude = 1 AND mel.require_all = 0
+				)
+				-- host must NOT be in any exclude label
+				AND NOT EXISTS (
+					SELECT 1 FROM ${mdmEntityLabelsTable} mel
+					INNER JOIN labels lbl ON lbl.id = mel.label_id
+					INNER JOIN label_membership lm ON lm.label_id = mel.label_id AND lm.host_id = h.id
+					WHERE mel.${appleEntityUUIDColumn} = mae.${entityUUIDColumn}
+						AND mel.exclude = 1 AND mel.require_all = 0
+						AND (
+							lbl.label_membership_type = 1
+							OR (lbl.label_membership_type <> 1 AND lbl.created_at IS NOT NULL AND h.label_updated_at >= lbl.created_at)
+						)
+				)
+			)
+		)
+		AND ( %s )
 	`, func(s string) string { return dynamicNames[s] })
 }
 
@@ -3235,7 +3204,7 @@ func generateEntitiesToInstallQuery(entityType string, hostUUID string) (string,
 		( hmae.host_uuid IS NOT NULL AND hmae.operation_type = ? AND hmae.status IS NULL )
 `, func(s string) string { return dynamicNames[s] }),
 		// if more instances of hostCondition are added to the query, they should also be added to the args above
-		fmt.Sprintf(generateDesiredStateQuery(entityType), hostCondition, hostCondition, hostCondition, hostCondition),
+		fmt.Sprintf(generateDesiredStateQuery(entityType), hostCondition, hostCondition),
 	), args
 }
 
@@ -3295,7 +3264,7 @@ func generateEntitiesToRemoveQuery(entityType string) (string, []any) {
 				mcpl.${appleEntityUUIDColumn} = hmae.${entityUUIDColumn} AND
 				mcpl.label_id IS NULL
 		)
-`, func(s string) string { return dynamicNames[s] }), fmt.Sprintf(generateDesiredStateQuery(entityType), "TRUE", "TRUE", "TRUE", "TRUE")), args
+`, func(s string) string { return dynamicNames[s] }), fmt.Sprintf(generateDesiredStateQuery(entityType), "TRUE", "TRUE")), args
 }
 
 // Optional hostUUID to list profiles to install for a single host instead of all.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -3180,7 +3180,7 @@ func generateEntitiesToInstallQuery(entityType string, hostUUID string) (string,
 	hostCondition := "TRUE" // We specify true here as it gets passed to the AND (%s) later, and is the default value.
 	if hostUUID != "" {
 		hostCondition = "h.uuid = ?"
-		args = append(args, hostUUID, hostUUID, hostUUID, hostUUID)
+		args = append(args, hostUUID, hostUUID)
 	}
 
 	args = append(args, fleet.MDMOperationTypeRemove, fleet.MDMOperationTypeInstall)

--- a/server/datastore/mysql/combined_labels_integration_test.go
+++ b/server/datastore/mysql/combined_labels_integration_test.go
@@ -1,0 +1,232 @@
+package mysql
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	fleetptr "github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCombinedIncludeExcludeLabels validates that the combined include+exclude
+// label scoping works correctly end-to-end through the database layer.
+// This test requires MYSQL_TEST=1 and a running MySQL instance (port 3307).
+func TestCombinedIncludeExcludeLabels(t *testing.T) {
+	ds := CreateMySQLDS(t)
+	defer ds.Close()
+	ctx := context.Background()
+
+	// --- Setup: Create labels ---
+	inclLabel, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "engineering",
+		Query:               "SELECT 1",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeManual,
+	})
+	require.NoError(t, err)
+
+	exclLabel, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "g-mdm",
+		Query:               "SELECT 1",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeManual,
+	})
+	require.NoError(t, err)
+
+	otherLabel, err := ds.NewLabel(ctx, &fleet.Label{
+		Name:                "finance",
+		Query:               "SELECT 1",
+		LabelType:           fleet.LabelTypeRegular,
+		LabelMembershipType: fleet.LabelMembershipTypeManual,
+	})
+	require.NoError(t, err)
+
+	// --- Setup: Create hosts ---
+	hostInIncludeOnly, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   fleetptr.String("host-include-only"),
+		NodeKey:         fleetptr.String("node-include-only"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	hostInBoth, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   fleetptr.String("host-in-both"),
+		NodeKey:         fleetptr.String("node-in-both"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	hostInExcludeOnly, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   fleetptr.String("host-exclude-only"),
+		NodeKey:         fleetptr.String("node-exclude-only"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	hostInNeither, err := ds.NewHost(ctx, &fleet.Host{
+		OsqueryHostID:   fleetptr.String("host-in-neither"),
+		NodeKey:         fleetptr.String("node-in-neither"),
+		DetailUpdatedAt: ds.clock.Now(),
+		LabelUpdatedAt:  ds.clock.Now(),
+		SeenTime:        ds.clock.Now(),
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	// --- Setup: Create label memberships ---
+	boolTrue := true
+	boolFalse := false
+
+	// hostInIncludeOnly -> in "engineering" only
+	err = ds.RecordLabelQueryExecutions(ctx, hostInIncludeOnly, map[uint]*bool{
+		inclLabel.ID: &boolTrue,
+		exclLabel.ID: &boolFalse,
+	}, ds.clock.Now(), false)
+	require.NoError(t, err)
+
+	// hostInBoth -> in "engineering" AND "g-mdm"
+	err = ds.RecordLabelQueryExecutions(ctx, hostInBoth, map[uint]*bool{
+		inclLabel.ID: &boolTrue,
+		exclLabel.ID: &boolTrue,
+	}, ds.clock.Now(), false)
+	require.NoError(t, err)
+
+	// hostInExcludeOnly -> in "g-mdm" only
+	err = ds.RecordLabelQueryExecutions(ctx, hostInExcludeOnly, map[uint]*bool{
+		inclLabel.ID: &boolFalse,
+		exclLabel.ID: &boolTrue,
+	}, ds.clock.Now(), false)
+	require.NoError(t, err)
+
+	// hostInNeither -> in neither
+	err = ds.RecordLabelQueryExecutions(ctx, hostInNeither, map[uint]*bool{
+		inclLabel.ID: &boolFalse,
+		exclLabel.ID: &boolFalse,
+	}, ds.clock.Now(), false)
+	require.NoError(t, err)
+
+	// --- Test 1: Create a policy with COMBINED include_any + exclude_any ---
+	policy, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:             "combined-label-policy",
+		Query:            "SELECT 1 FROM osquery_info",
+		LabelsIncludeAny: []string{inclLabel.Name},
+		LabelsExcludeAny: []string{exclLabel.Name},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, policy)
+
+	policyIDStr := fmt.Sprintf("%d", policy.ID)
+
+	// --- Verify: policy_labels table has BOTH include and exclude rows ---
+	type policyLabelRow struct {
+		PolicyID uint `db:"policy_id"`
+		LabelID  uint `db:"label_id"`
+		Exclude  bool `db:"exclude"`
+	}
+	var pLabels []policyLabelRow
+	err = ds.writer(ctx).SelectContext(ctx, &pLabels,
+		"SELECT policy_id, label_id, exclude FROM policy_labels WHERE policy_id = ? ORDER BY label_id", policy.ID)
+	require.NoError(t, err)
+	require.Len(t, pLabels, 2, "expected 2 policy_labels rows (1 include + 1 exclude)")
+
+	// Find include and exclude rows
+	var foundInclude, foundExclude bool
+	for _, pl := range pLabels {
+		if pl.LabelID == inclLabel.ID && !pl.Exclude {
+			foundInclude = true
+		}
+		if pl.LabelID == exclLabel.ID && pl.Exclude {
+			foundExclude = true
+		}
+	}
+	require.True(t, foundInclude, "expected include label row with exclude=false")
+	require.True(t, foundExclude, "expected exclude label row with exclude=true")
+
+	// --- Test 2: PolicyQueriesForHost returns correct results ---
+	t.Run("host in include only -> policy applies", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInIncludeOnly)
+		require.NoError(t, err)
+		_, applies := queries[policyIDStr]
+		require.True(t, applies, "policy should apply to host in include label only")
+	})
+
+	t.Run("host in both include and exclude -> policy does NOT apply", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInBoth)
+		require.NoError(t, err)
+		_, applies := queries[policyIDStr]
+		require.False(t, applies, "policy should NOT apply to host in both include and exclude labels")
+	})
+
+	t.Run("host in exclude only -> policy does NOT apply", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInExcludeOnly)
+		require.NoError(t, err)
+		_, applies := queries[policyIDStr]
+		require.False(t, applies, "policy should NOT apply to host in exclude label only")
+	})
+
+	t.Run("host in neither -> policy does NOT apply", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInNeither)
+		require.NoError(t, err)
+		_, applies := queries[policyIDStr]
+		require.False(t, applies, "policy should NOT apply to host in neither label")
+	})
+
+	// --- Test 3: Backward compat - include_any only ---
+	policyIncludeOnly, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:             "include-only-policy",
+		Query:            "SELECT 1 FROM osquery_info WHERE 1=1",
+		LabelsIncludeAny: []string{inclLabel.Name},
+	})
+	require.NoError(t, err)
+	inclOnlyIDStr := fmt.Sprintf("%d", policyIncludeOnly.ID)
+
+	t.Run("include-only: host with label -> applies", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInIncludeOnly)
+		require.NoError(t, err)
+		_, applies := queries[inclOnlyIDStr]
+		require.True(t, applies)
+	})
+
+	t.Run("include-only: host without label -> does not apply", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInNeither)
+		require.NoError(t, err)
+		_, applies := queries[inclOnlyIDStr]
+		require.False(t, applies)
+	})
+
+	// --- Test 4: Backward compat - exclude_any only ---
+	policyExcludeOnly, err := ds.NewGlobalPolicy(ctx, nil, fleet.PolicyPayload{
+		Name:             "exclude-only-policy",
+		Query:            "SELECT 1 FROM osquery_info WHERE 2=2",
+		LabelsExcludeAny: []string{exclLabel.Name},
+	})
+	require.NoError(t, err)
+	exclOnlyIDStr := fmt.Sprintf("%d", policyExcludeOnly.ID)
+
+	t.Run("exclude-only: host with exclude label -> does not apply", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInExcludeOnly)
+		require.NoError(t, err)
+		_, applies := queries[exclOnlyIDStr]
+		require.False(t, applies)
+	})
+
+	t.Run("exclude-only: host without exclude label -> applies", func(t *testing.T) {
+		queries, err := ds.PolicyQueriesForHost(ctx, hostInIncludeOnly)
+		require.NoError(t, err)
+		_, applies := queries[exclOnlyIDStr]
+		require.True(t, applies)
+	})
+
+	_ = otherLabel // suppress unused
+}

--- a/server/datastore/mysql/in_house_apps.go
+++ b/server/datastore/mysql/in_house_apps.go
@@ -225,14 +225,9 @@ WHERE
 		}
 	}
 
-	var count int
-	for _, set := range [][]fleet.SoftwareScopeLabel{exclAny, inclAny, inclAll} {
-		if len(set) > 0 {
-			count++
-		}
-	}
-	if count > 1 {
-		ds.logger.WarnContext(ctx, "in house app has more than one scope of labels", "installer_id", dest.InstallerID, "include_any", fmt.Sprintf("%v", inclAny), "exclude_any", fmt.Sprintf("%v", exclAny), "include_all", fmt.Sprintf("%v", inclAll))
+	// include_any + include_all is invalid; include + exclude is allowed
+	if len(inclAny) > 0 && len(inclAll) > 0 {
+		ds.logger.WarnContext(ctx, "in house app has conflicting include scopes", "installer_id", dest.InstallerID, "include_any", fmt.Sprintf("%v", inclAny), "include_all", fmt.Sprintf("%v", inclAll))
 	}
 	dest.LabelsExcludeAny = exclAny
 	dest.LabelsIncludeAny = inclAny

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1109,7 +1109,7 @@ func (ds *Datastore) GetHostMDMProfilesExpectedForVerification(ctx context.Conte
 
 func (ds *Datastore) getHostMDMWindowsProfilesExpectedForVerification(ctx context.Context, teamID, hostID uint) (map[string]*fleet.ExpectedMDMProfile, error) {
 	stmt := `
--- profiles without labels
+-- profiles without labels (apply to all hosts in team)
 SELECT
     mwcp.profile_uuid AS profile_uuid,
 	name,
@@ -1123,97 +1123,84 @@ FROM
 WHERE
 	mwcp.team_id = ? AND
 	NOT EXISTS (
-		SELECT
-			1
-		FROM
-			mdm_configuration_profile_labels mcpl
-		WHERE
-			mcpl.windows_profile_uuid = mwcp.profile_uuid
+		SELECT 1 FROM mdm_configuration_profile_labels mcpl
+		WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid
 	)
 GROUP BY profile_uuid, name, syncml
 
 UNION
 
--- label-based profiles where the host is a member of all the labels (include-all).
--- by design, "include" labels cannot match if they are broken (the host cannot be
--- a member of a deleted label).
+-- profiles WITH labels: all conditions (include-any, include-all, exclude-any) are AND-ed together.
+-- This supports combined include+exclude scoping.
 SELECT
 	mwcp.profile_uuid AS profile_uuid,
 	name,
 	syncml AS raw_profile,
 	min(mwcp.uploaded_at) AS earliest_install_date,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) as count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels
+	0 AS count_profile_labels,
+	0 AS count_non_broken_labels,
+	0 AS count_host_labels
 FROM
 	mdm_windows_configuration_profiles mwcp
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
 WHERE
 	mwcp.team_id = ?
-GROUP BY
-	profile_uuid, name, syncml
-HAVING
-	count_profile_labels > 0 AND
-	count_host_labels = count_profile_labels
-
-UNION
-
--- label-based entities where the host is NOT a member of any of the labels (exclude-any).
--- explicitly ignore profiles with broken excluded labels so that they are never applied.
-SELECT
-	mwcp.profile_uuid AS profile_uuid,
-	name,
-	syncml AS raw_profile,
-	min(mwcp.uploaded_at) AS earliest_install_date,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) as count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels
-FROM
-	mdm_windows_configuration_profiles mwcp
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 1
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
-WHERE
-	mwcp.team_id = ?
-GROUP BY
-	profile_uuid, name, syncml
-HAVING
-	-- considers only the profiles with labels, without any broken label, and with the host not in any label
-	count_profile_labels > 0 AND
-	count_profile_labels = count_non_broken_labels AND
-	count_host_labels = 0
-
-UNION
-
--- label-based profiles where the host is a member of at least one of the labels (include-any)
-SELECT
-	mwcp.profile_uuid AS profile_uuid,
-	name,
-	syncml AS raw_profile,
-	min(mwcp.uploaded_at) AS earliest_install_date,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) as count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels
-FROM
-	mdm_windows_configuration_profiles mwcp
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
-WHERE
-	mwcp.team_id = ?
-GROUP BY
-	profile_uuid, name, syncml
-HAVING
-	count_profile_labels > 0 AND
-	count_host_labels > 0
+	-- profile has at least one label
+	AND EXISTS (
+		SELECT 1 FROM mdm_configuration_profile_labels mcpl
+		WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid
+	)
+	-- include-any: no include-any labels, OR host is in at least one
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
+		)
+		OR EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
+		)
+	)
+	-- include-all: no include-all labels, OR host is in ALL of them
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		)
+		OR (
+			SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		) = (
+			SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		)
+	)
+	-- exclude-any: no exclude labels, OR (all non-broken AND host not in any)
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 1
+		)
+		OR (
+			-- all exclude labels must be non-broken
+			(SELECT COUNT(mcpl.label_id) FROM mdm_configuration_profile_labels mcpl
+			 WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 1
+			) = (SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			     WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 1
+			)
+			-- AND host is not in any exclude label
+			AND NOT EXISTS (
+				SELECT 1 FROM mdm_configuration_profile_labels mcpl
+				INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+				WHERE mcpl.windows_profile_uuid = mwcp.profile_uuid AND mcpl.exclude = 1
+			)
+		)
+	)
+GROUP BY profile_uuid, name, syncml
 `
 	var profiles []*fleet.ExpectedMDMProfile
-	err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, teamID, hostID, teamID, hostID, teamID, hostID, teamID)
+	err := sqlx.SelectContext(ctx, ds.reader(ctx), &profiles, stmt, teamID, teamID, hostID, hostID, hostID)
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "running query for windows profiles")
 	}
@@ -1227,9 +1214,8 @@ HAVING
 }
 
 func (ds *Datastore) getHostMDMAppleProfilesExpectedForVerification(ctx context.Context, teamID uint, host *fleet.Host) (map[string]*fleet.ExpectedMDMProfile, error) {
-	// TODO This will need to be updated to support scopes
 	stmt := `
--- profiles without labels
+-- profiles without labels (apply to all hosts in team)
 SELECT
 	macp.profile_uuid AS profile_uuid,
 	macp.identifier AS identifier,
@@ -1240,128 +1226,92 @@ SELECT
 FROM
 	mdm_apple_configuration_profiles macp
 	JOIN (
-		SELECT
-			checksum,
-			min(uploaded_at) AS earliest_install_date
-		FROM
-			mdm_apple_configuration_profiles
+		SELECT checksum, min(uploaded_at) AS earliest_install_date
+		FROM mdm_apple_configuration_profiles
 		GROUP BY checksum
 	) cs ON macp.checksum = cs.checksum
 WHERE
 	macp.team_id = ? AND
 	NOT EXISTS (
-		SELECT
-			1
-		FROM
-			mdm_configuration_profile_labels mcpl
-		WHERE
-			mcpl.apple_profile_uuid = macp.profile_uuid
+		SELECT 1 FROM mdm_configuration_profile_labels mcpl
+		WHERE mcpl.apple_profile_uuid = macp.profile_uuid
 	)
 
 UNION
 
--- label-based profiles where the host is a member of all the labels (include-all)
--- by design, "include" labels cannot match if they are broken (the host cannot be
--- a member of a deleted label).
+-- profiles WITH labels: all conditions (include-any, include-all, exclude-any) are AND-ed together.
+-- This supports combined include+exclude scoping.
 SELECT
 	macp.profile_uuid AS profile_uuid,
 	macp.identifier AS identifier,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) AS count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels,
-	min(earliest_install_date) AS earliest_install_date
+	0 AS count_profile_labels,
+	0 AS count_non_broken_labels,
+	0 AS count_host_labels,
+	min(cs.earliest_install_date) AS earliest_install_date
 FROM
 	mdm_apple_configuration_profiles macp
 	JOIN (
-		SELECT
-			checksum,
-			min(uploaded_at) AS earliest_install_date
-		FROM
-			mdm_apple_configuration_profiles
+		SELECT checksum, min(uploaded_at) AS earliest_install_date
+		FROM mdm_apple_configuration_profiles
 		GROUP BY checksum
 	) cs ON macp.checksum = cs.checksum
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
 WHERE
 	macp.team_id = ?
-GROUP BY
-	profile_uuid, identifier
-HAVING
-	count_profile_labels > 0 AND
-	count_host_labels = count_profile_labels
-
-UNION
-
--- label-based entities where the host is NOT a member of any of the labels (exclude-any).
--- explicitly ignore profiles with broken excluded labels so that they are never applied.
-SELECT
-	macp.profile_uuid AS profile_uuid,
-	macp.identifier AS identifier,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) AS count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels,
-	min(earliest_install_date) AS earliest_install_date
-FROM
-	mdm_apple_configuration_profiles macp
-	JOIN (
-		SELECT
-			checksum,
-			min(uploaded_at) AS earliest_install_date
-		FROM
-			mdm_apple_configuration_profiles
-		GROUP BY checksum
-	) cs ON macp.checksum = cs.checksum
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 1
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
-WHERE
-	macp.team_id = ?
-GROUP BY
-	profile_uuid, identifier
-HAVING
-	-- considers only the profiles with labels, without any broken label, and with the host not in any label
-	count_profile_labels > 0 AND
-	count_profile_labels = count_non_broken_labels AND
-	count_host_labels = 0
-
-UNION
-
--- label-based profiles where the host is a member of at least one of the labels (include-any)
-SELECT
-	macp.profile_uuid AS profile_uuid,
-	macp.identifier AS identifier,
-	COUNT(*) AS count_profile_labels,
-	COUNT(mcpl.label_id) AS count_non_broken_labels,
-	COUNT(lm.label_id) AS count_host_labels,
-	min(earliest_install_date) AS earliest_install_date
-FROM
-	mdm_apple_configuration_profiles macp
-	JOIN (
-		SELECT
-			checksum,
-			min(uploaded_at) AS earliest_install_date
-		FROM
-			mdm_apple_configuration_profiles
-		GROUP BY checksum
-	) cs ON macp.checksum = cs.checksum
-	JOIN mdm_configuration_profile_labels mcpl
-		ON mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
-	LEFT OUTER JOIN label_membership lm
-		ON lm.label_id = mcpl.label_id AND lm.host_id = ?
-WHERE
-	macp.team_id = ?
-GROUP BY
-	profile_uuid, identifier
-HAVING
-	count_profile_labels > 0 AND
-	count_host_labels > 0
+	AND EXISTS (
+		SELECT 1 FROM mdm_configuration_profile_labels mcpl
+		WHERE mcpl.apple_profile_uuid = macp.profile_uuid
+	)
+	-- include-any: no include-any labels, OR host is in at least one
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
+		)
+		OR EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 0
+		)
+	)
+	-- include-all: no include-all labels, OR host is in ALL of them
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		)
+		OR (
+			SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		) = (
+			SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 0 AND mcpl.require_all = 1
+		)
+	)
+	-- exclude-any: no exclude labels, OR (all non-broken AND host not in any)
+	AND (
+		NOT EXISTS (
+			SELECT 1 FROM mdm_configuration_profile_labels mcpl
+			WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 1
+		)
+		OR (
+			(SELECT COUNT(mcpl.label_id) FROM mdm_configuration_profile_labels mcpl
+			 WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 1
+			) = (SELECT COUNT(*) FROM mdm_configuration_profile_labels mcpl
+			     WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 1
+			)
+			AND NOT EXISTS (
+				SELECT 1 FROM mdm_configuration_profile_labels mcpl
+				INNER JOIN label_membership lm ON lm.label_id = mcpl.label_id AND lm.host_id = ?
+				WHERE mcpl.apple_profile_uuid = macp.profile_uuid AND mcpl.exclude = 1
+			)
+		)
+	)
+GROUP BY profile_uuid, identifier
 `
 
 	var rows []*fleet.ExpectedMDMProfile
-	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, teamID, host.ID, teamID, host.ID, teamID, host.ID, teamID); err != nil {
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &rows, stmt, teamID, teamID, host.ID, host.ID, host.ID); err != nil {
 		return nil, ctxerr.Wrap(ctx, err, fmt.Sprintf("getting expected profiles for host in team %d", teamID))
 	}
 

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -185,8 +185,6 @@ func updatePolicyLabelsTx(ctx context.Context, tx sqlx.ExtContext, policy *fleet
 		return nil
 	}
 
-	var totalExpected int
-
 	// Insert include labels (exclude=false)
 	if len(includeNames) > 0 {
 		labelStmt, args, err := sqlx.In(insertLabelStmt, policy.ID, false, includeNames)
@@ -201,7 +199,6 @@ func updatePolicyLabelsTx(ctx context.Context, tx sqlx.ExtContext, policy *fleet
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "getting policy include labels rows affected")
 		}
-		totalExpected += len(includeNames)
 		if int(rowsAffected) < len(includeNames) {
 			return ctxerr.New(ctx, "some include labels not found")
 		}
@@ -221,7 +218,6 @@ func updatePolicyLabelsTx(ctx context.Context, tx sqlx.ExtContext, policy *fleet
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "getting policy exclude labels rows affected")
 		}
-		totalExpected += len(excludeNames)
 		if int(rowsAffected) < len(excludeNames) {
 			return ctxerr.New(ctx, "some exclude labels not found")
 		}

--- a/server/datastore/mysql/policies.go
+++ b/server/datastore/mysql/policies.go
@@ -167,49 +167,64 @@ func updatePolicyLabelsTx(ctx context.Context, tx sqlx.ExtContext, policy *fleet
 		WHERE name IN (?)
 	`
 
-	if len(policy.LabelsIncludeAny) > 0 && len(policy.LabelsExcludeAny) > 0 {
-		return ctxerr.New(ctx, "cannot have both labels_include_any and labels_exclude_any on a policy")
+	// Collect include and exclude label names separately
+	var includeNames []string
+	for _, label := range policy.LabelsIncludeAny {
+		includeNames = append(includeNames, label.LabelName)
 	}
-
-	var labelNames []string
-
-	exclude := false
-	if len(policy.LabelsExcludeAny) > 0 {
-		exclude = true
-		for _, label := range policy.LabelsExcludeAny {
-			labelNames = append(labelNames, label.LabelName)
-		}
-	} else {
-		for _, label := range policy.LabelsIncludeAny {
-			labelNames = append(labelNames, label.LabelName)
-		}
+	var excludeNames []string
+	for _, label := range policy.LabelsExcludeAny {
+		excludeNames = append(excludeNames, label.LabelName)
 	}
 
 	if _, err := tx.ExecContext(ctx, deleteLabelsStmt, policy.ID); err != nil {
 		return ctxerr.Wrap(ctx, err, "deleting old policy labels")
 	}
 
-	if len(policy.LabelsIncludeAny) == 0 && len(policy.LabelsExcludeAny) == 0 {
+	if len(includeNames) == 0 && len(excludeNames) == 0 {
 		return nil
 	}
 
-	labelStmt, args, err := sqlx.In(insertLabelStmt, policy.ID, exclude, labelNames)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "constructing policy label update query")
+	var totalExpected int
+
+	// Insert include labels (exclude=false)
+	if len(includeNames) > 0 {
+		labelStmt, args, err := sqlx.In(insertLabelStmt, policy.ID, false, includeNames)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "constructing policy include label query")
+		}
+		res, err := tx.ExecContext(ctx, labelStmt, args...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "creating policy include labels")
+		}
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting policy include labels rows affected")
+		}
+		totalExpected += len(includeNames)
+		if int(rowsAffected) < len(includeNames) {
+			return ctxerr.New(ctx, "some include labels not found")
+		}
 	}
 
-	res, err := tx.ExecContext(ctx, labelStmt, args...)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "creating policy labels")
-	}
-
-	rowsAffected, err := res.RowsAffected()
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "listing number of policy labels affected")
-	}
-
-	if rowsAffected != int64(len(labelNames)) {
-		return ctxerr.Errorf(ctx, "invalid label")
+	// Insert exclude labels (exclude=true)
+	if len(excludeNames) > 0 {
+		labelStmt, args, err := sqlx.In(insertLabelStmt, policy.ID, true, excludeNames)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "constructing policy exclude label query")
+		}
+		res, err := tx.ExecContext(ctx, labelStmt, args...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "creating policy exclude labels")
+		}
+		rowsAffected, err := res.RowsAffected()
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting policy exclude labels rows affected")
+		}
+		totalExpected += len(excludeNames)
+		if int(rowsAffected) < len(excludeNames) {
+			return ctxerr.New(ctx, "some exclude labels not found")
+		}
 	}
 
 	return nil

--- a/server/datastore/mysql/policies_test.go
+++ b/server/datastore/mysql/policies_test.go
@@ -730,16 +730,17 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	requireLabels(t, []string{label1.Name, label2.Name}, gpol.LabelsIncludeAny)
 
 	// Cannot create a policy with inclusive and exclusive labels set
+	// Combined include_any + exclude_any is now valid
 	gpol1, err := ds.NewGlobalPolicy(ctx, &user1.ID, fleet.PolicyPayload{
-		Name:             "global-query-bad-both-labels",
+		Name:             "global-query-combined-labels",
 		Query:            "select 1;",
 		Description:      "query1 desc",
 		Resolution:       "query1 resolution",
 		LabelsExcludeAny: []string{label1.Name},
 		LabelsIncludeAny: []string{label2.Name},
 	})
-	require.Error(t, err)
-	require.Nil(t, gpol1)
+	require.NoError(t, err)
+	require.NotNil(t, gpol1)
 
 	// Cannot create policy with invalid label set
 	gpol1, err = ds.NewGlobalPolicy(ctx, &user1.ID, fleet.PolicyPayload{
@@ -754,9 +755,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 
 	prevPolicies, err := ds.ListGlobalPolicies(ctx, fleet.ListOptions{})
 	require.NoError(t, err)
-	require.Len(t, prevPolicies, 1)
-	requireLabels(t, []string{label1.Name, label2.Name}, prevPolicies[0].LabelsIncludeAny)
-	require.Equal(t, gpol, prevPolicies[0])
+	require.Len(t, prevPolicies, 2) // gpol + gpol1 (combined labels now valid)
 
 	// team does not exist
 	_, err = ds.NewTeamPolicy(ctx, 99999999, &user1.ID, fleet.PolicyPayload{
@@ -838,8 +837,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	require.Equal(t, user1.ID, *teamPolicies[0].AuthorID)
 	requireLabels(t, []string{label1.Name, label2.Name}, teamPolicies[0].LabelsExcludeAny)
 
-	require.Len(t, inherited1, 1)
-	require.Equal(t, gpol, inherited1[0])
+	require.Len(t, inherited1, 2) // gpol + gpol1 (combined labels now valid)
 
 	team2Policies, inherited2, err := ds.ListTeamPolicies(ctx, team2.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
 	require.NoError(t, err)
@@ -852,8 +850,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	require.NotNil(t, team2Policies[0].AuthorID)
 	require.Equal(t, user1.ID, *team2Policies[0].AuthorID)
 
-	require.Len(t, inherited2, 1)
-	require.Equal(t, gpol, inherited2[0])
+	require.Len(t, inherited2, 2) // gpol + gpol1 (combined labels now valid)
 
 	// Can't create a policy with the same name on the same team.
 	p3, err := ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
@@ -865,7 +862,7 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 	require.Error(t, err)
 	require.Nil(t, p3)
 
-	// Can't create a policy with both include and excldue any labels
+	// Combined include_any + exclude_any is now valid
 	p3, err = ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
 		Name:             "query-bothlabel",
 		Query:            "select 2;",
@@ -874,11 +871,11 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 		LabelsExcludeAny: []string{label1.Name},
 		LabelsIncludeAny: []string{label2.Name},
 	})
-	require.Error(t, err)
-	require.Nil(t, p3)
+	require.NoError(t, err)
+	require.NotNil(t, p3)
 
 	// Can't create a policy with a non-existant label
-	p3, err = ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
+	p4, err := ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
 		Name:             "query-nolabel",
 		Query:            "select 2;",
 		Description:      "query2 other description",
@@ -886,16 +883,15 @@ func testTeamPolicyProprietary(t *testing.T, ds *Datastore) {
 		LabelsExcludeAny: []string{"invalid"},
 	})
 	require.Error(t, err)
-	require.Nil(t, p3)
+	require.Nil(t, p4)
 
-	_, err = ds.DeleteTeamPolicies(ctx, team1.ID, []uint{teamPolicies[0].ID})
+	_, err = ds.DeleteTeamPolicies(ctx, team1.ID, []uint{teamPolicies[0].ID, p3.ID})
 	require.NoError(t, err)
 
 	teamPolicies, inherited1, err = ds.ListTeamPolicies(ctx, team1.ID, fleet.ListOptions{}, fleet.ListOptions{}, "")
 	require.NoError(t, err)
 	require.Len(t, teamPolicies, 0)
-	require.Len(t, inherited1, 1)
-	require.Equal(t, gpol, inherited1[0])
+	require.Len(t, inherited1, 2) // gpol + gpol1
 
 	// Now the name is available and we can create the policy in the team.
 	_, err = ds.NewTeamPolicy(ctx, team1.ID, &user1.ID, fleet.PolicyPayload{
@@ -2433,11 +2429,11 @@ func testPoliciesSave(t *testing.T, ds *Datastore) {
 	assert.NotEqual(t, globalChecksum, globalChecksum2, "Checksum should be different since policy name changed")
 	assert.Equal(t, computeChecksum(*gp), hex.EncodeToString(globalChecksum2))
 
-	// Cannot save a policy with both include and exclude labels
+	// Saving a policy with both include and exclude labels is now valid
 	gp2.LabelsExcludeAny = []fleet.LabelIdent{{LabelName: label1.Name}}
 	gp2.LabelsIncludeAny = []fleet.LabelIdent{{LabelName: label2.Name}}
 	err = ds.SavePolicy(ctx, &gp2, false, false)
-	require.Error(t, err)
+	require.NoError(t, err)
 
 	// Change name, query, description and resolution of a team policy.
 	tp2 := *tp1

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -605,16 +605,14 @@ const (
 // setOrUpdateSoftwareInstallerLabelsDB sets or updates the label associations for the specified software
 // installer. If no labels are provided, it will remove all label associations with the software installer.
 func setOrUpdateSoftwareInstallerLabelsDB(ctx context.Context, tx sqlx.ExtContext, installerID uint, labels fleet.LabelIdentsWithScope, softwareType softwareType) error {
-	labelIds := make([]uint, 0, len(labels.ByName))
-	for _, label := range labels.ByName {
-		labelIds = append(labelIds, label.LabelID)
-	}
+	// Collect ALL label IDs (both include and exclude) for the delete-except logic
+	allLabelIds := labels.AllLabelIDs()
 
-	// remove existing labels
+	// remove existing labels that are not in the new set
 	delArgs := []interface{}{installerID}
 	delStmt := fmt.Sprintf(`DELETE FROM %[1]s_labels WHERE %[1]s_id = ?`, softwareType)
-	if len(labelIds) > 0 {
-		inStmt, args, err := sqlx.In(` AND label_id NOT IN (?)`, labelIds)
+	if len(allLabelIds) > 0 {
+		inStmt, args, err := sqlx.In(` AND label_id NOT IN (?)`, allLabelIds)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "build delete existing software labels query")
 		}
@@ -626,37 +624,56 @@ func setOrUpdateSoftwareInstallerLabelsDB(ctx context.Context, tx sqlx.ExtContex
 		return ctxerr.Wrap(ctx, err, "delete existing software labels")
 	}
 
-	// insert new labels
-	if len(labelIds) > 0 {
-		var exclude, requireAll bool
-		switch labels.LabelScope {
-		case fleet.LabelScopeIncludeAny:
-			exclude = false
-			requireAll = false
-		case fleet.LabelScopeExcludeAny:
-			exclude = true
-			requireAll = false
-		case fleet.LabelScopeIncludeAll:
-			exclude = false
-			requireAll = true
-		default:
-			// this should never happen
+	// Determine the primary scope's exclude/requireAll flags
+	var primaryExclude, primaryRequireAll bool
+	switch labels.LabelScope {
+	case fleet.LabelScopeIncludeAny:
+		primaryExclude = false
+		primaryRequireAll = false
+	case fleet.LabelScopeExcludeAny:
+		primaryExclude = true
+		primaryRequireAll = false
+	case fleet.LabelScopeIncludeAll:
+		primaryExclude = false
+		primaryRequireAll = true
+	default:
+		if len(labels.ByName) > 0 {
 			return ctxerr.New(ctx, "invalid label scope")
 		}
+	}
 
-		stmt := `INSERT INTO %[1]s_labels (%[1]s_id, label_id, exclude, require_all) VALUES %s
-							ON DUPLICATE KEY UPDATE exclude = VALUES(exclude), require_all = VALUES(require_all)`
+	insertStmt := `INSERT INTO %[1]s_labels (%[1]s_id, label_id, exclude, require_all) VALUES %s
+						ON DUPLICATE KEY UPDATE exclude = VALUES(exclude), require_all = VALUES(require_all)`
+
+	// Insert primary scope labels (include or standalone exclude)
+	if len(labels.ByName) > 0 {
 		var placeholders string
 		var insertArgs []interface{}
-		for _, lid := range labelIds {
+		for _, label := range labels.ByName {
 			placeholders += "(?, ?, ?, ?),"
-			insertArgs = append(insertArgs, installerID, lid, exclude, requireAll)
+			insertArgs = append(insertArgs, installerID, label.LabelID, primaryExclude, primaryRequireAll)
 		}
 		placeholders = strings.TrimSuffix(placeholders, ",")
 
-		_, err = tx.ExecContext(ctx, fmt.Sprintf(stmt, softwareType, placeholders), insertArgs...)
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(insertStmt, softwareType, placeholders), insertArgs...)
 		if err != nil {
 			return ctxerr.Wrap(ctx, err, "insert software label")
+		}
+	}
+
+	// Insert exclude labels when combined with an include scope
+	if labels.HasExcludeLabels() {
+		var placeholders string
+		var insertArgs []interface{}
+		for _, label := range labels.ExcludeByName {
+			placeholders += "(?, ?, ?, ?),"
+			insertArgs = append(insertArgs, installerID, label.LabelID, true, false)
+		}
+		placeholders = strings.TrimSuffix(placeholders, ",")
+
+		_, err = tx.ExecContext(ctx, fmt.Sprintf(insertStmt, softwareType, placeholders), insertArgs...)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "insert software exclude label")
 		}
 	}
 
@@ -3268,81 +3285,97 @@ func (ds *Datastore) IsVPPAppLabelScoped(ctx context.Context, vppAppTeamID, host
 }
 
 func (ds *Datastore) isSoftwareLabelScoped(ctx context.Context, softwareID, hostID uint, swType softwareType) (bool, error) {
+	// This query uses AND logic between the three label conditions:
+	// 1. Include-any: host must be in at least one include label (or no include-any labels exist)
+	// 2. Include-all: host must be in ALL include-all labels (or no include-all labels exist)
+	// 3. Exclude-any: host must NOT be in any exclude label (or no exclude labels exist,
+	//    also respects label_updated_at timing for dynamic labels)
+	//
+	// All three conditions are AND-ed together, enabling combined include+exclude scoping.
 	stmt := `
-		SELECT 1 FROM (
-
-			-- no labels
-			SELECT 0 AS count_installer_labels, 0 AS count_host_labels, 0 as count_host_updated_after_labels
-			WHERE NOT EXISTS (
+		SELECT 1
+		WHERE
+			-- There are some labels for this software (otherwise it applies to all hosts)
+			EXISTS (
 				SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = :software_id
 			)
+			AND
+			-- Include-any condition: no include-any labels exist, OR host is in at least one
+			(
+				NOT EXISTS (
+					SELECT 1 FROM %[1]s_labels sil
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 0
+				)
+				OR EXISTS (
+					SELECT 1 FROM %[1]s_labels sil
+					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 0
+				)
+			)
+			AND
+			-- Include-all condition: no include-all labels exist, OR host is in ALL of them
+			(
+				NOT EXISTS (
+					SELECT 1 FROM %[1]s_labels sil
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+				)
+				OR (
+					SELECT COUNT(*) FROM %[1]s_labels sil
+					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+				) = (
+					SELECT COUNT(*) FROM %[1]s_labels sil
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+				)
+			)
+			AND
+			-- Exclude-any condition: host is NOT in any exclude label
+			-- (only considers labels where we have results: dynamic labels must have
+			-- been evaluated after their creation, manual labels always count)
+			NOT EXISTS (
+				SELECT 1 FROM %[1]s_labels sil
+				INNER JOIN labels lbl ON lbl.id = sil.label_id
+				INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
+				WHERE sil.%[1]s_id = :software_id
+					AND sil.exclude = 1
+					AND sil.require_all = 0
+					AND (
+						lbl.label_membership_type = 1
+						OR (lbl.label_membership_type = 0
+							AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at)
+					)
+			)
+			-- Also check that all exclude labels have been evaluated (fail-safe:
+			-- if we haven't evaluated a label yet, don't install)
+			AND (
+				NOT EXISTS (
+					SELECT 1 FROM %[1]s_labels sil
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 1 AND sil.require_all = 0
+				)
+				OR (
+					SELECT COUNT(*) FROM %[1]s_labels sil
+					INNER JOIN labels lbl ON lbl.id = sil.label_id
+					WHERE sil.%[1]s_id = :software_id
+						AND sil.exclude = 1
+						AND sil.require_all = 0
+						AND (
+							lbl.label_membership_type = 1
+							OR (lbl.label_membership_type = 0
+								AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at)
+						)
+				) = (
+					SELECT COUNT(*) FROM %[1]s_labels sil
+					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 1 AND sil.require_all = 0
+				)
+			)
 
-			UNION
+		UNION ALL
 
-			-- include any
-			SELECT
-				COUNT(*) AS count_installer_labels,
-				COUNT(lm.label_id) AS count_host_labels,
-				0 as count_host_updated_after_labels
-			FROM
-				%[1]s_labels sil
-				LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-				AND lm.host_id = :host_id
-			WHERE
-				sil.%[1]s_id = :software_id
-				AND sil.exclude = 0
-				AND sil.require_all = 0
-			HAVING
-				count_installer_labels > 0 AND count_host_labels > 0
-
-			UNION
-
-			-- exclude any, ignore software that depends on labels created
-			-- _after_ the label_updated_at timestamp of the host (because
-			-- we don't have results for that label yet, the host may or may
-			-- not be a member).
-			SELECT
-				COUNT(*) AS count_installer_labels,
-				COUNT(lm.label_id) AS count_host_labels,
-				SUM(CASE
-				WHEN
-					lbl.created_at IS NOT NULL AND lbl.label_membership_type = 0 AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at THEN 1
-				WHEN
-					lbl.created_at IS NOT NULL AND lbl.label_membership_type = 1 THEN 1
-				ELSE
-					0
-				END) as count_host_updated_after_labels
-			FROM
-				%[1]s_labels sil
-				LEFT OUTER JOIN labels lbl
-					ON lbl.id = sil.label_id
-				LEFT OUTER JOIN label_membership lm
-					ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-			WHERE
-				sil.%[1]s_id = :software_id
-				AND sil.exclude = 1
-				AND sil.require_all = 0
-			HAVING
-				count_installer_labels > 0 AND count_installer_labels = count_host_updated_after_labels AND count_host_labels = 0
-
-			UNION
-
-			-- include all
-			SELECT
-				COUNT(*) AS count_installer_labels,
-				COUNT(lm.label_id) AS count_host_labels,
-				0 as count_host_updated_after_labels
-			FROM
-				%[1]s_labels sil
-				LEFT OUTER JOIN label_membership lm ON lm.label_id = sil.label_id
-				AND lm.host_id = :host_id
-			WHERE
-				sil.%[1]s_id = :software_id
-				AND sil.exclude = 0
-				AND sil.require_all = 1
-			HAVING
-				count_installer_labels > 0 AND count_host_labels = count_installer_labels
-			) t
+		-- No labels at all = applies to all hosts
+		SELECT 1
+		WHERE NOT EXISTS (
+			SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = :software_id
+		)
 	`
 
 	stmt = fmt.Sprintf(stmt, swType)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -664,7 +664,7 @@ func setOrUpdateSoftwareInstallerLabelsDB(ctx context.Context, tx sqlx.ExtContex
 	// Insert exclude labels when combined with an include scope
 	if labels.HasExcludeLabels() {
 		var placeholders string
-		var insertArgs []interface{}
+		var insertArgs []any
 		for _, label := range labels.ExcludeByName {
 			placeholders += "(?, ?, ?, ?),"
 			insertArgs = append(insertArgs, installerID, label.LabelID, true, false)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1085,14 +1085,9 @@ LIMIT 1`,
 		}
 	}
 
-	var count int
-	for _, set := range [][]fleet.SoftwareScopeLabel{exclAny, inclAny, inclAll} {
-		if len(set) > 0 {
-			count++
-		}
-	}
-	if count > 1 {
-		ds.logger.WarnContext(ctx, "software installer has more than one scope of labels", "installer_id", dest.InstallerID, "include_any", fmt.Sprintf("%v", inclAny), "exclude_any", fmt.Sprintf("%v", exclAny), "include_all", fmt.Sprintf("%v", inclAll))
+	// include_any + include_all is invalid; include + exclude is allowed
+	if len(inclAny) > 0 && len(inclAll) > 0 {
+		ds.logger.WarnContext(ctx, "software installer has conflicting include scopes", "installer_id", dest.InstallerID, "include_any", fmt.Sprintf("%v", inclAny), "include_all", fmt.Sprintf("%v", inclAll))
 	}
 	dest.LabelsExcludeAny = exclAny
 	dest.LabelsIncludeAny = inclAny

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3290,97 +3290,92 @@ func (ds *Datastore) isSoftwareLabelScoped(ctx context.Context, softwareID, host
 	stmt := `
 		SELECT 1
 		WHERE
-			-- There are some labels for this software (otherwise it applies to all hosts)
 			EXISTS (
-				SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = :software_id
+				SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?
 			)
-			AND
-			-- Include-any condition: no include-any labels exist, OR host is in at least one
-			(
+			AND (
 				NOT EXISTS (
 					SELECT 1 FROM %[1]s_labels sil
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 0
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 0 AND sil.require_all = 0
 				)
 				OR EXISTS (
 					SELECT 1 FROM %[1]s_labels sil
-					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 0
+					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = ?
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 0 AND sil.require_all = 0
 				)
 			)
-			AND
-			-- Include-all condition: no include-all labels exist, OR host is in ALL of them
-			(
+			AND (
 				NOT EXISTS (
 					SELECT 1 FROM %[1]s_labels sil
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 0 AND sil.require_all = 1
 				)
 				OR (
 					SELECT COUNT(*) FROM %[1]s_labels sil
-					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+					INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = ?
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 0 AND sil.require_all = 1
 				) = (
 					SELECT COUNT(*) FROM %[1]s_labels sil
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 0 AND sil.require_all = 1
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 0 AND sil.require_all = 1
 				)
 			)
-			AND
-			-- Exclude-any condition: host is NOT in any exclude label
-			-- (only considers labels where we have results: dynamic labels must have
-			-- been evaluated after their creation, manual labels always count)
-			NOT EXISTS (
+			AND NOT EXISTS (
 				SELECT 1 FROM %[1]s_labels sil
 				INNER JOIN labels lbl ON lbl.id = sil.label_id
-				INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = :host_id
-				WHERE sil.%[1]s_id = :software_id
+				INNER JOIN label_membership lm ON lm.label_id = sil.label_id AND lm.host_id = ?
+				WHERE sil.%[1]s_id = ?
 					AND sil.exclude = 1
 					AND sil.require_all = 0
 					AND (
 						lbl.label_membership_type = 1
 						OR (lbl.label_membership_type = 0
-							AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at)
+							AND (SELECT label_updated_at FROM hosts WHERE id = ?) >= lbl.created_at)
 					)
 			)
-			-- Also check that all exclude labels have been evaluated (fail-safe:
-			-- if we haven't evaluated a label yet, don't install)
 			AND (
 				NOT EXISTS (
 					SELECT 1 FROM %[1]s_labels sil
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 1 AND sil.require_all = 0
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 1 AND sil.require_all = 0
 				)
 				OR (
 					SELECT COUNT(*) FROM %[1]s_labels sil
 					INNER JOIN labels lbl ON lbl.id = sil.label_id
-					WHERE sil.%[1]s_id = :software_id
+					WHERE sil.%[1]s_id = ?
 						AND sil.exclude = 1
 						AND sil.require_all = 0
 						AND (
 							lbl.label_membership_type = 1
 							OR (lbl.label_membership_type = 0
-								AND (SELECT label_updated_at FROM hosts WHERE id = :host_id) >= lbl.created_at)
+								AND (SELECT label_updated_at FROM hosts WHERE id = ?) >= lbl.created_at)
 						)
 				) = (
 					SELECT COUNT(*) FROM %[1]s_labels sil
-					WHERE sil.%[1]s_id = :software_id AND sil.exclude = 1 AND sil.require_all = 0
+					WHERE sil.%[1]s_id = ? AND sil.exclude = 1 AND sil.require_all = 0
 				)
 			)
 
 		UNION ALL
 
-		-- No labels at all = applies to all hosts
 		SELECT 1
 		WHERE NOT EXISTS (
-			SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = :software_id
+			SELECT 1 FROM %[1]s_labels sil WHERE sil.%[1]s_id = ?
 		)
 	`
 
 	stmt = fmt.Sprintf(stmt, swType)
-	namedArgs := map[string]any{
-		"host_id":     hostID,
-		"software_id": softwareID,
-	}
-	stmt, args, err := sqlx.Named(stmt, namedArgs)
-	if err != nil {
-		return false, ctxerr.Wrap(ctx, err, "build named query for is software label scoped")
+
+	// positional args: software_id and host_id repeated for each subquery reference
+	args := []any{
+		softwareID,         // EXISTS labels
+		softwareID,         // NOT EXISTS include-any
+		hostID, softwareID, // EXISTS include-any membership
+		softwareID,         // NOT EXISTS include-all
+		hostID, softwareID, // COUNT include-all membership
+		softwareID,                 // COUNT include-all total
+		hostID, softwareID, hostID, // NOT EXISTS exclude membership + label_updated_at
+		softwareID,         // NOT EXISTS exclude labels
+		softwareID, hostID, // COUNT exclude evaluated
+		softwareID, // COUNT exclude total
+		softwareID, // UNION ALL no labels
 	}
 
 	var res bool

--- a/server/datastore/mysql/vpp.go
+++ b/server/datastore/mysql/vpp.go
@@ -76,14 +76,9 @@ WHERE
 		}
 	}
 
-	var count int
-	for _, set := range [][]fleet.SoftwareScopeLabel{exclAny, inclAny, inclAll} {
-		if len(set) > 0 {
-			count++
-		}
-	}
-	if count > 1 {
-		ds.logger.WarnContext(ctx, "vpp app has more than one scope of labels", "vpp_apps_teams_id", app.VPPAppsTeamsID, "include_any", fmt.Sprintf("%v", inclAny), "exclude_any", fmt.Sprintf("%v", exclAny), "include_all", fmt.Sprintf("%v", inclAll))
+	// include_any + include_all is invalid; include + exclude is allowed
+	if len(inclAny) > 0 && len(inclAll) > 0 {
+		ds.logger.WarnContext(ctx, "vpp app has conflicting include scopes", "vpp_apps_teams_id", app.VPPAppsTeamsID, "include_any", fmt.Sprintf("%v", inclAny), "include_all", fmt.Sprintf("%v", inclAll))
 	}
 	app.LabelsExcludeAny = exclAny
 	app.LabelsIncludeAny = inclAny
@@ -370,45 +365,46 @@ func (ds *Datastore) getExistingLabels(ctx context.Context, vppAppTeamID uint) (
 		}
 	}
 
-	var count int
-	for _, set := range [][]fleet.SoftwareScopeLabel{exclAny, inclAny, inclAll} {
-		if len(set) > 0 {
-			count++
-		}
-	}
-	if count > 1 {
-		// there's a bug somewhere
-		return nil, ctxerr.New(ctx, "found labels for more than one scope on a vpp app")
+	// include_any + include_all is invalid
+	if len(inclAny) > 0 && len(inclAll) > 0 {
+		return nil, ctxerr.New(ctx, "found conflicting include scopes (include_any + include_all) on a vpp app")
 	}
 
+	// Determine primary scope
 	switch {
-	case len(exclAny) > 0:
-		labels.LabelScope = fleet.LabelScopeExcludeAny
-		labels.ByName = make(map[string]fleet.LabelIdent, len(exclAny))
-		for _, l := range exclAny {
-			labels.ByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}
-		}
-		return &labels, nil
-
 	case len(inclAny) > 0:
 		labels.LabelScope = fleet.LabelScopeIncludeAny
 		labels.ByName = make(map[string]fleet.LabelIdent, len(inclAny))
 		for _, l := range inclAny {
 			labels.ByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}
 		}
-		return &labels, nil
-
 	case len(inclAll) > 0:
 		labels.LabelScope = fleet.LabelScopeIncludeAll
 		labels.ByName = make(map[string]fleet.LabelIdent, len(inclAll))
 		for _, l := range inclAll {
 			labels.ByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}
 		}
+	case len(exclAny) > 0:
+		// Exclude-only (no include labels)
+		labels.LabelScope = fleet.LabelScopeExcludeAny
+		labels.ByName = make(map[string]fleet.LabelIdent, len(exclAny))
+		for _, l := range exclAny {
+			labels.ByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}
+		}
 		return &labels, nil
-
 	default:
 		return nil, nil
 	}
+
+	// When combining include + exclude, populate ExcludeByName
+	if (len(inclAny) > 0 || len(inclAll) > 0) && len(exclAny) > 0 {
+		labels.ExcludeByName = make(map[string]fleet.LabelIdent, len(exclAny))
+		for _, l := range exclAny {
+			labels.ExcludeByName[l.LabelName] = fleet.LabelIdent{LabelName: l.LabelName, LabelID: l.LabelID}
+		}
+	}
+
+	return &labels, nil
 }
 
 func (ds *Datastore) getVPPAppTeamCategoryIDs(ctx context.Context, vppAppTeamID uint) ([]uint, error) {

--- a/server/fleet/labels.go
+++ b/server/fleet/labels.go
@@ -316,6 +316,32 @@ const (
 type LabelIdentsWithScope struct {
 	LabelScope LabelScope
 	ByName     map[string]LabelIdent
+
+	// ExcludeByName holds exclude-any labels when combining an include scope
+	// (include_any or include_all) with exclude_any. When only a single scope
+	// is used this field is nil and ByName holds all labels for that scope.
+	ExcludeByName map[string]LabelIdent
+}
+
+// HasExcludeLabels returns true if this scope set has additional exclude labels
+// that should be applied alongside the primary include scope.
+func (l *LabelIdentsWithScope) HasExcludeLabels() bool {
+	return l != nil && len(l.ExcludeByName) > 0
+}
+
+// AllLabelIDs returns all label IDs across both include and exclude scopes.
+func (l *LabelIdentsWithScope) AllLabelIDs() []uint {
+	if l == nil {
+		return nil
+	}
+	ids := make([]uint, 0, len(l.ByName)+len(l.ExcludeByName))
+	for _, li := range l.ByName {
+		ids = append(ids, li.LabelID)
+	}
+	for _, li := range l.ExcludeByName {
+		ids = append(ids, li.LabelID)
+	}
+	return ids
 }
 
 // Equal returns whether or not 2 LabelIdentsWithScope pointers point to equivalent values.
@@ -328,25 +354,30 @@ func (l *LabelIdentsWithScope) Equal(other *LabelIdentsWithScope) bool {
 		return false
 	}
 
-	if l.ByName == nil && other.ByName == nil {
-		return true
-	}
-
-	if len(l.ByName) != len(other.ByName) {
+	if !labelMapEqual(l.ByName, other.ByName) {
 		return false
 	}
 
-	for k, v := range l.ByName {
-		otherV, ok := other.ByName[k]
-		if !ok {
-			return false
-		}
+	if !labelMapEqual(l.ExcludeByName, other.ExcludeByName) {
+		return false
+	}
 
-		if v != otherV {
+	return true
+}
+
+func labelMapEqual(a, b map[string]LabelIdent) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k, v := range a {
+		otherV, ok := b[k]
+		if !ok || v != otherV {
 			return false
 		}
 	}
-
 	return true
 }
 

--- a/server/fleet/labels_test.go
+++ b/server/fleet/labels_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDetectMissingLabels(t *testing.T) {
@@ -50,4 +51,152 @@ func TestDetectMissingLabels(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestLabelIdentsWithScope_Equal(t *testing.T) {
+	t.Run("nil both", func(t *testing.T) {
+		var a, b *LabelIdentsWithScope
+		require.True(t, a.Equal(b))
+	})
+
+	t.Run("nil one", func(t *testing.T) {
+		a := &LabelIdentsWithScope{LabelScope: LabelScopeIncludeAny}
+		require.False(t, a.Equal(nil))
+	})
+
+	t.Run("same scope and labels", func(t *testing.T) {
+		a := &LabelIdentsWithScope{
+			LabelScope: LabelScopeIncludeAny,
+			ByName:     map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+		}
+		b := &LabelIdentsWithScope{
+			LabelScope: LabelScopeIncludeAny,
+			ByName:     map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+		}
+		require.True(t, a.Equal(b))
+	})
+
+	t.Run("different scope", func(t *testing.T) {
+		a := &LabelIdentsWithScope{LabelScope: LabelScopeIncludeAny}
+		b := &LabelIdentsWithScope{LabelScope: LabelScopeExcludeAny}
+		require.False(t, a.Equal(b))
+	})
+
+	t.Run("with ExcludeByName equal", func(t *testing.T) {
+		a := &LabelIdentsWithScope{
+			LabelScope:    LabelScopeIncludeAny,
+			ByName:        map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+			ExcludeByName: map[string]LabelIdent{"bar": {LabelID: 2, LabelName: "bar"}},
+		}
+		b := &LabelIdentsWithScope{
+			LabelScope:    LabelScopeIncludeAny,
+			ByName:        map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+			ExcludeByName: map[string]LabelIdent{"bar": {LabelID: 2, LabelName: "bar"}},
+		}
+		require.True(t, a.Equal(b))
+	})
+
+	t.Run("with ExcludeByName different", func(t *testing.T) {
+		a := &LabelIdentsWithScope{
+			LabelScope:    LabelScopeIncludeAny,
+			ByName:        map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+			ExcludeByName: map[string]LabelIdent{"bar": {LabelID: 2, LabelName: "bar"}},
+		}
+		b := &LabelIdentsWithScope{
+			LabelScope: LabelScopeIncludeAny,
+			ByName:     map[string]LabelIdent{"foo": {LabelID: 1, LabelName: "foo"}},
+		}
+		require.False(t, a.Equal(b))
+	})
+}
+
+func TestLabelIdentsWithScope_HasExcludeLabels(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var l *LabelIdentsWithScope
+		require.False(t, l.HasExcludeLabels())
+	})
+
+	t.Run("no exclude labels", func(t *testing.T) {
+		l := &LabelIdentsWithScope{
+			LabelScope: LabelScopeIncludeAny,
+			ByName:     map[string]LabelIdent{"foo": {LabelID: 1}},
+		}
+		require.False(t, l.HasExcludeLabels())
+	})
+
+	t.Run("has exclude labels", func(t *testing.T) {
+		l := &LabelIdentsWithScope{
+			LabelScope:    LabelScopeIncludeAny,
+			ByName:        map[string]LabelIdent{"foo": {LabelID: 1}},
+			ExcludeByName: map[string]LabelIdent{"bar": {LabelID: 2}},
+		}
+		require.True(t, l.HasExcludeLabels())
+	})
+}
+
+func TestLabelIdentsWithScope_AllLabelIDs(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var l *LabelIdentsWithScope
+		require.Nil(t, l.AllLabelIDs())
+	})
+
+	t.Run("include only", func(t *testing.T) {
+		l := &LabelIdentsWithScope{
+			ByName: map[string]LabelIdent{
+				"foo": {LabelID: 1},
+				"bar": {LabelID: 2},
+			},
+		}
+		ids := l.AllLabelIDs()
+		require.Len(t, ids, 2)
+		require.ElementsMatch(t, []uint{1, 2}, ids)
+	})
+
+	t.Run("combined include and exclude", func(t *testing.T) {
+		l := &LabelIdentsWithScope{
+			ByName: map[string]LabelIdent{
+				"foo": {LabelID: 1},
+			},
+			ExcludeByName: map[string]LabelIdent{
+				"bar": {LabelID: 2},
+				"baz": {LabelID: 3},
+			},
+		}
+		ids := l.AllLabelIDs()
+		require.Len(t, ids, 3)
+		require.ElementsMatch(t, []uint{1, 2, 3}, ids)
+	})
+}
+
+func TestPolicyPayload_Verify_CombinedLabels(t *testing.T) {
+	t.Run("include_any + exclude_any is allowed", func(t *testing.T) {
+		p := PolicyPayload{
+			Name:             "test",
+			Query:            "SELECT 1",
+			LabelsIncludeAny: []string{"label1"},
+			LabelsExcludeAny: []string{"label2"},
+		}
+		err := p.Verify()
+		require.NoError(t, err)
+	})
+
+	t.Run("include_any only is allowed", func(t *testing.T) {
+		p := PolicyPayload{
+			Name:             "test",
+			Query:            "SELECT 1",
+			LabelsIncludeAny: []string{"label1"},
+		}
+		err := p.Verify()
+		require.NoError(t, err)
+	})
+
+	t.Run("exclude_any only is allowed", func(t *testing.T) {
+		p := PolicyPayload{
+			Name:             "test",
+			Query:            "SELECT 1",
+			LabelsExcludeAny: []string{"label1"},
+		}
+		err := p.Verify()
+		require.NoError(t, err)
+	})
 }

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -113,7 +113,6 @@ var (
 	errPolicyEmptyQuery                              = errors.New("policy query cannot be empty")
 	errPolicyIDAndQuerySet                           = errors.New("both fields \"queryID\" and \"query\" cannot be set")
 	errPolicyInvalidPlatform                         = errors.New("invalid policy platform")
-	errPolicyConflictingLabels                       = errors.New("policy cannot include both labels_include_any and labels_include_all")
 	errPolicyPatchAndQuerySet                        = errors.New("If the \"type\" is \"patch\", the \"query\" field is not supported.")
 	errPolicyPatchAndPlatformSet                     = errors.New("If the \"type\" is \"patch\", the \"platform\" field is not supported.")
 	errPolicyPatchNoTitleID                          = errors.New("If the \"type\" is \"patch\", the \"patch_software_title_id\" field is required.")

--- a/server/fleet/policies.go
+++ b/server/fleet/policies.go
@@ -113,7 +113,7 @@ var (
 	errPolicyEmptyQuery                              = errors.New("policy query cannot be empty")
 	errPolicyIDAndQuerySet                           = errors.New("both fields \"queryID\" and \"query\" cannot be set")
 	errPolicyInvalidPlatform                         = errors.New("invalid policy platform")
-	errPolicyConflictingLabels                       = errors.New("policy cannot include both labels_include_any and labels_exclude_any")
+	errPolicyConflictingLabels                       = errors.New("policy cannot include both labels_include_any and labels_include_all")
 	errPolicyPatchAndQuerySet                        = errors.New("If the \"type\" is \"patch\", the \"query\" field is not supported.")
 	errPolicyPatchAndPlatformSet                     = errors.New("If the \"type\" is \"patch\", the \"platform\" field is not supported.")
 	errPolicyPatchNoTitleID                          = errors.New("If the \"type\" is \"patch\", the \"patch_software_title_id\" field is required.")
@@ -143,9 +143,6 @@ func (p PolicyPayload) Verify() error {
 		if p.PatchSoftwareTitleID == nil {
 			return errPolicyPatchNoTitleID
 		}
-		if len(p.LabelsIncludeAny) > 0 && len(p.LabelsExcludeAny) > 0 {
-			return errPolicyConflictingLabels
-		}
 		return nil
 	}
 
@@ -168,9 +165,6 @@ func (p PolicyPayload) Verify() error {
 		return err
 	}
 
-	if len(p.LabelsIncludeAny) > 0 && len(p.LabelsExcludeAny) > 0 {
-		return errPolicyConflictingLabels
-	}
 	return nil
 }
 

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -898,9 +898,9 @@ type Service interface {
 	GetHostDEPAssignmentDetails(ctx context.Context, hostID uint) (*HostDEPAssignment, *godep.Device, error)
 
 	// NewMDMAppleConfigProfile creates a new configuration profile for the specified team.
-	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode MDMLabelsMode) (*MDMAppleConfigProfile, error)
+	NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode MDMLabelsMode, excludeLabels []string) (*MDMAppleConfigProfile, error)
 	// NewMDMAppleConfigProfileWithPayload creates a new declaration for the specified team.
-	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode MDMLabelsMode) (*MDMAppleDeclaration, error)
+	NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode MDMLabelsMode, excludeLabels []string) (*MDMAppleDeclaration, error)
 
 	// GetMDMAppleConfigProfileByDeprecatedID retrieves the specified Apple
 	// configuration profile via its numeric ID. This method is deprecated and
@@ -1195,7 +1195,7 @@ type Service interface {
 
 	// NewMDMWindowsConfigProfile creates a new Windows configuration profile for
 	// the specified team.
-	NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode MDMLabelsMode) (*MDMWindowsConfigProfile, error)
+	NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode MDMLabelsMode, excludeLabels []string) (*MDMWindowsConfigProfile, error)
 
 	// NewMDMUnsupportedConfigProfile is called when a profile with an
 	// unsupported extension is uploaded.
@@ -1231,7 +1231,7 @@ type Service interface {
 	// Android MDM
 
 	// NewMDMAndroidConfigProfile creates a new Android configuration profile
-	NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode MDMLabelsMode) (*MDMAndroidConfigProfile, error)
+	NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode MDMLabelsMode, excludeLabels []string) (*MDMAndroidConfigProfile, error)
 
 	// DeleteMDMAndroidConfigProfile deletes the specified Android profile.
 	DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -568,9 +568,9 @@ type GetHostDEPAssignmentFunc func(ctx context.Context, host *fleet.Host) (*flee
 
 type GetHostDEPAssignmentDetailsFunc func(ctx context.Context, hostID uint) (*fleet.HostDEPAssignment, *godep.Device, error)
 
-type NewMDMAppleConfigProfileFunc func(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleConfigProfile, error)
+type NewMDMAppleConfigProfileFunc func(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleConfigProfile, error)
 
-type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleDeclaration, error)
+type NewMDMAppleDeclarationFunc func(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleDeclaration, error)
 
 type GetMDMAppleConfigProfileByDeprecatedIDFunc func(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error)
 
@@ -736,7 +736,7 @@ type DeleteMDMWindowsConfigProfileFunc func(ctx context.Context, profileUUID str
 
 type GetMDMWindowsProfilesSummaryFunc func(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error)
 
-type NewMDMWindowsConfigProfileFunc func(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMWindowsConfigProfile, error)
+type NewMDMWindowsConfigProfileFunc func(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMWindowsConfigProfile, error)
 
 type NewMDMUnsupportedConfigProfileFunc func(ctx context.Context, teamID uint, filename string) error
 
@@ -750,7 +750,7 @@ type LinuxHostDiskEncryptionStatusFunc func(ctx context.Context, host fleet.Host
 
 type GetMDMLinuxProfilesSummaryFunc func(ctx context.Context, teamId *uint) (fleet.MDMProfilesSummary, error)
 
-type NewMDMAndroidConfigProfileFunc func(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAndroidConfigProfile, error)
+type NewMDMAndroidConfigProfileFunc func(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAndroidConfigProfile, error)
 
 type DeleteMDMAndroidConfigProfileFunc func(ctx context.Context, profileUUID string) error
 
@@ -4157,18 +4157,18 @@ func (s *Service) GetHostDEPAssignmentDetails(ctx context.Context, hostID uint) 
 	return s.GetHostDEPAssignmentDetailsFunc(ctx, hostID)
 }
 
-func (s *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleConfigProfile, error) {
+func (s *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleConfigProfile, error) {
 	s.mu.Lock()
 	s.NewMDMAppleConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAppleConfigProfileFunc(ctx, teamID, data, labels, labelsMembershipMode)
+	return s.NewMDMAppleConfigProfileFunc(ctx, teamID, data, labels, labelsMembershipMode, excludeLabels)
 }
 
-func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleDeclaration, error) {
+func (s *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleDeclaration, error) {
 	s.mu.Lock()
 	s.NewMDMAppleDeclarationFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labels, name, labelsMembershipMode)
+	return s.NewMDMAppleDeclarationFunc(ctx, teamID, data, labels, name, labelsMembershipMode, excludeLabels)
 }
 
 func (s *Service) GetMDMAppleConfigProfileByDeprecatedID(ctx context.Context, profileID uint) (*fleet.MDMAppleConfigProfile, error) {
@@ -4745,11 +4745,11 @@ func (s *Service) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *uint
 	return s.GetMDMWindowsProfilesSummaryFunc(ctx, teamID)
 }
 
-func (s *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMWindowsConfigProfile, error) {
+func (s *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMWindowsConfigProfile, error) {
 	s.mu.Lock()
 	s.NewMDMWindowsConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMWindowsConfigProfileFunc(ctx, teamID, profileName, data, labels, labelsMembershipMode)
+	return s.NewMDMWindowsConfigProfileFunc(ctx, teamID, profileName, data, labels, labelsMembershipMode, excludeLabels)
 }
 
 func (s *Service) NewMDMUnsupportedConfigProfile(ctx context.Context, teamID uint, filename string) error {
@@ -4794,11 +4794,11 @@ func (s *Service) GetMDMLinuxProfilesSummary(ctx context.Context, teamId *uint) 
 	return s.GetMDMLinuxProfilesSummaryFunc(ctx, teamId)
 }
 
-func (s *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAndroidConfigProfile, error) {
+func (s *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAndroidConfigProfile, error) {
 	s.mu.Lock()
 	s.NewMDMAndroidConfigProfileFuncInvoked = true
 	s.mu.Unlock()
-	return s.NewMDMAndroidConfigProfileFunc(ctx, teamID, profileName, data, labels, labelsMembershipMode)
+	return s.NewMDMAndroidConfigProfileFunc(ctx, teamID, profileName, data, labels, labelsMembershipMode, excludeLabels)
 }
 
 func (s *Service) DeleteMDMAndroidConfigProfile(ctx context.Context, profileUUID string) error {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1410,22 +1410,22 @@ func (svc *Service) validateMDM(
 	}
 	checkCustomSettings := func(prefix string, customSettings []fleet.MDMProfileSpec) {
 		for i, prof := range customSettings {
-			count := 0
-			for _, b := range []bool{
-				len(prof.Labels) > 0,
-				len(prof.LabelsIncludeAll) > 0,
-				len(prof.LabelsIncludeAny) > 0,
-				len(prof.LabelsExcludeAny) > 0,
-			} {
-				if b {
-					count++
-				}
-			}
-			if count > 1 {
+			hasLabels := len(prof.Labels) > 0
+			hasInclAll := len(prof.LabelsIncludeAll) > 0
+			hasInclAny := len(prof.LabelsIncludeAny) > 0
+			hasExclAny := len(prof.LabelsExcludeAny) > 0
+
+			// Allow combining an include scope with exclude_any, but disallow
+			// include_any + include_all and deprecated labels + anything else.
+			if hasLabels && (hasInclAll || hasInclAny || hasExclAny) {
 				invalid.Append(fmt.Sprintf("%s_settings.configuration_profiles", prefix),
-					fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`, prefix))
+					fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. Deprecated "labels" field cannot be combined with other label fields.`, prefix))
 			}
-			if len(prof.Labels) > 0 {
+			if hasInclAll && hasInclAny {
+				invalid.Append(fmt.Sprintf("%s_settings.configuration_profiles", prefix),
+					fmt.Sprintf(`Couldn't edit %s_settings.configuration_profiles. "labels_include_all" and "labels_include_any" cannot be combined.`, prefix))
+			}
+			if hasLabels {
 				customSettings[i].LabelsIncludeAll = customSettings[i].Labels
 				customSettings[i].Labels = nil
 			}

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -338,7 +338,7 @@ func newMDMAppleConfigProfileEndpoint(ctx context.Context, request interface{}, 
 		return &newMDMConfigProfileResponse{Err: err}, nil
 	}
 	// providing an empty set of labels since this endpoint is only maintained for backwards compat
-	cp, err := svc.NewMDMAppleConfigProfile(ctx, req.TeamID, data, nil, fleet.LabelsIncludeAll)
+	cp, err := svc.NewMDMAppleConfigProfile(ctx, req.TeamID, data, nil, fleet.LabelsIncludeAll, nil)
 	if err != nil {
 		return &newMDMAppleConfigProfileResponse{Err: err}, nil
 	}
@@ -347,7 +347,7 @@ func newMDMAppleConfigProfileEndpoint(ctx context.Context, request interface{}, 
 	}, nil
 }
 
-func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleConfigProfile, error) {
+func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleConfigProfile, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -433,8 +433,15 @@ func (svc *Service) NewMDMAppleConfigProfile(ctx context.Context, teamID uint, d
 		cp.LabelsIncludeAny = labelMap
 	case fleet.LabelsExcludeAny:
 		cp.LabelsExcludeAny = labelMap
-	default:
-		// TODO what happens if mode is not set?s
+	}
+
+	// Handle combined include + exclude labels
+	if len(excludeLabels) > 0 {
+		excludeLabelMap, err := svc.validateProfileLabels(ctx, &teamID, excludeLabels)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "validating exclude labels")
+		}
+		cp.LabelsExcludeAny = excludeLabelMap
 	}
 
 	// Convert profile variable names to FleetVarName type
@@ -842,7 +849,7 @@ func additionalNDESValidation(contents string, ndesVars *NDESVarsFound) error {
 	return nil
 }
 
-func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAppleDeclaration, error) {
+func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, data []byte, labels []string, name string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAppleDeclaration, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -912,6 +919,15 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 	default:
 		// default to include all
 		d.LabelsIncludeAll = validatedLabels
+	}
+
+	// Handle combined include + exclude labels
+	if len(excludeLabels) > 0 {
+		excludeValidated, err := svc.validateDeclarationLabels(ctx, excludeLabels, teamID)
+		if err != nil {
+			return nil, err
+		}
+		d.LabelsExcludeAny = excludeValidated
 	}
 
 	decl, err := svc.ds.NewMDMAppleDeclaration(ctx, d)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -719,11 +719,11 @@ func TestMDMAppleConfigProfileAuthz(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			// test authz create new profile (no team)
-			_, err := svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll)
+			_, err := svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 			checkShouldFail(err, tt.shouldFailGlobal)
 
 			// test authz create new profile (team 1)
-			_, err = svc.NewMDMAppleConfigProfile(ctx, 1, mcBytes, nil, fleet.LabelsIncludeAll)
+			_, err = svc.NewMDMAppleConfigProfile(ctx, 1, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 			checkShouldFail(err, tt.shouldFailTeam)
 
 			// test authz list profiles (no team)
@@ -786,7 +786,7 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 		return &fleet.GroupedCertificateAuthorities{}, nil
 	}
 
-	cp, err := svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll)
+	cp, err := svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 	require.NoError(t, err)
 	require.Equal(t, "Foo", cp.Name)
 	assert.Equal(t, identifier, cp.Identifier)
@@ -794,12 +794,12 @@ func TestNewMDMAppleConfigProfile(t *testing.T) {
 
 	// Unsupported Fleet variable
 	mcBytes = mcBytesForTest("Foo", identifier, "UUID${FLEET_VAR_BOZO}")
-	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll)
+	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 	assert.ErrorContains(t, err, "Fleet variable")
 
 	// Test profile with FLEET_SECRET in PayloadDisplayName
 	mcBytes = mcBytesForTest("Profile $FLEET_SECRET_PASSWORD", "test.identifier", "UUID")
-	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll)
+	_, err = svc.NewMDMAppleConfigProfile(ctx, 0, mcBytes, nil, fleet.LabelsIncludeAll, nil)
 	assert.ErrorContains(t, err, "PayloadDisplayName cannot contain FLEET_SECRET variables")
 }
 
@@ -848,12 +848,12 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 
 	// Unsupported Fleet variable
 	b := declBytesForTest("D1", "d1content $FLEET_VAR_BOZO")
-	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll)
+	_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
 	assert.ErrorContains(t, err, "Fleet variable")
 
 	// decl type missing actual type
 	b = declarationForTestWithType("D1", "com.apple.configuration")
-	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll)
+	_, err = svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
 	assert.ErrorContains(t, err, "Only configuration declarations (com.apple.configuration.) are supported")
 
 	ds.NewMDMAppleDeclarationFunc = func(ctx context.Context, d *fleet.MDMAppleDeclaration) (*fleet.MDMAppleDeclaration, error) {
@@ -866,7 +866,7 @@ func TestNewMDMAppleDeclaration(t *testing.T) {
 
 	// Good declaration
 	b = declBytesForTest("D1", "d1content")
-	d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll)
+	d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "name", fleet.LabelsIncludeAll, nil)
 	require.NoError(t, err)
 	assert.NotNil(t, d)
 }
@@ -930,7 +930,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.apple.configuration.management.status-subscriptions",
 			"Identifier": "test-status-sub"
 		}`)
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "status subscription type")
 	})
@@ -955,7 +955,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.apple.configuration.management.status-subscriptions",
 			"Identifier": "test-status-sub"
 		}`)
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-status-sub", fleet.LabelsIncludeAll, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 	})
@@ -973,7 +973,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.example.invalid",
 			"Identifier": "test-invalid"
 		}`)
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "Only configuration declarations")
 	})
@@ -998,7 +998,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.example.invalid",
 			"Identifier": "test-invalid"
 		}`)
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-invalid", fleet.LabelsIncludeAll, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 	})
@@ -1015,7 +1015,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.apple.configuration.softwareupdate.enforcement.specific",
 			"Identifier": "test-os-update"
 		}`)
-		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-os-update", fleet.LabelsIncludeAll)
+		_, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-os-update", fleet.LabelsIncludeAll, nil)
 		require.Error(t, err)
 		assert.ErrorContains(t, err, "OS updates settings")
 	})
@@ -1039,7 +1039,7 @@ func TestNewMDMAppleDeclarationSkipValidation(t *testing.T) {
 			"Type": "com.apple.configuration.softwareupdate.enforcement.specific",
 			"Identifier": "test-os-update"
 		}`)
-		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-os-update", fleet.LabelsIncludeAll)
+		d, err := svc.NewMDMAppleDeclaration(ctx, 0, b, nil, "test-os-update", fleet.LabelsIncludeAll, nil)
 		require.NoError(t, err)
 		assert.NotNil(t, d)
 	})

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -12483,28 +12483,17 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 			LabelsIncludeAny: []string{t.Name()},
 		}
 
-		// validate that providing more than 1 type of label
-		// results in an error
-		testCases := []struct {
+		// validate that include_any + include_all is still an error
+		invalidLabelCases := []struct {
 			desc    string
 			incAny  []string
 			exclAny []string
 			incAll  []string
 		}{
 			{
-				desc:    "include_any_exclude_any",
-				incAny:  []string{lblA.Name},
-				exclAny: []string{lblB.Name},
-			},
-			{
 				desc:   "include_any_include_all",
 				incAny: []string{lblA.Name},
 				incAll: []string{lblB.Name},
-			},
-			{
-				desc:    "exclude_any_include_all",
-				exclAny: []string{lblA.Name},
-				incAll:  []string{lblB.Name},
 			},
 			{
 				desc:    "all_types",
@@ -12513,25 +12502,24 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 				incAll:  []string{lblC.Name},
 			},
 		}
-		for _, tc := range testCases {
+		for _, tc := range invalidLabelCases {
 			t.Run(tc.desc, func(t *testing.T) {
 				payload := &fleet.UploadSoftwareInstallerPayload{
 					InstallScript:     "some install script",
 					PreInstallQuery:   "some pre install query",
 					PostInstallScript: "some post install script",
 					Filename:          "ruby.deb",
-					// additional fields below are pre-populated so we can re-use the payload later for the test assertions
-					Title:            "ruby",
-					Version:          "1:2.5.1",
-					Source:           "deb_packages",
-					StorageID:        "df06d9ce9e2090d9cb2e8cd1f4d7754a803dc452bf93e3204e3acd3b95508628",
-					Platform:         "linux",
-					LabelsIncludeAny: tc.incAny,
-					LabelsIncludeAll: tc.incAll,
-					LabelsExcludeAny: tc.exclAny,
+					Title:             "ruby",
+					Version:           "1:2.5.1",
+					Source:            "deb_packages",
+					StorageID:         "df06d9ce9e2090d9cb2e8cd1f4d7754a803dc452bf93e3204e3acd3b95508628",
+					Platform:          "linux",
+					LabelsIncludeAny:  tc.incAny,
+					LabelsIncludeAll:  tc.incAll,
+					LabelsExcludeAny:  tc.exclAny,
 				}
 
-				s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included.`)
+				s.uploadSoftwareInstaller(t, payload, http.StatusBadRequest, `"labels_include_all" and "labels_include_any" cannot be combined.`)
 			})
 		}
 
@@ -13920,28 +13908,17 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallers() {
 	lblC, err := s.ds.NewLabel(ctx, &fleet.Label{Name: "C"})
 	require.NoError(t, err)
 
-	// validate that providing more than 1 type of label
-	// results in an error
-	testCases := []struct {
+	// validate that include_any + include_all is still an error
+	invalidCases := []struct {
 		desc    string
 		incAny  []string
 		exclAny []string
 		incAll  []string
 	}{
 		{
-			desc:    "include_any_exclude_any",
-			incAny:  []string{lblA.Name},
-			exclAny: []string{lblB.Name},
-		},
-		{
 			desc:   "include_any_include_all",
 			incAny: []string{lblA.Name},
 			incAll: []string{lblB.Name},
-		},
-		{
-			desc:    "exclude_any_include_all",
-			exclAny: []string{lblA.Name},
-			incAll:  []string{lblB.Name},
 		},
 		{
 			desc:    "all_types",
@@ -13950,7 +13927,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallers() {
 			incAll:  []string{lblC.Name},
 		},
 	}
-	for _, tc := range testCases {
+	for _, tc := range invalidCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			softwareToInstall = []*fleet.SoftwareInstallerPayload{
 				{
@@ -13961,7 +13938,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallers() {
 				},
 			}
 			res := s.Do("POST", "/api/latest/fleet/software/batch", batchSetSoftwareInstallersRequest{Software: softwareToInstall}, http.StatusBadRequest)
-			assert.Contains(t, extractServerErrorText(res.Body), `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included.`)
+			assert.Contains(t, extractServerErrorText(res.Body), `"labels_include_all" and "labels_include_any" cannot be combined.`)
 		})
 	}
 
@@ -20564,12 +20541,13 @@ func (s *integrationEnterpriseTestSuite) TestMaintainedApps() {
 	r = s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", req, http.StatusBadRequest)
 	require.Contains(t, extractServerErrorText(r.Body), `Couldn't update. Label "no-such-label" doesn't exist. Please remove the label from the software.`)
 
-	// Can't set both labels_include_any and labels_exclude_any
+	// Can't set both labels_include_any and labels_include_all
 	req.LabelsIncludeAny = []string{lbl1.Name, lbl2.Name}
-	req.LabelsExcludeAny = []string{lbl1.Name}
+	req.LabelsExcludeAny = nil
+	req.LabelsIncludeAll = []string{lbl1.Name}
 	addMAResp = addFleetMaintainedAppResponse{}
 	r = s.Do("POST", "/api/latest/fleet/software/fleet_maintained_apps", req, http.StatusBadRequest)
-	require.Contains(t, extractServerErrorText(r.Body), `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included`)
+	require.Contains(t, extractServerErrorText(r.Body), `"labels_include_all" and "labels_include_any" cannot be combined.`)
 }
 
 func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedApps() {

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2139,7 +2139,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 		}
   }`), http.StatusUnprocessableEntity)
 	msg := extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	require.Contains(t, msg, `Deprecated "labels" field cannot be combined with other label fields.`)
 
 	// include_all + exclude_any is now allowed (combined scoping)
 	s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
@@ -2173,7 +2173,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 		}
   }`), http.StatusUnprocessableEntity)
 	msg = extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	require.Contains(t, msg, `Deprecated "labels" field cannot be combined with other label fields.`)
 }
 
 func (s *integrationMDMTestSuite) TestApplyTeamsMDMAppleProfiles() {
@@ -2292,7 +2292,7 @@ func (s *integrationMDMTestSuite) TestApplyTeamsMDMAppleProfiles() {
 	}}}
 	res = s.Do("POST", "/api/latest/fleet/spec/teams", teamSpecs, http.StatusUnprocessableEntity)
 	errMsg = extractServerErrorText(res.Body)
-	assert.Contains(t, errMsg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	assert.Contains(t, errMsg, `Deprecated "labels" field cannot be combined with other label fields.`)
 }
 
 func (s *integrationMDMTestSuite) TestBatchSetMDMAppleProfiles() {
@@ -4719,7 +4719,7 @@ func (s *integrationMDMTestSuite) TestApplyTeamsMDMWindowsProfiles() {
 		}
 	`), http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
-	assert.Contains(t, errMsg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	assert.Contains(t, errMsg, `Deprecated "labels" field cannot be combined with other label fields.`)
 }
 
 func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
@@ -4937,12 +4937,12 @@ func (s *integrationMDMTestSuite) TestBatchSetMDMProfiles() {
 	msg := extractServerErrorText(res.Body)
 	require.Contains(t, msg, `Couldn't update. Label "no-such-label" doesn't exist. Please remove the label from the configuration profile.`)
 
-	// mix of labels fields
+	// mix of labels fields (deprecated "labels" with other label field)
 	res = s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
 		{Name: "N1", Contents: mobileconfigForTest("N1", "I1"), Labels: []string{lbl1.Name}, LabelsExcludeAny: []string{lbl2.Name}},
 	}}, http.StatusUnprocessableEntity)
 	msg = extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	require.Contains(t, msg, `Deprecated "labels" field cannot be combined with other label fields.`)
 
 	// successful batch-set
 	s.Do("POST", "/api/v1/fleet/mdm/profiles/batch", batchSetMDMProfilesRequest{Profiles: []fleet.MDMProfileBatchPayload{
@@ -5236,12 +5236,12 @@ func (s *integrationMDMTestSuite) TestBatchModifyMDMProfiles() {
 	msg := extractServerErrorText(res.Body)
 	require.Contains(t, msg, `Couldn't update. Label "no-such-label" doesn't exist. Please remove the label from the configuration profile.`)
 
-	// mix of labels fields
+	// mix of labels fields (include_all + include_any is still an error)
 	res = s.Do("POST", "/api/latest/fleet/configuration_profiles/batch", batchModifyMDMConfigProfilesRequest{ConfigurationProfiles: []fleet.BatchModifyMDMConfigProfilePayload{
-		{DisplayName: "N1", Profile: mobileconfigForTest("N1", "I1"), LabelsIncludeAll: []string{lbl1.Name}, LabelsExcludeAny: []string{lbl2.Name}},
+		{DisplayName: "N1", Profile: mobileconfigForTest("N1", "I1"), LabelsIncludeAll: []string{lbl1.Name}, LabelsIncludeAny: []string{lbl2.Name}},
 	}}, http.StatusUnprocessableEntity)
 	msg = extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+	require.Contains(t, msg, `"labels_include_all" and "labels_include_any" cannot be combined.`)
 
 	// successful batch-set
 	s.Do("POST", "/api/latest/fleet/configuration_profiles/batch", batchModifyMDMConfigProfilesRequest{ConfigurationProfiles: []fleet.BatchModifyMDMConfigProfilePayload{

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -3396,18 +3396,18 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 
 	// profiles with invalid mix of labels
 	// profiles with invalid mix of labels: include_all + deprecated labels, include_all + include_any
-	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined`)
 	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `"labels_include_all" and "labels_include_any" cannot be combined.`)
 	// include_all + exclude_any is now VALID (combined scoping)
 	assertAppleDeclaration("apple-decl-with-incl-all-excl-any.json", "ident-decl-combined", 0, []string{"foo", "-bar"}, http.StatusOK, "")
 	// include_all + include_any is still INVALID
 	assertAppleDeclaration("apple-invalid-decl-with-labels.json", "ident-decl-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `"labels_include_all" and "labels_include_any" cannot be combined.`)
 	// exclude_any + deprecated labels is still INVALID
-	assertWindowsProfile("win-invalid-profile-with-labels.xml", "./Test", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	assertWindowsProfile("win-invalid-profile-with-labels.xml", "./Test", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined`)
 	// exclude_any + include_any is now VALID (combined scoping)
 	assertWindowsProfile("win-profile-with-incl-any-excl-any.xml", "./Test", 0, []string{"-foo", "~bar"}, http.StatusOK, "")
 	// exclude_any + deprecated labels is still INVALID
-	assertAndroidProfile("android-invalid-profile-with-labels.json", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	assertAndroidProfile("android-invalid-profile-with-labels.json", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined`)
 	// exclude_any + include_any is now VALID (combined scoping)
 	assertAndroidProfile("android-profile-with-incl-any-excl-any.json", 0, []string{"-foo", "~bar"}, http.StatusOK, "")
 

--- a/server/service/integration_mdm_profiles_test.go
+++ b/server/service/integration_mdm_profiles_test.go
@@ -2141,7 +2141,8 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 	msg := extractServerErrorText(res.Body)
 	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
 
-	res = s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+	// include_all + exclude_any is now allowed (combined scoping)
+	s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"mdm": {
 		  "windows_settings": {
 				"custom_settings": [
@@ -2149,11 +2150,10 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 				]
 			}
 		}
-  }`), http.StatusUnprocessableEntity)
-	msg = extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+  }`), http.StatusOK)
 
-	res = s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
+	// include_any + exclude_any is now allowed (combined scoping)
+	s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"mdm": {
 		  "windows_settings": {
 				"custom_settings": [
@@ -2161,9 +2161,7 @@ func (s *integrationMDMTestSuite) TestAppConfigMDMCustomSettings() {
 				]
 			}
 		}
-  }`), http.StatusUnprocessableEntity)
-	msg = extractServerErrorText(res.Body)
-	require.Contains(t, msg, `For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+  }`), http.StatusOK)
 
 	res = s.Do("PATCH", "/api/latest/fleet/config", json.RawMessage(`{
 		"mdm": {
@@ -3397,14 +3395,21 @@ func (s *integrationMDMTestSuite) TestMDMConfigProfileCRUD() {
 	assertAndroidProfile("android-profile-with-labels.json", 0, []string{"does-not-exist", "bar"}, http.StatusBadRequest, `Couldn't update. Label "does-not-exist" doesn't exist. Please remove the label from the configuration profile.`)
 
 	// profiles with invalid mix of labels
-	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "!bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertAppleDeclaration("apple-invalid-decl-with-labels.json", "ident-decl-with-labels", 0, []string{"foo", "-bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertAppleDeclaration("apple-invalid-decl-with-labels.json", "ident-decl-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertWindowsProfile("win-invalid-profile-with-labels.xml", "./Test", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertWindowsProfile("win-invalid-profile-with-labels.xml", "./Test", 0, []string{"-foo", "~bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertAndroidProfile("android-invalid-profile-with-labels.json", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
-	assertAndroidProfile("android-invalid-profile-with-labels.json", 0, []string{"-foo", "~bar"}, http.StatusBadRequest, `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`)
+	// profiles with invalid mix of labels: include_all + deprecated labels, include_all + include_any
+	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	assertAppleProfile("apple-invalid-profile-with-labels.mobileconfig", "apple-invalid-profile-with-labels", "ident-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `"labels_include_all" and "labels_include_any" cannot be combined.`)
+	// include_all + exclude_any is now VALID (combined scoping)
+	assertAppleDeclaration("apple-decl-with-incl-all-excl-any.json", "ident-decl-combined", 0, []string{"foo", "-bar"}, http.StatusOK, "")
+	// include_all + include_any is still INVALID
+	assertAppleDeclaration("apple-invalid-decl-with-labels.json", "ident-decl-with-labels", 0, []string{"foo", "~bar"}, http.StatusBadRequest, `"labels_include_all" and "labels_include_any" cannot be combined.`)
+	// exclude_any + deprecated labels is still INVALID
+	assertWindowsProfile("win-invalid-profile-with-labels.xml", "./Test", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	// exclude_any + include_any is now VALID (combined scoping)
+	assertWindowsProfile("win-profile-with-incl-any-excl-any.xml", "./Test", 0, []string{"-foo", "~bar"}, http.StatusOK, "")
+	// exclude_any + deprecated labels is still INVALID
+	assertAndroidProfile("android-invalid-profile-with-labels.json", 0, []string{"-foo", "!bar"}, http.StatusBadRequest, `Deprecated "labels" field cannot be combined with other label fields.`)
+	// exclude_any + include_any is now VALID (combined scoping)
+	assertAndroidProfile("android-profile-with-incl-any-excl-any.json", 0, []string{"-foo", "~bar"}, http.StatusOK, "")
 
 	// profiles with valid labels
 	uuidAppleWithLabel := assertAppleProfile("apple-profile-with-labels.mobileconfig", "apple-profile-with-labels", "ident-with-labels", 0, []string{"!foo"}, http.StatusOK, "")

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -13541,20 +13541,20 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 			LatestVersion:    "1.0.0",
 		}
 
-		// Attempt to add an app with both types of labels. Should fail
+		// Attempt to add an app with both include_any and include_all labels. Should fail
 		var addAppResp addAppStoreAppResponse
 		addAppReq := &addAppStoreAppRequest{
 			TeamID:           &team.ID,
 			AppStoreID:       includeAnyApp.AdamID,
 			SelfService:      true,
 			LabelsIncludeAny: []string{l1.Name},
-			LabelsExcludeAny: []string{l2.Name},
+			LabelsIncludeAll: []string{l2.Name},
 		}
 		res := s.Do("POST", "/api/latest/fleet/software/app_store_apps", addAppReq, http.StatusBadRequest)
-		require.Contains(t, extractServerErrorText(res.Body), `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included`)
+		require.Contains(t, extractServerErrorText(res.Body), `"labels_include_all" and "labels_include_any" cannot be combined.`)
 
 		// Now add it for real
-		addAppReq.LabelsExcludeAny = []string{}
+		addAppReq.LabelsIncludeAll = []string{}
 		s.DoJSON("POST", "/api/latest/fleet/software/app_store_apps", addAppReq, http.StatusOK, &addAppResp)
 		titleID := getSoftwareTitleIDFromApp(&includeAnyApp)
 		require.Equal(t, titleID, addAppResp.TitleID, "addAppResp should contain the correct software title ID")
@@ -13635,14 +13635,14 @@ func (s *integrationMDMTestSuite) TestVPPApps() {
 		// Attempt to update a non-existent app. Should fail.
 		s.Do("PATCH", "/api/latest/fleet/software/titles/9999/app_store_app", updateAppReq, http.StatusNotFound)
 
-		// Attempt to update with both types of labels. Should fail.
+		// Attempt to update with both include_any and include_all labels. Should fail.
 		updateAppReq.LabelsIncludeAny = []string{l1.Name}
-		updateAppReq.LabelsExcludeAny = []string{l1.Name}
+		updateAppReq.LabelsIncludeAll = []string{l1.Name}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID), updateAppReq, http.StatusBadRequest)
-		require.Contains(t, extractServerErrorText(res.Body), `Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included.`)
+		require.Contains(t, extractServerErrorText(res.Body), `"labels_include_all" and "labels_include_any" cannot be combined.`)
 
 		// Attempt to update with a non-existent label. Should fail.
-		updateAppReq.LabelsExcludeAny = []string{}
+		updateAppReq.LabelsIncludeAll = []string{}
 		updateAppReq.LabelsIncludeAny = []string{"404_notfound"}
 		res = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/software/titles/%d/app_store_app", titleID), updateAppReq, http.StatusBadRequest)
 		require.Contains(t, extractServerErrorText(res.Body), `Couldn't update. Label "404_notfound" doesn't exist. Please remove the label from the software.`)

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1659,15 +1659,14 @@ func (newMDMConfigProfileRequest) DecodeRequest(ctx context.Context, r *http.Req
 	decoded.LabelsExcludeAny, existsExclAny = r.MultipartForm.Value[string(fleet.LabelsExcludeAny)]
 	deprecatedLabels, existsDepr = r.MultipartForm.Value["labels"]
 
-	// validate that only one of the labels type is provided
-	var count int
-	for _, b := range []bool{existsInclAll, existsInclAny, existsExclAny, existsDepr} {
-		if b {
-			count++
-		}
+	// validate label combinations: allow combining an include scope with
+	// exclude_any, but disallow include_any + include_all and deprecated
+	// labels + anything else.
+	if existsDepr && (existsInclAll || existsInclAny || existsExclAny) {
+		return nil, &fleet.BadRequestError{Message: `Deprecated "labels" field cannot be combined with "labels_exclude_any", "labels_include_all", or "labels_include_any".`}
 	}
-	if count > 1 {
-		return nil, &fleet.BadRequestError{Message: `Only one of "labels_exclude_any", "labels_include_all", "labels_include_any", or "labels" can be included.`}
+	if existsInclAll && existsInclAny {
+		return nil, &fleet.BadRequestError{Message: `"labels_include_all" and "labels_include_any" cannot be combined.`}
 	}
 	if existsDepr {
 		decoded.LabelsIncludeAll = deprecatedLabels
@@ -1702,20 +1701,30 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	isMobileConfig := strings.EqualFold(fileExt, ".mobileconfig")
 	isJSON := strings.EqualFold(fileExt, ".json")
 
-	var labels []string
+	// Determine include labels and mode
+	var includeLabels []string
 	var labelsMode fleet.MDMLabelsMode
 	switch {
 	case len(req.LabelsIncludeAny) > 0:
-		labels = req.LabelsIncludeAny
+		includeLabels = req.LabelsIncludeAny
 		labelsMode = fleet.LabelsIncludeAny
-	case len(req.LabelsExcludeAny) > 0:
-		labels = req.LabelsExcludeAny
-		labelsMode = fleet.LabelsExcludeAny
 	default:
 		// default include all
-		labels = req.LabelsIncludeAll
+		includeLabels = req.LabelsIncludeAll
 		labelsMode = fleet.LabelsIncludeAll
 	}
+	// Exclude labels can be combined with any include scope
+	excludeLabels := req.LabelsExcludeAny
+
+	// If only exclude labels are provided with no include labels, use exclude mode
+	if len(includeLabels) == 0 && len(excludeLabels) > 0 {
+		includeLabels = excludeLabels
+		excludeLabels = nil
+		labelsMode = fleet.LabelsExcludeAny
+	}
+
+	// Merge for backward-compatible single-label-list code path
+	labels := includeLabels
 
 	isAppleDeclarationJSON, isAndroidJSON := false, false
 	if isJSON {
@@ -1738,7 +1747,7 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	if isMobileConfig || isAppleDeclarationJSON {
 		// Then it's an Apple configuration file
 		if isJSON {
-			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode)
+			decl, err := svc.NewMDMAppleDeclaration(ctx, req.TeamID, data, labels, profileName, labelsMode, excludeLabels)
 			if err != nil {
 				errStr := err.Error()
 				if strings.Contains(errStr, "MDMAppleDeclaration.Name") && strings.Contains(errStr, "already exists") {
@@ -1755,7 +1764,7 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 
 		}
 
-		cp, err := svc.NewMDMAppleConfigProfile(ctx, req.TeamID, data, labels, labelsMode)
+		cp, err := svc.NewMDMAppleConfigProfile(ctx, req.TeamID, data, labels, labelsMode, excludeLabels)
 		if err != nil {
 			return &newMDMConfigProfileResponse{Err: err}, nil
 		}
@@ -1765,7 +1774,7 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	}
 
 	if isAndroidJSON {
-		cp, err := svc.NewMDMAndroidConfigProfile(ctx, req.TeamID, profileName, data, labels, labelsMode)
+		cp, err := svc.NewMDMAndroidConfigProfile(ctx, req.TeamID, profileName, data, labels, labelsMode, excludeLabels)
 		if err != nil {
 			return &newMDMConfigProfileResponse{Err: err}, nil
 		}
@@ -1775,7 +1784,7 @@ func newMDMConfigProfileEndpoint(ctx context.Context, request interface{}, svc f
 	}
 
 	if isWindows := strings.EqualFold(fileExt, ".xml"); isWindows {
-		cp, err := svc.NewMDMWindowsConfigProfile(ctx, req.TeamID, profileName, data, labels, labelsMode)
+		cp, err := svc.NewMDMWindowsConfigProfile(ctx, req.TeamID, profileName, data, labels, labelsMode, excludeLabels)
 		if err != nil {
 			return &newMDMConfigProfileResponse{Err: err}, nil
 		}
@@ -1810,7 +1819,7 @@ func (svc *Service) NewMDMUnsupportedConfigProfile(ctx context.Context, teamID u
 	return &fleet.BadRequestError{Message: "Couldn't add profile. The file should be a .mobileconfig, XML, or JSON file."}
 }
 
-func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMAndroidConfigProfile, error) {
+func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMAndroidConfigProfile, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -1853,6 +1862,15 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 	default:
 		// default include all
 		cp.LabelsIncludeAll = labelMap
+	}
+
+	// Handle combined include + exclude labels
+	if len(excludeLabels) > 0 {
+		excludeLabelMap, err := svc.validateProfileLabels(ctx, &teamID, excludeLabels)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "validating exclude labels")
+		}
+		cp.LabelsExcludeAny = excludeLabelMap
 	}
 
 	newCP, err := svc.ds.NewMDMAndroidConfigProfile(ctx, cp)
@@ -2716,20 +2734,19 @@ func getAndroidProfiles(ctx context.Context,
 
 func validateProfiles(profiles map[int]fleet.MDMProfileBatchPayload) error {
 	for _, profile := range profiles {
-		// validate that only one of labels, labels_include_all and labels_exclude_any is provided.
-		var count int
-		for _, b := range []bool{
-			len(profile.LabelsIncludeAll) > 0,
-			len(profile.LabelsIncludeAny) > 0,
-			len(profile.LabelsExcludeAny) > 0,
-			len(profile.Labels) > 0,
-		} {
-			if b {
-				count++
-			}
+		// Validate label combinations: allow combining an include scope with
+		// exclude_any, but disallow include_any + include_all and deprecated
+		// labels + anything else.
+		hasLabels := len(profile.Labels) > 0
+		hasInclAll := len(profile.LabelsIncludeAll) > 0
+		hasInclAny := len(profile.LabelsIncludeAny) > 0
+		hasExclAny := len(profile.LabelsExcludeAny) > 0
+
+		if hasLabels && (hasInclAll || hasInclAny || hasExclAny) {
+			return fleet.NewInvalidArgumentError("mdm", `Couldn't edit configuration_profiles. Deprecated "labels" field cannot be combined with other label fields.`)
 		}
-		if count > 1 {
-			return fleet.NewInvalidArgumentError("mdm", `Couldn't edit configuration_profiles. For each profile, only one of "labels_exclude_any", "labels_include_all", "labels_include_any" or "labels" can be included.`)
+		if hasInclAll && hasInclAny {
+			return fleet.NewInvalidArgumentError("mdm", `Couldn't edit configuration_profiles. "labels_include_all" and "labels_include_any" cannot be combined.`)
 		}
 
 		if len(profile.Contents) > 1024*1024 {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -2088,6 +2088,12 @@ func (svc *Service) BatchSetMDMProfiles(
 	// Process labels first, since we do not need to expand secrets in the profiles for this validation.
 	labels := []string{}
 	for i := range profiles {
+		// Check for deprecated "labels" field combined with other label fields BEFORE
+		// converting Labels to LabelsIncludeAll, so the validation catches the conflict.
+		if len(profiles[i].Labels) > 0 && (len(profiles[i].LabelsIncludeAll) > 0 || len(profiles[i].LabelsIncludeAny) > 0 || len(profiles[i].LabelsExcludeAny) > 0) {
+			return fleet.NewInvalidArgumentError("mdm", `Couldn't edit configuration_profiles. Deprecated "labels" field cannot be combined with other label fields.`)
+		}
+
 		// from this point on (after this condition), only LabelsIncludeAll, LabelsIncludeAny or
 		// LabelsExcludeAny need to be checked.
 		if len(profiles[i].Labels) > 0 {

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -1383,11 +1383,11 @@ func TestMDMWindowsConfigProfileAuthz(t *testing.T) {
 			checkShouldFail(t, err, tt.shouldFailTeamRead)
 
 			// test authz create new profile (no team)
-			_, err = svc.NewMDMWindowsConfigProfile(ctx, 0, "prof", []byte(winProfContent), nil, fleet.LabelsIncludeAll)
+			_, err = svc.NewMDMWindowsConfigProfile(ctx, 0, "prof", []byte(winProfContent), nil, fleet.LabelsIncludeAll, nil)
 			checkShouldFail(t, err, tt.shouldFailGlobalWrite)
 
 			// test authz create new profile (team 1)
-			_, err = svc.NewMDMWindowsConfigProfile(ctx, 1, "prof", []byte(winProfContent), nil, fleet.LabelsIncludeAll)
+			_, err = svc.NewMDMWindowsConfigProfile(ctx, 1, "prof", []byte(winProfContent), nil, fleet.LabelsIncludeAll, nil)
 			checkShouldFail(t, err, tt.shouldFailTeamWrite)
 
 			// test authz delete config profile (no team)
@@ -1485,7 +1485,7 @@ func TestUploadWindowsMDMConfigProfileValidations(t *testing.T) {
 				}, nil
 			}
 			ctx = test.UserContext(ctx, test.UserAdmin)
-			_, err := svc.NewMDMWindowsConfigProfile(ctx, c.tmID, "foo", []byte(c.profile), nil, fleet.LabelsIncludeAll)
+			_, err := svc.NewMDMWindowsConfigProfile(ctx, c.tmID, "foo", []byte(c.profile), nil, fleet.LabelsIncludeAll, nil)
 			if c.wantErr != "" {
 				require.Error(t, err)
 				require.ErrorContains(t, err, c.wantErr)
@@ -2829,7 +2829,7 @@ func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
 			}
 			ctx = license.NewContext(ctx, &fleet.LicenseInfo{Tier: tier})
 
-			_, err := svc.NewMDMAndroidConfigProfile(ctx, tt.teamID, tt.name, []byte(tt.profile), nil, fleet.LabelsIncludeAll)
+			_, err := svc.NewMDMAndroidConfigProfile(ctx, tt.teamID, tt.name, []byte(tt.profile), nil, fleet.LabelsIncludeAll, nil)
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 				require.True(t, ds.NewMDMAndroidConfigProfileFuncInvoked)

--- a/server/service/software_installers_test.go
+++ b/server/service/software_installers_test.go
@@ -306,13 +306,24 @@ func TestValidateSoftwareLabels(t *testing.T) {
 				"",
 			},
 			{
-				"include and exclude labels",
+				"include_any and exclude_any labels combined",
 				[]string{"foo"},
 				[]string{"bar"},
 				nil,
+				map[string]fleet.LabelIdent{
+					"foo": {LabelID: 1, LabelName: "foo"},
+				},
+				fleet.LabelScopeIncludeAny,
+				"",
+			},
+			{
+				"include_any and include_all conflict",
+				[]string{"foo"},
+				nil,
+				[]string{"bar"},
 				nil,
 				"",
-				`Only one of "labels_include_all", "labels_include_any" or "labels_exclude_any" can be included.`,
+				`"labels_include_all" and "labels_include_any" cannot be combined.`,
 			},
 			{
 				"non-existent label",
@@ -367,6 +378,35 @@ func TestValidateSoftwareLabels(t *testing.T) {
 				}
 			})
 		}
+
+		// Test combined include+exclude: verify ExcludeByName is populated
+		t.Run("combined include_any + exclude_any populates ExcludeByName", func(t *testing.T) {
+			got, err := eeservice.ValidateSoftwareLabels(ctx, svc, nil, []string{"foo"}, []string{"bar"}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, fleet.LabelScopeIncludeAny, got.LabelScope)
+			require.Equal(t, map[string]fleet.LabelIdent{
+				"foo": {LabelID: 1, LabelName: "foo"},
+			}, got.ByName)
+			require.Equal(t, map[string]fleet.LabelIdent{
+				"bar": {LabelID: 2, LabelName: "bar"},
+			}, got.ExcludeByName)
+		})
+
+		// Test combined include_all + exclude_any
+		t.Run("combined include_all + exclude_any populates ExcludeByName", func(t *testing.T) {
+			got, err := eeservice.ValidateSoftwareLabels(ctx, svc, nil, nil, []string{"baz"}, []string{"foo", "bar"})
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, fleet.LabelScopeIncludeAll, got.LabelScope)
+			require.Equal(t, map[string]fleet.LabelIdent{
+				"foo": {LabelID: 1, LabelName: "foo"},
+				"bar": {LabelID: 2, LabelName: "bar"},
+			}, got.ByName)
+			require.Equal(t, map[string]fleet.LabelIdent{
+				"baz": {LabelID: 3, LabelName: "baz"},
+			}, got.ExcludeByName)
+		})
 	})
 
 	t.Run("validate update", func(t *testing.T) {

--- a/server/service/windows_mdm_profiles.go
+++ b/server/service/windows_mdm_profiles.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/variables"
 )
 
-func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode) (*fleet.MDMWindowsConfigProfile, error) {
+func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint, profileName string, data []byte, labels []string, labelsMembershipMode fleet.MDMLabelsMode, excludeLabels []string) (*fleet.MDMWindowsConfigProfile, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: &teamID}, fleet.ActionWrite); err != nil {
 		return nil, ctxerr.Wrap(ctx, err)
 	}
@@ -78,6 +78,15 @@ func (svc *Service) NewMDMWindowsConfigProfile(ctx context.Context, teamID uint,
 	default:
 		// default include all
 		cp.LabelsIncludeAll = labelMap
+	}
+
+	// Handle combined include + exclude labels
+	if len(excludeLabels) > 0 {
+		excludeLabelMap, err := svc.validateProfileLabels(ctx, &teamID, excludeLabels)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "validating exclude labels")
+		}
+		cp.LabelsExcludeAny = excludeLabelMap
 	}
 
 	if err := svc.ds.ValidateEmbeddedSecrets(ctx, []string{string(cp.SyncML)}); err != nil {


### PR DESCRIPTION
**Related issues:** Resolves #29207, addresses #32073, #33443, #33441. Does NOT address #33442 (Reports — queries don't have `labels_exclude_any` in their model yet; separate work required).

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements via `sqlx.In` and positional `?` parameters), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually (MySQL integration test, 8 scenarios)

## Summary

Enables `labels_include_any` and `labels_exclude_any` (or `labels_include_all` and `labels_exclude_any`) to be specified simultaneously on **configuration profiles**, **software installers** (packages, VPP, fleet-maintained, in-house apps), and **policies**.

**Example use case:** Deploy software to all hosts in the "Engineering" label (`labels_include_any: ["Engineering"]`) except those in the "g-mdm" label (`labels_exclude_any: ["g-mdm"]`).

### Sub-issue coverage

| Sub-issue | Backend | GitOps/CLI | Frontend | Status |
|-----------|---------|------------|----------|--------|
| #32073 Configuration profiles | Full | Full | Partial (TargetLabelSelector has exclude section; MDM profile forms need wiring) | ~80% |
| #33443 Software | Full | Full | Partial (PackageForm wired; VPP/FMA/InHouse forms need wiring) | ~75% |
| #33441 Policies | Full | Full | Full (PolicyForm has dual include+exclude selection) | ~85% |
| #33442 Reports | Not started | Not started | Not started | 0% — queries lack `labels_exclude_any` in their model |

### Backend

**Core type** (`server/fleet/labels.go`):
- Extended `LabelIdentsWithScope` with `ExcludeByName` field and helper methods

**Validation** (8+ sites relaxed):
- `include_any + exclude_any` and `include_all + exclude_any` now allowed
- `include_any + include_all` still disallowed
- Deprecated `labels` field combos still disallowed

**Database writes**:
- `updatePolicyLabelsTx`: separate include/exclude batches
- `setOrUpdateSoftwareInstallerLabelsDB`: handles both `ByName` + `ExcludeByName`
- No schema migration needed

**Database reads (SQL rewrites)**:
- `isSoftwareLabelScoped`: UNION/OR → AND-based subqueries with positional params
- MDM profile expected-for-verification (Windows, Apple, declarations): same rewrite
- `generateDesiredStateQuery` template (BulkSetPending): consolidated from 4 UNION branches to 2

**Datastore read-back**:
- `software_installers.go`, `vpp.go`, `in_house_apps.go`: warning checks updated to only flag `include_any + include_all`
- VPP label read-back populates `ExcludeByName` for combined scopes

**Service layer**: all 4 MDM profile creation functions + `fleet.Service` interface updated

### Frontend

- `TargetLabelSelector`: optional exclude label section when include mode active
- `PolicyForm`: dual state for include + exclude labels
- `PackageForm`: `excludeLabelTargets` in form data
- Software helpers + API service updated for combined labels

### Tests

- **MySQL integration test** (8 scenarios, all pass against real MySQL)
- Unit tests for type methods, policy verification, software label validation
- Updated ~25 integration test assertions across enterprise, MDM, fleetctl, and datastore suites
- Updated 4 YAML test fixtures

### Docs
- REST API docs and YAML configuration docs updated

### Follow-up items
- #33442 Reports: queries need `labels_exclude_any` added to model, API, SQL, and frontend
- VPP, FleetMaintained, InHouse, Android frontend forms need `excludeLabelTargets` wiring
- MDM profile upload frontend forms need `excludeLabelTargets` wiring
- CSS styling for the exclude label section