### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2278.0",
+      "version": "1.2581.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.2278.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.2581.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.2278.0/Claude-e5213fcf70d7f16280888f281833a19f6ee13156.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.2581.0/Claude-f103981571883c6ef0522635cf396089a3ae0e0f.zip",
       "install_script_ref": "d05235fc",
       "uninstall_script_ref": "4cfbec7d",
-      "sha256": "1853243aaaa2e5f268bac9e4cd1e50f2578acfb05c53c77d8ee18cc79dd64dc5",
+      "sha256": "6a48193c7c9cf0abaee494d774851fb2452cf7a6da6788af76a263bdeb18acd9",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/connect-fonts/darwin.json
+++ b/ee/maintained-apps/outputs/connect-fonts/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "28.1.0",
+      "version": "28.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion' AND version_compare(bundle_short_version, '28.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion' AND version_compare(bundle_short_version, '28.1.1') < 0);"
       },
-      "installer_url": "https://bin.extensis.com/ConnectFonts-M-28-1-0.dmg",
+      "installer_url": "https://bin.extensis.com/ConnectFonts-M-28-1-1.dmg",
       "install_script_ref": "e2e807f7",
       "uninstall_script_ref": "879ff30b",
-      "sha256": "4dc2d84f8a4f4d1236a618cd4751dbbd9ecdbc7f72d9756c4b48ce7e0d269173",
+      "sha256": "7437e8125df2eb3c37e5c42d860dfa48672a9363e70e78c06e132aab35a240f2",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/dropbox/darwin.json
+++ b/ee/maintained-apps/outputs/dropbox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "246.4.3513",
+      "version": "248.4.3576",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '246.4.3513') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.getdropbox.dropbox' AND version_compare(bundle_short_version, '248.4.3576') < 0);"
       },
-      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20246.4.3513.arm64.dmg",
+      "installer_url": "https://edge.dropboxstatic.com/dbx-releng/client/Dropbox%20248.4.3576.arm64.dmg",
       "install_script_ref": "d6eee0bc",
       "uninstall_script_ref": "c86e5f6d",
-      "sha256": "fb0d10ea8ea0ba102dd86fc99a62b1edeb33dfac34856335c9303e4f7876408b",
+      "sha256": "4893976d814d4e7bb91122e09e13e43dcdf0a4baea33cd797ae637f4fa5d00e7",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Claude Desktop macOS application metadata to version 1.2581.0, including new installer package and security verification checksums
  * Updated Connect Fonts (SuitcaseFusion) maintained-application metadata to version 28.1.1 with corresponding updated installation artifacts
  * Updated Dropbox macOS application metadata from version 246.4.3513 to 248.4.3576 with new installer packages and security checksums

<!-- end of auto-generated comment: release notes by coderabbit.ai -->