### PR TITLE
Update app name to 'Sourcetree'

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/sourcetree.json
+++ b/ee/maintained-apps/inputs/homebrew/sourcetree.json
@@ -1,5 +1,5 @@
 {
-  "name": "SourceTree",
+  "name": "Sourcetree",
   "unique_identifier": "com.torusknot.SourceTreeNotMAS",
   "token": "sourcetree",
   "installer_format": "zip",


### PR DESCRIPTION
Adjust the name field in ee/maintained-apps/inputs/homebrew/sourcetree.json from "SourceTree" to "Sourcetree" to match the expected branding/casing. No other fields were modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application name formatting for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->