### PR TITLE
Fix FMA patch policies breaking GitOps apply

### DIFF
--- a/server/service/team_policies.go
+++ b/server/service/team_policies.go
@@ -174,7 +174,27 @@ func (svc *Service) populatePolicyPatchSoftware(ctx context.Context, p *fleet.Po
 	if p.PatchSoftwareTitleID != nil {
 		installerMetadata, err := svc.ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, p.TeamID, *p.PatchSoftwareTitleID, false)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "get software installer metadata by title id")
+			if !fleet.IsNotFound(err) {
+				return ctxerr.Wrap(ctx, err, "get software installer metadata by title id")
+			}
+			// Software installer not found — this can happen when the
+			// installer was removed (e.g. by a GitOps software sync)
+			// while a patch policy still references the title. Fall
+			// back to the software_titles table for display info.
+			name, displayName, titleErr := svc.ds.SoftwareTitleNameForHostFilter(ctx, *p.PatchSoftwareTitleID)
+			if titleErr != nil {
+				if !fleet.IsNotFound(titleErr) {
+					return ctxerr.Wrap(ctx, titleErr, "get software title name for patch software fallback")
+				}
+				// Title is also gone; leave PatchSoftware nil.
+				return nil
+			}
+			p.PatchSoftware = &fleet.PolicySoftwareTitle{
+				SoftwareTitleID: *p.PatchSoftwareTitleID,
+				Name:            name,
+				DisplayName:     displayName,
+			}
+			return nil
 		}
 		p.PatchSoftware = &fleet.PolicySoftwareTitle{
 			SoftwareTitleID: *installerMetadata.TitleID,

--- a/server/service/team_policies_test.go
+++ b/server/service/team_policies_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -199,6 +200,74 @@ func TestTeamPolicyVPPAutomationRejectsNonMacOS(t *testing.T) {
 		SoftwareTitleID: ptr.Uint(123),
 	})
 	require.ErrorContains(t, err, "is associated to an iOS or iPadOS VPP app")
+}
+
+func TestPopulatePolicyPatchSoftwareFallback(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+	ctx = viewer.NewContext(ctx, viewer.Viewer{User: &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}})
+
+	titleID := uint(42)
+
+	ds.ListTeamPoliciesFunc = func(ctx context.Context, teamID uint, opts fleet.ListOptions, iopts fleet.ListOptions, automationFilter string) ([]*fleet.Policy, []*fleet.Policy, error) {
+		return []*fleet.Policy{
+			{
+				PolicyData: fleet.PolicyData{
+					ID:                   1,
+					TeamID:               ptr.Uint(1),
+					PatchSoftwareTitleID: &titleID,
+				},
+			},
+		}, nil, nil
+	}
+	ds.TeamLiteFunc = func(ctx context.Context, tid uint) (*fleet.TeamLite, error) {
+		return &fleet.TeamLite{ID: 1}, nil
+	}
+	ds.GetSoftwareInstallerMetadataByIDFunc = func(ctx context.Context, id uint) (*fleet.SoftwareInstaller, error) {
+		return &fleet.SoftwareInstaller{}, nil
+	}
+
+	t.Run("installer not found falls back to title", func(t *testing.T) {
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, tid uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			return nil, &notFoundError{}
+		}
+		ds.SoftwareTitleNameForHostFilterFunc = func(ctx context.Context, id uint) (string, string, error) {
+			return "", "Zoom Workplace", nil
+		}
+
+		teamPolicies, _, err := svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{}, false, "")
+		require.NoError(t, err)
+		require.Len(t, teamPolicies, 1)
+		require.NotNil(t, teamPolicies[0].PatchSoftware)
+		require.Equal(t, titleID, teamPolicies[0].PatchSoftware.SoftwareTitleID)
+		require.Equal(t, "Zoom Workplace", teamPolicies[0].PatchSoftware.DisplayName)
+	})
+
+	t.Run("installer not found and title lookup DB error propagates", func(t *testing.T) {
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, tid uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			return nil, &notFoundError{}
+		}
+		ds.SoftwareTitleNameForHostFilterFunc = func(ctx context.Context, id uint) (string, string, error) {
+			return "", "", errors.New("connection refused")
+		}
+
+		_, _, err := svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{}, false, "")
+		require.Error(t, err)
+	})
+
+	t.Run("both installer and title not found", func(t *testing.T) {
+		ds.GetSoftwareInstallerMetadataByTeamAndTitleIDFunc = func(ctx context.Context, teamID *uint, tid uint, withScriptContents bool) (*fleet.SoftwareInstaller, error) {
+			return nil, &notFoundError{}
+		}
+		ds.SoftwareTitleNameForHostFilterFunc = func(ctx context.Context, id uint) (string, string, error) {
+			return "", "", &notFoundError{}
+		}
+
+		teamPolicies, _, err := svc.ListTeamPolicies(ctx, 1, fleet.ListOptions{}, fleet.ListOptions{}, false, "")
+		require.NoError(t, err)
+		require.Len(t, teamPolicies, 1)
+		require.Nil(t, teamPolicies[0].PatchSoftware)
+	})
 }
 
 func checkAuthErr(t *testing.T, shouldFail bool, err error) {


### PR DESCRIPTION
Closes #43623

## Summary

- When a patch policy references a Fleet-maintained app (FMA) whose software installer record no longer exists (e.g. removed by a prior GitOps software sync step), `populatePolicyPatchSoftware` now falls back to the `software_titles` table for display info instead of returning a fatal not-found error.
- If the software title is also gone, `PatchSoftware` is left nil and no error is returned — the policy listing succeeds so GitOps can proceed to delete the orphaned policy.
- Non-not-found DB errors still propagate normally.

## Test plan

- [x] Added unit tests covering three scenarios: installer not found with title fallback, DB error propagation, and both installer and title missing.
- [x] Existing `TestTeamPoliciesAuth` and `TestTeamPolicyVPPAutomationRejectsNonMacOS` still pass.
- [ ] QA: Configure a patch policy for an FMA via the GUI, then run a GitOps apply that does not include that FMA in software — verify the apply succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of patch software policy resolution by implementing a fallback mechanism. When primary metadata lookup is unavailable, the system now attempts an alternative lookup approach instead of immediately failing.

* **Tests**
  * Added test coverage for patch software policy resolution with fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->