### PR TITLE
Adding marketing labels and updating rituals

### DIFF
--- a/handbook/marketing/README.md
+++ b/handbook/marketing/README.md
@@ -36,14 +36,16 @@ In the Marketing department, we're using the following issue labels to organize 
 
 | Label | Color | Hex Code | Definition (When to use it) |
 | :---- | :---- | :---- | :---- |
+| **:mktg-ar** | Teal | \#0F766E | For tasks related to analyst relations \- briefing, responding to reports, inquiries, etc. |
 | **:mktg-campaign** | Purple | \#6B4FBB | For tasks related to a specific, multi-touch marketing initiative (e.g., a product launch, awareness campaign, Q4 demand-gen). |
 | **:mktg-content** | Blue | \#0052CC | For creating or updating any marketing asset: blog posts, case studies, website copy, videos, white papers, etc. |
-| **:mktg-social** | Pink | \#E11D48 | For tasks related to managing organic social media channels or creating social posts. |
-| **:mktg-ops** | Green | \#10B981 | For internal "infrastructure" work: tooling (e.g., "Fix email automation"), analytics, reporting, list management, and process improvements. |
-| **:mktg-ar** | Teal | \#0F766E | For tasks related to analyst relations \- briefing, responding to reports, inquiries, etc. |
-| **:mktg-pr** | Gray | \#6B7280 | All tasks/effort related to public relations, press releases, earned media, interviews, responding to reporters, etc. |
 | **:mktg-enablement** | Gold | \#D97706 | All work associated with designing, developing, and delivering enablement content for sales, partners, etc. |
 | **:mktg-event** | Orange | \#F97316 | For tasks related to any event, virtual or in-person (e.g., webinars, conference logistics, booth design, talk submissions). |
+| **:mktg-ops** | Green | \#10B981 | For internal "infrastructure" work: tooling (e.g., "Fix email automation"), analytics, reporting, list management, and process improvements. |
+| **:mktg-pr** | Gray | \#6B7280 | All tasks/effort related to public relations, press releases, earned media, interviews, responding to reporters, etc. |
+| **:mktg-web** | Purple | \#2b27d0 | Tasks to update the website. |
+| **:mktg-ritual** | Red | \#9d2455 | Tasks created through automated rituals. |
+| **:mktg-social** | Pink | \#E11D48 | For tasks related to managing organic social media channels or creating social posts. |
 
 Note: for event execution, additional labels are used to manage the process and track specific events.
 

--- a/handbook/marketing/marketing.rituals.yml
+++ b/handbook/marketing/marketing.rituals.yml
@@ -44,7 +44,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/marketing#upload-to-youtube"
   dri: "irenareedy"
   autoIssue:
-    labels: [":help-marketing"]
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 - task: "Check ongoing events"
   startedOn: "2024-10-21"
@@ -65,7 +65,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/marketing#prepare-lets-get-you-set-up-meeting-notes"
   dri: "irenareedy"
   autoIssue:
-    labels: [":help-marketing"]
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 - task: "Update content calendar"
   startedOn: "2025-08-04"
@@ -74,7 +74,7 @@
   moreInfoUrl: "https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit?gid=390351382#gid=390351382"
   dri: "irenareedy"
   autoIssue:
-    labels: [":help-marketing"]
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 - task: "Update KPIs"
   startedOn: "2025-08-08"
@@ -83,7 +83,7 @@
   moreInfoUrl: "https://docs.google.com/spreadsheets/d/1Hso0LxqwrRVINCyW_n436bNHmoqhoLhC8bcbvLPOs9A/edit?gid=0#gid=0"
   dri: "irenareedy"
   autoIssue:
-    labels: [":help-marketing"]
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 - task: "Check new customers and add them to the Fleet Champions Community."
   startedOn: "2026-03-09"
@@ -111,7 +111,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/marketing/marketing-assets-new"
   dri: "irenareedy"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 -
   task: "Review CTRs of recently boosted posts"
@@ -121,7 +121,7 @@
   moreInfoUrl: "https://fleetdm.com/handbook/marketing#review-ctrs-of-recently-boosted-posts"
   dri: "irenareedy"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ]  
     repo: "confidential"	
 - 
   task: "Check LinkedIn comments"
@@ -138,7 +138,7 @@
   moreInfoUrl: "https://docs.google.com/spreadsheets/d/1fMs7qeZ9Rme1yf9_n8GxfEPzrAxPcvB5yk0w78VY_0A/edit?gid=1407640772#gid=1407640772"
   dri: "irenareedy"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 -
   task: "Add new customer closed/won logos to the website"
@@ -148,7 +148,7 @@
   moreInfoUrl: "https://docs.google.com/spreadsheets/d/1fMs7qeZ9Rme1yf9_n8GxfEPzrAxPcvB5yk0w78VY_0A/edit?gid=1407640772#gid=1407640772"
   dri: "mike-j-thomas"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential" 
 -
   task: "Approval draft orders in Printful"
@@ -158,7 +158,7 @@
   moreInfoUrl: "https://www.printful.com/dashboard/default/orders"
   dri: "irenareedy"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"
 -
   task: "Momentumize all customer closed/won accounts from the previous quarter"
@@ -168,5 +168,5 @@
   moreInfoUrl: "https://docs.google.com/spreadsheets/d/1fMs7qeZ9Rme1yf9_n8GxfEPzrAxPcvB5yk0w78VY_0A/edit?gid=1407640772#gid=1407640772"
   dri: "irenareedy"
   autoIssue:  
-    labels: [ ":help-marketing" ] 
+    labels: [ ":help-marketing",":mktg-ritual" ] 
     repo: "confidential"


### PR DESCRIPTION
Adds two marketing labels to the handbook for Marketing and also includes the :mktg-ritual label to the automation

Closes: https://github.com/fleetdm/confidential/issues/15424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated labeling configuration for marketing rituals to include an additional organizational label, improving task categorization and filtering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->