### PR TITLE
Disable Zoom FMA and related labels/policies

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -288,12 +288,12 @@ software:
       setup_experience: true
       categories:
         - Communication
-    - slug: zoom/darwin # Zoom for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Communication
-        - Productivity
+    # - slug: zoom/darwin # Zoom for macOS
+    #   self_service: true
+    #   setup_experience: true
+    #   categories:
+    #     - Communication
+    #     - Productivity
     - slug: okta-verify/darwin # Okta Verify for macOS
       self_service: true
       setup_experience: true
@@ -332,13 +332,13 @@ software:
         - Browsers
       labels_include_any:
         - "x86-based Windows hosts"
-    - slug: zoom/windows # Zoom for Windows (x86)
-      self_service: true
-      setup_experience: true
-      categories:
-        - Communication
-      labels_include_any:
-        - "x86-based Windows hosts"
+    # - slug: zoom/windows # Zoom for Windows (x86)
+    #   self_service: true
+    #   setup_experience: true
+    #   categories:
+    #     - Communication
+    #   labels_include_any:
+    #     - "x86-based Windows hosts"
     - slug: brave-browser/windows # Brave for Windows
       self_service: true
       categories:

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -33,11 +33,12 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';
   label_membership_type: dynamic
   platform: darwin
-- name: Macs with Zoom installed
-  description: macOS hosts with Zoom installed
-  query: SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';
-  label_membership_type: dynamic
-  platform: darwin
+# Used by macOS Zoom patch policy when enabled (see patch-fleet-maintained-apps.yml).
+# - name: Macs with Zoom installed
+#   description: macOS hosts with Zoom installed
+#   query: SELECT 1 FROM apps WHERE bundle_identifier = 'us.zoom.xos';
+#   label_membership_type: dynamic
+#   platform: darwin
 - name: Macs with Okta Verify installed
   description: macOS hosts with Okta Verify installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.okta.mobile';

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -18,11 +18,12 @@
   query: SELECT 1 FROM programs WHERE name = 'Google Chrome' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: x86 Windows hosts with Zoom installed
-  description: x86 Windows hosts with Zoom installed
-  query: SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
-  label_membership_type: dynamic
-  platform: windows
+# Used by Windows Zoom patch policy when enabled (see patch-fleet-maintained-apps.yml).
+# - name: x86 Windows hosts with Zoom installed
+#   description: x86 Windows hosts with Zoom installed
+#   query: SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+#   label_membership_type: dynamic
+#   platform: windows
 - name: Windows hosts with Brave Browser installed
   description: Windows hosts with Brave Browser installed
   query: SELECT 1 FROM programs WHERE name = 'Brave';

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -63,14 +63,15 @@
   install_software: false
   labels_include_any:
     - Macs with Slack installed
-- name: macOS - Zoom up to date
-  description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also delete Zoom if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: zoom/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with Zoom installed
+# Zoom patch policy disabled until Zoom FMA is present in Fleet.
+# - name: macOS - Zoom up to date
+#   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also delete Zoom if you are no longer using it."
+#   type: patch
+#   fleet_maintained_app_slug: zoom/darwin
+#   install_software: false
+#   labels_include_any:
+#     - Macs with Zoom installed
 - name: macOS - Okta Verify up to date
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality. You can also delete Okta Verify if you are no longer using it."

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -30,14 +30,15 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Google Chrome installed
-- name: Windows - Zoom up to date
-  description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also uninstall Zoom if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: zoom/windows
-  install_software: false
-  labels_include_any:
-    - x86 Windows hosts with Zoom installed
+# Zoom patch policy disabled until Zoom FMA is present in Fleet.
+# - name: Windows - Zoom up to date
+#   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also uninstall Zoom if you are no longer using it."
+#   type: patch
+#   fleet_maintained_app_slug: zoom/windows
+#   install_software: false
+#   labels_include_any:
+#     - x86 Windows hosts with Zoom installed
 - name: Windows - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also uninstall Brave Browser if you are no longer using it."


### PR DESCRIPTION
Comment out Zoom Fleet Maintained App entries and associated labels and patch policies until Zoom FMA is present in Fleet. Files updated: workstations.yml (zoom/darwin and zoom/windows software entries commented), labels/* (macOS and x86 Windows Zoom labels commented), and macOS/Windows patch policy files (Zoom patch policies disabled via comments). This prevents Fleet from referencing or enforcing Zoom policies while the FMA is not available.