### PR TITLE
Allow passthrough of securityContext.readOnlyRootFilesystem in Helm chart

### DIFF
--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -448,9 +448,9 @@ spec:
           capabilities:
             drop: [ALL]
           privileged: false
-          {{- if .Values.fleet.securityContext.readOnlyRootFilesystem }}
+          {{- if hasKey .Values.fleet.securityContext "readOnlyRootFilesystem" }}
           readOnlyRootFilesystem: {{ .Values.fleet.securityContext.readOnlyRootFilesystem }}
-          {{ else }}
+          {{- else }}
           readOnlyRootFilesystem: true
           {{- end }}
           {{- if .Values.fleet.securityContext.runAsGroup }}

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -448,7 +448,11 @@ spec:
           capabilities:
             drop: [ALL]
           privileged: false
+          {{- if .Values.fleet.securityContext.readOnlyRootFilesystem }}
+          readOnlyRootFilesystem: {{ .Values.fleet.securityContext.readOnlyRootFilesystem }}
+          {{ else }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
           {{- end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -125,7 +125,7 @@ fleet:
     licenseKey: license-key
   extraVolumes: []
   extraVolumeMounts: []
-  # Currently only passes runAsNonRoot, runAsUser, runAsGroup
+  # Currently only passes readOnlyRootFilesystem, runAsNonRoot, runAsUser, runAsGroup
   securityContext:
     readOnlyRootFilesystem: true
     runAsNonRoot: true

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -127,6 +127,7 @@ fleet:
   extraVolumeMounts: []
   # Currently only passes runAsNonRoot, runAsUser, runAsGroup
   securityContext:
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 3333
     runAsGroup: 3333


### PR DESCRIPTION
## Issue
Closes #43330 

## Description
This PR allows self-hosted, Kubernetes-based Fleet users to configure `securityContext.readOnlyRootFilesystem` in `values.yaml`, which is then propagated down to the `deployment.yaml` template.

This change provides a convenient mechanism for users to fix a known issue while preserving the current default behavior.

## Testing
The underlying `deployment.yaml` change has been tested in a standard Google Kubernetes Engine cluster, and is confirmed to fix the linked issue when using either Ubuntu-based or Container-Optimized OS (COS)-based `containerd` container runtimes in GKE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced fleet container security by making the read-only root filesystem setting configurable. Deployments can now customize this security parameter to meet specific requirements, while secure defaults are automatically applied for standard installations that don't require custom configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->