### PR TITLE
Add quarterly roadmap preview blog ritual

### DIFF
--- a/handbook/marketing/marketing.rituals.yml
+++ b/handbook/marketing/marketing.rituals.yml
@@ -170,3 +170,13 @@
   autoIssue:  
     labels: [ ":help-marketing" ] 
     repo: "confidential"
+-
+  task: "Publish quarterly roadmap preview blog"
+  startedOn: "2026-03-16"
+  frequency: "Quarterly"
+  description: "Once a quarter, engage with Noah to create a roadmap preview blog for the upcoming quarter, and own publishing it in beginning of the quarter it is for."
+  moreInfoUrl: "https://fleetdm.com/announcements/roadmap-preview-january-2026"
+  dri: "danbgordon"
+  autoIssue:  
+    labels: [ ":help-marketing" ] 
+    repo: "confidential"


### PR DESCRIPTION
Added a new ritual for publishing quarterly roadmap preview blog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new quarterly marketing ritual for publishing roadmap previews, effective March 2026. Includes automated issue creation and designated ownership to ensure consistent execution and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->