### PR TITLE
mdm/nanomdm: cap pushConcurrent workers, don't grow them to match pushes

### DIFF
--- a/changes/42898-nanopush-worker-cap
+++ b/changes/42898-nanopush-worker-cap
@@ -1,0 +1,1 @@
+* Fixed the APNs `nanopush` provider spawning one goroutine per push when more pushes than configured workers were queued, instead of capping at `p.workers`.

--- a/server/mdm/nanomdm/push/nanopush/provider.go
+++ b/server/mdm/nanomdm/push/nanopush/provider.go
@@ -116,7 +116,7 @@ func (p *Provider) pushSerial(ctx context.Context, pushInfos []*mdm.Push) (map[s
 func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	// don't start more workers than we have pushes to send
 	workers := p.workers
-	if len(pushInfos) > workers {
+	if len(pushInfos) < workers {
 		workers = len(pushInfos)
 	}
 

--- a/server/mdm/nanomdm/push/nanopush/provider.go
+++ b/server/mdm/nanomdm/push/nanopush/provider.go
@@ -116,6 +116,13 @@ func (p *Provider) pushSerial(ctx context.Context, pushInfos []*mdm.Push) (map[s
 func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	// don't start more workers than we have pushes to send
 	workers := p.workers
+	if workers < 1 {
+		// WithWorkers accepts any int and the Provider zero value has
+		// workers=0, so guard here before len(...) or wg.Add see it:
+		// wg.Add(<0) panics, and wg.Add(0) plus an unbuffered jobs
+		// channel would wedge the feeder forever.
+		workers = 1
+	}
 	if len(pushInfos) < workers {
 		workers = len(pushInfos)
 	}


### PR DESCRIPTION
**Related issue:** Resolves #42898

## What

`pushConcurrent` in `server/mdm/nanomdm/push/nanopush/provider.go` is guarded by a worker-count clamp whose comment says "don't start more workers than we have pushes to send", but the comparison was flipped:

```go
workers := p.workers
if len(pushInfos) > workers {
    workers = len(pushInfos)  // was growing the pool, not capping it
}
```

With `p.workers = 20` and a fleet-wide push of 10k devices, this spawned 10,000 goroutines instead of capping at the configured 20. APNs connection contention and memory use scaled with enrolled-device count instead of with the intentionally chosen pool size.

This PR flips `>` to `<` so the cap only drops when there are *fewer* pushes than configured workers — matching the comment and the original intent.

Small deployments (fewer devices than the worker count) are unaffected either way; the old check happened to behave correctly there, which is why the bug stayed latent.

## Testing

- `go test ./server/mdm/nanomdm/push/nanopush/...` passes.
- Manual check: with `p.workers=4` and 100 pushes, `runtime.NumGoroutine()` inside the worker loop tops out at 4 worker goroutines plus the caller — previously it jumped by ~100.

## Checklist

- [x] Changes file added: `changes/42898-nanopush-worker-cap`
- [x] DCO sign-off in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed APNs push notification worker spawning to enforce the configured capacity limit. When queued requests exceed the worker count, the system now caps concurrent workers to the configured limit and guarantees at least one worker, preventing excessive goroutine creation and improving stability and resource usage during high-volume notification delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->