### PR TITLE
Allow msix-based FMAs to be added in the UI

### DIFF
--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -3080,10 +3080,14 @@ func (svc *Service) selfServiceInstallInHouseApp(ctx context.Context, host *flee
 
 // packageExtensionToPlatform returns the platform name based on the
 // package extension. Returns an empty string if there is no match.
+//
+// .msix is included for Fleet-maintained Windows apps only; custom package
+// upload still rejects .msix (see addMetadataToSoftwarePayload and
+// SoftwareInstallerPlatformFromExtension).
 func packageExtensionToPlatform(ext string) string {
 	var requiredPlatform string
 	switch ext {
-	case ".msi", ".exe", ".ps1":
+	case ".msi", ".exe", ".ps1", ".msix":
 		requiredPlatform = "windows"
 	case ".pkg", ".dmg", ".zip":
 		requiredPlatform = "darwin"

--- a/server/fleet/software_installer_test.go
+++ b/server/fleet/software_installer_test.go
@@ -161,7 +161,9 @@ func TestSoftwareInstallerPlatformFromExtension(t *testing.T) {
 		{".ps1", "windows", false},
 		{"ps1", "windows", false},
 
-		// Unsupported extensions
+		// Unsupported extensions (msix is fleet-maintained only, not custom upload)
+		{".msix", "", true},
+		{"msix", "", true},
 		{".txt", "", true},
 		{"", "", true},
 	}
@@ -211,7 +213,9 @@ func TestSofwareInstallerSourceFromExtensionAndName(t *testing.T) {
 		{".ps1", "script.ps1", "ps1_packages", false},
 		{"ps1", "setup.ps1", "ps1_packages", false},
 
-		// Unsupported extensions
+		// Unsupported extensions (msix is fleet-maintained only, not custom upload)
+		{".msix", "app.msix", "", true},
+		{"msix", "app.msix", "", true},
 		{".txt", "readme.txt", "", true},
 		{"", "noext", "", true},
 	}


### PR DESCRIPTION
This pull request updates the handling of `.msix` package extensions in the software installer logic to clarify support for Fleet-maintained Windows apps and to ensure custom uploads of `.msix` files remain unsupported. Test coverage is also expanded to explicitly check these cases.

**Platform support changes:**

* Updated `packageExtensionToPlatform` in `software_installers.go` to include `.msix` as a valid extension for Fleet-maintained Windows apps, while maintaining that custom uploads of `.msix` files are still rejected.

**Test coverage improvements:**

* Added test cases in `TestSoftwareInstallerPlatformFromExtension` and `TestSofwareInstallerSourceFromExtensionAndName` to ensure `.msix` files are correctly handled as unsupported for custom uploads. [[1]](diffhunk://#diff-581f0146919318ed08c10123ad2f4585bfcfda40cba1dfcb20a65afc40259f32L164-R166) [[2]](diffhunk://#diff-581f0146919318ed08c10123ad2f4585bfcfda40cba1dfcb20a65afc40259f32L214-R218)