### PR TITLE
Add Fleet-maintained app labels and patch policies

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -110,6 +110,8 @@ labels:
   - path: ./lib/all/labels/team-g-software.yml
   - path: ./lib/all/labels/nudge-test-devices.yml
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
+  - path: ./lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+  - path: ./lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/department-information-technology.yml
   - path: ./lib/all/labels/department-sales.yml
   - path: ./lib/all/labels/department-marketing.yml

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,19 +117,16 @@ policies:
   - path: ../lib/macos/policies/disk-space-check.yml
   - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/install-nudge.yml
-  - path: ../lib/macos/policies/update-claude.yml
-  - path: ../lib/macos/policies/update-slack.yml
+  - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/macos/policies/battery-health-check.yml
   # Windows policies
-  - path: ../lib/windows/policies/update-firefox.yml
   - path: ../lib/windows/policies/antivirus-signatures-up-to-date.yml
   - path: ../lib/windows/policies/all-windows-updates-installed.yml
   - path: ../lib/windows/policies/disk-encryption-check.yml
   - path: ../lib/windows/policies/disk-space-check.yml
   - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/update-1password.yml
-  - path: ../lib/windows/policies/update-claude.yml
-  - path: ../lib/windows/policies/update-slack.yml
+  - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml
   # Linux policies

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -1,0 +1,45 @@
+- name: Macs with Google Chrome installed
+  description: macOS hosts with Google Chrome installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.Chrome';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Brave Browser installed
+  description: macOS hosts with Brave Browser installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Docker Desktop installed
+  description: macOS hosts with Docker Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.docker.docker';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Microsoft Edge installed
+  description: macOS hosts with Microsoft Edge installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Visual Studio Code installed
+  description: macOS hosts with Visual Studio Code installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Microsoft Teams installed
+  description: macOS hosts with Microsoft Teams installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Slack installed
+  description: macOS hosts with Slack installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Okta Verify installed
+  description: macOS hosts with Okta Verify installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.okta.mobile';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Claude installed
+  description: macOS hosts with Claude installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -1,0 +1,30 @@
+- name: Windows hosts with Slack installed
+  description: Windows hosts with Slack installed
+  query: SELECT 1 FROM programs WHERE name = 'Slack';
+  label_membership_type: dynamic
+  platform: windows
+- name: Windows hosts with Claude installed
+  description: Windows hosts with Claude installed
+  query: SELECT 1 FROM programs WHERE name = 'Claude';
+  label_membership_type: dynamic
+  platform: windows
+- name: Windows hosts with Firefox installed
+  description: Windows hosts with Firefox installed
+  query: SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox%' AND name NOT LIKE '%ESR%';
+  label_membership_type: dynamic
+  platform: windows
+- name: Windows hosts with Google Chrome installed
+  description: Windows hosts with Google Chrome installed
+  query: SELECT 1 FROM programs WHERE name = 'Google Chrome';
+  label_membership_type: dynamic
+  platform: windows
+- name: Windows hosts with Brave Browser installed
+  description: Windows hosts with Brave Browser installed
+  query: SELECT 1 FROM programs WHERE name = 'Brave';
+  label_membership_type: dynamic
+  platform: windows
+- name: Windows hosts with Visual Studio Code installed
+  description: Windows hosts with Visual Studio Code installed
+  query: SELECT 1 FROM programs WHERE name LIKE 'Microsoft Visual Studio Code%';
+  label_membership_type: dynamic
+  platform: windows

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -1,21 +1,21 @@
-- name: Windows hosts with Slack installed
-  description: Windows hosts with Slack installed
-  query: SELECT 1 FROM programs WHERE name = 'Slack';
+- name: x86 Windows hosts with Slack installed
+  description: x86 Windows hosts with Slack installed
+  query: SELECT 1 FROM programs WHERE name = 'Slack' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: Windows hosts with Claude installed
-  description: Windows hosts with Claude installed
-  query: SELECT 1 FROM programs WHERE name = 'Claude';
+- name: x86 Windows hosts with Claude installed
+  description: x86 Windows hosts with Claude installed
+  query: SELECT 1 FROM programs WHERE name = 'Claude' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: Windows hosts with Firefox installed
-  description: Windows hosts with Firefox installed
-  query: SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox%' AND name NOT LIKE '%ESR%';
+- name: x86 Windows hosts with Firefox installed
+  description: x86 Windows hosts with Firefox installed
+  query: SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox%' AND name NOT LIKE '%ESR%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: Windows hosts with Google Chrome installed
-  description: Windows hosts with Google Chrome installed
-  query: SELECT 1 FROM programs WHERE name = 'Google Chrome';
+- name: x86 Windows hosts with Google Chrome installed
+  description: x86 Windows hosts with Google Chrome installed
+  query: SELECT 1 FROM programs WHERE name = 'Google Chrome' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
 - name: Windows hosts with Brave Browser installed

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -1,0 +1,72 @@
+- name: macOS - Google Chrome up to date
+  description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality. You can also delete Google Chrome if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: google-chrome/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Google Chrome installed
+- name: macOS - Brave Browser up to date
+  description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: brave-browser/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Brave Browser installed
+- name: macOS - Docker Desktop up to date
+  description: The host may have an outdated version of Docker Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Docker Desktop's built-in update functionality. You can also delete Docker Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: docker-desktop/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Docker Desktop installed
+- name: macOS - Microsoft Edge up to date
+  description: The host may have an outdated version of Microsoft Edge, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Microsoft Edge's built-in update functionality. You can also delete Microsoft Edge if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: microsoft-edge/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Microsoft Edge installed
+- name: macOS - Visual Studio Code up to date
+  description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also delete Visual Studio Code if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: visual-studio-code/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Visual Studio Code installed
+- name: macOS - Microsoft Teams up to date
+  description: The host may have an outdated version of Microsoft Teams, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Microsoft Teams's built-in update functionality. You can also delete Microsoft Teams if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: microsoft-teams/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Microsoft Teams installed
+- name: macOS - Slack up to date
+  description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also delete Slack if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: slack/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Slack installed
+- name: macOS - Okta Verify up to date
+  description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality. You can also delete Okta Verify if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: okta-verify/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Okta Verify installed
+- name: macOS - Claude up to date
+  description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also delete Claude if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: claude/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Claude installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -4,36 +4,32 @@
   type: patch
   fleet_maintained_app_slug: slack/windows
   install_software: false
-  labels_include_all:
-    - Windows hosts with Slack installed
-    - x86-based Windows hosts
+  labels_include_any:
+    - x86 Windows hosts with Slack installed
 - name: Windows - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: claude/windows
   install_software: false
-  labels_include_all:
-    - Windows hosts with Claude installed
-    - x86-based Windows hosts
+  labels_include_any:
+    - x86 Windows hosts with Claude installed
 - name: Windows - Firefox up to date
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Firefox's built-in update functionality. You can also uninstall Firefox if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: firefox/windows
   install_software: false
-  labels_include_all:
-    - Windows hosts with Firefox installed
-    - x86-based Windows hosts
+  labels_include_any:
+    - x86 Windows hosts with Firefox installed
 - name: Windows - Google Chrome up to date
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality. You can also uninstall Google Chrome if you are no longer using it."
   type: patch
   fleet_maintained_app_slug: google-chrome/windows
   install_software: false
-  labels_include_all:
-    - Windows hosts with Google Chrome installed
-    - x86-based Windows hosts
+  labels_include_any:
+    - x86 Windows hosts with Google Chrome installed
 - name: Windows - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also uninstall Brave Browser if you are no longer using it."

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -1,0 +1,52 @@
+- name: Windows - Slack up to date
+  description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also uninstall Slack if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: slack/windows
+  install_software: false
+  labels_include_all:
+    - Windows hosts with Slack installed
+    - x86-based Windows hosts
+- name: Windows - Claude up to date
+  description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: claude/windows
+  install_software: false
+  labels_include_all:
+    - Windows hosts with Claude installed
+    - x86-based Windows hosts
+- name: Windows - Firefox up to date
+  description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Firefox's built-in update functionality. You can also uninstall Firefox if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: firefox/windows
+  install_software: false
+  labels_include_all:
+    - Windows hosts with Firefox installed
+    - x86-based Windows hosts
+- name: Windows - Google Chrome up to date
+  description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality. You can also uninstall Google Chrome if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: google-chrome/windows
+  install_software: false
+  labels_include_all:
+    - Windows hosts with Google Chrome installed
+    - x86-based Windows hosts
+- name: Windows - Brave Browser up to date
+  description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also uninstall Brave Browser if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: brave-browser/windows
+  install_software: false
+  labels_include_any:
+    - Windows hosts with Brave Browser installed
+- name: Windows - Visual Studio Code up to date
+  description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also uninstall Visual Studio Code if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: visual-studio-code/windows
+  install_software: false
+  labels_include_any:
+    - Windows hosts with Visual Studio Code installed


### PR DESCRIPTION
Introduce dynamic labels for common Fleet-maintained apps on macOS and Windows, and add corresponding patch policies for macOS and Windows. Update it-and-security/default.yml to include the new labels and it-and-security/fleets/workstations.yml to use the consolidated patch policies (replacing individual update policies). macOS policies use labels_include_any and reference fleet_maintained_app_slug entries; Windows policies include platform and architecture filters where applicable. This centralizes patch checks for Fleet-maintained apps and simplifies fleet policy management.