### PR TITLE
Updated scoping of Fleet-maintained apps on Workstations

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -262,6 +262,8 @@ software:
         - Browsers
     - slug: firefox/darwin # Mozilla Firefox for macOS
       self_service: true
+      labels_include_any:
+        - Macs with Firefox installed
       categories:
         - Browsers
     - slug: brave-browser/darwin # Brave for macOS (ARM)
@@ -282,12 +284,6 @@ software:
         - Macs with Visual Studio Code installed
       categories:
         - Developer tools
-    - slug: microsoft-teams/darwin # Microsoft Teams for macOS
-      self_service: true
-      labels_include_any:
-        - Macs with Microsoft Teams installed
-      categories:
-        - Communication
     - slug: slack/darwin # Slack for macOS
       self_service: true
       setup_experience: true
@@ -437,7 +433,7 @@ software:
       categories:
         - Browsers
       labels_include_any:
-        - "x86-based Windows hosts"
+        - "x86 Windows hosts with Firefox installed"
     - slug: google-chrome/windows # Google Chrome for Windows
       self_service: true
       setup_experience: true

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -18,11 +18,6 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.VSCode';
   label_membership_type: dynamic
   platform: darwin
-- name: Macs with Microsoft Teams installed
-  description: macOS hosts with Microsoft Teams installed
-  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.teams2';
-  label_membership_type: dynamic
-  platform: darwin
 - name: Macs with Slack installed
   description: macOS hosts with Slack installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -39,14 +39,6 @@
   install_software: false
   labels_include_any:
     - Macs with Visual Studio Code installed
-- name: macOS - Microsoft Teams up to date
-  description: The host may have an outdated version of Microsoft Teams, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service or check for updates using Microsoft Teams's built-in update functionality. You can also delete Microsoft Teams if you are no longer using it."
-  type: patch
-  fleet_maintained_app_slug: microsoft-teams/darwin
-  install_software: false
-  labels_include_any:
-    - Macs with Microsoft Teams installed
 - name: macOS - Slack up to date
   description: The host may have an outdated version of Slack, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Slack's built-in update functionality."


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Refined Firefox app targeting on macOS and Windows to improve deployment precision.
  * Removed Microsoft Teams from macOS fleet-managed app deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->