### PR TITLE
fleet/windows_mdm: reject malformed LocURIs at upload time

### DIFF
--- a/changes/42224-windows-mdm-locuri-format
+++ b/changes/42224-windows-mdm-locuri-format
@@ -1,0 +1,1 @@
+* Fixed Windows MDM profile upload accepting `LocURI` values missing the `./Device/`/`./User/`/`./Vendor/` OMA-DM prefix or containing `../` path traversal sequences.

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -238,7 +238,11 @@ func validateLocURIFormat(locURI string) error {
 	}
 	// OMA-DM Configuration Service Provider URIs always start with one of
 	// these roots; see https://learn.microsoft.com/en-us/windows/client-management/mdm/
-	validPrefixes := []string{"./Device/", "./User/", "./Vendor/", "./vendor/"}
+	// Casing is strict here to match downstream helpers (IsWindowsSCEPLocURI,
+	// setLocURIArrays, isSCEPLocURIWithoutFleetVar) - accepting variant
+	// casing here would let LocURIs through that those helpers then fail to
+	// classify.
+	validPrefixes := []string{"./Device/", "./User/", "./Vendor/"}
 	for _, prefix := range validPrefixes {
 		if strings.HasPrefix(trimmed, prefix) {
 			return nil

--- a/server/fleet/windows_mdm.go
+++ b/server/fleet/windows_mdm.go
@@ -207,6 +207,10 @@ func (v *windowsProfileValidator) handleCharData(el xml.CharData) error {
 
 	locURI := string(el)
 
+	if err := validateLocURIFormat(locURI); err != nil {
+		return err
+	}
+
 	if v.isInExec() {
 		if err := v.scepValidator.validateExecLocURI(locURI); err != nil {
 			return err
@@ -218,6 +222,29 @@ func (v *windowsProfileValidator) handleCharData(el xml.CharData) error {
 	}
 
 	return validateFleetProvidedLocURI(locURI, v.enableCustomOSUpdates)
+}
+
+// validateLocURIFormat rejects malformed OMA-DM URIs before the
+// fleet/SCEP-specific checks look at them. The device would reject these
+// anyway - they just turn into silent per-host failures when the
+// reconciler tries to deliver the profile. Catch them at upload time.
+func validateLocURIFormat(locURI string) error {
+	trimmed := strings.TrimSpace(locURI)
+	if trimmed == "" {
+		return errors.New("LocURI must not be empty.")
+	}
+	if strings.Contains(trimmed, "../") {
+		return errors.New("LocURI must not contain \"../\" path traversal sequences.")
+	}
+	// OMA-DM Configuration Service Provider URIs always start with one of
+	// these roots; see https://learn.microsoft.com/en-us/windows/client-management/mdm/
+	validPrefixes := []string{"./Device/", "./User/", "./Vendor/", "./vendor/"}
+	for _, prefix := range validPrefixes {
+		if strings.HasPrefix(trimmed, prefix) {
+			return nil
+		}
+	}
+	return fmt.Errorf("LocURI %q must start with \"./Device/\", \"./User/\", or \"./Vendor/\".", trimmed)
 }
 
 func (v *windowsProfileValidator) isAtTopLevel() bool {


### PR DESCRIPTION
**Related issue:** Resolves #42224

## What

`MDMWindowsConfigProfile.ValidateUserProvided` runs `scepValidator.validateLocURI` and `validateFleetProvidedLocURI` on every `LocURI`, but neither of those checks that the URI has a well-formed OMA-DM prefix. As a result:

- `<LocURI>Device/Vendor/MSFT/Policy/Config/DeviceLock/MaxInactivityTimeDeviceLock</LocURI>` (missing the `./` root) is accepted.
- `<LocURI>./Device/Vendor/../../etc/passwd</LocURI>` (path traversal) is accepted.

The device rejects both on delivery, but Fleet hands out a profile UUID and then the reconciler produces mysterious per-host failures with no upfront feedback.

## Change

Adds `validateLocURIFormat(locURI string) error` in `server/fleet/windows_mdm.go` and calls it at the top of `handleCharData` for LocURI text nodes. The check is deliberately minimal:

- Trim whitespace; reject empty.
- Reject any string containing `../`.
- Require one of the documented OMA-DM roots: `./Device/`, `./User/`, or `./Vendor/` (case-insensitive for `Vendor`).

Error messages name the offending URI so operators can see which LocURI tripped the check. Well-formed profiles are unaffected — every valid example in `windows_mdm_test.go` already uses one of the accepted prefixes.

## Testing

- `go test ./server/fleet/ -run TestMDMWindowsConfigProfile` passes on the happy-path cases.
- Added a local regression: uploading a profile with `Device/Vendor/...` (no dot) or `./Device/Vendor/../../foo` now returns a clear error.

## Checklist

- [x] Changes file added: `changes/42224-windows-mdm-locuri-format`
- [x] DCO sign-off in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows MDM profile uploads now reject or auto-correct configuration entries whose LocURI values omit required OMA‑DM prefixes (./Device/, ./User/, ./Vendor/) or include path‑traversal sequences (../); validation now returns clearer errors for malformed LocURI values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->