### PR TITLE
Update gitops exceptions message for 4.84

### DIFF
--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -578,7 +578,7 @@ agent_options:
 	require.NoError(t, err)
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `"labels" is excepted from GitOps management`)
+	assert.Contains(t, err.Error(), "remove `labels:` from your GitOps file")
 
 	// Secrets excepted + present → error
 	tmpFile2, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -598,7 +598,7 @@ agent_options:
 	require.NoError(t, err)
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile2.Name()})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `"secrets" is excepted from GitOps management`)
+	assert.Contains(t, err.Error(), "remove `secrets:` from your GitOps file")
 
 	// Secrets excepted + present → error
 	tmpFile3, err := os.CreateTemp(t.TempDir(), "*.yml")
@@ -613,7 +613,7 @@ software:
 	require.NoError(t, err)
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile3.Name()})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `"software" is excepted from GitOps management`)
+	assert.Contains(t, err.Error(), "remove `software:` from your GitOps file")
 
 	// Test: exceptions enforced even when GitOps mode is OFF (decoupled from UI mode)
 	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
@@ -626,7 +626,7 @@ software:
 	}
 	_, err = RunAppNoChecks([]string{"gitops", "-f", tmpFile.Name()})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `"labels" is excepted from GitOps management`)
+	assert.Contains(t, err.Error(), "remove `labels:` from your GitOps file")
 }
 
 // TestGitOpsExceptionsPreserveOmittedKeys verifies that when exceptions are ON,

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1913,7 +1913,7 @@ func (c *Client) DoGitOps(
 			return nil, fmt.Errorf("Starting in 4.84, secrets management in GitOps is turned off by default.  Either remove `secrets:` from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management", serverUrl)
 		}
 		if exceptions.Software && incoming.SoftwarePresent && incoming.TeamName != nil {
-			return nil, fmt.Errorf(`"software" is excepted from GitOps management. Either remove the "software:" key from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
+			return nil, fmt.Errorf("Software is excepted from GitOps management. Either remove `software:` from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management", serverUrl)
 		}
 	}
 

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1905,13 +1905,12 @@ func (c *Client) DoGitOps(
 	var exceptions fleet.GitOpsExceptions
 	if appConfig != nil {
 		exceptions = appConfig.GitOpsConfig.Exceptions
+		serverUrl := appConfig.ServerSettings.ServerURL
 		if exceptions.Labels && incoming.LabelsPresent {
-			return nil, errors.New(
-				`"labels" is excepted from GitOps management. Remove the "labels:" key from your GitOps file or disable the exception in Fleet settings.`)
+			return nil, fmt.Errorf(`Starting in 4.84, labels management in GitOps is turned off by default.  Either remove labels: from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
 		}
 		if exceptions.Secrets && incoming.SecretsPresent {
-			return nil, errors.New(
-				`"secrets" is excepted from GitOps management. Remove the "secrets:" key from your GitOps file or disable the exception in Fleet settings.`)
+			return nil, fmt.Errorf(`Starting in 4.84, secrets management in GitOps is turned off by default.  Either remove secrets: from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
 		}
 		if exceptions.Software && incoming.SoftwarePresent && incoming.TeamName != nil {
 			return nil, errors.New(

--- a/server/service/client.go
+++ b/server/service/client.go
@@ -1907,14 +1907,13 @@ func (c *Client) DoGitOps(
 		exceptions = appConfig.GitOpsConfig.Exceptions
 		serverUrl := appConfig.ServerSettings.ServerURL
 		if exceptions.Labels && incoming.LabelsPresent {
-			return nil, fmt.Errorf(`Starting in 4.84, labels management in GitOps is turned off by default.  Either remove labels: from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
+			return nil, fmt.Errorf("Starting in 4.84, labels management in GitOps is turned off by default.  Either remove `labels:` from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management", serverUrl)
 		}
 		if exceptions.Secrets && incoming.SecretsPresent {
-			return nil, fmt.Errorf(`Starting in 4.84, secrets management in GitOps is turned off by default.  Either remove secrets: from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
+			return nil, fmt.Errorf("Starting in 4.84, secrets management in GitOps is turned off by default.  Either remove `secrets:` from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management", serverUrl)
 		}
 		if exceptions.Software && incoming.SoftwarePresent && incoming.TeamName != nil {
-			return nil, errors.New(
-				`"software" is excepted from GitOps management. Remove the "software:" key from your GitOps file or disable the exception in Fleet settings.`)
+			return nil, fmt.Errorf(`"software" is excepted from GitOps management. Either remove the "software:" key from your GitOps file or disable the exception in the UI: %s/settings/integrations/change-management`, serverUrl)
 		}
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43461 

> ### Note this is a PR directly to 4.84 as the message contains 4.84-specific language that will be adjusted for 4.85 (all errors will look more like the "software" one, not mentioning defaults etc.)

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

Did `~/Development/fleet$ ./build/fleetctl gitops -f /tmp/test-ex-msg/fleets/💻-workstations.yml` with various settings:

**Labels:**
```
Error: Starting in 4.84, labels management in GitOps is turned off by default.  Either remove `labels:` from your GitOps file or disable the exception in the UI: https://localhost:8080/settings/integrations/change-management
```

**Secrets**
```
Error: Starting in 4.84, secrets management in GitOps is turned off by default.  Either remove `secrets:` from your GitOps file or disable the exception in the UI: https://localhost:8080/settings/integrations/change-management
```

**Software**
```
Error: Software is excepted from GitOps management. Either remove `software:` from your GitOps file or disable the exception in the UI: https://localhost:8080/settings/integrations/change-management
```


For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results
