### PR TITLE
Remove uninstall suggestion from some patch policies

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -1,6 +1,6 @@
 - name: macOS - Google Chrome up to date
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality. You can also delete Google Chrome if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: google-chrome/darwin
   install_software: false
@@ -57,7 +57,7 @@
     - Macs with Microsoft Teams installed
 - name: macOS - Slack up to date
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also delete Slack if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: slack/darwin
   install_software: false
@@ -65,7 +65,7 @@
     - Macs with Slack installed
 - name: macOS - Zoom up to date
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also delete Zoom if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: zoom/darwin
   install_software: false
@@ -73,7 +73,7 @@
     - Macs with Zoom installed
 - name: macOS - Okta Verify up to date
   description: The host may have an outdated version of Okta Verify, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality. You can also delete Okta Verify if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Okta Verify's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: okta-verify/darwin
   install_software: false

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -1,6 +1,6 @@
 - name: Windows - Slack up to date
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality. You can also uninstall Slack if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: slack/windows
   install_software: false
@@ -24,7 +24,7 @@
     - x86 Windows hosts with Firefox installed
 - name: Windows - Google Chrome up to date
   description: The host may have an outdated version of Google Chrome, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality. You can also uninstall Google Chrome if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Google Chrome's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: google-chrome/windows
   install_software: false
@@ -32,7 +32,7 @@
     - x86 Windows hosts with Google Chrome installed
 - name: Windows - Zoom up to date
   description: The host may have an outdated version of Zoom, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality. You can also uninstall Zoom if you are no longer using it."
+  resolution: "Download the latest version from Self-service or check for updates using Zoom's built-in update functionality."
   type: patch
   fleet_maintained_app_slug: zoom/windows
   install_software: false


### PR DESCRIPTION
Remove wording that suggested deleting/uninstalling apps from resolution text in fleet-maintained app patch policies. Updated macOS and Windows policy files to only advise updating via Self-service or each app's built-in update functionality (no mention of deleting/uninstalling). Affected files: it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml and it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml.