### PR TITLE
Use Fleet-maintained Firefox and remove legacy files

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -108,7 +108,6 @@ controls:
 policies:
   # macOS policies
   - path: ../lib/macos/policies/1password-emergency-kit-check.yml
-  - path: ../lib/macos/policies/update-firefox.yml
   - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/macos/policies/all-software-updates-installed.yml
   - path: ../lib/macos/policies/update-1password.yml
@@ -141,11 +140,6 @@ reports:
 software:
   packages:
     # macOS apps
-    - path: ../lib/macos/software/mozilla-firefox.yml # Mozilla Firefox for macOS (universal)
-      self_service: true
-      display_name: "Mozilla Firefox"
-      categories:
-        - Browsers
     - path: ../lib/macos/software/1password.yml # 1Password for macOS
       self_service: true
       setup_experience: true
@@ -269,6 +263,10 @@ software:
     - slug: google-chrome/darwin # Google Chrome for macOS
       self_service: true
       setup_experience: true
+      categories:
+        - Browsers
+    - slug: firefox/darwin # Mozilla Firefox for macOS
+      self_service: true
       categories:
         - Browsers
     - slug: brave-browser/darwin # Brave for macOS (ARM)

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -43,3 +43,8 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';
   label_membership_type: dynamic
   platform: darwin
+- name: Macs with Firefox installed
+  description: macOS hosts with Firefox installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -30,6 +30,15 @@
   install_software: false
   labels_include_any:
     - Macs with Microsoft Edge installed
+- name: macOS - Firefox up to date
+  description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
+  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
+  type: patch
+  fleet_maintained_app_slug: firefox/darwin
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - Macs with Firefox installed
 - name: macOS - Visual Studio Code up to date
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also delete Visual Studio Code if you are no longer using it."

--- a/it-and-security/lib/macos/policies/update-firefox.yml
+++ b/it-and-security/lib/macos/policies/update-firefox.yml
@@ -1,7 +1,0 @@
-- name: macOS - Firefox up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Firefox.app' AND version_compare(bundle_short_version, '149.0') < 0);
-  critical: false
-  description: This device may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
-  platform: darwin
-  calendar_events_enabled: true

--- a/it-and-security/lib/macos/software/mozilla-firefox.yml
+++ b/it-and-security/lib/macos/software/mozilla-firefox.yml
@@ -1,1 +1,0 @@
-url: https://download-installer.cdn.mozilla.net/pub/firefox/releases/149.0/mac/en-US/Firefox%20149.0.pkg

--- a/it-and-security/lib/windows/policies/update-firefox.yml
+++ b/it-and-security/lib/windows/policies/update-firefox.yml
@@ -1,7 +1,0 @@
-- name: Windows - Firefox up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Mozilla Firefox%' AND name NOT LIKE '%ESR%' AND version_compare(version, '149.0') < 0);
-  critical: false
-  description: This device may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
-  platform: windows
-  calendar_events_enabled: true


### PR DESCRIPTION
Migrate Firefox management to the fleet-maintained app slug (firefox/darwin): update workstations.yml to remove the old update policy and replace the macOS software entry with the firefox/darwin slug; add a dynamic label for Macs with Firefox installed; add a patch policy that targets the fleet_maintained_app_slug and uses the new label. Also remove legacy update policy and package files for Firefox (macOS and Windows) and the hardcoded Firefox pkg URL. This consolidates Firefox management under Fleet-maintained apps and removes duplicated/obsolete artifacts.