### PR TITLE
🤖 Fix installer dedupe for software that doesn't have a bundle ID

### DIFF
--- a/server/datastore/mysql/in_house_apps.go
+++ b/server/datastore/mysql/in_house_apps.go
@@ -1548,6 +1548,36 @@ WHERE
 	return exists == 1, nil
 }
 
+// checkInstallerExistsByTitleAndSource checks whether a software installer
+// already exists for the given title name, source, and platform within a team.
+// This is used for the name-based fallback dedup (when there is no
+// bundle_identifier or upgrade_code) so that packages with the same name but
+// different sources (e.g. ruby from deb_packages vs ruby from rpm_packages)
+// are not treated as duplicates.
+func (ds *Datastore) checkInstallerExistsByTitleAndSource(ctx context.Context, q sqlx.QueryerContext, teamID *uint, title, source, platform string) (bool, error) {
+	const stmt = `
+SELECT 1
+FROM
+	software_titles st
+	INNER JOIN software_installers ON st.id = software_installers.title_id AND software_installers.global_or_team_id = ?
+WHERE
+	st.name = ?
+	AND st.source = ?
+	AND software_installers.platform = ?
+`
+
+	var globalOrTeamID uint
+	if teamID != nil {
+		globalOrTeamID = *teamID
+	}
+	var exists int
+	err := sqlx.GetContext(ctx, q, &exists, stmt, globalOrTeamID, title, source, platform)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return false, ctxerr.Wrap(ctx, err, "check installer exists by title and source")
+	}
+	return exists == 1, nil
+}
+
 func (ds *Datastore) checkInHouseAppExistsForAdamID(ctx context.Context, q sqlx.QueryerContext, teamID *uint, appID fleet.VPPAppID) (exists bool, title string, err error) {
 	const stmt = `
 SELECT st.name

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3674,10 +3674,35 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 			}
 		}
 
-		if payload.Platform == "windows" {
+		// For platforms/installers without a bundle identifier, the DB unique
+		// constraint (global_or_team_id, title_id, version) is too loose to
+		// prevent duplicates (it was relaxed for FMA version rollback). We
+		// need explicit checks that mirror the unique_identifier generated
+		// column: COALESCE(bundle_identifier, application_id,
+		//                   NULLIF(upgrade_code,''), name).
+		//
+		// Windows MSI installers surface an upgrade_code that becomes the
+		// unique_identifier, so we must check by upgrade_code (not title).
+		// EXE/Linux/macOS-pkg-without-bundle-id all fall back to name.
+		if payload.BundleIdentifier == "" {
+			// 1. If the installer carries an UpgradeCode (Windows MSI), check
+			//    by that value because unique_identifier = upgrade_code.
+			if payload.UpgradeCode != "" {
+				exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.UpgradeCode, payload.Platform, softwareTypeInstaller)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "check if installer exists by upgrade code")
+				}
+				if exists {
+					return alreadyExists("installer", payload.Title)
+				}
+			}
+
+			// 2. Always check by title (= name), which is the final
+			//    COALESCE fallback and covers EXE, DEB, RPM, tar.gz,
+			//    pkg-without-bundle-id, and MSI without an upgrade code.
 			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.Title, payload.Platform, softwareTypeInstaller)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if installer exists for title identifier")
+				return ctxerr.Wrap(ctx, err, "check if installer exists by title")
 			}
 			if exists {
 				return alreadyExists("installer", payload.Title)

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3697,12 +3697,15 @@ func (ds *Datastore) checkSoftwareConflictsByIdentifier(ctx context.Context, pay
 				}
 			}
 
-			// 2. Always check by title (= name), which is the final
-			//    COALESCE fallback and covers EXE, DEB, RPM, tar.gz,
+			// 2. Always check by title (= name) AND source, which is the
+			//    final COALESCE fallback and covers EXE, DEB, RPM, tar.gz,
 			//    pkg-without-bundle-id, and MSI without an upgrade code.
-			exists, err := ds.checkInstallerOrInHouseAppExists(ctx, ds.reader(ctx), payload.TeamID, payload.Title, payload.Platform, softwareTypeInstaller)
+			//    We include source so that packages with the same name but
+			//    different sources (e.g. ruby from deb_packages vs ruby
+			//    from rpm_packages) are not treated as duplicates.
+			exists, err := ds.checkInstallerExistsByTitleAndSource(ctx, ds.reader(ctx), payload.TeamID, payload.Title, payload.Source, payload.Platform)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "check if installer exists by title")
+				return ctxerr.Wrap(ctx, err, "check if installer exists by title and source")
 			}
 			if exists {
 				return alreadyExists("installer", payload.Title)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4223,6 +4223,18 @@ func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Data
 		assert.Contains(t, err.Error(), "already has an installer")
 	})
 
+	// ---- Same platform, different sources (.deb vs .rpm) should NOT conflict ----
+	t.Run("same_platform_different_sources_no_conflict", func(t *testing.T) {
+		// A .deb and .rpm with the same title are different packages (different sources)
+		p1 := mkPayload("ruby", "deb", "linux", "deb_packages", "1.0", "", "", "ruby-deb-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		p2 := mkPayload("ruby", "rpm", "linux", "rpm_packages", "1.0", "", "", "ruby-rpm-hash-1")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.NoError(t, err, "same title with different sources (deb vs rpm) should be allowed")
+	})
+
 	// ---- Cross-platform: different platforms should NOT conflict ----
 	t.Run("different_platforms_no_conflict", func(t *testing.T) {
 		// A Linux package and a Windows package with the same title should not conflict

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4183,7 +4183,7 @@ func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Data
 		p2 := mkPayload("my-deb-pkg", "deb", "linux", "deb_packages", "2.0", "", "", "deb-hash-2")
 		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
 		require.Error(t, err, "adding a second .deb with the same title should fail")
-		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "my-deb-pkg", team.Name))
+		assert.Contains(t, err.Error(), "already has an installer")
 	})
 
 	// ---- Linux .rpm ----
@@ -4195,7 +4195,7 @@ func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Data
 		p2 := mkPayload("my-rpm-pkg", "rpm", "linux", "rpm_packages", "2.0", "", "", "rpm-hash-2")
 		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
 		require.Error(t, err, "adding a second .rpm with the same title should fail")
-		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "my-rpm-pkg", team.Name))
+		assert.Contains(t, err.Error(), "already has an installer")
 	})
 
 	// ---- Windows .exe ----
@@ -4207,7 +4207,7 @@ func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Data
 		p2 := mkPayload("My App", "exe", "windows", "programs", "2.0", "", "", "exe-hash-2")
 		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
 		require.Error(t, err, "adding a second .exe with the same title should fail")
-		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "My App", team.Name))
+		assert.Contains(t, err.Error(), "already has an installer")
 	})
 
 	// ---- Windows .msi with UpgradeCode ----
@@ -4220,7 +4220,7 @@ func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Data
 		p2 := mkPayload("MSI App Renamed", "msi", "windows", "programs", "2.0", "", "{UPGRADE-CODE-1}", "msi-hash-2")
 		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
 		require.Error(t, err, "adding a second .msi with the same upgrade code should fail")
-		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "MSI App Renamed", team.Name))
+		assert.Contains(t, err.Error(), "already has an installer")
 	})
 
 	// ---- Cross-platform: different platforms should NOT conflict ----

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -58,6 +58,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
+		{"MatchOrCreateSoftwareInstallerCrossPlatformDedup", testMatchOrCreateSoftwareInstallerCrossPlatformDedup},
 	}
 
 	for _, c := range cases {
@@ -4142,6 +4143,97 @@ func testSoftwareTitleDisplayName(t *testing.T, ds *Datastore) {
 	require.Len(t, names, 2)
 	require.Contains(t, names, "VPP1")
 	require.Contains(t, names, "ipa_foo")
+}
+
+func testMatchOrCreateSoftwareInstallerCrossPlatformDedup(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+	user := test.NewUser(t, ds, "Alice", "alice-dedup@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "dedup-team"})
+	require.NoError(t, err)
+
+	mkPayload := func(title, ext, platform, source, version, bundleID, upgradeCode, storageID string) *fleet.UploadSoftwareInstallerPayload {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(storageID), t.TempDir)
+		require.NoError(t, err)
+		return &fleet.UploadSoftwareInstallerPayload{
+			InstallerFile:    tfr,
+			Title:            title,
+			Extension:        ext,
+			Platform:         platform,
+			Source:           source,
+			Version:          version,
+			BundleIdentifier: bundleID,
+			UpgradeCode:      upgradeCode,
+			StorageID:        storageID,
+			Filename:         title + "." + ext,
+			InstallScript:    "echo install",
+			UninstallScript:  "echo uninstall",
+			UserID:           user.ID,
+			TeamID:           &team.ID,
+			ValidatedLabels:  &fleet.LabelIdentsWithScope{},
+		}
+	}
+
+	// ---- Linux .deb ----
+	t.Run("linux_deb_dedup", func(t *testing.T) {
+		p1 := mkPayload("my-deb-pkg", "deb", "linux", "deb_packages", "1.0", "", "", "deb-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		// Same title, different version → should be blocked by conflict check
+		p2 := mkPayload("my-deb-pkg", "deb", "linux", "deb_packages", "2.0", "", "", "deb-hash-2")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.Error(t, err, "adding a second .deb with the same title should fail")
+		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "my-deb-pkg", team.Name))
+	})
+
+	// ---- Linux .rpm ----
+	t.Run("linux_rpm_dedup", func(t *testing.T) {
+		p1 := mkPayload("my-rpm-pkg", "rpm", "linux", "rpm_packages", "1.0", "", "", "rpm-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		p2 := mkPayload("my-rpm-pkg", "rpm", "linux", "rpm_packages", "2.0", "", "", "rpm-hash-2")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.Error(t, err, "adding a second .rpm with the same title should fail")
+		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "my-rpm-pkg", team.Name))
+	})
+
+	// ---- Windows .exe ----
+	t.Run("windows_exe_dedup", func(t *testing.T) {
+		p1 := mkPayload("My App", "exe", "windows", "programs", "1.0", "", "", "exe-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		p2 := mkPayload("My App", "exe", "windows", "programs", "2.0", "", "", "exe-hash-2")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.Error(t, err, "adding a second .exe with the same title should fail")
+		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "My App", team.Name))
+	})
+
+	// ---- Windows .msi with UpgradeCode ----
+	t.Run("windows_msi_upgrade_code_dedup", func(t *testing.T) {
+		p1 := mkPayload("MSI App", "msi", "windows", "programs", "1.0", "", "{UPGRADE-CODE-1}", "msi-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		// Same upgrade code but different title and version → should still be blocked
+		p2 := mkPayload("MSI App Renamed", "msi", "windows", "programs", "2.0", "", "{UPGRADE-CODE-1}", "msi-hash-2")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.Error(t, err, "adding a second .msi with the same upgrade code should fail")
+		assert.Contains(t, err.Error(), fmt.Sprintf(fleet.CantAddSoftwareConflictMessage, "MSI App Renamed", team.Name))
+	})
+
+	// ---- Cross-platform: different platforms should NOT conflict ----
+	t.Run("different_platforms_no_conflict", func(t *testing.T) {
+		// A Linux package and a Windows package with the same title should not conflict
+		p1 := mkPayload("cross-plat-app", "deb", "linux", "deb_packages", "1.0", "", "", "cross-hash-1")
+		_, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, p1)
+		require.NoError(t, err)
+
+		p2 := mkPayload("cross-plat-app", "exe", "windows", "programs", "1.0", "", "", "cross-hash-2")
+		_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, p2)
+		require.NoError(t, err, "same title on different platforms should be allowed")
+	})
 }
 
 func testMatchOrCreateSoftwareInstallerDuplicateHash(t *testing.T, ds *Datastore) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -12554,7 +12554,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 		s.lastActivityMatches(fleet.ActivityTypeAddedSoftware{}.ActivityName(), activityData, 0)
 
 		// upload again fails
-		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already exists")
+		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already has an installer")
 
 		// update should succeed
 		s.updateSoftwareInstaller(t, &fleet.UpdateSoftwareInstallerPayload{
@@ -12759,7 +12759,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 		s.lastActivityOfTypeMatches(fleet.ActivityTypeAddedSoftware{}.ActivityName(), activityData, 0)
 
 		// upload again fails
-		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already exists")
+		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already has an installer")
 
 		// download the installer
 		r := s.Do("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package?alt=media", titleID), nil, http.StatusOK, "team_id", fmt.Sprintf("%d", *payload.TeamID))
@@ -12872,7 +12872,7 @@ func (s *integrationEnterpriseTestSuite) TestSoftwareInstallerUploadDownloadAndD
 			fmt.Sprintf(`{"software_title": "ruby", "software_package": "ruby.deb", "team_name": null, "team_id": 0, "fleet_name": null, "fleet_id": 0, "self_service": true, "software_title_id": %d}`, titleID), 0)
 
 		// upload again fails
-		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already exists")
+		s.uploadSoftwareInstaller(t, payload, http.StatusConflict, "already has an installer")
 
 		// download the installer
 		r := s.Do("GET", fmt.Sprintf("/api/latest/fleet/software/titles/%d/package?alt=media", titleID), nil, http.StatusOK, "team_id", fmt.Sprintf("%d", 0))


### PR DESCRIPTION
Zed + Opus 4.6; prompt below (Android apps were determined not to be affected):

It looks like we aren't properly deduplicating Windows and Linux (e.g. tarball, EXE) package-based installers on add, causing multiple installers to be add-able on top of each other, and deletions of one to reveal the previously uploaded installer rather than going to zero installers.

Diagnose when this issue started and why it happened. Then build a fix that works cross-platform. Looking for instances of `CantAddSoftwareConflictMessage` in the server-side codebase may help triage this.

This might also be an issue with Android VPP apps; check those too.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
