### PR TITLE
resolve https://github.com/fleetdm/fleet/security/dependabot/559

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -486,6 +486,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -534,6 +535,7 @@
       "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7030,6 +7032,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.0.tgz",
       "integrity": "sha512-meLUVPn2TWgJyLmy7el3fQQVwft4gU5NGyvV0XbD41iU9Jbg8lCH4zexhIkihDzVHJStlt6r088G6/fWeNjhXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-writer": "2.0.0",
         "packet-reader": "1.0.0",


### PR DESCRIPTION
Update package-lock.json file to automatically pick up a newer patched version of `debug` in deeply nested  i18n-2 dependency

Resolves https://github.com/fleetdm/fleet/security/dependabot/559

No exposure, as i18n features unused in fleetdm.com