### PR TITLE
FE: Add dark mode view to storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,3 +1,42 @@
+import React, { useEffect } from "react";
+import "../frontend/index.scss";
+
+export const globalTypes = {
+  theme: {
+    description: "Toggle dark/light mode",
+    defaultValue: "light",
+    toolbar: {
+      items: [
+        { value: "light", icon: "sun", title: "Light mode" },
+        { value: "dark", icon: "moon", title: "Dark mode" },
+      ],
+      dynamicTitle: true,
+    },
+  },
+};
+
+const applyTheme = (isDark) => {
+  document.body.classList.toggle("dark-mode", isDark);
+  document.body.style.backgroundColor = isDark ? "#181a1f" : "";
+  document.body.style.color = isDark ? "#e2e4ea" : "";
+
+  document.querySelectorAll(".docs-story").forEach((el) => {
+    el.style.backgroundColor = isDark ? "#181a1f" : "";
+  });
+};
+
+const withTheme = (Story, context) => {
+  const isDark = context.globals.theme === "dark";
+
+  useEffect(() => {
+    applyTheme(isDark);
+  }, [isDark]);
+
+  return <Story />;
+};
+
+export const decorators = [withTheme];
+
 export const parameters = {
   controls: {
     matchers: {
@@ -6,4 +45,5 @@ export const parameters = {
     },
   },
 };
+
 export const tags = ["autodocs"];

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -17,11 +17,11 @@ export const globalTypes = {
 
 const applyTheme = (isDark) => {
   document.body.classList.toggle("dark-mode", isDark);
-  document.body.style.backgroundColor = isDark ? "#181a1f" : "";
-  document.body.style.color = isDark ? "#e2e4ea" : "";
+  document.body.style.backgroundColor = isDark ? "var(--core-fleet-white)" : "";
+  document.body.style.color = isDark ? "var(--core-fleet-black)" : "";
 
   document.querySelectorAll(".docs-story").forEach((el) => {
-    el.style.backgroundColor = isDark ? "#181a1f" : "";
+    el.style.backgroundColor = isDark ? "var(--core-fleet-white)" : "";
   });
 };
 

--- a/frontend/components/LiveQuery/TargetChipSelector/TargetChipSelector.stories.tsx
+++ b/frontend/components/LiveQuery/TargetChipSelector/TargetChipSelector.stories.tsx
@@ -21,15 +21,6 @@ const meta: Meta<typeof TargetChipSelector> = {
       action: "clicked", // Use Storybook's action to track clicks
     },
   },
-  parameters: {
-    backgrounds: {
-      default: "light",
-      values: [
-        { name: "light", value: "#ffffff" },
-        { name: "dark", value: "#333333" },
-      ],
-    },
-  },
 };
 
 export default meta;

--- a/frontend/components/TabNav/TabNav.stories.tsx
+++ b/frontend/components/TabNav/TabNav.stories.tsx
@@ -7,21 +7,6 @@ import TabNav from "./TabNav";
 const meta: Meta<typeof TabNav> = {
   component: TabNav,
   title: "Components/TabNav",
-  parameters: {
-    backgrounds: {
-      default: "light",
-      values: [
-        {
-          name: "light",
-          value: "#ffffff",
-        },
-        {
-          name: "dark",
-          value: "#333333",
-        },
-      ],
-    },
-  },
 };
 
 export default meta;

--- a/frontend/components/TeamsDropdown/TeamsDropdown.stories.tsx
+++ b/frontend/components/TeamsDropdown/TeamsDropdown.stories.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { Meta, StoryObj } from "@storybook/react";
 import { noop } from "lodash";
 
@@ -6,6 +7,13 @@ import TeamsDropdown from ".";
 const meta: Meta<typeof TeamsDropdown> = {
   title: "Components/TeamsDropdown",
   component: TeamsDropdown,
+  decorators: [
+    (Story) => (
+      <div style={{ minHeight: 300 }}>
+        <Story />
+      </div>
+    ),
+  ],
   args: {
     currentUserTeams: [
       { id: 1, name: "Team 1" },

--- a/frontend/components/buttons/DropdownButton/DropdownButton.stories.tsx
+++ b/frontend/components/buttons/DropdownButton/DropdownButton.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta<typeof DropdownButton> = {
     variant: {
       options: [
         "default",
-        "success",
         "alert",
         "pill",
         "link",
@@ -47,17 +46,6 @@ const meta: Meta<typeof DropdownButton> = {
     type: {
       options: ["button", "submit", "reset"],
       control: "select",
-    },
-  },
-  parameters: {
-    backgrounds: {
-      default: "header",
-      values: [
-        {
-          name: "header",
-          value: "linear-gradient(270deg, #202226 0%, #353840 100%)",
-        },
-      ],
     },
   },
   args: {

--- a/frontend/components/buttons/DropdownButton/_styles.scss
+++ b/frontend/components/buttons/DropdownButton/_styles.scss
@@ -69,3 +69,9 @@
     margin-top: 1px;
   }
 }
+
+// Override the chevron icon stroke to inherit the button's text color
+// so it adapts correctly in dark mode
+.dropdown-button .icon svg path {
+  stroke: currentColor;
+}


### PR DESCRIPTION
## Issue
Closes #43468 

## Description
- Add dark mode toggle to storybook

## Screenrecording


https://github.com/user-attachments/assets/225dc9b1-3d4e-4d81-b9c1-eaae25ae95b9


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Storybook theme toolbar to toggle light/dark with automatic runtime theming.

* **Bug Fixes**
  * Dropdown button icons now inherit color correctly and adapt to theme.

* **Chores**
  * Cleaned up story configurations and removed legacy background overrides.
  * Added consistent story layout wrapper for improved rendering.
  * Removed an obsolete variant option from dropdown story controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->