### PR TITLE
Update workstations.yml

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -314,10 +314,6 @@ software:
       self_service: true
       categories:
         - Productivity
-    - slug: imazing-profile-editor/darwin # iMazing Profile Editor for macOS
-      self_service: true
-      categories:
-        - Developer tools
     - slug: postman/darwin # Postman for macOS
       self_service: true
       categories:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed imazing-profile-editor from the fleet-managed self-service applications available on macOS workstations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->