### PR TITLE
Disable locking of end-user info in macOS setup

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -80,6 +80,7 @@ controls:
   macos_setup:
     bootstrap_package: ""
     enable_end_user_authentication: true
+    lock_end_user_info: false
     macos_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
   macos_updates:
     deadline:


### PR DESCRIPTION
Add lock_end_user_info: false to it-and-security/fleets/workstations.yml under macos_setup so end-user information is not locked during macOS enrollment. This allows end users to view or edit their info while end-user authentication remains enabled.
