### PR TITLE
Revert switching FMA manifest retrieval to use Cloudflare R2 bucket in 4.84

### DIFF
--- a/changes/42751-r2-fma
+++ b/changes/42751-r2-fma
@@ -1,1 +1,0 @@
-* Switched Fleet-maintained apps serving location from GitHub to https://maintained-apps.fleetdm.com/manifests. If you limit outbound Fleet server traffic, make sure it can access the new FMA manifests location.

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -29,7 +29,7 @@ type AppsList struct {
 	Apps    []appListing `json:"apps"`
 }
 
-const fmaOutputsBase = "https://maintained-apps.fleetdm.com/manifests"
+const fmaOutputsBase = "https://raw.githubusercontent.com/fleetdm/fleet/refs/heads/main/ee/maintained-apps/outputs"
 
 // Refresh fetches the latest information about maintained apps from FMA's
 // apps list on GitHub and updates the Fleet database with the new information.

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -14127,7 +14127,7 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallers() {
 	defer manifestServer.Close()
 	mockTransport = &mockRoundTripper{
 		mockServer:  manifestServer.URL,
-		origBaseURL: "https://maintained-apps.fleetdm.com",
+		origBaseURL: "https://raw.githubusercontent.com",
 		next:        http.DefaultTransport,
 	}
 	http.DefaultTransport = mockTransport
@@ -20632,7 +20632,7 @@ func (s *integrationEnterpriseTestSuite) TestUpgradeCodesFromMaintainedApps() {
 
 	mockTransport := &mockRoundTripper{
 		mockServer:  manifestServer.URL,
-		origBaseURL: "https://maintained-apps.fleetdm.com",
+		origBaseURL: "https://raw.githubusercontent.com",
 		next:        http.DefaultTransport,
 	}
 	http.DefaultTransport = mockTransport


### PR DESCRIPTION
This reverts commit 77639d5549e5c5ddbd1d8b0d4836429e9502fa06, landed pre-RC in #43012.