### PR TITLE
Fix broken OTEL due to #43298

### DIFF
--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -114,7 +114,7 @@ import (
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 	"google.golang.org/grpc"
 	_ "google.golang.org/grpc/encoding/gzip" // Because we use gzip compression for OTLP
 )

--- a/cmd/fleet/serve_test.go
+++ b/cmd/fleet/serve_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/smallstep/pkcs7"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 // safeStore is a wrapper around mock.Store to allow for concurrent calling to
@@ -1321,4 +1323,21 @@ func TestHostVitalsLabelMembershipJob(t *testing.T) {
 	require.NoError(t, err)
 	// Only one label (the host vitals label) should have been processed.
 	require.Equal(t, 1, numCalls)
+}
+
+// TestOTELResourceCreation verifies that the OTEL resource can be created without schema URL
+// conflicts. The SDK's WithTelemetrySDK() detector embeds its own schema URL, which must match
+// the semconv version we import. A mismatch (e.g. after a dependabot SDK bump that doesn't
+// update our semconv import) causes a runtime error on server startup.
+func TestOTELResourceCreation(t *testing.T) {
+	res, err := resource.New(t.Context(),
+		resource.WithSchemaURL(semconv.SchemaURL),
+		resource.WithAttributes(
+			semconv.ServiceName("fleet-test"),
+			semconv.ServiceVersion("0.0.0-test"),
+		),
+		resource.WithTelemetrySDK(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res)
 }

--- a/server/datastore/mysql/mysql.go
+++ b/server/datastore/mysql/mysql.go
@@ -36,7 +36,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/jmoiron/sqlx"
 	"go.opentelemetry.io/otel/attribute"
-	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
 )
 
 const (


### PR DESCRIPTION
Resolves broken OTEL on main, which was introduced with dependabot update #43298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated OpenTelemetry semantic conventions dependency to the latest version.

* **Tests**
  * Added test coverage for OpenTelemetry resource creation validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->