### PR TITLE
Refine winget ingester installer selection

### DIFF
--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -122,11 +122,21 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 		return nil, fmt.Errorf("get data from winget repo: %w", err)
 	}
 
-	// sort the list of directories in descending order
-	slices.SortFunc(repoContents, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
+	versionDirs := make([]*github.RepositoryContent, 0, len(repoContents))
+	for _, c := range repoContents {
+		if c.GetType() == "dir" {
+			versionDirs = append(versionDirs, c)
+		}
+	}
+	if len(versionDirs) == 0 {
+		return nil, ctxerr.New(ctx, "no version directories found under winget package path")
+	}
+
+	// sort the list of version directories in descending order
+	slices.SortFunc(versionDirs, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
 
 	// this directory has the latest version data in it
-	latestVersionDir := repoContents[0]
+	latestVersionDir := versionDirs[0]
 	if latestVersionDir.GetName() == "" {
 		return nil, ctxerr.New(ctx, "latest version for app not found")
 	}
@@ -203,11 +213,14 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 		uninstallScript = string(scriptBytes)
 	}
 
-	for _, installer := range m.Installers {
+	for idx := range m.Installers {
+		installer := &m.Installers[idx]
 		i.logger.DebugContext(ctx, "checking installer", "arch", installer.Architecture, "type", installer.InstallerType, "locale", installer.InstallerLocale, "scope", installer.Scope)
-		installerType := m.InstallerType
-		if installerType == "" || isVendorType(installerType) {
-			installerType = installer.InstallerType
+		// Prefer per-installer fields; winget manifests often set a default InstallerType at the
+		// package level (e.g. exe) that does not apply to every nested installer (e.g. a wix MSI).
+		installerType := installer.InstallerType
+		if installerType == "" {
+			installerType = m.InstallerType
 		}
 
 		if installerType == "" || isVendorType(installerType) {
@@ -225,17 +238,17 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 			installerType = installerTypeExe
 		}
 
-		scope := m.Scope
+		scope := installer.Scope
 		if scope == "" {
-			scope = installer.Scope
-			if scope == "" {
-				switch installerType {
-				case installerTypeMSI:
-					scope = machineScope
-				case installerTypeMSIX, "zip":
-					// AppX/MSIX packages and zip files containing AppX are typically user-scoped
-					scope = userScope
-				}
+			scope = m.Scope
+		}
+		if scope == "" {
+			switch installerType {
+			case installerTypeMSI:
+				scope = machineScope
+			case installerTypeMSIX, "zip":
+				// AppX/MSIX packages and zip files containing AppX are typically user-scoped
+				scope = userScope
 			}
 		}
 
@@ -261,19 +274,34 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 			urlExt := strings.Trim(filepath.Ext(installer.InstallerURL), ".")
 			if urlExt == input.InstallerType {
 				// Perfect match - URL extension matches desired type
-				selectedInstaller = &installer
+				selectedInstaller = installer
 				break
 			}
 			// Keep as fallback candidate if we haven't found a perfect match yet
 			if selectedInstaller == nil {
-				selectedInstaller = &installer
+				selectedInstaller = installer
 			}
 		}
 
 	}
 
 	if selectedInstaller == nil {
-		return nil, ctxerr.New(ctx, "failed to find installer for app")
+		var detail strings.Builder
+		fmt.Fprintf(
+			&detail,
+			"failed to find installer for app %s (%s) version %s: want arch=%s type=%s scope=%s locale=%q; manifest has:",
+			input.Slug,
+			input.PackageIdentifier,
+			m.PackageVersion,
+			input.InstallerArch,
+			input.InstallerType,
+			input.InstallerScope,
+			input.InstallerLocale,
+		)
+		for _, ins := range m.Installers {
+			fmt.Fprintf(&detail, " [%s type=%s scope=%s locale=%q]", ins.Architecture, ins.InstallerType, ins.Scope, ins.InstallerLocale)
+		}
+		return nil, ctxerr.New(ctx, detail.String())
 	}
 
 	if input.InstallerType == installerTypeMSI && input.InstallerScope == machineScope {

--- a/ee/maintained-apps/ingesters/winget/ingester_test.go
+++ b/ee/maintained-apps/ingesters/winget/ingester_test.go
@@ -205,6 +205,31 @@ func TestIngestValidations(t *testing.T) {
 				upgradeCode:       "{ABCDEF}",
 			},
 		},
+		{
+			name:    "root default exe does not hide per-row wix MSI",
+			wantErr: "",
+			inputApp: inputApp{
+				Name:                "Foo",
+				UniqueIdentifier:    "Foo",
+				PackageIdentifier:   "Foo",
+				InstallerArch:       "x64",
+				Slug:                "foo/windows",
+				InstallScriptPath:   path.Join(tempDir, "install_script.ps1"),
+				UninstallScriptPath: path.Join(tempDir, "uninstall_script.ps1"),
+				InstallerType:       "msi",
+				InstallerScope:      "machine",
+			},
+			cfg: serverConfig{
+				productCode:        "{ABCDEF}",
+				installerType:      "msi",
+				rootInstallerType:  "exe",
+				rowInstallerType:   "wix",
+				installerScope:     "machine",
+				installerArch:      "x64",
+				installerProdCode:  "{ACBDEF}",
+				upgradeCode:        "{ABCDEF}",
+			},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -234,6 +259,8 @@ func TestIngestValidations(t *testing.T) {
 type serverConfig struct {
 	productCode       string
 	installerType     string
+	rootInstallerType string // manifest root InstallerType when set (else installerType)
+	rowInstallerType  string // per-row InstallerType when set (else installerType)
 	installerScope    string
 	installerArch     string
 	installerProdCode string
@@ -241,17 +268,29 @@ type serverConfig struct {
 }
 
 func newTestServer(t *testing.T, cfg serverConfig) *httptest.Server {
+	rootInstType := cfg.rootInstallerType
+	if rootInstType == "" {
+		rootInstType = cfg.installerType
+	}
+	rowInstType := cfg.rowInstallerType
+	if rowInstType == "" {
+		rowInstType = cfg.installerType
+	}
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 
 		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo":
-			content := []github.RepositoryContent{{Name: ptr.String("Foo")}}
+			dirType := "dir"
+			content := []github.RepositoryContent{{
+				Name: ptr.String("Foo"),
+				Type: &dirType,
+			}}
 			require.NoError(t, json.NewEncoder(w).Encode(content))
 
 		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/Foo/Foo.installer.yaml":
 			manifest := installerManifest{
 				ProductCode:    cfg.productCode,
-				InstallerType:  cfg.installerType,
+				InstallerType:  rootInstType,
 				Scope:          cfg.installerScope,
 				PackageVersion: "1.0",
 				AppsAndFeaturesEntries: []appsAndFeaturesEntries{
@@ -259,10 +298,12 @@ func newTestServer(t *testing.T, cfg serverConfig) *httptest.Server {
 				},
 				Installers: []installer{
 					{
-						Architecture:  cfg.installerArch,
-						InstallerType: cfg.installerType,
-						ProductCode:   cfg.installerProdCode,
-						Scope:         cfg.installerScope,
+						Architecture:    cfg.installerArch,
+						InstallerType:   rowInstType,
+						InstallerURL:    "https://example.com/foo.msi",
+						ProductCode:     cfg.installerProdCode,
+						Scope:           cfg.installerScope,
+						InstallerSha256: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 					},
 				},
 			}


### PR DESCRIPTION
This pull request refines the logic for ingesting and selecting installers from WinGet manifests, especially in cases where per-installer fields differ from package-level defaults. It also improves error reporting and expands test coverage to ensure correct behavior when installer types are overridden at different manifest levels.

**Improvements to installer selection logic:**

* Updated the selection logic in `ingestOne` to prefer per-installer (`row`) `InstallerType` and `Scope` over root manifest defaults, ensuring that nested installer-specific types (e.g., MSI, Wix) are not incorrectly overridden by package-level defaults [[1]](diffhunk://#diff-eb6c4ae7be41e61a2292c4240de750809d40c0686fb01f80f52df056ebc9c2a8L206-R223) [[2]](diffhunk://#diff-eb6c4ae7be41e61a2292c4240de750809d40c0686fb01f80f52df056ebc9c2a8L228-R244).
* Modified the sorting of version directories to only consider directories (not files), preventing errors when non-directory entries are present in the manifest path.

**Error handling and reporting:**

* Enhanced error messages when no suitable installer is found, including detailed information about the search criteria and available installers to ease debugging.

**Test coverage improvements:**

* Added a test case to verify that a root-level default installer type (e.g., "exe") does not hide a per-installer type (e.g., "wix" MSI), ensuring correct selection logic.
* Extended the test server and configuration to support root and per-row installer type overrides, and to properly simulate directory entries in the manifest [[1]](diffhunk://#diff-c68f0564df3c6e38ad333d4ca6e1040305eb079eb0d168d29c95b1b250463055R262-R293) [[2]](diffhunk://#diff-c68f0564df3c6e38ad333d4ca6e1040305eb079eb0d168d29c95b1b250463055L263-R306).