### PR TITLE
fix: fleet-desktop tray icon invisible on macOS 26 (Tahoe)

### DIFF
--- a/orbit/changes/macos-26-tray-icon
+++ b/orbit/changes/macos-26-tray-icon
@@ -1,0 +1,1 @@
+* Fixed Fleet Desktop tray icon not appearing on macOS 26 (Tahoe) by restarting ControlCenter before creating the status bar item and prompting the user to enable it in System Settings on first run.

--- a/orbit/cmd/desktop/desktop.go
+++ b/orbit/cmd/desktop/desktop.go
@@ -93,6 +93,9 @@ func main() {
 		runWithPermanentError(permanentError)
 	}
 
+	resetControlCenter()
+	promptMenuBarAccess()
+
 	identifierPath := os.Getenv("FLEET_DESKTOP_DEVICE_IDENTIFIER_PATH")
 	if identifierPath == "" {
 		log.Fatal().Msg("missing URL environment FLEET_DESKTOP_DEVICE_IDENTIFIER_PATH")

--- a/orbit/cmd/desktop/desktop_darwin.go
+++ b/orbit/cmd/desktop/desktop_darwin.go
@@ -2,6 +2,12 @@ package main
 
 import (
 	_ "embed"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -17,4 +23,75 @@ func blockWaitForStopEvent(_ string) error {
 func trayIconExists() bool {
 	log.Debug().Msg("tray icon checker is not implemented for this platform")
 	return true
+}
+
+// macOSMajorVersion returns the major version of macOS (e.g. 26 for macOS Tahoe).
+func macOSMajorVersion() int {
+	out, err := exec.Command("sw_vers", "-productVersion").Output()
+	if err != nil {
+		return 0
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(out)), ".", 2)
+	v, _ := strconv.Atoi(parts[0])
+	return v
+}
+
+// resetControlCenter restarts ControlCenter to clear stale NSStatusItem FBSScene state.
+//
+// On macOS 26 (Tahoe), ControlCenter adopted the FrontBoard/FBSScene architecture for status
+// bar items. When fleet-desktop is killed and restarted by orbit, the old FBSScene lingers in a
+// "reconnecting" state and the tray icon never reappears. Restarting ControlCenter forces a fresh
+// scene to be created on the next NSStatusItem allocation.
+//
+// This is a no-op on macOS versions before 26.
+func resetControlCenter() {
+	if macOSMajorVersion() < 26 {
+		return
+	}
+	log.Debug().Msg("macOS 26+: restarting ControlCenter to clear stale status bar scene")
+	if err := exec.Command("killall", "ControlCenter").Run(); err != nil {
+		log.Debug().Err(err).Msg("killall ControlCenter failed")
+		return
+	}
+	// Wait for ControlCenter to fully restart before systray.Run creates the NSStatusItem.
+	time.Sleep(2 * time.Second)
+	log.Debug().Msg("ControlCenter restarted")
+}
+
+// promptMenuBarAccess opens System Settings to the Control Center / Menu Bar section so the user
+// can enable the Fleet Desktop status item.
+//
+// On macOS 26 (Tahoe), new status bar items are blocked by default and require explicit user
+// approval via System Settings. A flag file is written after the first prompt to avoid repeating
+// it on every restart.
+//
+// This is a no-op on macOS versions before 26.
+func promptMenuBarAccess() {
+	if macOSMajorVersion() < 26 {
+		return
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to get user home directory for menu bar access prompt")
+		return
+	}
+	appSupportDir := filepath.Join(homeDir, "Library", "Application Support", "com.fleetdm.desktop")
+	flagFile := filepath.Join(appSupportDir, ".menubar-prompted")
+	if _, err := os.Stat(flagFile); err == nil {
+		return // already prompted
+	}
+	log.Info().Msg("macOS 26+: opening System Settings for menu bar access")
+	if err := exec.Command("open", "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension").Run(); err != nil {
+		log.Debug().Err(err).Msg("failed to open System Settings for menu bar access")
+	}
+	if err := os.MkdirAll(appSupportDir, 0o755); err != nil {
+		log.Debug().Err(err).Msg("failed to create application support directory")
+		return
+	}
+	f, err := os.Create(flagFile)
+	if err != nil {
+		log.Debug().Err(err).Msg("failed to write menu bar access prompt flag file")
+		return
+	}
+	f.Close()
 }

--- a/orbit/cmd/desktop/desktop_notdarwin.go
+++ b/orbit/cmd/desktop/desktop_notdarwin.go
@@ -1,0 +1,9 @@
+//go:build !darwin
+
+package main
+
+// resetControlCenter is a no-op on non-Darwin platforms.
+func resetControlCenter() {}
+
+// promptMenuBarAccess is a no-op on non-Darwin platforms.
+func promptMenuBarAccess() {}


### PR DESCRIPTION
## Problem

On macOS 26 (Tahoe), the Fleet Desktop tray icon never appears after orbit starts (or restarts) fleet-desktop. This blocks MDM enrollment because the icon is the entry point for users to initiate enrollment.

Two independent issues combine to cause this:

**Issue 1 — Stale FBSScene after restart**

macOS 26 adopted the FrontBoard/FBSScene architecture for status bar items. When fleet-desktop is killed and restarted by orbit, the old `NSStatusItem` FBSScene lingers in a `"reconnecting"` state. The new process creates a fresh `NSStatusItem`, but ControlCenter never surfaces it because it's still trying to reconnect to the dead scene. The icon is invisible until ControlCenter itself restarts.

Fix: call `killall ControlCenter` before `systray.Run()` creates the `NSStatusItem`. This forces ControlCenter to restart with a clean slate so the new scene gets properly initialized (`fromRemnant = 0` in ControlCenter system logs).

**Issue 2 — New status bar items blocked by default**

macOS 26 requires explicit user approval for new status bar items. On first launch, ControlCenter logs `"Starting to track blocked host com.fleetdm.desktop"` and the icon never appears in the menu bar until the user enables it in **System Settings → Control Center → Menu Bar**.

Fix: on first run on macOS 26+, automatically open System Settings to the correct page so the user can enable the toggle. A flag file (`~/Library/Application Support/com.fleetdm.desktop/.menubar-prompted`) prevents showing this on every restart.

Once the user enables the toggle, the preference is stored by bundle ID (`com.fleetdm.desktop`) and persists across fleet-desktop updates.

## Changes

- `orbit/cmd/desktop/desktop_darwin.go` — adds `macOSMajorVersion()`, `resetControlCenter()`, and `promptMenuBarAccess()`; both action functions are no-ops on macOS < 26
- `orbit/cmd/desktop/desktop_notdarwin.go` — no-op stubs so the binary compiles on Linux and Windows
- `orbit/cmd/desktop/desktop.go` — calls `resetControlCenter()` and `promptMenuBarAccess()` at startup

## Testing

Tested on macOS 26.0 (Tahoe beta, Apple Silicon):
- Without fix: icon never appears; ControlCenter logs `"Starting to track blocked host"`
- With fix: ControlCenter restarts cleanly, icon appears, System Settings opens on first run, toggle is visible and functional
- After enabling toggle: icon remains visible across fleet-desktop restarts and orbit-triggered updates
- On macOS 14/15: both functions return immediately (version check), no behavior change

## Checklist

- [x] Changes file added (`orbit/changes/macos-26-tray-icon`)
- [x] macOS-specific code in `desktop_darwin.go` with no-op stubs for other platforms (`desktop_notdarwin.go`)
- [x] Both functions are no-ops on macOS < 26
- [ ] Manual QA on Windows and Linux (no behavior change expected — no-op stubs)