### PR TITLE
Remove empty `resolution` attributes from two policies

### DIFF
--- a/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+++ b/docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
@@ -2189,7 +2189,6 @@ spec:
       AND line LIKE '%ocredit=-1%'
       AND line LIKE '%difok=3%'
       AND line LIKE '%enforce_for_root%';
-  resolution:
   tags: compliance, hardening, critical
   contributors: spalmesano0
   script: |
@@ -2252,7 +2251,6 @@ spec:
         AND trim(line) = 'idle-delay=uint32 300'
         AND ltrim(line) NOT LIKE '#%'
     ) > 0;
-  resolution:
   tags: compliance, hardening, critical
   contributors: spalmesano0
   script: |


### PR DESCRIPTION
Changes:
- Removed the `resolution` attribute from the two policies added in #43415 to fix the website's failing deploy workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed resolution information from two Linux policies in the standard query library: "Ubuntu GNOME password policy" and "Ubuntu GNOME lock screen after 5 minutes."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->