### PR TITLE
Revise deployment steps for Santa at Fleet

### DIFF
--- a/articles/how-we-deployed-santa-at-fleet.md
+++ b/articles/how-we-deployed-santa-at-fleet.md
@@ -79,15 +79,7 @@ Here's a snippet from our [Santa rules configuration profile](https://github.com
 </array>
 ```
 
-**Step 3. Deploy Santa Extensions**
-
-Policy to check if extensions exist: https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/macos/policies/install-santa-extension.yml 
-
-Script to install the extensions: https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/macos/scripts/install-santa-extension.sh
-
-We chose to deploy these via policy automation since the Santa extensions don't exist natively in Fleet. We have a policy that checks for the existence of the Santa extension. If it is not found, Fleet will immediately run a remediation script that handles the download and configuration of fleetd to start using the extension.
-
-**Step 4. Collect Santa Events**
+**Step 3. Collect Santa Events**
 
 Collect Santa denied logs: https://github.com/fleetdm/fleet/blob/main/it-and-security/lib/macos/queries/collect-santa-denied-logs.yml
 


### PR DESCRIPTION
Removed the section on deploying the Santa osquery extension manually, as we now include that in Fleet by default.

Slack thread for context: https://fleetdm.slack.com/archives/C08PCMKAFTP/p1775065630945889
