### PR TITLE
Add macOS Fleet Desktop label and attach to policy

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -111,6 +111,7 @@ labels:
   - path: ./lib/all/labels/nudge-test-devices.yml
   - path: ./lib/all/labels/macs-with-microsoft-autoupdate-installed.yml
   - path: ./lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+  - path: ./lib/all/labels/macs-with-fleet-desktop-installed.yml
   - path: ./lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
   - path: ./lib/all/labels/departments.yml
   - path: ./lib/all/labels/idp-group-saml-aws-vpn.yml

--- a/it-and-security/lib/all/labels/macs-with-fleet-desktop-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-desktop-installed.yml
@@ -1,0 +1,5 @@
+- name: Macs with Fleet Desktop installed
+  description: macOS hosts with Fleet Desktop installed
+  query: SELECT 1 FROM apps WHERE name = 'Fleet Desktop';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/all/labels/macs-with-fleet-desktop-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-desktop-installed.yml
@@ -1,5 +1,5 @@
 - name: Macs with Fleet Desktop installed
   description: macOS hosts with Fleet Desktop installed
-  query: SELECT 1 FROM apps WHERE name = 'Fleet Desktop';
+  query: SELECT 1 FROM apps WHERE name = 'Fleet Desktop.app';
   label_membership_type: dynamic
   platform: darwin

--- a/it-and-security/lib/macos/policies/update-fleet-desktop.yml
+++ b/it-and-security/lib/macos/policies/update-fleet-desktop.yml
@@ -1,5 +1,5 @@
 - name: macOS - Fleet Desktop up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Fleet Desktop' AND version_compare(bundle_short_version, '1.1.0') < 0);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = 'Fleet Desktop.app' AND version_compare(bundle_short_version, '1.1.0') < 0);
   critical: false
   description: The host may have an outdated version of Fleet Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service."

--- a/it-and-security/lib/macos/policies/update-fleet-desktop.yml
+++ b/it-and-security/lib/macos/policies/update-fleet-desktop.yml
@@ -4,5 +4,7 @@
   description: The host may have an outdated version of Fleet Desktop, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service."
   platform: darwin
+  labels_include_any:
+    - Macs with Fleet Desktop installed
   install_software:
     package_path: ../software/fleet-desktop.yml


### PR DESCRIPTION
Add a new dynamic label 'Macs with Fleet Desktop installed' (platform: darwin) that selects hosts where apps.name = 'Fleet Desktop'. Update the macOS policy update-fleet-desktop.yml to include this label via labels_include_any so the policy targets only hosts with Fleet Desktop installed. Files changed: it-and-security/lib/all/labels/macs-with-fleet-desktop-installed.yml (new) and it-and-security/lib/macos/policies/update-fleet-desktop.yml (modified).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new label to identify macOS systems with Fleet Desktop installed, enabling improved device classification and targeting.

* **Improvements**
  * Enhanced the Fleet Desktop update policy with refined device targeting capabilities and updated application detection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->