### PR TITLE
Add fleet apps, labels, and patch policies

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -310,6 +310,86 @@ software:
       setup_experience: true
       categories:
         - Productivity
+    - slug: github/darwin # GitHub Desktop for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: utm/darwin # UTM for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: imazing-profile-editor/darwin # iMazing Profile Editor for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: postman/darwin # Postman for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: grammarly-desktop/darwin # Grammarly Desktop for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: iterm2/darwin # iTerm2 for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: sublime-text/darwin # Sublime Text for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: parallels/darwin # Parallels Desktop for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: loom/darwin # Loom for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: spotify/darwin # Spotify for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: rectangle/darwin # Rectangle for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: logi-options+/darwin # Logi Options+ for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: suspicious-package/darwin # Suspicious Package for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: figma/darwin # Figma for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: whatsapp/darwin # WhatsApp for macOS
+      self_service: true
+      categories:
+        - Communication
+    - slug: android-studio/darwin # Android Studio for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: zed/darwin # Zed for macOS
+      self_service: true
+      categories:
+        - Developer tools
+    - slug: obsidian/darwin # Obsidian for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: google-drive/darwin # Google Drive for macOS
+      self_service: true
+      categories:
+        - Productivity
+    - slug: cursor/darwin # Cursor for macOS
+      self_service: true
+      categories:
+        - Developer tools
     # Windows apps
     - slug: slack/windows # Slack for Windows
       self_service: true
@@ -353,3 +433,51 @@ software:
       self_service: true
       categories:
         - Developer tools
+    - slug: docker/windows # Docker Desktop for Windows (x86)
+      self_service: true
+      categories:
+        - Developer tools
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: github-desktop/windows # GitHub Desktop for Windows (x86)
+      self_service: true
+      categories:
+        - Developer tools
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: postman/windows # Postman for Windows (x86)
+      self_service: true
+      categories:
+        - Developer tools
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: sublime-text/windows # Sublime Text for Windows (x86)
+      self_service: true
+      categories:
+        - Developer tools
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: spotify/windows # Spotify for Windows (x86)
+      self_service: true
+      categories:
+        - Productivity
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: figma/windows # Figma for Windows (x86)
+      self_service: true
+      categories:
+        - Productivity
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: google-drive/windows # Google Drive for Windows (x86)
+      self_service: true
+      categories:
+        - Productivity
+      labels_include_any:
+        - "x86-based Windows hosts"
+    - slug: cursor/windows # Cursor for Windows (x86)
+      self_service: true
+      categories:
+        - Developer tools
+      labels_include_any:
+        - "x86-based Windows hosts"

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -58,3 +58,103 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.amazonaws.acvc.osx';
   label_membership_type: dynamic
   platform: darwin
+- name: Macs with GitHub Desktop installed
+  description: macOS hosts with GitHub Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.GitHubClient';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with UTM installed
+  description: macOS hosts with UTM installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.utmapp.UTM';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with iMazing Profile Editor installed
+  description: macOS hosts with iMazing Profile Editor installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.DigiDNA.iMazingProfileEditorMac';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Postman installed
+  description: macOS hosts with Postman installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Grammarly Desktop installed
+  description: macOS hosts with Grammarly Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with iTerm2 installed
+  description: macOS hosts with iTerm2 installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.googlecode.iterm2';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Sublime Text installed
+  description: macOS hosts with Sublime Text installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.sublimetext.4';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Parallels Desktop installed
+  description: macOS hosts with Parallels Desktop installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.parallels.desktop.console';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Loom installed
+  description: macOS hosts with Loom installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Spotify installed
+  description: macOS hosts with Spotify installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Rectangle installed
+  description: macOS hosts with Rectangle installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.knollsoft.Rectangle';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Logi Options+ installed
+  description: macOS hosts with Logi Options+ installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.logi.optionsplus';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Suspicious Package installed
+  description: macOS hosts with Suspicious Package installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.SuspiciousPackage';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Figma installed
+  description: macOS hosts with Figma installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.figma.Desktop';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with WhatsApp installed
+  description: macOS hosts with WhatsApp installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'net.whatsapp.WhatsApp';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Android Studio installed
+  description: macOS hosts with Android Studio installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.android.studio';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Zed installed
+  description: macOS hosts with Zed installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Obsidian installed
+  description: macOS hosts with Obsidian installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'md.obsidian';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Google Drive installed
+  description: macOS hosts with Google Drive installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.drivefs';
+  label_membership_type: dynamic
+  platform: darwin
+- name: Macs with Cursor installed
+  description: macOS hosts with Cursor installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -23,14 +23,14 @@
   query: SELECT 1 FROM programs WHERE name = 'Zoom Workplace (X64)' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: Windows hosts with Brave Browser installed
-  description: Windows hosts with Brave Browser installed
-  query: SELECT 1 FROM programs WHERE name = 'Brave';
+- name: x86 Windows hosts with Brave Browser installed
+  description: x86 Windows hosts with Brave Browser installed
+  query: SELECT 1 FROM programs WHERE name = 'Brave' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
-- name: Windows hosts with Visual Studio Code installed
-  description: Windows hosts with Visual Studio Code installed
-  query: SELECT 1 FROM programs WHERE name LIKE 'Microsoft Visual Studio Code%';
+- name: x86 Windows hosts with Visual Studio Code installed
+  description: x86 Windows hosts with Visual Studio Code installed
+  query: SELECT 1 FROM programs WHERE name LIKE 'Microsoft Visual Studio Code%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
 - name: x86 Windows hosts with Docker Desktop installed

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -33,3 +33,43 @@
   query: SELECT 1 FROM programs WHERE name LIKE 'Microsoft Visual Studio Code%';
   label_membership_type: dynamic
   platform: windows
+- name: x86 Windows hosts with Docker Desktop installed
+  description: x86 Windows hosts with Docker Desktop installed
+  query: SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with GitHub Desktop installed
+  description: x86 Windows hosts with GitHub Desktop installed
+  query: SELECT 1 FROM programs WHERE name = 'GitHub Desktop' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Postman installed
+  description: x86 Windows hosts with Postman installed
+  query: SELECT 1 FROM programs WHERE name LIKE 'Postman%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Sublime Text installed
+  description: x86 Windows hosts with Sublime Text installed
+  query: SELECT 1 FROM programs WHERE name = 'Sublime Text' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Spotify installed
+  description: x86 Windows hosts with Spotify installed
+  query: SELECT 1 FROM programs WHERE name = 'Spotify' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Figma installed
+  description: x86 Windows hosts with Figma installed
+  query: SELECT 1 FROM programs WHERE name = 'Figma' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Google Drive installed
+  description: x86 Windows hosts with Google Drive installed
+  query: SELECT 1 FROM programs WHERE name = 'Google Drive' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
+- name: x86 Windows hosts with Cursor installed
+  description: x86 Windows hosts with Cursor installed
+  query: SELECT 1 FROM programs WHERE name = 'Cursor' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -95,3 +95,163 @@
   install_software: false
   labels_include_any:
     - Macs with AWS VPN Client installed
+- name: macOS - GitHub Desktop up to date
+  description: The host may have an outdated version of GitHub Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using GitHub Desktop's built-in update functionality. You can also delete GitHub Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: github/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with GitHub Desktop installed
+- name: macOS - UTM up to date
+  description: The host may have an outdated version of UTM, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using UTM's built-in update functionality. You can also delete UTM if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: utm/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with UTM installed
+- name: macOS - iMazing Profile Editor up to date
+  description: The host may have an outdated version of iMazing Profile Editor, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using iMazing Profile Editor's built-in update functionality. You can also delete iMazing Profile Editor if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: imazing-profile-editor/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with iMazing Profile Editor installed
+- name: macOS - Postman up to date
+  description: The host may have an outdated version of Postman, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Postman's built-in update functionality. You can also delete Postman if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: postman/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Postman installed
+- name: macOS - Grammarly Desktop up to date
+  description: The host may have an outdated version of Grammarly Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Grammarly Desktop's built-in update functionality. You can also delete Grammarly Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: grammarly-desktop/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Grammarly Desktop installed
+- name: macOS - iTerm2 up to date
+  description: The host may have an outdated version of iTerm2, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using iTerm2's built-in update functionality. You can also delete iTerm2 if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: iterm2/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with iTerm2 installed
+- name: macOS - Sublime Text up to date
+  description: The host may have an outdated version of Sublime Text, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Sublime Text's built-in update functionality. You can also delete Sublime Text if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: sublime-text/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Sublime Text installed
+- name: macOS - Parallels Desktop up to date
+  description: The host may have an outdated version of Parallels Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Parallels Desktop's built-in update functionality. You can also delete Parallels Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: parallels/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Parallels Desktop installed
+- name: macOS - Loom up to date
+  description: The host may have an outdated version of Loom, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Loom's built-in update functionality. You can also delete Loom if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: loom/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Loom installed
+- name: macOS - Spotify up to date
+  description: The host may have an outdated version of Spotify, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Spotify's built-in update functionality. You can also delete Spotify if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: spotify/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Spotify installed
+- name: macOS - Rectangle up to date
+  description: The host may have an outdated version of Rectangle, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Rectangle's built-in update functionality. You can also delete Rectangle if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: rectangle/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Rectangle installed
+- name: macOS - Logi Options+ up to date
+  description: The host may have an outdated version of Logi Options+, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Logi Options+'s built-in update functionality. You can also delete Logi Options+ if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: logi-options+/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Logi Options+ installed
+- name: macOS - Suspicious Package up to date
+  description: The host may have an outdated version of Suspicious Package, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Suspicious Package's built-in update functionality. You can also delete Suspicious Package if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: suspicious-package/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Suspicious Package installed
+- name: macOS - Figma up to date
+  description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also delete Figma if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: figma/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Figma installed
+- name: macOS - WhatsApp up to date
+  description: The host may have an outdated version of WhatsApp, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using WhatsApp's built-in update functionality. You can also delete WhatsApp if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: whatsapp/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with WhatsApp installed
+- name: macOS - Android Studio up to date
+  description: The host may have an outdated version of Android Studio, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Android Studio's built-in update functionality. You can also delete Android Studio if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: android-studio/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Android Studio installed
+- name: macOS - Zed up to date
+  description: The host may have an outdated version of Zed, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Zed's built-in update functionality. You can also delete Zed if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: zed/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Zed installed
+- name: macOS - Obsidian up to date
+  description: The host may have an outdated version of Obsidian, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Obsidian's built-in update functionality. You can also delete Obsidian if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: obsidian/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Obsidian installed
+- name: macOS - Google Drive up to date
+  description: The host may have an outdated version of Google Drive, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Google Drive's built-in update functionality. You can also delete Google Drive if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: google-drive/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Google Drive installed
+- name: macOS - Cursor up to date
+  description: The host may have an outdated version of Cursor, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Cursor's built-in update functionality. You can also delete Cursor if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: cursor/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Cursor installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -54,3 +54,67 @@
   install_software: false
   labels_include_any:
     - Windows hosts with Visual Studio Code installed
+- name: Windows - Docker Desktop up to date
+  description: The host may have an outdated version of Docker Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Docker Desktop's built-in update functionality. You can also uninstall Docker Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: docker/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Docker Desktop installed
+- name: Windows - GitHub Desktop up to date
+  description: The host may have an outdated version of GitHub Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using GitHub Desktop's built-in update functionality. You can also uninstall GitHub Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: github-desktop/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with GitHub Desktop installed
+- name: Windows - Postman up to date
+  description: The host may have an outdated version of Postman, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Postman's built-in update functionality. You can also uninstall Postman if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: postman/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Postman installed
+- name: Windows - Sublime Text up to date
+  description: The host may have an outdated version of Sublime Text, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Sublime Text's built-in update functionality. You can also uninstall Sublime Text if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: sublime-text/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Sublime Text installed
+- name: Windows - Spotify up to date
+  description: The host may have an outdated version of Spotify, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Spotify's built-in update functionality. You can also uninstall Spotify if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: spotify/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Spotify installed
+- name: Windows - Figma up to date
+  description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also uninstall Figma if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: figma/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Figma installed
+- name: Windows - Google Drive up to date
+  description: The host may have an outdated version of Google Drive, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Google Drive's built-in update functionality. You can also uninstall Google Drive if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: google-drive/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Google Drive installed
+- name: Windows - Cursor up to date
+  description: The host may have an outdated version of Cursor, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Cursor's built-in update functionality. You can also uninstall Cursor if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: cursor/windows
+  install_software: false
+  labels_include_any:
+    - x86 Windows hosts with Cursor installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -45,7 +45,7 @@
   fleet_maintained_app_slug: brave-browser/windows
   install_software: false
   labels_include_any:
-    - Windows hosts with Brave Browser installed
+    - x86 Windows hosts with Brave Browser installed
 - name: Windows - Visual Studio Code up to date
   description: The host may have an outdated version of Visual Studio Code, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Visual Studio Code's built-in update functionality. You can also uninstall Visual Studio Code if you are no longer using it."
@@ -53,7 +53,7 @@
   fleet_maintained_app_slug: visual-studio-code/windows
   install_software: false
   labels_include_any:
-    - Windows hosts with Visual Studio Code installed
+    - x86 Windows hosts with Visual Studio Code installed
 - name: Windows - Docker Desktop up to date
   description: The host may have an outdated version of Docker Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Docker Desktop's built-in update functionality. You can also uninstall Docker Desktop if you are no longer using it."


### PR DESCRIPTION
Add multiple Fleet-maintained apps to workstations (macOS and x86 Windows), create dynamic labels to detect installed apps, and add patch policies to flag out-of-date installs. workstations.yml: add numerous macOS self-service entries (e.g. GitHub Desktop, Postman, iTerm2, Sublime Text, Figma, Spotify, Google Drive, Cursor, etc.) and x86 Windows entries with labels_include_any for x86 hosts. lib/all/labels/...: add dynamic macOS labels using bundle identifiers and x86 Windows labels using program name plus arch checks. lib/macos/policies/... and lib/windows/policies/...: add patch policies for each new app to notify about outdated versions and provide remediation guidance (Self-service or app update/uninstall). These changes enable inventory, self-service deployment, and patch management for additional developer and productivity applications.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded macOS self-service app installation library with 20 new applications, including GitHub Desktop, Docker, Postman, Figma, Cursor, Sublime Text, Spotify, Google Drive, and others
  * Expanded Windows x86 self-service app installation with 8 new applications (Docker Desktop, GitHub Desktop, Postman, Figma, Spotify, Google Drive, Cursor, Sublime Text)
  * Added automatic update tracking for all self-service applications across both platforms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->