### PR TITLE
Use app-specific labels for macOS software

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -267,23 +267,25 @@ software:
     - slug: brave-browser/darwin # Brave for macOS (ARM)
       self_service: true
       labels_include_any:
-        - Apple Silicon macOS hosts
+        - Macs with Brave Browser installed
       categories:
         - Browsers
     - slug: docker-desktop/darwin # Docker for macOS (ARM)
       self_service: true
       labels_include_any:
-        - Apple Silicon macOS hosts
+        - Macs with Docker Desktop installed
       categories:
         - Developer tools
     - slug: visual-studio-code/darwin # Microsoft Visual Studio for macOS (ARM)
       self_service: true
       labels_include_any:
-        - Apple Silicon macOS hosts
+        - Macs with Visual Studio Code installed
       categories:
         - Developer tools
     - slug: microsoft-teams/darwin # Microsoft Teams for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Microsoft Teams installed
       categories:
         - Communication
     - slug: slack/darwin # Slack for macOS
@@ -309,74 +311,110 @@ software:
         - Productivity
     - slug: github/darwin # GitHub Desktop for macOS
       self_service: true
+      labels_include_any:
+        - Macs with GitHub Desktop installed
       categories:
         - Developer tools
     - slug: utm/darwin # UTM for macOS
       self_service: true
+      labels_include_any:
+        - Macs with UTM installed
       categories:
         - Productivity
     - slug: postman/darwin # Postman for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Postman installed
       categories:
         - Developer tools
     - slug: grammarly-desktop/darwin # Grammarly Desktop for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Grammarly Desktop installed
       categories:
         - Productivity
     - slug: iterm2/darwin # iTerm2 for macOS
       self_service: true
+      labels_include_any:
+        - Macs with iTerm2 installed
       categories:
         - Developer tools
     - slug: sublime-text/darwin # Sublime Text for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Sublime Text installed
       categories:
         - Developer tools
     - slug: parallels/darwin # Parallels Desktop for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Parallels Desktop installed
       categories:
         - Productivity
     - slug: loom/darwin # Loom for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Loom installed
       categories:
         - Productivity
     - slug: spotify/darwin # Spotify for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Spotify installed
       categories:
         - Productivity
     - slug: rectangle/darwin # Rectangle for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Rectangle installed
       categories:
         - Productivity
     - slug: logi-options+/darwin # Logi Options+ for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Logi Options+ installed
       categories:
         - Productivity
     - slug: figma/darwin # Figma for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Figma installed
       categories:
         - Productivity
     - slug: whatsapp/darwin # WhatsApp for macOS
       self_service: true
+      labels_include_any:
+        - Macs with WhatsApp installed
       categories:
         - Communication
     - slug: android-studio/darwin # Android Studio for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Android Studio installed
       categories:
         - Developer tools
     - slug: zed/darwin # Zed for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Zed installed
       categories:
         - Developer tools
     - slug: obsidian/darwin # Obsidian for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Obsidian installed
       categories:
         - Productivity
     - slug: google-drive/darwin # Google Drive for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Google Drive installed
       categories:
         - Productivity
     - slug: cursor/darwin # Cursor for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Cursor installed
       categories:
         - Developer tools
     # Windows apps
@@ -416,5 +454,7 @@ software:
         - "x86-based Windows hosts"
     - slug: visual-studio-code/windows # Microsoft Visual Studio for Windows
       self_service: true
+      labels_include_any:
+        - "x86 Windows hosts with Visual Studio Code installed"
       categories:
         - Developer tools


### PR DESCRIPTION
Replace the generic "Apple Silicon macOS hosts" label with app-specific labels_include_any entries for macOS packages and add a Windows label for VS Code. This change adds or updates labels for many self_service macOS apps (Brave, Docker Desktop, VS Code, Microsoft Teams, GitHub Desktop, UTM, Postman, Grammarly Desktop, iTerm2, Sublime Text, Parallels, Loom, Spotify, Rectangle, Logi Options+, Figma, WhatsApp, Android Studio, Zed, Obsidian, Google Drive, Cursor, etc.) to target hosts that have each app installed rather than relying on the Apple Silicon host label. Improves targeting for software availability in the fleet configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined software deployment targeting for multiple applications on macOS and Windows devices. Deployments now scope to devices that have the respective applications already installed, rather than broadly targeting all hosts of a specific architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->