### PR TITLE
Website: Add two exits to vpp app metadata proxy

### DIFF
--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -57,8 +57,8 @@ module.exports = {
       description: 'The Apple API returned a server error',
       statusCode: 500,
     },
-    appleApiReturnedUnauthorizedResponse: {
-      description: 'The Apple API returned an unauthorized response',
+    appleApiReturnedForbiddenResponse: {
+      description: 'The Apple API returned a forbidden response',
       statusCode: 403,
     },
   },
@@ -131,7 +131,7 @@ module.exports = {
     })
     .tolerate((err)=>{
       if(err.statusCode === 403){
-        return {appleApiReturnedUnauthorizedResponse: err.body};
+        return {appleApiReturnedForbiddenResponse: err.body};
       }
       if(err.statusCode === 500){
         return {appleApiReturnedServerError: err.body};

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -53,6 +53,14 @@ module.exports = {
       description: 'This request is missing a VPP app token',
       responseType: 'badRequest',
     },
+    appleApiReturnedServerError: {
+      description: 'The Apple API returned a server error',
+      statusCode: 500,
+    },
+    appleApiReturnedUnauthorizedResponse: {
+      description: 'The Apple API returned an unauthorized response',
+      statusCode: 403,
+    },
   },
 
 
@@ -122,8 +130,14 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
+      if(err.statusCode === 403){
+        return {appleApiReturnedUnauthorizedResponse: err.body};
+      }
+      if(err.statusCode === 500){
+        return {appleApiReturnedServerError: err.body};
+      }
       sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
-      return err;
+      return err.body;
     });
 
     return responseFromAppleApi;

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -136,7 +136,7 @@ module.exports = {
       if(err.statusCode === 500){
         return {appleApiReturnedServerError: err.body};
       }
-      sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
+      sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occurred. Full error: ${require('util').inspect(err)}`);
       return err.body;
     });
 

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -131,10 +131,10 @@ module.exports = {
     })
     .tolerate((err)=>{
       if(err.raw.statusCode === 403){
-        return {appleApiReturnedForbiddenResponse: err.raw.body};
+        throw {appleApiReturnedForbiddenResponse: err.raw.body};
       }
       if(err.raw.statusCode === 500){
-        return {appleApiReturnedServerError: err.raw.body};
+        throw {appleApiReturnedServerError: err.raw.body};
       }
       sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occurred. Full error: ${require('util').inspect(err)}`);
       return err.raw.body;

--- a/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
+++ b/website/api/controllers/vpp-proxy/get-vpp-app-metadata.js
@@ -130,14 +130,14 @@ module.exports = {
       }
     })
     .tolerate((err)=>{
-      if(err.statusCode === 403){
-        return {appleApiReturnedForbiddenResponse: err.body};
+      if(err.raw.statusCode === 403){
+        return {appleApiReturnedForbiddenResponse: err.raw.body};
       }
-      if(err.statusCode === 500){
-        return {appleApiReturnedServerError: err.body};
+      if(err.raw.statusCode === 500){
+        return {appleApiReturnedServerError: err.raw.body};
       }
       sails.log.warn(`When a Fleet instance sent a proxied request to the Apple App Store API, an error occured. Full error: ${require('util').inspect(err)}`);
-      return err.body;
+      return err.raw.body;
     });
 
     return responseFromAppleApi;


### PR DESCRIPTION
Related to: https://github.com/fleetdm/confidential/issues/15379

Changes:
- Added two exits to the VPP metadata proxy that are used when the Apple API returns errors. `appleApiReturnedServerError` Is returned when the Apple API returns a 500 error, and `appleApiReturnedForbiddenResponse` is used when the Apple API returns a 403 response.
- Updated the error handler in the VPP metadata proxy to return the body of the logged error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apple App Store API error handling: forbidden (403) and server (500) responses are now distinguished and mapped to specific error outcomes.
  * Other API errors now return the API response body (not the internal error object), and error logging text was clarified for better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->