### PR TITLE
Fleet UI: Add padding to calendar instructions

### DIFF
--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -393,7 +393,6 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
                 account.
               </li>
               <li>
-                {" "}
                 <div className={`${baseClass}__oauth-scopes`}>
                   For the OAuth scopes, paste the following value:
                   <InputField

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/Calendars.tsx
@@ -301,64 +301,68 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
                 work calendar.)
               </li>
               <li>
-                Save your changes.
-                <Card>
-                  <form onSubmit={onFormSubmit} autoComplete="off">
-                    <InputField
-                      label="API key JSON"
-                      onChange={onInputChange}
-                      name="apiKeyJson"
-                      value={apiKeyJson}
-                      parseTarget
-                      type="textarea"
-                      placeholder={API_KEY_JSON_PLACEHOLDER}
-                      ignore1password
-                      inputClassName={`${baseClass}__api-key-json`}
-                      error={formErrors.apiKeyJson}
-                      disabled={gomEnabled}
-                      helpText={
-                        apiKeyJson === UNCHANGED_PASSWORD_API_RESPONSE
-                          ? "API key is configured. Replace with a new key to update."
-                          : undefined
-                      }
-                    />
-                    <InputField
-                      label="Primary domain"
-                      onChange={onInputChange}
-                      name="domain"
-                      value={domain}
-                      parseTarget
-                      placeholder="example.com"
-                      helpText={
-                        <>
-                          You can find your primary domain in Google Workspace{" "}
-                          <CustomLink
-                            url={GOOGLE_WORKSPACE_DOMAINS}
-                            text="here"
-                            newTab
-                          />
-                        </>
-                      }
-                      error={formErrors.domain}
-                      disabled={gomEnabled}
-                    />
-                    <div className="button-wrap">
-                      <GitOpsModeTooltipWrapper
-                        tipOffset={8}
-                        renderChildren={(dC) => (
-                          <Button
-                            type="submit"
-                            disabled={Object.keys(formErrors).length > 0 || dC}
-                            className="save-loading"
-                            isLoading={isUpdatingSettings}
-                          >
-                            Save
-                          </Button>
-                        )}
+                <div className={`${baseClass}__save-changes`}>
+                  Save your changes.
+                  <Card>
+                    <form onSubmit={onFormSubmit} autoComplete="off">
+                      <InputField
+                        label="API key JSON"
+                        onChange={onInputChange}
+                        name="apiKeyJson"
+                        value={apiKeyJson}
+                        parseTarget
+                        type="textarea"
+                        placeholder={API_KEY_JSON_PLACEHOLDER}
+                        ignore1password
+                        inputClassName={`${baseClass}__api-key-json`}
+                        error={formErrors.apiKeyJson}
+                        disabled={gomEnabled}
+                        helpText={
+                          apiKeyJson === UNCHANGED_PASSWORD_API_RESPONSE
+                            ? "API key is configured. Replace with a new key to update."
+                            : undefined
+                        }
                       />
-                    </div>
-                  </form>
-                </Card>
+                      <InputField
+                        label="Primary domain"
+                        onChange={onInputChange}
+                        name="domain"
+                        value={domain}
+                        parseTarget
+                        placeholder="example.com"
+                        helpText={
+                          <>
+                            You can find your primary domain in Google Workspace{" "}
+                            <CustomLink
+                              url={GOOGLE_WORKSPACE_DOMAINS}
+                              text="here"
+                              newTab
+                            />
+                          </>
+                        }
+                        error={formErrors.domain}
+                        disabled={gomEnabled}
+                      />
+                      <div className="button-wrap">
+                        <GitOpsModeTooltipWrapper
+                          tipOffset={8}
+                          renderChildren={(dC) => (
+                            <Button
+                              type="submit"
+                              disabled={
+                                Object.keys(formErrors).length > 0 || dC
+                              }
+                              className="save-loading"
+                              isLoading={isUpdatingSettings}
+                            >
+                              Save
+                            </Button>
+                          )}
+                        />
+                      </div>
+                    </form>
+                  </Card>
+                </div>
               </li>
             </ul>
           </p>
@@ -389,15 +393,17 @@ const Calendars = ({ appConfig }: IAppConfigFormProps): JSX.Element => {
                 account.
               </li>
               <li>
-                For the OAuth scopes, paste the following value:
-                <InputField
-                  readOnly
-                  inputWrapperClass={`${baseClass}__oauth-scopes`}
-                  name="oauth-scopes"
-                  enableCopy
-                  type="textarea"
-                  value={OAUTH_SCOPES}
-                />
+                {" "}
+                <div className={`${baseClass}__oauth-scopes`}>
+                  For the OAuth scopes, paste the following value:
+                  <InputField
+                    readOnly
+                    name="oauth-scopes"
+                    enableCopy
+                    type="textarea"
+                    value={OAUTH_SCOPES}
+                  />
+                </div>
               </li>
               <li>
                 Click <b>Authorize</b>.

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -20,7 +20,7 @@
   }
 
   .card {
-    margin-top: $pad-small;
+    margin-top: $pad-large;
   }
 
   &__configuration {
@@ -36,12 +36,18 @@
     font-size: $x-small;
   }
 
+  &__save-changes,
+  &__oauth-scopes {
+    @include vertical-form-layout;
+    padding-bottom: $pad-large;
+  }
+
   #oauth-scopes {
     font-family: "SourceCodePro", $monospace;
     color: $core-fleet-black;
     min-height: 82px;
+    min-width: 100%;
     padding: $pad-medium;
-    padding-right: $pad-xxlarge;
     resize: none;
   }
 

--- a/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
+++ b/frontend/pages/admin/IntegrationsPage/cards/Calendars/_styles.scss
@@ -19,10 +19,6 @@
     margin: $pad-small 0;
   }
 
-  .card {
-    margin-top: $pad-large;
-  }
-
   &__configuration {
     button {
       align-self: flex-end;


### PR DESCRIPTION
## Issue
Closes #34128 

## Description
- Add 24px vertical padding around form/input field in calendar instructions

## Screenshot of update

<img width="1280" height="895" alt="Screenshot 2026-04-20 at 12 08 31 PM" src="https://github.com/user-attachments/assets/8d202051-b16c-42f7-8fe0-8b569df47381" />


## Testing
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout and styling of the calendar integration settings page, reorganizing the "Save your changes" section and OAuth scopes input for better visual organization and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->