### PR TITLE
Set MySQL binary logs expiration to save disk space in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
         "--max_allowed_packet=536870912",
         # Automatically expire binary logs after 1 day to save disk space in dev. Default is 30 days.
         "--binlog-expire-logs-seconds=86400",
-    ]
+      ]
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,9 @@ services:
         "--server-id=master-01",
         # Required for storage of Apple MDM bootstrap packages.
         "--max_allowed_packet=536870912",
-      ]
+        # Automatically expire binary logs after 1 day to save disk space in dev. Default is 30 days.
+        "--binlog-expire-logs-seconds=86400",
+    ]
     environment: &mysql-default-environment
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet
@@ -46,6 +48,8 @@ services:
         "--server-id=1",
         # Required for storage of Apple MDM bootstrap packages.
         "--max_allowed_packet=536870912",
+        # Automatically expire binary logs after 1 day to save disk space in dev. Default is 30 days.
+        "--binlog-expire-logs-seconds=86400",
       ]
     environment: *mysql-default-environment
     ports:
@@ -72,6 +76,8 @@ services:
         "--server-id=2",
         # Required for storage of Apple MDM bootstrap packages.
         "--max_allowed_packet=536870912",
+        # Automatically expire binary logs after 1 day to save disk space in dev. Default is 30 days.
+        "--binlog-expire-logs-seconds=86400",
       ]
     environment: *mysql-default-environment
     ports:


### PR DESCRIPTION
Manually tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database container configurations to manage log retention. Binary logs will now automatically expire after 24 hours in local development environments, helping manage disk space usage during testing and development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->