### PR TITLE
service/microsoft_mdm: iterate install/remove targets in sorted order

### DIFF
--- a/changes/42225-windows-mdm-deterministic-order
+++ b/changes/42225-windows-mdm-deterministic-order
@@ -1,0 +1,1 @@
+* Fixed Windows MDM profiles delivered in non-deterministic order when multiple profiles target the same LocURI by sorting install/remove targets by profile UUID in `ReconcileWindowsProfiles`.

--- a/server/service/microsoft_mdm.go
+++ b/server/service/microsoft_mdm.go
@@ -2694,7 +2694,18 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 		NDESChallengeErrorToDetail: scep.NDESChallengeErrorToDetail,
 	}
 
-	for profUUID, target := range installTargets {
+	// Iterate installTargets in a stable order so profiles reach the device
+	// deterministically. Some CSP nodes use LastWrite conflict resolution,
+	// so map-range order could otherwise change the effective value run to
+	// run when two profiles target the same LocURI (#42225).
+	installUUIDs := make([]string, 0, len(installTargets))
+	for uuid := range installTargets {
+		installUUIDs = append(installUUIDs, uuid)
+	}
+	slices.Sort(installUUIDs)
+
+	for _, profUUID := range installUUIDs {
+		target := installTargets[profUUID]
 		p, ok := profileContents[profUUID]
 		if !ok {
 			// this should never happen
@@ -2783,7 +2794,15 @@ func ReconcileWindowsProfiles(ctx context.Context, ds fleet.Datastore, logger *s
 	}
 
 	// Generate and enqueue <Delete> commands for profiles being removed from hosts.
-	for profUUID, target := range removeTargets {
+	// Same deterministic-iteration rationale as the install loop above.
+	removeUUIDs := make([]string, 0, len(removeTargets))
+	for uuid := range removeTargets {
+		removeUUIDs = append(removeUUIDs, uuid)
+	}
+	slices.Sort(removeUUIDs)
+
+	for _, profUUID := range removeUUIDs {
+		target := removeTargets[profUUID]
 		p, ok := profileContents[profUUID]
 		if !ok {
 			// Profile was deleted between list and fetch. (The deletion path already called cancelWindowsHostInstallsForDeletedMDMProfiles)


### PR DESCRIPTION
**Related issue:** Resolves #42225

## What

`ReconcileWindowsProfiles` in `server/service/microsoft_mdm.go` walks `installTargets` and `removeTargets` with Go's randomised map-range. Most CSP nodes use value-based conflict resolution (`LowestValueMostSecure`, `HighestValueMostSecure`), so delivery order doesn't matter for them. But CSP nodes that use `LastWrite` resolution see the effective on-device value change from one reconcile run to the next, depending on which profile happens to be sent last — with no config change to explain it.

## Change

Collect the profile UUIDs into slices, `slices.Sort` them, and range over the slice instead of the map. One small block for each of the install and remove loops. Everything inside the loops is unchanged.

## Testing

- `go test ./server/service/ -run TestReconcileWindowsProfiles` passes.
- Manual: with two Windows profiles targeting the same `LocURI` via `Replace`, `ReconcileWindowsProfiles` now produces the same sequence of outgoing commands across 20 runs; previously the order varied.

## Checklist

- [x] Changes file added: `changes/42225-windows-mdm-deterministic-order`
- [x] DCO sign-off in the commit message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Windows MDM profile reconciliation now delivers profiles in deterministic order when multiple profiles target the same location URI, ensuring consistent and predictable behavior during profile management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->