### PR TITLE
Android agent to always send the `platform` field on enrollment

### DIFF
--- a/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
+++ b/android/app/src/main/java/com/fleetdm/agent/ApiClient.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -438,6 +439,9 @@ object ApiClient : CertificateApiClient {
     )
 }
 
+// @EncodeDefault is marked @ExperimentalSerializationApi, but it has shipped in kotlinx.serialization since 1.3 (2022)
+// and is widely used and reliable in production. The opt-in only acknowledges that the API shape could change in a future version.
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
 @Serializable
 data class EnrollRequest(
     @SerialName("enroll_secret")
@@ -446,6 +450,7 @@ data class EnrollRequest(
     val hardwareUUID: String,
     @SerialName("hardware_serial")
     val hardwareSerial: String,
+    @EncodeDefault(EncodeDefault.Mode.ALWAYS)
     @SerialName("platform")
     val platform: String = "android",
     @SerialName("computer_name")

--- a/android/app/src/test/java/com/fleetdm/agent/ApiClientReenrollTest.kt
+++ b/android/app/src/test/java/com/fleetdm/agent/ApiClientReenrollTest.kt
@@ -100,10 +100,15 @@ class ApiClientReenrollTest {
         assertTrue("First call should succeed", firstResult.isSuccess)
         assertEquals(2, mockWebServer.requestCount) // enroll + config
 
-        // Verify first enrollment used the enroll secret
+        // Verify first enrollment used the enroll secret and sent platform="android" on the wire
         val firstEnroll = mockWebServer.takeRequest()
         assertEquals("/api/fleet/orbit/enroll", firstEnroll.path)
-        assertTrue(firstEnroll.body.readUtf8().contains("test-enroll-secret"))
+        val firstEnrollBody = firstEnroll.body.readUtf8()
+        assertTrue(firstEnrollBody.contains("test-enroll-secret"))
+        assertTrue(
+            "Expected platform=\"android\" in enroll body, got: $firstEnrollBody",
+            firstEnrollBody.contains("\"platform\":\"android\""),
+        )
 
         // Verify first config used first-node-key
         val firstConfig = mockWebServer.takeRequest()

--- a/android/changes/43807-android-enroll-platform
+++ b/android/changes/43807-android-enroll-platform
@@ -1,0 +1,1 @@
+- Fixed Android agent to always send the `platform` field on enrollment so the device is registered with the correct platform.


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43807

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed platform identification serialization in Android device enrollment to ensure the platform field is always included in registration requests, guaranteeing proper backend recognition of Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->