### PR TITLE
[YAML] Revert/Remove local IDP user account settings from YAML

### DIFF
--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -414,11 +414,6 @@ controls:
   setup_experience: # Available in Fleet Premium
     bootstrap_package: https://example.org/bootstrap_package.pkg
     enable_end_user_authentication: true
-    enable_create_local_idp_user_account: true
-    local_idp_user_account_configuration:
-      sso_configuration_profile_path: ../lib/platform-sso.mobileconfig
-      sso_software_package_path: ../lib/company-portal.package.yml
-      authentication_url: https://login.microsoftonline.com/common
     apple_enable_release_device_manually: true
     apple_setup_assistant: ../lib/dep-profile.json
     macos_script: ../lib/macos-setup-script.sh
@@ -518,12 +513,6 @@ The `setup_experience` section lets you control the out-of-the-box [setup experi
 - `bootstrap_package` is the URL to a bootstrap package. Fleet will download the bootstrap package. Applies to macOS only (default: `""`).
 - `macos_manual_agent_install` specifies whether Fleet's agent (fleetd) will be installed as part of setup experience. Applies to macOS only (default: `false`)
 - `enable_end_user_authentication` specifies whether or not to require end user authentication when the user first sets up their host. Applies to macOS, Windows, Linux, iOS/iPadOS, and Android.
-- `enable_create_local_idp_user_account` specifies whether or not to automatically create a local idp user account on the host. Requires `enable_end_user_authentication` to be `true` and must be accompanied by `local_idp_user_account_configuration` object. Applies to macOS only. (default: `false`)
-- `local_idp_user_account_configuration` specifies the Platform SSO configuration profile, SSO extension software package, and authentication URL used to automatically create a local user account with IdP credentials when the user first sets up their macOS host.
-  - `sso_configuration_profile_path` is the path to the Platform SSO configuration profile (.mobileconfig). The profile must have `com.apple.extensiblesso` PayloadType and include `EnableAuthorization` and `EnableCreateUserAtLogin` set to `true`.
-  - `sso_software_package_path` is the path to the SSO extension software package (.package.yml) that is added to the fleet.
-  - `authentication_url` is the URL used to authenticate the user with the IdP during Platform SSO setup.
-- `lock_end_user_info` specifies whether or not to enable end user to edit the local account Account Name and Full Name in macOS Setup Assistant. (default: `true`)
 - `require_all_software` specifies whether to cancel setup on a macOS host if any software installs fail.
 - `apple_enable_release_device_manually` when enabled, you're responsible for sending the [`DeviceConfigured` command](https://developer.apple.com/documentation/devicemanagement/device-configured-command). End users will be stuck in Setup Assistant until this command is sent. Applies to Apple (macOS, iOS, iPadOS) hosts that automatically enroll via Apple Business Manager (ABM).
 - `apple_setup_assistant` is a path to a custom [automatic enrollment (ADE) profile](https://support.apple.com/guide/deployment/automated-device-enrollment-management-dep73069dd57/web) (.json). Applies to macOS and iOS/iPadOS hosts.
@@ -538,11 +527,6 @@ setup_experience:
   bootstrap_package: "https://your-storage/package.pkg"
   macos_manual_agent_install: false
   enable_end_user_authentication: true
-  enable_create_local_idp_user_account: true
-  local_idp_user_account_configuration:
-    sso_configuration_profile_path: "./platform-sso.mobileconfig"
-    sso_software_package_path: "./company-portal.package.yml"
-    authentication_url: "https://login.microsoftonline.com/common"
   lock_end_user_info: true
   apple_enable_release_device_manually: false
   apple_setup_assistant: "./setup_assistant.json"


### PR DESCRIPTION
Removed local IDP user account configuration options from setup experience.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #30674