### PR TITLE
Update Android password policy and clarify how it works with BYOD

### DIFF
--- a/docs/solutions/android/configuration-profiles/README.md
+++ b/docs/solutions/android/configuration-profiles/README.md
@@ -1,0 +1,9 @@
+# Android Configuration Profiles
+
+
+## [Password Policy](password-policy.json)
+
+- This disables pattern and swipe, by only allowing PIN and password locks.
+- Google limits how the complexity requirements function on BYOD devices. For BYOD:
+  - `passwordMinimumLength` set to 8 makes the length requirement for PIN 8, password 6.
+  - `passwordMinimumLength` set to 6 makes the length requirement for PIN 6, password 4.

--- a/docs/solutions/android/configuration-profiles/password-policy.json
+++ b/docs/solutions/android/configuration-profiles/password-policy.json
@@ -1,7 +1,7 @@
 {
   "passwordPolicies": [
     {
-      "passwordMinimumLength": 6,
+      "passwordMinimumLength": 8,
       "passwordMinimumLetters": 1,
       "passwordMinimumSymbols": 1,
       "passwordQuality": "COMPLEX",


### PR DESCRIPTION
Discussed with `customer-pingali`, as the profile wasn't working the way they expected it to. After some additional testing, I figured out what was going on.

Unfortunately, Google limits the requirements we can enforce on BYOD devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Android password policy configuration to increase the minimum required password length from 6 to 8 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->