### PR TITLE
Fix UserMenu.tsx for multi-team user

### DIFF
--- a/changes/42979-fix-for-multi-team-user
+++ b/changes/42979-fix-for-multi-team-user
@@ -1,0 +1,1 @@
+* Fixed navigation to settings page on multi-team admin users.

--- a/frontend/components/top_nav/UserMenu/UserMenu.tsx
+++ b/frontend/components/top_nav/UserMenu/UserMenu.tsx
@@ -150,25 +150,31 @@ const UserMenu = ({
   dropdownItems.unshift(manageLabelsMenuItem);
 
   if (currentUser && (isAnyTeamAdmin || isGlobalAdmin)) {
-    const userAdminTeams = currentUser.teams.filter(
-      (thisTeam: ITeam) => thisTeam.role === "admin"
-    );
-    const sortedTeams = getSortedTeamOptions(userAdminTeams);
-
     let clickHandler = () => onUserMenuItemClick(PATHS.ADMIN_ORGANIZATION);
     if (currentUser.global_role !== "admin") {
+      const userAdminTeams = currentUser.teams.filter(
+        (thisTeam: ITeam) => thisTeam.role === "admin"
+      );
       clickHandler = () => {
-        const targetTeam = sortedTeams[0];
-        if (currentTeam && currentTeam.id !== targetTeam.value) {
-          const msg = (
-            <>
-              You&apos;re not authorized to view this page for{" "}
-              <b>{currentTeam.name}</b>. Now viewing <b>{targetTeam.label}</b>.
-            </>
-          );
-          renderFlash("warning-filled", msg);
+        const currentTeamIsAdmin =
+          currentTeam && userAdminTeams.some((t) => t.id === currentTeam.id);
+        if (currentTeamIsAdmin) {
+          onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(currentTeam.id));
+        } else {
+          // Sort and pick the first team the user is admin of to display.
+          const targetTeam = getSortedTeamOptions(userAdminTeams)[0];
+          if (currentTeam) {
+            const msg = (
+              <>
+                You&apos;re not authorized to view this page for{" "}
+                <b>{currentTeam.name}</b>. Now viewing <b>{targetTeam.label}</b>
+                .
+              </>
+            );
+            renderFlash("warning-filled", msg);
+          }
+          onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
         }
-        onUserMenuItemClick(PATHS.FLEET_DETAILS_USERS(targetTeam.value));
       };
     }
 


### PR DESCRIPTION
Resolves #42979

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

Tested UI flow described in issue with:
- Global admin.
- Global maintainer.
- Team admin of one team.
- Team admin of two teams (where bug manifests).
- Team maintainer of two teams.
- Team admin of one team, maintainer of another team.
- Team admin of one team, technician of another team.