### PR TITLE
Website: Update required meta tags for whitepaper articles

### DIFF
--- a/articles/modern-endpoint-management-managing-devices-as-code.md
+++ b/articles/modern-endpoint-management-managing-devices-as-code.md
@@ -58,6 +58,7 @@ You will also see how treating device management as a software discipline helps 
 
 <meta name="articleImageUrl" value="../website/assets/images/articles/modern-endpoint-management-managing-devices-as-code-cover-image-504x336@2x.png">
 
+<meta name="formCallToAction" value="Learn how GitOps transforms device management">
 <meta name="whitepaperFilename" value="fleet-modern-endpoint-device-management-managing-devices-as-code.pdf"> 
 <meta name="introductionTextBlockOne" value="Traditional device management does not scale. Teams still rely on manual updates, GUI tools, and scattered inventories."> 
 <meta name="introductionTextBlockTwo" value="Modern IT teams treat device management like software engineering. They define device state in code, review changes in Git, and deploy updates automatically.">

--- a/handbook/company/writing.md
+++ b/handbook/company/writing.md
@@ -158,6 +158,7 @@ Whitepaper articles use a separate article template that requires additional `<m
 
 - Required `<meta>` tags:
   - `whitepaperFilename`: The filename of the whitepaper PDF in the `website/assets/pdfs/` folder. Used to download the whitepaper after a user fills out the form on the whitepaper template page.
+  - `formCallToAction`: The heading displayed above the form to download the whitepaper. It should describe what users will get out of downloading a particular whitepaper. Example: "Learn how GitOps transforms device management"
   - `introductionTextBlockOne`: The introduction paragraph for the comparison. This is a required meta tag because the article title and introduction are displayed above the Markdown content of whitepaper articles.
   - `articleImageUrl`: A relative link to a cover image for the whitepaper. The specified image is placed next to the article title on the whitepaper article template page.
 - Optional `<meta>` tags:
@@ -176,6 +177,7 @@ Whitepaper articles use a separate article template that requires additional `<m
 <meta name="whitepaperFilename" value="fleet-modern-endpoint-device-management-managing-devices-as-code.pdf"> 
 <meta name="introductionTextBlockOne" value="Traditional device management does not scale. Teams still rely on manual updates, GUI tools, and scattered inventories."> 
 <meta name="introductionTextBlockTwo" value="Modern IT teams treat device management like software engineering. They define device state in code, review changes in Git, and deploy updates automatically.">
+<meta name="formCallToAction" value="Learn how GitOps transforms device management">
 ```
 
 

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -753,7 +753,7 @@ module.exports = {
                     }
                   }
                 }
-                // If this is a whitepaper article, we'll check to make sure it has a whitepaperFilename and TODO metatags
+                // If this is a whitepaper article, we'll check to make sure it has `whitepaperFilename` and `formCallToAction` meta tags.
                 if(embeddedMetadata.category === 'whitepaper') {
                   if(!embeddedMetadata.formCallToAction){
                     throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'formCallToAction' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a formCallToAction meta tag with a value set to the heading that should be displayed on the form to download the whitepaper (e.g., "Learn how GitOps transforms device management") and try running this script again.`);

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -755,6 +755,9 @@ module.exports = {
                 }
                 // If this is a whitepaper article, we'll check to make sure it has a whitepaperFilename and TODO metatags
                 if(embeddedMetadata.category === 'whitepaper') {
+                  if(!embeddedMetadata.formCallToAction){
+                    throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'formCallToAction' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a formCallToAction meta tag with a value set to the heading that should be displayed on the form to download the whitepaper (e.g., "Learn how GitOps transforms device management") and try running this script again.`);
+                  }
                   if(!embeddedMetadata.whitepaperFilename){
                     throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'whitepaperFilename' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a whitepaperFilename meta tag with a value that is the filename of a PDF whitepaper in the website/assets/pdf folder and try running this script again.`);
                   } else {

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -759,7 +759,7 @@ module.exports = {
                     throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'formCallToAction' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a formCallToAction meta tag with a value set to the heading that should be displayed on the form to download the whitepaper (e.g., "Learn how GitOps transforms device management") and try running this script again.`);
                   }
                   if(!embeddedMetadata.whitepaperFilename){
-                    throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'whitepaperFilename' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a whitepaperFilename meta tag with a value that is the filename of a PDF whitepaper in the website/assets/pdf folder and try running this script again.`);
+                    throw new Error(`Failed compiling markdown content: A whitepaper article is missing a 'whitepaperFilename' meta tag at ${path.join(topLvlRepoPath, pageSourcePath)}. To resolve, add a whitepaperFilename meta tag with a value that is the filename of a PDF whitepaper in the website/assets/pdfs folder and try running this script again.`);
                   } else {
                     let whitePaperPdfExists = await sails.helpers.fs.exists(path.join(topLvlRepoPath, 'website/assets/pdfs/'+embeddedMetadata.whitepaperFilename));
                     if(!whitePaperPdfExists){

--- a/website/views/pages/articles/basic-whitepaper.ejs
+++ b/website/views/pages/articles/basic-whitepaper.ejs
@@ -22,7 +22,7 @@
         <div purpose="right-sidebar" class="d-flex flex-column">
           <div purpose="form-container">
             <div id="download-form" purpose="whitepaper-download-form">
-              <h4>Learn how GitOps transforms device management</h4>
+              <h4><%- thisPage.meta.formCallToAction %></h4>
               <ajax-form class="w-100" action="deliverWhitepaperDownloadRequest" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" :syncing.sync="syncing" :cloud-error.sync="cloudError" @submitted="submittedDownloadForm()" v-if="!cloudSuccess">
                 <div class="form-group">
                   <label for="first-name">First name *</label>

--- a/website/views/pages/articles/basic-whitepaper.ejs
+++ b/website/views/pages/articles/basic-whitepaper.ejs
@@ -7,8 +7,8 @@
           <h1><%=thisPage.meta.articleTitle %></h1>
         </div>
         <div purpose="article-introduction">
-          <%if(thisPage.meta.introductionTextBlockOne){%><p><%- thisPage.meta.introductionTextBlockOne %></p><%}%>
-          <%if(thisPage.meta.introductionTextBlockTwo){%><p><%- thisPage.meta.introductionTextBlockTwo %></p><%}%>
+          <%if(thisPage.meta.introductionTextBlockOne){%><p><%= thisPage.meta.introductionTextBlockOne %></p><%}%>
+          <%if(thisPage.meta.introductionTextBlockTwo){%><p><%= thisPage.meta.introductionTextBlockTwo %></p><%}%>
         </div>
       </div>
       <%if(thisPage.meta.articleImageUrl){%>
@@ -22,7 +22,7 @@
         <div purpose="right-sidebar" class="d-flex flex-column">
           <div purpose="form-container">
             <div id="download-form" purpose="whitepaper-download-form">
-              <h4><%- thisPage.meta.formCallToAction %></h4>
+              <h4><%= thisPage.meta.formCallToAction %></h4>
               <ajax-form class="w-100" action="deliverWhitepaperDownloadRequest" :form-errors.sync="formErrors" :form-data="formData" :form-rules="formRules" :syncing.sync="syncing" :cloud-error.sync="cloudError" @submitted="submittedDownloadForm()" v-if="!cloudSuccess">
                 <div class="form-group">
                   <label for="first-name">First name *</label>

--- a/website/views/pages/articles/basic-whitepaper.ejs
+++ b/website/views/pages/articles/basic-whitepaper.ejs
@@ -8,7 +8,7 @@
         </div>
         <div purpose="article-introduction">
           <%if(thisPage.meta.introductionTextBlockOne){%><p><%- thisPage.meta.introductionTextBlockOne %></p><%}%>
-          <%if(thisPage.meta.introductionTextBlockOne){%><p><%- thisPage.meta.introductionTextBlockTwo %></p><%}%>
+          <%if(thisPage.meta.introductionTextBlockTwo){%><p><%- thisPage.meta.introductionTextBlockTwo %></p><%}%>
         </div>
       </div>
       <%if(thisPage.meta.articleImageUrl){%>


### PR DESCRIPTION
Changes:
- Documented a new required meta tag (`formCallToAction`) for whitepaper articles on the writing handbook page.
- Updated the heading on the form on the whitepaper template to use the `formCallToAction` meta tag value
- Updated the build-static-content script to throw an error if a whitepaper article is missing a `formCallToAction` meta tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed whitepaper intro paragraphs to render correctly and securely.
  * Sidebar download form headline now renders dynamically from whitepaper metadata.

* **Chores**
  * Build now validates presence of required whitepaper metadata and fails at build time if missing.
  * Improved validation messaging for missing whitepaper assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->