### PR TITLE
Add battery capacity ratio check

### DIFF
--- a/it-and-security/lib/macos/policies/battery-health-check.yml
+++ b/it-and-security/lib/macos/policies/battery-health-check.yml
@@ -4,6 +4,8 @@
       SELECT 1 FROM battery
       WHERE condition IN ('Service Needed', 'Permanent Failure')
       OR health IN ('Fair', 'Poor')
+      OR (max_capacity > 0 AND designed_capacity > 0
+          AND CAST(max_capacity AS REAL) / designed_capacity < 0.80)
     );
   critical: false
   description: >-


### PR DESCRIPTION
Extend the battery-health-check SQL to flag batteries whose max_capacity / designed_capacity is below 80%. The new clause guards against zero capacities and casts max_capacity to REAL for proper floating-point division, improving detection of degraded batteries in the macOS policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced battery health assessment to include battery capacity degradation checks. Systems now receive more comprehensive battery condition evaluation based on current vs. designed capacity levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->