### PR TITLE
Fleet UI: Update <code> purple to be grey

### DIFF
--- a/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
+++ b/frontend/components/AddHostsModal/PlatformWrapper/PlatformWrapper.tsx
@@ -275,7 +275,7 @@ const PlatformWrapper = ({
           hosts. For CentOS, Red Hat, and Fedora Linux, use{" "}
           <code>--type=rpm</code>. For Arch Linux, use{" "}
           <code>--type=pkg.tar.zst</code>. For ARM, use{" "}
-          <code>--arch=arm64</code>
+          <code>--arch=arm64</code>.
         </>
       );
     } else if (packageType === "msi") {

--- a/frontend/components/SQLEditor/_styles.scss
+++ b/frontend/components/SQLEditor/_styles.scss
@@ -94,7 +94,7 @@
     @include help-text;
 
     code {
-      color: $core-vibrant-blue;
+      color: $ui-fleet-black-75;
       background-color: $ui-light-grey;
       padding: $pad-xxsmall;
       font-family: "SourceCodePro", $monospace;

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -75,6 +75,7 @@
     margin-bottom: $pad-medium;
   }
 
+  // Same styling as .form-field__help-text TODO: consider consolidating
   &__help-text {
     font-size: $x-small;
     font-weight: $regular;
@@ -83,8 +84,8 @@
     color: $core-fleet-blue;
 
     code {
-      color: $core-vibrant-blue;
-      background-color: $ui-gray;
+      color: $ui-fleet-black-50;
+      background-color: $core-fleet-white;
       padding: $pad-xxsmall;
       font-family: "SourceCodePro", $monospace;
     }

--- a/frontend/components/forms/fields/InputField/_styles.scss
+++ b/frontend/components/forms/fields/InputField/_styles.scss
@@ -84,8 +84,8 @@
     color: $core-fleet-blue;
 
     code {
-      color: $ui-fleet-black-50;
-      background-color: $core-fleet-white;
+      color: $ui-fleet-black-75;
+      background-color: $ui-light-grey;
       padding: $pad-xxsmall;
       font-family: "SourceCodePro", $monospace;
     }

--- a/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
+++ b/frontend/pages/hosts/ManageHostsPage/components/CustomLabelGroupHeading/_styles.scss
@@ -96,20 +96,5 @@
     &__wrapper {
       margin-bottom: $pad-medium;
     }
-
-    &__help-text {
-      font-size: $x-small;
-      font-weight: $regular;
-      line-height: 1.57;
-      letter-spacing: 1px;
-      color: $core-fleet-blue;
-
-      code {
-        color: $ui-fleet-black-75;
-        background-color: $ui-gray;
-        padding: $pad-xxsmall;
-        font-family: "SourceCodePro", $monospace;
-      }
-    }
   }
 }

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -171,8 +171,8 @@ form,
       }
     }
     code {
-      color: $ui-fleet-black-50;
-      background-color: $core-fleet-white;
+      color: $ui-fleet-black-75;
+      background-color: $ui-light-grey;
       padding: $pad-xxsmall;
       font-family: "SourceCodePro", $monospace;
     }

--- a/frontend/styles/global/_global.scss
+++ b/frontend/styles/global/_global.scss
@@ -171,7 +171,7 @@ form,
       }
     }
     code {
-      color: $core-vibrant-blue;
+      color: $ui-fleet-black-50;
       background-color: $core-fleet-white;
       padding: $pad-xxsmall;
       font-family: "SourceCodePro", $monospace;


### PR DESCRIPTION
## Issue
Closes #41032 

## Description
- Update purple `<code>` blocks in help text to be grey `ui-fleet-black-50` per @marko-lisica 
- Ensure code blocks are styled the same

## Screenshot of fix

<img width="1107" height="633" alt="Screenshot 2026-04-08 at 3 50 05 PM" src="https://github.com/user-attachments/assets/b1c75621-3cd7-4808-8fe3-d3ed31bb7671" />


## Testing

- [x] QA'd all new/changed functionality manually
