### PR TITLE
Fleet UI: Align edit icon with first row of text

### DIFF
--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -603,7 +603,9 @@ const PolicyForm = ({
                 />
                 <Icon
                   name="pencil"
-                  className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
+                  className={`${baseClass}__edit-icon ${
+                    isEditingDescription ? `${baseClass}__edit-icon--hide` : ""
+                  }`}
                   size="small-medium"
                   color="core-fleet-green"
                 />
@@ -651,7 +653,9 @@ const PolicyForm = ({
                   />
                   <Icon
                     name="pencil"
-                    className={`edit-icon ${isEditingResolution ? "hide" : ""}`}
+                    className={`${baseClass}__edit-icon ${
+                      isEditingResolution ? `${baseClass}__edit-icon--hide` : ""
+                    }`}
                     size="small-medium"
                     color="core-fleet-green"
                   />

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -69,9 +69,10 @@
   &__policy-description-wrapper,
   &__policy-resolution-wrapper {
     display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
+    align-items: flex-start;
+    gap: $pad-small;
     width: fit-content;
+
     &:not(&--editing) {
       &:hover {
         cursor: pointer;
@@ -87,32 +88,35 @@
   }
 
   &__policy-name-wrapper {
+    line-height: $line-height-large;
+
     .no-value {
       min-width: 112px;
     }
   }
 
-  &__policy-description-wrapper {
-    .no-value {
-      min-width: 106px;
-    }
-    .edit-icon {
-      position: relative;
-      top: 0;
-    }
-  }
-  &__policy-resolution-wrapper {
-    .no-value {
-      min-width: 106px;
-    }
-  }
   &__edit-icon {
     opacity: 1;
     transition: opacity 0.2s;
     margin-left: 0;
+    /** Designed to be aligned with first line of text, not center of multiple
+    lines of text, without this, the icon will vertically center on multiline */
     align-self: initial;
+    height: 42px; // 24px font-size * 1.75 line height
+    align-items: center; // Centers the icon in the height area
+
     &--hide {
       opacity: 0;
+    }
+  }
+
+  &__policy-description-wrapper,
+  &__policy-resolution-wrapper {
+    .no-value {
+      min-width: 106px;
+    }
+    .policy-form__edit-icon {
+      height: 21px; // 14px font-size * 1.5 line height
     }
   }
 

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -515,7 +515,9 @@ const EditQueryForm = ({
                 />
                 <Icon
                   name="pencil"
-                  className={`edit-icon ${isEditingName ? "hide" : ""}`}
+                  className={`${baseClass}__edit-icon ${
+                    isEditingName ? `${baseClass}__edit-icon--hide` : ""
+                  }`}
                   size="small-medium"
                   color="core-fleet-green"
                 />
@@ -567,7 +569,9 @@ const EditQueryForm = ({
                 />
                 <Icon
                   name="pencil"
-                  className={`edit-icon ${isEditingDescription ? "hide" : ""}`}
+                  className={`${baseClass}__edit-icon ${
+                    isEditingDescription ? `${baseClass}__edit-icon--hide` : ""
+                  }`}
                   size="small-medium"
                   color="core-fleet-green"
                 />

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -52,6 +52,22 @@
       @include disabled;
     }
   }
+
+  &__edit-icon {
+    opacity: 1;
+    transition: opacity 0.2s;
+    margin-left: 0;
+    /** Designed to be aligned with first line of text, not center of multiple
+    lines of text, without this, the icon will vertically center on multiline */
+    align-self: initial;
+    height: 42px; // 24px font-size * 1.75 line height
+    align-items: center; // Centers the icon in the height area
+
+    &--hide {
+      opacity: 0;
+    }
+  }
+
   &__query-name-wrapper {
     .no-value {
       min-width: 168px;
@@ -62,14 +78,9 @@
     .no-value {
       min-width: 144px;
     }
-  }
 
-  .edit-icon {
-    align-self: initial;
-    opacity: 1;
-    transition: opacity 0.2s;
-    &.hide {
-      opacity: 0;
+    .edit-query-form__edit-icon {
+      height: 21px; // 14px font-size * 1.5 line height
     }
   }
 


### PR DESCRIPTION
## Issue
Closes #35315 

## Description
- Center align with top line of text

> Note: While working on this I found #41753 which overhauls these components all together with normal inputs

## Screen recording
https://fleetdm.zoom.us/clips/share/WIIneo1PRlq8w92Eb45CcQ


# Checklist for submitter

## Testing

- [x] QA'd all new/changed functionality manually
