### PR TITLE
Set 24h APNs expiration on MDM pushes (#40693)

### DIFF
--- a/changes/40693-apns-expiration
+++ b/changes/40693-apns-expiration
@@ -1,0 +1,1 @@
+* Set a 24 hour APNs expiration on MDM push notifications so that pushes are held by Apple and delivered when a device reconnects, instead of being dropped if the device is momentarily detached from APNs at the time a command is queued.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -665,11 +665,18 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 
 	var mdmPushService push.Pusher
 	nanoMDMLogger := service.NewNanoMDMLogger(logger.With("component", "apple-mdm-push"))
-	pushProviderFactory := buford.NewPushProviderFactory(buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
-		return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
-			Certificates: []tls.Certificate{*cert},
-		})), nil
-	}))
+	// Set a 24h APNs expiration so that if a device is not currently attached
+	// to APNs when a command is queued, Apple will hold the push and deliver
+	// it when the device reconnects (instead of silently dropping it, which
+	// is the behavior for a push with no/0 expiration). See #40693.
+	pushProviderFactory := buford.NewPushProviderFactory(
+		buford.WithExpiration(24*time.Hour),
+		buford.WithNewClient(func(cert *tls.Certificate) (*http.Client, error) {
+			return fleethttp.NewClient(fleethttp.WithTLSClientConfig(&tls.Config{
+				Certificates: []tls.Certificate{*cert},
+			})), nil
+		}),
+	)
 	if dev_mode.Env("FLEET_DEV_MDM_APPLE_DISABLE_PUSH") == "1" {
 		mdmPushService = nopPusher{}
 	} else {


### PR DESCRIPTION
For #40693 (short-term mitigation)

## Problem

Fleet constructs the buford APNs push provider without calling `WithExpiration`, so pushes are sent with no `apns-expiration` header. Apple treats this as "deliver once, do not store" — if the device is not currently attached to APNs at the instant Fleet sends the push (wifi flap, sleep/wake, network transition), the push is silently dropped and Fleet never knows.

Combined with the re-push cron (`GetEnrollmentIDsWithPendingMDMAppleCommands`) excluding rows with any `nano_command_results` status (including `NotNow`), this produces user-visible 15+ minute hangs on commands like `RemoveProfile` even though the device appears online in Fleet.

## Change

`cmd/fleet/serve.go`: pass `buford.WithExpiration(24 * time.Hour)` when building the push provider factory. APNs will now hold the push and deliver it as soon as the device reconnects, instead of dropping it.

This is the minimum change; it does not address the broader cron/query rework tracked in #40693 (longer-lived periodic pushes, dropping the 7-day `RAND() LIMIT 500` query, covering `NotNow`).

## Checklist for contributor

- [x] Changes file added (`changes/40693-apns-expiration`).
- [ ] Manual verification on a staging Fleet server: queue a command against a device that is briefly offline (e.g. lid closed), then reopen within 24h, and confirm the command is delivered without waiting for Fleet's 1-minute cron or for the device to reconnect and poll.
- [ ] Not adding tests — behavior depends on Apple's APNs server-side store-and-forward; existing `buford.WithExpiration` plumbing is already covered.

## Risk

Low. The change only sets an HTTP header on outgoing APNs requests. 24h is well within Apple's documented max (30 days) and matches the direction described in #40693.
