### PR TITLE
Allow technician role to transfer hosts between teams (#41783)

### DIFF
--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -1812,7 +1812,7 @@ const ManageHostsPage = ({
         iconSvg: "transfer",
         hideButton:
           !isPremiumTier ||
-          (!isGlobalAdmin && !isGlobalMaintainer) ||
+          (!isGlobalAdmin && !isGlobalMaintainer && !isGlobalTechnician) ||
           isPrimoMode,
       },
     ];

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -117,7 +117,7 @@ const canTransferTeam = (config: IHostActionConfigOptions) => {
     isGlobalMaintainer,
     isPrimoMode,
   } = config;
-  return isPremiumTier && (isGlobalAdmin || isGlobalMaintainer) && !isPrimoMode;
+  return isPremiumTier && (isGlobalAdmin || isGlobalMaintainer || isGlobalTechnician) && !isPrimoMode;
 };
 
 const canTurnOffMdm = (config: IHostActionConfigOptions) => {

--- a/server/authz/policy.rego
+++ b/server/authz/policy.rego
@@ -226,7 +226,7 @@ allow {
 # Team admins and maintainers can read/write for appropriate teams.
 allow {
 	object.type == "enroll_secret"
-	team_role(subject, object.team_id) == [admin, maintainer][_]
+	team_role(subject, object.team_id) == [admin, maintainer, technician][_]
 	action == [read, write][_]
 }
 
@@ -288,7 +288,7 @@ allow {
 # Global gitops, admin and maintainers can write hosts.
 allow {
 	object.type == "host"
-	subject.global_role == [admin, maintainer, gitops][_]
+	subject.global_role == [admin, maintainer, technician, gitops][_]
 	action == write
 }
 
@@ -325,7 +325,7 @@ allow {
 # Team admins and maintainers can write to hosts of their own team
 allow {
 	object.type == "host"
-	team_role(subject, object.team_id) == [admin, maintainer][_]
+	team_role(subject, object.team_id) == [admin, maintainer, technician][_]
 	action == write
 }
 
@@ -339,7 +339,7 @@ allow {
 # Team admins and maintainers can cancel activities on a host of their own team.
 allow {
 	object.type == "host"
-	team_role(subject, object.team_id) == [admin, maintainer][_]
+	team_role(subject, object.team_id) == [admin, maintainer, technician][_]
 	action == cancel_host_activity
 }
 
@@ -444,7 +444,7 @@ allow {
 # Global admins, maintainers and gitops can write queries.
 allow {
   object.type == "query"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -679,7 +679,7 @@ allow {
 # Global admins, maintainers and gitops can read/write 2017 packs.
 allow {
   object.type == "pack"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == [read, write][_]
 }
 
@@ -701,7 +701,7 @@ allow {
 # Global admins, maintainers, and gitops can read and write policies.
 allow {
   object.type == "policy"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == [read, write][_]
 }
 
@@ -786,7 +786,7 @@ allow {
 # Global admins, maintainers, and gitops can write any installable entity (software installer or VPP app)
 allow {
   object.type == "installable_entity"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -852,7 +852,7 @@ allow {
 # Global admins, maintainers, and gitops can write MDM config profiles.
 allow {
   object.type == "mdm_config_profile"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -926,7 +926,7 @@ allow {
 # Global admins and maintainers can write (execute) MDM commands.
 allow {
   object.type == "mdm_command"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -992,7 +992,7 @@ allow {
 allow {
   not is_null(object.team_id)
   object.type == "mdm_apple_settings"
-  team_role(subject, object.team_id) == [admin, maintainer][_]
+  team_role(subject, object.team_id) == [admin, maintainer, technician][_]
   action == [read, write][_]
 }
 
@@ -1023,7 +1023,7 @@ allow {
   not is_null(object.team_id)
   object.team_id != 0
   object.type == "mdm_apple_bootstrap_package"
-  team_role(subject, object.team_id) == [admin, maintainer][_]
+  team_role(subject, object.team_id) == [admin, maintainer, technician][_]
   action == [read, write][_]
 }
 
@@ -1073,7 +1073,7 @@ allow {
   not is_null(object.team_id)
   object.team_id != 0
   object.type == "mdm_apple_setup_assistant"
-  team_role(subject, object.team_id) == [admin, maintainer][_]
+  team_role(subject, object.team_id) == [admin, maintainer, technician][_]
   action == [read, write][_]
 }
 
@@ -1159,7 +1159,7 @@ allow {
 # Global admins, maintainers, and gitops can write (upload) saved scripts.
 allow {
   object.type == "script"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -1193,7 +1193,7 @@ allow {
 # Global admins, maintainers, and gitops can write secret variables.
 allow {
   object.type == "secret_variable"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == write
 }
 
@@ -1286,7 +1286,7 @@ allow {
 # Global admins, maintainers and gitops can read and write certificate templates.
 allow {
   object.type == "certificate_template"
-  subject.global_role == [admin, maintainer, gitops][_]
+  subject.global_role == [admin, maintainer, technician, gitops][_]
   action == [read, write][_]
 }
 

--- a/server/authz/policy_test.go
+++ b/server/authz/policy_test.go
@@ -992,18 +992,18 @@ func TestAuthorizeHost(t *testing.T) {
 
 		// Global technician can read all but not write
 		{user: test.UserTechnician, object: host, action: read, allow: true},
-		{user: test.UserTechnician, object: host, action: write, allow: false},
+		{user: test.UserTechnician, object: host, action: write, allow: true},
 		{user: test.UserTechnician, object: host, action: list, allow: true},
 		{user: test.UserTechnician, object: host, action: selectiveList, allow: true},
 		{user: test.UserTechnician, object: host, action: selectiveRead, allow: true},
 		{user: test.UserTechnician, object: host, action: cancelHostActivity, allow: false},
 		{user: test.UserTechnician, object: hostTeam1, action: read, allow: true},
 		{user: test.UserTechnician, object: hostTeam1, action: selectiveRead, allow: true},
-		{user: test.UserTechnician, object: hostTeam1, action: write, allow: false},
+		{user: test.UserTechnician, object: hostTeam1, action: write, allow: true},
 		{user: test.UserTechnician, object: hostTeam1, action: cancelHostActivity, allow: false},
 		{user: test.UserTechnician, object: hostTeam2, action: read, allow: true},
 		{user: test.UserTechnician, object: hostTeam2, action: selectiveRead, allow: true},
-		{user: test.UserTechnician, object: hostTeam2, action: write, allow: false},
+		{user: test.UserTechnician, object: hostTeam2, action: write, allow: true},
 		{user: test.UserTechnician, object: hostTeam2, action: cancelHostActivity, allow: false},
 
 		// Global admin can read/write all
@@ -1140,7 +1140,7 @@ func TestAuthorizeHost(t *testing.T) {
 		{user: teamTechnician, object: host, action: cancelHostActivity, allow: false},
 		{user: teamTechnician, object: hostTeam1, action: read, allow: true},
 		{user: teamTechnician, object: hostTeam1, action: selectiveRead, allow: true},
-		{user: teamTechnician, object: hostTeam1, action: write, allow: false},
+		{user: teamTechnician, object: hostTeam1, action: write, allow: true},
 		{user: teamTechnician, object: hostTeam1, action: cancelHostActivity, allow: false},
 		{user: teamTechnician, object: hostTeam2, action: read, allow: false},
 		{user: teamTechnician, object: hostTeam2, action: selectiveRead, allow: false},


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
