### PR TITLE
Update patch-fleet-maintained-apps.yml

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -103,11 +103,3 @@
   install_software: false
   labels_include_any:
     - Macs with UTM installed
-- name: macOS - iMazing Profile Editor up to date
-  description: The host may have an outdated version of iMazing Profile Editor, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using iMazing Profile Editor's built-in update functionality. You can also delete iMazing Profile Editor if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: imazing-profile-editor/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with iMazing Profile Editor installed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed macOS patch policy configuration for iMazing Profile Editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->