### PR TITLE
Fixed Android pubsub panic when host was deleted

### DIFF
--- a/changes/42494-android-pubsub-panic-deleted-host
+++ b/changes/42494-android-pubsub-panic-deleted-host
@@ -1,0 +1,1 @@
+- Fixed a server panic (502) when an Android pubsub status report arrived for a host that had been deleted from Fleet.

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -50,17 +50,30 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			"uuid":              host.UUID,
 		}
 
-		var existingID uint
-		err := sqlx.GetContext(ctx, tx, &existingID,
-			`SELECT id FROM hosts WHERE uuid = ? AND (platform = 'android' OR platform = '') ORDER BY id LIMIT 1`,
-			host.UUID,
+		// Only look up an existing host when we have a non-empty UUID. An empty UUID
+		// would match every hosts row with uuid='' and falsely dedupe unrelated hosts.
+		// When multiple rows share this uuid (e.g. one orbit-enrolled with
+		// node_key=<orbitKey> and one Android with node_key=android/<uuid>), prefer the
+		// row whose node_key already matches host.NodeKey. Updating that row's node_key
+		// to itself is a no-op and avoids colliding with the UNIQUE idx_host_unique_nodekey
+		// constraint that would fire if we picked the other duplicate and tried to flip
+		// its node_key over to an already-taken value.
+		var (
+			existingID uint
+			foundHost  bool
 		)
-		notExist := errors.Is(err, sql.ErrNoRows)
-		if err != nil && !notExist {
-			return ctxerr.Wrap(ctx, err, "check for existing orbit-enrolled Android host")
+		if host.UUID != "" {
+			err := sqlx.GetContext(ctx, tx, &existingID,
+				`SELECT id FROM hosts WHERE uuid = ? AND platform IN ('android', '') ORDER BY (node_key = ?) DESC, id LIMIT 1`,
+				host.UUID, host.NodeKey,
+			)
+			if err != nil && !errors.Is(err, sql.ErrNoRows) {
+				return ctxerr.Wrap(ctx, err, "check for existing orbit-enrolled Android host")
+			}
+			foundHost = err == nil
 		}
 
-		if notExist {
+		if !foundHost {
 			// No orbit-enrolled host for this uuid. Insert as usual.
 			// We use node_key as a unique identifier for the host table row. It matches: android/{enterpriseSpecificID}.
 			insertStmt := `

--- a/server/datastore/mysql/android.go
+++ b/server/datastore/mysql/android.go
@@ -29,57 +29,10 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 	}
 
 	err = ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-		// We use node_key as a unique identifier for the host table row. It matches: android/{enterpriseSpecificID}.
-		stmt := `
-		INSERT INTO hosts (
-			node_key,
-			hostname,
-			computer_name,
-			platform,
-			os_version,
-			build,
-			memory,
-			team_id,
-			hardware_serial,
-			cpu_type,
-			hardware_model,
-			hardware_vendor,
-			detail_updated_at,
-			label_updated_at,
-			uuid
-		) VALUES (
-			:node_key,
-			:hostname,
-			:computer_name,
-			:platform,
-			:os_version,
-			:build,
-			:memory,
-			:team_id,
-			:hardware_serial,
-			:cpu_type,
-			:hardware_model,
-			:hardware_vendor,
-			:detail_updated_at,
-			:label_updated_at,
-			:uuid
-		) ON DUPLICATE KEY UPDATE
-			hostname = VALUES(hostname),
-			computer_name = VALUES(computer_name),
-			platform = VALUES(platform),
-			os_version = VALUES(os_version),
-			build = VALUES(build),
-			memory = VALUES(memory),
-			team_id = VALUES(team_id),
-			hardware_serial = VALUES(hardware_serial),
-			cpu_type = VALUES(cpu_type),
-			hardware_model = VALUES(hardware_model),
-			hardware_vendor = VALUES(hardware_vendor),
-			detail_updated_at = VALUES(detail_updated_at),
-			label_updated_at = VALUES(label_updated_at),
-			uuid = VALUES(uuid)
-		`
-		result, err := sqlx.NamedExecContext(ctx, tx, stmt, map[string]interface{}{
+		// If the Fleet Android agent already orbit-enrolled this device, a hosts row exists
+		// keyed by uuid = enterpriseSpecificId. Reuse it instead of inserting a duplicate.
+		// (platform = '' covers agents that didn't send platform on orbit enroll.)
+		params := map[string]any{
 			"node_key":          host.NodeKey,
 			"hostname":          host.Hostname,
 			"computer_name":     host.ComputerName,
@@ -95,21 +48,112 @@ func (ds *Datastore) NewAndroidHost(ctx context.Context, host *fleet.AndroidHost
 			"detail_updated_at": host.DetailUpdatedAt,
 			"label_updated_at":  host.LabelUpdatedAt,
 			"uuid":              host.UUID,
-		})
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "new Android host")
 		}
-		id, _ := result.LastInsertId()
-		if id == 0 {
-			// This was an UPDATE, not an INSERT, so we need to get the host ID
-			var hostID uint
-			err := sqlx.GetContext(ctx, tx, &hostID, `SELECT id FROM hosts WHERE node_key = ?`, host.NodeKey)
+
+		var existingID uint
+		err := sqlx.GetContext(ctx, tx, &existingID,
+			`SELECT id FROM hosts WHERE uuid = ? AND (platform = 'android' OR platform = '') ORDER BY id LIMIT 1`,
+			host.UUID,
+		)
+		notExist := errors.Is(err, sql.ErrNoRows)
+		if err != nil && !notExist {
+			return ctxerr.Wrap(ctx, err, "check for existing orbit-enrolled Android host")
+		}
+
+		if notExist {
+			// No orbit-enrolled host for this uuid. Insert as usual.
+			// We use node_key as a unique identifier for the host table row. It matches: android/{enterpriseSpecificID}.
+			insertStmt := `
+			INSERT INTO hosts (
+				node_key,
+				hostname,
+				computer_name,
+				platform,
+				os_version,
+				build,
+				memory,
+				team_id,
+				hardware_serial,
+				cpu_type,
+				hardware_model,
+				hardware_vendor,
+				detail_updated_at,
+				label_updated_at,
+				uuid
+			) VALUES (
+				:node_key,
+				:hostname,
+				:computer_name,
+				:platform,
+				:os_version,
+				:build,
+				:memory,
+				:team_id,
+				:hardware_serial,
+				:cpu_type,
+				:hardware_model,
+				:hardware_vendor,
+				:detail_updated_at,
+				:label_updated_at,
+				:uuid
+			) ON DUPLICATE KEY UPDATE
+				hostname = VALUES(hostname),
+				computer_name = VALUES(computer_name),
+				platform = VALUES(platform),
+				os_version = VALUES(os_version),
+				build = VALUES(build),
+				memory = VALUES(memory),
+				team_id = VALUES(team_id),
+				hardware_serial = VALUES(hardware_serial),
+				cpu_type = VALUES(cpu_type),
+				hardware_model = VALUES(hardware_model),
+				hardware_vendor = VALUES(hardware_vendor),
+				detail_updated_at = VALUES(detail_updated_at),
+				label_updated_at = VALUES(label_updated_at),
+				uuid = VALUES(uuid)
+			`
+			result, err := sqlx.NamedExecContext(ctx, tx, insertStmt, params)
 			if err != nil {
-				return ctxerr.Wrap(ctx, err, "get host ID after update")
+				return ctxerr.Wrap(ctx, err, "new Android host")
 			}
-			host.Host.ID = hostID
+			id, _ := result.LastInsertId()
+			if id == 0 {
+				// This was an UPDATE, not an INSERT, so we need to get the host ID
+				var hostID uint
+				err := sqlx.GetContext(ctx, tx, &hostID, `SELECT id FROM hosts WHERE node_key = ?`, host.NodeKey)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "get host ID after update")
+				}
+				host.Host.ID = hostID
+			} else {
+				host.Host.ID = uint(id) // nolint:gosec
+			}
 		} else {
-			host.Host.ID = uint(id) // nolint:gosec
+			// Orbit-enrolled Android host already exists; update it in place so both
+			// enrollment paths converge on a single hosts row.
+			params["id"] = existingID
+			updateStmt := `
+			UPDATE hosts SET
+				node_key = :node_key,
+				hostname = :hostname,
+				computer_name = :computer_name,
+				platform = :platform,
+				os_version = :os_version,
+				build = :build,
+				memory = :memory,
+				team_id = :team_id,
+				hardware_serial = :hardware_serial,
+				cpu_type = :cpu_type,
+				hardware_model = :hardware_model,
+				hardware_vendor = :hardware_vendor,
+				detail_updated_at = :detail_updated_at,
+				label_updated_at = :label_updated_at,
+				uuid = :uuid
+			WHERE id = :id`
+			if _, err := sqlx.NamedExecContext(ctx, tx, updateStmt, params); err != nil {
+				return ctxerr.Wrap(ctx, err, "update existing orbit-enrolled Android host")
+			}
+			host.Host.ID = existingID
 		}
 		host.Device.HostID = host.Host.ID
 

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -214,6 +214,54 @@ func testNewAndroidHostDedupesOrbitEnrolled(t *testing.T, ds *Datastore) {
 			require.Equal(t, 1, deviceCount)
 		})
 	}
+
+	// Two hosts already exist with the same uuid -- one orbit-enrolled
+	// (node_key=orbitKey) and one Android (node_key=android/<id>). A NewAndroidHost call
+	// with node_key=android/<id> must pick the Android row (not the orbit-enrolled one),
+	// otherwise the UPDATE would try to flip the orbit row's node_key to a value already
+	// held by the Android row and hit idx_host_unique_nodekey.
+	t.Run("Android orphan duplicates, prefers matching node_key", func(t *testing.T) {
+		ctx := testCtx()
+		enterpriseSpecificID := strings.ToUpper(uuid.New().String())
+
+		orbitHost, err := ds.EnrollOrbit(ctx,
+			fleet.WithEnrollOrbitMDMEnabled(true),
+			fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+				HardwareUUID:   enterpriseSpecificID,
+				HardwareSerial: enterpriseSpecificID,
+				Platform:       "android",
+				Hostname:       "orbit",
+				ComputerName:   "orbit",
+				HardwareModel:  "TestModel",
+			}),
+			fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+		)
+		require.NoError(t, err)
+
+		// Insert a second hosts row directly, with the same uuid but the Android-derived
+		// node_key, to simulate the duplicate state the dedupe must handle.
+		androidNodeKey := "android/" + enterpriseSpecificID
+		res, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO hosts (node_key, uuid, platform, hostname, computer_name, hardware_serial,
+				detail_updated_at, label_updated_at, policy_updated_at)
+			 VALUES (?, ?, 'android', 'android-dup', 'android-dup', 'serial-dup', NOW(), NOW(), NOW())`,
+			androidNodeKey, enterpriseSpecificID,
+		)
+		require.NoError(t, err)
+		androidDupID, err := res.LastInsertId()
+		require.NoError(t, err)
+
+		// NewAndroidHost must pick the existing Android row (not the orbit-enrolled one
+		// with the lower id). Otherwise the UPDATE would hit the UNIQUE node_key index.
+		newHost := createAndroidHost(enterpriseSpecificID)
+		require.Equal(t, androidNodeKey, *newHost.NodeKey,
+			"createAndroidHost is expected to build node_key=android/<uuid>")
+		returned, err := ds.NewAndroidHost(ctx, newHost, false)
+		require.NoError(t, err, "must not violate UNIQUE node_key when duplicate hosts share this uuid")
+		require.EqualValues(t, androidDupID, returned.Host.ID,
+			"NewAndroidHost should pick the row whose node_key matches, leaving the orbit-enrolled row alone")
+		require.NotEqual(t, orbitHost.ID, returned.Host.ID)
+	})
 }
 
 func createAndroidHost(enterpriseSpecificID string) *fleet.AndroidHost {

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -28,6 +28,7 @@ func TestAndroid(t *testing.T) {
 		fn   func(t *testing.T, ds *Datastore)
 	}{
 		{"NewAndroidHost", testNewAndroidHost},
+		{"NewAndroidHostDedupesOrbitEnrolled", testNewAndroidHostDedupesOrbitEnrolled},
 		{"UpdateAndroidHost", testUpdateAndroidHost},
 		{"AndroidMDMStats", testAndroidMDMStats},
 		{"AndroidHostStorageData", testAndroidHostStorageData},
@@ -122,6 +123,97 @@ func testNewAndroidHost(t *testing.T, ds *Datastore) {
 	lbls, err = ds.ListLabelsForHost(testCtx(), result.Host.ID)
 	require.NoError(t, err)
 	require.Empty(t, lbls)
+}
+
+// testNewAndroidHostDedupesOrbitEnrolled covers the duplicate-Android-hosts fix.
+// The Fleet Android agent enrolls first via /api/fleet/orbit/enroll,
+// then later the AMAPI pubsub flow delivers a STATUS_REPORT that lands in
+// NewAndroidHost. The dedupe works whether the agent also sends
+// platform="android" (newer agents) or leaves it blank (older agents).
+func testNewAndroidHostDedupesOrbitEnrolled(t *testing.T, ds *Datastore) {
+	test.AddBuiltinLabels(t, ds)
+
+	cases := []struct {
+		name     string
+		platform string
+	}{
+		{"agent sends no platform", ""},
+		{"agent sends platform=android", "android"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := testCtx()
+			enterpriseSpecificID := strings.ToUpper(uuid.New().String())
+
+			orbitHost, err := ds.EnrollOrbit(ctx,
+				fleet.WithEnrollOrbitMDMEnabled(true),
+				fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+					HardwareUUID:   enterpriseSpecificID,
+					HardwareSerial: enterpriseSpecificID,
+					Platform:       tc.platform,
+					Hostname:       "Samsung TestDevice",
+					ComputerName:   "Samsung TestDevice",
+					HardwareModel:  "TestModel",
+				}),
+				fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+			)
+			require.NoError(t, err)
+			require.NotZero(t, orbitHost.ID)
+
+			// Orbit enroll alone does not write an android_devices row; AndroidHostLite misses.
+			_, err = ds.AndroidHostLite(ctx, enterpriseSpecificID)
+			require.True(t, fleet.IsNotFound(err),
+				"before AMAPI arrives there is no android_devices row, so AndroidHostLite should miss")
+
+			// Simulate the AMAPI pubsub path calling NewAndroidHost. The fix makes
+			// NewAndroidHost find the existing orbit-enrolled hosts row by uuid and
+			// reuse it instead of inserting a duplicate.
+			newHost := createAndroidHost(enterpriseSpecificID)
+			returned, err := ds.NewAndroidHost(ctx, newHost, false)
+			require.NoError(t, err)
+			require.NotNil(t, returned)
+			require.Equal(t, orbitHost.ID, returned.Host.ID,
+				"NewAndroidHost must reuse the orbit-enrolled hosts row, not insert a duplicate")
+
+			// AndroidHostLite now finds the host via the newly-created android_devices row.
+			androidHost, err := ds.AndroidHostLite(ctx, enterpriseSpecificID)
+			require.NoError(t, err)
+			require.NotNil(t, androidHost)
+			require.Equal(t, orbitHost.ID, androidHost.Host.ID)
+			require.Equal(t, enterpriseSpecificID, androidHost.Host.UUID)
+
+			// Exactly one hosts row and one android_devices row for this device.
+			var hostCount, deviceCount int
+			require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &hostCount,
+				`SELECT COUNT(*) FROM hosts WHERE uuid = ?`, enterpriseSpecificID))
+			require.Equal(t, 1, hostCount)
+			require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &deviceCount,
+				`SELECT COUNT(*) FROM android_devices WHERE enterprise_specific_id = ?`, enterpriseSpecificID))
+			require.Equal(t, 1, deviceCount)
+
+			// Subsequent orbit re-enroll (agent node-key wipe, reinstall) stays idempotent.
+			_, err = ds.EnrollOrbit(ctx,
+				fleet.WithEnrollOrbitMDMEnabled(true),
+				fleet.WithEnrollOrbitHostInfo(fleet.OrbitHostInfo{
+					HardwareUUID:   enterpriseSpecificID,
+					HardwareSerial: enterpriseSpecificID,
+					Platform:       tc.platform,
+					Hostname:       "Samsung TestDevice",
+					ComputerName:   "Samsung TestDevice",
+					HardwareModel:  "TestModel",
+				}),
+				fleet.WithEnrollOrbitNodeKey(uuid.New().String()),
+			)
+			require.NoError(t, err)
+			require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &hostCount,
+				`SELECT COUNT(*) FROM hosts WHERE uuid = ?`, enterpriseSpecificID))
+			require.Equal(t, 1, hostCount)
+			require.NoError(t, sqlx.GetContext(ctx, ds.writer(ctx), &deviceCount,
+				`SELECT COUNT(*) FROM android_devices WHERE enterprise_specific_id = ?`, enterpriseSpecificID))
+			require.Equal(t, 1, deviceCount)
+		})
+	}
 }
 
 func createAndroidHost(enterpriseSpecificID string) *fleet.AndroidHost {

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
@@ -209,6 +210,16 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 		if err != nil {
 			svc.logger.DebugContext(ctx, "Error re-enrolling Android host", "data", rawData)
 			return ctxerr.Wrap(ctx, err, "re-enrolling deleted Android host")
+		}
+		// Re-fetch the host so the subsequent updateHost/updateHostSoftware calls have a
+		// non-nil host. Force primary: enrollHost just INSERTed the host on the writer,
+		// and the default reader can be on a replica that hasn't caught up yet.
+		host, err = svc.getExistingHost(ctxdb.RequirePrimary(ctx, true), &device)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "getting re-enrolled Android host")
+		}
+		if host == nil {
+			return ctxerr.New(ctx, "re-enrolled Android host not found")
 		}
 	}
 	err = svc.updateHost(ctx, &device, host, false)

--- a/server/mdm/android/service/pubsub.go
+++ b/server/mdm/android/service/pubsub.go
@@ -219,7 +219,8 @@ func (svc *Service) handlePubSubStatusReport(ctx context.Context, token string, 
 			return ctxerr.Wrap(ctx, err, "getting re-enrolled Android host")
 		}
 		if host == nil {
-			return ctxerr.New(ctx, "re-enrolled Android host not found")
+			return ctxerr.Errorf(ctx, "re-enrolled Android host not found: enterpriseSpecificId=%s",
+				device.HardwareInfo.EnterpriseSpecificId)
 		}
 	}
 	err = svc.updateHost(ctx, &device, host, false)

--- a/server/mdm/android/service/pubsub_test.go
+++ b/server/mdm/android/service/pubsub_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/fleetdm/fleet/v4/server/config"
+	"github.com/fleetdm/fleet/v4/server/contexts/ctxdb"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/mdm/android"
 	android_mock "github.com/fleetdm/fleet/v4/server/mdm/android/mock"
@@ -1698,4 +1699,66 @@ func TestStatusReportAppInstallVerification(t *testing.T) {
 		require.True(t, mockDS.BulkSetVPPInstallsAsFailedFuncInvoked)
 		require.True(t, mockDS.GetPastActivityDataForAndroidVPPAppInstallFuncInvoked)
 	})
+}
+
+// Status report arrives for an Android host that was deleted from Fleet: the
+// handler must re-enroll the host and then read it back from primary (issue #42494).
+func TestPubSubStatusReportHostDeletedFromFleet(t *testing.T) {
+	svc, mockDS := createAndroidService(t)
+
+	mockDS.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{MDM: fleet.MDM{AndroidEnabledAndConfigured: true}}, nil
+	}
+
+	// AndroidHostLite returns not-found initially (host was deleted from Fleet) and
+	// returns the created host only after enrollHost has run.
+	var createdHost *fleet.AndroidHost
+	mockDS.AndroidHostLiteFunc = func(ctx context.Context, enterpriseSpecificID string) (*fleet.AndroidHost, error) {
+		if createdHost != nil && ctxdb.IsPrimaryRequired(ctx) {
+			return createdHost, nil
+		}
+		return nil, common_mysql.NotFound("android host lite mock")
+	}
+	mockDS.VerifyEnrollSecretFunc = func(ctx context.Context, secret string) (*fleet.EnrollSecret, error) {
+		return &fleet.EnrollSecret{Secret: "global"}, nil
+	}
+	mockDS.NewAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, companyOwned bool) (*fleet.AndroidHost, error) {
+		createdHost = host
+		return host, nil
+	}
+	mockDS.UpdateAndroidHostFunc = func(ctx context.Context, host *fleet.AndroidHost, fromEnroll, companyOwned bool) error {
+		return nil
+	}
+
+	// Minimal device: no AppliedPolicyName / ApplicationReports, so the status report
+	// handler stays on the simple path (skips policy + software verification).
+	// EnrollmentTokenData is present because production AMAPI payloads include it;
+	// without it, enrollHost would fail to unmarshal and never exercise the fix.
+	device := androidmanagement.Device{
+		Name:                createAndroidDeviceId("deleted-from-fleet"),
+		EnrollmentTokenData: `{"enroll_secret": "global"}`,
+		HardwareInfo: &androidmanagement.HardwareInfo{
+			EnterpriseSpecificId: strings.ToUpper(uuid.New().String()),
+			Brand:                "TestBrand",
+			Model:                "TestModel",
+			SerialNumber:         "test-serial",
+			Hardware:             "test-hardware",
+		},
+		SoftwareInfo: &androidmanagement.SoftwareInfo{AndroidBuildNumber: "test-build", AndroidVersion: "1"},
+		MemoryInfo: &androidmanagement.MemoryInfo{
+			TotalRam:             int64(8 * 1024 * 1024 * 1024),
+			TotalInternalStorage: int64(64 * 1024 * 1024 * 1024),
+		},
+	}
+	data, err := json.Marshal(device)
+	require.NoError(t, err)
+	statusReport := &android.PubSubMessage{
+		Attributes: map[string]string{"notificationType": string(android.PubSubStatusReport)},
+		Data:       base64.StdEncoding.EncodeToString(data),
+	}
+
+	err = svc.ProcessPubSubPush(context.Background(), "value", statusReport)
+	require.NoError(t, err)
+	require.True(t, mockDS.NewAndroidHostFuncInvoked, "re-enrollment should create the host")
+	require.True(t, mockDS.UpdateAndroidHostFuncInvoked, "status report update should run against the re-enrolled host")
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42494 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented a server panic (HTTP 502) when Android pubsub status reports arrive for hosts deleted from Fleet by validating re-enrollment before processing.
  * Improved Android host creation to avoid creating duplicate hosts when an Orbit-only enrollment already exists.

* **Tests**
  * Added unit tests for the re-enrollment flow for deleted hosts and deduplication between Orbit and Android enrollments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->