### PR TITLE
Propose a new reliability issue type.

### DIFF
--- a/.github/ISSUE_TEMPLATE/reliability.md
+++ b/.github/ISSUE_TEMPLATE/reliability.md
@@ -2,7 +2,7 @@
 name: 🔧 Reliability
 about: Report a scaling, performance, or reliability issue, including post-mortem action items.
 title: ''
-labels: 'reliability'
+labels: 'reliability,:product'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/reliability.md
+++ b/.github/ISSUE_TEMPLATE/reliability.md
@@ -2,7 +2,7 @@
 name: 🔧 Reliability
 about: Report a scaling, performance, or reliability issue, including post-mortem action items.
 title: ''
-labels: 'reliability,:product'
+labels: 'reliability,:help-engineering'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/reliability.md
+++ b/.github/ISSUE_TEMPLATE/reliability.md
@@ -1,0 +1,28 @@
+---
+name: 🔧 Reliability
+about: Report a scaling, performance, or reliability issue, including post-mortem action items.
+title: ''
+labels: 'reliability'
+assignees: ''
+
+---
+
+## Problem
+
+<!-- Describe the reliability, scaling, or performance issue. Include any relevant metrics, error rates, or incidents. -->
+TODO
+
+## Impact
+
+<!-- How does this affect users or the system? Include severity, frequency, and blast radius. -->
+TODO
+
+## Proposed fix
+
+<!-- Describe the proposed solution or mitigation. If unknown, leave blank for engineering to specify. -->
+TODO
+
+## Evidence
+
+<!-- Link to any related incidents, post-mortem documents, dashboards, or logs. -->
+N/A

--- a/handbook/company/communications.md
+++ b/handbook/company/communications.md
@@ -424,6 +424,7 @@ _**Note:**_ There are only a few "special" labels that are exceptions to this ru
 - `bug` A defect in the product.
 - `story` A user story.
 - `timebox` A timeboxed issue (a task or bug limited to a fixed duration, after which work stops regardless of completion).
+- `reliability` A scaling, performance, or reliability issue, including post-mortem action items.
 -  `prospect-` A customer prospect.
 - `P-` A [priority level](https://fleetdm.com/handbook/product-groups#high-priority-user-stories-and-bugs).
 

--- a/handbook/company/product-groups.md
+++ b/handbook/company/product-groups.md
@@ -1059,7 +1059,7 @@ New tickets are estimated, specified, and prioritized on the [drafting board](ht
 
 ### Scrum items
 
-Our scrum boards are exclusively composed of four types of scrum items:
+Our scrum boards are exclusively composed of the following types of scrum items:
 
 1. **User stories**: These are simple and concise descriptions of features or requirements from the user's perspective, marked with the `story` label. They keep our focus on delivering value to our customers.
 
@@ -1070,6 +1070,8 @@ Our scrum boards are exclusively composed of four types of scrum items:
 4. **Bugs**: Representing errors or flaws that result in incorrect or unexpected outcomes, bugs are marked with the `bug` label. Like user stories and sub-tasks, bugs are documented, prioritized, and addressed during a sprint.
 
 5. **Quick wins**: These are small copy or UX improvements that aren't quite bugs but they're so small that they're worthwhile. Quick wins skip user story review and go straight to the current sprint. It's up to the individual who opened the pull request (PR) to make sure the quick win is moved to "Awaiting QA" when the PR is merged. Like other product changes, quick wins are brought to [design review](https://fleetdm.com/handbook/product-design#rituals). To keep momentum, the PR can be approved and merged before design review.
+
+6. **Reliability issues**: These represent scaling, performance, or reliability concerns, including post-mortem action items, marked with the `reliability` label. Reliability issues are prioritized by severity by both product and engineering. They are used to track work that improves system stability, addresses incident follow-ups, and resolves operational risks.
 
 > Our sprint boards do not accommodate any other type of ticket. By strictly adhering to these scrum items, we maintain an organized and focused workflow that consistently adds value for our users.
 


### PR DESCRIPTION
Most engineering organizations maintain a dedicated category for operational and reliability work: scaling issues, performance regressions, post-mortem action items, and infrastructure improvements. This is standard practice in the industry, formalized by disciplines like Site Reliability Engineering (SRE) and widely adopted across companies of all sizes.

Without a dedicated category, this work either gets filed as bugs (which it often isn't) or as stories (which distorts product planning) or as eng-initiated (which it is not because it impacts customers). A separate "reliability" label gives product and engineering a shared queue to prioritize by severity, making it easier to track operational health alongside feature work.