### PR TITLE
[Activity] Refine cleared_passcode event to be platform agnostic

### DIFF
--- a/docs/Contributing/reference/audit-logs.md
+++ b/docs/Contributing/reference/audit-logs.md
@@ -2507,7 +2507,7 @@ This activity contains the following fields:
 
 ## cleared_passcode
 
-Generated when a user clears the passcode on an iOS or iPadOS host.
+Generated when a user clears the passcode on a host.
 
 This activity contains the following fields:
 - "host_id": ID of the host.


### PR DESCRIPTION
Updated the description of the cleared_passcode event to remove platform-specific references. We want this to also work for Android later.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** #39570
