### PR TITLE
Update X509 description for CA certificate

### DIFF
--- a/articles/configure-eap-tls-wifi-android.md
+++ b/articles/configure-eap-tls-wifi-android.md
@@ -62,7 +62,7 @@ Follow the steps below to connect your Android hosts to enterprise Wi-Fi:
 | `Identity` | Usually the user's email. |
 | `DomainSuffixMatch` | Domain suffix used to verify the RADIUS server's identity. The host checks that the server certificate's SAN DNS name (or CN if no SAN is present) ends with this suffix. |
 | `ClientCertKeyPairAlias` | Name of the certificate you added in Fleet under **Controls > OS settings > Certificates**. |
-| `X509` | Base64-encoded content of the root CA certificate that signed both server and client certificates. Exclude header and footer (`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`). |
+| `X509` | Base64-encoded content of the root CA certificate that signed the server certificate. Exclude header and footer (`-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`). |
 
 ## See status
 


### PR DESCRIPTION
I learned that it doesn't matter if the client certificate is signed by a root CA certificate specified under `Certificates[0].X509` when `Type` is `Authority`.

In the case of `customer-pingali`, they have a client certificate signed by a different CA, which confused their IT team. They initially used the root CA that signed the client certificate and assumed that the same certificate also signed the server certificate.