### PR TITLE
Add RHEL support to osv-processor

### DIFF
--- a/cmd/osv-processor/main.go
+++ b/cmd/osv-processor/main.go
@@ -91,13 +91,22 @@ type RHELArtifactData struct {
 
 func main() {
 	platform := flag.String("platform", "ubuntu", "Platform to process: ubuntu or rhel")
-	inputDir := flag.String("input", "/tmp/ubuntu-osv", "Input directory with OSV JSON files")
+	inputDir := flag.String("input", "", "Input directory with OSV JSON files (default: /tmp/ubuntu-osv for ubuntu, /tmp/rhel-osv for rhel)")
 	outputDir := flag.String("output", "./artifacts", "Output directory for artifacts")
 	versions := flag.String("versions", "", "Comma-separated versions to process (inclusive)")
 	excludeVersions := flag.String("exclude-versions", "", "Comma-separated versions to exclude (ignored if --versions is set)")
-	changedFilesToday := flag.String("changed-files-today", "", "Path to file containing CVE files changed today (generates today's deltas)")
-	changedFilesYesterday := flag.String("changed-files-yesterday", "", "Path to file containing CVE files changed yesterday (generates yesterday's deltas)")
+	changedFilesToday := flag.String("changed-files-today", "", "Path to file containing CVE files changed today (ubuntu only)")
+	changedFilesYesterday := flag.String("changed-files-yesterday", "", "Path to file containing CVE files changed yesterday (ubuntu only)")
 	flag.Parse()
+
+	if *inputDir == "" {
+		switch *platform {
+		case "rhel":
+			*inputDir = "/tmp/rhel-osv"
+		default:
+			*inputDir = "/tmp/ubuntu-osv"
+		}
+	}
 
 	runTime := time.Now().UTC()
 
@@ -583,6 +592,12 @@ type vulnKey struct {
 }
 
 func runRHEL(cfg Config) error {
+	// Delta generation is not supported for RHEL — the data source is a full GCS zip
+	// download with no git-based change tracking. Fail fast if callers pass delta flags.
+	if cfg.ChangedFilesToday != "" || cfg.ChangedFilesYesterday != "" {
+		return fmt.Errorf("--changed-files-today and --changed-files-yesterday are not supported with --platform rhel (no git-based change tracking for GCS data)")
+	}
+
 	if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}

--- a/cmd/osv-processor/main.go
+++ b/cmd/osv-processor/main.go
@@ -58,6 +58,7 @@ type ProcessedVuln struct {
 }
 
 type Config struct {
+	Platform              string
 	InputDir              string
 	OutputDir             string
 	Versions              string
@@ -79,11 +80,21 @@ type ArtifactData struct {
 	Vulnerabilities map[string][]ProcessedVuln `json:"vulnerabilities"`
 }
 
+type RHELArtifactData struct {
+	SchemaVersion   string                     `json:"schema_version"`
+	RHELVersion     string                     `json:"rhel_version"`
+	Generated       string                     `json:"generated"`
+	TotalCVEs       int                        `json:"total_cves"`
+	TotalPackages   int                        `json:"total_packages"`
+	Vulnerabilities map[string][]ProcessedVuln `json:"vulnerabilities"`
+}
+
 func main() {
+	platform := flag.String("platform", "ubuntu", "Platform to process: ubuntu or rhel")
 	inputDir := flag.String("input", "/tmp/ubuntu-osv", "Input directory with OSV JSON files")
 	outputDir := flag.String("output", "./artifacts", "Output directory for artifacts")
-	versions := flag.String("versions", "", "Comma-separated Ubuntu versions to process (inclusive)")
-	excludeVersions := flag.String("exclude-versions", "", "Comma-separated Ubuntu versions to exclude (ignored if --versions is set)")
+	versions := flag.String("versions", "", "Comma-separated versions to process (inclusive)")
+	excludeVersions := flag.String("exclude-versions", "", "Comma-separated versions to exclude (ignored if --versions is set)")
 	changedFilesToday := flag.String("changed-files-today", "", "Path to file containing CVE files changed today (generates today's deltas)")
 	changedFilesYesterday := flag.String("changed-files-yesterday", "", "Path to file containing CVE files changed yesterday (generates yesterday's deltas)")
 	flag.Parse()
@@ -91,6 +102,7 @@ func main() {
 	runTime := time.Now().UTC()
 
 	cfg := Config{
+		Platform:              *platform,
 		InputDir:              *inputDir,
 		OutputDir:             *outputDir,
 		Versions:              *versions,
@@ -103,8 +115,17 @@ func main() {
 		RunTime:               runTime,
 	}
 
-	if err := run(cfg); err != nil {
-		log.Fatalf("Error: %v", err)
+	switch cfg.Platform {
+	case "ubuntu":
+		if err := run(cfg); err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+	case "rhel":
+		if err := runRHEL(cfg); err != nil {
+			log.Fatalf("Error: %v", err)
+		}
+	default:
+		log.Fatalf("Unknown platform: %s (supported: ubuntu, rhel)", cfg.Platform)
 	}
 }
 
@@ -516,4 +537,243 @@ func loadChangedFiles(changedFilesPath string) (map[string]struct{}, error) {
 	}
 
 	return changedFiles, nil
+}
+
+// extractRHELVersion extracts the major RHEL version from an ecosystem string.
+// Only "enterprise_linux" ecosystems are supported; variants like rhel_e4s, rhel_eus,
+// and rhel_software_collections are skipped.
+//
+// Repository suffixes (appstream, baseos, crb, nfv, realtime) and variant suffixes
+// (server, workstation, client, computenode, fastdatapath, hypervisor) are stripped —
+// all collapse to the same major version. For example, both
+// "Red Hat:enterprise_linux:7::server" and "Red Hat:enterprise_linux:7::workstation"
+// map to "7". Deduplication of CVE+package pairs across these variants happens in
+// runRHEL.
+//
+// Examples:
+//
+//	"Red Hat:enterprise_linux:9::appstream"  -> "9"
+//	"Red Hat:enterprise_linux:8::baseos"     -> "8"
+//	"Red Hat:enterprise_linux:7::server"     -> "7"
+//	"Red Hat:enterprise_linux:7::workstation"-> "7"
+//	"Red Hat:enterprise_linux:10.0"          -> "10"
+//	"Red Hat:enterprise_linux:10.1"          -> "10"
+//	"Red Hat:rhel_e4s:8.8::appstream"        -> ""  (not enterprise_linux)
+func extractRHELVersion(ecosystem string) string {
+	parts := strings.Split(ecosystem, ":")
+	if len(parts) < 3 || parts[0] != "Red Hat" {
+		return ""
+	}
+	if parts[1] != "enterprise_linux" {
+		return ""
+	}
+	// parts[2] is the version, possibly with minor: "9", "8", "10.0", "10.1"
+	ver := parts[2]
+	// Extract major version only
+	if dotIdx := strings.Index(ver, "."); dotIdx >= 0 {
+		ver = ver[:dotIdx]
+	}
+	return ver
+}
+
+// vulnKey is used for deduplication of CVE+package entries across ecosystems.
+type vulnKey struct {
+	pkg string
+	cve string
+}
+
+func runRHEL(cfg Config) error {
+	if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	targetVersions, excludedVersions := buildVersionFilter(cfg.Versions, cfg.ExcludeVersions)
+	log.Printf("Processing RHEL OSV files from %s", cfg.InputDir)
+
+	artifacts := make(map[string]*RHELArtifactData)
+	// Track seen CVE+package pairs per version for deduplication across ecosystems
+	seen := make(map[string]map[vulnKey]struct{})
+
+	filesProcessed := 0
+	filesSkipped := 0
+
+	err := filepath.Walk(cfg.InputDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() || !strings.HasSuffix(path, ".json") {
+			return nil
+		}
+
+		osvData, err := parseOSVFile(path)
+		if err != nil {
+			log.Printf("Failed to parse %s: %v", path, err)
+			filesSkipped++
+			return nil
+		}
+
+		// Extract all CVE IDs from this advisory
+		cveIDs := extractCVEIDs(osvData)
+		if len(cveIDs) == 0 {
+			filesSkipped++
+			return nil
+		}
+
+		for _, affected := range osvData.Affected {
+			ecosystem := affected.Package.Ecosystem
+			packageName := affected.Package.Name
+
+			rhelVer := extractRHELVersion(ecosystem)
+			if rhelVer == "" {
+				continue
+			}
+
+			if targetVersions != nil {
+				if !targetVersions[rhelVer] {
+					continue
+				}
+			} else if excludedVersions != nil {
+				if excludedVersions[rhelVer] {
+					continue
+				}
+			}
+
+			introduced, fixed := extractVersionRange(affected.Ranges)
+
+			for _, cveID := range cveIDs {
+				// Deduplicate: same CVE+package can appear in baseos, appstream, crb
+				if seen[rhelVer] == nil {
+					seen[rhelVer] = make(map[vulnKey]struct{})
+				}
+				key := vulnKey{pkg: packageName, cve: cveID}
+				if _, exists := seen[rhelVer][key]; exists {
+					continue
+				}
+				seen[rhelVer][key] = struct{}{}
+
+				vuln := ProcessedVuln{
+					CVE:        cveID,
+					Published:  osvData.Published,
+					Modified:   osvData.Modified,
+					Introduced: introduced,
+					Fixed:      fixed,
+					Versions:   affected.Versions,
+				}
+
+				packages, modifiedVuln := transformVuln(packageName, cveID, &vuln)
+				if packages == nil {
+					continue
+				}
+				vulnToUse := &vuln
+				if modifiedVuln != nil {
+					vulnToUse = modifiedVuln
+				}
+
+				for _, pkg := range packages {
+					if _, exists := artifacts[rhelVer]; !exists {
+						artifacts[rhelVer] = &RHELArtifactData{
+							SchemaVersion:   "1.0",
+							RHELVersion:     rhelVer,
+							Vulnerabilities: make(map[string][]ProcessedVuln),
+						}
+					}
+					artifacts[rhelVer].Vulnerabilities[pkg] = append(artifacts[rhelVer].Vulnerabilities[pkg], *vulnToUse)
+				}
+			}
+		}
+
+		filesProcessed++
+		if filesProcessed%1000 == 0 {
+			log.Printf("Processed %d files...", filesProcessed)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error walking directory: %w", err)
+	}
+
+	log.Printf("Processed %d files, skipped %d files", filesProcessed, filesSkipped)
+	log.Printf("Discovered %d RHEL versions", len(artifacts))
+
+	for ver, artifact := range artifacts {
+		artifact.Generated = cfg.GeneratedTimestamp
+		artifact.TotalCVEs = countTotalRHELCVEs(artifact)
+		artifact.TotalPackages = len(artifact.Vulnerabilities)
+
+		outputFile := filepath.Join(cfg.OutputDir, fmt.Sprintf("osv-rhel-%s-%s.json.gz", ver, cfg.DateStr))
+
+		if err := writeRHELArtifact(outputFile, artifact); err != nil {
+			return fmt.Errorf("failed to write artifact for RHEL %s: %w", ver, err)
+		}
+
+		log.Printf("RHEL %s: %d packages, %d CVEs -> %s",
+			ver, artifact.TotalPackages, artifact.TotalCVEs, outputFile)
+	}
+
+	return nil
+}
+
+// extractCVEIDs returns all CVE IDs from an OSV entry.
+// RHEL advisories list CVEs in the "upstream" field (same as Ubuntu).
+func extractCVEIDs(osv *OSVData) []string {
+	var cves []string
+	for _, upstream := range osv.Upstream {
+		if strings.HasPrefix(upstream, "CVE-") {
+			cves = append(cves, upstream)
+		}
+	}
+	// Fallback: check Related field
+	if len(cves) == 0 {
+		for _, related := range osv.Related {
+			if strings.HasPrefix(related, "CVE-") {
+				cves = append(cves, related)
+			}
+		}
+	}
+	// Fallback: check ID itself
+	if len(cves) == 0 {
+		if strings.HasPrefix(osv.ID, "CVE-") {
+			cves = append(cves, osv.ID)
+		}
+	}
+	return cves
+}
+
+func countTotalRHELCVEs(artifact *RHELArtifactData) int {
+	seen := make(map[string]bool)
+	for _, vulns := range artifact.Vulnerabilities {
+		for _, vuln := range vulns {
+			seen[vuln.CVE] = true
+		}
+	}
+	return len(seen)
+}
+
+func writeRHELArtifact(path string, artifact *RHELArtifactData) (err error) {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := file.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+
+	gzWriter := gzip.NewWriter(file)
+	defer func() {
+		if cerr := gzWriter.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
+
+	encoder := json.NewEncoder(gzWriter)
+
+	if err = encoder.Encode(artifact); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/osv-processor/main.go
+++ b/cmd/osv-processor/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"compress/gzip"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -595,7 +596,7 @@ func runRHEL(cfg Config) error {
 	// Delta generation is not supported for RHEL — the data source is a full GCS zip
 	// download with no git-based change tracking. Fail fast if callers pass delta flags.
 	if cfg.ChangedFilesToday != "" || cfg.ChangedFilesYesterday != "" {
-		return fmt.Errorf("--changed-files-today and --changed-files-yesterday are not supported with --platform rhel (no git-based change tracking for GCS data)")
+		return errors.New("--changed-files-today and --changed-files-yesterday are not supported with --platform rhel (no git-based change tracking for GCS data)")
 	}
 
 	if err := os.MkdirAll(cfg.OutputDir, 0o755); err != nil {

--- a/cmd/osv-processor/main_test.go
+++ b/cmd/osv-processor/main_test.go
@@ -838,6 +838,299 @@ func TestRunWithVersionFiltering(t *testing.T) {
 	}
 }
 
+func TestExtractRHELVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		ecosystem string
+		expected  string
+	}{
+		{
+			name:      "RHEL 9 appstream",
+			ecosystem: "Red Hat:enterprise_linux:9::appstream",
+			expected:  "9",
+		},
+		{
+			name:      "RHEL 8 baseos",
+			ecosystem: "Red Hat:enterprise_linux:8::baseos",
+			expected:  "8",
+		},
+		{
+			name:      "RHEL 8 crb",
+			ecosystem: "Red Hat:enterprise_linux:8::crb",
+			expected:  "8",
+		},
+		{
+			name:      "RHEL 10 with minor version",
+			ecosystem: "Red Hat:enterprise_linux:10.0",
+			expected:  "10",
+		},
+		{
+			name:      "RHEL 10.1 with minor version",
+			ecosystem: "Red Hat:enterprise_linux:10.1",
+			expected:  "10",
+		},
+		{
+			name:      "RHEL 7 software collections",
+			ecosystem: "Red Hat:rhel_software_collections:3::el7",
+			expected:  "",
+		},
+		{
+			name:      "RHEL EUS not supported",
+			ecosystem: "Red Hat:rhel_e4s:8.8::appstream",
+			expected:  "",
+		},
+		{
+			name:      "Empty string",
+			ecosystem: "",
+			expected:  "",
+		},
+		{
+			name:      "Ubuntu ecosystem",
+			ecosystem: "Ubuntu:24.04:LTS",
+			expected:  "",
+		},
+		{
+			name:      "RHEL 9 no repository suffix",
+			ecosystem: "Red Hat:enterprise_linux:9",
+			expected:  "9",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractRHELVersion(tt.ecosystem)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExtractCVEIDs(t *testing.T) {
+	tests := []struct {
+		name     string
+		osv      *OSVData
+		expected []string
+	}{
+		{
+			name: "CVEs in upstream",
+			osv: &OSVData{
+				ID:       "RHSA-2025:9978",
+				Upstream: []string{"CVE-2025-32462"},
+			},
+			expected: []string{"CVE-2025-32462"},
+		},
+		{
+			name: "Multiple CVEs in upstream",
+			osv: &OSVData{
+				ID:       "RHSA-2026:0001",
+				Upstream: []string{"CVE-2025-59375", "CVE-2025-6965", "CVE-2025-8176", "CVE-2025-9900"},
+			},
+			expected: []string{"CVE-2025-59375", "CVE-2025-6965", "CVE-2025-8176", "CVE-2025-9900"},
+		},
+		{
+			name: "CVE in related field as fallback",
+			osv: &OSVData{
+				ID:      "RHSA-2025:1234",
+				Related: []string{"CVE-2025-1111"},
+			},
+			expected: []string{"CVE-2025-1111"},
+		},
+		{
+			name: "CVE as ID fallback",
+			osv: &OSVData{
+				ID: "CVE-2025-9999",
+			},
+			expected: []string{"CVE-2025-9999"},
+		},
+		{
+			name: "No CVE found",
+			osv: &OSVData{
+				ID:       "RHBA-2025:5678",
+				Upstream: []string{"https://example.com"},
+			},
+			expected: nil,
+		},
+		{
+			name: "Non-CVE upstream entries filtered",
+			osv: &OSVData{
+				ID:       "RHSA-2025:0001",
+				Upstream: []string{"https://bugzilla.redhat.com/123", "CVE-2025-4444"},
+			},
+			expected: []string{"CVE-2025-4444"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractCVEIDs(tt.osv)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRunRHEL(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Create a RHEL OSV advisory with one CVE affecting sudo on RHEL 9
+	testData := `{
+		"schema_version": "1.7.5",
+		"id": "RHSA-2025:9978",
+		"published": "2025-07-01T10:06:01Z",
+		"modified": "2026-03-18T11:30:33Z",
+		"upstream": ["CVE-2025-32462"],
+		"summary": "sudo security update",
+		"affected": [
+			{
+				"package": {
+					"name": "sudo",
+					"ecosystem": "Red Hat:enterprise_linux:9::appstream"
+				},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:1.9.5p2-10.el9_6.1"}]}]
+			},
+			{
+				"package": {
+					"name": "sudo",
+					"ecosystem": "Red Hat:enterprise_linux:9::baseos"
+				},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:1.9.5p2-10.el9_6.1"}]}]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "RHSA-2025-9978.json"), []byte(testData), 0o644))
+
+	cfg := Config{
+		Platform:           "rhel",
+		InputDir:           inputDir,
+		OutputDir:          outputDir,
+		DateStr:            "2026-04-08",
+		GeneratedTimestamp: "2026-04-08T00:00:00Z",
+		RunTime:            time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+	}
+
+	err := runRHEL(cfg)
+	require.NoError(t, err)
+
+	// Verify artifact was created
+	expectedFile := filepath.Join(outputDir, "osv-rhel-9-2026-04-08.json.gz")
+	require.FileExists(t, expectedFile)
+
+	artifact, err := readRHELArtifact(expectedFile)
+	require.NoError(t, err)
+	require.Equal(t, "1.0", artifact.SchemaVersion)
+	require.Equal(t, "9", artifact.RHELVersion)
+	require.Equal(t, 1, artifact.TotalCVEs)
+	require.Contains(t, artifact.Vulnerabilities, "sudo")
+	// Deduplication: sudo appears in both appstream and baseos, should be deduplicated
+	require.Len(t, artifact.Vulnerabilities["sudo"], 1)
+	require.Equal(t, "CVE-2025-32462", artifact.Vulnerabilities["sudo"][0].CVE)
+	require.Equal(t, "0:1.9.5p2-10.el9_6.1", artifact.Vulnerabilities["sudo"][0].Fixed)
+}
+
+func TestRunRHELMultiCVEAdvisory(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	// Advisory with 2 CVEs and packages across RHEL 8 and 9
+	testData := `{
+		"schema_version": "1.7.5",
+		"id": "RHSA-2026:0001",
+		"published": "2026-01-05T10:11:47Z",
+		"modified": "2026-04-03T10:05:48Z",
+		"upstream": ["CVE-2025-1111", "CVE-2025-2222"],
+		"affected": [
+			{
+				"package": {"name": "curl", "ecosystem": "Red Hat:enterprise_linux:9::baseos"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:7.76.1-29.el9_4.2"}]}]
+			},
+			{
+				"package": {"name": "curl", "ecosystem": "Red Hat:enterprise_linux:8::baseos"},
+				"ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:7.61.1-34.el8_10"}]}]
+			}
+		]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "RHSA-2026-0001.json"), []byte(testData), 0o644))
+
+	cfg := Config{
+		Platform:           "rhel",
+		InputDir:           inputDir,
+		OutputDir:          outputDir,
+		DateStr:            "2026-04-08",
+		GeneratedTimestamp: "2026-04-08T00:00:00Z",
+		RunTime:            time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+	}
+
+	err := runRHEL(cfg)
+	require.NoError(t, err)
+
+	// Should produce artifacts for both RHEL 8 and 9
+	rhel9, err := readRHELArtifact(filepath.Join(outputDir, "osv-rhel-9-2026-04-08.json.gz"))
+	require.NoError(t, err)
+	require.Equal(t, 2, rhel9.TotalCVEs)
+	require.Len(t, rhel9.Vulnerabilities["curl"], 2)
+
+	rhel8, err := readRHELArtifact(filepath.Join(outputDir, "osv-rhel-8-2026-04-08.json.gz"))
+	require.NoError(t, err)
+	require.Equal(t, 2, rhel8.TotalCVEs)
+	require.Len(t, rhel8.Vulnerabilities["curl"], 2)
+}
+
+func TestRunRHELVersionFiltering(t *testing.T) {
+	inputDir := t.TempDir()
+	outputDir := t.TempDir()
+
+	testData := `{
+		"schema_version": "1.7.5",
+		"id": "RHSA-2025:1234",
+		"published": "2025-01-01T00:00:00Z",
+		"modified": "2025-01-02T00:00:00Z",
+		"upstream": ["CVE-2025-5555"],
+		"affected": [
+			{"package": {"name": "pkg", "ecosystem": "Red Hat:enterprise_linux:8::baseos"}, "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:1.0-1.el8"}]}]},
+			{"package": {"name": "pkg", "ecosystem": "Red Hat:enterprise_linux:9::baseos"}, "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:1.0-1.el9"}]}]}
+		]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(inputDir, "RHSA-2025-1234.json"), []byte(testData), 0o644))
+
+	cfg := Config{
+		Platform:           "rhel",
+		InputDir:           inputDir,
+		OutputDir:          outputDir,
+		Versions:           "9",
+		DateStr:            "2026-04-08",
+		GeneratedTimestamp: "2026-04-08T00:00:00Z",
+		RunTime:            time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC),
+	}
+
+	err := runRHEL(cfg)
+	require.NoError(t, err)
+
+	// Only RHEL 9 should be generated
+	require.FileExists(t, filepath.Join(outputDir, "osv-rhel-9-2026-04-08.json.gz"))
+	_, err = os.Stat(filepath.Join(outputDir, "osv-rhel-8-2026-04-08.json.gz"))
+	require.True(t, os.IsNotExist(err), "RHEL 8 artifact should not exist when filtering to version 9")
+}
+
+func readRHELArtifact(path string) (*RHELArtifactData, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	gzReader, err := gzip.NewReader(file)
+	if err != nil {
+		return nil, err
+	}
+	defer gzReader.Close()
+
+	var artifact RHELArtifactData
+	if err := json.NewDecoder(gzReader).Decode(&artifact); err != nil {
+		return nil, err
+	}
+
+	return &artifact, nil
+}
+
 func readArtifact(path string) (*ArtifactData, error) {
 	file, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
Resolves #43183

## Summary

Extends the `osv-processor` CI tool to generate RHEL OSV artifacts from Red Hat's GCS-published vulnerability data. Adds a `--platform rhel` flag that processes `Red Hat:enterprise_linux` ecosystem entries, collapses repository/variant suffixes (appstream, baseos, server, workstation, etc.) to major version, and deduplicates CVE+package pairs across ecosystems.

## How to test locally

Download the Red Hat OSV feed from GCS and run the processor:

```bash
# Download (~23MB)
curl -sL "https://storage.googleapis.com/osv-vulnerabilities/Red%20Hat/all.zip" \
  -o /tmp/rhel-osv.zip
unzip -q /tmp/rhel-osv.zip -d /tmp/rhel-osv

# Run processor
go run ./cmd/osv-processor \
  --platform rhel \
  --input /tmp/rhel-osv \
  --output /tmp/rhel-osv-artifacts \
  --versions "7,8,9,10"

# Inspect output
ls -lh /tmp/rhel-osv-artifacts/
```

Expected output (19,084 advisories, ~4 seconds):
```
RHEL 7:  4,041 packages, 4,610 CVEs  (~335KB)
RHEL 8:  6,764 packages, 6,868 CVEs  (~1.1MB)
RHEL 9:  4,415 packages, 5,922 CVEs  (~1.3MB)
RHEL 10: 1,851 packages, 966 CVEs    (~252KB)
```


## Related

- Workflow change in fleetdm/vulnerabilities#32 (adds the GCS download + `--platform rhel` step to `generate-cve.yml`)
- Fleet server consumption in a follow-up PR (#40056)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RHEL platform support with a new `--platform` flag to select between Ubuntu and RHEL processing modes
  * RHEL mode includes version-specific filtering and CVE extraction with deduplication capabilities

* **Tests**
  * Added comprehensive test coverage for RHEL processing, including version parsing, CVE extraction logic, and artifact generation validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->