### PR TITLE
Update patch-fleet-maintained-apps.yml

### DIFF
--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -103,3 +103,131 @@
   install_software: false
   labels_include_any:
     - Macs with UTM installed
+- name: macOS - Postman up to date
+  description: The host may have an outdated version of Postman, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Postman's built-in update functionality. You can also delete Postman if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: postman/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Postman installed
+- name: macOS - Grammarly Desktop up to date
+  description: The host may have an outdated version of Grammarly Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Grammarly Desktop's built-in update functionality. You can also delete Grammarly Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: grammarly-desktop/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Grammarly Desktop installed
+- name: macOS - iTerm2 up to date
+  description: The host may have an outdated version of iTerm2, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using iTerm2's built-in update functionality. You can also delete iTerm2 if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: iterm2/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with iTerm2 installed
+- name: macOS - Sublime Text up to date
+  description: The host may have an outdated version of Sublime Text, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Sublime Text's built-in update functionality. You can also delete Sublime Text if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: sublime-text/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Sublime Text installed
+- name: macOS - Parallels Desktop up to date
+  description: The host may have an outdated version of Parallels Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Parallels Desktop's built-in update functionality. You can also delete Parallels Desktop if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: parallels/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Parallels Desktop installed
+- name: macOS - Loom up to date
+  description: The host may have an outdated version of Loom, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Loom's built-in update functionality. You can also delete Loom if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: loom/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Loom installed
+- name: macOS - Spotify up to date
+  description: The host may have an outdated version of Spotify, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Spotify's built-in update functionality. You can also delete Spotify if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: spotify/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Spotify installed
+- name: macOS - Rectangle up to date
+  description: The host may have an outdated version of Rectangle, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Rectangle's built-in update functionality. You can also delete Rectangle if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: rectangle/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Rectangle installed
+- name: macOS - Logi Options+ up to date
+  description: The host may have an outdated version of Logi Options+, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Logi Options+'s built-in update functionality. You can also delete Logi Options+ if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: logi-options+/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Logi Options+ installed
+- name: macOS - Figma up to date
+  description: The host may have an outdated version of Figma, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Figma's built-in update functionality. You can also delete Figma if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: figma/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Figma installed
+- name: macOS - WhatsApp up to date
+  description: The host may have an outdated version of WhatsApp, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using WhatsApp's built-in update functionality. You can also delete WhatsApp if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: whatsapp/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with WhatsApp installed
+- name: macOS - Android Studio up to date
+  description: The host may have an outdated version of Android Studio, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Android Studio's built-in update functionality. You can also delete Android Studio if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: android-studio/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Android Studio installed
+- name: macOS - Zed up to date
+  description: The host may have an outdated version of Zed, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Zed's built-in update functionality. You can also delete Zed if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: zed/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Zed installed
+- name: macOS - Obsidian up to date
+  description: The host may have an outdated version of Obsidian, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Obsidian's built-in update functionality. You can also delete Obsidian if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: obsidian/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Obsidian installed
+- name: macOS - Google Drive up to date
+  description: The host may have an outdated version of Google Drive, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Google Drive's built-in update functionality. You can also delete Google Drive if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: google-drive/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Google Drive installed
+- name: macOS - Cursor up to date
+  description: The host may have an outdated version of Cursor, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service or check for updates using Cursor's built-in update functionality. You can also delete Cursor if you are no longer using it."
+  type: patch
+  fleet_maintained_app_slug: cursor/darwin
+  install_software: false
+  labels_include_any:
+    - Macs with Cursor installed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated patch management support for 16 additional macOS applications: Postman, Grammarly Desktop, iTerm2, Sublime Text, Parallels Desktop, Loom, Spotify, Rectangle, Logi Options+, Figma, WhatsApp, Android Studio, Zed, Obsidian, Google Drive, and Cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->