### PR TITLE
[Activity] Document rotated recovery lock password activity

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -2420,6 +2420,23 @@ This activity contains the following fields:
 }
 ```
 
+## rotated_recovery_lock_password
+
+Generated when a Recovery Lock password is rotated.
+
+This activity contains the following fields:
+- "host_id": ID of the host.
+- "host_display_name": Display name of the host.
+
+#### Example
+
+```json
+{
+	"host_id": 123,
+	"host_display_name": "Anna's MacBook Pro"
+}
+```
+
 ## enabled_recovery_lock_password
 
 Generated when a user turns on Recovery Lock password for a team (or no team).


### PR DESCRIPTION
Added documentation for rotated recovery lock password activity, including fields and example.
To fix some lost changes: https://github.com/fleetdm/fleet/issues/37498#issuecomment-4201936975

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #37498
