### PR TITLE
Updated eula pdf upload size check to default max request body size

### DIFF
--- a/changes/40856-eula-upload-updated-to-default-max-request-body-size-and-error
+++ b/changes/40856-eula-upload-updated-to-default-max-request-body-size-and-error
@@ -1,0 +1,1 @@
+- Updated to default max request body size for eula pdf upload size check

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -81,6 +81,7 @@ import (
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest/scep_server"
@@ -4589,6 +4590,13 @@ func (s *integrationMDMTestSuite) TestEULA() {
 	s.uploadEULA(&fleet.MDMEULA{Bytes: []byte("should-fail"), Name: "should-fail.pdf"}, http.StatusBadRequest, "invalid file type")
 	// trying to upload an empty file fails
 	s.uploadEULA(&fleet.MDMEULA{Bytes: []byte{}, Name: "should-fail.pdf"}, http.StatusBadRequest, "invalid file type")
+
+	// file larger than the default max request body size should be rejected
+	largePDF := append(
+		[]byte("%PDF-1.7\n"),
+		bytes.Repeat([]byte("A"), int(platform_http.MaxRequestBodySize)+1-len("%PDF-1.7\n"))...,
+	)
+	s.uploadEULA(&fleet.MDMEULA{Bytes: largePDF, Name: "oversize.pdf"}, http.StatusBadRequest, "Request exceeds the max size limit")
 
 	// admin is able to upload a new EULA
 	s.uploadEULA(&fleet.MDMEULA{Bytes: pdfBytes, Name: pdfName}, http.StatusOK, "")

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/MicahParks/jwkset"
 	"github.com/davecgh/go-spew/spew"
+	"github.com/docker/go-units"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
 	"github.com/fleetdm/fleet/v4/server/mdm/acme/testhelpers"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
@@ -48,6 +49,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/mdm/android/tests"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/apple_apps"
 	"github.com/fleetdm/fleet/v4/server/mdm/assets"
+	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/pubsub"
 	"github.com/golang-jwt/jwt/v4"
 	"google.golang.org/api/androidmanagement/v1"
@@ -81,7 +83,6 @@ import (
 	nanomdm_pushsvc "github.com/fleetdm/fleet/v4/server/mdm/nanomdm/push/service"
 	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
-	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest/scep_server"
@@ -4591,12 +4592,32 @@ func (s *integrationMDMTestSuite) TestEULA() {
 	// trying to upload an empty file fails
 	s.uploadEULA(&fleet.MDMEULA{Bytes: []byte{}, Name: "should-fail.pdf"}, http.StatusBadRequest, "invalid file type")
 
-	// file larger than the default max request body size should be rejected
+	// file larger than the max EULA size should be rejected by the request size limit
 	largePDF := append(
 		[]byte("%PDF-1.7\n"),
-		bytes.Repeat([]byte("A"), int(platform_http.MaxRequestBodySize)+1-len("%PDF-1.7\n"))...,
+		bytes.Repeat([]byte("A"), int(fleet.MaxEULASize)+1-len("%PDF-1.7\n"))...,
 	)
-	s.uploadEULA(&fleet.MDMEULA{Bytes: largePDF, Name: "oversize.pdf"}, http.StatusBadRequest, "Request exceeds the max size limit")
+
+	s.uploadEULA(&fleet.MDMEULA{Bytes: largePDF, Name: "oversize.pdf"}, http.StatusRequestEntityTooLarge, "Request exceeds the max size limit")
+
+	// Test with MaxRequestBodySize set to unlimited (-1) - the endpoint still enforces the EULA request body limit
+	oldLimit := platform_http.MaxRequestBodySize
+	platform_http.MaxRequestBodySize = -1
+	largePDFUnlimited := append(
+		[]byte("%PDF-1.7\n"),
+		bytes.Repeat([]byte("A"), int(fleet.MaxEULASize)+1-len("%PDF-1.7\n"))...,
+	)
+	s.uploadEULA(&fleet.MDMEULA{Bytes: largePDFUnlimited, Name: "oversize_unlimited.pdf"}, http.StatusRequestEntityTooLarge, "Request exceeds the max size limit")
+	platform_http.MaxRequestBodySize = oldLimit
+
+	// Test with MaxRequestBodySize larger than MaxEULASize - should reject at MaxRequestBodySize
+	platform_http.MaxRequestBodySize = 50 * units.MiB
+	largePDFLarge := append(
+		[]byte("%PDF-1.7\n"),
+		bytes.Repeat([]byte("A"), int(50*units.MiB)+1-len("%PDF-1.7\n"))...,
+	)
+	s.uploadEULA(&fleet.MDMEULA{Bytes: largePDFLarge, Name: "oversize_large.pdf"}, http.StatusRequestEntityTooLarge, "Request exceeds the max size limit")
+	platform_http.MaxRequestBodySize = oldLimit
 
 	// admin is able to upload a new EULA
 	s.uploadEULA(&fleet.MDMEULA{Bytes: pdfBytes, Name: pdfName}, http.StatusOK, "")

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -36,7 +36,6 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 
-	"github.com/docker/go-units"
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -268,23 +267,9 @@ func (createMDMEULARequest) DecodeRequest(ctx context.Context, r *http.Request) 
 
 	eula := r.MultipartForm.File["eula"][0]
 
-	// Determine the effective size limit: allow whichever value is greater
-	effectiveLimit := fleet.MaxEULASize
-	if platform_http.MaxRequestBodySize != -1 {
-		if platform_http.MaxRequestBodySize > effectiveLimit {
-			effectiveLimit = platform_http.MaxRequestBodySize
-		}
-	}
-
-	if effectiveLimit != -1 && eula.Size > effectiveLimit {
-		var message string
-		if effectiveLimit == fleet.MaxEULASize {
-			message = fmt.Sprintf("EULA file exceeds the maximum allowed size of %s", units.HumanSize(float64(fleet.MaxEULASize)))
-		} else {
-			message = fmt.Sprintf("Request exceeds the max size limit of %s. Configure the limit: https://fleetdm.com/docs/configuration/fleet-server-configuration#server-default-max-request-body-size", units.HumanSize(float64(platform_http.MaxRequestBodySize)))
-		}
+	if eula.Size > fleet.MaxEULASize {
 		return nil, &fleet.BadRequestError{
-			Message: message,
+			Message: fmt.Sprintf("Uploaded EULA exceeds maximum allowed size of %d MiB", fleet.MaxEULASize/1024/1024),
 		}
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -36,6 +36,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	platform_http "github.com/fleetdm/fleet/v4/server/platform/http"
 
+	"github.com/docker/go-units"
 	"github.com/fleetdm/fleet/v4/server/mdm"
 	apple_mdm "github.com/fleetdm/fleet/v4/server/mdm/apple"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
@@ -267,9 +268,9 @@ func (createMDMEULARequest) DecodeRequest(ctx context.Context, r *http.Request) 
 
 	eula := r.MultipartForm.File["eula"][0]
 
-	if eula.Size > fleet.MaxEULASize {
+	if platform_http.MaxRequestBodySize != -1 && eula.Size > platform_http.MaxRequestBodySize {
 		return nil, &fleet.BadRequestError{
-			Message: "Uploaded EULA exceeds maximum allowed size of 500 MiB",
+			Message: fmt.Sprintf("Request exceeds the max size limit of %s. Configure the limit: https://fleetdm.com/docs/configuration/fleet-server-configuration#server-default-max-request-body-size", units.HumanSize(float64(platform_http.MaxRequestBodySize))),
 		}
 	}
 

--- a/server/service/mdm.go
+++ b/server/service/mdm.go
@@ -268,9 +268,23 @@ func (createMDMEULARequest) DecodeRequest(ctx context.Context, r *http.Request) 
 
 	eula := r.MultipartForm.File["eula"][0]
 
-	if platform_http.MaxRequestBodySize != -1 && eula.Size > platform_http.MaxRequestBodySize {
+	// Determine the effective size limit: allow whichever value is greater
+	effectiveLimit := fleet.MaxEULASize
+	if platform_http.MaxRequestBodySize != -1 {
+		if platform_http.MaxRequestBodySize > effectiveLimit {
+			effectiveLimit = platform_http.MaxRequestBodySize
+		}
+	}
+
+	if effectiveLimit != -1 && eula.Size > effectiveLimit {
+		var message string
+		if effectiveLimit == fleet.MaxEULASize {
+			message = fmt.Sprintf("EULA file exceeds the maximum allowed size of %s", units.HumanSize(float64(fleet.MaxEULASize)))
+		} else {
+			message = fmt.Sprintf("Request exceeds the max size limit of %s. Configure the limit: https://fleetdm.com/docs/configuration/fleet-server-configuration#server-default-max-request-body-size", units.HumanSize(float64(platform_http.MaxRequestBodySize)))
+		}
 		return nil, &fleet.BadRequestError{
-			Message: fmt.Sprintf("Request exceeds the max size limit of %s. Configure the limit: https://fleetdm.com/docs/configuration/fleet-server-configuration#server-default-max-request-body-size", units.HumanSize(float64(platform_http.MaxRequestBodySize))),
+			Message: message,
 		}
 	}
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #40856

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * EULA PDF upload size validation now reports the configured maximum upload size (in MiB) instead of a fixed value, improving clarity of rejection messages.

* **Tests**
  * Added tests covering EULA upload size validation, ensuring oversized uploads are rejected with the proper status and that configured request-body limits are respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->