### PR TITLE
Add alt text to Fleet logo in ee/fleet-agent-downloader

### DIFF
--- a/ee/fleet-agent-downloader/views/pages/dashboard/welcome.ejs
+++ b/ee/fleet-agent-downloader/views/pages/dashboard/welcome.ejs
@@ -11,7 +11,7 @@
     </div>
     <p>2. Double-click to open and install the software.</p>
     <p>You're done! You can confirm that your computer was added by clicking the Fleet icon in your system tray to open Fleet Desktop. There, you can see the information your organization collects from your computer.</p>
-    <div purpose="logo"><img src="/images/fleet-logo-black-33-69x24@2x.png"></div>
+    <div purpose="logo"><img alt="Fleet logo" src="/images/fleet-logo-black-33-69x24@2x.png"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Changes:
- Added alt text to the Fleet logo on the homepage of the ee/fleet-agent-downloader app