### PR TITLE
Fix OSV sync shallow clone failing on quiet weekends

### DIFF
--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Configuration
 REPO_URL="https://github.com/canonical/ubuntu-security-notices.git"
 REPO_DIR="ubuntu-security-notices"
-DAYS_TO_KEEP=3 # how much git history to get for initial clone
+DAYS_TO_KEEP=7 # how much git history to get for initial clone
 
 echo "=== OSV Repository Sync ==="
 echo ""
@@ -57,7 +57,11 @@ else
     git config core.sparseCheckout true
     echo "osv/" > .git/info/sparse-checkout
 
-    git fetch --shallow-since="${DAYS_TO_KEEP} days ago" origin main
+    # --shallow-since fails with "error processing shallow info: 4" when the
+    # remote has no commits newer than the cutoff (e.g. a quiet weekend). Fall
+    # back to a depth-based fetch so the initial clone always succeeds.
+    git fetch --shallow-since="${DAYS_TO_KEEP} days ago" origin main \
+        || git fetch --depth=50 origin main
     git checkout -b main --track origin/main
 
     COMMIT_SHA=$(git rev-parse HEAD)

--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 # Configuration
 REPO_URL="https://github.com/canonical/ubuntu-security-notices.git"
 REPO_DIR="ubuntu-security-notices"
-DAYS_TO_KEEP=7 # how much git history to get for initial clone
+DAYS_TO_KEEP=3 # how much git history to get for initial clone
 
 echo "=== OSV Repository Sync ==="
 echo ""
@@ -57,11 +57,17 @@ else
     git config core.sparseCheckout true
     echo "osv/" > .git/info/sparse-checkout
 
-    # --shallow-since fails with "error processing shallow info: 4" when the
-    # remote has no commits newer than the cutoff (e.g. a quiet weekend). Fall
-    # back to a depth-based fetch so the initial clone always succeeds.
-    git fetch --shallow-since="${DAYS_TO_KEEP} days ago" origin main \
-        || git fetch --depth=50 origin main
+    if ! git fetch --shallow-since="${DAYS_TO_KEEP} days ago" origin main; then
+        echo ""
+        echo "WARNING: --shallow-since=${DAYS_TO_KEEP}d returned no commits."
+        echo "Upstream has been quiet for >${DAYS_TO_KEEP} days. Falling back to --depth=3."
+        echo ""
+        git fetch --depth=3 origin main
+        echo "Recent history:"
+        git log --pretty=format:'%h %ci %s' origin/main
+        echo ""
+        echo ""
+    fi
     git checkout -b main --track origin/main
 
     COMMIT_SHA=$(git rev-parse HEAD)

--- a/cmd/osv-processor/sync-and-detect-changes.sh
+++ b/cmd/osv-processor/sync-and-detect-changes.sh
@@ -16,6 +16,10 @@ set -euo pipefail
 REPO_URL="https://github.com/canonical/ubuntu-security-notices.git"
 REPO_DIR="ubuntu-security-notices"
 DAYS_TO_KEEP=3 # how much git history to get for initial clone
+# Fallback depth used when --shallow-since returns no commits (upstream was quiet).
+# The sync only needs the tip commit to populate the working tree.
+# We grab a few extra commits so the warning log shows recent upstream activity for debugging.
+FALLBACK_DEPTH=3
 
 echo "=== OSV Repository Sync ==="
 echo ""
@@ -60,9 +64,9 @@ else
     if ! git fetch --shallow-since="${DAYS_TO_KEEP} days ago" origin main; then
         echo ""
         echo "WARNING: --shallow-since=${DAYS_TO_KEEP}d returned no commits."
-        echo "Upstream has been quiet for >${DAYS_TO_KEEP} days. Falling back to --depth=3."
+        echo "Upstream has been quiet for >${DAYS_TO_KEEP} days. Falling back to --depth=${FALLBACK_DEPTH}."
         echo ""
-        git fetch --depth=3 origin main
+        git fetch --depth="${FALLBACK_DEPTH}" origin main
         echo "Recent history:"
         git log --pretty=format:'%h %ci %s' origin/main
         echo ""


### PR DESCRIPTION
## Summary

The nightly OSV artifact generation in `fleetdm/vulnerabilities` failed over the weekend with:

```
fatal: error processing shallow info: 4
```

at `cmd/osv-processor/sync-and-detect-changes.sh` during:

```bash
git fetch --shallow-since="3 days ago" origin main
```

Root cause: `git fetch --shallow-since` errors out when the upstream (`canonical/ubuntu-security-notices`) has zero commits newer than the cutoff. Canonical didn't push anything over the weekend, so the 3-day window returned empty and upload-pack produced an unusable shallow response.

Fix:
- Fall back to `git fetch --depth=3` if `--shallow-since` still returns empty, so the initial clone always succeeds.

Subsequent runs reuse the existing clone and take the other branch of the script (plain `git fetch origin main`), which doesn't have this failure mode.

Failing run: https://github.com/fleetdm/vulnerabilities/actions/runs/24330589309/job/71035337352

## Test plan

- [x] Re-run the Ubuntu OSV artifact generation workflow; initial clone succeeds regardless of upstream push frequency.
- [x] Manually exercise the cold-cache path locally: `rm -rf ubuntu-security-notices && ./cmd/osv-processor/sync-and-detect-changes.sh` — completes without error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved initial repository sync: if the primary shallow fetch returns no commits, the process now falls back to a limited-depth fetch, warns the user, and shows recent commit history before continuing. Downstream change detection and existing behavior for already-cloned repos remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->