### PR TITLE
Ignore vulnerabilities in fleetdm/bomutils

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -503,6 +503,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/bomutils` docker image
 
+### [CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/bomutils does not connect to TLS servers using OpenSSL.
+- **Products:**: `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-20 11:48:55
+
 ### [CVE-2026-0861](https://nvd.nist.gov/vuln/detail/CVE-2026-0861)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/vex/bomutils/CVE-2026-28390.vex.json
+++ b/security/vex/bomutils/CVE-2026-28390.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-40bb280a46610256b8838be81c1666ffd343828e62043f457bf3e4b64343fe5e",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-20T11:48:55.894935-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28390"
+      },
+      "timestamp": "2026-04-20T11:48:55.894935-03:00",
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/bomutils does not connect to TLS servers using OpenSSL",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Run: https://github.com/fleetdm/fleet/actions/runs/24673271270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Added vulnerability assessment documentation for CVE-2026-28390, confirming that bomutils is not affected by this vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->