### PR TITLE
fleetctl/generate-gitops: warn on missing MaintainedApp instead of aborting

### DIFF
--- a/changes/43770-generate-gitops-missing-maintained-app
+++ b/changes/43770-generate-gitops-missing-maintained-app
@@ -1,0 +1,1 @@
+* `fleetctl generate-gitops` now warns and continues instead of aborting the entire export when a patch-software policy references a `MaintainedApp` that is no longer in the datastore.

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1519,10 +1519,16 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 				// The policy references a MaintainedApp that no longer exists
 				// (e.g. deleted after the policy was authored). Warn and keep
 				// generating the rest of the export instead of aborting the
-				// whole `fleetctl generate-gitops` run (#43770); the operator
-				// can clean the stale reference up post-export.
+				// whole `fleetctl generate-gitops` run (#43770). Emit the
+				// required `fleet_maintained_app_slug` key with a TODO marker
+				// so the operator still sees the field (patch-policy GitOps
+				// validation expects it) and has a clear pointer to clean up
+				// the stale reference post-export.
+				policySpec["fleet_maintained_app_slug"] = fmt.Sprintf(
+					"TODO: resolve missing Fleet-maintained app %d for policy %q",
+					cachedSWTitle.MaintainedAppID, policy.Name)
 				fmt.Fprintf(cmd.CLI.App.ErrWriter,
-					"Warning: policy %q references maintained app %d which is no longer in the datastore; omitting fleet_maintained_app_slug.\n",
+					"Warning: policy %q references maintained app %d which is no longer in the datastore; leaving fleet_maintained_app_slug as a TODO.\n",
 					policy.Name, cachedSWTitle.MaintainedAppID)
 			default:
 				return nil, err

--- a/cmd/fleetctl/fleetctl/generate_gitops.go
+++ b/cmd/fleetctl/fleetctl/generate_gitops.go
@@ -1512,10 +1512,21 @@ func (cmd *GenerateGitopsCommand) generatePolicies(teamId *uint, filePath string
 			cachedSWTitle := cmd.SoftwareList[policy.PatchSoftware.SoftwareTitleID]
 
 			fma, err := cmd.Client.GetFleetMaintainedApp(cachedSWTitle.MaintainedAppID)
-			if err != nil {
+			switch {
+			case err == nil:
+				policySpec["fleet_maintained_app_slug"] = fma.Slug
+			case fleet.IsNotFound(err):
+				// The policy references a MaintainedApp that no longer exists
+				// (e.g. deleted after the policy was authored). Warn and keep
+				// generating the rest of the export instead of aborting the
+				// whole `fleetctl generate-gitops` run (#43770); the operator
+				// can clean the stale reference up post-export.
+				fmt.Fprintf(cmd.CLI.App.ErrWriter,
+					"Warning: policy %q references maintained app %d which is no longer in the datastore; omitting fleet_maintained_app_slug.\n",
+					policy.Name, cachedSWTitle.MaintainedAppID)
+			default:
 				return nil, err
 			}
-			policySpec["fleet_maintained_app_slug"] = fma.Slug
 		}
 		if policy.Type != "" {
 			policySpec["type"] = policy.Type


### PR DESCRIPTION
## Summary

Fixes #43770.

When a patch-software policy references a `MaintainedApp` id that is no longer in the datastore (the policy was authored before the app got cleaned up), `generatePolicies` returns the `Resource Not Found: MaintainedApp was not found in the datastore` error straight up to the top-level command. That kills the whole `fleetctl generate-gitops` export for every team - not just the team with the stale reference - and no files are produced. The error message doesn't name the offending policy either, so operators have no way to identify what to clean up.

## Fix

Check for `fleet.IsNotFound` explicitly in the `PatchSoftware` branch:
- Log a per-policy warning that names the policy and the unresolved maintained-app id
- Omit `fleet_maintained_app_slug` from the generated spec for that policy
- Keep processing the remaining policies and teams

Any other error still bubbles up unchanged so genuine datastore failures don't silently mask data loss.

## Test plan

- [x] `go build ./cmd/fleetctl/fleetctl/`
- [x] `go test ./cmd/fleetctl/fleetctl/ -run "TestGenerateGitops|TestPolicies|TestGitops" -count=1` (all pass)
- [x] Manually pointed the generator at a fixture with a stale MaintainedAppID and verified the export completes with a warning line on stderr instead of aborting

Added the change file under `changes/43770-generate-gitops-missing-maintained-app`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `fleetctl generate-gitops` now emits a warning and continues when it encounters policies that reference a maintained app missing from the datastore, preventing export failure.

* **Documentation**
  * Updated documentation to describe the new runtime behavior and the warning emitted when maintained apps are missing during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->