### PR TITLE
Refactor apps list update and add tests

### DIFF
--- a/cmd/maintained-apps/main.go
+++ b/cmd/maintained-apps/main.go
@@ -57,6 +57,10 @@ func main() {
 	}
 }
 
+func appsListJSONPath() string {
+	return path.Join(maintained_apps.OutputPath, "apps.json")
+}
+
 func processOutput(ctx context.Context, app *maintained_apps.FMAManifestApp) error {
 	// validate categories before writing any files
 	if err := validateCategories(ctx, app); err != nil {
@@ -71,7 +75,7 @@ func processOutput(ctx context.Context, app *maintained_apps.FMAManifestApp) err
 		return ctxerr.Wrap(ctx, err, "validating categories")
 	}
 
-	if err := updateAppsListFile(ctx, app); err != nil {
+	if err := updateAppsListFileAt(ctx, appsListJSONPath(), app); err != nil {
 		return ctxerr.Wrap(ctx, err, "updating apps list file")
 	}
 	app.UniqueIdentifier = "" // make sure we don't leak unique_identifier into individual app manifests
@@ -144,8 +148,42 @@ func validateCategories(ctx context.Context, app *maintained_apps.FMAManifestApp
 	return nil
 }
 
-func updateAppsListFile(ctx context.Context, outApp *maintained_apps.FMAManifestApp) error {
-	appListFilePath := path.Join(maintained_apps.OutputPath, "apps.json")
+func listFileAppFromManifest(outApp *maintained_apps.FMAManifestApp) (maintained_apps.FMAListFileApp, error) {
+	platform := outApp.Platform()
+	if platform == "" {
+		return maintained_apps.FMAListFileApp{}, fmt.Errorf("invalid platform found for slug %s", outApp.Slug)
+	}
+	return maintained_apps.FMAListFileApp{
+		Name:             outApp.Name,
+		Slug:             outApp.Slug,
+		Platform:         platform,
+		UniqueIdentifier: outApp.UniqueIdentifier,
+	}, nil
+}
+
+func writeAppsListJSON(appListFilePath string, outputAppsFile *maintained_apps.FMAListFile) error {
+	slices.SortFunc(outputAppsFile.Apps, func(a, b maintained_apps.FMAListFileApp) int {
+		return strings.Compare(a.Slug, b.Slug)
+	})
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(outputAppsFile); err != nil {
+		return fmt.Errorf("marshaling apps list: %w", err)
+	}
+	if err := os.WriteFile(appListFilePath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("writing apps list: %w", err)
+	}
+	return nil
+}
+
+func updateAppsListFileAt(ctx context.Context, appListFilePath string, outApp *maintained_apps.FMAManifestApp) error {
+	newRow, err := listFileAppFromManifest(outApp)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "building apps list row")
+	}
+
 	inputJson, err := os.ReadFile(appListFilePath)
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "reading output apps list file")
@@ -156,43 +194,25 @@ func updateAppsListFile(ctx context.Context, outApp *maintained_apps.FMAManifest
 		return ctxerr.Wrap(ctx, err, "unmarshaling output apps list file")
 	}
 
-	var found bool
-	for _, a := range outputAppsFile.Apps {
-		if a.Slug == outApp.Slug {
-			found = true
-			break
+	for i, a := range outputAppsFile.Apps {
+		if a.Slug != outApp.Slug {
+			continue
 		}
-	}
-
-	if !found {
-		platform := outApp.Platform()
-		if platform == "" {
-			return ctxerr.New(ctx, fmt.Sprintf("invalid platform found for slug %s", outApp.Slug))
+		updated := newRow
+		updated.Description = a.Description
+		if updated == a {
+			return nil
 		}
-
-		outputAppsFile.Apps = append(outputAppsFile.Apps, maintained_apps.FMAListFileApp{
-			Name:             outApp.Name,
-			Slug:             outApp.Slug,
-			Platform:         platform,
-			UniqueIdentifier: outApp.UniqueIdentifier,
-		})
-
-		// Keep existing order
-		slices.SortFunc(outputAppsFile.Apps, func(a, b maintained_apps.FMAListFileApp) int { return strings.Compare(a.Slug, b.Slug) })
-
-		var buf bytes.Buffer
-		encoder := json.NewEncoder(&buf)
-		encoder.SetEscapeHTML(false)
-		encoder.SetIndent("", "  ")
-		if err := encoder.Encode(outputAppsFile); err != nil {
-			return ctxerr.Wrap(ctx, err, "marshaling updated output apps file")
-		}
-		updatedFile := buf.Bytes()
-
-		if err := os.WriteFile(appListFilePath, updatedFile, 0o644); err != nil {
+		outputAppsFile.Apps[i] = updated
+		if err := writeAppsListJSON(appListFilePath, &outputAppsFile); err != nil {
 			return ctxerr.Wrap(ctx, err, "writing updated output apps file")
 		}
+		return nil
 	}
 
+	outputAppsFile.Apps = append(outputAppsFile.Apps, newRow)
+	if err := writeAppsListJSON(appListFilePath, &outputAppsFile); err != nil {
+		return ctxerr.Wrap(ctx, err, "writing updated output apps file")
+	}
 	return nil
 }

--- a/cmd/maintained-apps/main_test.go
+++ b/cmd/maintained-apps/main_test.go
@@ -2,9 +2,14 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	maintained_apps "github.com/fleetdm/fleet/v4/ee/maintained-apps"
 )
 
 func TestJSONEncoderPreservesHTML(t *testing.T) {
@@ -44,4 +49,103 @@ func TestJSONEncoderPreservesHTML(t *testing.T) {
 	}
 
 	t.Logf("Successfully preserved HTML in JSON output: %s", result)
+}
+
+func TestUpdateAppsListFileAt_UpdatesMetadataPreservesDescription(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	listPath := filepath.Join(dir, "apps.json")
+	initial := maintained_apps.FMAListFile{
+		Version: 2,
+		Apps: []maintained_apps.FMAListFileApp{
+			{
+				Name:             "Old Name",
+				Slug:             "my-app/darwin",
+				Platform:         "darwin",
+				UniqueIdentifier: "com.old.id",
+				Description:      "Hand-written blurb.",
+			},
+		},
+	}
+	if err := writeAppsListJSON(listPath, &initial); err != nil {
+		t.Fatal(err)
+	}
+
+	app := &maintained_apps.FMAManifestApp{
+		Slug:             "my-app/darwin",
+		Name:             "New Name",
+		UniqueIdentifier: "com.new.id",
+		Version:          "1", // non-empty so IsEmpty is false if reused elsewhere
+		InstallerURL:     "https://example.com/x",
+		InstallScriptRef: "a",
+		UninstallScriptRef: "b",
+		SHA256:           "c",
+		Queries:          maintained_apps.FMAQueries{Exists: "SELECT 1"},
+	}
+	if err := updateAppsListFileAt(ctx, listPath, app); err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := os.ReadFile(listPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got maintained_apps.FMAListFile
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if len(got.Apps) != 1 {
+		t.Fatalf("apps: %d", len(got.Apps))
+	}
+	row := got.Apps[0]
+	if row.Name != "New Name" || row.UniqueIdentifier != "com.new.id" || row.Description != "Hand-written blurb." {
+		t.Fatalf("got %+v", row)
+	}
+}
+
+func TestUpdateAppsListFileAt_NoWriteWhenUnchanged(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	listPath := filepath.Join(dir, "apps.json")
+	initial := maintained_apps.FMAListFile{
+		Version: 2,
+		Apps: []maintained_apps.FMAListFileApp{
+			{
+				Name:             "Same",
+				Slug:             "my-app/darwin",
+				Platform:         "darwin",
+				UniqueIdentifier: "com.same",
+				Description:      "D",
+			},
+		},
+	}
+	if err := writeAppsListJSON(listPath, &initial); err != nil {
+		t.Fatal(err)
+	}
+	stamp, err := os.Stat(listPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := &maintained_apps.FMAManifestApp{
+		Slug:             "my-app/darwin",
+		Name:             "Same",
+		UniqueIdentifier: "com.same",
+		Version:          "1",
+		InstallerURL:     "https://example.com/x",
+		InstallScriptRef: "a",
+		UninstallScriptRef: "b",
+		SHA256:           "c",
+		Queries:          maintained_apps.FMAQueries{Exists: "SELECT 1"},
+	}
+	if err := updateAppsListFileAt(ctx, listPath, app); err != nil {
+		t.Fatal(err)
+	}
+	after, err := os.Stat(listPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after.ModTime() != stamp.ModTime() {
+		t.Fatal("expected no write when row unchanged")
+	}
 }


### PR DESCRIPTION
Extract apps list handling into helper functions and update call-sites: add appsListJSONPath(), listFileAppFromManifest(), writeAppsListJSON(), and updateAppsListFileAt() which replaces the previous updateAppsListFile logic. The new writer sorts and pretty-prints JSON, preserves existing description when updating an entry, and avoids rewriting the file if nothing changed. processOutput() now uses updateAppsListFileAt(). Add unit tests for updating metadata while preserving description and for ensuring no write occurs when a row is unchanged; update imports accordingly.