### PR TITLE
Fix incorrect "Fleet Desktop" in VPP edit success message for iOS/iPadOS

### DIFF
--- a/changes/fix-vpp-edit-fleet-desktop-message
+++ b/changes/fix-vpp-edit-fleet-desktop-message
@@ -1,0 +1,1 @@
+- Fixed incorrect "Fleet Desktop" reference in success message when editing iOS/iPadOS VPP apps with self-service enabled.

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditSoftwareModal/EditSoftwareModal.tsx
@@ -30,6 +30,7 @@ import { ISoftwareVppFormData } from "pages/SoftwarePage/components/forms/Softwa
 import {
   generateSelectedLabels,
   getCustomTarget,
+  getInstallSourceText,
   getInstallType,
   getTargetType,
 } from "pages/SoftwarePage/helpers";
@@ -302,7 +303,7 @@ const EditSoftwareModal = ({
         <>
           Successfully edited <b>{softwareInstaller.name}</b>.
           {formData.selfService
-            ? " The end user can install from Fleet Desktop."
+            ? ` The end user can install from ${getInstallSourceText(softwareInstaller)}.`
             : ""}
         </>
       );

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -14,6 +14,7 @@ import {
   IHostSoftware,
   ISoftwarePackage,
   IAppStoreApp,
+  isSoftwarePackage,
   ISoftwareTitle,
   ISoftwareInstallPolicyUI,
   ISoftwareInstallPolicy,
@@ -204,6 +205,20 @@ export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
     disabled: false,
   },
 ];
+
+export const getInstallSourceText = (
+  installer: ISoftwarePackage | IAppStoreApp
+): string => {
+  if (!isSoftwarePackage(installer)) {
+    if (installer.platform === "ios" || installer.platform === "ipados") {
+      return "self-service";
+    }
+    if (installer.platform === "android") {
+      return "the Play Store";
+    }
+  }
+  return "Fleet Desktop";
+};
 
 export const getSelfServiceTooltip = (
   isIosOrIpadosApp: boolean,


### PR DESCRIPTION
When editing an iOS or iPadOS VPP app with self-service enabled, the success notification incorrectly stated "The end user can install from Fleet Desktop." iOS/iPadOS devices use a self-service webclip, not Fleet Desktop. Android devices use the Google Play Store. This adds a platform-aware helper that returns the correct install source text based on the app platform.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
