### PR TITLE
🤖 Add fallback for FMA manifest URL pulls

### DIFF
--- a/changes/42751-r2-fma
+++ b/changes/42751-r2-fma
@@ -1,1 +1,1 @@
-* Switched Fleet-maintained apps serving location from GitHub to https://maintained-apps.fleetdm.com/manifests. If you limit outbound Fleet server traffic, make sure it can access the new FMA manifests location.
+* Switched Fleet-maintained apps serving location from GitHub to https://maintained-apps.fleetdm.com/manifests. If this site is inaccessible, Fleet will fall back to the previous GitHub-hosted copies of manifest files.

--- a/changes/42754-fma-fallback-cdn
+++ b/changes/42754-fma-fallback-cdn
@@ -1,1 +1,0 @@
-* Added automatic fallback for Fleet-maintained app manifest downloads. If the primary CDN is unavailable, Fleet will automatically retry from a secondary source (GitHub). The fallback base URL can be overridden via `FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL`.

--- a/changes/42754-fma-fallback-cdn
+++ b/changes/42754-fma-fallback-cdn
@@ -1,0 +1,1 @@
+* Added automatic fallback for Fleet-maintained app manifest downloads. If the primary CDN is unavailable, Fleet will automatically retry from a secondary source (GitHub). The fallback base URL can be overridden via `FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL`.

--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -2005,7 +2005,7 @@ func newMaintainedAppSchedule(
 		// ensures it runs a few seconds after Fleet is started
 		schedule.WithDefaultPrevRunCreatedAt(time.Now().Add(priorJobDiff)),
 		schedule.WithJob("refresh_maintained_apps", func(ctx context.Context) error {
-			return maintained_apps.Refresh(ctx, ds, logger)
+			return maintained_apps.SyncAppsList(ctx, ds)
 		}),
 	)
 

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -30,6 +30,79 @@ type AppsList struct {
 }
 
 const fmaOutputsBase = "https://maintained-apps.fleetdm.com/manifests"
+const fmaOutputsFallbackBase = "https://raw.githubusercontent.com/fleetdm/fleet/refs/heads/main/ee/maintained-apps/outputs"
+
+// resolveBaseURLs returns the primary and fallback base URLs for FMA manifests,
+// taking into account any dev-mode env var overrides.
+func resolveBaseURLs() (primary, fallback string) {
+	primary = fmaOutputsBase
+	if baseFromEnvVar := dev_mode.Env("FLEET_DEV_MAINTAINED_APPS_BASE_URL"); baseFromEnvVar != "" {
+		primary = baseFromEnvVar
+	}
+
+	fallback = fmaOutputsFallbackBase
+	if fallbackFromEnvVar := dev_mode.Env("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL"); fallbackFromEnvVar != "" {
+		fallback = fallbackFromEnvVar
+	}
+
+	return primary, fallback
+}
+
+// fetchManifestData fetches the given path (e.g. "/apps.json") from the primary
+// FMA base URL. If the primary request fails for any reason (network error,
+// non-200 status), it immediately retries with the fallback base URL. If both
+// fail, the returned error includes context from both attempts.
+func fetchManifestData(ctx context.Context, path string) ([]byte, error) {
+	primaryBase, fallbackBase := resolveBaseURLs()
+
+	body, primaryErr := doFetch(ctx, primaryBase, path)
+	if primaryErr == nil {
+		return body, nil
+	}
+
+	// Primary failed; try fallback.
+	body, fallbackErr := doFetch(ctx, fallbackBase, path)
+	if fallbackErr == nil {
+		return body, nil
+	}
+
+	return nil, ctxerr.Errorf(ctx, "fetching %s: primary (%s) failed: %v; fallback (%s) also failed: %v",
+		path, primaryBase, primaryErr, fallbackBase, fallbackErr)
+}
+
+// doFetch performs a single HTTP GET for baseURL+path and returns the response
+// body on success (HTTP 200). Any other outcome is returned as an error.
+func doFetch(ctx context.Context, baseURL, path string) ([]byte, error) {
+	httpClient := fleethttp.NewClient(fleethttp.WithTimeout(10 * time.Second))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s%s", baseURL, path), nil)
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute http request: %w", err)
+	}
+	defer res.Body.Close()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read http response body: %w", err)
+	}
+
+	switch res.StatusCode {
+	case http.StatusOK:
+		return body, nil
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("not found (HTTP 404)")
+	default:
+		if len(body) > 512 {
+			body = body[:512]
+		}
+		return nil, fmt.Errorf("HTTP status %d: %s", res.StatusCode, string(body))
+	}
+}
 
 // Refresh fetches the latest information about maintained apps from FMA's
 // apps list on GitHub and updates the Fleet database with the new information.
@@ -43,38 +116,9 @@ func Refresh(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error
 }
 
 func FetchAppsList(ctx context.Context) (*AppsList, error) {
-	httpClient := fleethttp.NewClient(fleethttp.WithTimeout(10 * time.Second))
-	baseURL := fmaOutputsBase
-	if baseFromEnvVar := dev_mode.Env("FLEET_DEV_MAINTAINED_APPS_BASE_URL"); baseFromEnvVar != "" {
-		baseURL = baseFromEnvVar
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/apps.json", baseURL), nil)
+	body, err := fetchManifestData(ctx, "/apps.json")
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "create http request")
-	}
-
-	res, err := httpClient.Do(req)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "execute http request")
-	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "read http response body")
-	}
-
-	switch res.StatusCode {
-	case http.StatusOK:
-		// success, go on
-	case http.StatusNotFound:
-		return nil, ctxerr.New(ctx, "maintained apps list not found")
-	default:
-		if len(body) > 512 {
-			body = body[:512]
-		}
-		return nil, ctxerr.Errorf(ctx, "apps list returned HTTP status %d: %s", res.StatusCode, string(body))
+		return nil, ctxerr.Wrap(ctx, err, "fetch apps list")
 	}
 
 	var appsList AppsList
@@ -163,38 +207,9 @@ func Hydrate(ctx context.Context, app *fleet.MaintainedApp, version string, team
 		return app, nil
 	}
 
-	httpClient := fleethttp.NewClient(fleethttp.WithTimeout(10 * time.Second))
-	baseURL := fmaOutputsBase
-	if baseFromEnvVar := dev_mode.Env("FLEET_DEV_MAINTAINED_APPS_BASE_URL"); baseFromEnvVar != "" {
-		baseURL = baseFromEnvVar
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("%s/%s.json", baseURL, app.Slug), nil)
+	body, err := fetchManifestData(ctx, fmt.Sprintf("/%s.json", app.Slug))
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "create http request")
-	}
-
-	res, err := httpClient.Do(req)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "execute http request")
-	}
-	defer res.Body.Close()
-
-	body, err := io.ReadAll(res.Body)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "read http response body")
-	}
-
-	switch res.StatusCode {
-	case http.StatusOK:
-		// success, go on
-	case http.StatusNotFound:
-		return nil, ctxerr.New(ctx, "app not found in Fleet manifests")
-	default:
-		if len(body) > 512 {
-			body = body[:512]
-		}
-		return nil, ctxerr.Errorf(ctx, "manifest retrieval returned HTTP status %d: %s", res.StatusCode, string(body))
+		return nil, ctxerr.Wrap(ctx, err, "fetch app manifest")
 	}
 
 	var manifest ma.FMAManifestFile

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -92,7 +93,7 @@ func doFetch(ctx context.Context, baseURL, path string) ([]byte, error) {
 	case http.StatusOK:
 		return body, nil
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("not found (HTTP 404)")
+		return nil, errors.New("not found (HTTP 404)")
 	default:
 		if len(body) > 512 {
 			body = body[:512]

--- a/server/mdm/maintainedapps/sync.go
+++ b/server/mdm/maintainedapps/sync.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
 	"time"
 
@@ -48,11 +47,9 @@ func resolveBaseURLs() (primary, fallback string) {
 	return primary, fallback
 }
 
-// fetchManifestData fetches the given path (e.g. "/apps.json") from the primary
-// FMA base URL. If the primary request fails for any reason (network error,
-// non-200 status), it immediately retries with the fallback base URL. If both
-// fail, the returned error includes context from both attempts.
-func fetchManifestData(ctx context.Context, path string) ([]byte, error) {
+// fetchManifestFile fetches a manifest file from the primary FMA CDN, falling back to the
+// fallback CDN if the primary fails.
+func fetchManifestFile(ctx context.Context, path string) ([]byte, error) {
 	primaryBase, fallbackBase := resolveBaseURLs()
 
 	body, primaryErr := doFetch(ctx, primaryBase, path)
@@ -66,7 +63,7 @@ func fetchManifestData(ctx context.Context, path string) ([]byte, error) {
 		return body, nil
 	}
 
-	return nil, ctxerr.Errorf(ctx, "fetching %s: primary (%s) failed: %v; fallback (%s) also failed: %v",
+	return nil, ctxerr.Errorf(ctx, "fetching FMA manifest file %q: primary (%s) failed: %v; fallback (%s) also failed: %v",
 		path, primaryBase, primaryErr, fallbackBase, fallbackErr)
 }
 
@@ -104,9 +101,8 @@ func doFetch(ctx context.Context, baseURL, path string) ([]byte, error) {
 	}
 }
 
-// Refresh fetches the latest information about maintained apps from FMA's
-// apps list on GitHub and updates the Fleet database with the new information.
-func Refresh(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error {
+// SyncAppsList fetches the latest FMA apps list and updates the apps list copy cached in the DB
+func SyncAppsList(ctx context.Context, ds fleet.Datastore) error {
 	appsList, err := FetchAppsList(ctx)
 	if err != nil {
 		return err
@@ -116,7 +112,7 @@ func Refresh(ctx context.Context, ds fleet.Datastore, logger *slog.Logger) error
 }
 
 func FetchAppsList(ctx context.Context) (*AppsList, error) {
-	body, err := fetchManifestData(ctx, "/apps.json")
+	body, err := fetchManifestFile(ctx, "/apps.json")
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "fetch apps list")
 	}
@@ -207,7 +203,7 @@ func Hydrate(ctx context.Context, app *fleet.MaintainedApp, version string, team
 		return app, nil
 	}
 
-	body, err := fetchManifestData(ctx, fmt.Sprintf("/%s.json", app.Slug))
+	body, err := fetchManifestFile(ctx, fmt.Sprintf("/%s.json", app.Slug))
 	if err != nil {
 		return nil, ctxerr.Wrap(ctx, err, "fetch app manifest")
 	}

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -1,7 +1,6 @@
 package maintained_apps
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,7 @@ func TestFetchAppsListPrimarySuccess(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
@@ -65,7 +64,7 @@ func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
@@ -87,7 +86,7 @@ func TestFetchAppsListFallbackOnPrimary404(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 }
@@ -108,7 +107,7 @@ func TestFetchAppsListBothFail(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	_, err := FetchAppsList(context.Background())
+	_, err := FetchAppsList(t.Context())
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "primary")
 	assert.Contains(t, err.Error(), "fallback")
@@ -128,7 +127,7 @@ func TestFetchAppsListFallbackOnPrimaryNetworkError(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 }
@@ -148,7 +147,7 @@ func TestFetchAppsListOnlyFallbackFails(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 }
@@ -173,7 +172,7 @@ func TestFetchManifestDataFallbackUsedForSlugPath(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	body, err := fetchManifestFile(context.Background(), "/test-app.json")
+	body, err := fetchManifestFile(t.Context(), "/test-app.json")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"test"`)
 	assert.Equal(t, int32(1), primaryHits.Load(), "primary should have been tried once")
@@ -196,7 +195,7 @@ func TestFetchManifestDataPrimarySucceedsSkipsFallback(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	body, err := fetchManifestFile(context.Background(), "/something.json")
+	body, err := fetchManifestFile(t.Context(), "/something.json")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"ok"`)
 	assert.Equal(t, int32(0), fallbackHits.Load(), "fallback must not be contacted when primary succeeds")
@@ -227,7 +226,7 @@ func TestDoFetchSuccess(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	body, err := doFetch(context.Background(), srv.URL, "/test.json")
+	body, err := doFetch(t.Context(), srv.URL, "/test.json")
 	require.NoError(t, err)
 	assert.Equal(t, "ok", string(body))
 }
@@ -238,7 +237,7 @@ func TestDoFetchNotFound(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := doFetch(context.Background(), srv.URL, "/missing.json")
+	_, err := doFetch(t.Context(), srv.URL, "/missing.json")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "404")
 }
@@ -250,7 +249,7 @@ func TestDoFetchServerError(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := doFetch(context.Background(), srv.URL, "/broken.json")
+	_, err := doFetch(t.Context(), srv.URL, "/broken.json")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "502")
 }
@@ -259,7 +258,7 @@ func TestDoFetchNetworkError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
 	srv.Close() // immediately close to force connection errors
 
-	_, err := doFetch(context.Background(), srv.URL, "/anything.json")
+	_, err := doFetch(t.Context(), srv.URL, "/anything.json")
 	require.Error(t, err)
 }
 
@@ -275,7 +274,7 @@ func TestDoFetchTruncatesLargeBodyInErrorMessage(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	_, err := doFetch(context.Background(), srv.URL, "/big.json")
+	_, err := doFetch(t.Context(), srv.URL, "/big.json")
 	require.Error(t, err)
 	// The error message should contain at most 512 bytes of body.
 	assert.LessOrEqual(t, len(err.Error()), 600) // 512 body + status prefix
@@ -298,7 +297,7 @@ func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", customFallback.URL, t)
 
-	apps, err := FetchAppsList(context.Background())
+	apps, err := FetchAppsList(t.Context())
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -170,7 +170,7 @@ func TestFetchManifestDataFallbackUsedForSlugPath(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	body, err := fetchManifestData(context.Background(), "/test-app.json")
+	body, err := fetchManifestFile(context.Background(), "/test-app.json")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"test"`)
 	assert.Equal(t, int32(1), primaryHits.Load(), "primary should have been tried once")
@@ -193,7 +193,7 @@ func TestFetchManifestDataPrimarySucceedsSkipsFallback(t *testing.T) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
 
-	body, err := fetchManifestData(context.Background(), "/something.json")
+	body, err := fetchManifestFile(context.Background(), "/something.json")
 	require.NoError(t, err)
 	assert.Contains(t, string(body), `"ok"`)
 	assert.Equal(t, int32(0), fallbackHits.Load(), "fallback must not be contacted when primary succeeds")

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -47,7 +47,7 @@ func TestFetchAppsListPrimarySuccess(t *testing.T) {
 }
 
 func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
-	wasSecondaryCalled := false
+	var fallbackWasCalled atomic.Bool
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("primary is down"))
@@ -58,7 +58,7 @@ func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
 		assert.Equal(t, "/apps.json", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(newTestAppsJSON())
-		wasSecondaryCalled = true
+		fallbackWasCalled.Store(true)
 	}))
 	t.Cleanup(fallback.Close)
 
@@ -69,7 +69,7 @@ func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
-	assert.True(t, wasSecondaryCalled)
+	assert.True(t, fallbackWasCalled.Load())
 }
 
 func TestFetchAppsListFallbackOnPrimary404(t *testing.T) {
@@ -287,11 +287,11 @@ func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
 	}))
 	t.Cleanup(primary.Close)
 
-	fallbackWasCalled := false
+	var fallbackWasCalled atomic.Bool
 	customFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(newTestAppsJSON())
-		fallbackWasCalled = true
+		fallbackWasCalled.Store(true)
 	}))
 	t.Cleanup(customFallback.Close)
 
@@ -302,5 +302,5 @@ func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
-	assert.True(t, fallbackWasCalled)
+	assert.True(t, fallbackWasCalled.Load())
 }

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -47,6 +47,7 @@ func TestFetchAppsListPrimarySuccess(t *testing.T) {
 }
 
 func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
+	wasSecondaryCalled := false
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write([]byte("primary is down"))
@@ -57,6 +58,7 @@ func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
 		assert.Equal(t, "/apps.json", r.URL.Path)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(newTestAppsJSON())
+		wasSecondaryCalled = true
 	}))
 	t.Cleanup(fallback.Close)
 
@@ -67,6 +69,7 @@ func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
+	assert.True(t, wasSecondaryCalled)
 }
 
 func TestFetchAppsListFallbackOnPrimary404(t *testing.T) {

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -1,0 +1,304 @@
+package maintained_apps
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/fleetdm/fleet/v4/server/dev_mode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestAppsJSON returns a valid apps.json payload for testing.
+func newTestAppsJSON() []byte {
+	data, _ := json.Marshal(AppsList{
+		Version: 2,
+		Apps: []appListing{
+			{Name: "Test App", Slug: "test-app", Platform: "darwin", UniqueIdentifier: "com.test.app"},
+		},
+	})
+	return data
+}
+
+func TestFetchAppsListPrimarySuccess(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/apps.json", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(primary.Close)
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("fallback should not be called when primary succeeds")
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+	assert.Equal(t, "test-app", apps.Apps[0].Slug)
+}
+
+func TestFetchAppsListFallbackOnPrimaryFailure(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("primary is down"))
+	}))
+	t.Cleanup(primary.Close)
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/apps.json", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+	assert.Equal(t, "test-app", apps.Apps[0].Slug)
+}
+
+func TestFetchAppsListFallbackOnPrimary404(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(primary.Close)
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+}
+
+func TestFetchAppsListBothFail(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte("primary down"))
+	}))
+	t.Cleanup(primary.Close)
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("fallback down"))
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	_, err := FetchAppsList(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "primary")
+	assert.Contains(t, err.Error(), "fallback")
+}
+
+func TestFetchAppsListFallbackOnPrimaryNetworkError(t *testing.T) {
+	// Start and immediately close the primary to simulate a connection-refused error.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	primary.Close()
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+}
+
+func TestFetchAppsListOnlyFallbackFails(t *testing.T) {
+	// Primary works; fallback is broken. Nothing should break.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(primary.Close)
+
+	// Closed server as broken fallback.
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	fallback.Close()
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+}
+
+func TestFetchManifestDataFallbackUsedForSlugPath(t *testing.T) {
+	var primaryHits, fallbackHits atomic.Int32
+
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		primaryHits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(primary.Close)
+
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits.Add(1)
+		assert.Equal(t, "/test-app.json", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"test": true}`))
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	body, err := fetchManifestData(context.Background(), "/test-app.json")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"test"`)
+	assert.Equal(t, int32(1), primaryHits.Load(), "primary should have been tried once")
+	assert.Equal(t, int32(1), fallbackHits.Load(), "fallback should have been tried once")
+}
+
+func TestFetchManifestDataPrimarySucceedsSkipsFallback(t *testing.T) {
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok": true}`))
+	}))
+	t.Cleanup(primary.Close)
+
+	var fallbackHits atomic.Int32
+	fallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fallbackHits.Add(1)
+	}))
+	t.Cleanup(fallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", fallback.URL, t)
+
+	body, err := fetchManifestData(context.Background(), "/something.json")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), `"ok"`)
+	assert.Equal(t, int32(0), fallbackHits.Load(), "fallback must not be contacted when primary succeeds")
+}
+
+func TestResolveBaseURLsDefaults(t *testing.T) {
+	// Without any overrides and with dev mode disabled, resolveBaseURLs should
+	// return the hardcoded constants (dev_mode.Env returns "" when not enabled).
+	primary, fallback := resolveBaseURLs()
+	// We can't guarantee dev mode is off in the test runner, so just assert
+	// the values are non-empty.
+	assert.NotEmpty(t, primary)
+	assert.NotEmpty(t, fallback)
+}
+
+func TestResolveBaseURLsWithOverrides(t *testing.T) {
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", "http://custom-primary", t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", "http://custom-fallback", t)
+
+	primary, fallback := resolveBaseURLs()
+	assert.Equal(t, "http://custom-primary", primary)
+	assert.Equal(t, "http://custom-fallback", fallback)
+}
+
+func TestDoFetchSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/test.json", r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	t.Cleanup(srv.Close)
+
+	body, err := doFetch(context.Background(), srv.URL, "/test.json")
+	require.NoError(t, err)
+	assert.Equal(t, "ok", string(body))
+}
+
+func TestDoFetchNotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := doFetch(context.Background(), srv.URL, "/missing.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestDoFetchServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := doFetch(context.Background(), srv.URL, "/broken.json")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "502")
+}
+
+func TestDoFetchNetworkError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	srv.Close() // immediately close to force connection errors
+
+	_, err := doFetch(context.Background(), srv.URL, "/anything.json")
+	require.Error(t, err)
+}
+
+func TestDoFetchTruncatesLargeBody(t *testing.T) {
+	largeBody := make([]byte, 1024)
+	for i := range largeBody {
+		largeBody[i] = 'x'
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write(largeBody)
+	}))
+	t.Cleanup(srv.Close)
+
+	_, err := doFetch(context.Background(), srv.URL, "/big.json")
+	require.Error(t, err)
+	// The error message should contain at most 512 bytes of body.
+	assert.LessOrEqual(t, len(err.Error()), 600) // 512 body + status prefix
+}
+
+func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
+	// Both primary and original fallback are down; a custom fallback URL (set
+	// via the env var override) serves the request.
+	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(primary.Close)
+
+	customFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newTestAppsJSON())
+	}))
+	t.Cleanup(customFallback.Close)
+
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", primary.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", customFallback.URL, t)
+
+	apps, err := FetchAppsList(context.Background())
+	require.NoError(t, err)
+	require.Len(t, apps.Apps, 1)
+	assert.Equal(t, "test-app", apps.Apps[0].Slug)
+}

--- a/server/mdm/maintainedapps/sync_test.go
+++ b/server/mdm/maintainedapps/sync_test.go
@@ -203,13 +203,11 @@ func TestFetchManifestDataPrimarySucceedsSkipsFallback(t *testing.T) {
 }
 
 func TestResolveBaseURLsDefaults(t *testing.T) {
-	// Without any overrides and with dev mode disabled, resolveBaseURLs should
-	// return the hardcoded constants (dev_mode.Env returns "" when not enabled).
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", "", t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", "", t)
 	primary, fallback := resolveBaseURLs()
-	// We can't guarantee dev mode is off in the test runner, so just assert
-	// the values are non-empty.
-	assert.NotEmpty(t, primary)
-	assert.NotEmpty(t, fallback)
+	assert.Equal(t, fmaOutputsBase, primary)
+	assert.Equal(t, fmaOutputsFallbackBase, fallback)
 }
 
 func TestResolveBaseURLsWithOverrides(t *testing.T) {
@@ -265,7 +263,7 @@ func TestDoFetchNetworkError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestDoFetchTruncatesLargeBody(t *testing.T) {
+func TestDoFetchTruncatesLargeBodyInErrorMessage(t *testing.T) {
 	largeBody := make([]byte, 1024)
 	for i := range largeBody {
 		largeBody[i] = 'x'
@@ -284,16 +282,16 @@ func TestDoFetchTruncatesLargeBody(t *testing.T) {
 }
 
 func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
-	// Both primary and original fallback are down; a custom fallback URL (set
-	// via the env var override) serves the request.
 	primary := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	t.Cleanup(primary.Close)
 
+	fallbackWasCalled := false
 	customFallback := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write(newTestAppsJSON())
+		fallbackWasCalled = true
 	}))
 	t.Cleanup(customFallback.Close)
 
@@ -304,4 +302,5 @@ func TestFetchAppsListFallbackOverrideViaEnvVar(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, apps.Apps, 1)
 	assert.Equal(t, "test-app", apps.Apps[0].Slug)
+	assert.True(t, fallbackWasCalled)
 }

--- a/server/mdm/maintainedapps/testing_utils.go
+++ b/server/mdm/maintainedapps/testing_utils.go
@@ -3,7 +3,6 @@ package maintained_apps
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -45,7 +44,7 @@ func SyncApps(t *testing.T, ds fleet.Datastore) []fleet.MaintainedApp {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", srv.URL)
 	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL")
 
-	err := Refresh(context.Background(), ds, slog.New(slog.DiscardHandler))
+	err := SyncAppsList(context.Background(), ds)
 	require.NoError(t, err)
 
 	apps, _, err := ds.ListAvailableFleetMaintainedApps(context.Background(), nil, fleet.ListOptions{
@@ -101,7 +100,7 @@ func SyncAndRemoveApps(t *testing.T, ds fleet.Datastore) {
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", srv.URL)
 	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL")
 
-	err = Refresh(context.Background(), ds, slog.New(slog.DiscardHandler))
+	err = SyncAppsList(context.Background(), ds)
 	require.NoError(t, err)
 
 	originalApps, _, err := ds.ListAvailableFleetMaintainedApps(context.Background(), nil, fleet.ListOptions{})
@@ -113,7 +112,7 @@ func SyncAndRemoveApps(t *testing.T, ds fleet.Datastore) {
 	removedApp := appsFile.Apps[0]
 	appsFile.Apps = appsFile.Apps[1:]
 
-	err = Refresh(context.Background(), ds, slog.New(slog.DiscardHandler))
+	err = SyncAppsList(context.Background(), ds)
 	require.NoError(t, err)
 
 	modifiedApps, _, err := ds.ListAvailableFleetMaintainedApps(context.Background(), nil, fleet.ListOptions{})
@@ -128,7 +127,7 @@ func SyncAndRemoveApps(t *testing.T, ds fleet.Datastore) {
 	// remove all apps from upstream.
 	appsFile.Apps = []appListing{}
 
-	err = Refresh(context.Background(), ds, slog.New(slog.DiscardHandler))
+	err = SyncAppsList(context.Background(), ds)
 	require.NoError(t, err)
 
 	modifiedApps, _, err = ds.ListAvailableFleetMaintainedApps(context.Background(), nil, fleet.ListOptions{})

--- a/server/mdm/maintainedapps/testing_utils.go
+++ b/server/mdm/maintainedapps/testing_utils.go
@@ -43,6 +43,8 @@ func SyncApps(t *testing.T, ds fleet.Datastore) []fleet.MaintainedApp {
 	// this call
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", srv.URL)
 	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL")
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", srv.URL)
+	defer dev_mode.ClearOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL")
 
 	err := SyncAppsList(context.Background(), ds)
 	require.NoError(t, err)

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -1494,9 +1494,9 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 		_, _ = w.Write(state.installerBytes)
 	}))
 
-	// call Refresh directly (instead of SyncApps) since we're using the server above and not the file server
+	// call SyncAppsList directly (instead of SyncApps) since we're using the server above and not the file server
 	// created in SyncApps
-	err := maintained_apps.Refresh(t.Context(), ds, slog.New(slog.DiscardHandler))
+	err := maintained_apps.SyncAppsList(t.Context(), ds)
 	require.NoError(t, err)
 
 	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -15,6 +15,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1494,12 +1496,22 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 		_, _ = w.Write(state.installerBytes)
 	}))
 
-	// call SyncAppsList directly (instead of SyncApps) since we're using the server above and not the file server
-	// created in SyncApps
-	err := maintained_apps.SyncAppsList(t.Context(), ds)
-	require.NoError(t, err)
+	// Locate the repo's apps.json so the manifest server can serve it.
+	_, thisFile, _, _ := runtime.Caller(0)
+	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
+	appsJSONPath := filepath.Join(repoRoot, "ee", "maintained-apps", "outputs", "apps.json")
 
 	manifestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/apps.json" {
+			b, err := os.ReadFile(appsJSONPath)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			_, _ = w.Write(b)
+			return
+		}
+
 		var state *fmaTestState
 		state, found := states[r.URL.Path]
 		if !found {
@@ -1532,6 +1544,9 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 		installerServer.Close()
 	})
 	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_BASE_URL", manifestServer.URL, t)
+	dev_mode.SetOverride("FLEET_DEV_MAINTAINED_APPS_FALLBACK_BASE_URL", manifestServer.URL, t)
+
+	require.NoError(t, maintained_apps.SyncAppsList(t.Context(), ds))
 }
 
 // acmeCSRSigner adapts a depot.Signer to the acme.CSRSigner interface.

--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -1497,7 +1497,10 @@ func startFMAServers(t *testing.T, ds fleet.Datastore, states map[string]*fmaTes
 	}))
 
 	// Locate the repo's apps.json so the manifest server can serve it.
-	_, thisFile, _, _ := runtime.Caller(0)
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatalf("could not locate myself to serve apps.json file")
+	}
 	repoRoot := filepath.Dir(filepath.Dir(filepath.Dir(thisFile)))
 	appsJSONPath := filepath.Join(repoRoot, "ee", "maintained-apps", "outputs", "apps.json")
 


### PR DESCRIPTION
**Related issue:** Resolves #42754

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app manifest retrieval with automatic fallback to hosted copies when the primary source is unavailable, reducing sync failures.

* **Documentation**
  * Clarified that Fleet will fall back to hosted manifest copies if the new manifest site is inaccessible.

* **New Features**
  * Streamlined maintained-app synchronization to use a simpler sync entrypoint and unified primary/fallback fetch logic.

* **Tests**
  * Added comprehensive tests for primary/fallback fetch flows, error handling, large-response truncation, and environment-based overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->