### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/dbeaver-community/darwin.json
+++ b/ee/maintained-apps/outputs/dbeaver-community/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.0.2",
+      "version": "26.0.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.jkiss.dbeaver.core.product' AND version_compare(bundle_short_version, '26.0.3') < 0);"
       },
-      "installer_url": "https://dbeaver.io/files/26.0.2/dbeaver-ce-26.0.2-macos-aarch64.dmg",
+      "installer_url": "https://dbeaver.io/files/26.0.3/dbeaver-ce-26.0.3-macos-aarch64.dmg",
       "install_script_ref": "6f101bb8",
       "uninstall_script_ref": "d5f7201c",
-      "sha256": "6000d9eedb444dfb3edc70b4e397879ed2e3d71f06444c34dbb1860d2188783c",
+      "sha256": "bfc0902d04403b32d8d4fab120417368aa374622dbfe2f508713d06474ae82e2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.9",
+      "version": "2.12.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.9') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.11') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.9/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.11/Stats.dmg",
       "install_script_ref": "3de99bb8",
       "uninstall_script_ref": "4222ba77",
-      "sha256": "0d6d6dde8956a72c597e4e41af07063d07ced2df9a395adcff2a8bc171d89a4e",
+      "sha256": "41edc5bc9c6a4503f9b48826ea1040ea3b94f76221f0801788c8714d18924093",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DBeaver Community macOS version metadata to 26.0.3, including installer URL and validation checksums
  * Updated Stats macOS version metadata to 2.12.11, including installer URL and validation checksums

<!-- end of auto-generated comment: release notes by coderabbit.ai -->