### PR TITLE
Host activities: show all attempts (up to 3) for failed software/scripts

### DIFF
--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -877,7 +877,6 @@ type ActivityTypeRanScript struct {
 	Async               bool    `json:"async"`
 	PolicyID            *uint   `json:"policy_id"`
 	PolicyName          *string `json:"policy_name"`
-	AttemptNumber       *int    `json:"attempt_number,omitempty"`
 	FromSetupExperience bool    `json:"-"`
 }
 
@@ -1087,7 +1086,6 @@ type ActivityTypeInstalledSoftware struct {
 	Source              *string `json:"source,omitempty"`
 	PolicyID            *uint   `json:"policy_id"`
 	PolicyName          *string `json:"policy_name"`
-	AttemptNumber       *int    `json:"attempt_number,omitempty"`
 	FromSetupExperience bool    `json:"-"`
 	CommandUUID         string  `json:"command_uuid,omitempty"`
 }

--- a/server/fleet/activities.go
+++ b/server/fleet/activities.go
@@ -877,6 +877,7 @@ type ActivityTypeRanScript struct {
 	Async               bool    `json:"async"`
 	PolicyID            *uint   `json:"policy_id"`
 	PolicyName          *string `json:"policy_name"`
+	AttemptNumber       *int    `json:"attempt_number,omitempty"`
 	FromSetupExperience bool    `json:"-"`
 }
 
@@ -1086,6 +1087,7 @@ type ActivityTypeInstalledSoftware struct {
 	Source              *string `json:"source,omitempty"`
 	PolicyID            *uint   `json:"policy_id"`
 	PolicyName          *string `json:"policy_name"`
+	AttemptNumber       *int    `json:"attempt_number,omitempty"`
 	FromSetupExperience bool    `json:"-"`
 	CommandUUID         string  `json:"command_uuid,omitempty"`
 }

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -837,7 +837,6 @@ func (svc *Service) SaveHostScriptResult(ctx context.Context, result *fleet.Host
 	result.HostID = host.ID
 
 	// Calculate attempt_number for policy automation retries by counting existing attempts
-	attemptNumber, err := svc.getPolicyAutomationScriptAttemptNumber(ctx, host, result.ExecutionID)
 	if err != nil {
 		return err
 	}
@@ -949,7 +948,6 @@ func (svc *Service) SaveHostScriptResult(ctx context.Context, result *fleet.Host
 						Async:               !hsr.SyncRequest,
 						PolicyID:            hsr.PolicyID,
 						PolicyName:          policyName,
-						AttemptNumber:       hsr.AttemptNumber,
 						FromSetupExperience: fromSetupExperience,
 					},
 				); err != nil {
@@ -1285,7 +1283,6 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 	}
 
 	// Calculate attempt_number for retries by counting existing attempts
-	attemptNumber, err := svc.getSoftwareInstallerAttemptNumber(ctx, host, result.InstallUUID)
 	if err != nil {
 		return err
 	}
@@ -1425,7 +1422,6 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 					SelfService:         hsi.SelfService,
 					PolicyID:            hsi.PolicyID,
 					PolicyName:          policyName,
-					AttemptNumber:       hsi.AttemptNumber,
 					FromSetupExperience: fromSetupExperience,
 				},
 			); err != nil {
@@ -1446,12 +1442,10 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 // shouldRetryPolicyAutomationSoftwareInstall checks if a failed policy automation software install should be retried.
 // Returns true if retry should be queued
 func (svc *Service) shouldRetryPolicyAutomationSoftwareInstall(ctx context.Context, host *fleet.Host, hsi *fleet.HostSoftwareInstallerResult) (bool, error) {
-	if hsi.AttemptNumber == nil {
 		// should not happen
 		return false, ctxerr.New(ctx, "attempt_number is nil for policy automation install")
 	}
 
-	currentAttempt := *hsi.AttemptNumber
 
 	if currentAttempt >= fleet.MaxPolicyAutomationRetries {
 		return false, nil
@@ -1473,7 +1467,6 @@ func (svc *Service) retryPolicyAutomationSoftwareInstall(ctx context.Context, ho
 		"host_id", host.ID,
 		"policy_id", *hsi.PolicyID,
 		"software_installer_id", *hsi.SoftwareInstallerID,
-		"current_attempt", *hsi.AttemptNumber,
 	)
 	_, err := svc.ds.InsertSoftwareInstallRequest(ctx, host.ID, *hsi.SoftwareInstallerID, fleet.HostSoftwareInstallOptions{
 		PolicyID: hsi.PolicyID,
@@ -1483,10 +1476,8 @@ func (svc *Service) retryPolicyAutomationSoftwareInstall(ctx context.Context, ho
 
 // shouldRetrySoftwareInstall checks if a failed non-policy software install should be retried.
 func (svc *Service) shouldRetrySoftwareInstall(ctx context.Context, hsi *fleet.HostSoftwareInstallerResult) (bool, error) {
-	if hsi.AttemptNumber == nil {
 		return false, nil
 	}
-	return *hsi.AttemptNumber < fleet.MaxSoftwareInstallAttempts, nil
 }
 
 // retrySoftwareInstall queues a retry for a non-policy software install.
@@ -1496,7 +1487,6 @@ func (svc *Service) retrySoftwareInstall(ctx context.Context, host *fleet.Host, 
 		"host_id", host.ID,
 		"software_installer_id", *hsi.SoftwareInstallerID,
 		"self_service", hsi.SelfService,
-		"current_attempt", *hsi.AttemptNumber,
 	)
 	_, err := svc.ds.InsertSoftwareInstallRequest(ctx, host.ID, *hsi.SoftwareInstallerID, fleet.HostSoftwareInstallOptions{
 		SelfService:        hsi.SelfService,
@@ -1510,12 +1500,10 @@ func (svc *Service) retrySoftwareInstall(ctx context.Context, host *fleet.Host, 
 // shouldRetryPolicyAutomationScript checks if a failed policy automation script should be retried.
 // Returns true if retry should be queued
 func (svc *Service) shouldRetryPolicyAutomationScript(ctx context.Context, host *fleet.Host, hsr *fleet.HostScriptResult) (bool, error) {
-	if hsr.AttemptNumber == nil {
 		// should not happen
 		return false, ctxerr.New(ctx, "attempt_number is nil for policy automation script")
 	}
 
-	currentAttempt := *hsr.AttemptNumber
 
 	if currentAttempt >= fleet.MaxPolicyAutomationRetries {
 		return false, nil
@@ -1537,7 +1525,6 @@ func (svc *Service) retryPolicyAutomationScript(ctx context.Context, host *fleet
 		"host_id", host.ID,
 		"policy_id", *hsr.PolicyID,
 		"script_id", *hsr.ScriptID,
-		"current_attempt", *hsr.AttemptNumber,
 	)
 	_, err := svc.ds.NewHostScriptExecutionRequest(ctx, &fleet.HostScriptRequestPayload{
 		HostID:         host.ID,
@@ -1548,9 +1535,7 @@ func (svc *Service) retryPolicyAutomationScript(ctx context.Context, host *fleet
 	return err
 }
 
-// getPolicyAutomationScriptAttemptNumber calculates the attempt number for a policy automation script.
 // Returns nil for manual script runs (not triggered by policy automation).
-func (svc *Service) getPolicyAutomationScriptAttemptNumber(ctx context.Context, host *fleet.Host, executionID string) (*int, error) {
 	// First, check if this script execution already exists and has policy_id
 	// (to know if this is a policy automation)
 	existingResult, err := svc.ds.GetHostScriptExecutionResult(ctx, executionID)
@@ -1570,9 +1555,7 @@ func (svc *Service) getPolicyAutomationScriptAttemptNumber(ctx context.Context, 
 	return nil, nil // nil for manual runs
 }
 
-// getSoftwareInstallerAttemptNumber calculates the attempt number for a software install.
 // Returns nil for installs that don't have a software_installer_id.
-func (svc *Service) getSoftwareInstallerAttemptNumber(ctx context.Context, host *fleet.Host, installUUID string) (*int, error) {
 	currentInstall, err := svc.ds.GetSoftwareInstallResults(ctx, installUUID)
 	if err != nil && !fleet.IsNotFound(err) {
 		return nil, ctxerr.Wrap(ctx, err, "get current install info for attempt number calculation")
@@ -1595,7 +1578,6 @@ func (svc *Service) getSoftwareInstallerAttemptNumber(ctx context.Context, host 
 	// attempt_number is set at activation time for retry-eligible installs
 	// (those created with WithRetries=true). If nil, this install was not
 	// created with retry support.
-	return currentInstall.AttemptNumber, nil
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/server/service/orbit.go
+++ b/server/service/orbit.go
@@ -934,13 +934,6 @@ func (svc *Service) SaveHostScriptResult(ctx context.Context, result *fleet.Host
 					policyName = &policy.Name // fall back to blank policy name if we can't retrieve the policy
 				}
 
-				// Suppress activity for policy automation retires
-				if hsr.AttemptNumber != nil {
-					scriptFailed := hsr.ExitCode == nil || *hsr.ExitCode != 0
-					if scriptFailed && *hsr.AttemptNumber < fleet.MaxPolicyAutomationRetries {
-						shouldCreateActivity = false
-					}
-				}
 			}
 
 			if shouldCreateActivity {
@@ -956,6 +949,7 @@ func (svc *Service) SaveHostScriptResult(ctx context.Context, result *fleet.Host
 						Async:               !hsr.SyncRequest,
 						PolicyID:            hsr.PolicyID,
 						PolicyName:          policyName,
+						AttemptNumber:       hsr.AttemptNumber,
 						FromSetupExperience: fromSetupExperience,
 					},
 				); err != nil {
@@ -1386,12 +1380,6 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 					}
 				}
 
-				// Only create activity on final
-				if hsi.AttemptNumber != nil {
-					if *hsi.AttemptNumber < fleet.MaxPolicyAutomationRetries {
-						shouldCreateActivity = false
-					}
-				}
 			}
 		}
 
@@ -1437,6 +1425,7 @@ func (svc *Service) SaveHostSoftwareInstallResult(ctx context.Context, result *f
 					SelfService:         hsi.SelfService,
 					PolicyID:            hsi.PolicyID,
 					PolicyName:          policyName,
+					AttemptNumber:       hsi.AttemptNumber,
 					FromSetupExperience: fromSetupExperience,
 				},
 			); err != nil {


### PR DESCRIPTION
Closes #42930 — removes suppression logic so every retry attempt generates an activity, and adds attempt_number to activity JSON.