### PR TITLE
API reference: Add `exclude_software` to "Get host by Fleet Desktop token"

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -3973,6 +3973,8 @@ If `hostname` is specified when there is more than one host with the same hostna
 
 ### Get host by Fleet Desktop token
 
+> If you're hitting this endpoint often (e.g. every hour) for a large number of hosts (e.g. 1k+) the best practice is to set the `exclude_software` to `true` to prevent overloading the Fleet server.
+
 Returns a subset of information about the host specified by `token`. To get all information about a host, use the ["Get host"](#get-host) endpoint.
 
 This is the API route used by the **My device** page in Fleet Desktop to display information about the host to the end user.
@@ -3986,6 +3988,7 @@ This endpoint doesn't require API token authentication. Authentication on macOS,
 | Name  | Type   | In   | Description                        |
 | ----- | ------ | ---- | ---------------------------------- |
 | token | string | path | The host's [Fleet Desktop token](https://fleetdm.com/guides/fleet-desktop#secure-fleet-desktop). For macOS, Windows, and Linux, this is a random UUID that rotates hourly. For iOS and iPadOS, this is the host's hardware UUID. |
+| exclude_software | boolean | query | If `true`, the response will not include a list of installed software for the host.     |
 
 #### Request headers
 


### PR DESCRIPTION
Added best practice recommendation for using the endpoint with a large number of hosts. Learning from `shackleton`: https://fleetdm.slack.com/archives/C094ZAWGDHC/p1773423670254519
