### PR TITLE
fleet/windows_mdm: require a top-level SyncML element when validating

### DIFF
--- a/changes/42219-windows-mdm-no-top-level-element
+++ b/changes/42219-windows-mdm-no-top-level-element
@@ -1,0 +1,1 @@
+* Fixed Windows MDM profile upload accepting plain-text or element-less XML by requiring at least one `<Replace>`, `<Add>`, `<Exec>`, or `<Atomic>` top-level SyncML element.

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -60,6 +60,12 @@ type windowsProfileValidator struct {
 	// can be empty if not within a top-level element.
 	currentTopLevelElement string
 
+	// Set to true the first time we see a valid top-level SyncML element.
+	// Plain text and pure-comment inputs pass xml.Decoder as well-formed,
+	// so without this flag we'd accept content that carries no profile
+	// payload at all (#42219).
+	sawTopLevelElement bool
+
 	// The decoder which is used for reading the XML tokens.
 	decoder *xml.Decoder
 
@@ -130,6 +136,10 @@ func (v *windowsProfileValidator) validate() error {
 		}
 	}
 
+	if !v.sawTopLevelElement {
+		return errors.New("The file should include valid SyncML XML with at least one <Replace>, <Add>, <Exec>, or <Atomic> top-level element.")
+	}
+
 	return v.scepValidator.finalizeValidation()
 }
 
@@ -176,6 +186,7 @@ func (v *windowsProfileValidator) handleStartElement(el xml.StartElement) error 
 		}
 
 		v.currentTopLevelElement = elementName
+		v.sawTopLevelElement = true
 		if v.isAtomicProfile == nil {
 			// We are at top level, and we see a non-Atomic element first, mark the profile as non-Atomic.
 			v.isAtomicProfile = ptr.Bool(false)


### PR DESCRIPTION
**Related issue:** Resolves #42219

## What

`MDMWindowsConfigProfile.ValidateUserProvided` walks the uploaded content with `xml.Decoder` and only rejects it when the walk actively hits an invalid element (unknown top-level tag, reserved `LocURI`, etc.). Well-formed bytes that carry no SyncML payload at all — plain text like `this is not xml`, files that are pure comments, or files with zero elements — passed validation, got a UUID, and then failed on every host during reconciliation.

Repro is trivial:

```bash
echo "this is not xml" > notxml.xml
curl -X POST /api/v1/fleet/configuration_profiles?team_id=1 -F "profile=@notxml.xml"
# 200 OK with a profile UUID; hosts immediately start failing this profile.
```

## Change

`server/fleet/windows_mdm.go`:

- Add a `sawTopLevelElement bool` flag to `windowsProfileValidator`.
- Set it to `true` in `handleStartElement` the first time we accept a top-level element (`Replace`, `Add`, `Exec`, or `Atomic`).
- After `validate()`'s token loop, return a clear error if it's still `false`:

  > The file should include valid SyncML XML with at least one `<Replace>`, `<Add>`, `<Exec>`, or `<Atomic>` top-level element.

Normal profiles are unaffected — the flag flips on the first valid top-level element and the rest of the walk is unchanged.

## Testing

- `go test ./server/fleet/ -run TestMDMWindowsConfigProfile` passes, including the existing happy-path cases.
- Added a local regression case: uploading `this is not xml` now returns the new error instead of succeeding.

## Checklist

- [x] Changes file added: `changes/42219-windows-mdm-no-top-level-element`
- [x] DCO sign-off in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Windows MDM profile uploads now require at least one top-level SyncML element (`<Replace>`, `<Add>`, `<Exec>`, or `<Atomic>`). Previously accepted profiles lacking these elements are no longer accepted and will be rejected. All Windows MDM profile uploads must now include at least one of the specified top-level elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->