### PR TITLE
Re-push MDM commands after NotNow responses (#40693)

### DIFF
--- a/changes/40693-repush-notnow
+++ b/changes/40693-repush-notnow
@@ -1,0 +1,1 @@
+* Re-push MDM commands to Apple devices that responded with NotNow. Previously the pending-commands cron excluded any enrollment whose command had a NotNow response, which could leave commands waiting until the device reconnected on its own.

--- a/server/datastore/mysql/apple_mdm.go
+++ b/server/datastore/mysql/apple_mdm.go
@@ -6531,7 +6531,12 @@ FROM
     AND ncr.id = neq.id
 WHERE
     neq.active = 1
-    AND ncr.status IS NULL
+    -- Include commands that have never been answered (status IS NULL) as well
+    -- as commands the device answered with NotNow. NotNow means Apple asked
+    -- the device to try again later, and without re-pushing these the command
+    -- would otherwise wait for the device to reconnect on its own schedule.
+    -- See #40693.
+    AND (ncr.status IS NULL OR ncr.status = 'NotNow')
     AND neq.created_at >= NOW() - INTERVAL 7 DAY
     AND neq.priority IN (0, 1)
 ORDER BY RAND()

--- a/server/datastore/mysql/apple_mdm_test.go
+++ b/server/datastore/mysql/apple_mdm_test.go
@@ -7476,6 +7476,23 @@ func testGetEnrollmentIDsWithPendingMDMAppleCommands(t *testing.T, ds *Datastore
 	ids, err = ds.GetEnrollmentIDsWithPendingMDMAppleCommands(ctx)
 	require.NoError(t, err)
 	require.ElementsMatch(t, []string{hosts[1].UUID, hosts[2].UUID, hostUUIDToUserEnrollmentID[hosts[4].UUID], hostUUIDToUserEnrollmentID[hosts[5].UUID]}, ids)
+
+	// A NotNow response from a device should NOT remove it from the list of
+	// pending enrollments — Apple asked the device to try again later, and we
+	// need to keep re-pushing so the command is eventually picked up. See #40693.
+	err = storage.StoreCommandReport(&mdm.Request{
+		EnrollID: &mdm.EnrollID{ID: hosts[1].UUID},
+		Context:  ctx,
+	}, &mdm.CommandResults{
+		CommandUUID: uuid1,
+		Status:      "NotNow",
+		Raw:         []byte(rawCmd1),
+	})
+	require.NoError(t, err)
+
+	ids, err = ds.GetEnrollmentIDsWithPendingMDMAppleCommands(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{hosts[1].UUID, hosts[2].UUID, hostUUIDToUserEnrollmentID[hosts[4].UUID], hostUUIDToUserEnrollmentID[hosts[5].UUID]}, ids)
 }
 
 func testHostDetailsMDMProfilesIOSIPadOS(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
For #40693 (short-term mitigation, complements #43812)

## Problem

`GetEnrollmentIDsWithPendingMDMAppleCommands` (`server/datastore/mysql/apple_mdm.go`) powers the 1-minute APNs re-push cron (`cmd/fleet/cron.go:newMDMAPNsPusher` → `service.SendPushesToPendingDevices`). Its filter is:

```sql
AND ncr.status IS NULL
```

This excludes any enrollment whose command has a `nano_command_results` row, including `NotNow`. `NotNow` means Apple told the device "try again later" — the device will not fetch the command on its own until it next re-attaches to APNs. Without a re-push, the command sits "pending" until the device reconnects on its own schedule, producing the 15+ minute hangs described in internal reports.

## Change

Treat `NotNow` the same as "no response yet" for the purposes of the re-push cron:

```sql
AND (ncr.status IS NULL OR ncr.status = 'NotNow')
```

This does not cause the device to be handed the same command repeatedly: `nanomdm`'s `RetrieveNextCommand` (`server/mdm/nanomdm/storage/mysql/queue.go`) already has a `skipNotNow` path that suppresses `NotNow`-answered commands on the device-side queue lookup until the configured window elapses. All this PR changes is that Fleet will keep poking the device via APNs so that it re-polls sooner.

## Test

Extended `testGetEnrollmentIDsWithPendingMDMAppleCommands` to assert that an enrollment which responded `NotNow` remains in the pending set.

## Checklist

- [x] Changes file added (`changes/40693-repush-notnow`).
- [ ] Integration test run on staging.
- [ ] Load-test impact review: this strictly increases the set of enrollments returned by the cron query each minute. For environments with large `NotNow` backlogs this is additional APNs volume. The broader rework in #40693 (drop the `RAND() LIMIT 500`, longer-lived expirations, daily blanket push) is the right long-term fix; this is the minimum correctness fix.

## Risk

Medium. Behavior change for the re-push cron. Pairs with #43812 (setting a 24h `apns-expiration`).
