### PR TITLE
Website: Update note blocks on docs pages to use tip-block mixin

### DIFF
--- a/website/assets/styles/pages/docs/policy-details.less
+++ b/website/assets/styles/pages/docs/policy-details.less
@@ -98,47 +98,7 @@
     min-width: 0px;// Prevents long overflowing nowrap text from keeping this element from shrinking.
   }
   [purpose='powershell-note'] {
-    display: flex;
-    padding: 16px 24px;
-    align-items: center;
-    gap: 8px;
-    align-self: stretch;
-    border-radius: 8px;
-    border: 1px solid #B4B2FE;
-    background: #F7F7FC;
-    margin-bottom: 40px;
-    img {
-      width: 16px;
-      height: 16px;
-    }
-    p {
-      margin-bottom: 0px;
-      color: #515774;
-
-      /* Body SM (FKA Card text) */
-      font-family: Inter;
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 150%;
-    }
-    code {
-      color: #515774;
-      font-family: 'Source Code Pro';
-      font-size: 14px;
-      line-height: 16px; /* 114.286% */
-      border-radius: 2px;
-      background: #F1F0FF;
-      padding: 2px 1px;
-    }
-    a {
-      color: #515774;
-      font-family: Inter;
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 150%; /* 150% */
-      text-decoration: underline #C5C7D1;
-      text-underline-offset: 3px;
-    }
+    .tip-block();
   }
   [purpose='policy-check'] {
     padding-bottom: 24px;

--- a/website/assets/styles/pages/docs/query-detail.less
+++ b/website/assets/styles/pages/docs/query-detail.less
@@ -215,47 +215,7 @@
     }
   }
   [purpose='powershell-note'] {
-    display: flex;
-    padding: 16px 24px;
-    align-items: center;
-    gap: 8px;
-    align-self: stretch;
-    border-radius: 8px;
-    border: 1px solid #B4B2FE;
-    background: #F7F7FC;
-    margin-bottom: 40px;
-    img {
-      min-width: 16px;
-      height: 16px;
-    }
-    p {
-      margin-bottom: 0px;
-      color: #515774;
-
-      /* Body SM (FKA Card text) */
-      font-family: Inter;
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 150%;
-    }
-    [purpose='note-text'] {
-      margin-left: 8px;
-    }
-    code {
-      color: #515774;
-      font-family: 'Source Code Pro';
-      font-size: 14px;
-      line-height: 16px; /* 114.286% */
-      border-radius: 2px;
-      background: #F1F0FF;
-      padding: 2px 1px;
-    }
-    a {
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 150%; /* 150% */
-      text-underline-offset: 3px;
-    }
+    .tip-block();
   }
   [purpose='query-check'] {
     [purpose='codeblock'] {

--- a/website/assets/styles/pages/docs/vital-details.less
+++ b/website/assets/styles/pages/docs/vital-details.less
@@ -504,25 +504,12 @@
   }
 
   [purpose='discovery-table-note'], [purpose='powershell-note'] {
-    display: flex;
-    padding: 16px 24px;
-    align-items: center;
-    gap: 8px;
-    align-self: stretch;
-    border-radius: 8px;
-    border: 1px solid #B4B2FE;
-    background: #F7F7FC;
+    .tip-block();
     margin-bottom: 24px;
-    img {
-      width: 16px;
-      height: 16px;
-    }
+    margin-top: 0px;
     p {
       margin-bottom: 0px;
       color: #515774;
-
-      /* Body SM (FKA Card text) */
-      font-family: Inter;
       font-size: 14px;
       font-weight: 400;
       line-height: 150%;
@@ -535,15 +522,6 @@
       border-radius: 2px;
       background: #F1F0FF;
       padding: 2px 1px;
-    }
-    a {
-      color: #515774;
-      font-family: Inter;
-      font-size: 14px;
-      font-weight: 400;
-      line-height: 150%; /* 150% */
-      text-decoration: underline #C5C7D1;
-      text-underline-offset: 3px;
     }
   }
   [purpose='edit-button'] {


### PR DESCRIPTION
Changes:
- Updated the notes on the vital-details, policy-details, and query-details template pages to use the tip-block mixin

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined styling consistency across documentation pages while maintaining visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->