### PR TITLE
Revert "Temporarily disable FMA patch policies"

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,8 +117,7 @@ policies:
   - path: ../lib/macos/policies/disk-space-check.yml
   - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/install-nudge.yml
-  # TEMP: commenting out to re-establish FMA software state
-  # - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
+  - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/macos/policies/battery-health-check.yml
   # Windows policies
   - path: ../lib/windows/policies/antivirus-signatures-up-to-date.yml
@@ -127,8 +126,7 @@ policies:
   - path: ../lib/windows/policies/disk-space-check.yml
   - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/update-1password.yml
-  # TEMP: commenting out to re-establish FMA software state
-  # - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
+  - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml
   # Linux policies


### PR DESCRIPTION
Reverts fleetdm/fleet#43611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Re-enabled fleet maintenance and patching policies for macOS and Windows workstations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->