### PR TITLE
Enroll page media screen max width updated

### DIFF
--- a/changes/41568-enroll-page-enroll-button-update-to-full-width-for-larger-res-mobiles
+++ b/changes/41568-enroll-page-enroll-button-update-to-full-width-for-larger-res-mobiles
@@ -1,0 +1,1 @@
+- Enrolment page enroll button updated to render full screen width for larger resolution mobile devices

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -184,7 +184,7 @@
         text-align: center;
       }
 
-      @media screen and (max-width: 430px) {
+      @media screen and (max-width: 1344px) {
         .device-instructions-content {
           gap: 24px;
         }

--- a/frontend/templates/enroll-ota.html
+++ b/frontend/templates/enroll-ota.html
@@ -184,7 +184,7 @@
         text-align: center;
       }
 
-      @media screen and (max-width: 1344px) {
+      @media screen and (max-width: 1344px) and (pointer: coarse) {
         .device-instructions-content {
           gap: 24px;
         }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41568

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually
<img width="751" height="239" alt="Localhost pixel 9pro xl emulation" src="https://github.com/user-attachments/assets/2ad2d07a-aca8-4c4f-bbe2-0700736a51a4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the enrollment page responsive layout so the enroll button renders at full width on larger-resolution mobile and medium screens.
  * Increased spacing between device instructions and the enrollment action to improve layout clarity.
  * Visual-only change — no functional or behavioral modifications to the enrollment flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->