### PR TITLE
updated AB tokens renew and delete options to enabled in gitops mode

### DIFF
--- a/changes/42440-renew-ab-tokens-gitopsmode-dropdown-fix
+++ b/changes/42440-renew-ab-tokens-gitopsmode-dropdown-fix
@@ -1,0 +1,1 @@
+- Renewing and deleting AB tokens in the UI is now enabled in gitops mode

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTable.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import { IMdmAbmToken } from "interfaces/mdm";
+import useGitOpsMode from "hooks/useGitOpsMode";
 
 import TableContainer from "components/TableContainer";
 
@@ -21,6 +22,8 @@ const AppleBusinessManagerTable = ({
   onRenewToken,
   onDeleteToken,
 }: IAppleBusinessManagerTableProps) => {
+  const { gitOpsModeEnabled, repoURL } = useGitOpsMode();
+
   const onSelectAction = (action: string, abmToken: IMdmAbmToken) => {
     switch (action) {
       case "editTeams":
@@ -37,7 +40,11 @@ const AppleBusinessManagerTable = ({
     }
   };
 
-  const tableConfig = generateTableConfig(onSelectAction);
+  const tableConfig = generateTableConfig(
+    onSelectAction,
+    gitOpsModeEnabled,
+    repoURL
+  );
 
   return (
     <TableContainer<IMdmAbmToken>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
@@ -23,12 +23,12 @@ type IRenewDateCellProps = CellProps<IMdmAbmToken, IMdmAbmToken["renew_date"]>;
 type ITableHeaderProps = IHeaderProps<IMdmAbmToken>;
 
 const DEFAULT_ACTION_OPTIONS: IDropdownOption[] = [
-  { value: "editTeams", label: "Edit fleets", disabled: false, tooltip: true },
+  { value: "editTeams", label: "Edit fleets", disabled: false },
   { value: "renew", label: "Renew", disabled: false },
   { value: "delete", label: "Delete", disabled: false },
 ];
 
-const generateActions = (gitopsModeEnabled: boolean, repoURL: string) => {
+const generateActions = (gitopsModeEnabled: boolean, repoURL?: string) => {
   if (!gitopsModeEnabled) {
     return DEFAULT_ACTION_OPTIONS;
   }
@@ -41,7 +41,12 @@ const generateActions = (gitopsModeEnabled: boolean, repoURL: string) => {
     return {
       ...option,
       disabled: true,
-      tooltipContent: getGitOpsModeTipContent(repoURL),
+      ...(repoURL
+       ? {
+            tooltip: true,
+            tooltipContent: getGitOpsModeTipContent(repoURL),
+          }
+        :{}),
     };
   });
 };
@@ -68,7 +73,7 @@ const RENEW_DATE_CELL_STATUS_CONFIG: IRenewDateCellStatusConfig = {
 export const generateTableConfig = (
   actionSelectHandler: (value: string, team: IMdmAbmToken) => void,
   gitopsModeEnabled: boolean,
-  repoURL: string
+  repoURL?: string
 ): IAbmTableConfig[] => {
   return [
     {

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
@@ -10,7 +10,7 @@ import HeaderCell from "components/TableContainer/DataTable/HeaderCell";
 import ActionsDropdown from "components/ActionsDropdown";
 import TextCell from "components/TableContainer/DataTable/TextCell";
 import TooltipWrapper from "components/TooltipWrapper";
-import GitOpsModeTooltipWrapper from "components/GitOpsModeTooltipWrapper";
+import { getGitOpsModeTipContent } from "utilities/helpers";
 
 import RenewDateCell from "../../../components/RenewDateCell";
 import OrgNameCell from "./OrgNameCell";
@@ -23,13 +23,27 @@ type IRenewDateCellProps = CellProps<IMdmAbmToken, IMdmAbmToken["renew_date"]>;
 type ITableHeaderProps = IHeaderProps<IMdmAbmToken>;
 
 const DEFAULT_ACTION_OPTIONS: IDropdownOption[] = [
-  { value: "editTeams", label: "Edit fleets", disabled: false },
+  { value: "editTeams", label: "Edit fleets", disabled: false, tooltip: true },
   { value: "renew", label: "Renew", disabled: false },
   { value: "delete", label: "Delete", disabled: false },
 ];
 
-const generateActions = () => {
-  return DEFAULT_ACTION_OPTIONS;
+const generateActions = (gitopsModeEnabled: boolean, repoURL: string) => {
+  if (!gitopsModeEnabled) {
+    return DEFAULT_ACTION_OPTIONS;
+  }
+
+  return DEFAULT_ACTION_OPTIONS.map((option) => {
+    if (option.value !== "editTeams") {
+      return option;
+    }
+
+    return {
+      ...option,
+      disabled: true,
+      tooltipContent: getGitOpsModeTipContent(repoURL),
+    };
+  });
 };
 
 const RENEW_DATE_CELL_STATUS_CONFIG: IRenewDateCellStatusConfig = {
@@ -52,7 +66,9 @@ const RENEW_DATE_CELL_STATUS_CONFIG: IRenewDateCellStatusConfig = {
 };
 
 export const generateTableConfig = (
-  actionSelectHandler: (value: string, team: IMdmAbmToken) => void
+  actionSelectHandler: (value: string, team: IMdmAbmToken) => void,
+  gitopsModeEnabled: boolean,
+  repoURL: string
 ): IAbmTableConfig[] => {
   return [
     {
@@ -171,28 +187,17 @@ export const generateTableConfig = (
       // but we don't use it.
       accessor: "id",
       Cell: (cellProps) => (
-        <GitOpsModeTooltipWrapper
-          position="left"
-          renderChildren={(disableChildren) => (
-            <div
-              className={
-                disableChildren
-                  ? "disabled-by-gitops-mode abm-actions-wrapper"
-                  : "abm-actions-wrapper"
-              }
-            >
-              <ActionsDropdown
-                options={generateActions()}
-                onChange={(value: string) =>
-                  actionSelectHandler(value, cellProps.row.original)
-                }
-                placeholder="Actions"
-                disabled={disableChildren}
-                variant="small-button"
-              />
-            </div>
-          )}
-        />
+        <div className="abm-actions-wrapper">
+          <ActionsDropdown
+            options={generateActions(gitopsModeEnabled, repoURL)}
+            onChange={(value: string) =>
+              actionSelectHandler(value, cellProps.row.original)
+            }
+            placeholder="Actions"
+            disabled={false}
+            variant="small-button"
+          />
+        </div>
       ),
     },
   ];

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
@@ -42,11 +42,11 @@ const generateActions = (gitopsModeEnabled: boolean, repoURL?: string) => {
       ...option,
       disabled: true,
       ...(repoURL
-       ? {
+        ? {
             tooltip: true,
             tooltipContent: getGitOpsModeTipContent(repoURL),
           }
-        :{}),
+        : {}),
     };
   });
 };


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42440

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled renewing and deleting Apple Business Manager (AB) tokens in the UI when running in GitOps mode.
  * Apple Business Manager table actions now adapt to GitOps mode: some actions are disabled and contextual tooltips explain unavailable options (including repository-linked guidance when applicable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->