### PR TITLE
Fix typos in Elgato app descriptions

### DIFF
--- a/ee/maintained-apps/outputs/apps.json
+++ b/ee/maintained-apps/outputs/apps.json
@@ -650,14 +650,14 @@
       "slug": "elgato-control-center/darwin",
       "platform": "darwin",
       "unique_identifier": "com.corsair.ControlCenter",
-      "description": "Elgate Control Center is an app to control your Elgato key lights."
+      "description": "Elgato Control Center is an app to control your Elgato key lights."
     },
     {
       "name": "Elgato Stream Deck",
       "slug": "elgato-stream-deck/darwin",
       "platform": "darwin",
       "unique_identifier": "com.elgato.StreamDeck",
-      "description": "Elgateo Stream Deck is an app to assign keys, and then decorate and label them, on a Stream Deck."
+      "description": "Elgato Stream Deck is an app to assign keys, and then decorate and label them, on a Stream Deck."
     },
     {
       "name": "Evernote",


### PR DESCRIPTION
Correct misspellings in ee/maintained-apps/outputs/apps.json for two entries: update "Elgate" to "Elgato" in the Elgato Control Center description and "Elgateo" to "Elgato" in the Elgato Stream Deck description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected spelling errors in application descriptions for Elgato Control Center and Elgato Stream Deck to ensure accurate product information display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->