### PR TITLE
Add AWS VPN Client label, app, and patch policy

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -113,3 +113,4 @@ labels:
   - path: ./lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/departments.yml
+  - path: ./lib/all/labels/idp-group-saml-aws-vpn.yml

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -248,6 +248,12 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
+    - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
+      self_service: true
+      labels_include_any:
+        - "IdP group: SAML-aws-vpn"
+      categories:
+        - Utilities
     - slug: google-chrome/darwin # Google Chrome for macOS
       self_service: true
       setup_experience: true

--- a/it-and-security/lib/all/labels/idp-group-saml-aws-vpn.yml
+++ b/it-and-security/lib/all/labels/idp-group-saml-aws-vpn.yml
@@ -1,0 +1,6 @@
+- name: "IdP group: SAML-aws-vpn"
+  description: Hosts belonging to members of the SAML-aws-vpn IdP group
+  label_membership_type: host_vitals
+  criteria:
+    vital: end_user_idp_group
+    value: SAML-aws-vpn

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -53,3 +53,8 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';
   label_membership_type: dynamic
   platform: darwin
+- name: Macs with AWS VPN Client installed
+  description: macOS hosts with AWS VPN Client installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -87,3 +87,11 @@
   install_software: false
   labels_include_any:
     - Macs with Claude installed
+- name: macOS - AWS VPN Client up to date
+  description: The host may have an outdated version of AWS VPN Client, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using AWS VPN Client's built-in update functionality. You can also delete AWS VPN Client if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: aws-vpn-client/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with AWS VPN Client installed


### PR DESCRIPTION
Register AWS VPN Client in fleet configs: add an IdP group label (IdP group: SAML-aws-vpn), include that label in default.yml, and add aws-vpn-client/darwin to fleet_maintained_apps (self_service=true, labeled for the SAML-aws-vpn group). Add a dynamic label for macOS hosts with AWS VPN Client installed (bundle id com.amazonaws.acvc.osx) and add a macOS patch policy to surface/update hosts with out-of-date AWS VPN Client. These changes enable inventorying, self-service installation, and patch tracking for the AWS VPN Client.
