### PR TITLE
Increase workflow timeout to 30 minutes

### DIFF
--- a/.github/workflows/dogfood-gitops.yml
+++ b/.github/workflows/dogfood-gitops.yml
@@ -30,7 +30,7 @@ permissions:
 
 jobs:
   fleet-gitops:
-    timeout-minutes: 10
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner


### PR DESCRIPTION
Update .github/workflows/dogfood-gitops.yml to raise the fleet-gitops job timeout from 10 to 30 minutes. This prevents premature cancellation for longer-running steps (e.g., runner hardening and related tasks).

Our workflow is starting to timeout now that we have more apps being applied via GitOps.