### PR TITLE
Remove Edge and Suspicious Package entries

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -275,10 +275,6 @@ software:
         - Apple Silicon macOS hosts
       categories:
         - Developer tools
-    - slug: microsoft-edge/darwin # Microsoft Edge for macOS
-      self_service: true
-      categories:
-        - Browsers
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
       self_service: true
       labels_include_any:
@@ -358,10 +354,6 @@ software:
       self_service: true
       categories:
         - Productivity
-    - slug: suspicious-package/darwin # Suspicious Package for macOS
-      self_service: true
-      categories:
-        - Developer tools
     - slug: figma/darwin # Figma for macOS
       self_service: true
       categories:

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -13,11 +13,6 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.docker.docker';
   label_membership_type: dynamic
   platform: darwin
-- name: Macs with Microsoft Edge installed
-  description: macOS hosts with Microsoft Edge installed
-  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.edgemac';
-  label_membership_type: dynamic
-  platform: darwin
 - name: Macs with Visual Studio Code installed
   description: macOS hosts with Visual Studio Code installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';
@@ -116,11 +111,6 @@
 - name: Macs with Logi Options+ installed
   description: macOS hosts with Logi Options+ installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.logi.optionsplus';
-  label_membership_type: dynamic
-  platform: darwin
-- name: Macs with Suspicious Package installed
-  description: macOS hosts with Suspicious Package installed
-  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.mothersruin.SuspiciousPackage';
   label_membership_type: dynamic
   platform: darwin
 - name: Macs with Figma installed

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -22,14 +22,6 @@
   install_software: false
   labels_include_any:
     - Macs with Docker Desktop installed
-- name: macOS - Microsoft Edge up to date
-  description: The host may have an outdated version of Microsoft Edge, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Microsoft Edge's built-in update functionality. You can also delete Microsoft Edge if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: microsoft-edge/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with Microsoft Edge installed
 - name: macOS - Firefox up to date
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
   resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
@@ -191,14 +183,6 @@
   install_software: false
   labels_include_any:
     - Macs with Logi Options+ installed
-- name: macOS - Suspicious Package up to date
-  description: The host may have an outdated version of Suspicious Package, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Suspicious Package's built-in update functionality. You can also delete Suspicious Package if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: suspicious-package/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with Suspicious Package installed
 - name: macOS - Figma up to date
   description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also delete Figma if you are no longer using it."


### PR DESCRIPTION
Remove Microsoft Edge and Suspicious Package from fleet configurations: deleted their software entries in it-and-security/fleets/workstations.yml, removed corresponding dynamic labels in it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml, and removed their patch policies in it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml. These apps are no longer included in the fleet-maintained app lists and patch checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Microsoft Edge and Suspicious Package from macOS fleet-managed applications and automatic patch policies.
  * These applications will no longer receive automatic updates through the organization's fleet management system on macOS devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->