### PR TITLE
Loadtest osquery perf workflow wording and enroll.sh remainder updates

### DIFF
--- a/.github/workflows/loadtest-osquery-perf.yml
+++ b/.github/workflows/loadtest-osquery-perf.yml
@@ -13,7 +13,7 @@ on:
         default: "main"
         required: true
       loadtest_containers:
-        description: "Deploys osquery-perf containers all at once. Total number of osquery-perf tasks to run (should be a multiple of 8, if setting loadtest_containers_starting_index). This is also used as the end index in enroll.sh"
+        description: "Deploys osquery-perf containers all at once. Total number of osquery-perf tasks to run. This is also used as the end index in enroll.sh"
         type: string
         required: true
       loadtest_containers_starting_index:
@@ -22,7 +22,7 @@ on:
         default: 0
         required: true
       task_size:
-        description: "CPU and Memory setting for osquery-perf containers. Example: {\"cpu\":\"4098\",\"memory\":\"8192\"}"
+        description: "CPU and Memory setting for osquery-perf containers. Example: {\"cpu\":\"4096\",\"memory\":\"8192\"}"
         type: string
         default: "{\"cpu\":\"4096\",\"memory\":\"8192\"}"
         required: true

--- a/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
+++ b/infrastructure/loadtesting/terraform/osquery_perf/enroll.sh
@@ -32,6 +32,11 @@ fi
 set -x
 
 for (( c=$START_INDEX; c<=$END_INDEX; c+=$INCREMENT )); do
-        terraform apply -var git_tag_branch=$BRANCH_NAME -var task_size="$TASK_SIZE" -var loadtest_containers=$c -auto-approve
+    terraform apply -var git_tag_branch=$BRANCH_NAME -var task_size="$TASK_SIZE" -var loadtest_containers=$c -auto-approve
 	sleep $SLEEP_TIME_SECONDS
 done
+
+# Apply the remainder if the loop didn't land exactly on END_INDEX.
+if (( $c - $INCREMENT != $END_INDEX )); then
+	terraform apply -var git_tag_branch=$BRANCH_NAME -var task_size="$TASK_SIZE" -var loadtest_containers=$END_INDEX -auto-approve
+fi


### PR DESCRIPTION
- Updates wording in `.github/workflows/loadtest-osquery-perf.yml` 
  - `4098` -> `4096`
  - Removes: `(should be a multiple of 8, if setting loadtest_containers_starting_index)`
- Updates `infrastructure/loadtesting/terraform/osquery_perf/enroll.sh` to handle values that are not multiples of 8. If the value is not a multiple of 8, logic has been added to apply the remainder.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated load testing workflow configuration input descriptions for improved clarity of parameters and their usage examples.

* **Bug Fixes**
  * Fixed container count allocation logic in the load testing process to ensure the final target count is always properly applied, even when using increment values that don't divide evenly into the specified total range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->