### PR TITLE
Update Cursor and Docker metadata

### DIFF
--- a/ee/maintained-apps/inputs/winget/cursor.json
+++ b/ee/maintained-apps/inputs/winget/cursor.json
@@ -8,5 +8,5 @@
   "installer_arch": "x64",
   "installer_type": "exe",
   "installer_scope": "machine",
-  "default_categories": ["Developer Tools"]
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/inputs/winget/docker.json
+++ b/ee/maintained-apps/inputs/winget/docker.json
@@ -8,5 +8,5 @@
   "installer_arch": "x64",
   "installer_type": "exe",
   "installer_scope": "machine",
-  "default_categories": ["Developer Tools"]
+  "default_categories": ["Developer tools"]
 }

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,16 +1,17 @@
 {
   "versions": [
     {
-      "version": "2.3.21",
+      "version": "3.0.12",
       "queries": {
-        "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';"
+        "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.0.12') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/68e0a0385b87408d050869ea543e3778ad53f78a/win32/x64/system-setup/CursorSetup-x64-2.3.21.exe",
+      "installer_url": "https://downloads.cursor.com/production/a80ff7dfcaa45d7750f6e30be457261379c29b06/win32/x64/system-setup/CursorSetup-x64-3.0.12.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "ce96fe184f4376600d971b67bb8724a92ff6a3729eff8361a35e5cbc1357e730",
+      "sha256": "1ba2e7f58c959d60fba8200f3dc0eee735d70596511baece4d88e97959a1af58",
       "default_categories": [
-        "Developer Tools"
+        "Developer tools"
       ]
     }
   ],

--- a/ee/maintained-apps/outputs/docker/windows.json
+++ b/ee/maintained-apps/outputs/docker/windows.json
@@ -1,16 +1,17 @@
 {
   "versions": [
     {
-      "version": "4.55.0",
+      "version": "4.67.0",
       "queries": {
-        "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';"
+        "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';",
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.67.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/win/main/amd64/213807/Docker%20Desktop%20Installer.exe",
+      "installer_url": "https://desktop.docker.com/win/main/amd64/222858/Docker%20Desktop%20Installer.exe",
       "install_script_ref": "f938db79",
       "uninstall_script_ref": "000be0a3",
-      "sha256": "7f424725af2297e346ea5ac8c9ff51f7a14055c4de7f3ad4877b1c2d9fa67e1b",
+      "sha256": "9e334622293ddf15eb7ecb935b829370899a93c92a53385a2e4c7749e5d57c77",
       "default_categories": [
-        "Developer Tools"
+        "Developer tools"
       ]
     }
   ],


### PR DESCRIPTION
Bump Cursor to 3.0.12 and Docker to 4.67.0: update installer URLs and SHA256 hashes, add 'patched' SQL queries for version checks in Windows outputs, and normalize default_categories from "Developer Tools" to "Developer tools" in winget inputs and outputs.