### PR TITLE
🤖 Add "confirm is pending" else block back to setup experience test

### DIFF
--- a/server/service/integration_mdm_setup_experience_test.go
+++ b/server/service/integration_mdm_setup_experience_test.go
@@ -2155,9 +2155,9 @@ func (s *integrationMDMTestSuite) TestSetupExperienceWithLotsOfVPPApps() {
 		_, ok := expectedAppsByName[software.Name]
 		require.True(t, ok)
 		if software.Name == macOSApp1.Name {
-			require.Equal(t, fleet.SetupExperienceStatusSuccess, software.Status)
+			require.Equalf(t, fleet.SetupExperienceStatusSuccess, software.Status, "software %s should have succeeded", software.Name)
 		} else {
-			require.Equal(t, fleet.SetupExperienceStatusPending, software.Status)
+			require.Equalf(t, fleet.SetupExperienceStatusPending, software.Status, "software %s should be pending", software.Name)
 		}
 		require.NotNil(t, software.SoftwareTitleID)
 		require.NotZero(t, *software.SoftwareTitleID)
@@ -2200,6 +2200,8 @@ func (s *integrationMDMTestSuite) TestSetupExperienceWithLotsOfVPPApps() {
 			_, shouldBeInstalled := installedApps[software.Name]
 			if shouldBeInstalled {
 				require.Equalf(t, fleet.SetupExperienceStatusSuccess, software.Status, "software %s should have succeeded", software.Name)
+			} else {
+				require.Equalf(t, fleet.SetupExperienceStatusPending, software.Status, "software %s should be pending", software.Name)
 			}
 			require.NotNil(t, software.SoftwareTitleID)
 			require.NotZero(t, *software.SoftwareTitleID)


### PR DESCRIPTION
Zed + Opus 4.6; prompts below all in the same conversation:

Relates to #41741.

> What hanged between the base branch and now in `TestSetupExperienceVPPInstallError`, and why?

(sic)

> Explain what changed around L2179

(agent assumed something without actually running the tests)

> Run the test first to validate existing behavior; the current test *does* pass. Thinking we want to put the else block back but use the slice index to differentiate between the first item in the list (expected to be running) and the rest (expected to be pending).

(agent found that an app is _not_ listed as running on the polling cycle that we're looking at and suggested testing for everything being pending)

> Yep