### PR TITLE
Update go to 1.26.2 and update tooling to update it

### DIFF
--- a/Dockerfile-desktop-linux
+++ b/Dockerfile-desktop-linux
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 golang:1.26.1-trixie@sha256:96b28783b99bcd265fbfe0b36a3ac6462416ce6bf1feac85d4c4ff533cbaa473
+FROM --platform=linux/amd64 golang:1.26.2-trixie@sha256:b53c282df83967299380adbd6a2dc67e750a58217f39285d6240f6f80b19eaad
 LABEL maintainer="Fleet Developers"
 
 RUN apt-get update && apt-get install -y musl-tools && rm -rf /var/lib/apt/lists/*

--- a/Makefile
+++ b/Makefile
@@ -889,7 +889,15 @@ vex-report:
 
 # make update-go version=1.24.4
 UPDATE_GO_DOCKERFILES := ./Dockerfile-desktop-linux ./infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile ./tools/mdm/migration/mdmproxy/Dockerfile
-UPDATE_GO_MODS := go.mod ./tools/mdm/windows/bitlocker/go.mod ./tools/snapshot/go.mod ./tools/terraform/go.mod
+UPDATE_GO_MODS := \
+	go.mod \
+	./tools/mdm/windows/bitlocker/go.mod \
+	./tools/snapshot/go.mod \
+	./tools/terraform/go.mod \
+	./third_party/vuln-check/go.mod \
+	./tools/ci/setboolcheck/go.mod \
+	./tools/github-manage/go.mod \
+	./tools/qacheck/go.mod
 update-go:
 	@test $(version) || (echo "Mising 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
 	@for dockerfile in $(UPDATE_GO_DOCKERFILES) ; do \

--- a/Makefile
+++ b/Makefile
@@ -897,7 +897,9 @@ UPDATE_GO_MODS := \
 	./third_party/vuln-check/go.mod \
 	./tools/ci/setboolcheck/go.mod \
 	./tools/github-manage/go.mod \
-	./tools/qacheck/go.mod
+	./tools/qacheck/go.mod \
+	./third_party/goval-dictionary/go.mod \
+	./tools/fleet-mcp/go.mod
 update-go:
 	@test $(version) || (echo "Mising 'version' argument, usage: 'make update-go version=1.24.4'" ; exit 1)
 	@for dockerfile in $(UPDATE_GO_DOCKERFILES) ; do \

--- a/changes/update-go-1.26.2
+++ b/changes/update-go-1.26.2
@@ -1,0 +1,1 @@
+* Updated go to 1.26.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4
 
-go 1.26.1
+go 1.26.2
 
 require (
 	cloud.google.com/go/pubsub v1.50.1

--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.23@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039
+FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
 ARG TAG
 RUN apk add git sqlite gcc musl-dev sqlite-dev
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/cmd/osquery-perf/ && go build .

--- a/orbit/changes/update-go-1.26.2
+++ b/orbit/changes/update-go-1.26.2
@@ -1,0 +1,1 @@
+* Updated go to 1.26.2

--- a/third_party/goval-dictionary/go.mod
+++ b/third_party/goval-dictionary/go.mod
@@ -1,6 +1,6 @@
 module github.com/vulsio/goval-dictionary
 
-go 1.24.0
+go 1.26.2
 
 require (
 	github.com/cheggaaa/pb/v3 v3.1.7

--- a/third_party/vuln-check/go.mod
+++ b/third_party/vuln-check/go.mod
@@ -9,7 +9,7 @@
 
 module github.com/fleetdm/fleet/v4/third_party/vuln-check
 
-go 1.26.1
+go 1.26.2
 
 require (
 	// NanoMDM - Apple MDM server (server/mdm/nanomdm/)

--- a/tools/ci/setboolcheck/go.mod
+++ b/tools/ci/setboolcheck/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/ci/setboolcheck
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/golangci/plugin-module-register v0.1.2

--- a/tools/fleet-mcp/go.mod
+++ b/tools/fleet-mcp/go.mod
@@ -1,6 +1,6 @@
 module fleet-mcp
 
-go 1.25.7
+go 1.26.2
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/tools/github-manage/go.mod
+++ b/tools/github-manage/go.mod
@@ -1,6 +1,6 @@
 module fleetdm/gm
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.1-alpine3.23@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039
+FROM golang:1.26.2-alpine3.23@sha256:80fbb8f9b2fa541a7d34378f1ad10f4f1c433817c4ed39ddb3e2f3ec3e961271
 ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .

--- a/tools/mdm/windows/bitlocker/go.mod
+++ b/tools/mdm/windows/bitlocker/go.mod
@@ -1,6 +1,6 @@
 module bitlocker
 
-go 1.26.1
+go 1.26.2
 
 require github.com/go-ole/go-ole v1.3.0
 

--- a/tools/qacheck/go.mod
+++ b/tools/qacheck/go.mod
@@ -1,6 +1,6 @@
 module qacheck
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/shurcooL/githubv4 v0.0.0-20260209031235-2402fdf4a9ed

--- a/tools/snapshot/go.mod
+++ b/tools/snapshot/go.mod
@@ -1,6 +1,6 @@
 module github.com/fleetdm/fleet/v4/tools/snapshot
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/manifoldco/promptui v0.9.0

--- a/tools/terraform/go.mod
+++ b/tools/terraform/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-fleetdm
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.7.0


### PR DESCRIPTION
Golang 1.26.2 has been released. It fixes some CVEs: https://github.com/golang/go/issues?q=milestone%3AGo1.26.2+label%3ACherryPickApproved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to 1.26.2 across the repository and build configs.
  * Updated Docker build images to use Go 1.26.2.
  * Expanded the set of tracked modules for the Go version update so additional module files are included in automated updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->