### PR TITLE
Clicking outside a modal should close the modal (excluding forms that have been interacted with)

### DIFF
--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 import { noop } from "lodash";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import Modal from "./Modal";
 
 const clickBackground = async (background: Element | null) => {
   if (!background) throw new Error("Background element not found");
-  const user = userEvent.setup();
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
   await user.pointer([
     { keys: "[MouseLeft>]", target: background },
     { keys: "[/MouseLeft]", target: background },
@@ -15,6 +15,9 @@ const clickBackground = async (background: Element | null) => {
 };
 
 describe("Modal", () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
   it("renders title", () => {
     render(
       <Modal title="Foobar" onExit={noop}>
@@ -35,6 +38,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
@@ -71,6 +75,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
   });
 
@@ -89,6 +94,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
   });
 
@@ -107,6 +113,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
   });
 
@@ -127,6 +134,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
   });
 
@@ -142,6 +150,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
@@ -155,6 +164,7 @@ describe("Modal", () => {
 
     const background = container.querySelector(".modal__background");
     await clickBackground(background);
+    act(() => jest.runAllTimers());
     expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -4,6 +4,12 @@ import { render, screen, fireEvent } from "@testing-library/react";
 
 import Modal from "./Modal";
 
+const clickBackground = (background: Element | null) => {
+  if (!background) throw new Error("Background element not found");
+  fireEvent.mouseDown(background);
+  fireEvent.mouseUp(background);
+};
+
 describe("Modal", () => {
   it("renders title", () => {
     render(
@@ -24,7 +30,7 @@ describe("Modal", () => {
     );
 
     const background = container.querySelector(".modal__background");
-    fireEvent.click(background!);
+    clickBackground(background);
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
@@ -40,6 +46,39 @@ describe("Modal", () => {
     expect(onExit).not.toHaveBeenCalled();
   });
 
+  it("does not call onExit when clicking the background if a form inside has been interacted with", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <form>
+          <input type="text" />
+        </form>
+      </Modal>
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "hello" } });
+
+    const background = container.querySelector(".modal__background");
+    clickBackground(background);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("calls onExit when clicking the background if a form inside has not been interacted with", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <form>
+          <input type="text" />
+        </form>
+      </Modal>
+    );
+
+    const background = container.querySelector(".modal__background");
+    clickBackground(background);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
   it("does not call onExit when clicking the background if disableClosingModal is true", () => {
     const onExit = jest.fn();
     const { container } = render(
@@ -49,7 +88,7 @@ describe("Modal", () => {
     );
 
     const background = container.querySelector(".modal__background");
-    fireEvent.click(background!);
+    clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -1,13 +1,17 @@
 import React from "react";
 import { noop } from "lodash";
 import { render, screen, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 import Modal from "./Modal";
 
-const clickBackground = (background: Element | null) => {
+const clickBackground = async (background: Element | null) => {
   if (!background) throw new Error("Background element not found");
-  fireEvent.mouseDown(background);
-  fireEvent.mouseUp(background);
+  const user = userEvent.setup();
+  await user.pointer([
+    { keys: "[MouseLeft>]", target: background },
+    { keys: "[/MouseLeft]", target: background },
+  ]);
 };
 
 describe("Modal", () => {
@@ -21,7 +25,7 @@ describe("Modal", () => {
     expect(screen.getByText("Foobar")).toBeVisible();
   });
 
-  it("calls onExit when clicking the background overlay", () => {
+  it("calls onExit when clicking the background overlay", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -30,23 +34,29 @@ describe("Modal", () => {
     );
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
   it("does not call onExit when clicking inside the modal container", () => {
     const onExit = jest.fn();
-    render(
+    const { container } = render(
       <Modal title="Test" onExit={onExit}>
         <div>content</div>
       </Modal>
     );
 
-    fireEvent.click(screen.getByText("content"));
+    // Simulate drag that starts inside the container and releases on the background.
+    // The container stops mouseDown propagation so isDownOnBackgroundRef stays false,
+    // meaning the background's mouseUp handler must not fire onExit.
+    fireEvent.mouseDown(screen.getByText("content"));
+    const background = container.querySelector(".modal__background");
+    if (!background) throw new Error("Background element not found");
+    fireEvent.mouseUp(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 
-  it("does not call onExit when clicking the background if a form inside has been interacted with", () => {
+  it("does not call onExit when clicking the background if a form inside has been interacted with", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -60,11 +70,11 @@ describe("Modal", () => {
     fireEvent.input(input, { target: { value: "hello" } });
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 
-  it("does not call onExit when clicking the background if a text input outside a form has been interacted with", () => {
+  it("does not call onExit when clicking the background if a text input outside a form has been interacted with", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -78,11 +88,11 @@ describe("Modal", () => {
     fireEvent.input(input, { target: { value: "hello" } });
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 
-  it("does not call onExit when clicking the background if a checkbox has been checked", () => {
+  it("does not call onExit when clicking the background if a checkbox has been checked", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -96,11 +106,11 @@ describe("Modal", () => {
     fireEvent.click(checkbox);
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 
-  it("does not call onExit when clicking the background if a toggle has been clicked", () => {
+  it("does not call onExit when clicking the background if a toggle has been clicked", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -116,11 +126,11 @@ describe("Modal", () => {
     fireEvent.click(toggle);
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 
-  it("calls onExit when clicking the background if a form inside has not been interacted with", () => {
+  it("calls onExit when clicking the background if a form inside has not been interacted with", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit}>
@@ -131,11 +141,11 @@ describe("Modal", () => {
     );
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).toHaveBeenCalledTimes(1);
   });
 
-  it("does not call onExit when clicking the background if disableClosingModal is true", () => {
+  it("does not call onExit when clicking the background if disableClosingModal is true", async () => {
     const onExit = jest.fn();
     const { container } = render(
       <Modal title="Test" onExit={onExit} disableClosingModal>
@@ -144,7 +154,7 @@ describe("Modal", () => {
     );
 
     const background = container.querySelector(".modal__background");
-    clickBackground(background);
+    await clickBackground(background);
     expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -64,6 +64,62 @@ describe("Modal", () => {
     expect(onExit).not.toHaveBeenCalled();
   });
 
+  it("does not call onExit when clicking the background if a text input outside a form has been interacted with", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <div>
+          <input type="text" />
+        </div>
+      </Modal>
+    );
+
+    const input = screen.getByRole("textbox");
+    fireEvent.input(input, { target: { value: "hello" } });
+
+    const background = container.querySelector(".modal__background");
+    clickBackground(background);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("does not call onExit when clicking the background if a checkbox has been checked", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <div>
+          <input type="checkbox" />
+        </div>
+      </Modal>
+    );
+
+    const checkbox = screen.getByRole("checkbox");
+    fireEvent.click(checkbox);
+
+    const background = container.querySelector(".modal__background");
+    clickBackground(background);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("does not call onExit when clicking the background if a toggle has been clicked", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <div>
+          <button type="button" role="switch" aria-checked={false}>
+            Toggle
+          </button>
+        </div>
+      </Modal>
+    );
+
+    const toggle = screen.getByRole("switch");
+    fireEvent.click(toggle);
+
+    const background = container.querySelector(".modal__background");
+    clickBackground(background);
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
   it("calls onExit when clicking the background if a form inside has not been interacted with", () => {
     const onExit = jest.fn();
     const { container } = render(

--- a/frontend/components/Modal/Modal.tests.tsx
+++ b/frontend/components/Modal/Modal.tests.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { noop } from "lodash";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 
 import Modal from "./Modal";
 
@@ -13,5 +13,43 @@ describe("Modal", () => {
     );
 
     expect(screen.getByText("Foobar")).toBeVisible();
+  });
+
+  it("calls onExit when clicking the background overlay", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit}>
+        <div>content</div>
+      </Modal>
+    );
+
+    const background = container.querySelector(".modal__background");
+    fireEvent.click(background!);
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not call onExit when clicking inside the modal container", () => {
+    const onExit = jest.fn();
+    render(
+      <Modal title="Test" onExit={onExit}>
+        <div>content</div>
+      </Modal>
+    );
+
+    fireEvent.click(screen.getByText("content"));
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("does not call onExit when clicking the background if disableClosingModal is true", () => {
+    const onExit = jest.fn();
+    const { container } = render(
+      <Modal title="Test" onExit={onExit} disableClosingModal>
+        <div>content</div>
+      </Modal>
+    );
+
+    const background = container.querySelector(".modal__background");
+    fireEvent.click(background!);
+    expect(onExit).not.toHaveBeenCalled();
   });
 });

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
 
 const baseClass = "modal";
+const CLOSE_ANIMATION_MS = 100;
 
 type ModalWidth = "medium" | "large" | "xlarge" | "auto";
 //                  650px    800px      850px      auto
@@ -63,7 +64,7 @@ const Modal = ({
     setIsClosing(true);
     setTimeout(() => {
       onExit();
-    }, 150);
+    }, CLOSE_ANIMATION_MS);
   }, [onExit]);
 
   useEffect(() => {
@@ -124,40 +125,56 @@ const Modal = ({
     [`${baseClass}__content-disabled`]: isContentDisabled,
   });
 
+  const handleBackgroundMouseDown = () => {
+    isDownOnBackgroundRef.current = true;
+  };
+
+  const handleBackgroundMouseUp = () => {
+    if (
+      !disableClosingModal &&
+      isDownOnBackgroundRef.current &&
+      !isFormDirtyRef.current
+    ) {
+      handleClose();
+    }
+    isDownOnBackgroundRef.current = false;
+  };
+
+  const handleContainerMouseDown = (e: React.MouseEvent) =>
+    e.stopPropagation();
+
+  const handleContainerMouseUp = (e: React.MouseEvent) => e.stopPropagation();
+
+  const handleContainerInput = () => {
+    isFormDirtyRef.current = true;
+  };
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    const target = e.target as HTMLElement;
+    const isCheckbox =
+      target instanceof HTMLInputElement && target.type === "checkbox";
+    const isToggle = !!target.closest('button[role="switch"]');
+    if (isCheckbox || isToggle) {
+      isFormDirtyRef.current = true;
+    }
+  };
+
   return (
     <div
       className={backgroundClasses}
-      onMouseDown={() => {
-        isDownOnBackgroundRef.current = true;
-      }}
-      onMouseUp={() => {
-        if (
-          !disableClosingModal &&
-          isDownOnBackgroundRef.current &&
-          !isFormDirtyRef.current
-        ) {
-          handleClose();
-        }
-        isDownOnBackgroundRef.current = false;
-      }}
+      style={
+        { "--modal-close-duration": `${CLOSE_ANIMATION_MS}ms` } as React.CSSProperties
+      }
+      onMouseDown={handleBackgroundMouseDown}
+      onMouseUp={handleBackgroundMouseUp}
     >
       <div
         className={modalContainerClasses}
         tabIndex={-1} // Make focusable
-        onMouseDown={(e) => e.stopPropagation()}
-        onMouseUp={(e) => e.stopPropagation()}
-        onInput={() => {
-          isFormDirtyRef.current = true;
-        }}
-        onClick={(e) => {
-          const target = e.target as HTMLElement;
-          const isCheckbox =
-            target instanceof HTMLInputElement && target.type === "checkbox";
-          const isToggle = !!target.closest('button[role="switch"]');
-          if (isCheckbox || isToggle) {
-            isFormDirtyRef.current = true;
-          }
-        }}
+        onMouseDown={handleContainerMouseDown}
+        onMouseUp={handleContainerMouseUp}
+        onInput={handleContainerInput}
+        onClick={handleContainerClick}
       >
         <div className={`${baseClass}__header`}>
           <span>{title}</span>

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -140,8 +140,7 @@ const Modal = ({
     isDownOnBackgroundRef.current = false;
   };
 
-  const handleContainerMouseDown = (e: React.MouseEvent) =>
-    e.stopPropagation();
+  const handleContainerMouseDown = (e: React.MouseEvent) => e.stopPropagation();
 
   const handleContainerMouseUp = (e: React.MouseEvent) => e.stopPropagation();
 
@@ -163,7 +162,9 @@ const Modal = ({
     <div
       className={backgroundClasses}
       style={
-        { "--modal-close-duration": `${CLOSE_ANIMATION_MS}ms` } as React.CSSProperties
+        {
+          "--modal-close-duration": `${CLOSE_ANIMATION_MS}ms`,
+        } as React.CSSProperties
       }
       onMouseDown={handleBackgroundMouseDown}
       onMouseUp={handleBackgroundMouseUp}

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -133,8 +133,15 @@ const Modal = ({
         tabIndex={-1} // Make focusable
         onMouseDown={(e) => e.stopPropagation()}
         onMouseUp={(e) => e.stopPropagation()}
-        onInput={(e) => {
-          if ((e.target as HTMLElement).closest("form")) {
+        onInput={() => {
+          isFormDirtyRef.current = true;
+        }}
+        onClick={(e) => {
+          const target = e.target as HTMLElement;
+          const isCheckbox =
+            target instanceof HTMLInputElement && target.type === "checkbox";
+          const isToggle = !!target.closest('button[role="switch"]');
+          if (isCheckbox || isToggle) {
             isFormDirtyRef.current = true;
           }
         }}

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -109,10 +109,14 @@ const Modal = ({
   });
 
   return (
-    <div className={backgroundClasses}>
+    <div
+      className={backgroundClasses}
+      onClick={disableClosingModal ? undefined : onExit}
+    >
       <div
         className={modalContainerClasses}
         tabIndex={-1} // Make focusable
+        onClick={(e) => e.stopPropagation()}
       >
         <div className={`${baseClass}__header`}>
           <span>{title}</span>

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useRef } from "react";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -52,6 +52,8 @@ const Modal = ({
   disableClosingModal = false,
   className,
 }: IModalProps): JSX.Element => {
+  const isDownOnBackgroundRef = useRef(false);
+
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
@@ -111,12 +113,21 @@ const Modal = ({
   return (
     <div
       className={backgroundClasses}
-      onClick={disableClosingModal ? undefined : onExit}
+      onMouseDown={() => {
+        isDownOnBackgroundRef.current = true;
+      }}
+      onMouseUp={() => {
+        if (!disableClosingModal && isDownOnBackgroundRef.current) {
+          onExit();
+        }
+        isDownOnBackgroundRef.current = false;
+      }}
     >
       <div
         className={modalContainerClasses}
         tabIndex={-1} // Make focusable
-        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+        onMouseUp={(e) => e.stopPropagation()}
       >
         <div className={`${baseClass}__header`}>
           <span>{title}</span>

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -53,6 +53,7 @@ const Modal = ({
   className,
 }: IModalProps): JSX.Element => {
   const isDownOnBackgroundRef = useRef(false);
+  const isFormDirtyRef = useRef(false);
 
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
@@ -117,7 +118,11 @@ const Modal = ({
         isDownOnBackgroundRef.current = true;
       }}
       onMouseUp={() => {
-        if (!disableClosingModal && isDownOnBackgroundRef.current) {
+        if (
+          !disableClosingModal &&
+          isDownOnBackgroundRef.current &&
+          !isFormDirtyRef.current
+        ) {
           onExit();
         }
         isDownOnBackgroundRef.current = false;
@@ -128,6 +133,11 @@ const Modal = ({
         tabIndex={-1} // Make focusable
         onMouseDown={(e) => e.stopPropagation()}
         onMouseUp={(e) => e.stopPropagation()}
+        onInput={(e) => {
+          if ((e.target as HTMLElement).closest("form")) {
+            isFormDirtyRef.current = true;
+          }
+        }}
       >
         <div className={`${baseClass}__header`}>
           <span>{title}</span>

--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import classnames from "classnames";
 import Button from "components/buttons/Button/Button";
 import Icon from "components/Icon/Icon";
@@ -54,11 +54,22 @@ const Modal = ({
 }: IModalProps): JSX.Element => {
   const isDownOnBackgroundRef = useRef(false);
   const isFormDirtyRef = useRef(false);
+  const [isClosing, setIsClosing] = useState(false);
+  const isClosingRef = useRef(false);
+
+  const handleClose = useCallback(() => {
+    if (isClosingRef.current) return;
+    isClosingRef.current = true;
+    setIsClosing(true);
+    setTimeout(() => {
+      onExit();
+    }, 150);
+  }, [onExit]);
 
   useEffect(() => {
     const closeWithEscapeKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        onExit();
+        handleClose();
       }
     };
 
@@ -71,7 +82,7 @@ const Modal = ({
         document.removeEventListener("keydown", closeWithEscapeKey);
       }
     };
-  }, [disableClosingModal, onExit]);
+  }, [disableClosingModal, handleClose]);
 
   useEffect(() => {
     if (onEnter) {
@@ -92,6 +103,7 @@ const Modal = ({
 
   const backgroundClasses = classnames(`${baseClass}__background`, {
     [`${baseClass}__hidden`]: isHidden,
+    [`${baseClass}__closing`]: isClosing,
   });
 
   const modalContainerClasses = classnames(
@@ -100,6 +112,7 @@ const Modal = ({
     `${baseClass}__modal_container__${width}`,
     {
       [`${className}__loading`]: isLoading,
+      [`${baseClass}__closing`]: isClosing,
     }
   );
 
@@ -123,7 +136,7 @@ const Modal = ({
           isDownOnBackgroundRef.current &&
           !isFormDirtyRef.current
         ) {
-          onExit();
+          handleClose();
         }
         isDownOnBackgroundRef.current = false;
       }}
@@ -152,7 +165,7 @@ const Modal = ({
             <div className={`${baseClass}__ex`}>
               <Button
                 variant="icon"
-                onClick={onExit}
+                onClick={handleClose}
                 iconStroke
                 autofocus={isContentDisabled}
               >

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -12,7 +12,7 @@
     transition: opacity 150ms ease-out, visibility 0s; // Used for transitions between modals
 
     &.modal__closing {
-      animation: fade-out 100ms ease-in forwards;
+      animation: fade-out var(--modal-close-duration) ease-in forwards;
     }
   }
 
@@ -72,7 +72,7 @@
     animation: scale-up 150ms ease-out;
 
     &.modal__closing {
-      animation: scale-down 100ms ease-in forwards;
+      animation: scale-down var(--modal-close-duration) ease-in forwards;
     }
 
     &__medium {

--- a/frontend/components/Modal/_styles.scss
+++ b/frontend/components/Modal/_styles.scss
@@ -10,6 +10,10 @@
     visibility: visible;
     opacity: 1; // Used for transitions between modals
     transition: opacity 150ms ease-out, visibility 0s; // Used for transitions between modals
+
+    &.modal__closing {
+      animation: fade-out 100ms ease-in forwards;
+    }
   }
 
   &__hidden {
@@ -67,15 +71,22 @@
     border-radius: 8px;
     animation: scale-up 150ms ease-out;
 
+    &.modal__closing {
+      animation: scale-down 100ms ease-in forwards;
+    }
+
     &__medium {
       width: 650px;
     }
+
     &__large {
       width: 800px;
     }
+
     &__xlarge {
       width: 850px;
     }
+
     &__auto {
       width: auto;
     }
@@ -104,7 +115,7 @@
     padding-top: $pad-medium;
 
     // Styles both primary-actions and secondary-actions
-    > * {
+    >* {
       display: flex;
       justify-content: space-between;
       gap: $pad-medium;

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tests.tsx
@@ -68,7 +68,7 @@ describe("EditConfigurationModal", () => {
 
     await user.keyboard("{Escape}");
 
-    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalled());
+    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalledTimes(1));
   });
 
   it("disables Save button when configuration JSON is invalid and shows the error", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tests.tsx
@@ -68,7 +68,7 @@ describe("EditConfigurationModal", () => {
 
     await user.keyboard("{Escape}");
 
-    expect(MOCK_PROPS.onExit).toHaveBeenCalled();
+    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalled());
   });
 
   it("disables Save button when configuration JSON is invalid and shows the error", async () => {

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
@@ -61,7 +61,7 @@ describe("EditIconModal", () => {
 
     await user.keyboard("{Escape}");
 
-    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalled());
+    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalledTimes(1));
   });
 
   // Note: Rely on QA Wolf for E2e testing of file upload, preview, save, and remove icon

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
@@ -100,7 +100,7 @@ describe("EditIconModal", () => {
     it("only edits the display name when icon is not changed", async () => {
       const editSoftwarePackageSpy = jest
         .spyOn(softwareAPI, "editSoftwarePackage")
-        .mockResolvedValue({} as any);
+        .mockResolvedValue({});
       const deleteSoftwareIconSpy = jest.spyOn(
         softwareAPI,
         "deleteSoftwareIcon"
@@ -129,7 +129,7 @@ describe("EditIconModal", () => {
     it("only edits the display name when removing a custom name", async () => {
       const editSoftwarePackageSpy = jest
         .spyOn(softwareAPI, "editSoftwarePackage")
-        .mockResolvedValue({} as any);
+        .mockResolvedValue({});
 
       const MODIFIED_PROPS = {
         ...MOCK_PROPS,

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditIconModal/EditIconModal.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen } from "@testing-library/react";
+import { screen, waitFor } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import {
   createMockSoftwarePackage,
@@ -61,7 +61,7 @@ describe("EditIconModal", () => {
 
     await user.keyboard("{Escape}");
 
-    expect(MOCK_PROPS.onExit).toHaveBeenCalled();
+    await waitFor(() => expect(MOCK_PROPS.onExit).toHaveBeenCalled());
   });
 
   // Note: Rely on QA Wolf for E2e testing of file upload, preview, save, and remove icon

--- a/frontend/styles/global/_animations.scss
+++ b/frontend/styles/global/_animations.scss
@@ -1,61 +1,79 @@
 @keyframes fade-in {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fade-out {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes scale-down {
+  from {
+    transform: scale(1);
+  }
+  to {
+    transform: scale(0.75);
+  }
 }
 
 @keyframes fade-and-scale {
-    from {
-        opacity: 0;
-        transform: scale(0);
-    }
-    to {
-        opacity: 1;
-        transform: scale(1);
-    }
+  from {
+    opacity: 0;
+    transform: scale(0);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes scale-up {
-    from {
-        transform: scale(0.75);
-    }
-    to {
-        transform: scale(1);
-    }
+  from {
+    transform: scale(0.75);
+  }
+  to {
+    transform: scale(1);
+  }
 }
 
 // Page transition animation
 @keyframes page-transition {
-    from {
-        opacity: 0;
-        transform: translateX(-10px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .loading-placeholder {
-    $from: #f5f5f5;
-    $to: scale-color($from, $lightness: -10%);
+  $from: #f5f5f5;
+  $to: scale-color($from, $lightness: -10%);
 
-    height: 100%;
-    width: 100%;
-    background: linear-gradient(-90deg, #efefef 0%, #fcfcfc 50%, #efefef 100%);
-    background-size: 400% 400%;
-    animation: pulse 1s ease-in-out infinite;
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(-90deg, #efefef 0%, #fcfcfc 50%, #efefef 100%);
+  background-size: 400% 400%;
+  animation: pulse 1s ease-in-out infinite;
 
-    @keyframes pulse {
-        0% {
-            background-position: 0% 0%
-        }
-
-        100% {
-            background-position: -135% 0%
-        }
+  @keyframes pulse {
+    0% {
+      background-position: 0% 0%;
     }
+
+    100% {
+      background-position: -135% 0%;
+    }
+  }
 }


### PR DESCRIPTION
For the following quick win:
- https://github.com/fleetdm/fleet/issues/43732


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Background overlay clicks now reliably close the modal only for true background interactions; internal clicks and drags no longer trigger closes.
  * Modal suppresses background-close after interacting with form controls, inputs, checkboxes, or toggles.
  * Internal mouse events are stopped to prevent accidental closes.

* **Bug Fixes**
  * Respect for disable-closing prevents overlay clicks from closing the modal.

* **Tests**
  * Added tests for overlay clicks, input interactions, drag scenarios, and disable-closing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->