### PR TITLE
Add scripts for Linux and macOS to set hostnames

### DIFF
--- a/docs/solutions/linux/scripts/linux_sethostname.sh
+++ b/docs/solutions/linux/scripts/linux_sethostname.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get the serial number of the host
+serial_number=$(cat /sys/class/dmi/id/product_serial 2>/dev/null || cat /sys/class/dmi/id/board_serial 2>/dev/null)
+
+# Check if the serial number was retrieved successfully
+if [ -z "$serial_number" ]; then
+    echo "Error: Could not retrieve the serial number."
+    exit 1
+fi
+
+# Define the new hostname
+new_hostname="COMPANY-LNX-$serial_number"
+
+# Set the new hostname
+sudo hostnamectl set-hostname "$new_hostname"
+
+# Update the /etc/hosts file to reflect the new hostname
+sudo sed -i "s/$(hostname)/$new_hostname/g" /etc/hosts
+
+echo "Hostname updated to $new_hostname"

--- a/docs/solutions/linux/scripts/linux_sethostname.sh
+++ b/docs/solutions/linux/scripts/linux_sethostname.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 
 # Get the serial number of the host
-serial_number=$(cat /sys/class/dmi/id/product_serial 2>/dev/null || cat /sys/class/dmi/id/board_serial 2>/dev/null)
+serial_number=""
+for serial_path in /sys/class/dmi/id/product_serial /sys/class/dmi/id/board_serial; do
+    if [ -r "$serial_path" ]; then
+        candidate=$(tr -d '\n' < "$serial_path")
+        if [ -n "$candidate" ]; then
+            serial_number="$candidate"
+            break
+        fi
+    fi
+done
 
 # Check if the serial number was retrieved successfully
 if [ -z "$serial_number" ]; then
@@ -12,10 +21,19 @@ fi
 # Define the new hostname
 new_hostname="COMPANY-LNX-$serial_number"
 
+# Capture old hostname before changing it
+old_hostname="$(hostname)"
+
 # Set the new hostname
 sudo hostnamectl set-hostname "$new_hostname"
 
 # Update the /etc/hosts file to reflect the new hostname
-sudo sed -i "s/$(hostname)/$new_hostname/g" /etc/hosts
+tmp_hosts="$(mktemp)"
+awk -v old="$old_hostname" -v new="$new_hostname" '{
+  for (i = 1; i <= NF; i++) if ($i == old) $i = new
+  print
+}' /etc/hosts > "$tmp_hosts"
+sudo cp "$tmp_hosts" /etc/hosts
+rm -f "$tmp_hosts"
 
 echo "Hostname updated to $new_hostname"

--- a/docs/solutions/macos/scripts/macos_sethostname.sh
+++ b/docs/solutions/macos/scripts/macos_sethostname.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Get the serial number of the host
+serial_number=$(ioreg -l | grep IOPlatformSerialNumber | awk '{print $4}' | tr -d '"')
+
+# Check if the serial number was retrieved successfully
+if [ -z "$serial_number" ]; then
+    echo "Error: Could not retrieve the serial number."
+    exit 1
+fi
+
+# Define the new hostname
+new_hostname="COMPANY-MAC-$serial_number"
+
+# Set the new hostname
+sudo scutil --set ComputerName "$new_hostname"
+sudo scutil --set LocalHostName "$new_hostname"
+sudo scutil --set HostName "$new_hostname"
+
+# Print the new hostname
+echo "Hostname updated to $new_hostname"

--- a/docs/solutions/macos/scripts/macos_sethostname.sh
+++ b/docs/solutions/macos/scripts/macos_sethostname.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # Get the serial number of the host
 serial_number=$(ioreg -l | grep IOPlatformSerialNumber | awk '{print $4}' | tr -d '"')


### PR DESCRIPTION
Multiple customers have now requested scripts for setting hostnames on macOS, and a couple for Linux. This adds scripts to the solutions folder for that purpose.

Linux tested against `Ubuntu 26.04` and `openSUSE Tumbleweed`
macOS tested against `Tahoe 26.4.1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an automated Linux hostname configuration solution that derives a hostname from the device serial, applies it system-wide, and updates host entries.
  * Added an automated macOS hostname configuration solution that sets ComputerName/LocalHostName/HostName from the device serial and reports the new hostname.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->