### PR TITLE
Missed ABM UI instances (#43506)

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/AppleBusinessManagerPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/AppleBusinessManagerPage.tsx
@@ -185,7 +185,7 @@ const AppleBusinessManagerPage = ({ router }: { router: InjectedRouter }) => {
       return (
         <>
           <p>
-            Add your ABM to enable automatic enrollment for company-owned hosts
+            Add your AB to enable automatic enrollment for company-owned hosts
             and enrollment, via a Managed Apple Account, for personal (BYOD)
             hosts.
           </p>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/AppleBusinessManagerTable/AppleBusinessManagerTableConfig.tsx
@@ -36,7 +36,7 @@ const RENEW_DATE_CELL_STATUS_CONFIG: IRenewDateCellStatusConfig = {
   warning: {
     tooltipText: (
       <>
-        ABM server token is less than 30 days from expiration.
+        AB server token is less than 30 days from expiration.
         <br /> To renew, go to <b>Actions {">"} Renew.</b>
       </>
     ),
@@ -44,7 +44,7 @@ const RENEW_DATE_CELL_STATUS_CONFIG: IRenewDateCellStatusConfig = {
   error: {
     tooltipText: (
       <>
-        ABM server token is expired.
+        AB server token is expired.
         <br /> To renew, go to <b>Actions {">"} Renew</b>.
       </>
     ),
@@ -98,7 +98,7 @@ export const generateTableConfig = (
             tipContent={
               <>
                 macOS hosts are automatically added to this fleet on initial
-                sync from ABM. If a host is manually assigned to a different
+                sync from AB. If a host is manually assigned to a different
                 fleet before enrollment, it will enroll to the newly assigned
                 fleet and not the default.
               </>
@@ -123,7 +123,7 @@ export const generateTableConfig = (
             tipContent={
               <>
                 iOS hosts are automatically added to this fleet on initial sync
-                from ABM. If a host is manually assigned to a different fleet
+                from AB. If a host is manually assigned to a different fleet
                 before enrollment, it will enroll to the newly assigned fleet
                 and not the default.
               </>
@@ -148,7 +148,7 @@ export const generateTableConfig = (
             tipContent={
               <>
                 iPadOS hosts are automatically added to this fleet on initial
-                sync from ABM. If a host is manually assigned to a different
+                sync from AB. If a host is manually assigned to a different
                 fleet before enrollment, it will enroll to the newly assigned
                 fleet and not the default.
               </>

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/DeleteAbmModal/DeleteAbmModal.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/AppleBusinessManagerPage/components/DeleteAbmModal/DeleteAbmModal.tsx
@@ -44,7 +44,7 @@ const DeleteAbmModal = ({
 
   return (
     <Modal
-      title="Delete ABM"
+      title="Delete AB"
       className={baseClass}
       onExit={onCancel}
       isContentDisabled={isDeleting}
@@ -55,7 +55,7 @@ const DeleteAbmModal = ({
       </p>
       <p>
         If you want to re-enable automatic enrollment, you&apos;ll have to
-        upload a new ABM token.
+        upload a new AB token.
       </p>
 
       <div className="modal-cta-wrap">

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/VppPage.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/VppPage.tsx
@@ -144,8 +144,8 @@ const VppPage = ({ router }: IVppPageProps) => {
           router={router}
           header="Turn on Apple MDM"
           buttonText="Turn on"
-          info=" To install Apple App Store apps purchased through Apple Business
-        Manager, first turn on Apple MDM."
+          info=" To install Apple App Store apps purchased through Apple Business,
+          first turn on Apple MDM."
         />
       );
     }
@@ -168,7 +168,7 @@ const VppPage = ({ router }: IVppPageProps) => {
         <>
           <PageDescription
             content="Add your VPP to install Apple App Store apps purchased through Apple
-            Business Manager."
+            Business."
           />
           <VppTable
             vppTokens={vppTokens}

--- a/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/VppSetupSteps/VppSetupSteps.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/MdmSettings/VppPage/components/VppSetupSteps/VppSetupSteps.tsx
@@ -51,8 +51,7 @@ const VppSetupSteps = ({ extendendSteps = false }: IVppSetupStepsProps) => {
           you want to use.
           {extendendSteps && (
             <>
-              <br /> Each token is based on a location in Apple Business
-              Manager.
+              <br /> Each token is based on a location in Apple Business.
             </>
           )}
         </p>


### PR DESCRIPTION
Missed a few AMB UI instances as part of [Rename Apple Business Manager (ABM) to Apple Business (AB) in
UI](https://github.com/fleetdm/fleet/issues/42512)

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:**https://github.com/fleetdm/fleet/pull/43506
https://github.com/fleetdm/fleet/issues/42512#issuecomment-4238323552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
* Updated user-facing text and messaging across Apple Business Manager integration pages, including modal titles, instructional content, and setup guides
* Refined terminology, formatting, and punctuation throughout tooltip content, administrative configuration descriptions, and user guidance
* Adjusted messaging and instructional text in Apple Business Manager and VPP settings pages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [ ] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [ ] Confirmed that the fix is not expected to adversely impact load test results
- [ ] Alerted the release DRI if additional load testing is needed

## Database migrations

- [ ] Checked schema for all modified table for columns that will auto-update timestamps during migration.
- [ ] Confirmed that updating the timestamps is acceptable, and will not cause unwanted side effects.
- [ ] Ensured the correct collation is explicitly set for character columns (`COLLATE utf8mb4_unicode_ci`).

## New Fleet configuration settings

- [ ] Setting(s) is/are explicitly excluded from GitOps

If you didn't check the box above, follow this checklist for GitOps-enabled settings:

- [ ] Verified that the setting is exported via `fleetctl generate-gitops`
- [ ] Verified the setting is documented in a separate PR to [the GitOps documentation](https://github.com/fleetdm/fleet/blob/main/docs/Configuration/yaml-files.md#L485)
- [ ] Verified that the setting is cleared on the server if it is not supplied in a YAML file (or that it is documented as being optional)
- [ ] Verified that any relevant UI is disabled when GitOps mode is enabled

## fleetd/orbit/Fleet Desktop

- [ ] Verified compatibility with the latest released version of Fleet (see [Must rule](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/workflows/fleetd-development-and-release-strategy.md))
- [ ] If the change applies to only one platform, confirmed that `runtime.GOOS` is used as needed to isolate changes
- [ ] Verified that fleetd runs on macOS, Linux and Windows
- [ ] Verified auto-update works from the released version of component to the new version (see [tools/tuf/test](../tools/tuf/test/README.md))
