### PR TITLE
Reset verified certificates to pending during Android host re-enrollment (#43443)

### DIFF
--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -220,18 +220,9 @@ func (ds *Datastore) UpdateAndroidHost(ctx context.Context, host *fleet.AndroidH
 			if err := upsertAndroidHostMDMInfoDB(ctx, tx, appCfg.ServerSettings.ServerURL, companyOwned, true, host.Host.ID); err != nil {
 				return ctxerr.Wrap(ctx, err, "update Android host MDM info")
 			}
-
-			// Create pending certificate template records for re-enrolling host.
-			// This ensures hosts that were unenrolled and re-enrolled get any certificate
-			// templates that were added while they were unenrolled.
-			// Uses ON DUPLICATE KEY UPDATE so it's safe to call even if records already exist.
-			teamID := uint(0)
-			if host.TeamID != nil {
-				teamID = *host.TeamID
-			}
-			if _, err := ds.CreatePendingCertificateTemplatesForNewHost(ctx, host.UUID, teamID); err != nil {
-				return ctxerr.Wrap(ctx, err, "create pending certificate templates for re-enrolling host")
-			}
+			// Certificate template records for re-enrolling hosts are created by the caller
+			// (Service.updateHost) via CreatePendingCertificateTemplatesForNewHost after this
+			// transaction commits. Doing it here would result in a duplicate call.
 		}
 
 		err = ds.UpdateDeviceTx(ctx, tx, host.Device)

--- a/server/datastore/mysql/certificate_templates.go
+++ b/server/datastore/mysql/certificate_templates.go
@@ -387,14 +387,21 @@ func (ds *Datastore) CreatePendingCertificateTemplatesForNewHost(
 		FROM certificate_templates
 		WHERE team_id = ?
 		ON DUPLICATE KEY UPDATE
-		    -- allow 'remove' to transition to 'pending install', generating new uuid
-			uuid = IF(operation_type = '%s', UUID_TO_BIN(UUID(), true), uuid),
-			status = IF(operation_type = '%s', '%s', status),
-			operation_type = IF(operation_type = '%s', '%s', operation_type)
+		    -- Unconditionally reset to pending install with a new UUID so the certificate is
+		    -- re-delivered. This handles re-enrollment after work profile removal, where the device
+		    -- lost all certs but the old records may still exist. Clear stale certificate metadata
+		    -- from the previous lifecycle to match ResendHostCertificateTemplate behavior.
+			uuid = UUID_TO_BIN(UUID(), true),
+			status = '%s',
+			operation_type = '%s',
+			retry_count = 0,
+			fleet_challenge = NULL,
+			not_valid_before = NULL,
+			not_valid_after = NULL,
+			serial = NULL,
+			detail = NULL
 	`, fleet.CertificateTemplatePending, fleet.MDMOperationTypeInstall,
-		fleet.MDMOperationTypeRemove,
-		fleet.MDMOperationTypeRemove, fleet.CertificateTemplatePending,
-		fleet.MDMOperationTypeRemove, fleet.MDMOperationTypeInstall)
+		fleet.CertificateTemplatePending, fleet.MDMOperationTypeInstall)
 	result, err := ds.writer(ctx).ExecContext(ctx, stmt, hostUUID, teamID)
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "create pending certificate templates for new host")

--- a/server/datastore/mysql/host_certificate_templates.go
+++ b/server/datastore/mysql/host_certificate_templates.go
@@ -286,6 +286,30 @@ func (ds *Datastore) DeleteHostCertificateTemplate(ctx context.Context, hostUUID
 	return nil
 }
 
+// DeleteAllHostCertificateTemplates deletes all host_certificate_templates records for a host.
+// Used during re-enrollment to clear stale cert records (including those from previous teams)
+// before creating fresh pending records for the host's current team. Associated one-time
+// challenge rows are also removed to avoid leaving orphaned entries in the challenges table.
+func (ds *Datastore) DeleteAllHostCertificateTemplates(ctx context.Context, hostUUID string) error {
+	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		// Delete challenges linked to this host's certificate templates before the host rows go away.
+		const deleteChallenges = `
+			DELETE c FROM challenges c
+			INNER JOIN host_certificate_templates hct ON hct.fleet_challenge = c.challenge
+			WHERE hct.host_uuid = ?
+		`
+		if _, err := tx.ExecContext(ctx, deleteChallenges, hostUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete challenges for host certificate templates")
+		}
+
+		const deleteTemplates = `DELETE FROM host_certificate_templates WHERE host_uuid = ?`
+		if _, err := tx.ExecContext(ctx, deleteTemplates, hostUUID); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete all host_certificate_templates for host")
+		}
+		return nil
+	})
+}
+
 func (ds *Datastore) UpsertCertificateStatus(ctx context.Context, update *fleet.CertificateStatusUpdate) error {
 	// Validate the status.
 	if !update.Status.IsValid() {

--- a/server/datastore/mysql/host_certificate_templates_test.go
+++ b/server/datastore/mysql/host_certificate_templates_test.go
@@ -977,6 +977,88 @@ func testCreatePendingCertificateTemplatesForNewHost(t *testing.T, ds *Datastore
 		require.NoError(t, err)
 		require.Equal(t, int64(0), rowsAffected)
 	})
+
+	t.Run("resets verified certs to pending on re-enrollment", func(t *testing.T) {
+		// Reproduces https://github.com/fleetdm/fleet/issues/42600:
+		// When an Android host removes the work profile and re-installs it without Fleet receiving
+		// a DELETED notification, old certificate records with status "verified" remain in the table.
+		// CreatePendingCertificateTemplatesForNewHost must reset them to "pending" so certs are re-delivered.
+		defer TruncateTables(t, ds)
+		setup := createCertTemplateTestSetup(t, ctx, ds, "")
+
+		hostUUID := "re-enroll-android-host"
+		createEnrolledAndroidHost(t, ctx, ds, hostUUID, &setup.team.ID)
+
+		// Simulate initial enrollment: create pending cert records
+		rowsAffected, err := ds.CreatePendingCertificateTemplatesForNewHost(ctx, hostUUID, setup.team.ID)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rowsAffected)
+
+		// Simulate certs being delivered and verified with stale metadata from the previous lifecycle
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`UPDATE host_certificate_templates
+			SET status = ?, operation_type = ?, fleet_challenge = 'old-challenge',
+				detail = 'old detail', not_valid_before = '2025-01-01', not_valid_after = '2026-01-01',
+				serial = 'ABC123', retry_count = 2
+			WHERE host_uuid = ? AND certificate_template_id = ?`,
+			fleet.CertificateTemplateVerified, fleet.MDMOperationTypeInstall, hostUUID, setup.template.ID,
+		)
+		require.NoError(t, err)
+
+		// Verify the record is "verified" before re-enrollment
+		records, err := ds.ListCertificateTemplatesForHosts(ctx, []string{hostUUID})
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.NotNil(t, records[0].Status)
+		require.Equal(t, fleet.CertificateTemplateVerified, *records[0].Status)
+
+		// Simulate re-enrollment (work profile removed and re-installed, no DELETED notification received).
+		// The delete is what clears stale rows from a previous team, if any.
+		err = ds.DeleteAllHostCertificateTemplates(ctx, hostUUID)
+		require.NoError(t, err)
+		// ListCertificateTemplatesForHosts joins from certificate_templates and synthesizes a row
+		// for the host's team even when host_certificate_templates has no matching row, so we
+		// must query the raw table directly to confirm the delete worked.
+		var countAfterDelete int
+		err = sqlx.GetContext(ctx, ds.writer(ctx), &countAfterDelete,
+			`SELECT COUNT(*) FROM host_certificate_templates WHERE host_uuid = ? AND certificate_template_id = ?`,
+			hostUUID, setup.template.ID)
+		require.NoError(t, err)
+		require.Zero(t, countAfterDelete)
+
+		rowsAffected, err = ds.CreatePendingCertificateTemplatesForNewHost(ctx, hostUUID, setup.team.ID)
+		require.NoError(t, err)
+		require.Positive(t, rowsAffected)
+
+		// The record must be reset to "pending" with stale metadata cleared
+		records, err = ds.ListCertificateTemplatesForHosts(ctx, []string{hostUUID})
+		require.NoError(t, err)
+		require.Len(t, records, 1)
+		require.NotNil(t, records[0].Status)
+		require.Equal(t, fleet.CertificateTemplatePending, *records[0].Status)
+		require.NotNil(t, records[0].OperationType)
+		require.Equal(t, fleet.MDMOperationTypeInstall, *records[0].OperationType)
+		require.Nil(t, records[0].FleetChallenge)
+
+		// Verify stale certificate metadata was cleared
+		var staleFields struct {
+			Detail         *string    `db:"detail"`
+			NotValidBefore *time.Time `db:"not_valid_before"`
+			NotValidAfter  *time.Time `db:"not_valid_after"`
+			Serial         *string    `db:"serial"`
+			RetryCount     int        `db:"retry_count"`
+		}
+		err = sqlx.GetContext(ctx, ds.writer(ctx), &staleFields,
+			`SELECT detail, not_valid_before, not_valid_after, serial, retry_count
+			FROM host_certificate_templates WHERE host_uuid = ? AND certificate_template_id = ?`,
+			hostUUID, setup.template.ID)
+		require.NoError(t, err)
+		require.Nil(t, staleFields.Detail)
+		require.Nil(t, staleFields.NotValidBefore)
+		require.Nil(t, staleFields.NotValidAfter)
+		require.Nil(t, staleFields.Serial)
+		require.Zero(t, staleFields.RetryCount)
+	})
 }
 
 func testRevertStaleCertificateTemplates(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -2807,6 +2807,10 @@ type Datastore interface {
 	// DeleteHostCertificateTemplate deletes a single host_certificate_template record
 	// identified by host_uuid and certificate_template_id.
 	DeleteHostCertificateTemplate(ctx context.Context, hostUUID string, certificateTemplateID uint) error
+	// DeleteAllHostCertificateTemplates deletes all host_certificate_templates records for a host.
+	// Used during re-enrollment to clear stale cert records (including those from previous teams)
+	// before creating fresh pending records for the host's current team.
+	DeleteAllHostCertificateTemplates(ctx context.Context, hostUUID string) error
 	// ResendHostCertificateTemplate queues a certificate template to be resent to a device
 	ResendHostCertificateTemplate(ctx context.Context, hostID uint, templateID uint) error
 

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -458,6 +458,14 @@ func (svc *Service) updateHost(ctx context.Context, device *androidmanagement.De
 	}
 
 	if fromEnroll {
+		// Delete any existing certificate template records for this host. The device has
+		// lost all certificates on re-enrollment (work profile removed and re-installed, or
+		// unenrolled/re-enrolled). This also clears stale rows from a previous team if the
+		// host is re-enrolling into a different team via a new enroll secret.
+		if err := svc.fleetDS.DeleteAllHostCertificateTemplates(ctx, host.Host.UUID); err != nil {
+			svc.logger.ErrorContext(ctx, "failed to delete existing certificate templates for re-enrolled host", "host_uuid", host.Host.UUID, "err", err)
+			return ctxerr.Wrap(ctx, err, "deleting existing certificate templates for re-enrolled host")
+		}
 		// Create pending certificate templates for this re-enrolled host.
 		// Use teamID = 0 for hosts with no team (certificate_templates uses team_id = 0 for "no team").
 		teamID := uint(0)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -1823,6 +1823,8 @@ type DeleteHostCertificateTemplatesFunc func(ctx context.Context, hostCertTempla
 
 type DeleteHostCertificateTemplateFunc func(ctx context.Context, hostUUID string, certificateTemplateID uint) error
 
+type DeleteAllHostCertificateTemplatesFunc func(ctx context.Context, hostUUID string) error
+
 type ResendHostCertificateTemplateFunc func(ctx context.Context, hostID uint, templateID uint) error
 
 type ListAndroidHostUUIDsWithPendingCertificateTemplatesFunc func(ctx context.Context, offset int, limit int) ([]string, error)
@@ -4557,6 +4559,9 @@ type DataStore struct {
 
 	DeleteHostCertificateTemplateFunc        DeleteHostCertificateTemplateFunc
 	DeleteHostCertificateTemplateFuncInvoked bool
+
+	DeleteAllHostCertificateTemplatesFunc        DeleteAllHostCertificateTemplatesFunc
+	DeleteAllHostCertificateTemplatesFuncInvoked bool
 
 	ResendHostCertificateTemplateFunc        ResendHostCertificateTemplateFunc
 	ResendHostCertificateTemplateFuncInvoked bool
@@ -10910,6 +10915,13 @@ func (s *DataStore) DeleteHostCertificateTemplate(ctx context.Context, hostUUID 
 	s.DeleteHostCertificateTemplateFuncInvoked = true
 	s.mu.Unlock()
 	return s.DeleteHostCertificateTemplateFunc(ctx, hostUUID, certificateTemplateID)
+}
+
+func (s *DataStore) DeleteAllHostCertificateTemplates(ctx context.Context, hostUUID string) error {
+	s.mu.Lock()
+	s.DeleteAllHostCertificateTemplatesFuncInvoked = true
+	s.mu.Unlock()
+	return s.DeleteAllHostCertificateTemplatesFunc(ctx, hostUUID)
 }
 
 func (s *DataStore) ResendHostCertificateTemplate(ctx context.Context, hostID uint, templateID uint) error {

--- a/server/service/integration_android_certificate_templates_test.go
+++ b/server/service/integration_android_certificate_templates_test.go
@@ -689,8 +689,18 @@ func (s *integrationMDMTestSuite) TestCertificateTemplateUnenrollReenroll() {
 	s.DoJSON("GET", fmt.Sprintf("/api/latest/fleet/hosts/%d", host.ID), nil, http.StatusOK, &getHostResp)
 	require.Nil(t, getHostResp.Host.MDM.Profiles, "All certificate template records should be cleared on unenroll")
 
-	// Step: Re-enroll the host (simulates pubsub status report triggering UpdateAndroidHost with fromEnroll=true)
+	// Step: Re-enroll the host (simulates pubsub status report triggering UpdateAndroidHost with fromEnroll=true).
+	// The full re-enrollment sequence in Service.updateHost is: UpdateAndroidHost, then delete stale certificate
+	// templates (no-op here since SetAndroidHostUnenrolled already removed them), then create fresh pending ones.
 	err = s.ds.UpdateAndroidHost(ctx, createdAndroidHost, true, false)
+	require.NoError(t, err)
+	err = s.ds.DeleteAllHostCertificateTemplates(ctx, host.UUID)
+	require.NoError(t, err)
+	teamIDForCerts := uint(0)
+	if createdAndroidHost.Host.TeamID != nil {
+		teamIDForCerts = *createdAndroidHost.Host.TeamID
+	}
+	_, err = s.ds.CreatePendingCertificateTemplatesForNewHost(ctx, host.UUID, teamIDForCerts)
 	require.NoError(t, err)
 
 	// Verify host is re-enrolled


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42600

Unreleased bug:
https://github.com/fleetdm/fleet/issues/42600#issuecomment-4220428519

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
* Re-enrolling devices now fully reset certificate templates: templates return to pending (install retained), retry counts and delivery metadata are cleared to avoid stale state.

* **Behavior**
* Re-enrollment explicitly deletes prior device certificate entries before creating fresh pending templates to prevent duplicates and stale data.

* **Tests**
* Added tests covering Android re-enrollment to verify templates are recreated and metadata is cleared.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit 67d0c576b15b251b01d5de403a4627cb76f9d00e)

