### PR TITLE
Query results table: fix `id` column header and cell styles

### DIFF
--- a/changes/42402-fix-query-results-deduplication
+++ b/changes/42402-fix-query-results-deduplication
@@ -1,0 +1,1 @@
+* Fixed query results table deduplicating rows when query data contains an `id` column, and fixed `id` column header and cell styling.

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -120,9 +120,7 @@ $shadow-transition-width: 10px;
           border-top-right-radius: 6px;
         }
 
-        &.actions__header,
-        &.id__header // Same as actions__header on some pages
-        {
+        &.actions__header {
           border-left: none;
           width: 99px;
         }
@@ -277,9 +275,7 @@ $shadow-transition-width: 10px;
         max-width: 500px;
         word-wrap: break-word;
 
-        &.actions__cell,
-        &.id__cell // Same as actions__cell on some pages
-        {
+        &.actions__cell {
           display: flex;
           justify-content: end; // Aligns actions dropdown to right of table
           max-width: 99px;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42402

- Added missing left border to `id` table header.
- Changed `display: flex` to `display: table-cell` for `id` table cells.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. (Original PR didn't have one: https://github.com/fleetdm/fleet/pull/42937.)

## Testing

- [x] QA'd all new/changed functionality manually

#### Before

<img width="1769" height="572" alt="Screenshot 2026-04-08 at 1 17 34 PM" src="https://github.com/user-attachments/assets/c4131e55-5213-431a-ae81-ffdd8b99fb03" />


#### After

<img width="1760" height="572" alt="Screenshot 2026-04-08 at 1 17 21 PM" src="https://github.com/user-attachments/assets/5e482160-9b5a-4115-bf14-e64e4514e192" />
