### PR TITLE
41676 updated apple crs invalid domain error message

### DIFF
--- a/changes/41676-update-APNS-cert-invalid-domain-error-message
+++ b/changes/41676-update-APNS-cert-invalid-domain-error-message
@@ -1,0 +1,1 @@
+- Updated error message returned when an invalid domain is supplied for MDM Apple CSR signing

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
@@ -50,13 +50,13 @@ const ApplePushCertSetup = ({
   const onDownloadError = useCallback(
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if (msg.toLowerCase().includes("email address")) {
+      if (msg.includes("is not permitted for APNS certificate signing.")) {
         renderFlash("error", msg);
       } else if (msg.toLowerCase().includes("required private key")) {
         // replace link with actually clickable link
         renderFlash("error", ClickableUrls({ text: msg }));
       } else {
-        renderFlash("error", "Something's gone wrong. Please try again.");
+        renderFlash("error", "Something's gone wrong. Please try again3.");
       }
     },
     [renderFlash]

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/content/ApplePushCertSetup.tsx
@@ -56,7 +56,7 @@ const ApplePushCertSetup = ({
         // replace link with actually clickable link
         renderFlash("error", ClickableUrls({ text: msg }));
       } else {
-        renderFlash("error", "Something's gone wrong. Please try again3.");
+        renderFlash("error", "Something's gone wrong. Please try again.");
       }
     },
     [renderFlash]

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -121,8 +121,9 @@ const RenewCertModal = ({
         </ol>
         <div className={`${baseClass}__button-wrap`}>
           <Button
-            className={`${baseClass}__submit-button ${isUploading ? `uploading` : ""
-              }`}
+            className={`${baseClass}__submit-button ${
+              isUploading ? `uploading` : ""
+            }`}
             disabled={!certFile || isUploading}
             isLoading={isUploading}
             type="button"

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -62,7 +62,7 @@ const RenewCertModal = ({
   const onDownloadError = useCallback(
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if ((e as any)?.response?.headers?.['invalidEmailDomain']) {
+      if ((e as any)?.response?.headers?.["invalidEmailDomain"]) {
         renderFlash("error", msg);
       } else {
         renderFlash("error", "Something's gone wrong. Please try again.");

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -62,7 +62,7 @@ const RenewCertModal = ({
   const onDownloadError = useCallback(
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if ((e as any)?.response?.headers?.["invalidEmailDomain"]) {
+      if (msg.toLowerCase().includes("email address is not valid")) {
         renderFlash("error", msg);
       } else {
         renderFlash("error", "Something's gone wrong. Please try again.");

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -63,8 +63,7 @@ const RenewCertModal = ({
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (e: unknown) => {
       const msg = getErrorReason(e);
-
-      if (msg.toLowerCase().includes("email address is not valid")) {
+      if (msg.toLowerCase().includes("Email domain is not permitted")) {
         renderFlash("error", msg);
       } else {
         renderFlash("error", "Something's gone wrong. Please try again.");
@@ -122,9 +121,8 @@ const RenewCertModal = ({
         </ol>
         <div className={`${baseClass}__button-wrap`}>
           <Button
-            className={`${baseClass}__submit-button ${
-              isUploading ? `uploading` : ""
-            }`}
+            className={`${baseClass}__submit-button ${isUploading ? `uploading` : ""
+              }`}
             disabled={!certFile || isUploading}
             isLoading={isUploading}
             type="button"

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -60,10 +60,9 @@ const RenewCertModal = ({
   }, [certFile, renderFlash, onCancel, onRenew]);
 
   const onDownloadError = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if (msg.toLowerCase().includes("Email domain is not permitted")) {
+      if ((e as any)?.response?.headers?.['invalidEmailDomain']) {
         renderFlash("error", msg);
       } else {
         renderFlash("error", "Something's gone wrong. Please try again.");

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -65,7 +65,7 @@ const RenewCertModal = ({
       if (msg.includes("is not permitted for APNS certificate signing.")) {
         renderFlash("error", msg);
       } else {
-        renderFlash("error", "Something's gone wrong. Please try again2.");
+        renderFlash("error", "Something's gone wrong. Please try again.");
       }
     },
     [renderFlash]

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleMdmPage/components/modals/RenewCertModal/RenewCertModal.tsx
@@ -62,10 +62,10 @@ const RenewCertModal = ({
   const onDownloadError = useCallback(
     (e: unknown) => {
       const msg = getErrorReason(e);
-      if (msg.toLowerCase().includes("email address is not valid")) {
+      if (msg.includes("is not permitted for APNS certificate signing.")) {
         renderFlash("error", msg);
       } else {
-        renderFlash("error", "Something's gone wrong. Please try again.");
+        renderFlash("error", "Something's gone wrong. Please try again2.");
       }
     },
     [renderFlash]

--- a/server/mdm/apple/cert.go
+++ b/server/mdm/apple/cert.go
@@ -92,8 +92,9 @@ func NewPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 type FleetWebsiteError struct {
-	Status  int
-	message string
+	Status   int
+	message  string
+	ExitType string // populated from x-exit response header
 }
 
 func (e FleetWebsiteError) Error() string {
@@ -142,7 +143,11 @@ func GetSignedAPNSCSR(client *http.Client, csr *x509.CertificateRequest) error {
 
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(resp.Body)
-		return FleetWebsiteError{Status: resp.StatusCode, message: string(b)}
+		return FleetWebsiteError{
+			Status:   resp.StatusCode,
+			message:  string(b),
+			ExitType: resp.Header.Get("x-exit"),
+		}
 	}
 	return nil
 }
@@ -188,7 +193,7 @@ func GetSignedAPNSCSRNoEmail(client *http.Client, csr *x509.CertificateRequest) 
 		return nil, fmt.Errorf("parsing CSR body response from fleetdm api: %w", err)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, FleetWebsiteError{Status: resp.StatusCode, message: string(respBytes)}
+		return nil, FleetWebsiteError{Status: resp.StatusCode, message: string(respBytes), ExitType: resp.Header.Get("x-exit")}
 	}
 
 	var csrResp websiteSignCSRResponse

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -1957,9 +1957,9 @@ func (s *integrationMDMTestSuite) TestAppleMDMCSRRequest() {
 	// fleetdm CSR request failed
 	s.FailNextCSRRequestWith(http.StatusBadRequest)
 	errResp = validationErrResp{}
-	s.DoJSON("POST", "/api/latest/fleet/mdm/apple/request_csr", requestMDMAppleCSRRequest{EmailAddress: "a@b.c", Organization: "test"}, http.StatusUnprocessableEntity, &errResp)
+	s.DoJSON("POST", "/api/latest/fleet/mdm/apple/request_csr", requestMDMAppleCSRRequest{EmailAddress: "a@gmail.com", Organization: "test"}, http.StatusUnprocessableEntity, &errResp)
 	require.Len(t, errResp.Errors, 1)
-	require.Contains(t, errResp.Errors[0].Reason, "this email address is not valid")
+	require.Contains(t, errResp.Errors[0].Reason, "CSR request failed. Email domain '@gmail.com' is not permitted for APNS certificate signing. Please use a corporate or organization email address.")
 
 	s.FailNextCSRRequestWith(http.StatusInternalServerError)
 	errResp = validationErrResp{}
@@ -2017,7 +2017,7 @@ func (s *integrationMDMTestSuite) TestGetMDMCSR() {
 	errResp = validationErrResp{}
 	s.DoJSON("GET", "/api/latest/fleet/mdm/apple/request_csr", getMDMAppleCSRRequest{}, http.StatusUnprocessableEntity, &errResp)
 	require.Len(t, errResp.Errors, 1)
-	require.Contains(t, errResp.Errors[0].Reason, "this email address is not valid")
+	require.Contains(t, errResp.Errors[0].Reason, "CSR request failed. Email domain '@example.com' is not permitted for APNS certificate signing. Please use a corporate or organization email address.")
 
 	// Invalid APNS cert upload attempt
 	s.uploadDataViaForm("/api/latest/fleet/mdm/apple/apns_certificate", "certificate", "certificate.pem", []byte("invalid-cert"), http.StatusUnprocessableEntity, "Invalid certificate. Please provide a valid certificate from Apple Push Certificate Portal.", nil)

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -559,9 +559,14 @@ func (s *integrationMDMTestSuite) SetupSuite() {
 
 	fleetdmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		status := s.fleetDMNextCSRStatus.Swap(http.StatusOK)
-		w.WriteHeader(status.(int))
-		resp := []byte(fmt.Sprintf("status: %d", status))
-		if status == http.StatusOK && strings.Contains(r.URL.RawQuery, "deliveryMethod=json") {
+		statusCode := status.(int)
+		// Set x-exit header for invalid email domain errors (400 or 422 status)
+		if statusCode == http.StatusBadRequest || statusCode == http.StatusUnprocessableEntity {
+			w.Header().Set("x-exit", "invalidEmailDomain")
+		}
+		w.WriteHeader(statusCode)
+		resp := []byte(fmt.Sprintf("status: %d", statusCode))
+		if statusCode == http.StatusOK && strings.Contains(r.URL.RawQuery, "deliveryMethod=json") {
 			rawBody, err := io.ReadAll(r.Body)
 			require.NoError(s.T(), err)
 			var req struct {

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -183,6 +183,7 @@ func (svc *Service) RequestMDMAppleCSR(ctx context.Context, email, org string) (
 		if ferr, ok := err.(apple_mdm.FleetWebsiteError); ok {
 			status := http.StatusBadGateway
 			if ferr.Status >= 400 && ferr.Status <= 499 {
+				domain := "@" + strings.SplitN(email, "@", 2)[1]
 				// TODO: fleetdm.com returns a genereric "Bad
 				// Request" message, we should coordinate and
 				// stablish a response schema from which we can get
@@ -196,7 +197,7 @@ func (svc *Service) RequestMDMAppleCSR(ctx context.Context, email, org string) (
 					ctx,
 					fleet.NewInvalidArgumentError(
 						"email_address",
-						fmt.Sprintf("this email address is not valid: %v", err),
+						fmt.Sprintf("CSR request failed. Email domain '%s' is not permitted for APNS certificate signing. Please use a corporate or organization email address.:%v", domain, err),
 					),
 				)
 			}
@@ -3131,11 +3132,12 @@ func (svc *Service) GetMDMAppleCSR(ctx context.Context) ([]byte, error) {
 		if errors.As(err, &fwe) {
 			// From svc.RequestMDMAppleCSR: fleetdm.com returns a bad request here if the email is invalid.
 			if fwe.Status >= 400 && fwe.Status <= 499 {
+				domain := "@" + strings.SplitN(vc.Email(), "@", 2)[1]
 				return nil, ctxerr.Wrap(
 					ctx,
 					fleet.NewInvalidArgumentError(
 						"email_address",
-						fmt.Sprintf("this email address is not valid: %v", err),
+						fmt.Sprintf("CSR request failed. Email domain '%s' is not permitted for APNS certificate signing. Please use a corporate or organization email address.", domain),
 					),
 				)
 			}

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -182,22 +182,13 @@ func (svc *Service) RequestMDMAppleCSR(ctx context.Context, email, org string) (
 	if err := apple_mdm.GetSignedAPNSCSR(client, apnsCSR); err != nil {
 		if ferr, ok := err.(apple_mdm.FleetWebsiteError); ok {
 			status := http.StatusBadGateway
-			if ferr.Status >= 400 && ferr.Status <= 499 {
+			if ferr.ExitType == "invalidEmailDomain" {
 				domain := "@" + strings.SplitN(email, "@", 2)[1]
-				// TODO: fleetdm.com returns a genereric "Bad
-				// Request" message, we should coordinate and
-				// stablish a response schema from which we can get
-				// the invalid field and use
-				// fleet.NewInvalidArgumentError instead
-				//
-				// For now, since we have already validated
-				// everything else, we assume that a 4xx
-				// response is an email with an invalid domain
 				return nil, ctxerr.Wrap(
 					ctx,
 					fleet.NewInvalidArgumentError(
 						"email_address",
-						fmt.Sprintf("CSR request failed. Email domain '%s' is not permitted for APNS certificate signing. Please use a corporate or organization email address.:%v", domain, err),
+						fmt.Sprintf("CSR request failed. Email domain '%s' is not permitted for APNS certificate signing. Please use a corporate or organization email address.", domain),
 					),
 				)
 			}
@@ -3131,7 +3122,7 @@ func (svc *Service) GetMDMAppleCSR(ctx context.Context) ([]byte, error) {
 		var fwe apple_mdm.FleetWebsiteError
 		if errors.As(err, &fwe) {
 			// From svc.RequestMDMAppleCSR: fleetdm.com returns a bad request here if the email is invalid.
-			if fwe.Status >= 400 && fwe.Status <= 499 {
+			if fwe.ExitType == "invalidEmailDomain" {
 				domain := "@" + strings.SplitN(vc.Email(), "@", 2)[1]
 				return nil, ctxerr.Wrap(
 					ctx,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41676

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ x] Added/updated automated tests

- [x ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple MDM APNS certificate signing now shows a clear, domain-specific error when an unsupported email domain is supplied (applies to CSR requests and renewal flows), replacing the previous generic "invalid email" message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->