### PR TITLE
Filter winget version dirs and update Ollama outputs

### DIFF
--- a/ee/maintained-apps/ingesters/winget/ingester.go
+++ b/ee/maintained-apps/ingesters/winget/ingester.go
@@ -104,6 +104,27 @@ type wingetIngester struct {
 	logger       *slog.Logger
 }
 
+// wingetVersionManifestDirs keeps only subdirectory entries whose names look like winget
+// package version folders (semver-style). The upstream repo may add other top-level
+// folders (e.g. "Portable") that sort after numeric versions but are not manifest roots.
+func wingetVersionManifestDirs(contents []*github.RepositoryContent) []*github.RepositoryContent {
+	var out []*github.RepositoryContent
+	for _, c := range contents {
+		if c.GetType() != "dir" {
+			continue
+		}
+		name := c.GetName()
+		if len(name) == 0 {
+			continue
+		}
+		if name[0] < '0' || name[0] > '9' {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
 func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*maintained_apps.FMAManifestApp, error) {
 	// this is the path within the winget GitHub repo where the manifests are located
 	dirPath := path.Join(
@@ -122,11 +143,18 @@ func (i *wingetIngester) ingestOne(ctx context.Context, input inputApp) (*mainta
 		return nil, fmt.Errorf("get data from winget repo: %w", err)
 	}
 
+	versionDirs := wingetVersionManifestDirs(repoContents)
+	if len(versionDirs) == 0 {
+		return nil, ctxerr.NewWithData(ctx, "no version manifest directories found under package path", map[string]any{
+			"path": dirPath,
+		})
+	}
+
 	// sort the list of directories in descending order
-	slices.SortFunc(repoContents, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
+	slices.SortFunc(versionDirs, func(a, b *github.RepositoryContent) int { return feednvd.SmartVerCmp(b.GetName(), a.GetName()) })
 
 	// this directory has the latest version data in it
-	latestVersionDir := repoContents[0]
+	latestVersionDir := versionDirs[0]
 	if latestVersionDir.GetName() == "" {
 		return nil, ctxerr.New(ctx, "latest version for app not found")
 	}

--- a/ee/maintained-apps/ingesters/winget/ingester_test.go
+++ b/ee/maintained-apps/ingesters/winget/ingester_test.go
@@ -18,6 +18,25 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+func TestWingetVersionManifestDirs(t *testing.T) {
+	dir := func(name string) *github.RepositoryContent {
+		return &github.RepositoryContent{Name: &name, Type: ptr.String("dir")}
+	}
+	file := func(name string) *github.RepositoryContent {
+		return &github.RepositoryContent{Name: &name, Type: ptr.String("file")}
+	}
+	in := []*github.RepositoryContent{
+		dir("Portable"),
+		dir("0.9.6"),
+		dir("0.20.4"),
+		file("README.md"),
+	}
+	got := wingetVersionManifestDirs(in)
+	require.Len(t, got, 2)
+	assert.Equal(t, "0.9.6", got[0].GetName())
+	assert.Equal(t, "0.20.4", got[1].GetName())
+}
+
 func TestBuildUpgradeCodeBasedUninstallScript(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -245,10 +264,13 @@ func newTestServer(t *testing.T, cfg serverConfig) *httptest.Server {
 		switch r.URL.Path {
 
 		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo":
-			content := []github.RepositoryContent{{Name: ptr.String("Foo")}}
+			content := []github.RepositoryContent{{
+				Name: ptr.String("1.0"),
+				Type: ptr.String("dir"),
+			}}
 			require.NoError(t, json.NewEncoder(w).Encode(content))
 
-		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/Foo/Foo.installer.yaml":
+		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/1.0/Foo.installer.yaml":
 			manifest := installerManifest{
 				ProductCode:    cfg.productCode,
 				InstallerType:  cfg.installerType,
@@ -277,7 +299,7 @@ func newTestServer(t *testing.T, cfg serverConfig) *httptest.Server {
 			}
 			require.NoError(t, json.NewEncoder(w).Encode(content))
 
-		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/Foo/Foo.locale.en-US.yaml":
+		case "/repos/microsoft/winget-pkgs/contents/manifests/f/Foo/1.0/Foo.locale.en-US.yaml":
 			lManifest := localeManifest{
 				PackageName: "foo",
 				Publisher:   "Bar, Inc.",

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.20.3",
+      "version": "0.20.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.20.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.20.4') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.20.3/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.20.4/Ollama-darwin.zip",
       "install_script_ref": "306a3ea4",
       "uninstall_script_ref": "f60ddfee",
-      "sha256": "06539bf399b5733e64c0d0027b778921692aa54bc61f5a0c540bcac1d6bedd1f",
+      "sha256": "bdb988e4ffb68454df18789c3af13b52c79440c7033808b37fb0798e37272cdc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ollama/windows.json
+++ b/ee/maintained-apps/outputs/ollama/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.20.2",
+      "version": "0.20.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.20.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.20.4') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.20.2/OllamaSetup.exe",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.20.4/OllamaSetup.exe",
       "install_script_ref": "e14c71ee",
       "uninstall_script_ref": "3f049b5d",
-      "sha256": "31358c5062d608353a69f0f0ef3006dc397b7017819b9cb412a9a96ed2aa0bcc",
+      "sha256": "0a9530b8227313436447d90fc55c2cf033d48e1f6c2a4d87d907068689392c03",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Add wingetVersionManifestDirs to ignore non-version subfolders (e.g. "Portable") and only consider semver-style directories when selecting the latest manifest. Use the filtered list in ingestOne, return an error if no version dirs found, and update unit tests and test server paths to reflect the versioned directory layout. Also bump Ollama macOS and Windows outputs to v0.20.4, updating installer URLs, patched queries, and SHA256 checksums.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package version directory detection and filtering with enhanced error handling when version manifest directories are not found, providing clearer diagnostics.
* **Chores**
  * Updated Ollama to version 0.20.4 on macOS and Windows platforms, including updated checksums and installer references.
* **Tests**
  * Added test coverage for version directory filtering and updated test fixtures for manifest endpoint handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->