### PR TITLE
Don't resend pending certificates

### DIFF
--- a/server/service/certificate_templates_test.go
+++ b/server/service/certificate_templates_test.go
@@ -412,6 +412,18 @@ func TestResendHostCertificateTemplate(t *testing.T) {
 		}, nil
 	}
 
+	ds.GetCertificateTemplateByIdForHostFunc = func(ctx context.Context, id uint, hostUUID string) (*fleet.CertificateTemplateResponseForHost, error) {
+		return &fleet.CertificateTemplateResponseForHost{
+			CertificateTemplateResponse: fleet.CertificateTemplateResponse{
+				CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+					ID:   id,
+					Name: templateName,
+				},
+			},
+			Status: fleet.CertificateTemplateDelivered,
+		}, nil
+	}
+
 	t.Run("succeeds and creates activity", func(t *testing.T) {
 		ds.ResendHostCertificateTemplateFunc = func(ctx context.Context, hID uint, tID uint) error {
 			require.Equal(t, hostID, hID)
@@ -453,6 +465,30 @@ func TestResendHostCertificateTemplate(t *testing.T) {
 		err := svc.ResendHostCertificateTemplate(ctx, hostID, templateID)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "db error")
+		require.False(t, opts.ActivityMock.NewActivityFuncInvoked)
+	})
+
+	t.Run("returns 400 when template is pending for host", func(t *testing.T) {
+		ds.GetCertificateTemplateByIdForHostFunc = func(ctx context.Context, id uint, hostUUID string) (*fleet.CertificateTemplateResponseForHost, error) {
+			return &fleet.CertificateTemplateResponseForHost{
+				CertificateTemplateResponse: fleet.CertificateTemplateResponse{
+					CertificateTemplateResponseSummary: fleet.CertificateTemplateResponseSummary{
+						ID:   id,
+						Name: templateName,
+					},
+				},
+				Status: fleet.CertificateTemplatePending,
+			}, nil
+		}
+		ds.ResendHostCertificateTemplateFuncInvoked = false
+
+		err := svc.ResendHostCertificateTemplate(ctx, hostID, templateID)
+		require.Error(t, err)
+
+		var umErr interface{ StatusCode() int }
+		require.ErrorAs(t, err, &umErr)
+		require.Equal(t, 400, umErr.StatusCode())
+		require.False(t, ds.ResendHostCertificateTemplateFuncInvoked)
 		require.False(t, opts.ActivityMock.NewActivityFuncInvoked)
 	})
 }

--- a/server/service/certificates.go
+++ b/server/service/certificates.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -778,6 +779,15 @@ func (svc *Service) ResendHostCertificateTemplate(ctx context.Context, hostID ui
 
 	if err := svc.authz.Authorize(ctx, &fleet.MDMConfigProfileAuthz{TeamID: host.TeamID}, fleet.ActionResend); err != nil {
 		return ctxerr.Wrap(ctx, err)
+	}
+
+	template, err := svc.ds.GetCertificateTemplateByIdForHost(ctx, templateID, host.UUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "checking host certificate template")
+	}
+
+	if template.Status == fleet.CertificateTemplatePending {
+		return fleet.NewUserMessageError(errors.New("Couldn't resend pending certificate template."), http.StatusBadRequest)
 	}
 
 	if err := svc.ds.ResendHostCertificateTemplate(ctx, hostID, templateID); err != nil {


### PR DESCRIPTION
**Related issue:** Resolves #37556

Fixes an issue caught in QA where a pending certificate could get resent using the API

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed certificate template resending to prevent invalid operations on pending templates. Users attempting to resend a pending template will now receive a clear error message.

* **Tests**
  * Added test coverage for certificate template resending with pending status validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->