### PR TITLE
Fleet UI: Update label target copies

### DIFF
--- a/frontend/components/TargetLabelSelector/_styles.scss
+++ b/frontend/components/TargetLabelSelector/_styles.scss
@@ -6,6 +6,16 @@
     display: flex;
     flex-direction: column;
     gap: $pad-medium;
+
+    // Hardcoded to fit all 3 custom target options (Exclude any, Include all,
+    // Include any) without scrolling
+    .Select-menu-outer {
+      max-height: 260px;
+    }
+
+    .Select-menu {
+      max-height: 244px;
+    }
   }
 
   &__checkboxes {

--- a/frontend/pages/SoftwarePage/helpers.tsx
+++ b/frontend/pages/SoftwarePage/helpers.tsx
@@ -188,19 +188,34 @@ export const CUSTOM_TARGET_OPTIONS: IDropdownOption[] = [
   {
     value: "labelsIncludeAny",
     label: "Include any",
-    helpText: "Hosts that have any of the selected labels.",
+    helpText: (
+      <>
+        Software will only be available for install on hosts that{" "}
+        <strong>have any</strong> of these labels.
+      </>
+    ),
     disabled: false,
   },
   {
     value: "labelsIncludeAll",
     label: "Include all",
-    helpText: "Hosts that have all of the selected labels.",
+    helpText: (
+      <>
+        Software will only be available for install on hosts that{" "}
+        <strong>have all</strong> of these labels.
+      </>
+    ),
     disabled: false,
   },
   {
     value: "labelsExcludeAny",
     label: "Exclude any",
-    helpText: "Hosts that don't have any of the selected labels.",
+    helpText: (
+      <>
+        Software will only be available for install on hosts that{" "}
+        <strong>don&apos;t have any</strong> of these labels.
+      </>
+    ),
     disabled: false,
   },
 ];


### PR DESCRIPTION
## Issue
Closes #39916 

## Description
- Copy changes

> Note: Will need to be cherry-picked into 4.84.0

## Screenshot of change

<img width="1160" height="891" alt="Screenshot 2026-04-20 at 10 42 28 AM" src="https://github.com/user-attachments/assets/2b8a9081-179b-4e1e-8105-52ced2fc1d5a" />



## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Fixed dropdown menu overflow in target label selector by constraining menu height to prevent unwanted scrolling.
  * Enhanced help text for custom target options with clearer phrasing about software availability and visual emphasis on key matching conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->