### PR TITLE
Fleet UI: Fix page oscillation

### DIFF
--- a/changes/43114-pagination-bug
+++ b/changes/43114-pagination-bug
@@ -1,0 +1,1 @@
+- Fleet UI: Fixed infinite page loop pagination bug on software table page happening when viewing a subsequent page and then using the software filter dropdown to filter.

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -230,7 +230,9 @@ const SoftwareTable = ({
       teamId,
       orderDirection,
       orderKey,
-      page: 0, // resets page index
+      // Do not reset page as it creates a race condition with TableContainer's useDeepEffect
+      // Rely on TableContainer's prevPageIndex to reset to 0 when detects additonalQueries changed
+      page: currentPage,
       ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
       ...buildSoftwareFilterQueryParams(value),
     };

--- a/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitles/SoftwareTable/SoftwareTable.tsx
@@ -231,7 +231,7 @@ const SoftwareTable = ({
       orderDirection,
       orderKey,
       // Do not reset page as it creates a race condition with TableContainer's useDeepEffect
-      // Rely on TableContainer's prevPageIndex to reset to 0 when detects additonalQueries changed
+      // Rely on TableContainer's prevPageIndex to reset to 0 when it detects additionalQueries changed
       page: currentPage,
       ...buildSoftwareVulnFiltersQueryParams(vulnFilters),
       ...buildSoftwareFilterQueryParams(value),


### PR DESCRIPTION
## Issue
Closes #43114 

## Description
- Fixes crazy oscillation bug between pages

## Screen recording of fix
https://fleetdm.zoom.us/clips/share/TVnlvYddSDCbo51gc-gwdA

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
