### PR TITLE
Website: update search and article styles

### DIFF
--- a/website/assets/styles/docsearch.less
+++ b/website/assets/styles/docsearch.less
@@ -1,14 +1,14 @@
 /* Variables */
 
-@docsearch-primary-color: @core-vibrant-blue;
+@docsearch-primary-color: @core-vibrant-green;
 @docsearch-text-color: @core-fleet-black;
 @docsearch-spacing: 12px;
 @docsearch-icon-stroke-width: 1.4;
-@docsearch-highlight-color: @core-vibrant-blue;
+@docsearch-highlight-color: @core-vibrant-green;
 @docsearch-muted-color: @core-fleet-black-50;
 @docsearch-container-background: rgba(101, 108, 133, 0.8);
-@docsearch-logo-color: @core-vibrant-blue;
-@docsearch-icon-color: @core-vibrant-blue;
+@docsearch-logo-color: @core-vibrant-green;
+@docsearch-icon-color: @core-vibrant-green;
 
 /* modal */
 @docsearch-modal-width: 560px;
@@ -267,6 +267,10 @@
 
 .DocSearch-Logo svg {
   color: @docsearch-logo-color;
+  path, rect {
+    fill: @docsearch-logo-color;
+
+  }
   margin-left: 8px;
 }
 

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -504,7 +504,7 @@
       padding-bottom: 16px;
     }
     li::marker {
-      color: @core-vibrant-blue;
+      color: @core-vibrant-green;
     }
     .markdown-heading {
       scroll-margin-top: 140px;
@@ -518,7 +518,7 @@
         align-self: center;
       }
       input:checked, input:active {
-        accent-color: @core-vibrant-blue;
+        accent-color: @core-vibrant-green;
       }
       [purpose='task'] {
         margin-left: 16px;


### PR DESCRIPTION
Related to: #42652

Changes:
- Updated the colors of the docsearch search menu
- Updated the `<li>` marker color on article pages