### PR TITLE
Website: Update code styles inside callout blocks

### DIFF
--- a/website/assets/styles/mixins-and-variables/tip-block.less
+++ b/website/assets/styles/mixins-and-variables/tip-block.less
@@ -17,6 +17,9 @@
     margin-bottom: 16px;
     line-height: 24px;
     font-size: 14px;
+    code {
+      padding: 2px 4px;
+    }
   }
   p:only-child, p:last-child {
     margin-bottom: 0px;
@@ -27,7 +30,7 @@
   li:last-child {
     padding-bottom: 0px;
   }
-  :first-child {// Remove top padding from the first element inside purpose="tip" blockquotes
+  :first-child:not(code) {// Remove top padding from the first element inside purpose="tip" blockquotes
     padding-top: 0;
   }
 }


### PR DESCRIPTION
Fixed uneven padding and made the code blocks a little more compact inside callout blocks to blend better with the smaller text size. 

#### Before:
<img width="644" height="115" alt="Screenshot 2026-04-17 at 12 12 06 PM" src="https://github.com/user-attachments/assets/c9b65b35-8025-454a-b707-374790259f66" />

#### After:
<img width="653" height="129" alt="Screenshot 2026-04-17 at 12 23 38 PM" src="https://github.com/user-attachments/assets/59909631-9107-4347-a8d9-1e7ad0809f2b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced spacing for inline code elements within tip blocks
  * Improved first-child element padding handling to better accommodate code formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->