### PR TITLE
Comment out Zoom FMA labels and patch policies

### DIFF
--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -33,11 +33,12 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';
   label_membership_type: dynamic
   platform: darwin
-- name: Macs with Zoom installed
-  description: macOS hosts with Zoom installed
-  query: SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';
-  label_membership_type: dynamic
-  platform: darwin
+# Used by macOS Zoom patch policy when re-enabled (see patch-fleet-maintained-apps.yml).
+# - name: Macs with Zoom installed
+#   description: macOS hosts with Zoom installed
+#   query: SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';
+#   label_membership_type: dynamic
+#   platform: darwin
 - name: Macs with Okta Verify installed
   description: macOS hosts with Okta Verify installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.okta.mobile';

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -18,11 +18,12 @@
   query: SELECT 1 FROM programs WHERE name = 'Google Chrome' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: x86 Windows hosts with Zoom installed
-  description: x86 Windows hosts with Zoom installed
-  query: SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
-  label_membership_type: dynamic
-  platform: windows
+# Used by Windows Zoom patch policy when re-enabled (see patch-fleet-maintained-apps.yml).
+# - name: x86 Windows hosts with Zoom installed
+#   description: x86 Windows hosts with Zoom installed
+#   query: SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+#   label_membership_type: dynamic
+#   platform: windows
 - name: Windows hosts with Brave Browser installed
   description: Windows hosts with Brave Browser installed
   query: SELECT 1 FROM programs WHERE name = 'Brave';

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -63,14 +63,17 @@
   install_software: false
   labels_include_any:
     - Macs with Slack installed
-- name: macOS - Zoom up to date
-  description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also delete Zoom if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: zoom/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with Zoom installed
+# Zoom patch policy: disabled until FMA installer resolves in gitops (sql no rows).
+# Uncomment together with "Macs with Zoom installed" label in
+# lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+# - name: macOS - Zoom up to date
+#   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also delete Zoom if you are no longer using it."
+#   type: patch
+#   fleet_maintained_app_slug: zoom/darwin
+#   install_software: false
+#   labels_include_any:
+#     - Macs with Zoom installed
 - name: macOS - Okta Verify up to date
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality. You can also delete Okta Verify if you are no longer using it."

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -30,14 +30,17 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Google Chrome installed
-- name: Windows - Zoom up to date
-  description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also uninstall Zoom if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: zoom/windows
-  install_software: false
-  labels_include_any:
-    - x86 Windows hosts with Zoom installed
+# Zoom patch policy: disabled until FMA installer resolves in gitops (sql no rows).
+# Uncomment together with "x86 Windows hosts with Zoom installed" label in
+# lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+# - name: Windows - Zoom up to date
+#   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also uninstall Zoom if you are no longer using it."
+#   type: patch
+#   fleet_maintained_app_slug: zoom/windows
+#   install_software: false
+#   labels_include_any:
+#     - x86 Windows hosts with Zoom installed
 - name: Windows - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also uninstall Brave Browser if you are no longer using it."


### PR DESCRIPTION
Temporarily disable Zoom-related Fleet Maintained App (FMA) labels and patch policies across macOS and Windows while the FMA installer issue is resolved in gitops (SQL returned no rows). Commented out the Zoom label entries in lib/all/labels/*-with-fleet-maintained-apps-installed.yml and the corresponding Zoom patch policies in it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml and it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml, with comments noting to uncomment them together when re-enabling.