### PR TITLE
Website: update when stripe customers are created for new users

### DIFF
--- a/website/api/controllers/customers/get-stripe-checkout-session-url.js
+++ b/website/api/controllers/customers/get-stripe-checkout-session-url.js
@@ -25,6 +25,11 @@ module.exports = {
 
 
   fn: async function (inputs) {
+
+    if (!sails.config.custom.enableBillingFeatures) {// Note: this variable is set in the custom hook if stripePublishableKey and stripeSecret config variables are set.
+      throw new Error('The Stripe configuration variables (sails.config.custom.stripePublishableKey and sails.config.custom.stripeSecret) are missing!');
+    }
+
     // Configure Stripe
     const stripe = require('stripe')(sails.config.custom.stripeSecret);
 
@@ -34,13 +39,24 @@ module.exports = {
       throw new Error(`Consistency violation: The specified quote (${inputs.quoteId}) no longer seems to exist.`);
     }
 
+    let stripeCustomerId = this.req.me.stripeCustomerId;
     // What if the stripe customer id doesn't already exist on the user?
-    if (!this.req.me.stripeCustomerId) {
-      throw new Error(`Consistency violation: The logged-in user's (${this.req.me.emailAddress}) Stripe customer id has somehow gone missing!`);
+    if (!stripeCustomerId) {
+      // Create a new customer entry in the Stripe API for this user before we create a checkout session for their license dispenser purchase.
+      stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
+        emailAddress: this.req.me.emailAddress
+      })
+      .timeout(5000)
+      .retry()
+      .intercept((error)=>{
+        return new Error(`An error occurred when trying to create a Stripe Customer for a user with the using the email address ${this.req.me.emailAddress} tried to create a Stripe checkout session to purchase a self-service license. Full error: ${error.raw}`);
+      });
+
+      await User.updateOne({id: this.req.me.id}).set({stripeCustomerId: stripeCustomerId});
     }
     // Create a new Stripe checkout session for this subscription.
     let stripeCheckoutSession = await stripe.checkout.sessions.create({
-      customer: this.req.me.stripeCustomerId,
+      customer: stripeCustomerId,
       customer_update: {// eslint-disable-line camelcase
         name: 'auto',
         address: 'auto',

--- a/website/api/controllers/customers/get-stripe-checkout-session-url.js
+++ b/website/api/controllers/customers/get-stripe-checkout-session-url.js
@@ -49,7 +49,7 @@ module.exports = {
       .timeout(5000)
       .retry()
       .intercept((error)=>{
-        return new Error(`An error occurred when trying to create a Stripe Customer for a user with the using the email address ${this.req.me.emailAddress} tried to create a Stripe checkout session to purchase a self-service license. Full error: ${error.raw}`);
+        return new Error(`An error occurred when trying to create a Stripe Customer for a user (email address: ${this.req.me.emailAddress}) tried to create a Stripe checkout session to purchase a self-service license. Full error: ${error.raw}`);
       });
 
       await User.updateOne({id: this.req.me.id}).set({stripeCustomerId: stripeCustomerId});

--- a/website/api/controllers/entrance/signup.js
+++ b/website/api/controllers/entrance/signup.js
@@ -110,20 +110,6 @@ the account verification message.)`,
       organization = emailDomain;
     }
 
-
-    if (!sails.config.custom.enableBillingFeatures) {
-      throw new Error('The Stripe configuration variables (sails.config.custom.stripePublishableKey and sails.config.custom.stripeSecret) are missing!');
-    }
-
-    // Create a new customer entry in the Stripe API for this user before we send a request to the cloud provisioner.
-    let stripeCustomerId = await sails.helpers.stripe.saveBillingInfo.with({
-      emailAddress: newEmailAddress
-    })
-    .timeout(5000)
-    .retry()
-    .intercept((error)=>{
-      return new Error(`An error occurred when trying to create a Stripe Customer for a new user with the using the email address ${newEmailAddress}. The incomplete user record has not been saved in the database, and the user will be asked to try signing up again. Full error: ${error.raw}`);
-    });
     let newUserRecord = await User.create(_.extend({
       firstName,
       lastName,
@@ -131,7 +117,6 @@ the account verification message.)`,
       emailAddress: newEmailAddress,
       signupReason,
       password: await sails.helpers.passwords.hashPassword(password),
-      stripeCustomerId,
       tosAcceptedByIp: this.req.ip
     }, sails.config.custom.verifyEmailAddresses? {
       emailProofToken: await sails.helpers.strings.random('url-friendly'),


### PR DESCRIPTION
Changes:
- Updated when Stripe customers are created for users who sign up on the website. A Stripe customer will be created for new users if they purchase a self-service Fleet Premium license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stripe customer accounts are now created during checkout instead of at signup, deferring billing setup until needed.
  * Signup no longer creates a Stripe customer record as part of user registration.
  * Checkout now enforces billing feature availability and includes improved handling when creating customer billing records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->