### PR TITLE
Website: add maintainer and DRI for ee/fleet-agent-downloader to website custom config.

### DIFF
--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -162,8 +162,8 @@ module.exports.custom = {
     'ee/vulnerability-dashboard/scripts': 'eashaw',
     'ee/vulnerability-dashboard/package.json': 'eashaw',
 
-    // 🫧 Bulk operations dashboard
-    'ee/bulk-operations-dashboard': 'eashaw',// (catch-all)
+    // 🫧 Fleet agent downloader app
+    'ee/fleet-agent-downloader': 'eashaw',// (catch-all)
 
     // Handbook
     'handbook/company/pricing-features-table.yml': 'noahtalerman',
@@ -263,8 +263,8 @@ module.exports.custom = {
     'ee/vulnerability-dashboard/config/routes.js': 'eashaw',
     'ee/vulnerability-dashboard/package.json': 'eashaw',
 
-    // 🫧 Bulk operations dashboard
-    'ee/bulk-operations-dashboard': 'eashaw',
+    // 🫧 Fleet agent downloader app
+    'ee/fleet-agent-downloader': 'eashaw',
 
     // FMA and icons
     'frontend/pages/SoftwarePage/components/icons': 'allenhouchins',


### PR DESCRIPTION
Changes:
- Added the `ee/fleet-agent-downloader` directory to the `githubRepoDRIByPath` and `githubRepoMaintainersByPath` config values to the website's custom configuration, and removed `ee/bulk-operations-dashboard` (which was removed in the PR that added that directory).