### PR TITLE
Fixed panic when uploading DDM/Android JSON profile to a team on Fleet Free

### DIFF
--- a/changes/41484-fix-windows-mdm-profile-upload-panic
+++ b/changes/41484-fix-windows-mdm-profile-upload-panic
@@ -1,1 +1,1 @@
-- Fixed a server panic when uploading a Windows MDM profile to a fleet on a free license.
+- Fixed a server panic when uploading a Windows/Apple/Android MDM profile to a fleet on a free license (fleets are a premium feature).

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -861,7 +861,11 @@ func (svc *Service) NewMDMAppleDeclaration(ctx context.Context, teamID uint, dat
 	}
 
 	var teamName string
-	if teamID >= 1 {
+	if teamID > 0 {
+		lic, _ := license.FromContext(ctx)
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.ErrMissingLicense)
+		}
 		tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, &teamID, nil)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err)

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -863,6 +863,16 @@ func TestBatchSetMDMAppleProfilesWithSecrets(t *testing.T) {
 	assert.ErrorContains(t, err, "profiles[1]")
 }
 
+func TestNewMDMAppleDeclarationFreeLicenseTeam(t *testing.T) {
+	svc, ctx, _, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierFree})
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	b := declBytesForTest("D1", "d1content")
+
+	_, err := svc.NewMDMAppleDeclaration(ctx, 1, b, nil, "name", fleet.LabelsIncludeAll)
+	assert.ErrorIs(t, err, fleet.ErrMissingLicense)
+}
+
 func TestNewMDMAppleDeclaration(t *testing.T) {
 	svc, ctx, ds, _ := setupAppleMDMService(t, &fleet.LicenseInfo{Tier: fleet.TierPremium})
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -1825,6 +1825,10 @@ func (svc *Service) NewMDMAndroidConfigProfile(ctx context.Context, teamID uint,
 
 	var teamName string
 	if teamID > 0 {
+		lic, _ := license.FromContext(ctx)
+		if lic == nil || !lic.IsPremium() {
+			return nil, ctxerr.Wrap(ctx, fleet.ErrMissingLicense)
+		}
 		tm, err := svc.EnterpriseOverrides.TeamByIDOrName(ctx, &teamID, nil)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err)

--- a/server/service/mdm_test.go
+++ b/server/service/mdm_test.go
@@ -2815,6 +2815,22 @@ func TestNewMDMProfilePremiumOnlyAndroid(t *testing.T) {
 			`{"systemUpdate": {"type": "AUTOMATIC"}}`,
 			"",
 		},
+		{
+			"android profile with team and free license",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			false,
+			1,
+			`{"screenCaptureDisabled": true}`,
+			"Requires Fleet Premium license",
+		},
+		{
+			"android profile with team and premium license",
+			&fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)},
+			true,
+			1,
+			`{"screenCaptureDisabled": true}`,
+			"",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41484

Unreleased bug.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **License Enforcement Updates**
  * Team-scoped Mobile Device Management operations now require a premium license. Free-tier users will receive an error when attempting to create or manage team-level MDM declarations and profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->