### PR TITLE
Temporarily disable FMA patch policies

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,7 +117,8 @@ policies:
   - path: ../lib/macos/policies/disk-space-check.yml
   - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/install-nudge.yml
-  - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
+  # TEMP: commenting out to re-establish FMA software state
+  # - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/macos/policies/battery-health-check.yml
   # Windows policies
   - path: ../lib/windows/policies/antivirus-signatures-up-to-date.yml
@@ -126,7 +127,8 @@ policies:
   - path: ../lib/windows/policies/disk-space-check.yml
   - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/update-1password.yml
-  - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
+  # TEMP: commenting out to re-establish FMA software state
+  # - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml
   # Linux policies


### PR DESCRIPTION
Comment out the patch-fleet-maintained-apps.yml entries for macOS and Windows in it-and-security/fleets/workstations.yml. This temporarily disables the FMA patch policies (kept as commented lines with a TEMP note) to allow re-establishing the Fleet Maintained Apps software state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Patch and maintenance policies for macOS and Windows workstations have been temporarily disabled in the configuration while preserving all other policy settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->