### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.160.0",
+      "version": "1.161.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.160.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.161.1') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.160.0.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.161.1.0/Grammarly.dmg",
       "install_script_ref": "962d8d13",
       "uninstall_script_ref": "7b5a67c7",
-      "sha256": "8f2e9ba013a6d0cc8cf5982cbfb2080db63b1542142a6916431f2a3d0cf25087",
+      "sha256": "bafcd6ea392c7f2368cf6cc52f20375fe70cfcba869e4f773f9f1bd0978221b7",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
+++ b/ee/maintained-apps/outputs/jetbrains-toolbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.4.1",
+      "version": "3.4.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.4.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.toolbox' AND version_compare(bundle_short_version, '3.4.2') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.4.1.78303-arm64.dmg",
+      "installer_url": "https://download.jetbrains.com/toolbox/jetbrains-toolbox-3.4.2.80952-arm64.dmg",
       "install_script_ref": "44713f4b",
       "uninstall_script_ref": "c03d182a",
-      "sha256": "b66b2012026d0be666910ceda90270f0496f7f624622e4385f4c5cf649481f7d",
+      "sha256": "c5a1700d39f19fd5e02e4a5cbe1cf4a495dd603a93d320f4efe2dfeadd785291",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/surfshark/darwin.json
+++ b/ee/maintained-apps/outputs/surfshark/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.26.2",
+      "version": "4.27.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct' AND version_compare(bundle_short_version, '4.26.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.surfshark.vpnclient.macos.direct' AND version_compare(bundle_short_version, '4.27.0') < 0);"
       },
-      "installer_url": "https://downloads.surfshark.com/macOS/stable/4.26.2/4284/Surfshark.dmg",
+      "installer_url": "https://downloads.surfshark.com/macOS/stable/4.27.0/4324/Surfshark.dmg",
       "install_script_ref": "9c554a39",
       "uninstall_script_ref": "a2b88fd6",
-      "sha256": "eefc220835eb594090b4fb7b41911158277a42680bbec4595c2e3d4f53cf75db",
+      "sha256": "e4c4c5d7d3f92b652f418585b8b7588034db79945502e5cd3959a74c55fd794d",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated managed application metadata for macOS: Grammarly Desktop (1.161.1), JetBrains Toolbox (3.4.2), and Surfshark (4.27.0) with new installer URLs and verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->