### PR TITLE
Update VSCode Typescript version setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -37,5 +37,6 @@
     "prettier.requireConfig": true,
     "yaml.schemas": {
         "https://json.schemastore.org/codecov.json": ".github/workflows/codecov.yml"
-    }
+    },
+    "js/ts.tsdk.path": "node_modules/typescript/lib"
 }


### PR DESCRIPTION
This PR updates VSCode settings to use Fleet's installed version of Typescript (v4.7.4) for its language server (linting, autocomplete, etc.) instead of what's built in to VSCode (v6.0.2).  As the two can drift, we end up with VSCode incorrectly highlighting certain syntax as incorrect.  