### PR TITLE
Add Fleet Desktop update policy and bump package

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -118,6 +118,7 @@ policies:
   - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/install-nudge.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
+  - path: ../lib/macos/policies/update-fleet-desktop.yml
   - path: ../lib/macos/policies/battery-health-check.yml
   # Windows policies
   - path: ../lib/windows/policies/antivirus-signatures-up-to-date.yml

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -24,7 +24,7 @@
     - Macs with Docker Desktop installed
 - name: macOS - Firefox up to date
   description: The host may have an outdated version of Firefox, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   type: patch
   fleet_maintained_app_slug: firefox/darwin
   install_software: false

--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -2,6 +2,6 @@
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.10') < 0);
   critical: false
   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
   platform: darwin
   calendar_events_enabled: true

--- a/it-and-security/lib/macos/policies/update-fleet-desktop.yml
+++ b/it-and-security/lib/macos/policies/update-fleet-desktop.yml
@@ -1,0 +1,8 @@
+- name: macOS - Fleet Desktop up to date
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Fleet Desktop' AND version_compare(bundle_short_version, '1.1.0') < 0);
+  critical: false
+  description: The host may have an outdated version of Fleet Desktop, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service."
+  platform: darwin
+  install_software:
+    package_path: ../software/fleet-desktop.yml

--- a/it-and-security/lib/macos/software/fleet-desktop.yml
+++ b/it-and-security/lib/macos/software/fleet-desktop.yml
@@ -1,4 +1,4 @@
-# Fleet Desktop (fleet_desktop-v1.0.0.pkg) version 1.0.0
-- hash_sha256: 3c9aa6fda9ec4e852a48ac505ebb1409173d9d5eccf4edde3bf866249d85c3a3
+# Fleet Desktop (fleet_desktop-v1.1.0.pkg) version 1.1.0
+- hash_sha256: 238e72b02fb585ca0f4f81b626404838d32dbdfdc1be1ed894cdfb74c2fd9123
   icon:
     path: ../../all/icons/fleet-desktop-icon.png


### PR DESCRIPTION
Add a macOS policy to check Fleet Desktop is at least v1.1.0 and reference it from the workstations fleet. Update the Fleet Desktop installer metadata to v1.1.0 (new SHA256). Also wrap long resolution strings in quotes for consistency in Firefox and 1Password policies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a macOS security policy that monitors Fleet Desktop installations and alerts users when updates are needed, with guidance to download the latest version from Self-service.

* **Chores**
  * Updated Fleet Desktop package to version 1.1.0 with new package metadata and verification hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->