### PR TITLE
Shorten Grammarly Desktop version and outputs

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/main.go
@@ -38,6 +38,7 @@ var Funcs = map[string][]func(*maintained_apps.FMAManifestApp) (*maintained_apps
 	"sublime-merge/darwin":          {SublimeVersionTransformer},
 	"mysqlworkbench/darwin":         {MySQLWorkbenchVersionTransformer},
 	"lens/darwin":                   {LensVersionTransformer},
+	"grammarly-desktop/darwin":      {GrammarlyDesktopVersionShortener},
 }
 
 func ChromePKGInstaller(app *maintained_apps.FMAManifestApp) (*maintained_apps.FMAManifestApp, error) {

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener.go
@@ -36,6 +36,7 @@ var (
 	ElgatoStreamDeckVersionShortener    = makeVersionShortener(3) // "7.3.1.22604" → "7.3.1"
 	FileMakerProVersionShortener        = makeVersionShortener(3) // "22.0.5.500" → "22.0.5"
 	RoyalTSXVersionShortener            = makeVersionShortener(3) // "6.4.2.1000" → "6.4.2"
+	GrammarlyDesktopVersionShortener    = makeVersionShortener(3) // "1.160.0.0" → "1.160.0"
 )
 
 // SublimeVersionTransformer prepends "Build " to match what macOS reports as

--- a/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
+++ b/ee/maintained-apps/ingesters/homebrew/external_refs/version_shortener_test.go
@@ -41,10 +41,24 @@ func TestMakeVersionShortener(t *testing.T) {
 func TestMakeVersionShortenerKeep3(t *testing.T) {
 	shortener := makeVersionShortener(3)
 
-	app := &maintained_apps.FMAManifestApp{Version: "25.11.1.42", Slug: "citrix-workspace"}
-	result, err := shortener(app)
-	require.NoError(t, err)
-	assert.Equal(t, "25.11.1", result.Version)
+	tcs := []struct {
+		name     string
+		version  string
+		slug     string
+		expected string
+	}{
+		{name: "citrix workspace", version: "25.11.1.42", slug: "citrix-workspace", expected: "25.11.1"},
+		{name: "grammarly desktop", version: "1.160.0.0", slug: "grammarly-desktop", expected: "1.160.0"},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			app := &maintained_apps.FMAManifestApp{Version: tc.version, Slug: tc.slug}
+			result, err := shortener(app)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result.Version)
+		})
+	}
 }
 
 func TestSublimeVersionTransformer(t *testing.T) {

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.160.0.0",
+      "version": "1.160.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.160.0.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.160.0') < 0);"
       },
       "installer_url": "https://download-mac.grammarly.com/versions/1.160.0.0/Grammarly.dmg",
       "install_script_ref": "962d8d13",


### PR DESCRIPTION
Add a 3-part version shortener for Grammarly Desktop and register it in the Homebrew ingester functions. Update tests to include the grammarly-desktop case to ensure versions like "1.160.0.0" become "1.160.0". Update the grammarly-desktop darwin output to use the shortened version in the version field and patched query (installer_url left pointing to the original full version). Files changed: main.go, version_shortener.go, version_shortener_test.go, and outputs/grammarly-desktop/darwin.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grammarly Desktop support for macOS with version normalization.

* **Tests**
  * Expanded test coverage with comprehensive version shortening scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->