### PR TITLE
Website: update code block syntax highlighting styles

### DIFF
--- a/website/assets/js/pages/articles/basic-article.page.js
+++ b/website/assets/js/pages/articles/basic-article.page.js
@@ -66,6 +66,34 @@ parasails.registerPage('basic-article', {
         }
       });
     }
+    // https://github.com/sailshq/sailsjs.com/blob/7a74d4901dcc1e63080b502492b03fc971d3d3b2/assets/js/functions/sails-website-actions.js#L177-L239
+    (function highlightThatSyntax(){
+      $('pre code').each((i, block) => {
+        window.hljs.highlightElement(block);
+      });
+
+      // Make sure the <pre> tags whose code isn't being highlighted
+      // has that nice muted look we like.
+      $('.nohighlight').each(function() {
+        var $codeBlock = $(this);
+        $codeBlock.closest('pre').addClass('muted');
+      });
+      // Also make sure the 'usage' (and 'usage-*') code blocks have special styles.
+      $('.usage,.usage-exec').each(function() {
+        var $codeBlock = $(this);
+        $codeBlock.closest('pre').addClass('usage-wrapper');
+      });
+
+      // Now let's make the `function` keywords blue like in sublime.
+      $('.hljs-keyword').each(function() {
+        var $highlightedKeyword = $(this);
+        if($highlightedKeyword.text() === 'function') {
+          $highlightedKeyword.removeClass('hljs-keyword');
+          $highlightedKeyword.addClass('hljs-function-keyword');
+        }
+      });
+    })();
+
     // Add an event listener to add a class to the right sidebar when the header is hidden.
     window.addEventListener('scroll', this.handleScrollingInArticle);
 

--- a/website/assets/js/pages/docs/app-details.page.js
+++ b/website/assets/js/pages/docs/app-details.page.js
@@ -13,6 +13,47 @@ parasails.registerPage('app-details', {
     //…
   },
   mounted: async function() {
+
+    let columnNamesForThisQuery = ['bundle_short_version', 'bundle_identifier', 'version', 'name'];
+    let tableNamesForThisQuery = ['programs', 'apps'];
+    (()=>{
+      $('pre code').each((i, block) => {
+        if(block.classList.contains('ps') || block.classList.contains('sh')){
+          window.hljs.highlightElement(block);
+          return;
+        } else {
+          let tableNamesToHighlight = [];// Empty array to track the keywords that we will need to highlight
+          for(let tableName of tableNamesForThisQuery){// Going through the array of keywords for this table, if the entire word matches, we'll add it to the
+            for(let match of block.innerHTML.match(tableName)|| []){
+              tableNamesToHighlight.push(match);
+            }
+          }
+          // Now iterate through the tableNamesToHighlight, replacing all matches in the elements innerHTML.
+          let replacementHMTL = block.innerHTML;
+          for(let keywordInExample of tableNamesToHighlight) {
+            let regexForThisExample = new RegExp(keywordInExample, 'g');
+            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-attr">'+_.trim(keywordInExample)+'</span>');
+          }
+          $(block).html(replacementHMTL);
+          let columnNamesToHighlight = [];// Empty array to track the keywords that we will need to highlight
+          for(let columnName of columnNamesForThisQuery){// Going through the array of keywords for this table, if the entire word matches, we'll add it to the
+            for(let match of block.innerHTML.match(columnName)||[]){
+              columnNamesToHighlight.push(match);
+            }
+          }
+
+          for(let keywordInExample of columnNamesToHighlight) {
+            let regexForThisExample = new RegExp(keywordInExample, 'g');
+            replacementHMTL = replacementHMTL.replace(regexForThisExample, '<span class="hljs-string">'+_.trim(keywordInExample)+'</span>');
+          }
+          $(block).html(replacementHMTL);
+          window.hljs.highlightElement(block);
+          // After we've highlighted our keywords, we'll highlight the rest of the codeblock
+          // If this example is a single-line, we'll do some basic formatting to make it more human-readable.
+        }
+      });
+    })();
+
     $('[purpose="copy-button"]').on('click', async function() {
       let code = $(this).siblings('pre').find('code').text();
       $(this).addClass('copied');

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -613,6 +613,40 @@
         line-height: 16px;
         color: @core-fleet-black;
       }
+
+      .hljs-keyword,
+      .hljs-selector-tag,
+      .hljs-name {
+        color: #515774;
+      }
+      .hljs-built_in {
+        color: #4271ae;
+      }
+      .hljs-variable {
+        color: #c82829;
+      }
+      .hljs-symbol,
+      .hljs-attribute,
+      .hljs-function-keyword,
+      .hljs-attr,
+      .hljs-class,
+      .hljs-title,
+      .hljs-string,
+      .hljs-type,
+      .hljs-builtin-name,
+      .hljs-selector-id,
+      .hljs-selector-attr,
+      .hljs-selector-pseudo,
+      .hljs-addition,
+      .hljs-template-variable {
+        color: #4fd061;
+      }
+      .hljs-comment,
+      .hljs-deletion,
+      .hljs-meta {
+        color: @core-fleet-black-50;
+      }
+
       padding: 24px;
       border: 1px solid #E2E4EA;
       border-radius: 6px;

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -1,3 +1,4 @@
+// lesshint-disable spaceAroundComma
 #basic-article {
   h1 {
     font-size: 36px;

--- a/website/assets/styles/pages/docs/app-details.less
+++ b/website/assets/styles/pages/docs/app-details.less
@@ -1,3 +1,4 @@
+// lesshint-disable spaceAroundComma
 #app-details {
 
     h3 {

--- a/website/assets/styles/pages/docs/app-details.less
+++ b/website/assets/styles/pages/docs/app-details.less
@@ -242,12 +242,47 @@
       padding: 16px 44px 16px 24px;
       border: 1px solid #E2E4EA;
       background: #F9FAFC;
+      background-color: @ui-off-white;
       border-radius: 4px;
       margin-top: 32px;
       margin-bottom: 24px;
       white-space: nowrap;
       word-wrap: break-word;
       overflow: auto;
+      .ps, .bash {
+        .hljs-keyword,
+        .hljs-selector-tag,
+        .hljs-name {
+          color: #515774;
+        }
+        .hljs-built_in {
+          color: #4271ae;
+        }
+        .hljs-variable {
+          color: #c82829;
+        }
+        .hljs-symbol,
+        .hljs-attribute,
+        .hljs-function-keyword,
+        .hljs-attr,
+        .hljs-class,
+        .hljs-title,
+        .hljs-string,
+        .hljs-type,
+        .hljs-builtin-name,
+        .hljs-selector-id,
+        .hljs-selector-attr,
+        .hljs-selector-pseudo,
+        .hljs-addition,
+        .hljs-template-variable {
+          color: #4fd061;
+        }
+        .hljs-comment,
+        .hljs-deletion,
+        .hljs-meta {
+          color: @core-fleet-black-50;
+        }
+      }
       code {
         color: #515774;
         font-family: 'Source Code Pro';
@@ -257,8 +292,41 @@
         background-color: @ui-off-white;
         border: none;
         padding: 0;
-        dispaly: block;
+
+
+        .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
+          color: #515774;
+        }
+        .hljs-operator {
+          color: #3e999f;
+        }
+        .hljs-attr { // For table and column names
+          .hljs-keyword {
+            color: #FFF;
+          }
+          .hljs-string { // For words wrapped in quotation marks
+            color: #FFF;
+          }
+          color: #FFF;
+          background-color: #AE6DDF;
+          border-radius: 3px;
+          white-space: pre;
+          vertical-align: baseline;
+          span {
+            padding: 0;
+          }
+        }
+        .hljs-number {
+          color: #f5871f;
+        }
+        .hljs-string { // For words wrapped in quotation marks
+          color: #4fd061;
+          .hljs-keyword {
+            color: #4fd061;
+          }
+        }
       }
+
     }
 
     @media (max-width: 1200px) {

--- a/website/assets/styles/pages/docs/command-details.less
+++ b/website/assets/styles/pages/docs/command-details.less
@@ -397,9 +397,14 @@
         .hljs-keyword,
         .hljs-selector-tag,
         .hljs-name {
-          color: #AE6DDF;
+          color: #515774;
         }
-
+        .hljs-tag {
+          color: #4271ae;
+          .hljs-name {
+            color: #c82829;
+          }
+        }
         .hljs-symbol,
         .hljs-attribute,
         .hljs-function-keyword,

--- a/website/assets/styles/pages/docs/osquery-table-details.less
+++ b/website/assets/styles/pages/docs/osquery-table-details.less
@@ -327,7 +327,7 @@
       margin-bottom: 0px;
       code {
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
           white-space: pre;
         }
         [purpose='line-break']:not(:first-of-type)::before {
@@ -351,6 +351,9 @@
         }
         .hljs-number {
           color: #f5871f;
+        }
+        .hljs-operator {
+          color: #3e999f;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;

--- a/website/assets/styles/pages/docs/policy-details.less
+++ b/website/assets/styles/pages/docs/policy-details.less
@@ -253,7 +253,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -273,6 +273,9 @@
           span {
             padding: 0;
           }
+        }
+        .hljs-operator {
+          color: #3e999f;
         }
         .hljs-number {
           color: #f5871f;
@@ -378,9 +381,14 @@
       .hljs-keyword,
       .hljs-selector-tag,
       .hljs-name {
-        color: #AE6DDF;
+        color: #515774;
       }
-
+      .hljs-tag {
+        color: #4271ae;
+        .hljs-name {
+          color: #c82829;
+        }
+      }
       .hljs-symbol,
       .hljs-attribute,
       .hljs-function-keyword,
@@ -457,7 +465,7 @@
 
       &.sql {
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
         }
         .hljs-attr { // For table and column names
           .hljs-keyword {

--- a/website/assets/styles/pages/docs/query-detail.less
+++ b/website/assets/styles/pages/docs/query-detail.less
@@ -356,12 +356,18 @@
       background: #F9FAFC;
       border-radius: 0px 0px 4px 4px;
       .ps, .sh {
+        color: #ff5850;
         .hljs-keyword,
         .hljs-selector-tag,
         .hljs-name {
-          color: #AE6DDF;
+          color: #515774;
         }
-
+        .hljs-built_in {
+          color: #4271ae;
+        }
+        .hljs-variable {
+          color: #c82829;
+        }
         .hljs-symbol,
         .hljs-attribute,
         .hljs-function-keyword,
@@ -375,7 +381,6 @@
         .hljs-selector-attr,
         .hljs-selector-pseudo,
         .hljs-addition,
-        .hljs-variable,
         .hljs-template-variable {
           color: #4fd061;
         }
@@ -399,11 +404,15 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
         }
+        .hljs-operator {
+          color: #3e999f;
+        }
+
         .hljs-attr { // For table and column names
           .hljs-keyword {
             color: #FFF;

--- a/website/assets/styles/pages/docs/script-details.less
+++ b/website/assets/styles/pages/docs/script-details.less
@@ -355,9 +355,14 @@
         .hljs-keyword,
         .hljs-selector-tag,
         .hljs-name {
-          color: #AE6DDF;
+          color: #515774;
         }
-
+        .hljs-built_in {
+          color: #4271ae;
+        }
+        .hljs-variable {
+          color: #c82829;
+        }
         .hljs-symbol,
         .hljs-attribute,
         .hljs-function-keyword,
@@ -371,7 +376,6 @@
         .hljs-selector-attr,
         .hljs-selector-pseudo,
         .hljs-addition,
-        .hljs-variable,
         .hljs-template-variable {
           color: #4fd061;
         }
@@ -395,7 +399,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -418,6 +422,9 @@
         }
         .hljs-number {
           color: #f5871f;
+        }
+        .hljs-operator {
+          color: #3e999f;
         }
         .hljs-string { // For words wrapped in quotation marks
           color: #4fd061;

--- a/website/assets/styles/pages/docs/vital-details.less
+++ b/website/assets/styles/pages/docs/vital-details.less
@@ -462,7 +462,7 @@
         font-weight: 400;
         line-height: 150%;
         .hljs-keyword { // SQL keywords (SELECT, FROM, WHERE, IN, etc.)
-          color: #AE6DDF;
+          color: #515774;
         }
         [purpose='line-break']:not(:first-of-type)::before {
           content: '\a';
@@ -482,6 +482,9 @@
           span {
             padding: 0;
           }
+        }
+        .hljs-operator {
+          color: #3e999f;
         }
         .hljs-number {
           color: #f5871f;


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/42116 

Changes:
- Updated the syntax highlighting styles on documentation pages (app-details, query-details, osquery-table-details, vital-details, command-details, script-details, and policy-details)
- Added support and styles for syntax highlighting on article pages.