### PR TITLE
Update API endpoint reference in yaml-files.md

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -236,7 +236,7 @@ Reports can be specified inline in your `default.yml` file or `fleets/fleet-name
 
 ### Options
 
-For possible options, see the parameters for the [Create query API endpoint](https://fleetdm.com/docs/rest-api/rest-api#create-query).
+For possible options, see the parameters for the [Create report API endpoint](https://fleetdm.com/docs/rest-api/rest-api#create-report).
 
 ### Example
 


### PR DESCRIPTION
The GitOps documentation for reports was referencing an old url for queries.