### PR TITLE
Fleet UI: *New* policy details page + updates to the edit policy and edit report pages

### DIFF
--- a/frontend/components/TableContainer/_styles.scss
+++ b/frontend/components/TableContainer/_styles.scss
@@ -237,7 +237,7 @@
     }
 
     .icon {
-      vertical-align: sub;
+      vertical-align: center;
     }
   }
   .linkToFilteredHosts__header {

--- a/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
+++ b/frontend/components/TargetLabelSelector/TargetLabelSelector.tsx
@@ -106,6 +106,7 @@ const LabelChooser = ({
   customTargetOptions = [],
   onSelectCustomTarget,
   onSelectLabel,
+  disableOptions,
 }: ILabelChooserProps) => {
   const getHelpText = (value?: string) => {
     if (dropdownHelpText) return dropdownHelpText;
@@ -138,6 +139,7 @@ const LabelChooser = ({
           options={customTargetOptions}
           searchable={false}
           onChange={onSelectCustomTarget}
+          disabled={disableOptions}
         />
       )}
       <div className={`${baseClass}__description`}>
@@ -155,8 +157,10 @@ const LabelChooser = ({
                 value={!!selectedLabels[label.name]}
                 onChange={onSelectLabel}
                 parseTarget
-              />
-              <div className={`${baseClass}__label-name`}>{label.name}</div>
+                disabled={disableOptions}
+              >
+                {label.name}
+              </Checkbox>
             </div>
           );
         })}

--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -10,7 +10,7 @@
 
   &__checkboxes {
     display: flex;
-    max-height: 187px;
+    max-height: 189px; // Fits 5 options before scrolling
     flex-direction: column;
     border-radius: $border-radius;
     border: 1px solid $ui-fleet-black-10;
@@ -38,6 +38,6 @@
   }
 
   &__label-name {
-    padding-left: $pad-large;
+    padding-left: $pad-small;
   }
 }

--- a/frontend/components/buttons/Button/Button.tsx
+++ b/frontend/components/buttons/Button/Button.tsx
@@ -8,6 +8,7 @@ export type ButtonVariant =
   | "default"
   | "alert"
   | "pill"
+  | "grey-pill"
   | "text-link" // Underlines on hover
   | "text-link-dark" // underline on hover, dark text
   | "brand-inverse-icon" // Green icon with text, no underline on hover
@@ -146,7 +147,8 @@ class Button extends React.Component<IButtonProps, IButtonState> {
       variant === "inverse" ||
       variant === "brand-inverse-icon" ||
       variant === "text-icon" ||
-      variant === "pill";
+      variant === "pill" ||
+      variant === "grey-pill";
 
     return (
       <button

--- a/frontend/components/buttons/Button/_styles.scss
+++ b/frontend/components/buttons/Button/_styles.scss
@@ -190,6 +190,33 @@ $base-class: "button";
     }
   }
 
+  &--grey-pill {
+    @include button-variant(
+      $core-fleet-white,
+      $ui-off-white,
+      null,
+      $inverse: true
+    );
+    color: $ui-fleet-black-75;
+    border: 1px solid $ui-fleet-black-25;
+    border-radius: 4px;
+    box-sizing: border-box;
+    font-size: $xx-small;
+    font-weight: $bold;
+    padding: 0 $pad-small;
+    height: 28px;
+    white-space: nowrap;
+
+    &:hover,
+    &:focus {
+      border: 1px solid $ui-fleet-black-50;
+    }
+
+    &:active {
+      box-shadow: inset 2px 2px 2px rgba(0, 0, 0, 0.1);
+    }
+  }
+
   &--text-link {
     @include button-variant(transparent);
     border: 0;

--- a/frontend/components/forms/fields/Dropdown/_styles.scss
+++ b/frontend/components/forms/fields/Dropdown/_styles.scss
@@ -206,7 +206,7 @@
 
     &.is-disabled {
       > .Select-control .Select-value .Select-value-label {
-        color: $ui-fleet-black-5;
+        color: $ui-fleet-black-50;
       }
     }
   }

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditAutoUpdateConfigModal/EditAutoUpdateConfigModal.tests.tsx
@@ -401,11 +401,15 @@ describe("Edit Auto Update Config Modal", () => {
       await screen.findByLabelText("Custom");
 
       // Now wait specifically for one label to appear
-      const freshLabel = await screen.findByLabelText(mockLabels[1].name);
+      const freshLabel = await screen.findByRole("checkbox", {
+        name: mockLabels[1].name,
+      });
       expect(freshLabel).toBeInTheDocument();
       expect(freshLabel).toBeChecked();
 
-      const funLabel = screen.getByLabelText(mockLabels[0].name);
+      const funLabel = screen.getByRole("checkbox", {
+        name: mockLabels[0].name,
+      });
       expect(funLabel).toBeInTheDocument();
       expect(funLabel).not.toBeChecked();
     });
@@ -426,10 +430,12 @@ describe("Edit Auto Update Config Modal", () => {
         />
       );
       // Wait for labels to load
-      await screen.findByLabelText(mockLabels[1].name);
+      await screen.findByRole("checkbox", { name: mockLabels[1].name });
       const customOption = screen.getByLabelText("Custom");
       expect(customOption).toBeChecked();
-      const labelOption = screen.getByLabelText(mockLabels[1].name);
+      const labelOption = screen.getByRole("checkbox", {
+        name: mockLabels[1].name,
+      });
       expect(labelOption).toBeChecked();
       await user.click(labelOption);
       expect(labelOption).not.toBeChecked();

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerPoliciesTable/InstallerPoliciesTableConfig.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/SoftwareInstallerCard/InstallerPoliciesTable/InstallerPoliciesTableConfig.tsx
@@ -42,7 +42,7 @@ const generateInstallerPoliciesTableConfig = ({
           value={cellProps.cell.value}
           tooltipTruncate
           path={getPathWithQueryParams(
-            PATHS.EDIT_POLICY(cellProps.row.original.id),
+            PATHS.POLICY_DETAILS(cellProps.row.original.id),
             {
               fleet_id: teamId,
             }

--- a/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
+++ b/frontend/pages/policies/ManagePoliciesPage/components/PoliciesTable/PoliciesTableConfig.tsx
@@ -131,8 +131,8 @@ const generateTableHeaders = (
                 )}
               </>
             }
-            path={getPathWithQueryParams(PATHS.EDIT_POLICY(id), {
-              fleet_id: team_id,
+            path={getPathWithQueryParams(PATHS.POLICY_DETAILS(id), {
+              team_id,
             })}
           />
         );

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -197,7 +197,7 @@ const PolicyDetailsPage = ({
         className={`${baseClass}__author`}
         title="Author"
         value={
-          <>
+          <div className={`${baseClass}__author-info`}>
             <Avatar
               user={addGravatarUrlToResource({
                 email: storedPolicy.author_email,
@@ -209,7 +209,7 @@ const PolicyDetailsPage = ({
                 ? "You"
                 : storedPolicy.author_name}
             </span>
-          </>
+          </div>
         }
       />
     );
@@ -255,28 +255,31 @@ const PolicyDetailsPage = ({
     const labels = isInclude ? includeAny : excludeAny;
 
     return (
-      <div className={`${baseClass}__labels-section`}>
-        <dt className={`${baseClass}__labels-title`}>Labels</dt>
-        <dd>
-          <p className={`${baseClass}__labels-help-text`}>
-            Policy will target hosts that{" "}
-            <b>{isInclude ? "have any" : "exclude any"}</b> of these labels:
-          </p>
-          <ul className={`${baseClass}__labels-list`}>
-            {labels?.map((label) => (
-              <li key={label.id}>
-                <Button
-                  onClick={() => onLabelClick(label)}
-                  variant="grey-pill"
-                  className={`${baseClass}__label-pill`}
-                >
-                  {label.name}
-                </Button>
-              </li>
-            ))}
-          </ul>
-        </dd>
-      </div>
+      <DataSet
+        className={`${baseClass}__labels`}
+        title="Labels"
+        value={
+          <div className={`${baseClass}__labels-section`}>
+            <p>
+              Policy will target hosts that{" "}
+              <b>{isInclude ? "have any" : "exclude any"}</b> of these labels:
+            </p>
+            <ul className={`${baseClass}__labels-list`}>
+              {labels?.map((label: ILabelPolicy) => (
+                <li key={label.id}>
+                  <Button
+                    onClick={() => onLabelClick(label)}
+                    variant="grey-pill"
+                    className={`${baseClass}__label-pill`}
+                  >
+                    {label.name}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        }
+      />
     );
   };
 
@@ -357,14 +360,11 @@ const PolicyDetailsPage = ({
               </div>
             </div>
             {lastEditedQueryResolution && (
-              <div className={`${baseClass}__resolve-section`}>
-                <p className={`${baseClass}__resolve-title`}>
-                  <strong>Resolve</strong>
-                </p>
-                <p className={`${baseClass}__resolve-text`}>
-                  {lastEditedQueryResolution}
-                </p>
-              </div>
+              <DataSet
+                className={`${baseClass}__resolve`}
+                title="Resolve"
+                value={lastEditedQueryResolution}
+              />
             )}
             {renderAuthor()}
             {currentTeam && (

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -1,0 +1,286 @@
+import React, { useContext, useEffect, useState } from "react";
+import { useQuery } from "react-query";
+import { InjectedRouter, Params } from "react-router/lib/Router";
+import { useErrorHandler } from "react-error-boundary";
+import PATHS from "router/paths";
+import { AppContext } from "context/app";
+import { PolicyContext } from "context/policy";
+import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
+import globalPoliciesAPI from "services/entities/global_policies";
+import { addGravatarUrlToResource } from "utilities/helpers";
+import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
+import { getPathWithQueryParams } from "utilities/url";
+import useTeamIdParam from "hooks/useTeamIdParam";
+
+import BackButton from "components/BackButton";
+import Button from "components/buttons/Button";
+import DataSet from "components/DataSet";
+import Icon from "components/Icon";
+import MainContent from "components/MainContent";
+import PageDescription from "components/PageDescription";
+import Spinner from "components/Spinner";
+import Avatar from "components/Avatar";
+import ShowQueryModal from "components/modals/ShowQueryModal";
+
+interface IPolicyDetailsPageProps {
+  router: InjectedRouter;
+  params: Params;
+  location: {
+    pathname: string;
+    search: string;
+    query: { team_id?: string };
+  };
+}
+
+const baseClass = "policy-details-page";
+
+const PolicyDetailsPage = ({
+  router,
+  params: { id: paramsPolicyId },
+  location,
+}: IPolicyDetailsPageProps): JSX.Element => {
+  const policyId = paramsPolicyId ? parseInt(paramsPolicyId, 10) : null;
+  const handlePageError = useErrorHandler();
+
+  const {
+    currentUser,
+    isGlobalAdmin,
+    isGlobalMaintainer,
+    config,
+    currentTeam,
+  } = useContext(AppContext);
+
+  const {
+    lastEditedQueryName,
+    lastEditedQueryDescription,
+    lastEditedQueryResolution,
+    lastEditedQueryBody,
+    lastEditedQueryPlatform,
+    setLastEditedQueryId,
+    setLastEditedQueryName,
+    setLastEditedQueryDescription,
+    setLastEditedQueryBody,
+    setLastEditedQueryResolution,
+    setLastEditedQueryCritical,
+    setLastEditedQueryPlatform,
+    setLastEditedQueryLabelsIncludeAny,
+    setLastEditedQueryLabelsExcludeAny,
+    setPolicyTeamId,
+  } = useContext(PolicyContext);
+
+  const {
+    isRouteOk,
+    teamIdForApi,
+    isTeamMaintainerOrTeamAdmin,
+    isObserverPlus,
+  } = useTeamIdParam({
+    location,
+    router,
+    includeAllTeams: true,
+    includeNoTeam: true,
+    permittedAccessByTeamRole: {
+      admin: true,
+      maintainer: true,
+      observer: true,
+      observer_plus: true,
+    },
+  });
+
+  const [showQueryModal, setShowQueryModal] = useState(false);
+
+  if (policyId === null || isNaN(policyId)) {
+    router.push(PATHS.MANAGE_POLICIES);
+  }
+
+  const { isLoading, data: storedPolicy, error: apiError } = useQuery<
+    IStoredPolicyResponse,
+    Error,
+    IPolicy
+  >(["policy", policyId], () => globalPoliciesAPI.load(policyId as number), {
+    enabled: isRouteOk && !!policyId,
+    refetchOnWindowFocus: false,
+    retry: false,
+    select: (data: IStoredPolicyResponse) => data.policy,
+    onSuccess: (returnedPolicy) => {
+      setLastEditedQueryId(returnedPolicy.id);
+      setLastEditedQueryName(returnedPolicy.name);
+      setLastEditedQueryDescription(returnedPolicy.description);
+      setLastEditedQueryBody(returnedPolicy.query);
+      setLastEditedQueryResolution(returnedPolicy.resolution);
+      setLastEditedQueryCritical(returnedPolicy.critical);
+      setLastEditedQueryPlatform(returnedPolicy.platform);
+      setLastEditedQueryLabelsIncludeAny(
+        returnedPolicy.labels_include_any || []
+      );
+      setLastEditedQueryLabelsExcludeAny(
+        returnedPolicy.labels_exclude_any || []
+      );
+      setPolicyTeamId(returnedPolicy.team_id ?? undefined);
+    },
+    onError: (error) => handlePageError(error),
+  });
+
+  useEffect(() => {
+    if (storedPolicy?.name) {
+      document.title = `${storedPolicy.name} | Policies | ${DOCUMENT_TITLE_SUFFIX}`;
+    } else {
+      document.title = `Policies | ${DOCUMENT_TITLE_SUFFIX}`;
+    }
+  }, [location.pathname, storedPolicy?.name]);
+
+  const canEditPolicy =
+    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
+
+  const canRunPolicy = canEditPolicy || isObserverPlus;
+
+  const disabledLiveQuery = config?.server_settings.live_query_disabled;
+
+  const backToPoliciesPath = getPathWithQueryParams(PATHS.MANAGE_POLICIES, {
+    team_id: teamIdForApi,
+  });
+
+  const renderAuthor = (): JSX.Element | null => {
+    if (!storedPolicy) return null;
+    return (
+      <DataSet
+        className={`${baseClass}__author`}
+        title="Author"
+        value={
+          <>
+            <Avatar
+              user={addGravatarUrlToResource({
+                email: storedPolicy.author_email,
+              })}
+              size="xsmall"
+            />
+            <span>
+              {storedPolicy.author_name === currentUser?.name
+                ? "You"
+                : storedPolicy.author_name}
+            </span>
+          </>
+        }
+      />
+    );
+  };
+
+  const renderPlatforms = (): JSX.Element | null => {
+    if (!lastEditedQueryPlatform) return null;
+    const platforms = lastEditedQueryPlatform
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean);
+    if (platforms.length === 0) return null;
+
+    return (
+      <DataSet
+        className={`${baseClass}__platforms`}
+        title="Platforms"
+        value={platforms.join(", ")}
+      />
+    );
+  };
+
+  const renderHeader = () => {
+    return (
+      <>
+        <div className={`${baseClass}__header-links`}>
+          <BackButton text="Back to policies" path={backToPoliciesPath} />
+        </div>
+        {!isLoading && !apiError && (
+          <>
+            <div className={`${baseClass}__title-bar`}>
+              <div className="name-description">
+                <h1 className={`${baseClass}__policy-name`}>
+                  {lastEditedQueryName}
+                </h1>
+              </div>
+              <div className={`${baseClass}__action-button-container`}>
+                <Button
+                  className={`${baseClass}__show-query-btn`}
+                  onClick={() => setShowQueryModal(true)}
+                  variant="inverse"
+                >
+                  Show query
+                </Button>
+                {canRunPolicy && (
+                  <Button
+                    className={`${baseClass}__run`}
+                    variant="inverse"
+                    onClick={() => {
+                      policyId &&
+                        router.push(
+                          getPathWithQueryParams(PATHS.EDIT_POLICY(policyId), {
+                            team_id: teamIdForApi,
+                          })
+                        );
+                    }}
+                    disabled={!!disabledLiveQuery}
+                  >
+                    Run policy <Icon name="run" />
+                  </Button>
+                )}
+                {canEditPolicy && (
+                  <Button
+                    onClick={() => {
+                      policyId &&
+                        router.push(
+                          getPathWithQueryParams(PATHS.EDIT_POLICY(policyId), {
+                            team_id: teamIdForApi,
+                          })
+                        );
+                    }}
+                    className={`${baseClass}__edit-policy-btn`}
+                  >
+                    Edit policy
+                  </Button>
+                )}
+              </div>
+            </div>
+            <PageDescription
+              className={`${baseClass}__policy-description`}
+              content={lastEditedQueryDescription}
+            />
+            {lastEditedQueryResolution && (
+              <div className={`${baseClass}__resolve-section`}>
+                <p className={`${baseClass}__resolve-title`}>
+                  <strong>Resolve</strong>
+                </p>
+                <p className={`${baseClass}__resolve-text`}>
+                  {lastEditedQueryResolution}
+                </p>
+              </div>
+            )}
+            {renderAuthor()}
+            {currentTeam && (
+              <DataSet
+                className={`${baseClass}__fleet`}
+                title="Fleet"
+                value={currentTeam.name}
+              />
+            )}
+            {renderPlatforms()}
+          </>
+        )}
+      </>
+    );
+  };
+
+  if (!isRouteOk) {
+    return <Spinner />;
+  }
+
+  return (
+    <MainContent className={baseClass}>
+      {isLoading ? <Spinner /> : renderHeader()}
+      {showQueryModal && (
+        <ShowQueryModal
+          query={lastEditedQueryBody}
+          onCancel={() => setShowQueryModal(false)}
+        />
+      )}
+    </MainContent>
+  );
+};
+
+export default PolicyDetailsPage;

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import { InjectedRouter, Params } from "react-router/lib/Router";
 import { useErrorHandler } from "react-error-boundary";
+import { noop } from "lodash";
 import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
@@ -10,6 +11,7 @@ import { ILabelPolicy } from "interfaces/label";
 import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
 import { PLATFORM_DISPLAY_NAMES, Platform } from "interfaces/platform";
 import globalPoliciesAPI from "services/entities/global_policies";
+import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
 import { getPathWithQueryParams } from "utilities/url";
@@ -25,6 +27,7 @@ import Spinner from "components/Spinner";
 import TooltipWrapper from "components/TooltipWrapper";
 import Avatar from "components/Avatar";
 import ShowQueryModal from "components/modals/ShowQueryModal";
+import PolicyAutomations from "pages/policies/PolicyPage/components/PolicyAutomations";
 
 interface IPolicyDetailsPageProps {
   router: InjectedRouter;
@@ -50,6 +53,9 @@ const PolicyDetailsPage = ({
     currentUser,
     isGlobalAdmin,
     isGlobalMaintainer,
+    isGlobalObserver,
+    isGlobalTechnician,
+    isOnGlobalTeam,
     config,
     currentTeam,
   } = useContext(AppContext);
@@ -76,6 +82,7 @@ const PolicyDetailsPage = ({
     isRouteOk,
     teamIdForApi,
     isTeamMaintainerOrTeamAdmin,
+    isTeamTechnician,
     isObserverPlus,
   } = useTeamIdParam({
     location,
@@ -130,6 +137,30 @@ const PolicyDetailsPage = ({
     onError: (error) => handlePageError(error),
   });
 
+  const { data: teamData } = useQuery<ILoadTeamResponse>(
+    ["team", teamIdForApi],
+    () => teamsAPI.load(teamIdForApi as number),
+    {
+      enabled: !!teamIdForApi && teamIdForApi > 0,
+      refetchOnWindowFocus: false,
+    }
+  );
+
+  let currentAutomatedPolicies: number[] = [];
+  if (teamData?.team) {
+    const {
+      webhook_settings: { failing_policies_webhook: webhook },
+      integrations,
+    } = teamData.team;
+    const isIntegrationEnabled =
+      (integrations?.jira?.some((j: any) => j.enable_failing_policies) ||
+        integrations?.zendesk?.some((z: any) => z.enable_failing_policies)) ??
+      false;
+    if (isIntegrationEnabled || webhook?.enable_failing_policies_webhook) {
+      currentAutomatedPolicies = webhook?.policy_ids || [];
+    }
+  }
+
   useEffect(() => {
     if (storedPolicy?.name) {
       document.title = `${storedPolicy.name} | Policies | ${DOCUMENT_TITLE_SUFFIX}`;
@@ -138,10 +169,20 @@ const PolicyDetailsPage = ({
     }
   }, [location.pathname, storedPolicy?.name]);
 
-  const canEditPolicy =
-    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
+  const isInheritedPolicy = storedPolicy?.team_id === null;
 
-  const canRunPolicy = canEditPolicy || isObserverPlus;
+  const canEditPolicy =
+    (isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin) &&
+    // Team users cannot edit inherited (global) policies
+    !(isInheritedPolicy && !isOnGlobalTeam);
+
+  const canRunPolicy =
+    isObserverPlus ||
+    isTeamMaintainerOrTeamAdmin ||
+    isGlobalAdmin ||
+    isGlobalMaintainer ||
+    isGlobalTechnician ||
+    isTeamTechnician;
 
   const disabledLiveQuery = config?.server_settings.live_query_disabled;
 
@@ -281,9 +322,12 @@ const PolicyDetailsPage = ({
                     onClick={() => {
                       policyId &&
                         router.push(
-                          getPathWithQueryParams(PATHS.EDIT_POLICY(policyId), {
-                            team_id: teamIdForApi,
-                          })
+                          `${getPathWithQueryParams(
+                            PATHS.EDIT_POLICY(policyId),
+                            {
+                              team_id: teamIdForApi,
+                            }
+                          )}#targets`
                         );
                     }}
                     disabled={!!disabledLiveQuery}
@@ -332,6 +376,15 @@ const PolicyDetailsPage = ({
             )}
             {renderPlatforms()}
             {renderLabels()}
+            {storedPolicy && (
+              <PolicyAutomations
+                storedPolicy={storedPolicy}
+                currentAutomatedPolicies={currentAutomatedPolicies}
+                onAddAutomation={noop}
+                isAddingAutomation={false}
+                gitOpsModeEnabled={false}
+              />
+            )}
           </>
         )}
       </>

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -87,6 +87,7 @@ const PolicyDetailsPage = ({
       maintainer: true,
       observer: true,
       observer_plus: true,
+      technician: true,
     },
   });
 

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -6,6 +6,9 @@ import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { PolicyContext } from "context/policy";
 import { IPolicy, IStoredPolicyResponse } from "interfaces/policy";
+import { ILabelPolicy } from "interfaces/label";
+import { API_ALL_TEAMS_ID, APP_CONTEXT_ALL_TEAMS_ID } from "interfaces/team";
+import { PLATFORM_DISPLAY_NAMES, Platform } from "interfaces/platform";
 import globalPoliciesAPI from "services/entities/global_policies";
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { DOCUMENT_TITLE_SUFFIX } from "utilities/constants";
@@ -19,6 +22,7 @@ import Icon from "components/Icon";
 import MainContent from "components/MainContent";
 import PageDescription from "components/PageDescription";
 import Spinner from "components/Spinner";
+import TooltipWrapper from "components/TooltipWrapper";
 import Avatar from "components/Avatar";
 import ShowQueryModal from "components/modals/ShowQueryModal";
 
@@ -115,7 +119,12 @@ const PolicyDetailsPage = ({
       setLastEditedQueryLabelsExcludeAny(
         returnedPolicy.labels_exclude_any || []
       );
-      setPolicyTeamId(returnedPolicy.team_id ?? undefined);
+      const deNulledTeamId = returnedPolicy.team_id ?? undefined;
+      setPolicyTeamId(
+        deNulledTeamId === API_ALL_TEAMS_ID
+          ? APP_CONTEXT_ALL_TEAMS_ID
+          : deNulledTeamId
+      );
     },
     onError: (error) => handlePageError(error),
   });
@@ -169,15 +178,63 @@ const PolicyDetailsPage = ({
     const platforms = lastEditedQueryPlatform
       .split(",")
       .map((p) => p.trim())
-      .filter(Boolean);
+      .filter((p): p is Platform => p in PLATFORM_DISPLAY_NAMES);
     if (platforms.length === 0) return null;
 
     return (
       <DataSet
         className={`${baseClass}__platforms`}
         title="Platforms"
-        value={platforms.join(", ")}
+        value={
+          <div className={`${baseClass}__platform-list`}>
+            {platforms.map((platform) => (
+              <span key={platform} className={`${baseClass}__platform-item`}>
+                <Icon name={platform} color="ui-fleet-black-50" />
+                {PLATFORM_DISPLAY_NAMES[platform] || platform}
+              </span>
+            ))}
+          </div>
+        }
       />
+    );
+  };
+
+  const onLabelClick = (label: ILabelPolicy) => {
+    router.push(PATHS.MANAGE_HOSTS_LABEL(label.id));
+  };
+
+  const renderLabels = (): JSX.Element | null => {
+    const includeAny = storedPolicy?.labels_include_any;
+    const excludeAny = storedPolicy?.labels_exclude_any;
+
+    if (!includeAny?.length && !excludeAny?.length) return null;
+
+    const isInclude = !!includeAny?.length;
+    const labels = isInclude ? includeAny : excludeAny;
+
+    return (
+      <div className={`${baseClass}__labels-section`}>
+        <dt className={`${baseClass}__labels-title`}>Labels</dt>
+        <dd>
+          <p className={`${baseClass}__labels-help-text`}>
+            Policy will target hosts that{" "}
+            <b>{isInclude ? "have any" : "exclude any"}</b> of these labels:
+          </p>
+          <ul className={`${baseClass}__labels-list`}>
+            {labels?.map((label) => (
+              <li key={label.id}>
+                <Button
+                  onClick={() => onLabelClick(label)}
+                  variant="grey-pill"
+                  className={`${baseClass}__label-pill`}
+                >
+                  {label.name}
+                </Button>
+              </li>
+            ))}
+          </ul>
+        </dd>
+      </div>
     );
   };
 
@@ -193,6 +250,19 @@ const PolicyDetailsPage = ({
               <div className="name-description">
                 <h1 className={`${baseClass}__policy-name`}>
                   {lastEditedQueryName}
+                  {storedPolicy?.critical && (
+                    <TooltipWrapper
+                      tipContent="This policy has been marked as critical."
+                      showArrow
+                      underline={false}
+                    >
+                      <Icon
+                        className="critical-policy-icon"
+                        name="policy"
+                        color="ui-fleet-black-50"
+                      />
+                    </TooltipWrapper>
+                  )}
                 </h1>
               </div>
               <div className={`${baseClass}__action-button-container`}>
@@ -260,6 +330,7 @@ const PolicyDetailsPage = ({
               />
             )}
             {renderPlatforms()}
+            {renderLabels()}
           </>
         )}
       </>

--- a/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
+++ b/frontend/pages/policies/PolicyDetailsPage/PolicyDetailsPage.tsx
@@ -231,7 +231,7 @@ const PolicyDetailsPage = ({
           <div className={`${baseClass}__platform-list`}>
             {platforms.map((platform) => (
               <span key={platform} className={`${baseClass}__platform-item`}>
-                <Icon name={platform} color="ui-fleet-black-50" />
+                <Icon name={platform} color="ui-fleet-black-75" />
                 {PLATFORM_DISPLAY_NAMES[platform] || platform}
               </span>
             ))}
@@ -289,7 +289,7 @@ const PolicyDetailsPage = ({
         {!isLoading && !apiError && (
           <>
             <div className={`${baseClass}__title-bar`}>
-              <div className="name-description">
+              <div className={`${baseClass}__name-description`}>
                 <h1 className={`${baseClass}__policy-name`}>
                   {lastEditedQueryName}
                   {storedPolicy?.critical && (
@@ -306,6 +306,10 @@ const PolicyDetailsPage = ({
                     </TooltipWrapper>
                   )}
                 </h1>
+                <PageDescription
+                  className={`${baseClass}__policy-description`}
+                  content={lastEditedQueryDescription}
+                />
               </div>
               <div className={`${baseClass}__action-button-container`}>
                 <Button
@@ -352,10 +356,6 @@ const PolicyDetailsPage = ({
                 )}
               </div>
             </div>
-            <PageDescription
-              className={`${baseClass}__policy-description`}
-              content={lastEditedQueryDescription}
-            />
             {lastEditedQueryResolution && (
               <div className={`${baseClass}__resolve-section`}>
                 <p className={`${baseClass}__resolve-title`}>

--- a/frontend/pages/policies/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/PolicyDetailsPage/_styles.scss
@@ -1,17 +1,26 @@
 .policy-details-page {
   @include vertical-page-layout;
 
+  p {
+    margin: 0; // Until this is an app-wide style
+  }
+
   &__title-bar {
     display: flex;
     justify-content: space-between;
     gap: $pad-xlarge;
   }
 
-  &__name-description {
+  &__name-description,
+  &__platform-list,
+  &__labels-section {
     display: flex;
     flex-direction: column;
     gap: $pad-small;
-    min-width: 0;
+  }
+
+  &__platform-list {
+    flex-direction: row;
   }
 
   &__action-button-container {
@@ -22,7 +31,6 @@
   }
 
   &__policy-name {
-    margin-top: 0;
     font-size: $large;
     display: flex;
     align-items: center;
@@ -33,35 +41,12 @@
     }
   }
 
-  &__resolve-section {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-small;
-    font-size: $x-small;
-  }
-
-  &__resolve-title {
-    margin: 0;
-  }
-
-  &__resolve-text {
-    margin: 0;
-  }
-
   // Override DataSet 4px gap to 8px for all instances on this page
   .data-set {
     gap: $pad-small;
   }
 
-  &__author {
-    dd {
-      display: flex;
-      align-items: center;
-      gap: $pad-small;
-    }
-  }
-
-  &__platform-list {
+  &__author-info {
     display: flex;
     align-items: center;
     gap: $pad-small;
@@ -71,24 +56,6 @@
     display: flex;
     align-items: center;
     gap: $pad-xsmall;
-  }
-
-  &__labels-section {
-    display: flex;
-    flex-direction: column;
-    gap: $pad-small;
-    font-size: $x-small;
-
-    dd {
-      display: flex;
-      flex-direction: column;
-      gap: $pad-small;
-    }
-  }
-
-  &__labels-title {
-    font-weight: $bold;
-    margin: 0;
   }
 
   &__labels-help-text {

--- a/frontend/pages/policies/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/PolicyDetailsPage/_styles.scss
@@ -4,7 +4,14 @@
   &__title-bar {
     display: flex;
     justify-content: space-between;
-    gap: $pad-medium;
+    gap: $pad-xlarge;
+  }
+
+  &__name-description {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
+    min-width: 0;
   }
 
   &__action-button-container {
@@ -27,15 +34,23 @@
   }
 
   &__resolve-section {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
     font-size: $x-small;
   }
 
   &__resolve-title {
-    margin: 0 0 $pad-xsmall;
+    margin: 0;
   }
 
   &__resolve-text {
     margin: 0;
+  }
+
+  // Override DataSet 4px gap to 8px for all instances on this page
+  .data-set {
+    gap: $pad-small;
   }
 
   &__author {
@@ -49,26 +64,35 @@
   &__platform-list {
     display: flex;
     align-items: center;
-    gap: $pad-small; // 8px
+    gap: $pad-small;
   }
 
   &__platform-item {
     display: flex;
     align-items: center;
-    gap: $pad-xsmall; // 4px
+    gap: $pad-xsmall;
   }
 
   &__labels-section {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
     font-size: $x-small;
+
+    dd {
+      display: flex;
+      flex-direction: column;
+      gap: $pad-small;
+    }
   }
 
   &__labels-title {
     font-weight: $bold;
-    margin: 0 0 $pad-xsmall;
+    margin: 0;
   }
 
   &__labels-help-text {
-    margin: 0 0 $pad-small;
+    margin: 0;
     font-weight: $regular;
   }
 

--- a/frontend/pages/policies/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/PolicyDetailsPage/_styles.scss
@@ -17,6 +17,13 @@
   &__policy-name {
     margin-top: 0;
     font-size: $large;
+    display: flex;
+    align-items: center;
+    gap: $pad-small;
+
+    .critical-policy-icon {
+      flex-shrink: 0;
+    }
   }
 
   &__resolve-section {
@@ -39,11 +46,38 @@
     }
   }
 
-  &__platforms {
-    dd {
-      display: flex;
-      align-items: center;
-      gap: $pad-small;
-    }
+  &__platform-list {
+    display: flex;
+    align-items: center;
+    gap: $pad-small; // 8px
+  }
+
+  &__platform-item {
+    display: flex;
+    align-items: center;
+    gap: $pad-xsmall; // 4px
+  }
+
+  &__labels-section {
+    font-size: $x-small;
+  }
+
+  &__labels-title {
+    font-weight: $bold;
+    margin: 0 0 $pad-xsmall;
+  }
+
+  &__labels-help-text {
+    margin: 0 0 $pad-small;
+    font-weight: $regular;
+  }
+
+  &__labels-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $pad-small;
+    list-style: none;
+    margin: 0;
+    padding: 0;
   }
 }

--- a/frontend/pages/policies/PolicyDetailsPage/_styles.scss
+++ b/frontend/pages/policies/PolicyDetailsPage/_styles.scss
@@ -1,0 +1,49 @@
+.policy-details-page {
+  @include vertical-page-layout;
+
+  &__title-bar {
+    display: flex;
+    justify-content: space-between;
+    gap: $pad-medium;
+  }
+
+  &__action-button-container {
+    display: flex;
+    justify-content: flex-end;
+    min-width: max-content;
+    gap: $pad-medium;
+  }
+
+  &__policy-name {
+    margin-top: 0;
+    font-size: $large;
+  }
+
+  &__resolve-section {
+    font-size: $x-small;
+  }
+
+  &__resolve-title {
+    margin: 0 0 $pad-xsmall;
+  }
+
+  &__resolve-text {
+    margin: 0;
+  }
+
+  &__author {
+    dd {
+      display: flex;
+      align-items: center;
+      gap: $pad-small;
+    }
+  }
+
+  &__platforms {
+    dd {
+      display: flex;
+      align-items: center;
+      gap: $pad-small;
+    }
+  }
+}

--- a/frontend/pages/policies/PolicyDetailsPage/index.ts
+++ b/frontend/pages/policies/PolicyDetailsPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./PolicyDetailsPage";

--- a/frontend/pages/policies/PolicyPage/PolicyPage.tsx
+++ b/frontend/pages/policies/PolicyPage/PolicyPage.tsx
@@ -144,7 +144,9 @@ const PolicyPage = ({
     };
   }, []);
 
-  const [step, setStep] = useState(LIVE_POLICY_STEPS[1]);
+  const [step, setStep] = useState(
+    location.hash === "#targets" ? LIVE_POLICY_STEPS[2] : LIVE_POLICY_STEPS[1]
+  );
   const [selectedTargets, setSelectedTargets] = useState<ITarget[]>([]);
   const [targetedHosts, setTargetedHosts] = useState<IHost[]>([]);
   const [targetedLabels, setTargetedLabels] = useState<ILabel[]>([]);

--- a/frontend/pages/policies/PolicyPage/components/PolicyAutomations/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyAutomations/_styles.scss
@@ -1,5 +1,6 @@
 .policy-automations {
   max-width: 600px;
+  font-size: $x-small;
 
   &__cta-card {
     display: flex;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -368,7 +368,9 @@ describe("PolicyForm - component", () => {
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeDisabled();
 
-        const funButton = screen.getByLabelText("Fun");
+        const funButton = await screen.findByRole("checkbox", {
+          name: "Fun",
+        });
         expect(funButton).not.toBeChecked();
         await userEvent.click(funButton);
         await waitFor(() => {
@@ -386,7 +388,11 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(
+          await screen.findByRole("checkbox", {
+            name: "Fun",
+          })
+        );
 
         const saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeEnabled();
@@ -406,7 +412,11 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(
+          await screen.findByRole("checkbox", {
+            name: "Fun",
+          })
+        );
 
         // Click "Include any" to open the dropdown.
         const includeAnyOption = screen.getByRole("option", {
@@ -441,7 +451,11 @@ describe("PolicyForm - component", () => {
 
         // Set a label.
         await userEvent.click(screen.getByLabelText("Custom"));
-        await userEvent.click(screen.getByLabelText("Fun"));
+        await userEvent.click(
+          await screen.findByRole("checkbox", {
+            name: "Fun",
+          })
+        );
 
         await userEvent.click(screen.getByLabelText("All hosts"));
 

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { screen, waitFor } from "@testing-library/react";
-import { createCustomRenderer } from "test/test-utils";
+import { createCustomRenderer, createMockRouter } from "test/test-utils";
 import { http, HttpResponse } from "msw";
 import mockServer from "test/mock-server";
 import userEvent from "@testing-library/user-event";
@@ -42,6 +42,8 @@ const labelSummariesHandler = http.get(baseUrl("/labels/summary"), () => {
 
 describe("PolicyForm - component", () => {
   const defaultProps = {
+    router: createMockRouter(),
+    teamIdForApi: 3,
     policyIdForEdit: mockPolicy.id,
     showOpenSchemaActionText: false,
     storedPolicy: createMockPolicy({ name: "Foo" }),
@@ -127,6 +129,8 @@ describe("PolicyForm - component", () => {
 
       render(
         <PolicyForm
+          router={createMockRouter()}
+          teamIdForApi={3}
           policyIdForEdit={mockPolicy.id}
           showOpenSchemaActionText={false}
           storedPolicy={createMockPolicy({ name: "" })}
@@ -190,6 +194,8 @@ describe("PolicyForm - component", () => {
 
       const { user } = render(
         <PolicyForm
+          router={createMockRouter()}
+          teamIdForApi={3}
           policyIdForEdit={mockPolicy.id}
           showOpenSchemaActionText={false}
           storedPolicy={createMockPolicy({ platform: undefined })}
@@ -266,6 +272,8 @@ describe("PolicyForm - component", () => {
 
       const { user } = render(
         <PolicyForm
+          router={createMockRouter()}
+          teamIdForApi={3}
           policyIdForEdit={mockPolicy.id}
           showOpenSchemaActionText={false}
           storedPolicy={createMockPolicy()}
@@ -650,53 +658,6 @@ describe("PolicyForm - component", () => {
       render(<PolicyForm {...defaultProps} />);
 
       expect(screen.getByText(/Editing policy for/i)).toBeInTheDocument();
-      expect(
-        screen.getByText(createMockTeamSummary().name)
-      ).toBeInTheDocument();
-    });
-
-    it("shows 'Viewing policy' when existing policy and user has no save permissions", () => {
-      const render = createCustomRenderer({
-        withBackendMock: true,
-        context: {
-          app: {
-            currentUser: createMockUser(),
-            currentTeam: createMockTeamSummary(),
-            isGlobalObserver: true, // no save perms
-            isGlobalAdmin: false,
-            isGlobalMaintainer: false,
-            isTeamMaintainerOrTeamAdmin: false,
-            isOnGlobalTeam: true,
-            isPremiumTier: true,
-            isSandboxMode: false,
-            isFreeTier: false,
-            config: createMockConfig(),
-          },
-          policy: {
-            policyTeamId: undefined,
-            lastEditedQueryId: mockPolicy.id,
-            lastEditedQueryName: mockPolicy.name,
-            lastEditedQueryDescription: mockPolicy.description,
-            lastEditedQueryBody: mockPolicy.query,
-            lastEditedQueryResolution: mockPolicy.resolution,
-            lastEditedQueryCritical: mockPolicy.critical,
-            lastEditedQueryPlatform: mockPolicy.platform,
-            lastEditedQueryLabelsIncludeAny: [],
-            lastEditedQueryLabelsExcludeAny: [],
-            defaultPolicy: false,
-            setLastEditedQueryName: jest.fn(),
-            setLastEditedQueryDescription: jest.fn(),
-            setLastEditedQueryBody: jest.fn(),
-            setLastEditedQueryResolution: jest.fn(),
-            setLastEditedQueryCritical: jest.fn(),
-            setLastEditedQueryPlatform: jest.fn(),
-          },
-        },
-      });
-
-      render(<PolicyForm {...defaultProps} />);
-
-      expect(screen.getByText(/Viewing policy for/i)).toBeInTheDocument();
       expect(
         screen.getByText(createMockTeamSummary().name)
       ).toBeInTheDocument();

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -54,7 +54,7 @@ const baseClass = "policy-form";
 
 interface IPolicyFormProps {
   router: InjectedRouter;
-  teamIdForApi: number | null;
+  teamIdForApi?: number;
   policyIdForEdit: number | null;
   showOpenSchemaActionText: boolean;
   storedPolicy: IPolicy | undefined;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -1,12 +1,11 @@
 /* eslint-disable jsx-a11y/no-noninteractive-element-to-interactive-role */
 /* eslint-disable jsx-a11y/interactive-supports-focus */
-import React, { useState, useContext, useEffect, KeyboardEvent } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import { useQuery, useQueryClient } from "react-query";
 
 import { Ace } from "ace-builds";
 import { useDebouncedCallback } from "use-debounce";
-import { size } from "lodash";
-import classnames from "classnames";
+import { noop, size } from "lodash";
 
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { AppContext } from "context/app";
@@ -35,7 +34,8 @@ import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon/Icon";
-import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
 import PageDescription from "components/PageDescription";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import CustomLink from "components/CustomLink";
@@ -114,9 +114,6 @@ const PolicyForm = ({
     false
   );
   const [showQueryEditor, setShowQueryEditor] = useState(false);
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
-  const [isEditingResolution, setIsEditingResolution] = useState(false);
 
   const [selectedTargetType, setSelectedTargetType] = useState("All hosts");
   const [selectedCustomTarget, setSelectedCustomTarget] = useState(
@@ -239,10 +236,10 @@ const PolicyForm = ({
 
   policyIdForEdit = policyIdForEdit || 0;
 
-  const isExistingPolicy = !!policyIdForEdit;
+  const isEditMode = !!policyIdForEdit && !isTeamObserver && !isGlobalObserver;
 
   const isNewTemplatePolicy =
-    !isExistingPolicy &&
+    !policyIdForEdit &&
     DEFAULT_POLICIES.find((p) => p.name === lastEditedQueryName);
 
   useEffect(() => {
@@ -313,16 +310,6 @@ const PolicyForm = ({
     resetAiAutofillData(); // Allows retry of AI autofill API if the SQL has changed
   };
 
-  const onInputKeypress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key.toLowerCase() === "enter" && !event.shiftKey) {
-      event.preventDefault();
-      event.currentTarget.blur();
-      setIsEditingName(false);
-      setIsEditingDescription(false);
-      setIsEditingResolution(false);
-    }
-  };
-
   const onAddPatchAutomation = async () => {
     if (
       !storedPolicy?.patch_software?.software_title_id ||
@@ -348,21 +335,21 @@ const PolicyForm = ({
   const promptSavePolicy = () => (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    if (isExistingPolicy && !lastEditedQueryName) {
+    if (isEditMode && !lastEditedQueryName) {
       return setErrors({
         ...errors,
         name: "Policy name must be present",
       });
     }
 
-    if (isExistingPolicy && !isPatchPolicy && !isAnyPlatformSelected) {
+    if (isEditMode && !isPatchPolicy && !isAnyPlatformSelected) {
       return setErrors({
         ...errors,
         name: "At least one platform must be selected",
       });
     }
 
-    if (isPatchPolicy && isExistingPolicy) {
+    if (isPatchPolicy && isEditMode) {
       // Patch policies: only send editable fields, not query/platform
       const payload: IPolicyFormData = {
         name: lastEditedQueryName,
@@ -373,14 +360,11 @@ const PolicyForm = ({
         payload.critical = lastEditedQueryCritical;
       }
       onUpdate(payload);
-      setIsEditingName(false);
-      setIsEditingDescription(false);
-      setIsEditingResolution(false);
       return;
     }
 
     let selectedPlatforms = getSelectedPlatforms();
-    if (selectedPlatforms.length === 0 && !isExistingPolicy && !defaultPolicy) {
+    if (selectedPlatforms.length === 0 && !isEditMode && !defaultPolicy) {
       // If no platforms are selected, default to all compatible platforms
       selectedPlatforms = getCompatiblePlatforms();
       setSelectedPlatforms(selectedPlatforms);
@@ -394,7 +378,7 @@ const PolicyForm = ({
       setLastEditedQueryPlatform(newPlatformString);
     }
 
-    if (!isExistingPolicy) {
+    if (!isEditMode) {
       setIsSaveNewPolicyModalOpen(true);
     } else {
       const payload: IPolicyFormData = {
@@ -423,10 +407,6 @@ const PolicyForm = ({
       }
       onUpdate(payload);
     }
-
-    setIsEditingName(false);
-    setIsEditingDescription(false);
-    setIsEditingResolution(false);
   };
 
   const renderAuthor = (): JSX.Element | null => {
@@ -476,88 +456,23 @@ const PolicyForm = ({
     );
   };
 
-  const editName = () => {
-    if (!isEditingName) {
-      setIsEditingName(true);
-    }
-  };
-
-  const editDescription = () => {
-    if (!isEditingDescription) {
-      setIsEditingDescription(true);
-    }
-  };
-
-  const editResolution = () => {
-    if (!isEditingResolution) {
-      setIsEditingResolution(true);
-    }
-  };
-
-  const policyNameWrapperBase = `${baseClass}__policy-name-wrapper`;
-  const policyNameWrapperClasses = classnames(policyNameWrapperBase, {
-    [`${baseClass}--editing`]: isEditingName,
-  });
-
-  const policyDescriptionWrapperBase = `${baseClass}__policy-description-wrapper`;
-  const policyDescriptionWrapperClasses = classnames(
-    policyDescriptionWrapperBase,
-    {
-      [`${baseClass}--editing`]: isEditingDescription,
-    }
-  );
-
-  const policyResolutionWrapperBase = `${baseClass}__policy-resolution-wrapper`;
-  const policyResolutionWrapperClasses = classnames(
-    policyResolutionWrapperBase,
-    {
-      [`${baseClass}--editing`]: isEditingResolution,
-    }
-  );
-
   const renderName = () => {
-    if (isExistingPolicy) {
+    if (isEditMode) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
           tipOffset={16}
-          renderChildren={(disableChildren) => {
-            const classes = classnames(policyNameWrapperClasses, {
-              [`${policyNameWrapperBase}--disabled-by-gitops-mode`]: disableChildren,
-            });
-            return (
-              <div
-                className={classes}
-                onFocus={() => setIsEditingName(true)}
-                onBlur={() => setIsEditingName(false)}
-                onClick={editName}
-              >
-                <AutoSizeInputField
-                  name="policy-name"
-                  placeholder="Add name here"
-                  value={lastEditedQueryName}
-                  hasError={errors && errors.name}
-                  inputClassName={`${baseClass}__policy-name ${
-                    !lastEditedQueryName ? "no-value" : ""
-                  }
-              `}
-                  maxLength={160}
-                  onChange={setLastEditedQueryName}
-                  onKeyPress={onInputKeypress}
-                  isFocused={isEditingName}
-                  disableTabability={disableChildren}
-                />
-                <Icon
-                  name="pencil"
-                  className={`${baseClass}__edit-icon ${
-                    isEditingName ? `${baseClass}__edit-icon--hide` : ""
-                  }`}
-                  size="small-medium"
-                  color="core-fleet-green"
-                />
-              </div>
-            );
-          }}
+          renderChildren={(disableChildren) => (
+            <InputField
+              name="policy-name"
+              label="Name"
+              placeholder="Add name here"
+              value={lastEditedQueryName}
+              error={errors && errors.name}
+              onChange={(value: string) => setLastEditedQueryName(value)}
+              disabled={disableChildren}
+            />
+          )}
         />
       );
     }
@@ -572,46 +487,23 @@ const PolicyForm = ({
   };
 
   const renderDescription = () => {
-    if (isExistingPolicy) {
+    if (isEditMode) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
           tipOffset={16}
-          renderChildren={(disableChildren) => {
-            const classes = classnames(policyDescriptionWrapperClasses, {
-              [`${policyDescriptionWrapperBase}--disabled-by-gitops-mode`]: disableChildren,
-            });
-            return (
-              <div
-                className={classes}
-                onFocus={() => setIsEditingDescription(true)}
-                onBlur={() => setIsEditingDescription(false)}
-                onClick={editDescription}
-              >
-                <AutoSizeInputField
-                  name="policy-description"
-                  placeholder="Add description here."
-                  value={lastEditedQueryDescription}
-                  inputClassName={`${baseClass}__policy-description ${
-                    !lastEditedQueryDescription ? "no-value" : ""
-                  }`}
-                  maxLength={250}
-                  onChange={setLastEditedQueryDescription}
-                  onKeyPress={onInputKeypress}
-                  isFocused={isEditingDescription}
-                  disableTabability={disableChildren}
-                />
-                <Icon
-                  name="pencil"
-                  className={`${baseClass}__edit-icon ${
-                    isEditingDescription ? `${baseClass}__edit-icon--hide` : ""
-                  }`}
-                  size="small-medium"
-                  color="core-fleet-green"
-                />
-              </div>
-            );
-          }}
+          renderChildren={(disableChildren) => (
+            <InputField
+              name="policy-description"
+              label="Description"
+              placeholder="Add description here."
+              value={lastEditedQueryDescription}
+              type="textarea"
+              helpText="How does this policy's failure put the organization at risk?"
+              onChange={(value: string) => setLastEditedQueryDescription(value)}
+              disabled={disableChildren}
+            />
+          )}
         />
       );
     }
@@ -620,50 +512,24 @@ const PolicyForm = ({
   };
 
   const renderResolution = () => {
-    if (isExistingPolicy) {
+    if (isEditMode) {
       return (
-        <div className={`form-field ${baseClass}__policy-resolve`}>
-          <div className="form-field__label">Resolve</div>
-          <GitOpsModeTooltipWrapper
-            position="right"
-            tipOffset={16}
-            renderChildren={(disableChildren) => {
-              const classes = classnames(policyResolutionWrapperClasses, {
-                [`${policyResolutionWrapperBase}--disabled-by-gitops-mode`]: disableChildren,
-              });
-              return (
-                <div
-                  className={classes}
-                  onFocus={() => setIsEditingResolution(true)}
-                  onBlur={() => setIsEditingResolution(false)}
-                  onClick={editResolution}
-                >
-                  <AutoSizeInputField
-                    name="policy-resolution"
-                    placeholder="Add resolution here."
-                    value={lastEditedQueryResolution}
-                    inputClassName={`${baseClass}__policy-resolution ${
-                      !lastEditedQueryResolution ? "no-value" : ""
-                    }`}
-                    maxLength={500}
-                    onChange={setLastEditedQueryResolution}
-                    onKeyPress={onInputKeypress}
-                    isFocused={isEditingResolution}
-                    disableTabability={disableChildren}
-                  />
-                  <Icon
-                    name="pencil"
-                    className={`${baseClass}__edit-icon ${
-                      isEditingResolution ? `${baseClass}__edit-icon--hide` : ""
-                    }`}
-                    size="small-medium"
-                    color="core-fleet-green"
-                  />
-                </div>
-              );
-            }}
-          />
-        </div>
+        <GitOpsModeTooltipWrapper
+          position="right"
+          tipOffset={16}
+          renderChildren={(disableChildren) => (
+            <InputField
+              name="policy-resolution"
+              label="Resolution"
+              placeholder="Add resolution here."
+              value={lastEditedQueryResolution}
+              type="textarea"
+              helpText="If this policy fails, what should the end user expect?"
+              onChange={(value: string) => setLastEditedQueryResolution(value)}
+              disabled={disableChildren}
+            />
+          )}
+        />
       );
     }
 
@@ -672,7 +538,7 @@ const PolicyForm = ({
 
   const renderPlatformCompatibility = () => {
     if (
-      isExistingPolicy &&
+      isEditMode &&
       (isStoredPolicyLoading || policyIdForEdit !== lastEditedQueryId)
     ) {
       return null;
@@ -711,7 +577,7 @@ const PolicyForm = ({
   const renderPolicyFleetName = () => {
     if (isFreeTier || !currentTeam?.name) return null;
 
-    if (isExistingPolicy) {
+    if (isEditMode) {
       return hasSavePermissions ? (
         <p>
           Editing policy for <strong>{currentTeam?.name}</strong>.
@@ -787,7 +653,7 @@ const PolicyForm = ({
           <Button
             className={`${baseClass}__run`}
             onClick={goToSelectTargets}
-            disabled={isExistingPolicy && !isAnyPlatformSelected}
+            disabled={isEditMode && !isAnyPlatformSelected}
           >
             Run
           </Button>
@@ -803,7 +669,7 @@ const PolicyForm = ({
     // Save disabled for no platforms selected, query name blank on existing query, or sql errors
     const disableSaveFormErrors =
       isAddingAutomation ||
-      (isExistingPolicy && !isPatchPolicy && !isAnyPlatformSelected) ||
+      (isEditMode && !isPatchPolicy && !isAnyPlatformSelected) ||
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {
@@ -814,13 +680,54 @@ const PolicyForm = ({
     return (
       <>
         <form className={`${baseClass}__wrapper`} autoComplete="off">
-          <div className={`${baseClass}__title-bar`}>
-            <div className={`${baseClass}__policy-name`}>{renderName()}</div>
-            {isExistingPolicy && renderAuthor()}
-          </div>
-          {renderPolicyFleetName()}
+          {isEditMode ? (
+            <div className={`${baseClass}__page-header`}>
+              <h1 className={`${baseClass}__page-title`}>Edit policy</h1>
+              {currentTeam && (
+                <p className={`${baseClass}__page-subtitle`}>
+                  Editing policy for {currentTeam.name}.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className={`${baseClass}__title-bar`}>
+              <div className={`${baseClass}__policy-name`}>{renderName()}</div>
+            </div>
+          )}
+          {isEditMode && renderName()}
           {renderDescription()}
           {renderResolution()}
+          {isEditMode && !isPatchPolicy && platformSelector.render()}
+          {isEditMode && isPremiumTier && !isPatchPolicy && (
+            <TargetLabelSelector
+              selectedTargetType={selectedTargetType}
+              selectedCustomTarget={selectedCustomTarget}
+              customTargetOptions={CUSTOM_TARGET_OPTIONS}
+              onSelectCustomTarget={setSelectedCustomTarget}
+              selectedLabels={selectedLabels}
+              className={`${baseClass}__target`}
+              onSelectTargetType={setSelectedTargetType}
+              onSelectLabel={onSelectLabel}
+              labels={labels || []}
+              customHelpText={
+                <span className="form-field__help-text">
+                  Policy will target hosts on selected platforms that{" "}
+                  <b>have any</b> of these labels:
+                </span>
+              }
+              suppressTitle
+            />
+          )}
+          {isEditMode && storedPolicy && (
+            <PolicyAutomations
+              storedPolicy={storedPolicy}
+              currentAutomatedPolicies={currentAutomatedPolicies}
+              onAddAutomation={onAddPatchAutomation}
+              isAddingAutomation={isAddingAutomation}
+              gitOpsModeEnabled={!!gitOpsModeEnabled}
+            />
+          )}
+          {isEditMode && isPremiumTier && !isPatchPolicy && renderCriticalPolicy()}
           <SQLEditor
             value={lastEditedQueryBody}
             error={errors.query}
@@ -846,43 +753,17 @@ const PolicyForm = ({
             onChange={onChangePolicySql}
             handleSubmit={promptSavePolicy}
             wrapEnabled
-            focus={!isExistingPolicy}
+            focus={!isEditMode}
             readOnly={isPatchPolicy}
           />
           {renderPlatformCompatibility()}
-          {isExistingPolicy && !isPatchPolicy && platformSelector.render()}
-          {isExistingPolicy && isPremiumTier && !isPatchPolicy && (
-            <TargetLabelSelector
-              selectedTargetType={selectedTargetType}
-              selectedCustomTarget={selectedCustomTarget}
-              customTargetOptions={CUSTOM_TARGET_OPTIONS}
-              onSelectCustomTarget={setSelectedCustomTarget}
-              selectedLabels={selectedLabels}
-              className={`${baseClass}__target`}
-              onSelectTargetType={setSelectedTargetType}
-              onSelectLabel={onSelectLabel}
-              labels={labels || []}
-              customHelpText={
-                <span className="form-field__help-text">
-                  Policy will target hosts on selected platforms that{" "}
-                  <b>have any</b> of these labels:
-                </span>
-              }
-              suppressTitle
-            />
-          )}
-          {isExistingPolicy && storedPolicy && (
-            <PolicyAutomations
-              storedPolicy={storedPolicy}
-              currentAutomatedPolicies={currentAutomatedPolicies}
-              onAddAutomation={onAddPatchAutomation}
-              isAddingAutomation={isAddingAutomation}
-              gitOpsModeEnabled={!!gitOpsModeEnabled}
-            />
-          )}
-          {isExistingPolicy && isPremiumTier && renderCriticalPolicy()}
           {renderLiveQueryWarning()}
           <div className="button-wrap">
+            {isEditMode && (
+              <Button variant="inverse" onClick={noop}>
+                Cancel
+              </Button>
+            )}
             {hasSavePermissions && (
               <GitOpsModeTooltipWrapper
                 renderChildren={(disableChildren) => (
@@ -898,7 +779,7 @@ const PolicyForm = ({
                     }
                     tooltipClass={`${baseClass}__button-wrap--tooltip`}
                     position="top"
-                    disableTooltip={!isExistingPolicy || isAnyPlatformSelected}
+                    disableTooltip={!isEditMode || isAnyPlatformSelected}
                     underline={false}
                   >
                     <span className={`${baseClass}__button-wrap--tooltip`}>
@@ -931,7 +812,7 @@ const PolicyForm = ({
                 )
               }
               disableTooltip={
-                (!isExistingPolicy || isAnyPlatformSelected) &&
+                (!isEditMode || isAnyPlatformSelected) &&
                 !disabledLiveQuery
               }
               underline={false}
@@ -943,7 +824,7 @@ const PolicyForm = ({
                   onClick={goToSelectTargets}
                   disabled={
                     isAddingAutomation ||
-                    (isExistingPolicy && !isAnyPlatformSelected) ||
+                    (isEditMode && !isAnyPlatformSelected) ||
                     disabledLiveQuery
                   }
                   variant="inverse"
@@ -979,7 +860,7 @@ const PolicyForm = ({
     return <Spinner />;
   }
 
-  const isInheritedPolicy = isExistingPolicy && storedPolicy?.team_id === null;
+  const isInheritedPolicy = isEditMode && storedPolicy?.team_id === null;
 
   const noEditPermissions =
     isTeamObserver ||

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -411,30 +411,6 @@ const PolicyForm = ({
     }
   };
 
-  const renderAuthor = (): JSX.Element | null => {
-    return storedPolicy ? (
-      <DataSet
-        className={`${baseClass}__author`}
-        title="Author"
-        value={
-          <>
-            <Avatar
-              user={addGravatarUrlToResource({
-                email: storedPolicy.author_email,
-              })}
-              size="xsmall"
-            />
-            <span>
-              {storedPolicy.author_name === currentUser?.name
-                ? "You"
-                : storedPolicy.author_name}
-            </span>
-          </>
-        }
-      />
-    ) : null;
-  };
-
   const renderLabelComponent = (): JSX.Element | null => {
     return (
       <div className={`${baseClass}__sql-editor-label-actions`}>
@@ -605,14 +581,11 @@ const PolicyForm = ({
   // - Global technicians and team technicians viewing any team's policies and any inherited policies
   const renderNonEditableForm = (
     <form className={`${baseClass}__wrapper`}>
-      <div className={`${baseClass}__title-bar`}>
-        <h1
-          className={`${baseClass}__policy-name ${baseClass}__policy-name--no-hover`}
-        >
-          {lastEditedQueryName}
-        </h1>
-        {renderAuthor()}
-      </div>
+      <h1
+        className={`${baseClass}__policy-name ${baseClass}__policy-name--no-hover`}
+      >
+        {lastEditedQueryName}
+      </h1>
       {renderPolicyFleetName()}
       {lastEditedQueryDescription && (
         <PageDescription
@@ -685,18 +658,18 @@ const PolicyForm = ({
           {isEditMode ? (
             <div className={`${baseClass}__page-header`}>
               <h1 className={`${baseClass}__page-title`}>Edit policy</h1>
-              {currentTeam && (
-                <p className={`${baseClass}__page-subtitle`}>
-                  Editing policy for {currentTeam.name}.
-                </p>
-              )}
+              {renderPolicyFleetName()}
             </div>
           ) : (
             <div className={`${baseClass}__title-bar`}>
-              <div className={`${baseClass}__policy-name`}>{renderName()}</div>
+              <div className={`${baseClass}__policy-name-fleet-name`}>
+                {renderName()}
+                {renderPolicyFleetName()}
+              </div>
             </div>
           )}
           {isEditMode && renderName()}
+
           {renderDescription()}
           {renderResolution()}
           {isEditMode && !isPatchPolicy && platformSelector.render()}

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -6,14 +6,16 @@ import { useQuery, useQueryClient } from "react-query";
 import { Ace } from "ace-builds";
 import { useDebouncedCallback } from "use-debounce";
 import { size } from "lodash";
+import { InjectedRouter } from "react-router";
 
-import { addGravatarUrlToResource } from "utilities/helpers";
 import { AppContext } from "context/app";
 import { NotificationContext } from "context/notification";
 import { PolicyContext } from "context/policy";
 import usePlatformCompatibility from "hooks/usePlatformCompatibility";
 import usePlatformSelector from "hooks/usePlatformSelector";
+import PATHS from "router/paths";
 import CUSTOM_TARGET_OPTIONS from "pages/policies/helpers";
+import { getPathWithQueryParams } from "utilities/url";
 
 import { IPolicy, IPolicyFormData } from "interfaces/policy";
 import { CommaSeparatedPlatformString } from "interfaces/platform";
@@ -24,23 +26,19 @@ import {
   LEARN_MORE_ABOUT_BASE_LINK,
 } from "utilities/constants";
 
-import Avatar from "components/Avatar";
 import SQLEditor from "components/SQLEditor";
 // @ts-ignore
 import { validateQuery } from "components/forms/validators/validate_query";
 import Button from "components/buttons/Button";
-import RevealButton from "components/buttons/RevealButton";
 import Checkbox from "components/forms/fields/Checkbox";
 import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon/Icon";
 // @ts-ignore
 import InputField from "components/forms/fields/InputField";
-import PageDescription from "components/PageDescription";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import CustomLink from "components/CustomLink";
 import TargetLabelSelector from "components/TargetLabelSelector";
-import DataSet from "components/DataSet";
 
 import labelsAPI, {
   getCustomLabels,
@@ -55,6 +53,8 @@ import PolicyAutomations from "../PolicyAutomations";
 const baseClass = "policy-form";
 
 interface IPolicyFormProps {
+  router: InjectedRouter;
+  teamIdForApi: number | null;
   policyIdForEdit: number | null;
   showOpenSchemaActionText: boolean;
   storedPolicy: IPolicy | undefined;
@@ -90,6 +90,8 @@ const validateQuerySQL = (query: string) => {
 };
 
 const PolicyForm = ({
+  router,
+  teamIdForApi,
   policyIdForEdit,
   showOpenSchemaActionText,
   storedPolicy,
@@ -244,6 +246,33 @@ const PolicyForm = ({
     !policyIdForEdit &&
     DEFAULT_POLICIES.find((p) => p.name === lastEditedQueryName);
 
+  /* - Observer/Observer+ and Technicians cannot edit existing policies
+     - Team users cannot edit inherited policies
+    Reroute edit existing policy page (/:policyId/edit) to policy details page (/:policyId) */
+  useEffect(() => {
+    const isInheritedPolicy = isEditMode && storedPolicy?.team_id === null;
+
+    const noEditPermissions =
+      isTeamObserver ||
+      isGlobalObserver ||
+      isTeamTechnician ||
+      isGlobalTechnician ||
+      (!isOnGlobalTeam && isInheritedPolicy); // Team user viewing inherited policy
+
+    if (
+      !isStoredPolicyLoading && // Confirms teamId for storedQuery before RBAC reroute
+      policyIdForEdit &&
+      policyIdForEdit > 0 &&
+      noEditPermissions
+    ) {
+      router.push(
+        getPathWithQueryParams(PATHS.POLICY_DETAILS(policyIdForEdit), {
+          fleet_id: teamIdForApi,
+        })
+      );
+    }
+  }, [policyIdForEdit, isTeamMaintainerOrTeamAdmin, isStoredPolicyLoading]);
+
   useEffect(() => {
     setSelectedTargetType(
       !lastEditedQueryLabelsIncludeAny.length &&
@@ -284,9 +313,6 @@ const PolicyForm = ({
     }
     setCompatiblePlatforms(lastEditedQueryBody);
   }, [lastEditedQueryBody, lastEditedQueryId]);
-
-  const hasSavePermissions =
-    isGlobalAdmin || isGlobalMaintainer || isTeamMaintainerOrTeamAdmin;
 
   const onLoad = (editor: Ace.Editor) => {
     editor.setOptions({
@@ -555,92 +581,18 @@ const PolicyForm = ({
   const renderPolicyFleetName = () => {
     if (isFreeTier || !currentTeam?.name) return null;
 
-    if (isEditMode) {
-      return hasSavePermissions ? (
-        <p>
-          Editing policy for <strong>{currentTeam?.name}</strong>.
-        </p>
-      ) : (
-        <p>
-          Viewing policy for <strong>{currentTeam?.name}</strong>.
-        </p>
-      );
-    }
-
-    return (
+    return isEditMode ? (
+      <p>
+        Editing policy for <strong>{currentTeam?.name}</strong>.
+      </p>
+    ) : (
       <p>
         Creating a new policy for <strong>{currentTeam?.name}</strong>.
       </p>
     );
   };
 
-  // Non-editable form used for:
-  // - Team observers and team observer+ viewing any of their team's policies and any inherited policies
-  // - Team admins and team maintainers viewing any inherited policy
-  // - Global observers and global observer+ viewing any team's policies and any inherited policies
-  // - Global technicians and team technicians viewing any team's policies and any inherited policies
-  const renderNonEditableForm = (
-    <form className={`${baseClass}__wrapper`}>
-      <h1
-        className={`${baseClass}__policy-name ${baseClass}__policy-name--no-hover`}
-      >
-        {lastEditedQueryName}
-      </h1>
-      {renderPolicyFleetName()}
-      {lastEditedQueryDescription && (
-        <PageDescription
-          className={`${baseClass}__policy-description no-hover`}
-          content={lastEditedQueryDescription}
-        />
-      )}
-      {lastEditedQueryResolution && (
-        <>
-          <p className="resolve-title">
-            <strong>Resolve:</strong>
-          </p>
-          <p className={`${baseClass}__policy-resolution no-hover`}>
-            {lastEditedQueryResolution}
-          </p>
-        </>
-      )}
-      <RevealButton
-        isShowing={showQueryEditor}
-        className={baseClass}
-        hideText="Hide SQL"
-        showText="Show SQL"
-        onClick={() => setShowQueryEditor(!showQueryEditor)}
-      />
-      {showQueryEditor && (
-        <SQLEditor
-          value={lastEditedQueryBody}
-          name="query editor"
-          wrapperClassName={`${baseClass}__text-editor-wrapper form-field`}
-          wrapEnabled
-          readOnly
-        />
-      )}
-      {renderLiveQueryWarning()}
-      {(isObserverPlus ||
-        isTeamMaintainerOrTeamAdmin ||
-        isGlobalTechnician ||
-        isTeamTechnician) && ( // Team admin, team maintainer, any Observer+ and any Technician can run a policy
-        <div className="button-wrap">
-          <Button
-            className={`${baseClass}__run`}
-            onClick={goToSelectTargets}
-            disabled={isEditMode && !isAnyPlatformSelected}
-          >
-            Run
-          </Button>
-        </div>
-      )}
-    </form>
-  );
-
-  // Editable form is used for:
-  // Global admins and global maintainers
-  // Team admins and team maintainers viewing any of their team's policies
-  const renderEditablePolicyForm = () => {
+  const renderPolicyForm = () => {
     // Save disabled for no platforms selected, query name blank on existing query, or sql errors
     const disableSaveFormErrors =
       isAddingAutomation ||
@@ -742,38 +694,36 @@ const PolicyForm = ({
                 Cancel
               </Button>
             )}
-            {hasSavePermissions && (
-              <GitOpsModeTooltipWrapper
-                renderChildren={(disableChildren) => (
-                  <TooltipWrapper
-                    tipContent={
-                      <>
-                        Select the platforms this
-                        <br />
-                        policy will be checked on
-                        <br />
-                        to save or run the policy.
-                      </>
-                    }
-                    tooltipClass={`${baseClass}__button-wrap--tooltip`}
-                    position="top"
-                    disableTooltip={!isEditMode || isAnyPlatformSelected}
-                    underline={false}
-                  >
-                    <span className={`${baseClass}__button-wrap--tooltip`}>
-                      <Button
-                        onClick={promptSavePolicy()}
-                        disabled={disableSaveFormErrors || disableChildren}
-                        className="save-loading"
-                        isLoading={isUpdatingPolicy}
-                      >
-                        Save
-                      </Button>
-                    </span>
-                  </TooltipWrapper>
-                )}
-              />
-            )}
+            <GitOpsModeTooltipWrapper
+              renderChildren={(disableChildren) => (
+                <TooltipWrapper
+                  tipContent={
+                    <>
+                      Select the platforms this
+                      <br />
+                      policy will be checked on
+                      <br />
+                      to save or run the policy.
+                    </>
+                  }
+                  tooltipClass={`${baseClass}__button-wrap--tooltip`}
+                  position="top"
+                  disableTooltip={!isEditMode || isAnyPlatformSelected}
+                  underline={false}
+                >
+                  <span className={`${baseClass}__button-wrap--tooltip`}>
+                    <Button
+                      onClick={promptSavePolicy()}
+                      disabled={disableSaveFormErrors || disableChildren}
+                      className="save-loading"
+                      isLoading={isUpdatingPolicy}
+                    >
+                      Save
+                    </Button>
+                  </span>
+                </TooltipWrapper>
+              )}
+            />
             <TooltipWrapper
               tipContent={
                 disabledLiveQuery ? (
@@ -837,22 +787,7 @@ const PolicyForm = ({
     return <Spinner />;
   }
 
-  const isInheritedPolicy = isEditMode && storedPolicy?.team_id === null;
-
-  const noEditPermissions =
-    isTeamObserver ||
-    isGlobalObserver ||
-    isTeamTechnician ||
-    isGlobalTechnician ||
-    (!isOnGlobalTeam && isInheritedPolicy); // Team user viewing inherited policy
-
-  // Render non-editable form only
-  if (noEditPermissions) {
-    return renderNonEditableForm;
-  }
-
-  // Render default editable form
-  return renderEditablePolicyForm();
+  return renderPolicyForm();
 };
 
 export default PolicyForm;

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -463,20 +463,14 @@ const PolicyForm = ({
   const renderName = () => {
     if (isEditMode) {
       return (
-        <GitOpsModeTooltipWrapper
-          position="right"
-          tipOffset={16}
-          renderChildren={(disableChildren) => (
-            <InputField
-              name="policy-name"
-              label="Name"
-              placeholder="Add name here"
-              value={lastEditedQueryName}
-              error={errors && errors.name}
-              onChange={(value: string) => setLastEditedQueryName(value)}
-              disabled={disableChildren}
-            />
-          )}
+        <InputField
+          name="policy-name"
+          label="Name"
+          placeholder="Add name here"
+          value={lastEditedQueryName}
+          error={errors && errors.name}
+          onChange={(value: string) => setLastEditedQueryName(value)}
+          disabled={gitOpsModeEnabled}
         />
       );
     }
@@ -493,21 +487,15 @@ const PolicyForm = ({
   const renderDescription = () => {
     if (isEditMode) {
       return (
-        <GitOpsModeTooltipWrapper
-          position="right"
-          tipOffset={16}
-          renderChildren={(disableChildren) => (
-            <InputField
-              name="policy-description"
-              label="Description"
-              placeholder="Add description here."
-              value={lastEditedQueryDescription}
-              type="textarea"
-              helpText="How does this policy's failure put the organization at risk?"
-              onChange={(value: string) => setLastEditedQueryDescription(value)}
-              disabled={disableChildren}
-            />
-          )}
+        <InputField
+          name="policy-description"
+          label="Description"
+          placeholder="Add description here."
+          value={lastEditedQueryDescription}
+          type="textarea"
+          helpText="How does this policy's failure put the organization at risk?"
+          onChange={(value: string) => setLastEditedQueryDescription(value)}
+          disabled={gitOpsModeEnabled}
         />
       );
     }
@@ -518,21 +506,15 @@ const PolicyForm = ({
   const renderResolution = () => {
     if (isEditMode) {
       return (
-        <GitOpsModeTooltipWrapper
-          position="right"
-          tipOffset={16}
-          renderChildren={(disableChildren) => (
-            <InputField
-              name="policy-resolution"
-              label="Resolution"
-              placeholder="Add resolution here."
-              value={lastEditedQueryResolution}
-              type="textarea"
-              helpText="If this policy fails, what should the end user expect?"
-              onChange={(value: string) => setLastEditedQueryResolution(value)}
-              disabled={disableChildren}
-            />
-          )}
+        <InputField
+          name="policy-resolution"
+          label="Resolution"
+          placeholder="Add resolution here."
+          value={lastEditedQueryResolution}
+          type="textarea"
+          helpText="If this policy fails, what should the end user expect?"
+          onChange={(value: string) => setLastEditedQueryResolution(value)}
+          disabled={gitOpsModeEnabled}
         />
       );
     }
@@ -621,7 +603,6 @@ const PolicyForm = ({
             </div>
           )}
           {isEditMode && renderName()}
-
           {renderDescription()}
           {renderResolution()}
           {isEditMode && !isPatchPolicy && platformSelector.render()}
@@ -642,6 +623,7 @@ const PolicyForm = ({
                   <b>have any</b> of these labels:
                 </span>
               }
+              disableOptions={gitOpsModeEnabled}
               suppressTitle
             />
           )}

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from "react-query";
 
 import { Ace } from "ace-builds";
 import { useDebouncedCallback } from "use-debounce";
-import { noop, size } from "lodash";
+import { size } from "lodash";
 
 import { addGravatarUrlToResource } from "utilities/helpers";
 import { AppContext } from "context/app";
@@ -74,6 +74,7 @@ interface IPolicyFormProps {
   onClickAutofillResolution: () => Promise<void>;
   resetAiAutofillData: () => void;
   currentAutomatedPolicies: number[];
+  onCancel?: () => void;
 }
 
 const validateQuerySQL = (query: string) => {
@@ -108,6 +109,7 @@ const PolicyForm = ({
   onClickAutofillResolution,
   resetAiAutofillData,
   currentAutomatedPolicies,
+  onCancel,
 }: IPolicyFormProps): JSX.Element => {
   const [errors, setErrors] = useState<{ [key: string]: any }>({}); // string | null | undefined or boolean | undefined
   const [isSaveNewPolicyModalOpen, setIsSaveNewPolicyModalOpen] = useState(
@@ -759,8 +761,8 @@ const PolicyForm = ({
           {renderPlatformCompatibility()}
           {renderLiveQueryWarning()}
           <div className="button-wrap">
-            {isEditMode && (
-              <Button variant="inverse" onClick={noop}>
+            {isEditMode && onCancel && (
+              <Button variant="inverse" onClick={onCancel}>
                 Cancel
               </Button>
             )}

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/PolicyForm.tsx
@@ -729,7 +729,10 @@ const PolicyForm = ({
               gitOpsModeEnabled={!!gitOpsModeEnabled}
             />
           )}
-          {isEditMode && isPremiumTier && !isPatchPolicy && renderCriticalPolicy()}
+          {isEditMode &&
+            isPremiumTier &&
+            !isPatchPolicy &&
+            renderCriticalPolicy()}
           <SQLEditor
             value={lastEditedQueryBody}
             error={errors.query}
@@ -814,8 +817,7 @@ const PolicyForm = ({
                 )
               }
               disableTooltip={
-                (!isEditMode || isAnyPlatformSelected) &&
-                !disabledLiveQuery
+                (!isEditMode || isAnyPlatformSelected) && !disabledLiveQuery
               }
               underline={false}
               showArrow

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -52,15 +52,8 @@
     }
   }
 
-  .input-field,
-  .input-field__text-area {
-    min-height: auto;
-    white-space: normal;
-  }
-
   .input-field__textarea {
     min-width: 100%;
-    resize: vertical;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera */
@@ -79,7 +72,7 @@
     height: 18px;
   }
 
-  &__policy-name,
+  &__policy-name-fleet-name,
   &__description,
   &__resolution {
     .button--text-icon {
@@ -88,11 +81,10 @@
     }
   }
 
-  &__policy-name {
-    &--new {
-      font-size: $large;
-      margin: 0;
-    }
+  &__policy-name-fleet-name {
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
   }
 
   &__autofill-label {

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -18,7 +18,9 @@
   }
 
   &__page-header {
-    margin-bottom: $pad-small;
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
   }
 
   &__page-title {
@@ -30,7 +32,7 @@
   &__page-subtitle {
     font-size: $x-small;
     color: $ui-fleet-black-75;
-    margin: $pad-xsmall 0 0;
+    margin: 0;
   }
 
   &__title-bar {

--- a/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
+++ b/frontend/pages/policies/PolicyPage/components/PolicyForm/_styles.scss
@@ -17,6 +17,22 @@
     }
   }
 
+  &__page-header {
+    margin-bottom: $pad-small;
+  }
+
+  &__page-title {
+    font-size: $large;
+    font-weight: $bold;
+    margin: 0;
+  }
+
+  &__page-subtitle {
+    font-size: $x-small;
+    color: $ui-fleet-black-75;
+    margin: $pad-xsmall 0 0;
+  }
+
   &__title-bar {
     display: flex;
     justify-content: space-between;
@@ -38,6 +54,11 @@
   .input-field__text-area {
     min-height: auto;
     white-space: normal;
+  }
+
+  .input-field__textarea {
+    min-width: 100%;
+    resize: vertical;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera */
@@ -65,80 +86,10 @@
     }
   }
 
-  &__policy-name-wrapper,
-  &__policy-description-wrapper,
-  &__policy-resolution-wrapper {
-    display: flex;
-    align-items: flex-start;
-    gap: $pad-small;
-    width: fit-content;
-
-    &:not(&--editing) {
-      &:hover {
-        cursor: pointer;
-        * {
-          color: $core-fleet-green;
-          cursor: pointer;
-        }
-      }
-    }
-    &--disabled-by-gitops-mode {
-      @include disabled;
-    }
-  }
-
-  &__policy-name-wrapper {
-    line-height: $line-height-large;
-
-    .no-value {
-      min-width: 112px;
-    }
-  }
-
-  &__edit-icon {
-    opacity: 1;
-    transition: opacity 0.2s;
-    margin-left: 0;
-    /** Designed to be aligned with first line of text, not center of multiple
-    lines of text, without this, the icon will vertically center on multiline */
-    align-self: initial;
-    height: 42px; // 24px font-size * 1.75 line height
-    align-items: center; // Centers the icon in the height area
-
-    &--hide {
-      opacity: 0;
-    }
-  }
-
-  &__policy-description-wrapper,
-  &__policy-resolution-wrapper {
-    .no-value {
-      min-width: 106px;
-    }
-    .policy-form__edit-icon {
-      height: 21px; // 14px font-size * 1.5 line height
-    }
-  }
-
-  &__policy-name,
-  &__policy-description,
-  &__policy-resolution {
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    resize: none;
-    white-space: normal;
-    background-color: transparent;
-    overflow: hidden;
-    font-size: $x-small;
-  }
-
   &__policy-name {
-    font-size: $large;
-
-    &.input-field--error {
-      border: 1px solid $core-vibrant-red;
+    &--new {
+      font-size: $large;
+      margin: 0;
     }
   }
 
@@ -146,9 +97,21 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    .autofill-tooltip-wrapper {
+      display: flex; // Required for vertical centering
+    }
+
+    .autofill-button-tooltip {
+      font-weight: $regular;
+    }
   }
 
   &__button-wrap {
+    &--tooltip {
+      display: flex;
+    }
+
     .policy-form__run {
       min-width: 64px;
     }

--- a/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
+++ b/frontend/pages/policies/PolicyPage/components/SaveNewPolicyModal/SaveNewPolicyModal.tests.tsx
@@ -125,7 +125,9 @@ describe("SaveNewPolicyModal", () => {
       const saveButton = screen.getByRole("button", { name: "Save" });
       expect(saveButton).toBeDisabled();
 
-      const funButton = screen.getByLabelText("Fun");
+      const funButton = await screen.findByRole("checkbox", {
+        name: "Fun",
+      });
       expect(funButton).not.toBeChecked();
       await userEvent.click(funButton);
       expect(saveButton).toBeEnabled();
@@ -149,7 +151,9 @@ describe("SaveNewPolicyModal", () => {
 
       // Set a label.
       await userEvent.click(screen.getByLabelText("Custom"));
-      await userEvent.click(screen.getByLabelText("Fun"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
       await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       expect(onCreatePolicy.mock.calls[0][0].labels_include_any).toEqual([
@@ -175,7 +179,9 @@ describe("SaveNewPolicyModal", () => {
 
       // Set a label.
       await userEvent.click(screen.getByLabelText("Custom"));
-      await userEvent.click(screen.getByLabelText("Fun"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
 
       // Click "Include any" to open the dropdown.
       const includeAnyOption = screen.getByRole("option", {

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -273,6 +273,8 @@ const QueryEditor = ({
         <BackButton text={backText} path={backPath} />
       </div>
       <PolicyForm
+        router={router}
+        teamIdForApi={teamIdForApi}
         onCreatePolicy={onCreatePolicy}
         goToSelectTargets={goToSelectTargets}
         onOsqueryTableSelect={onOsqueryTableSelect}
@@ -298,7 +300,7 @@ const QueryEditor = ({
                 router.push(
                   getPathWithQueryParams(
                     PATHS.POLICY_DETAILS(policyIdForEdit),
-                    { team_id: teamIdForApi }
+                    { fleet_id: teamIdForApi }
                   )
                 )
             : undefined

--- a/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/PolicyPage/screens/QueryEditor.tsx
@@ -259,10 +259,18 @@ const QueryEditor = ({
     );
   };
 
+  const backPath = policyIdForEdit
+    ? getPathWithQueryParams(PATHS.POLICY_DETAILS(policyIdForEdit), {
+        team_id: teamIdForApi,
+      })
+    : backToPoliciesPath();
+
+  const backText = policyIdForEdit ? "Back to policy" : "Back to policies";
+
   return (
     <div className={`${baseClass}__form`}>
       <div className={`${baseClass}__header-links`}>
-        <BackButton text="Back to policies" path={backToPoliciesPath()} />
+        <BackButton text={backText} path={backPath} />
       </div>
       <PolicyForm
         onCreatePolicy={onCreatePolicy}
@@ -284,6 +292,17 @@ const QueryEditor = ({
         onClickAutofillResolution={onClickAutofillResolution}
         resetAiAutofillData={() => setPolicyAutofillData(null)}
         currentAutomatedPolicies={currentAutomatedPolicies || []}
+        onCancel={
+          policyIdForEdit
+            ? () =>
+                router.push(
+                  getPathWithQueryParams(
+                    PATHS.POLICY_DETAILS(policyIdForEdit),
+                    { team_id: teamIdForApi }
+                  )
+                )
+            : undefined
+        }
       />
     </div>
   );

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
@@ -429,9 +429,7 @@ describe("EditQueryForm - component", () => {
         expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeChecked();
-        expect(
-          screen.getByRole("checkbox", { name: "Fun" })
-        ).toBeChecked();
+        expect(screen.getByRole("checkbox", { name: "Fun" })).toBeChecked();
         expect(
           screen.getByRole("checkbox", { name: "Fresh" })
         ).not.toBeChecked();

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tests.tsx
@@ -429,8 +429,12 @@ describe("EditQueryForm - component", () => {
         expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeChecked();
-        expect(screen.getByLabelText("Fun")).toBeChecked();
-        expect(screen.getByLabelText("Fresh")).not.toBeChecked();
+        expect(
+          screen.getByRole("checkbox", { name: "Fun" })
+        ).toBeChecked();
+        expect(
+          screen.getByRole("checkbox", { name: "Fresh" })
+        ).not.toBeChecked();
         expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
       });
     });
@@ -449,9 +453,11 @@ describe("EditQueryForm - component", () => {
         expect(screen.getByLabelText("All hosts")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeInTheDocument();
         expect(screen.getByLabelText("Custom")).toBeChecked();
-        funButton = screen.getByLabelText("Fun");
+        funButton = screen.getByRole("checkbox", { name: "Fun" });
         expect(funButton).toBeChecked();
-        expect(screen.getByLabelText("Fresh")).not.toBeChecked();
+        expect(
+          screen.getByRole("checkbox", { name: "Fresh" })
+        ).not.toBeChecked();
         saveButton = screen.getByRole("button", { name: "Save" });
         expect(saveButton).toBeEnabled();
       });

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -9,7 +9,7 @@ import { InjectedRouter } from "react-router";
 import { Location } from "history";
 import { useQuery } from "react-query";
 
-import { noop, size } from "lodash";
+import { size } from "lodash";
 import { useDebouncedCallback } from "use-debounce";
 import { Ace } from "ace-builds";
 
@@ -491,9 +491,7 @@ const EditQueryForm = ({
               value={lastEditedQueryDescription}
               type="textarea"
               helpText="What information does your report reveal? (Optional)"
-              onChange={(value: string) =>
-                setLastEditedQueryDescription(value)
-              }
+              onChange={(value: string) => setLastEditedQueryDescription(value)}
               disabled={disableChildren}
             />
           )}
@@ -576,6 +574,7 @@ const EditQueryForm = ({
         isAnyTeamObserverPlus) && (
         <div className={`button-wrap ${baseClass}__button-wrap--new-query`}>
           <TooltipWrapper
+            className="live-query-button-tooltip"
             tipContent="Live reports are disabled in organization settings"
             disableTooltip={!disabledLiveQuery}
             position="top"
@@ -669,9 +668,7 @@ const EditQueryForm = ({
               )}
             </div>
           ) : (
-            <div className={`${baseClass}__title-bar`}>
-              {renderName()}
-            </div>
+            <div className={`${baseClass}__title-bar`}>{renderName()}</div>
           )}
           {savedQueryMode && renderName()}
           {renderDescription()}
@@ -868,6 +865,7 @@ const EditQueryForm = ({
               </>
             )}
             <TooltipWrapper
+              className="live-query-button-tooltip"
               tipContent="Live reports are disabled in organization settings"
               disableTooltip={!disabledLiveQuery}
               position="top"

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -2,7 +2,6 @@ import React, {
   useState,
   useContext,
   useEffect,
-  KeyboardEvent,
   useCallback,
   useMemo,
 } from "react";
@@ -10,8 +9,7 @@ import { InjectedRouter } from "react-router";
 import { Location } from "history";
 import { useQuery } from "react-query";
 
-import { size } from "lodash";
-import classnames from "classnames";
+import { noop, size } from "lodash";
 import { useDebouncedCallback } from "use-debounce";
 import { Ace } from "ace-builds";
 
@@ -65,7 +63,8 @@ import Slider from "components/forms/fields/Slider";
 import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
 import Icon from "components/Icon/Icon";
-import AutoSizeInputField from "components/forms/fields/AutoSizeInputField";
+// @ts-ignore
+import InputField from "components/forms/fields/InputField";
 import LogDestinationIndicator from "components/LogDestinationIndicator";
 import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
 import TargetLabelSelector from "components/TargetLabelSelector";
@@ -192,9 +191,10 @@ const EditQueryForm = ({
     config,
     isPremiumTier,
     isFreeTier,
+    currentTeam,
   } = useContext(AppContext);
 
-  const isExistingQuery = !!queryIdForEdit;
+  const savedQueryMode = !!queryIdForEdit;
   const disabledLiveQuery = config?.server_settings.live_query_disabled;
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
@@ -207,8 +207,6 @@ const EditQueryForm = ({
   const [showQueryEditor, setShowQueryEditor] = useState(
     isObserverPlus || isAnyTeamObserverPlus || false
   );
-  const [isEditingName, setIsEditingName] = useState(false);
-  const [isEditingDescription, setIsEditingDescription] = useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const [queryWasChanged, setQueryWasChanged] = useState(false);
   const [selectedTargetType, setSelectedTargetType] = useState("");
@@ -327,14 +325,6 @@ const EditQueryForm = ({
     setLastEditedQueryBody(sqlString);
   };
 
-  const onInputKeypress = (event: KeyboardEvent<HTMLTextAreaElement>) => {
-    if (event.key.toLowerCase() === "enter" && !event.shiftKey) {
-      event.preventDefault();
-      event.currentTarget.blur();
-      setIsEditingName(false);
-      setIsEditingDescription(false);
-    }
-  };
   const frequencyOptions = useMemo(
     () =>
       getCustomDropdownOptions(
@@ -389,7 +379,7 @@ const EditQueryForm = ({
   const handleSaveQuery = () => (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    if (isExistingQuery && !lastEditedQueryName) {
+    if (savedQueryMode && !lastEditedQueryName) {
       return setErrors({
         ...errors,
         name: "Report name must be present",
@@ -402,7 +392,7 @@ const EditQueryForm = ({
     const canSave = valid || (!valid && newErrs.query !== EMPTY_QUERY_ERR);
 
     if (canSave) {
-      if (!isExistingQuery) {
+      if (!savedQueryMode) {
         platformSelector.setSelectedPlatforms(
           platformCompatibility.getCompatiblePlatforms()
         );
@@ -460,70 +450,26 @@ const EditQueryForm = ({
     return platformCompatibility.render();
   };
 
-  const editName = () => {
-    if (!isEditingName) {
-      setIsEditingName(true);
-    }
-  };
-
-  const queryNameWrapperClass = `${baseClass}__query-name-wrapper`;
-  const queryNameWrapperClasses = classnames(queryNameWrapperClass, {
-    [`${baseClass}--editing`]: isEditingName,
-  });
-
-  const queryDescriptionWrapperClass = `${baseClass}__query-description-wrapper`;
-  const queryDescriptionWrapperClasses = classnames(
-    queryDescriptionWrapperClass,
-    {
-      [`${baseClass}--editing`]: isEditingDescription,
-    }
-  );
-
   const renderName = () => {
-    if (isExistingQuery) {
+    if (savedQueryMode) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
           tipOffset={16}
-          renderChildren={(disableChildren) => {
-            const classes = classnames(queryNameWrapperClasses, {
-              [`${queryNameWrapperClass}--disabled-by-gitops-mode`]: disableChildren,
-            });
-            return (
-              <div
-                className={classes}
-                onFocus={() => setIsEditingName(true)}
-                onBlur={() => setIsEditingName(false)}
-                onClick={editName}
-              >
-                <AutoSizeInputField
-                  name="query-name"
-                  placeholder="Add name"
-                  value={lastEditedQueryName}
-                  inputClassName={`${baseClass}__query-name ${
-                    !lastEditedQueryName ? "no-value" : ""
-                  }`}
-                  maxLength={160}
-                  hasError={errors && errors.name}
-                  onChange={setLastEditedQueryName}
-                  onBlur={() => {
-                    setLastEditedQueryName(lastEditedQueryName.trim());
-                  }}
-                  onKeyPress={onInputKeypress}
-                  isFocused={isEditingName}
-                  disableTabability={disableChildren}
-                />
-                <Icon
-                  name="pencil"
-                  className={`${baseClass}__edit-icon ${
-                    isEditingName ? `${baseClass}__edit-icon--hide` : ""
-                  }`}
-                  size="small-medium"
-                  color="core-fleet-green"
-                />
-              </div>
-            );
-          }}
+          renderChildren={(disableChildren) => (
+            <InputField
+              name="query-name"
+              label="Name"
+              placeholder="Add name"
+              value={lastEditedQueryName}
+              error={errors && errors.name}
+              onChange={(value: string) => setLastEditedQueryName(value)}
+              onBlur={() => {
+                setLastEditedQueryName(lastEditedQueryName.trim());
+              }}
+              disabled={disableChildren}
+            />
+          )}
         />
       );
     }
@@ -531,53 +477,26 @@ const EditQueryForm = ({
     return <h1 className={`${baseClass}__query-name no-hover`}>New report</h1>;
   };
 
-  const editDescription = () => {
-    if (!isEditingDescription) {
-      setIsEditingDescription(true);
-    }
-  };
-
   const renderDescription = () => {
-    if (isExistingQuery) {
+    if (savedQueryMode) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
           tipOffset={16}
-          renderChildren={(disableChildren) => {
-            const classes = classnames(queryDescriptionWrapperClasses, {
-              [`${queryDescriptionWrapperClass}--disabled-by-gitops-mode`]: disableChildren,
-            });
-            return (
-              <div
-                className={classes}
-                onFocus={() => setIsEditingDescription(true)}
-                onBlur={() => setIsEditingDescription(false)}
-                onClick={editDescription}
-              >
-                <AutoSizeInputField
-                  name="query-description"
-                  placeholder="Add description"
-                  value={lastEditedQueryDescription}
-                  maxLength={250}
-                  inputClassName={`${baseClass}__query-description ${
-                    !lastEditedQueryDescription ? "no-value" : ""
-                  }`}
-                  onChange={setLastEditedQueryDescription}
-                  onKeyPress={onInputKeypress}
-                  isFocused={isEditingDescription}
-                  disableTabability={disableChildren}
-                />
-                <Icon
-                  name="pencil"
-                  className={`${baseClass}__edit-icon ${
-                    isEditingDescription ? `${baseClass}__edit-icon--hide` : ""
-                  }`}
-                  size="small-medium"
-                  color="core-fleet-green"
-                />
-              </div>
-            );
-          }}
+          renderChildren={(disableChildren) => (
+            <InputField
+              name="query-description"
+              label="Description"
+              placeholder="Add description"
+              value={lastEditedQueryDescription}
+              type="textarea"
+              helpText="What information does your report reveal? (Optional)"
+              onChange={(value: string) =>
+                setLastEditedQueryDescription(value)
+              }
+              disabled={disableChildren}
+            />
+          )}
         />
       );
     }
@@ -590,7 +509,7 @@ const EditQueryForm = ({
   const renderQueryTeam = () => {
     if (isFreeTier || !currentTeamName) return null;
 
-    if (isExistingQuery) {
+    if (savedQueryMode) {
       return hasSavePermissions ? (
         <p>
           Editing report for <strong>{currentTeamName}</strong>.
@@ -643,7 +562,7 @@ const EditQueryForm = ({
           label="Query"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           readOnly={
-            (!isObserverPlus && !isAnyTeamObserverPlus) || isExistingQuery
+            (!isObserverPlus && !isAnyTeamObserverPlus) || savedQueryMode
           }
           labelActionComponent={isObserverPlus && renderLabelComponent()}
           wrapEnabled
@@ -731,7 +650,7 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
       (!!errors.query && errors.query === EMPTY_QUERY_ERR) ||
-      (isExistingQuery && !platformSelector.isAnyPlatformSelected) ||
+      (savedQueryMode && !platformSelector.isAnyPlatformSelected) ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {
           return value;
@@ -740,30 +659,24 @@ const EditQueryForm = ({
     return (
       <>
         <form className={baseClass} autoComplete="off">
-          <div className={`${baseClass}__title-bar`}>
-            {renderName()}
-            {isExistingQuery && renderAuthor()}
-          </div>
-          {renderQueryTeam()}
+          {savedQueryMode ? (
+            <div className={`${baseClass}__page-header`}>
+              <h1 className={`${baseClass}__page-title`}>Edit report</h1>
+              {currentTeam && (
+                <p className={`${baseClass}__page-subtitle`}>
+                  Editing report for {currentTeam.name}.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div className={`${baseClass}__title-bar`}>
+              {renderName()}
+            </div>
+          )}
+          {savedQueryMode && renderName()}
           {renderDescription()}
-          <SQLEditor
-            value={lastEditedQueryBody}
-            error={errors.query}
-            label="Query"
-            labelActionComponent={renderLabelComponent()}
-            name="query editor"
-            onLoad={onLoad}
-            wrapperClassName={`${baseClass}__text-editor-wrapper form-field`}
-            onChange={onChangeQuery}
-            handleSubmit={
-              confirmChanges ? toggleConfirmSaveChangesModal : handleSaveQuery
-            }
-            wrapEnabled
-            focus={!isExistingQuery}
-          />
-          {renderPlatformCompatibility()}
 
-          {isExistingQuery && (
+          {savedQueryMode && (
             <div
               // including `form` class here keeps the children fields subject to the global form
               // children styles
@@ -840,7 +753,7 @@ const EditQueryForm = ({
               >
                 Observers can run
               </Checkbox>
-              {isExistingQuery && platformSelector.render()}
+              {savedQueryMode && platformSelector.render()}
               {isPremiumTier && (
                 <TargetLabelSelector
                   selectedTargetType={selectedTargetType}
@@ -858,6 +771,26 @@ const EditQueryForm = ({
                   suppressTitle
                 />
               )}
+            </div>
+          )}
+          <SQLEditor
+            value={lastEditedQueryBody}
+            error={errors.query}
+            label="Query"
+            labelActionComponent={renderLabelComponent()}
+            name="query editor"
+            onLoad={onLoad}
+            wrapperClassName={`${baseClass}__text-editor-wrapper form-field`}
+            onChange={onChangeQuery}
+            handleSubmit={
+              confirmChanges ? toggleConfirmSaveChangesModal : handleSaveQuery
+            }
+            wrapEnabled
+            focus={!savedQueryMode}
+          />
+          {renderPlatformCompatibility()}
+          {savedQueryMode && (
+            <>
               <RevealButton
                 isShowing={showAdvancedOptions}
                 className="advanced-options-toggle"
@@ -894,13 +827,13 @@ const EditQueryForm = ({
                   )}
                 </>
               )}
-            </div>
+            </>
           )}
           {renderLiveQueryWarning()}
           <div className={`button-wrap ${baseClass}__button-wrap--new-query`}>
             {hasSavePermissions && (
               <>
-                {isExistingQuery && (
+                {savedQueryMode && (
                   <GitOpsModeTooltipWrapper
                     renderChildren={(disableChildren) => (
                       <Button

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -429,23 +429,17 @@ const EditQueryForm = ({
   const renderName = () => {
     if (isExistingQuery) {
       return (
-        <GitOpsModeTooltipWrapper
-          position="right"
-          tipOffset={16}
-          renderChildren={(disableChildren) => (
-            <InputField
-              name="query-name"
-              label="Name"
-              placeholder="Add name"
-              value={lastEditedQueryName}
-              error={errors && errors.name}
-              onChange={(value: string) => setLastEditedQueryName(value)}
-              onBlur={() => {
-                setLastEditedQueryName(lastEditedQueryName.trim());
-              }}
-              disabled={disableChildren}
-            />
-          )}
+        <InputField
+          name="query-name"
+          label="Name"
+          placeholder="Add name"
+          value={lastEditedQueryName}
+          error={errors && errors.name}
+          onChange={(value: string) => setLastEditedQueryName(value)}
+          onBlur={() => {
+            setLastEditedQueryName(lastEditedQueryName.trim());
+          }}
+          disabled={gitOpsModeEnabled}
         />
       );
     }
@@ -456,21 +450,15 @@ const EditQueryForm = ({
   const renderDescription = () => {
     if (isExistingQuery) {
       return (
-        <GitOpsModeTooltipWrapper
-          position="right"
-          tipOffset={16}
-          renderChildren={(disableChildren) => (
-            <InputField
-              name="query-description"
-              label="Description"
-              placeholder="Add description"
-              value={lastEditedQueryDescription}
-              type="textarea"
-              helpText="What information does your report reveal? (Optional)"
-              onChange={(value: string) => setLastEditedQueryDescription(value)}
-              disabled={disableChildren}
-            />
-          )}
+        <InputField
+          name="query-description"
+          label="Description"
+          placeholder="Add description"
+          value={lastEditedQueryDescription}
+          type="textarea"
+          helpText="What information does your report reveal? (Optional)"
+          onChange={(value: string) => setLastEditedQueryDescription(value)}
+          disabled={gitOpsModeEnabled}
         />
       );
     }

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -194,7 +194,7 @@ const EditQueryForm = ({
     currentTeam,
   } = useContext(AppContext);
 
-  const savedQueryMode = !!queryIdForEdit;
+  const isExistingQuery = !!queryIdForEdit;
   const disabledLiveQuery = config?.server_settings.live_query_disabled;
   const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
@@ -379,7 +379,7 @@ const EditQueryForm = ({
   const handleSaveQuery = () => (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.preventDefault();
 
-    if (savedQueryMode && !lastEditedQueryName) {
+    if (isExistingQuery && !lastEditedQueryName) {
       return setErrors({
         ...errors,
         name: "Report name must be present",
@@ -392,7 +392,7 @@ const EditQueryForm = ({
     const canSave = valid || (!valid && newErrs.query !== EMPTY_QUERY_ERR);
 
     if (canSave) {
-      if (!savedQueryMode) {
+      if (!isExistingQuery) {
         platformSelector.setSelectedPlatforms(
           platformCompatibility.getCompatiblePlatforms()
         );
@@ -451,7 +451,7 @@ const EditQueryForm = ({
   };
 
   const renderName = () => {
-    if (savedQueryMode) {
+    if (isExistingQuery) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
@@ -478,7 +478,7 @@ const EditQueryForm = ({
   };
 
   const renderDescription = () => {
-    if (savedQueryMode) {
+    if (isExistingQuery) {
       return (
         <GitOpsModeTooltipWrapper
           position="right"
@@ -507,7 +507,7 @@ const EditQueryForm = ({
   const renderQueryTeam = () => {
     if (isFreeTier || !currentTeamName) return null;
 
-    if (savedQueryMode) {
+    if (isExistingQuery) {
       return hasSavePermissions ? (
         <p>
           Editing report for <strong>{currentTeamName}</strong>.
@@ -560,7 +560,7 @@ const EditQueryForm = ({
           label="Query"
           wrapperClassName={`${baseClass}__text-editor-wrapper`}
           readOnly={
-            (!isObserverPlus && !isAnyTeamObserverPlus) || savedQueryMode
+            (!isObserverPlus && !isAnyTeamObserverPlus) || isExistingQuery
           }
           labelActionComponent={isObserverPlus && renderLabelComponent()}
           wrapEnabled
@@ -649,7 +649,7 @@ const EditQueryForm = ({
     const disableSaveFormErrors =
       (lastEditedQueryName === "" && !!lastEditedQueryId) ||
       (!!errors.query && errors.query === EMPTY_QUERY_ERR) ||
-      (savedQueryMode && !platformSelector.isAnyPlatformSelected) ||
+      (isExistingQuery && !platformSelector.isAnyPlatformSelected) ||
       (selectedTargetType === "Custom" &&
         !Object.entries(selectedLabels).some(([, value]) => {
           return value;
@@ -658,7 +658,7 @@ const EditQueryForm = ({
     return (
       <>
         <form className={baseClass} autoComplete="off">
-          {savedQueryMode ? (
+          {isExistingQuery ? (
             <div className={`${baseClass}__page-header`}>
               <h1 className={`${baseClass}__page-title`}>Edit report</h1>
               {currentTeam && (
@@ -670,10 +670,10 @@ const EditQueryForm = ({
           ) : (
             <div className={`${baseClass}__title-bar`}>{renderName()}</div>
           )}
-          {savedQueryMode && renderName()}
+          {isExistingQuery && renderName()}
           {renderDescription()}
 
-          {savedQueryMode && (
+          {isExistingQuery && (
             <div
               // including `form` class here keeps the children fields subject to the global form
               // children styles
@@ -750,7 +750,7 @@ const EditQueryForm = ({
               >
                 Observers can run
               </Checkbox>
-              {savedQueryMode && platformSelector.render()}
+              {isExistingQuery && platformSelector.render()}
               {isPremiumTier && (
                 <TargetLabelSelector
                   selectedTargetType={selectedTargetType}
@@ -783,10 +783,10 @@ const EditQueryForm = ({
               confirmChanges ? toggleConfirmSaveChangesModal : handleSaveQuery
             }
             wrapEnabled
-            focus={!savedQueryMode}
+            focus={!isExistingQuery}
           />
           {renderPlatformCompatibility()}
-          {savedQueryMode && (
+          {isExistingQuery && (
             <>
               <RevealButton
                 isShowing={showAdvancedOptions}
@@ -830,7 +830,7 @@ const EditQueryForm = ({
           <div className={`button-wrap ${baseClass}__button-wrap--new-query`}>
             {hasSavePermissions && (
               <>
-                {savedQueryMode && (
+                {isExistingQuery && (
                   <GitOpsModeTooltipWrapper
                     renderChildren={(disableChildren) => (
                       <Button

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -403,30 +403,6 @@ const EditQueryForm = ({
     }
   };
 
-  const renderAuthor = (): JSX.Element | null => {
-    return storedQuery ? (
-      <DataSet
-        className={`${baseClass}__author`}
-        title="Author"
-        value={
-          <>
-            <Avatar
-              user={addGravatarUrlToResource({
-                email: storedQuery.author_email,
-              })}
-              size="xsmall"
-            />
-            <span>
-              {storedQuery.author_name === currentUser?.name
-                ? "You"
-                : storedQuery.author_name}
-            </span>
-          </>
-        }
-      />
-    ) : null;
-  };
-
   const renderLabelComponent = (): JSX.Element | null => {
     if (!showOpenSchemaActionText) {
       return null;
@@ -533,12 +509,9 @@ const EditQueryForm = ({
   // Observers and observer+ of existing query
   const renderNonEditableForm = (
     <form className={`${baseClass}`}>
-      <div className={`${baseClass}__title-bar`}>
-        <h1 className={`${baseClass}__query-name no-hover`}>
-          {lastEditedQueryName}
-        </h1>
-        {renderAuthor()}
-      </div>
+      <h1 className={`${baseClass}__query-name no-hover`}>
+        {lastEditedQueryName}
+      </h1>
       {renderQueryTeam()}
       <PageDescription
         className={`${baseClass}__query-description no-hover`}
@@ -661,14 +634,13 @@ const EditQueryForm = ({
           {isExistingQuery ? (
             <div className={`${baseClass}__page-header`}>
               <h1 className={`${baseClass}__page-title`}>Edit report</h1>
-              {currentTeam && (
-                <p className={`${baseClass}__page-subtitle`}>
-                  Editing report for {currentTeam.name}.
-                </p>
-              )}
+              {renderQueryTeam()}
             </div>
           ) : (
-            <div className={`${baseClass}__title-bar`}>{renderName()}</div>
+            <div className={`${baseClass}__query-name-fleet-name`}>
+              {renderName()}
+              {renderQueryTeam()}
+            </div>
           )}
           {isExistingQuery && renderName()}
           {renderDescription()}

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -6,6 +6,22 @@
     margin: 0;
   }
 
+  &__page-header {
+    margin-bottom: $pad-small;
+  }
+
+  &__page-title {
+    font-size: $large;
+    font-weight: $bold;
+    margin: 0;
+  }
+
+  &__page-subtitle {
+    font-size: $x-small;
+    color: $ui-fleet-black-75;
+    margin: $pad-xsmall 0 0;
+  }
+
   &__title-bar {
     display: flex;
     justify-content: space-between;
@@ -22,6 +38,10 @@
     white-space: normal;
   }
 
+  .input-field__textarea {
+    min-width: 100%;
+  }
+
   /* Hide scrollbar for Chrome, Safari and Opera */
   .input-field::-webkit-scrollbar {
     display: none;
@@ -31,57 +51,6 @@
   .input-field {
     -ms-overflow-style: none; /* IE and Edge */
     scrollbar-width: none; /* Firefox */
-  }
-
-  &__query-name-wrapper,
-  &__query-description-wrapper {
-    display: flex;
-    align-items: baseline;
-    gap: 0.5rem;
-    width: fit-content;
-    &:not(.edit-query-form--editing) {
-      &:hover {
-        cursor: pointer;
-        * {
-          color: $core-fleet-green;
-          cursor: pointer;
-        }
-      }
-    }
-    &--disabled-by-gitops-mode {
-      @include disabled;
-    }
-  }
-
-  &__edit-icon {
-    opacity: 1;
-    transition: opacity 0.2s;
-    margin-left: 0;
-    /** Designed to be aligned with first line of text, not center of multiple
-    lines of text, without this, the icon will vertically center on multiline */
-    align-self: initial;
-    height: 42px; // 24px font-size * 1.75 line height
-    align-items: center; // Centers the icon in the height area
-
-    &--hide {
-      opacity: 0;
-    }
-  }
-
-  &__query-name-wrapper {
-    .no-value {
-      min-width: 168px;
-    }
-  }
-
-  &__query-description-wrapper {
-    .no-value {
-      min-width: 144px;
-    }
-
-    .edit-query-form__edit-icon {
-      height: 21px; // 14px font-size * 1.5 line height
-    }
   }
 
   // Author section
@@ -94,49 +63,6 @@
       align-items: center;
       gap: $pad-small;
     }
-  }
-
-  &__query-name,
-  &__query-description {
-    width: 100%;
-    margin: 0;
-    padding: 0;
-    border: 0;
-    resize: none;
-    white-space: normal;
-    background-color: transparent;
-    overflow: hidden;
-    &.focus-visible {
-      outline: 0;
-    }
-  }
-
-  // Future iteration: move size="large" into AutoSizeInputField isntead of styling here
-  &__query-name-wrapper {
-    color: $core-fleet-black;
-    font-size: $large;
-    line-height: $line-height-large;
-
-    .no-value {
-      min-width: 168px;
-    }
-    .edit-query-form__query-name,
-    .input-sizer::after {
-      font-size: $large;
-      line-height: $line-height-large;
-    }
-    .component__auto-size-input-field {
-      font-size: $large;
-      line-height: $line-height-large;
-    }
-
-    &.input-field--error {
-      border: 1px solid $core-vibrant-red;
-    }
-  }
-
-  &__query-description {
-    color: $ui-fleet-black-75;
   }
 
   &__button-wrap {

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -7,7 +7,9 @@
   }
 
   &__page-header {
-    margin-bottom: $pad-small;
+    display: flex;
+    flex-direction: column;
+    gap: $pad-small;
   }
 
   &__page-title {
@@ -19,7 +21,7 @@
   &__page-subtitle {
     font-size: $x-small;
     color: $ui-fleet-black-75;
-    margin: $pad-xsmall 0 0;
+    margin: 0;
   }
 
   &__title-bar {
@@ -40,6 +42,7 @@
 
   .input-field__textarea {
     min-width: 100%;
+    resize: vertical;
   }
 
   /* Hide scrollbar for Chrome, Safari and Opera */

--- a/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
+++ b/frontend/pages/queries/edit/components/EditQueryForm/_styles.scss
@@ -24,20 +24,14 @@
     margin: 0;
   }
 
-  &__title-bar {
+  &__query-name-fleet-name {
     display: flex;
-    justify-content: space-between;
-    gap: 1.5rem;
-  }
-  .form-field {
-    margin-bottom: 0px;
+    flex-direction: column;
+    gap: $pad-small;
   }
 
-  .input-field,
-  .input-field__text-area {
-    min-height: auto;
-    line-height: normal;
-    white-space: normal;
+  .form-field {
+    margin-bottom: 0px;
   }
 
   .input-field__textarea {

--- a/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tests.tsx
+++ b/frontend/pages/queries/edit/components/SaveNewQueryModal/SaveNewQueryModal.tests.tsx
@@ -261,7 +261,9 @@ describe("SaveNewQueryModal", () => {
       const saveButton = screen.getByRole("button", { name: "Save" });
       expect(saveButton).toBeDisabled();
 
-      const funButton = screen.getByLabelText("Fun");
+      const funButton = await screen.findByRole("checkbox", {
+        name: "Fun",
+      });
       expect(funButton).not.toBeChecked();
       await userEvent.click(funButton);
       expect(saveButton).toBeEnabled();
@@ -280,7 +282,9 @@ describe("SaveNewQueryModal", () => {
 
       // Set a label.
       await userEvent.click(screen.getByLabelText("Custom"));
-      await userEvent.click(screen.getByLabelText("Fun"));
+      await userEvent.click(
+        await screen.findByRole("checkbox", { name: "Fun" })
+      );
       await userEvent.click(screen.getByRole("button", { name: "Save" }));
 
       expect(saveQuery.mock.calls[0][0].labels_include_any).toEqual(["Fun"]);

--- a/frontend/router/index.tsx
+++ b/frontend/router/index.tsx
@@ -42,6 +42,7 @@ import ManagePacksPage from "pages/packs/ManagePacksPage";
 import ManagePoliciesPage from "pages/policies/ManagePoliciesPage";
 import NoAccessPage from "pages/NoAccessPage";
 import PackComposerPage from "pages/packs/PackComposerPage";
+import PolicyDetailsPage from "pages/policies/PolicyDetailsPage";
 import PolicyPage from "pages/policies/PolicyPage";
 import QueryDetailsPage from "pages/queries/details/QueryDetailsPage";
 import LiveQueryPage from "pages/queries/live/LiveQueryPage";
@@ -411,7 +412,10 @@ const routes = (
             <Route component={AuthAnyMaintainerAnyAdminRoutes}>
               <Route path="new" component={PolicyPage} />
             </Route>
-            <Route path=":id" component={PolicyPage} />
+            <Route path=":id">
+              <IndexRoute component={PolicyDetailsPage} />
+              <Route path="edit" component={PolicyPage} />
+            </Route>
           </Route>
           <Redirect from="profile" to="account" /> {/* deprecated URL */}
           <Route path="account" component={AccountPage} />

--- a/frontend/router/paths.ts
+++ b/frontend/router/paths.ts
@@ -124,8 +124,10 @@ export default {
     `${URL_PREFIX}/reports/${queryId || "new"}/live`,
   REPORT_DETAILS: (queryId: number): string =>
     `${URL_PREFIX}/reports/${queryId}`,
-  EDIT_POLICY: (policyId: number): string =>
+  POLICY_DETAILS: (policyId: number): string =>
     `${URL_PREFIX}/policies/${policyId}`,
+  EDIT_POLICY: (policyId: number): string =>
+    `${URL_PREFIX}/policies/${policyId}/edit`,
   FORGOT_PASSWORD: `${URL_PREFIX}/login/forgot`,
   MFA: `${URL_PREFIX}/login/mfa`,
   NO_ACCESS: `${URL_PREFIX}/login/denied`,


### PR DESCRIPTION
## Issue
Closes #41753 
Closes #43284

## Description
- New Policy Details Page
- Updates to Edit report and Edit policy pages
- Confirmed gitops looks good
- Confirmed users with no edit permissions get re-routed to policy details page if they somehow try to get to the edit page

## Screen recording
https://fleetdm.zoom.us/clips/share/Ived04qvTgaWFp8TIA5YVw

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually