### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/coteditor/darwin.json
+++ b/ee/maintained-apps/outputs/coteditor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.2.6",
+      "version": "7.0.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor' AND version_compare(bundle_short_version, '6.2.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.coteditor.CotEditor' AND version_compare(bundle_short_version, '7.0.0') < 0);"
       },
-      "installer_url": "https://github.com/coteditor/CotEditor/releases/download/6.2.6/CotEditor_6.2.6.dmg",
+      "installer_url": "https://github.com/coteditor/CotEditor/releases/download/7.0.0/CotEditor_7.0.0.dmg",
       "install_script_ref": "e5de4a42",
       "uninstall_script_ref": "37cee933",
-      "sha256": "6ccc029ede9da8eb497f31a8423cfea91bf34e7a08c67b66be0e331a922e8fc2",
+      "sha256": "9eb8c709fe29046673d56e9e62c0176d4eb5869166860825cc005267f26da68d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/gimp/darwin.json
+++ b/ee/maintained-apps/outputs/gimp/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.2",
+      "version": "3.2.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.gimp.gimp-3.0';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.gimp.gimp-3.0' AND version_compare(bundle_short_version, '3.2.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.gimp.gimp-3.0' AND version_compare(bundle_short_version, '3.2.4') < 0);"
       },
-      "installer_url": "https://download.gimp.org/gimp/v3.2/macos/gimp-3.2.2-arm64.dmg",
+      "installer_url": "https://download.gimp.org/gimp/v3.2/macos/gimp-3.2.4-arm64.dmg",
       "install_script_ref": "9d89c548",
       "uninstall_script_ref": "c6d835f1",
-      "sha256": "899706072aca7db958a6f2f8ed25123f5bd4c0dd0228c880c50d4e7064da4dc3",
+      "sha256": "294c016dca7795999129a38b462f80fac3c13cb963e6de9d04eeb5d6e519392b",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/gimp/windows.json
+++ b/ee/maintained-apps/outputs/gimp/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.2.2.0",
+      "version": "3.2.4.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team' AND version_compare(version, '3.2.2.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'GIMP %' AND publisher = 'The GIMP Team' AND version_compare(version, '3.2.4.0') < 0);"
       },
-      "installer_url": "https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.2-setup.exe",
+      "installer_url": "https://download.gimp.org/gimp/v3.2/windows/gimp-3.2.4-setup.exe",
       "install_script_ref": "7e5269bc",
       "uninstall_script_ref": "79fb181d",
-      "sha256": "cbdcdb49c144d5ef26693f03939fff22770bed22b83da7c420cdfe78a18b383e",
+      "sha256": "ec31d757dd82831d201ffcf47ffeac4175df739e0c02d5122e89aeeadfb988cc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/iina/darwin.json
+++ b/ee/maintained-apps/outputs/iina/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.colliderli.iina' AND version_compare(bundle_short_version, '1.4.2') < 0);"
       },
-      "installer_url": "https://dl-portal.iina.io/IINA.v1.4.2.dmg",
+      "installer_url": "https://dl-portal.iina.io/IINA.v1.4.2-build164.dmg",
       "install_script_ref": "18ab90f9",
       "uninstall_script_ref": "20f465cb",
-      "sha256": "2e0fd89fbba1c92a6c115171e5b51904883bb497fbe513a6961d080fbab08ff6",
+      "sha256": "804e3368518f19039ebfbc3d698e1fabc9cd20f15fc4e42de635456cdf6a7f58",
       "default_categories": [
         "Utilities"
       ]

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.0.5",
+      "version": "2.1.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.0.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.1.0') < 0);"
       },
-      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.0.5_19905_arm64.dmg",
+      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.0_19993_arm64.dmg",
       "install_script_ref": "3d018c85",
       "uninstall_script_ref": "401d288b",
-      "sha256": "601889551cdfdc7feee148b7fdb0480fa0ba5c0db0be8f1c047fc840886a7571",
+      "sha256": "65dcb7ac3f53022eed732d962ce97af000a10e8a3de77fa4ed47645b7591f4c3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.6.8",
+      "version": "12.7.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.6.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.7.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.6.8/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.7.0/osx_arm64",
       "install_script_ref": "b89b1fb9",
       "uninstall_script_ref": "15e9f11c",
-      "sha256": "816fc1367eafc0b1f3cafc649f693c98904f0874b564646ed77b158560f27050",
+      "sha256": "c6dc1084cb40cc01edb65d2fb2bcf5e8ceea4fb129a65c0235c25eeed81b7770",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.6.8",
+      "version": "12.7.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.6.8') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.7.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.6.8/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.7.0/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "476a09854a5f19d57d741f35765475991bedee3e84389abcbabc2c3cba0d7fc6",
+      "sha256": "077849da6aa3adc674870e2d46209c5fa7e456535f3536af9529027a74cf69a4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rapidapi/darwin.json
+++ b/ee/maintained-apps/outputs/rapidapi/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.5.4",
+      "version": "4.5.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.luckymarmot.Paw';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.luckymarmot.Paw' AND version_compare(bundle_short_version, '4.5.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.luckymarmot.Paw' AND version_compare(bundle_short_version, '4.5.5') < 0);"
       },
-      "installer_url": "https://cdn-builds.paw.cloud/paw/RapidAPI-4.5.4.zip",
+      "installer_url": "https://cdn-builds.paw.cloud/paw/RapidAPI-4.5.5.zip",
       "install_script_ref": "1c8ec07f",
       "uninstall_script_ref": "eb82b992",
-      "sha256": "cc8953efdde6eb142c294001d4dec30b49d1389513a7cecd7ad87eaf7c1f7991",
+      "sha256": "d5447b2e3ff87dd870608be55a3b28f2d1833bed2c1fc5e48b2b173768baffbf",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated maintained application metadata for CotEditor (6.2.6 → 7.0.0), GIMP (3.2.2/3.2.2.0 → 3.2.4/3.2.4.0), IINA (build artifact updated), OrbStack (2.0.5 → 2.1.0), Postman (12.6.8 → 12.7.0), and RapidAPI (4.5.4 → 4.5.5) including installer references and integrity verification data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->