### PR TITLE
Add python to allowed script extensions

### DIFF
--- a/pkg/spec/gitops.go
+++ b/pkg/spec/gitops.go
@@ -1140,6 +1140,7 @@ var defaultAllowedExtensions = map[string]bool{
 var allowedScriptExtensions = map[string]bool{
 	".sh":  true,
 	".ps1": true,
+	".py":  true,
 }
 
 // GlobExpandOptions configures how flattenBaseItems expands glob patterns.

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2000,11 +2000,12 @@ func TestResolveScriptPaths(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "c.py"), []byte("#!/usr/bin/env python3"), 0o644))
 
-		items := []fleet.BaseItem{{Paths: ptr.String("*.sh")}} //nolint:modernize
+		items := []fleet.BaseItem{{Paths: ptr.String("*")}} //nolint:modernize
 		result, errs := resolveScriptPaths(items, dir, nopLogf)
 		require.Empty(t, errs)
-		require.Len(t, result, 2)
+		require.Len(t, result, 3)
 	})
 
 	t.Run("inline_not_allowed", func(t *testing.T) {

--- a/pkg/spec/gitops_test.go
+++ b/pkg/spec/gitops_test.go
@@ -2000,12 +2000,30 @@ func TestResolveScriptPaths(t *testing.T) {
 		dir := t.TempDir()
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.sh"), []byte("#!/bin/bash"), 0o644))
+
+		items := []fleet.BaseItem{{Paths: ptr.String("*.sh")}} //nolint:modernize
+		result, errs := resolveScriptPaths(items, dir, nopLogf)
+		require.Empty(t, errs)
+		require.Len(t, result, 2)
+	})
+
+	t.Run("glob_filters_non_script_extensions", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "a.sh"), []byte("#!/bin/bash"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "b.ps1"), []byte("Write-Host"), 0o644))
 		require.NoError(t, os.WriteFile(filepath.Join(dir, "c.py"), []byte("#!/usr/bin/env python3"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "d.txt"), []byte("not a script"), 0o644))
 
 		items := []fleet.BaseItem{{Paths: ptr.String("*")}} //nolint:modernize
 		result, errs := resolveScriptPaths(items, dir, nopLogf)
 		require.Empty(t, errs)
 		require.Len(t, result, 3)
+		got := make([]string, 0, len(result))
+		for _, r := range result {
+			got = append(got, filepath.Base(*r.Path))
+		}
+		assert.Equal(t, []string{"a.sh", "b.ps1", "c.py"}, got)
 	})
 
 	t.Run("inline_not_allowed", func(t *testing.T) {


### PR DESCRIPTION
Fixes #43334

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitOps run-script handling now accepts Python (.py) files alongside shell and PowerShell, so glob-expanded script lists will include Python scripts.

* **Tests**
  * Added a test validating glob filtering to ensure only supported script extensions (shell, PowerShell, Python) are returned and non-script files are excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->