### PR TITLE
Fleet-maintained apps: Rename "Firefox" to "Mozilla Firefox"

### DIFF
--- a/ee/maintained-apps/inputs/winget/firefox.json
+++ b/ee/maintained-apps/inputs/winget/firefox.json
@@ -1,5 +1,5 @@
 {
-  "name": "Firefox",
+  "name": "Mozilla Firefox",
   "slug": "firefox/windows",
   "package_identifier": "Mozilla.Firefox",
   "unique_identifier": "Mozilla Firefox (x64 en-US)",


### PR DESCRIPTION
To be consistent w/ macOS: https://github.com/fleetdm/fleet/blob/3a6ecb5a11fdbdf290faf7fdd7ffa6b29335892f/ee/maintained-apps/inputs/homebrew/firefox.json#L2
