### PR TITLE
Website: Add mixins for checklists and cta buttons

### DIFF
--- a/website/assets/styles/components/call-to-action.component.less
+++ b/website/assets/styles/components/call-to-action.component.less
@@ -21,39 +21,13 @@
       white-space: nowrap;
     }
     [purpose='cta-button'] {
+      .cta-button();
       cursor: pointer;
       margin-right: 24px;
-      background: @core-vibrant-green;
-      border-radius: 8px;
       padding: 16px;
       height: 36px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #FFF;
-      position: relative;
       text-decoration: none;
       overflow: hidden;
-      &:hover {
-        color: #FFF;
-      }
-    }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: ' ';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 70%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      opacity: 0;
-      left: 160px;
-      width: 110%;
     }
 
   }

--- a/website/assets/styles/layout.less
+++ b/website/assets/styles/layout.less
@@ -280,39 +280,12 @@ html, body {
   }
 
   [purpose='glass-header-btn'] {
-    color: #FFFFFF;
+    .cta-button();
     height: 36px;
-    position: relative;
     font-size: 14px;
-    font-weight: 700;
     line-height: 1;
     padding: 16px 12px;
     border-radius: 8px;
-    background-color: @core-vibrant-green;
-    text-decoration: none;
-    white-space: nowrap;
-    overflow: hidden;
-    &:hover {
-      color: #FFF;
-    }
-  }
-
-  [purpose='glass-header-btn']::before {
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-    opacity: 1;
-    content: ' ';
-    position: absolute;
-    top: 0;
-    left: -5px;
-    width: 60%;
-    height: 100%;
-    transform: skew(-10deg);
-    transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-  }
-  [purpose='glass-header-btn']:hover:before {
-    opacity: 0;
-    left: 160px;
-    width: 110%;
   }
 
   [purpose='layout-animated-arrow-button'] {

--- a/website/assets/styles/mixins-and-variables/buttons.less
+++ b/website/assets/styles/mixins-and-variables/buttons.less
@@ -97,6 +97,7 @@
   justify-content: center;
   align-items: center;
   font-weight: 700;
+  border-radius: 8px;
   &:before {
     background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
     opacity: 1;

--- a/website/assets/styles/mixins-and-variables/buttons.less
+++ b/website/assets/styles/mixins-and-variables/buttons.less
@@ -84,3 +84,39 @@
   /*   opacity:1; */
   }
 }
+
+.cta-button() {
+  background-color: @core-vibrant-green;
+  border: none;
+  cursor: pointer;
+  color: #FFF;
+  overflow: hidden;
+  text-decoration: none;
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-weight: 700;
+  &:before {
+    background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
+    opacity: 1;
+    content: ' ';
+    position: absolute;
+    top: 0;
+    left: -5px;
+    width: 50%;
+    height: 100%;
+    transform: skew(-10deg);
+    transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
+  }
+  &:hover:before {
+    opacity: 0;
+    left: 160px;
+    width: 110%;
+  }
+  &:focus:before {
+    opacity: 0;
+    left: 160px;
+    width: 110%;
+  }
+}

--- a/website/assets/styles/mixins-and-variables/checklist.less
+++ b/website/assets/styles/mixins-and-variables/checklist.less
@@ -1,0 +1,26 @@
+// Renders <p> children of a container as checklist items with a green checkmark icon.
+// Apply directly on a [purpose='checklist'] selector.
+// To customize (font size, spacing, etc.), add overrides on the selector after calling the mixin.
+.checklist() {
+  p {
+    font-size: 14px;
+    font-weight: 400;
+    padding-left: 37px;
+    text-indent: -37px;
+    margin-bottom: 1.5rem;
+    &:last-of-type {
+      margin-bottom: 0px;
+    }
+  }
+  p::before {
+    content: ' ';
+    background-image: url('/images/icon-checkmark-green-20x20@2x.png');
+    background-size: 20px 20px;
+    display: inline-block;
+    position: relative;
+    top: 5px;
+    margin-right: 16px;
+    width: 20px;
+    height: 20px;
+  }
+}

--- a/website/assets/styles/mixins-and-variables/checklist.less
+++ b/website/assets/styles/mixins-and-variables/checklist.less
@@ -24,3 +24,32 @@
     height: 20px;
   }
 }
+
+.article-checklist() {
+  margin-bottom: 32px;
+  p {
+    font-size: 16px;
+    line-height: 150%;
+    font-style: normal;
+    font-weight: 400;
+    padding-left: 40px;
+    text-indent: -40px;
+    margin-bottom: 16px;
+    padding-top: 12px;
+    padding-bottom: 12px;
+    &:last-of-type {
+      margin-bottom: 0px;
+    }
+  }
+  p::before {
+    content: ' ';
+    background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
+    background-size: 24px 24px;
+    display: inline-block;
+    position: relative;
+    top: 7px;
+    margin-right: 16px;
+    width: 24px;
+    height: 24px;
+  }
+}

--- a/website/assets/styles/mixins-and-variables/checklist.less
+++ b/website/assets/styles/mixins-and-variables/checklist.less
@@ -7,7 +7,7 @@
     font-weight: 400;
     padding-left: 37px;
     text-indent: -37px;
-    margin-bottom: 1.5rem;
+    margin-bottom: 24px;
     &:last-of-type {
       margin-bottom: 0px;
     }

--- a/website/assets/styles/mixins-and-variables/index.less
+++ b/website/assets/styles/mixins-and-variables/index.less
@@ -5,3 +5,4 @@
 @import 'truncate.less';
 @import 'containers.less';
 @import 'tip-block.less';
+@import 'checklist.less';

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -748,32 +748,8 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/basic-article.less
+++ b/website/assets/styles/pages/articles/basic-article.less
@@ -748,8 +748,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/basic-webinar.less
+++ b/website/assets/styles/pages/articles/basic-webinar.less
@@ -508,65 +508,11 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
-      margin: 16px 0 32px;
-      background: #F7F7FC;
-      border: 1px solid @core-vibrant-blue-50;
-      padding: 16px;
-      border-radius: 8px;
-      display: flex;
-      img {
-        display: flex;
-        margin: 4px 12px 0 0;
-        height: 16px;
-        width: 16px;
-        padding: 0px;
-      }
-      p {
-        display: block;
-        margin-bottom: 16px;
-        line-height: 24px;
-        font-size: 16px;
-      }
-      p:only-child, p:last-child {
-        margin-bottom: 0px;
-      }
-      ul:last-child {
-        margin-bottom: 0px;
-      }
-      li:last-child {
-        padding-bottom: 0px;
-      }
-      :first-child {// Remove top padding from the first element inside purpose="tip" blockquotes
-        padding-top: 0;
-      }
+      .tip-block();
     }
     [purpose='embedded-content'] {
       position: relative;

--- a/website/assets/styles/pages/articles/basic-webinar.less
+++ b/website/assets/styles/pages/articles/basic-webinar.less
@@ -508,8 +508,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/basic-whitepaper.less
+++ b/website/assets/styles/pages/articles/basic-whitepaper.less
@@ -477,32 +477,8 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/basic-whitepaper.less
+++ b/website/assets/styles/pages/articles/basic-whitepaper.less
@@ -477,8 +477,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/case-study.less
+++ b/website/assets/styles/pages/articles/case-study.less
@@ -544,32 +544,8 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 0px;
-        padding-top: 8px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/articles/case-study.less
+++ b/website/assets/styles/pages/articles/case-study.less
@@ -590,34 +590,11 @@
       text-decoration: none;
     }
     [purpose='cta-button'] {
+      .cta-button();
       cursor: pointer;
       margin-right: 32px;
-      background: @core-vibrant-green;
-      border-radius: 8px;
       padding: 16px;
       height: 36px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #FFF;
-      position: relative;
-      overflow: hidden;
-    }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 50%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      left: 160px;
-      width: 110%;
     }
   }
 

--- a/website/assets/styles/pages/articles/case-study.less
+++ b/website/assets/styles/pages/articles/case-study.less
@@ -544,8 +544,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/customers.less
+++ b/website/assets/styles/pages/customers.less
@@ -361,42 +361,13 @@
       text-decoration: none;
     }
     [purpose='cta-button'] {
-      display: flex;
+      .cta-button();
       height: 36px;
       padding: 16px;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-      border-radius: 8px;
-      background: @core-vibrant-green;
-      color: #FFF;
-      text-align: center;
       width: 140px;
-      /* Body MD (bold) */
-      font-family: Inter;
       font-size: 16px;
-      font-style: normal;
-      font-weight: 700;
       line-height: 150%;
       margin-right: 24px;
-      position: relative;
-      cursor: pointer;
-    }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 50%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      left: 160px;
-      width: 110%;
     }
     [parasails-component='animated-arrow-button'] {
       width: fit-content;

--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -553,28 +553,7 @@
     }
   }
   [purpose='checklist'] {
-    p {
-      font-size: 14px;
-      font-style: normal;
-      font-weight: 400;
-      padding-left: 37px;
-      text-indent: -37px;
-      margin-bottom: 24px;
-      &:last-of-type {
-        margin-bottom: 0px;
-      }
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
-    }
+    .checklist();
   }
   [purpose='feature-headline'] {
     max-width: 510px;

--- a/website/assets/styles/pages/device-management.less
+++ b/website/assets/styles/pages/device-management.less
@@ -619,36 +619,10 @@
       white-space: nowrap;
     }
     [purpose='cta-button'] {
-      cursor: pointer;
+      .cta-button();
       margin-right: 24px;
-      background: @core-vibrant-green;
-      border-radius: 8px;
       padding: 16px;
       height: 36px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #FFF;
-      position: relative;
-      text-decoration: none;
-      overflow: hidden;
-    }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: ' ';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 70%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      opacity: 0;
-      left: 160px;
-      width: 110%;
     }
   }
 

--- a/website/assets/styles/pages/fast-track.less
+++ b/website/assets/styles/pages/fast-track.less
@@ -133,28 +133,8 @@
     }
   }
   [purpose='checklist'] {
+    .checklist();
     padding: 8px 0px;
-    p {
-      font-size: 14px;
-      font-style: normal;
-      font-weight: 400;
-      padding-left: 37px;
-      text-indent: -37px;
-      &:last-of-type {
-        margin-bottom: 0px;
-      }
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
-    }
   }
 
 

--- a/website/assets/styles/pages/homepage.less
+++ b/website/assets/styles/pages/homepage.less
@@ -166,34 +166,11 @@
       text-decoration: none;
     }
     [purpose='cta-button'] {
-      cursor: pointer;
+      .cta-button();
       margin-right: 24px;
-      background: @core-vibrant-green;
       border-radius: 8px;
       padding: 8px 16px;
       height: 36px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #FFF;
-      position: relative;
-      overflow: hidden;
-    }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 50%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      left: 160px;
-      width: 110%;
     }
   }
 

--- a/website/assets/styles/pages/infrastructure-as-code.less
+++ b/website/assets/styles/pages/infrastructure-as-code.less
@@ -118,22 +118,11 @@
     align-self: stretch;
     flex-wrap: wrap;
     [purpose='cta-button'] {
-      display: flex;
+      .cta-button();
       height: 36px;
       min-width: 140px;
       padding: 8px 16px;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-      border-radius: 8px;
-      background: #009A7D;
-      color: #FFF;
-      text-align: center;
-
-
-      font-family: Inter;
       font-size: 14px;
-      font-style: normal;
       font-weight: 700;
       line-height: 150%;
     }

--- a/website/assets/styles/pages/landing-pages/deployment.less
+++ b/website/assets/styles/pages/landing-pages/deployment.less
@@ -179,31 +179,16 @@
   }
 
   [purpose='checklist'] {
+    .checklist();
+    p {
+      margin-bottom: 0px;
+    }
     padding: 8px 0px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
     gap: 24px;
     align-self: stretch;
-    p {
-      font-size: 14px;
-      font-style: normal;
-      font-weight: 400;
-      padding-left: 37px;
-      text-indent: -37px;
-      margin-bottom: 0px;
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
-    }
   }
 
 

--- a/website/assets/styles/pages/landing-pages/deployment.less
+++ b/website/assets/styles/pages/landing-pages/deployment.less
@@ -283,27 +283,13 @@
     gap: 24px;
   }
   [ purpose='cta-button'] {
-    display: flex;
+    .cta-button();
     height: 36px;
     min-width: 140px;
     padding: 8px 16px;
-    justify-content: center;
-    align-items: center;
-    border-radius: 8px;
-    background: #009A7D;
-    color: #FFF;
-    text-align: center;
-
-    /* Body/Emphasis/SM */
-    font-family: Inter;
     font-size: 14px;
-    font-style: normal;
     font-weight: 700;
     line-height: 150%;
-    &:hover {
-      color: #FFF;
-    }
-    gap: 4px;
   }
   [purpose='carousel-image'] {
     max-width: 50%;

--- a/website/assets/styles/pages/landing-pages/gitops-workshop.less
+++ b/website/assets/styles/pages/landing-pages/gitops-workshop.less
@@ -352,23 +352,14 @@
       margin-bottom: 0px;
     }
     a {
-      color: #FFF;
-      text-align: center;
-
-
+      .cta-button();
       font-size: 14px;
-      font-style: normal;
       font-weight: 700;
       line-height: 150%;
-      display: flex;
       width: 260px;
       height: 36px;
       min-width: 140px;
       padding: 8px 16px;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-      flex-shrink: 0;
     }
   }
 

--- a/website/assets/styles/pages/landing-pages/linux-management.less
+++ b/website/assets/styles/pages/landing-pages/linux-management.less
@@ -213,26 +213,13 @@
     gap: 24px;
   }
   [ purpose='cta-button'] {
+    .cta-button();
     display: flex;
     height: 36px;
     min-width: 140px;
     padding: 8px 16px;
-    justify-content: center;
-    align-items: center;
-    border-radius: 8px;
-    background: #009A7D;
-    color: #FFF;
-    text-align: center;
-
-
-    font-family: Inter;
-    font-size: 14px;
-    font-style: normal;
-    font-weight: 700;
     line-height: 150%;
-    &:hover {
-      color: #FFF;
-    }
+    font-size: 14px;
     gap: 4px;
   }
 

--- a/website/assets/styles/pages/landing-pages/linux-management.less
+++ b/website/assets/styles/pages/landing-pages/linux-management.less
@@ -195,6 +195,7 @@
   }
 
   [purpose='checklist'] {
+    .checklist();
     padding: 8px 0px;
     display: flex;
     flex-direction: column;
@@ -202,23 +203,7 @@
     gap: 24px;
     align-self: stretch;
     p {
-      font-size: 14px;
-      font-style: normal;
-      font-weight: 400;
-      padding-left: 37px;
-      text-indent: -37px;
       margin-bottom: 0px;
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
     }
   }
 

--- a/website/assets/styles/pages/landing-pages/replace-jamf.less
+++ b/website/assets/styles/pages/landing-pages/replace-jamf.less
@@ -110,37 +110,13 @@
       white-space: nowrap;
     }
     [purpose='cta-button'] {
-      cursor: pointer;
-      background: @core-vibrant-green;
+      .cta-button();
       border-radius: 8px;
       padding: 8px 16px;
       height: 36px;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      color: #FFF;
-      position: relative;
-      text-decoration: none;
-      overflow: hidden;
       min-width: 140px;
     }
-    [purpose='cta-button']::before {
-      background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-      opacity: 1;
-      content: ' ';
-      position: absolute;
-      top: 0;
-      left: -5px;
-      width: 70%;
-      height: 100%;
-      transform: skew(-10deg);
-      transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-    }
-    [purpose='cta-button']:hover:before {
-      opacity: 0;
-      left: 160px;
-      width: 110%;
-    }
+
     [purpose='video-button'] {
       display: flex;
       flex-direction: row;

--- a/website/assets/styles/pages/legal/privacy.less
+++ b/website/assets/styles/pages/legal/privacy.less
@@ -664,8 +664,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/legal/privacy.less
+++ b/website/assets/styles/pages/legal/privacy.less
@@ -664,32 +664,8 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/legal/terms.less
+++ b/website/assets/styles/pages/legal/terms.less
@@ -563,32 +563,8 @@
       height: 17px;
     }
     [purpose='checklist'] {
+      .checklist();
       margin-bottom: 32px;
-      p {
-        font-size: 16px;
-        line-height: 150%;
-        font-style: normal;
-        font-weight: 400;
-        padding-left: 40px;
-        text-indent: -40px;
-        margin-bottom: 16px;
-        padding-top: 12px;
-        padding-bottom: 12px;
-        &:last-of-type {
-          margin-bottom: 0px;
-        }
-      }
-      p::before {
-        content: ' ';
-        background-image: url('/images/icon-checkbox-checked-24x24@2x.png');
-        background-size: 24px 24px;
-        display: inline-block;
-        position: relative;
-        top: 7px;
-        margin-right: 16px;
-        width: 24px;
-        height: 24px;
-      }
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/legal/terms.less
+++ b/website/assets/styles/pages/legal/terms.less
@@ -563,8 +563,7 @@
       height: 17px;
     }
     [purpose='checklist'] {
-      .checklist();
-      margin-bottom: 32px;
+      .article-checklist();
     }
     [purpose='tip'] {
       .tip-block();

--- a/website/assets/styles/pages/observability.less
+++ b/website/assets/styles/pages/observability.less
@@ -450,30 +450,8 @@
   }
 
   [purpose='checklist'] {
+    .checklist();
     margin-top: 8px;
-    p {
-      font-size: 14px;
-      font-style: normal;
-      font-weight: 400;
-      line-height: 21px;
-      padding-left: 37px;
-      text-indent: -37px;
-      margin-bottom: 1.5rem;
-      &:last-of-type {
-        margin-bottom: 0px;
-      }
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
-    }
   }
 
   [purpose='feature-link'] {

--- a/website/assets/styles/pages/observability.less
+++ b/website/assets/styles/pages/observability.less
@@ -90,36 +90,10 @@
     }
   }
   [purpose='cta-button'] {
-    cursor: pointer;
+    .cta-button();
     margin-right: 24px;
-    background: @core-vibrant-green;
-    border-radius: 8px;
     padding: 16px 32px;
     height: 36px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: #FFF;
-    position: relative;
-    text-decoration: none;
-    overflow: hidden;
-  }
-  [purpose='cta-button']::before {
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-    opacity: 1;
-    content: ' ';
-    position: absolute;
-    top: 0;
-    left: -5px;
-    width: 50%;
-    height: 100%;
-    transform: skew(-10deg);
-    transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-  }
-  [purpose='cta-button']:hover:before {
-    opacity: 0;
-    left: 160px;
-    width: 110%;
   }
   [purpose='testimonials'] {
     margin-bottom: 80px;

--- a/website/assets/styles/pages/partners.less
+++ b/website/assets/styles/pages/partners.less
@@ -192,6 +192,7 @@
 
       }
       [purpose='checklist'] {
+        .checklist();
         padding: 8px 0px;
         display: flex;
         flex-direction: column;
@@ -199,23 +200,7 @@
         gap: 24px;
         align-self: stretch;
         p {
-          font-size: 16px;
-          font-style: normal;
-          font-weight: 400;
-          padding-left: 37px;
-          text-indent: -37px;
           margin-bottom: 0px;
-        }
-        p::before {
-          content: ' ';
-          background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-          background-size: 20px 20px;
-          display: inline-block;
-          position: relative;
-          top: 5px;
-          margin-right: 16px;
-          width: 20px;
-          height: 20px;
         }
       }
     }

--- a/website/assets/styles/pages/partners.less
+++ b/website/assets/styles/pages/partners.less
@@ -90,40 +90,14 @@
     gap: @inner-gap-s;
   }
   [purpose='cta-button'] {
-    cursor: pointer;
-    background: @core-vibrant-green;
-    border-radius: 8px;
+    .cta-button();
     padding: 8px 16px;
     height: 36px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: #FFF;
-    position: relative;
-    text-decoration: none;
-    overflow: hidden;
     min-width: 140px;
     font-weight: 700;
     font-size: 14px;
     line-height: @text-lineheight;
     white-space: nowrap;
-  }
-  [purpose='cta-button']::before {
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-    opacity: 1;
-    content: ' ';
-    position: absolute;
-    top: 0;
-    left: -5px;
-    width: 70%;
-    height: 100%;
-    transform: skew(-10deg);
-    transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-  }
-  [purpose='cta-button']:hover:before {
-    opacity: 0;
-    left: 160px;
-    width: 110%;
   }
 
   [purpose='logos'] {

--- a/website/assets/styles/pages/pricing.less
+++ b/website/assets/styles/pages/pricing.less
@@ -227,32 +227,15 @@
   }
 
   [purpose='card-button'] {
+    .cta-button();
     font-size: 16px;
     padding: 15px;
     margin-top: 8px;
     margin-bottom: 0px;
-    color: #FFF;
   }
 
   [purpose='chat-button'], [purpose='card-button'] {
     position: relative;
-  }
-  [purpose='card-button']::before, [purpose='chat-button']::before {
-    background: linear-gradient(180deg, rgba(255, 255, 255, 0.2) 0%, rgba(255, 255, 255, 0) 100%);
-    opacity: 1;
-    content: ' ';
-    position: absolute;
-    top: 0;
-    left: -5px;
-    width: 50%;
-    height: 100%;
-    transform: skew(-10deg);
-    transition: left 0.5s ease-in, opacity 0.50s ease-in, width 0.5s ease-in;
-  }
-  [purpose='card-button']:hover:before, [purpose='chat-button']:hover:before, [purpose='table-button']:hover:before {
-    opacity: 0;
-    left: 160px;
-    width: 110%;
   }
 
   [purpose='features-table'].hide {

--- a/website/assets/styles/pages/software-management.less
+++ b/website/assets/styles/pages/software-management.less
@@ -184,29 +184,8 @@
     }
   }
   [purpose='checklist'] {
+    .checklist();
     margin-top: 8px;
-    p {
-      font-size: 14px;
-      font-weight: 400;
-      line-height: @text-lineheight;
-      padding-left: 37px;
-      text-indent: -37px;
-      margin-bottom: 1.5rem;
-      &:last-of-type {
-        margin-bottom: 0px;
-      }
-    }
-    p::before {
-      content: ' ';
-      background-image: url('/images/icon-checkmark-green-20x20@2x.png');
-      background-size: 20px 20px;
-      display: inline-block;
-      position: relative;
-      top: 5px;
-      margin-right: 16px;
-      width: 20px;
-      height: 20px;
-    }
   }
   [purpose='feature-link'] {
     padding-top: 32px;

--- a/website/assets/styles/pages/software-management.less
+++ b/website/assets/styles/pages/software-management.less
@@ -58,25 +58,14 @@
   }
   [purpose='button-row'] {
     flex-direction: row;
-    [purpose='contact-button'] {
-      display: flex;
-      height: 36px;
-      padding: 16px;
-      justify-content: center;
-      align-items: center;
-      gap: 4px;
-      border-radius: 8px;
-      background: @core-vibrant-green;
-      color: #FFF;
-      text-align: center;
-      font-size: 16px;
-      font-weight: 700;
-      line-height: @text-lineheight;
-      margin-right: 24px;
-      &:hover {
-        text-decoration: none;
-      }
-    }
+  }
+  [purpose='contact-button'] {
+    .cta-button();
+    display: flex;
+    height: 36px;
+    padding: 16px;
+    font-size: 16px;
+    line-height: @text-lineheight;
   }
   [purpose='hero-slides'] {
     padding-top: 64px;


### PR DESCRIPTION
Changes:
- Created checklist.less, a file that contains two mixins for checklists (`.checklist()` and `.article-checklist()`), and updated stylesheets to use the mixins.
- Added a mixin for CTA buttons (`.cta-button()`), and updated stylesheets to use the mixin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized call-to-action button styling across all pages with a unified design system approach.
  * Consolidated checklist styling for improved visual consistency throughout articles and landing pages.
  * Refined button hover effects for a more cohesive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->