### PR TITLE
Skip startup library for primo mode

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1499,11 +1499,20 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		if setupRequired {
 			// Pass in a closure to run the fleetctl command, so that the service layer
 			// doesn't need to import the CLI package.
-			applyStarterLibrary := func(ctx context.Context, serverURL, token string) error {
-				return service.ApplyStarterLibrary(ctx, serverURL, token, logger, func(args []string) error {
-					_, err := fleetctl.RunApp(args)
-					return err
-				})
+			// When Primo mode is enabled, skip the starter library as Primo has its own setup flow.
+			var applyStarterLibrary func(ctx context.Context, serverURL, token string) error
+			if config.Partnerships.EnablePrimo {
+				applyStarterLibrary = func(ctx context.Context, _, _ string) error {
+					logger.DebugContext(ctx, "Skipping starter library application due to Primo being enabled")
+					return nil
+				}
+			} else {
+				applyStarterLibrary = func(ctx context.Context, serverURL, token string) error {
+					return service.ApplyStarterLibrary(ctx, serverURL, token, logger, func(args []string) error {
+						_, err := fleetctl.RunApp(args)
+						return err
+					})
+				}
 			}
 			apiHandler = service.WithSetup(svc, logger, applyStarterLibrary, apiHandler)
 			frontendHandler = service.RedirectLoginToSetup(svc, logger, frontendHandler, config.Server.URLPrefix)

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1499,11 +1499,11 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		if setupRequired {
 			// Pass in a closure to run the fleetctl command, so that the service layer
 			// doesn't need to import the CLI package.
-			// When Primo mode is enabled, skip the starter library as Primo has its own setup flow.
+			// When Primo mode is enabled, skip the starter library.
 			var applyStarterLibrary func(ctx context.Context, serverURL, token string) error
 			if config.Partnerships.EnablePrimo {
 				applyStarterLibrary = func(ctx context.Context, _, _ string) error {
-					logger.DebugContext(ctx, "Skipping starter library application due to Primo being enabled")
+					logger.DebugContext(ctx, "Skipping starter library application in Primo mode")
 					return nil
 				}
 			} else {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -1622,7 +1622,7 @@ func (man Manager) addConfigs() {
 	man.addConfigString("microsoft_compliance_partner.proxy_api_key", "", "Shared key required to use the Microsoft Compliance Partner proxy API")
 	man.addConfigString("microsoft_compliance_partner.proxy_uri", "https://fleetdm.com", "URI of the Microsoft Compliance Partner proxy (for development/testing)")
 
-	man.addConfigBool("partnerships.enable_primo", false, "Cosmetically disables team capabilities in the UI")
+	man.addConfigBool("partnerships.enable_primo", false, "Disables the ability to manage multiple fleets in an instance, even in premium tier")
 
 	// Conditional Access
 	man.addConfigString("conditional_access.cert_serial_format", "hex",


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40791

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
We don't typically do new primo mode tests. As long as existing tests for startup library pass, we're good.
- [X] QA'd all new/changed functionality manually
  - [X] tested that starting a new instance with `FLEET_PARTNERSHIPS_ENABLE_PRIMO=true` causes the starter library not to be applied (no fleets, labels or policies

