### PR TITLE
Add `-s -w` when building fleetd components to remove debugging information and reduce binary sizes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -819,7 +819,7 @@ desktop-linux-arm64:
 	docker build -f Dockerfile-desktop-linux -t desktop-linux-builder .
 	docker run --rm -v $(shell pwd):/output desktop-linux-builder /bin/bash -c "\
 		mkdir -p /output/fleet-desktop && \
-		GOARCH=arm64 go build -o /output/fleet-desktop/fleet-desktop -ldflags "-s -w -X=main.version=$(FLEET_DESKTOP_VERSION)" /usr/src/fleet/orbit/cmd/desktop && \
+		GOARCH=arm64 go build -o /output/fleet-desktop/fleet-desktop -ldflags \"-s -w -X=main.version=$(FLEET_DESKTOP_VERSION)\" /usr/src/fleet/orbit/cmd/desktop && \
 		cd /output && \
 		tar czf desktop.tar.gz fleet-desktop && \
 		rm -r fleet-desktop"

--- a/Makefile
+++ b/Makefile
@@ -804,7 +804,7 @@ desktop-linux:
 	docker build -f Dockerfile-desktop-linux -t desktop-linux-builder .
 	docker run --rm -v $(shell pwd):/output desktop-linux-builder /bin/bash -c "\
 		mkdir -p /output/fleet-desktop && \
-		CGO_ENABLED=1 CC=musl-gcc go build -o /output/fleet-desktop/fleet-desktop -ldflags \"-linkmode external -extldflags \\\"-static\\\" -X=main.version=$(FLEET_DESKTOP_VERSION)\" /usr/src/fleet/orbit/cmd/desktop && \
+		CGO_ENABLED=1 CC=musl-gcc go build -o /output/fleet-desktop/fleet-desktop -ldflags \"-s -w -linkmode external -extldflags \\\"-static\\\" -X=main.version=$(FLEET_DESKTOP_VERSION)\" /usr/src/fleet/orbit/cmd/desktop && \
 		cd /output && \
 		tar czf desktop.tar.gz fleet-desktop && \
 		rm -r fleet-desktop"
@@ -819,7 +819,7 @@ desktop-linux-arm64:
 	docker build -f Dockerfile-desktop-linux -t desktop-linux-builder .
 	docker run --rm -v $(shell pwd):/output desktop-linux-builder /bin/bash -c "\
 		mkdir -p /output/fleet-desktop && \
-		GOARCH=arm64 go build -o /output/fleet-desktop/fleet-desktop -ldflags "-X=main.version=$(FLEET_DESKTOP_VERSION)" /usr/src/fleet/orbit/cmd/desktop && \
+		GOARCH=arm64 go build -o /output/fleet-desktop/fleet-desktop -ldflags "-s -w -X=main.version=$(FLEET_DESKTOP_VERSION)" /usr/src/fleet/orbit/cmd/desktop && \
 		cd /output && \
 		tar czf desktop.tar.gz fleet-desktop && \
 		rm -r fleet-desktop"

--- a/orbit/README.md
+++ b/orbit/README.md
@@ -37,7 +37,7 @@ GOOS=windows \
 GOARCH=amd64 \
 go build \
 -trimpath \
--ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$VERSION \
+-ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$VERSION \
 -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$COMMIT \
 -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=$DATE" \
 -o ./orbit.exe ./orbit/cmd/orbit
@@ -50,7 +50,7 @@ GOOS=linux \
 GOARCH=amd64 \
 go build \
 -trimpath \
--ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$VERSION \
+-ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$VERSION \
 -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$COMMIT \
 -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=$DATE" \
 -o ./orbit-linux ./orbit/cmd/orbit

--- a/orbit/changes/43259-fleetd-remove-debugging-symbols
+++ b/orbit/changes/43259-fleetd-remove-debugging-symbols
@@ -1,0 +1,1 @@
+* Removed debugging symbols from orbit and Fleet Desktop executables.

--- a/orbit/goreleaser-linux-arm64.yml
+++ b/orbit/goreleaser-linux-arm64.yml
@@ -19,6 +19,8 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date={{.Date}}

--- a/orbit/goreleaser-linux.yml
+++ b/orbit/goreleaser-linux.yml
@@ -23,6 +23,8 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -s
+      - -w
       - -linkmode external -extldflags "-static"
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}

--- a/orbit/goreleaser-macos.yml
+++ b/orbit/goreleaser-macos.yml
@@ -20,6 +20,8 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date={{.Date}}

--- a/orbit/goreleaser-windows-arm64.yml
+++ b/orbit/goreleaser-windows-arm64.yml
@@ -19,6 +19,8 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date={{.Date}}

--- a/orbit/goreleaser-windows.yml
+++ b/orbit/goreleaser-windows.yml
@@ -19,6 +19,8 @@ builds:
     flags:
       - -trimpath
     ldflags:
+      - -s
+      - -w
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version={{.Version}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit={{.Commit}}
       - -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date={{.Date}}

--- a/orbit/tools/build/build-windows.go
+++ b/orbit/tools/build/build-windows.go
@@ -225,10 +225,10 @@ func buildTargetBinary(cmdDir string, version string, binaryPath string, arch st
 	// check if cmdDir contains desktop
 	// if it does, add -ldflags "-H=windowsgui" to exec.Command
 	if strings.Contains(cmdDir, "desktop") {
-		linkFlags := fmt.Sprintf("-H=windowsgui -X=main.version=%s", version)
+		linkFlags := fmt.Sprintf("-s -w -H=windowsgui -X=main.version=%s", version)
 		buildExec = exec.Command("go", "build", "-ldflags", linkFlags, "-o", outputBinary)
 	} else {
-		linkFlags := fmt.Sprintf("-X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=%s", version)
+		linkFlags := fmt.Sprintf("-s -w -X=github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=%s", version)
 		buildExec = exec.Command("go", "build", "-ldflags", linkFlags, "-o", outputBinary)
 	}
 	buildExec.Env = append(os.Environ(), "GOOS=windows", fmt.Sprintf("GOARCH=%s", arch))

--- a/orbit/tools/build/build.go
+++ b/orbit/tools/build/build.go
@@ -106,7 +106,7 @@ func buildOrbit(binaryPath, arch, version, commit, date string) error {
 	/* #nosec G204 -- arguments are actually well defined */
 	buildExec := exec.Command("go", "build",
 		"-o", binaryPath,
-		"-ldflags", fmt.Sprintf("-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=%s -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=%s -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=%s", version, commit, date),
+		"-ldflags", fmt.Sprintf("-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=%s -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=%s -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Date=%s", version, commit, date),
 		"./"+filepath.Join("orbit", "cmd", "orbit"),
 	)
 	buildExec.Env = append(os.Environ(), "GOOS=darwin", "GOARCH="+arch)

--- a/tools/desktop/desktop.go
+++ b/tools/desktop/desktop.go
@@ -156,7 +156,7 @@ func createMacOSApp(version, authority string, notarize bool) error {
 	/* #nosec G204 -- arguments are actually well defined */
 	buildExec := exec.Command("go", "build",
 		"-o", amdBinaryPath,
-		"-ldflags", os.ExpandEnv("-X=main.version=$FLEET_DESKTOP_VERSION"),
+		"-ldflags", os.ExpandEnv("-s -w -X=main.version=$FLEET_DESKTOP_VERSION"),
 		"./"+filepath.Join("orbit", "cmd", "desktop"),
 	)
 	buildExec.Env = append(os.Environ(), "CGO_ENABLED=1", "GOOS=darwin", "GOARCH=amd64")
@@ -172,7 +172,7 @@ func createMacOSApp(version, authority string, notarize bool) error {
 	/* #nosec G204 -- arguments are actually well defined */
 	buildExec = exec.Command("go", "build",
 		"-o", armBinaryPath,
-		"-ldflags", os.ExpandEnv("-X=main.version=$FLEET_DESKTOP_VERSION"),
+		"-ldflags", os.ExpandEnv("-s -w -X=main.version=$FLEET_DESKTOP_VERSION"),
 		"./"+filepath.Join("orbit", "cmd", "desktop"),
 	)
 	buildExec.Env = append(os.Environ(), "CGO_ENABLED=1", "GOOS=darwin", "GOARCH=arm64")

--- a/tools/test_extensions/hello_world/build.sh
+++ b/tools/test_extensions/hello_world/build.sh
@@ -8,26 +8,26 @@ mkdir -p $SCRIPT_DIR/macos $SCRIPT_DIR/windows $SCRIPT_DIR/linux $SCRIPT_DIR/lin
 
 # 1. build hello_world table extensions
 
-GOOS=darwin GOARCH=amd64 go build -o $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR
-GOOS=darwin GOARCH=arm64 go build -o $SCRIPT_DIR/macos/hello_world_macos_arm64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=amd64 go build -ldflags '-s -w' -o $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=arm64 go build -ldflags '-s -w' -o $SCRIPT_DIR/macos/hello_world_macos_arm64.ext $SCRIPT_DIR
 lipo -create $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR/macos/hello_world_macos_arm64.ext -output $SCRIPT_DIR/macos/hello_world_macos.ext
 rm $SCRIPT_DIR/macos/hello_world_macos_amd64.ext $SCRIPT_DIR/macos/hello_world_macos_arm64.ext
 
-GOOS=windows GOARCH=amd64 go build -o $SCRIPT_DIR/windows/hello_world_windows.ext.exe $SCRIPT_DIR
-GOOS=windows GOARCH=arm64 go build -o $SCRIPT_DIR/windows-arm64/hello_world_windows_arm64.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=amd64 go build -ldflags '-s -w' -o $SCRIPT_DIR/windows/hello_world_windows.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=arm64 go build -ldflags '-s -w' -o $SCRIPT_DIR/windows-arm64/hello_world_windows_arm64.ext.exe $SCRIPT_DIR
 
-GOOS=linux GOARCH=amd64 go build -o $SCRIPT_DIR/linux/hello_world_linux.ext $SCRIPT_DIR
-GOOS=linux GOARCH=arm64 go build -o $SCRIPT_DIR/linux-arm64/hello_world_linux_arm64.ext $SCRIPT_DIR
+GOOS=linux GOARCH=amd64 go build -ldflags '-s -w' -o $SCRIPT_DIR/linux/hello_world_linux.ext $SCRIPT_DIR
+GOOS=linux GOARCH=arm64 go build -ldflags '-s -w' -o $SCRIPT_DIR/linux-arm64/hello_world_linux_arm64.ext $SCRIPT_DIR
 
 # 2. build hello_mars table extensions
 
-GOOS=darwin GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR
-GOOS=darwin GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=amd64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR
+GOOS=darwin GOARCH=arm64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext $SCRIPT_DIR
 lipo -create $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext -output $SCRIPT_DIR/macos/hello_mars_macos.ext
 rm $SCRIPT_DIR/macos/hello_mars_macos_amd64.ext $SCRIPT_DIR/macos/hello_mars_macos_arm64.ext
 
-GOOS=windows GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows/hello_mars_windows.ext.exe $SCRIPT_DIR
-GOOS=windows GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows-arm64/hello_mars_windows_arm64.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=amd64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows/hello_mars_windows.ext.exe $SCRIPT_DIR
+GOOS=windows GOARCH=arm64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/windows-arm64/hello_mars_windows_arm64.ext.exe $SCRIPT_DIR
 
-GOOS=linux GOARCH=amd64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux/hello_mars_linux.ext $SCRIPT_DIR
-GOOS=linux GOARCH=arm64 go build -ldflags '-X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux-arm64/hello_mars_linux_arm64.ext $SCRIPT_DIR
+GOOS=linux GOARCH=amd64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux/hello_mars_linux.ext $SCRIPT_DIR
+GOOS=linux GOARCH=arm64 go build -ldflags '-s -w -X "main.extensionName=test_extensions.hello_mars" -X "main.tableName=hello_mars" -X "main.columnValue=mars"' -o $SCRIPT_DIR/linux-arm64/hello_mars_linux_arm64.ext $SCRIPT_DIR

--- a/tools/tuf/test/Fleetd-auto-update-test-guide.md
+++ b/tools/tuf/test/Fleetd-auto-update-test-guide.md
@@ -20,9 +20,9 @@ source ./tools/tuf/test/load_orbit_version_vars.sh
 
 Build:
 ```sh
-GOOS=darwin GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-darwin ./orbit/cmd/orbit
-GOOS=linux GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-linux ./orbit/cmd/orbit
-GOOS=windows GOARCH=amd64 go build -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit.exe ./orbit/cmd/orbit
+GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-darwin ./orbit/cmd/orbit
+GOOS=linux GOARCH=amd64 go build -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit-linux ./orbit/cmd/orbit
+GOOS=windows GOARCH=amd64 go build -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION" -o orbit.exe ./orbit/cmd/orbit
 ```
 Push:
 ```sh

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -111,7 +111,7 @@ source ./tools/tuf/test/load_orbit_version_vars.sh
 # Compile a new version of Orbit:
 GOOS=windows GOARCH=amd64 go build \
     -o orbit-windows.exe \
-    -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
+    -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
     -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$ORBIT_COMMIT" \
     ./orbit/cmd/orbit
 

--- a/tools/tuf/test/create_repository.sh
+++ b/tools/tuf/test/create_repository.sh
@@ -145,7 +145,7 @@ for system in $SYSTEMS; do
       GOARCH=$goarch_value \
       go build \
       -race=$race_value \
-      -ldflags="-X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
+      -ldflags="-s -w -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Version=$ORBIT_VERSION \
         -X github.com/fleetdm/fleet/v4/orbit/pkg/build.Commit=$ORBIT_COMMIT" \
       -o $orbit_target ./orbit/cmd/orbit
     fi


### PR DESCRIPTION
Resolves #43259.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually

## fleetd/orbit/Fleet Desktop

- [x] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [x] Verified that fleetd runs on macOS, Linux and Windows
- [x] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
