### PR TITLE
server/datastore/s3: guard S3 CarveStore.CleanupCarves against empty list

### DIFF
--- a/changes/43045-s3-carve-cleanup-empty-slice-panic
+++ b/changes/43045-s3-carve-cleanup-empty-slice-panic
@@ -1,0 +1,1 @@
+* Fixed an index-out-of-range panic in the S3 carve store's `CleanupCarves` when there are no non-expired carves.

--- a/server/datastore/s3/carves.go
+++ b/server/datastore/s3/carves.go
@@ -147,6 +147,11 @@ func (c *CarveStore) CleanupCarves(ctx context.Context, now time.Time) (int, err
 	if err != nil {
 		return 0, ctxerr.Wrap(ctx, err, "s3 carve cleanup")
 	}
+	if len(nonExpiredCarves) == 0 {
+		// Nothing to compare against; without this guard the lastCarveNextHour
+		// line below would panic with index out of range.
+		return 0, nil
+	}
 	// List carves in S3 up to a hour+1 prefix
 	lastCarveNextHour := nonExpiredCarves[len(nonExpiredCarves)-1].CreatedAt.Add(time.Hour)
 	lastCarvePrefix := c.prefix + lastCarveNextHour.Format(timePrefixFormat)


### PR DESCRIPTION
**Related issue:** Resolves partial #43045 (Bug 2 only — the empty-slice panic).

## What

`S3 CarveStore.CleanupCarves` (`server/datastore/s3/carves.go`) pulls up to `cleanupSize` non-expired carves and then reads `nonExpiredCarves[len(...)-1]` to compute the upper bound for the S3 listing prefix:

```go
nonExpiredCarves, err := c.ListCarves(ctx, fleet.CarveListOptions{...})
if err != nil {
    return 0, ctxerr.Wrap(ctx, err, "s3 carve cleanup")
}
lastCarveNextHour := nonExpiredCarves[len(nonExpiredCarves)-1].CreatedAt.Add(time.Hour)
```

If the query returns an empty slice — which is expected whenever there are no non-expired carves in the DB — the last-index access panics with `runtime error: index out of range`. That kills the cleanup goroutine; Go's HTTP server recovers per-request, but the scheduler context doesn't benefit.

This PR adds an early return:

```go
if len(nonExpiredCarves) == 0 {
    return 0, nil
}
```

Nothing else changes. Bug 1 from #43045 (the MySQL-vs-S3 wiring in `cmd/fleet/cron.go`) is explicitly out of scope — that one needs product decisions about how the two cleanup paths interact.

## Testing

- `go test ./server/datastore/s3/...` passes.
- Added a targeted unit test path locally: `ListCarves` returning an empty slice now yields `(0, nil)` from `CleanupCarves`, and the function doesn't touch S3.

## Checklist

- [x] Changes file added: `changes/43045-s3-carve-cleanup-empty-slice-panic`
- [x] DCO sign-off in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed a crash in the carve cleanup process that occurred when there were no active carves to process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->