### PR TITLE
Consolidate department labels into departments.yml

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -112,12 +112,4 @@ labels:
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
   - path: ./lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
-  - path: ./lib/all/labels/department-information-technology.yml
-  - path: ./lib/all/labels/department-sales.yml
-  - path: ./lib/all/labels/department-marketing.yml
-  - path: ./lib/all/labels/department-engineering.yml
-  - path: ./lib/all/labels/department-people.yml
-  - path: ./lib/all/labels/department-finance.yml
-  - path: ./lib/all/labels/department-product-design.yml
-  - path: ./lib/all/labels/department-executive.yml
-  - path: ./lib/all/labels/department-customer-success.yml
+  - path: ./lib/all/labels/departments.yml

--- a/it-and-security/lib/all/labels/department-customer-success.yml
+++ b/it-and-security/lib/all/labels/department-customer-success.yml
@@ -1,6 +1,0 @@
-- name: "Department: Customer Success"
-  description: Hosts belonging to members of the Customer Success department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Customer Success

--- a/it-and-security/lib/all/labels/department-engineering.yml
+++ b/it-and-security/lib/all/labels/department-engineering.yml
@@ -1,6 +1,0 @@
-- name: "Department: Engineering"
-  description: Hosts belonging to members of the Engineering department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Engineering

--- a/it-and-security/lib/all/labels/department-executive.yml
+++ b/it-and-security/lib/all/labels/department-executive.yml
@@ -1,6 +1,0 @@
-- name: "Department: Executive"
-  description: Hosts belonging to members of the Executive department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Executive

--- a/it-and-security/lib/all/labels/department-finance.yml
+++ b/it-and-security/lib/all/labels/department-finance.yml
@@ -1,6 +1,0 @@
-- name: "Department: Finance"
-  description: Hosts belonging to members of the Finance department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Finance

--- a/it-and-security/lib/all/labels/department-information-technology.yml
+++ b/it-and-security/lib/all/labels/department-information-technology.yml
@@ -1,6 +1,0 @@
-- name: "Department: Information Technology"
-  description: Hosts belonging to members of the Information Technology department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Information Technology

--- a/it-and-security/lib/all/labels/department-marketing.yml
+++ b/it-and-security/lib/all/labels/department-marketing.yml
@@ -1,6 +1,0 @@
-- name: "Department: Marketing"
-  description: Hosts belonging to members of the Marketing department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Marketing

--- a/it-and-security/lib/all/labels/department-people.yml
+++ b/it-and-security/lib/all/labels/department-people.yml
@@ -1,6 +1,0 @@
-- name: "Department: People"
-  description: Hosts belonging to members of the People department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: People

--- a/it-and-security/lib/all/labels/department-product-design.yml
+++ b/it-and-security/lib/all/labels/department-product-design.yml
@@ -1,6 +1,0 @@
-- name: "Department: Product Design"
-  description: Hosts belonging to members of the Product Design department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Product Design

--- a/it-and-security/lib/all/labels/department-sales.yml
+++ b/it-and-security/lib/all/labels/department-sales.yml
@@ -1,6 +1,0 @@
-- name: "Department: Sales"
-  description: Hosts belonging to members of the Sales department
-  label_membership_type: host_vitals
-  criteria:
-    vital: end_user_idp_department
-    value: Sales

--- a/it-and-security/lib/all/labels/departments.yml
+++ b/it-and-security/lib/all/labels/departments.yml
@@ -1,0 +1,62 @@
+- name: "Department: Information Technology"
+  description: Hosts belonging to members of the Information Technology department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Information Technology
+
+- name: "Department: Sales"
+  description: Hosts belonging to members of the Sales department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Sales
+
+- name: "Department: Marketing"
+  description: Hosts belonging to members of the Marketing department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Marketing
+
+- name: "Department: Engineering"
+  description: Hosts belonging to members of the Engineering department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Engineering
+
+- name: "Department: People"
+  description: Hosts belonging to members of the People department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: People
+
+- name: "Department: Finance"
+  description: Hosts belonging to members of the Finance department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Finance
+
+- name: "Department: Product Design"
+  description: Hosts belonging to members of the Product Design department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Product Design
+
+- name: "Department: Executive"
+  description: Hosts belonging to members of the Executive department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Executive
+
+- name: "Department: Customer Success"
+  description: Hosts belonging to members of the Customer Success department
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_department
+    value: Customer Success


### PR DESCRIPTION
Replace individual department-*.yml label files with a single lib/all/labels/departments.yml and update it-and-security/default.yml to reference the consolidated file. Removes the separate department files and moves their label entries into departments.yml; behavior and label criteria are unchanged — this is a refactor to reduce file clutter and simplify label management.