### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/chatgpt/darwin.json
+++ b/ee/maintained-apps/outputs/chatgpt/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.2026.098",
+      "version": "1.2026.099",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.098') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.openai.chat' AND version_compare(bundle_short_version, '1.2026.099') < 0);"
       },
-      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.098_1776453807.dmg",
+      "installer_url": "https://persistent.oaistatic.com/sidekick/public/ChatGPT_Desktop_public_1.2026.099_1776706502.dmg",
       "install_script_ref": "105f16ab",
       "uninstall_script_ref": "dbaa4d2e",
-      "sha256": "87883fbc5761f55114a658432c0f3a3c83edd9104bb8524ebcf04ae229dff798",
+      "sha256": "f3a6d63494ff9ef8af8abf6dd3be5297db7f904ea01040b790251e6846b4ac88",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/claude/darwin.json
+++ b/ee/maintained-apps/outputs/claude/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.3109.0",
+      "version": "1.3561.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.3109.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.anthropic.claudefordesktop' AND version_compare(bundle_short_version, '1.3561.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.3109.0/Claude-35cbf6530e05912137624cde0f075dc7f121fa60.zip",
+      "installer_url": "https://downloads.claude.ai/releases/darwin/universal/1.3561.0/Claude-fbc74be3fdc714a2c46ef1fb84f71d4e4c062930.zip",
       "install_script_ref": "d05235fc",
       "uninstall_script_ref": "4cfbec7d",
-      "sha256": "f159693ebecd8a628cfe882c913a1979fc9a4b1d3bc9a218051f0f115c88bb68",
+      "sha256": "b037ee8ebe3d11e7eba959179dfdc534951ae8e387e96cacda1dceeecd035b52",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/claude/windows.json
+++ b/ee/maintained-apps/outputs/claude/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.3109.0",
+      "version": "1.3561.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.3109.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Claude' AND publisher = 'Anthropic, PBC' AND version_compare(version, '1.3561.0') < 0);"
       },
-      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.3109.0/Claude-35cbf6530e05912137624cde0f075dc7f121fa60.msix",
+      "installer_url": "https://downloads.claude.ai/releases/win32/x64/1.3561.0/Claude-fbc74be3fdc714a2c46ef1fb84f71d4e4c062930.msix",
       "install_script_ref": "31a0b698",
       "uninstall_script_ref": "03f72055",
-      "sha256": "4c664c5390a4d5b46286158f67e21102431a1c9863dc5edb2b8683ef69e1e300",
+      "sha256": "726cf8552406f0a6260c5ddce9d5a6f560fb0f9098137447e636adfe752174cc",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/cursor/darwin.json
+++ b/ee/maintained-apps/outputs/cursor/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.15",
+      "version": "3.1.17",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.1.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.todesktop.230313mzl4w4u92' AND version_compare(bundle_short_version, '3.1.17') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/3a67af7b780e0bfc8d32aefa96b8ff1cb8817f88/darwin/arm64/Cursor-darwin-arm64.zip",
+      "installer_url": "https://downloads.cursor.com/production/fce1e9ab7844f9ea35793da01e634aa7e50bce90/darwin/arm64/Cursor-darwin-arm64.zip",
       "install_script_ref": "5a1b1299",
       "uninstall_script_ref": "f7561d44",
-      "sha256": "e0b65b57d30d94eb668151c9b44d474f7fbb9c78a2bc4ec1bdff1a537bbc21a2",
+      "sha256": "2c308456eb5b834da262fe4f3cca744e179e68eb25591d0b4f83c3b742956290",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/cursor/windows.json
+++ b/ee/maintained-apps/outputs/cursor/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "3.1.15",
+      "version": "3.1.17",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.1.15') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Cursor' AND publisher = 'Anysphere' AND version_compare(version, '3.1.17') < 0);"
       },
-      "installer_url": "https://downloads.cursor.com/production/3a67af7b780e0bfc8d32aefa96b8ff1cb8817f88/win32/x64/system-setup/CursorSetup-x64-3.1.15.exe",
+      "installer_url": "https://downloads.cursor.com/production/fce1e9ab7844f9ea35793da01e634aa7e50bce90/win32/x64/system-setup/CursorSetup-x64-3.1.17.exe",
       "install_script_ref": "03589b5e",
       "uninstall_script_ref": "6c8096c5",
-      "sha256": "d667e13c7e538e11b23569071f2a47b271494038f9ae0be6c424a30c318bc73b",
+      "sha256": "14f6e7c8244175496bf8be1af05a7004d7013b6928576a0cdc350705baa8808d",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.0.385",
+      "version": "0.0.386",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.385') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.386') < 0);"
       },
-      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.385/Discord.dmg",
+      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.386/Discord.dmg",
       "install_script_ref": "dac37ced",
       "uninstall_script_ref": "8ed76f08",
-      "sha256": "c5b69b1d27abd56d610cdb6173b4575ec84971aa1bbf91875e992c85bad3cff7",
+      "sha256": "a01cf51f325bb95f4f9dd2ca96f9c1a03f547ac00c4e2034164835508cd8a04d",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/discord/windows.json
+++ b/ee/maintained-apps/outputs/discord/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.0.9233",
+      "version": "1.0.9234",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9233') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Discord' AND publisher = 'Discord Inc.' AND version_compare(version, '1.0.9234') < 0);"
       },
-      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9233/DiscordSetup.exe",
+      "installer_url": "https://stable.dl2.discordapp.net/distro/app/stable/win/x64/1.0.9234/DiscordSetup.exe",
       "install_script_ref": "fd04e860",
       "uninstall_script_ref": "73fc6eff",
-      "sha256": "eaba7863d5a7ed017a865f991267583e0768914aba99590874da0980832e45a3",
+      "sha256": "3f0306caceaa9594c608b39dbee8ceaba4422abc51052ee21deda7280eee9173",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.69.0",
+      "version": "4.70.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.69.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.70.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/224084/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/224270/Docker.dmg",
       "install_script_ref": "091b8a34",
       "uninstall_script_ref": "c31a36e7",
-      "sha256": "8e4638f2d427a4fb9d0f86f21d0975a344a164228d20fc22a620750b7943d644",
+      "sha256": "38a19ac039dee38e0e445118da34962039ef1601b0656dc4d138592efda2caba",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.344.0",
+      "version": "0.345.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.344.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.345.1') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.344.0-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.345.1-arm64.dmg",
       "install_script_ref": "8185f7a5",
       "uninstall_script_ref": "393b959f",
-      "sha256": "c5c561c45ce97d6bfaf344b0f12417165345e69a78dee3cfd02705e3c56b929d",
+      "sha256": "dc837812b1e3255575e44e72b0a84f34b0f6500e91af32b234eb65f8fcd115ad",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/orbstack/darwin.json
+++ b/ee/maintained-apps/outputs/orbstack/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.1.0",
+      "version": "2.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.1.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.kdrag0n.MacVirt' AND version_compare(bundle_short_version, '2.1.1') < 0);"
       },
-      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.0_19993_arm64.dmg",
+      "installer_url": "https://cdn-updates.orbstack.dev/arm64/OrbStack_v2.1.1_20026_arm64.dmg",
       "install_script_ref": "3d018c85",
       "uninstall_script_ref": "401d288b",
-      "sha256": "65dcb7ac3f53022eed732d962ce97af000a10e8a3de77fa4ed47645b7591f4c3",
+      "sha256": "18a41f759958e1fa0951696b820b5478d3ed7353f8ca486fe9d026a1a7d97207",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/zed/darwin.json
+++ b/ee/maintained-apps/outputs/zed/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.232.2",
+      "version": "0.232.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '0.232.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.zed.Zed' AND version_compare(bundle_short_version, '0.232.3') < 0);"
       },
-      "installer_url": "https://zed.dev/api/releases/stable/0.232.2/Zed-aarch64.dmg",
+      "installer_url": "https://zed.dev/api/releases/stable/0.232.3/Zed-aarch64.dmg",
       "install_script_ref": "b0e5ef67",
       "uninstall_script_ref": "a96df5e9",
-      "sha256": "82717ddea4c03ad033a9c99d1440d1b71d6f6141b02eedd1aa1cb8eb3dcb938f",
+      "sha256": "2f6ca2b175772e57c1d5b2893f8c8556e16581341f9568ee0ce4f84f5128b488",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application metadata to support newer versions of ChatGPT, Claude, Cursor, Discord, Docker Desktop, Loom, OrbStack, and Zed across macOS and Windows platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->