### PR TITLE
Add Product & Eng handbook weekly summary action

### DIFF
--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -1,7 +1,9 @@
 name: Product & Engineering Handbook Weekly Summary
 
 on:
-  workflow_dispatch: # Manual trigger only for now; add schedule later
+  schedule:
+    - cron: '0 13 * * 1' # Every Monday at 8am EST (1pm UTC)
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -68,7 +68,7 @@ jobs:
           HANDBOOK_PATHS="handbook/engineering/ handbook/product-design/"
           SINCE_DATE="${{ steps.diffs.outputs.since_date }}"
 
-          # Get unique merge commit SHAs for handbook changes
+          # Get unique commit SHAs for handbook changes
           COMMIT_SHAS=$(git log --since="$SINCE_DATE" --pretty=format:'%H' -- $HANDBOOK_PATHS | sort -u)
 
           echo "PR_CONTEXT:" > /tmp/pr_context.txt

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -191,6 +191,7 @@ jobs:
 
             ($summary | chunk_text($max_len)) as $chunks |
             {
+              "text": ("Product & Engineering handbook weekly summary (since " + $since + ")"),
               "blocks": [
                 {
                   "type": "header",
@@ -236,6 +237,7 @@ jobs:
           fi
 
           jq -n '{
+            "text": "Product & Engineering handbook weekly summary — no changes this week.",
             "blocks": [
               {
                 "type": "header",

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -169,9 +169,28 @@ jobs:
 
           SUMMARY=$(cat /tmp/summary.txt)
 
-          # Build Slack Block Kit payload with jq for safe JSON escaping
+          # Slack section.text.mrkdwn has a 3000 char limit. Split into
+          # multiple section blocks if the summary exceeds it.
+          MAX_BLOCK_LEN=2900 # leave margin for safety
+
+          # Build Slack Block Kit payload with jq for safe JSON escaping.
+          # jq splits the summary into <=MAX_BLOCK_LEN chunks on line boundaries
+          # and emits a section block for each chunk.
           jq -n --arg since "$SINCE_DATE" --arg summary "$SUMMARY" \
-            '{
+            --argjson max_len "$MAX_BLOCK_LEN" \
+            '
+            # Split summary into chunks that fit in a single section block
+            def chunk_text($max):
+              if length <= $max then [.]
+              else
+                # Find last newline before $max to split on a line boundary
+                (.[:$max] | ltrimstr("") | rindex("\n")) as $split_at |
+                (if $split_at == null or $split_at == 0 then $max else $split_at end) as $pos |
+                [.[:$pos]] + (.[($pos + 1):] | chunk_text($max))
+              end;
+
+            ($summary | chunk_text($max_len)) as $chunks |
+            {
               "blocks": [
                 {
                   "type": "header",
@@ -192,12 +211,13 @@ jobs:
                 },
                 {
                   "type": "divider"
-                },
-                {
+                }
+              ] + [
+                $chunks[] | {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": $summary
+                    "text": .
                   }
                 }
               ]

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -189,8 +189,7 @@ jobs:
               CURRENT="$LINE"
             else
               if [ -n "$CURRENT" ]; then
-                CURRENT="${CURRENT}
-${LINE}"
+                CURRENT="${CURRENT}"$'\n'"${LINE}"
               else
                 CURRENT="$LINE"
               fi

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -1,0 +1,176 @@
+name: Product & Engineering Handbook Weekly Summary
+
+on:
+  workflow_dispatch: # Manual trigger only for now; add schedule later
+
+permissions:
+  contents: read
+  models: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  summarize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          fetch-depth: 0
+
+      - name: Collect handbook diffs
+        id: diffs
+        run: |
+          SINCE_DATE=$(date -d '7 days ago' '+%Y-%m-%d' 2>/dev/null || date -v-7d '+%Y-%m-%d')
+          echo "since_date=$SINCE_DATE" >> "$GITHUB_OUTPUT"
+
+          HANDBOOK_PATHS="handbook/engineering/ handbook/product-design/"
+
+          # Get commit log for the period
+          COMMITS=$(git log --since="$SINCE_DATE" --pretty=format:'- %h %s (%an, %as)' -- $HANDBOOK_PATHS)
+
+          if [ -z "$COMMITS" ]; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No handbook changes in the last 7 days."
+            exit 0
+          fi
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          # Get the diff
+          FIRST_COMMIT=$(git log --since="$SINCE_DATE" --reverse --pretty=format:'%H' -- $HANDBOOK_PATHS | head -1)
+          DIFF=$(git diff "${FIRST_COMMIT}^..HEAD" -- $HANDBOOK_PATHS 2>/dev/null || git diff "${FIRST_COMMIT}..HEAD" -- $HANDBOOK_PATHS)
+
+          # Truncate diff to ~80K chars to stay within model context limits
+          DIFF=$(echo "$DIFF" | head -c 80000)
+
+          # Write to files for next steps
+          echo "$COMMITS" > /tmp/commits.txt
+          echo "$DIFF" > /tmp/diff.txt
+
+      - name: Summarize with AI
+        if: steps.diffs.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SINCE_DATE: ${{ steps.diffs.outputs.since_date }}
+        run: |
+          COMMITS=$(cat /tmp/commits.txt)
+          DIFF=$(cat /tmp/diff.txt)
+
+          # Build the prompt
+          PROMPT="You are summarizing changes to a company handbook for a Slack post.
+
+          Below are the commits and diffs made to the Product Design and Engineering sections of the Fleet handbook in the past week (since ${SINCE_DATE}).
+
+          COMMITS:
+          ${COMMITS}
+
+          DIFF:
+          ${DIFF}
+
+          Write a concise, well-organized summary suitable for posting in Slack. Format it using Slack mrkdwn syntax (use *bold* not **bold**, use • for bullets).
+          Group changes by section (Engineering vs Product Design) if both have changes.
+          Focus on WHAT changed and WHY it matters — skip trivial whitespace or formatting-only changes.
+          Keep it under 3000 characters. Do not include a greeting or sign-off."
+
+          # Call GitHub Models API (OpenAI-compatible endpoint, no extra secrets needed)
+          RESPONSE=$(jq -n --arg prompt "$PROMPT" \
+            '{
+              "model": "openai/gpt-4.1",
+              "max_tokens": 1024,
+              "messages": [{"role": "user", "content": $prompt}]
+            }' | curl -sf -L -X POST "https://models.github.ai/inference/chat/completions" \
+            -H "Content-Type: application/json" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            -d @-)
+
+          # Extract the text content (OpenAI-compatible response format)
+          SUMMARY=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+          if [ -z "$SUMMARY" ]; then
+            echo "::error::Failed to get summary from GitHub Models API"
+            echo "$RESPONSE" | jq . || echo "$RESPONSE"
+            exit 1
+          fi
+
+          echo "$SUMMARY" > /tmp/summary.txt
+
+      - name: Post summary to Slack
+        if: steps.diffs.outputs.has_changes == 'true'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL }}
+          SINCE_DATE: ${{ steps.diffs.outputs.since_date }}
+        run: |
+          SUMMARY=$(cat /tmp/summary.txt)
+
+          # Build Slack Block Kit payload with jq for safe JSON escaping
+          jq -n --arg since "$SINCE_DATE" --arg summary "$SUMMARY" \
+            '{
+              "blocks": [
+                {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "📋 Product & Engineering Handbook Weekly Summary",
+                    "emoji": true
+                  }
+                },
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ("Changes since " + $since)
+                    }
+                  ]
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": $summary
+                  }
+                }
+              ]
+            }' | curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @-
+
+      - name: Post no-changes notice to Slack
+        if: steps.diffs.outputs.has_changes == 'false'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL }}
+        run: |
+          jq -n '{
+            "blocks": [
+              {
+                "type": "header",
+                "text": {
+                  "type": "plain_text",
+                  "text": "📋 Product & Engineering Handbook Weekly Summary",
+                  "emoji": true
+                }
+              },
+              {
+                "type": "section",
+                "text": {
+                  "type": "mrkdwn",
+                  "text": "No changes to the Product Design or Engineering handbook sections this week. 🎉"
+                }
+              }
+            ]
+          }' | curl -sf -X POST "$SLACK_WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -d @-

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.diffs.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: fleetdm/fleet
+          GH_REPO: ${{ github.repository }}
         run: |
           HANDBOOK_PATHS="handbook/engineering/ handbook/product-design/"
           SINCE_DATE="${{ steps.diffs.outputs.since_date }}"

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -162,6 +162,11 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL }}
           SINCE_DATE: ${{ steps.diffs.outputs.since_date }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL secret is not set or is empty. Add it in repo Settings → Secrets → Actions."
+            exit 1
+          fi
+
           SUMMARY=$(cat /tmp/summary.txt)
 
           # Build Slack Block Kit payload with jq for safe JSON escaping
@@ -205,6 +210,11 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL }}
         run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "::error::TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL secret is not set or is empty. Add it in repo Settings → Secrets → Actions."
+            exit 1
+          fi
+
           jq -n '{
             "blocks": [
               {

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -6,6 +6,7 @@ on:
 permissions:
   contents: read
   models: read
+  pull-requests: read
 
 defaults:
   run:
@@ -55,6 +56,52 @@ jobs:
           echo "$COMMITS" > /tmp/commits.txt
           echo "$DIFF" > /tmp/diff.txt
 
+      - name: Collect PR context
+        if: steps.diffs.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          HANDBOOK_PATHS="handbook/engineering/ handbook/product-design/"
+          SINCE_DATE="${{ steps.diffs.outputs.since_date }}"
+
+          # Get unique merge commit SHAs for handbook changes
+          COMMIT_SHAS=$(git log --since="$SINCE_DATE" --pretty=format:'%H' -- $HANDBOOK_PATHS | sort -u)
+
+          echo "PR_CONTEXT:" > /tmp/pr_context.txt
+
+          # Track PRs we've already processed to avoid duplicates
+          declare -A SEEN_PRS
+
+          for SHA in $COMMIT_SHAS; do
+            # Find the PR that introduced this commit
+            PR_JSON=$(gh api "repos/${GH_REPO}/commits/${SHA}/pulls" \
+              --jq '.[0] | {number, title, html_url, body}' 2>/dev/null || echo "")
+
+            if [ -z "$PR_JSON" ] || [ "$PR_JSON" = "null" ]; then
+              continue
+            fi
+
+            PR_NUM=$(echo "$PR_JSON" | jq -r '.number')
+
+            # Skip if we already processed this PR
+            if [ -n "${SEEN_PRS[$PR_NUM]:-}" ]; then
+              continue
+            fi
+            SEEN_PRS[$PR_NUM]=1
+
+            PR_TITLE=$(echo "$PR_JSON" | jq -r '.title')
+            PR_URL=$(echo "$PR_JSON" | jq -r '.html_url')
+            # Truncate PR body to 500 chars to keep context manageable
+            PR_BODY=$(echo "$PR_JSON" | jq -r '.body // ""' | head -c 500)
+
+            echo "" >> /tmp/pr_context.txt
+            echo "---" >> /tmp/pr_context.txt
+            echo "PR #${PR_NUM}: ${PR_TITLE}" >> /tmp/pr_context.txt
+            echo "URL: ${PR_URL}" >> /tmp/pr_context.txt
+            echo "Description: ${PR_BODY}" >> /tmp/pr_context.txt
+          done
+
       - name: Summarize with AI
         if: steps.diffs.outputs.has_changes == 'true'
         env:
@@ -63,21 +110,26 @@ jobs:
         run: |
           COMMITS=$(cat /tmp/commits.txt)
           DIFF=$(cat /tmp/diff.txt)
+          PR_CONTEXT=$(cat /tmp/pr_context.txt)
 
           # Build the prompt
           PROMPT="You are summarizing changes to a company handbook for a Slack post.
 
-          Below are the commits and diffs made to the Product Design and Engineering sections of the Fleet handbook in the past week (since ${SINCE_DATE}).
+          Below are the commits, associated pull requests, and diffs made to the Product Design and Engineering sections of the Fleet handbook in the past week (since ${SINCE_DATE}).
 
           COMMITS:
           ${COMMITS}
+
+          PULL REQUESTS (with descriptions for additional context):
+          ${PR_CONTEXT}
 
           DIFF:
           ${DIFF}
 
           Write a concise, well-organized summary suitable for posting in Slack. Format it using Slack mrkdwn syntax (use *bold* not **bold**, use • for bullets).
           Group changes by section (Engineering vs Product Design) if both have changes.
-          Focus on WHAT changed and WHY it matters — skip trivial whitespace or formatting-only changes.
+          Focus on WHAT changed and WHY it matters — use the PR descriptions for context on the intent behind changes. Skip trivial whitespace or formatting-only changes.
+          For each significant change, include a link to the relevant PR using Slack link syntax: <URL|PR #123>.
           Keep it under 3000 characters. Do not include a greeting or sign-off."
 
           # Call GitHub Models API (OpenAI-compatible endpoint, no extra secrets needed)

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -3,6 +3,9 @@ name: Product & Engineering Handbook Weekly Summary
 on:
   workflow_dispatch: # Manual trigger only for now; add schedule later
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 permissions:
   contents: read
   models: read

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -45,9 +45,17 @@ jobs:
 
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-          # Get the diff
+          # Get the diff. Use FIRST_COMMIT^ as the base when possible;
+          # fall back to diffing against the empty tree if the commit has no
+          # parent (root commit) or is HEAD itself.
           FIRST_COMMIT=$(git log --since="$SINCE_DATE" --reverse --pretty=format:'%H' -- $HANDBOOK_PATHS | head -1)
-          DIFF=$(git diff "${FIRST_COMMIT}^..HEAD" -- $HANDBOOK_PATHS 2>/dev/null || git diff "${FIRST_COMMIT}..HEAD" -- $HANDBOOK_PATHS)
+          EMPTY_TREE=$(git hash-object -t tree /dev/null)
+          if git rev-parse "${FIRST_COMMIT}^" >/dev/null 2>&1; then
+            DIFF_BASE="${FIRST_COMMIT}^"
+          else
+            DIFF_BASE="$EMPTY_TREE"
+          fi
+          DIFF=$(git diff "${DIFF_BASE}..HEAD" -- $HANDBOOK_PATHS)
 
           # Truncate diff to ~80K chars to stay within model context limits
           DIFF=$(echo "$DIFF" | head -c 80000)

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -68,7 +68,7 @@ jobs:
         if: steps.diffs.outputs.has_changes == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+          GH_REPO: fleetdm/fleet
         run: |
           HANDBOOK_PATHS="handbook/engineering/ handbook/product-design/"
           SINCE_DATE="${{ steps.diffs.outputs.since_date }}"

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -177,59 +177,44 @@ jobs:
 
           SUMMARY=$(cat /tmp/summary.txt)
 
-          # Slack section.text.mrkdwn has a 3000 char limit. Split into
-          # multiple section blocks if the summary exceeds it.
-          MAX_BLOCK_LEN=2900 # leave margin for safety
-
-          # Build Slack Block Kit payload with jq for safe JSON escaping.
-          # jq splits the summary into <=MAX_BLOCK_LEN chunks on line boundaries
-          # and emits a section block for each chunk.
-          jq -n --arg since "$SINCE_DATE" --arg summary "$SUMMARY" \
-            --argjson max_len "$MAX_BLOCK_LEN" \
-            '
-            # Split summary into chunks that fit in a single section block
-            def chunk_text($max):
-              if length <= $max then [.]
+          # Slack section.text.mrkdwn has a 3000 char limit. Split the
+          # summary into chunks on line boundaries in bash, then build
+          # a section block per chunk via jq.
+          MAX_LEN=2900
+          CHUNKS=()
+          CURRENT=""
+          while IFS= read -r LINE || [ -n "$LINE" ]; do
+            if [ $(( ${#CURRENT} + ${#LINE} + 1 )) -gt "$MAX_LEN" ] && [ -n "$CURRENT" ]; then
+              CHUNKS+=("$CURRENT")
+              CURRENT="$LINE"
+            else
+              if [ -n "$CURRENT" ]; then
+                CURRENT="${CURRENT}
+${LINE}"
               else
-                # Find last newline before $max to split on a line boundary
-                (.[:$max] | ltrimstr("") | rindex("\n")) as $split_at |
-                (if $split_at == null or $split_at == 0 then $max else $split_at end) as $pos |
-                [.[:$pos]] + (.[($pos + 1):] | chunk_text($max))
-              end;
+                CURRENT="$LINE"
+              fi
+            fi
+          done <<< "$SUMMARY"
+          [ -n "$CURRENT" ] && CHUNKS+=("$CURRENT")
 
-            ($summary | chunk_text($max_len)) as $chunks |
-            {
-              "text": ("Product & Engineering handbook weekly summary (since " + $since + ")"),
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "📋 Product & Engineering Handbook Weekly Summary",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "context",
-                  "elements": [
-                    {
-                      "type": "mrkdwn",
-                      "text": ("Changes since " + $since)
-                    }
-                  ]
-                },
-                {
-                  "type": "divider"
-                }
-              ] + [
-                $chunks[] | {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": .
-                  }
-                }
-              ]
+          # Build a JSON array of chunks, preserving newlines within each chunk
+          CHUNKS_JSON=$(jq -n '$ARGS.positional' --args -- "${CHUNKS[@]}")
+
+          # Build Slack Block Kit payload
+          FALLBACK="Product & Engineering handbook weekly summary (since ${SINCE_DATE})"
+          jq -n --arg fallback "$FALLBACK" --arg since "$SINCE_DATE" --argjson chunks "$CHUNKS_JSON" \
+            '{
+              "text": $fallback,
+              "blocks": (
+                [
+                  {"type": "header", "text": {"type": "plain_text", "text": "📋 Product & Engineering Handbook Weekly Summary", "emoji": true}},
+                  {"type": "context", "elements": [{"type": "mrkdwn", "text": ("Changes since " + $since)}]},
+                  {"type": "divider"}
+                ] + [
+                  $chunks[] | {"type": "section", "text": {"type": "mrkdwn", "text": .}}
+                ]
+              )
             }' | curl -sf -X POST "$SLACK_WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -d @-

--- a/.github/workflows/product-eng-handbook-summary.yml
+++ b/.github/workflows/product-eng-handbook-summary.yml
@@ -3,9 +3,6 @@ name: Product & Engineering Handbook Weekly Summary
 on:
   workflow_dispatch: # Manual trigger only for now; add schedule later
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 permissions:
   contents: read
   models: read


### PR DESCRIPTION
## Summary
- Adds a GitHub Action that summarizes weekly diffs in `handbook/engineering/` and `handbook/product-design/` using GitHub Models (GPT-4.1)
- Looks up associated PRs for each handbook commit and includes PR descriptions as context for richer summaries
- AI-generated summary includes Slack-formatted links to relevant PRs
- Posts the summary to Slack via webhook (currently pointed to a [#test-eng-summary](https://fleetdm.slack.com/archives/C0ARBJ4VC78) to evaluate output quality)
- Manual trigger (`workflow_dispatch`) only for now; weekly cron schedule to be added after validation

## Quick links
- [Workflow file](https://github.com/fleetdm/fleet/blob/claude/romantic-almeida/.github/workflows/product-eng-handbook-summary.yml)

## Secrets required
- `TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL` — Slack incoming webhook for the target channel (rename to `SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL` when moving to production)
- No AI API key needed — uses GitHub Models via built-in `GITHUB_TOKEN`

## Test plan
- [x] Tested on [mostlikelee/fleet](https://github.com/mostlikelee/fleet) fork
- [x] Add `TEST_SLACK_PRODUCT_ENG_HANDBOOK_SUMMARY_WEBHOOK_URL` secret to repo
- [ ] Merge, then trigger manually from Actions tab
- [ ] Verify Slack post appears with PR links and AI summary
- [ ] Once validated, add weekly cron schedule and rename secret