### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/mattermost/darwin.json
+++ b/ee/maintained-apps/outputs/mattermost/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.1.1",
+      "version": "6.1.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop' AND version_compare(bundle_short_version, '6.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'Mattermost.Desktop' AND version_compare(bundle_short_version, '6.1.2') < 0);"
       },
-      "installer_url": "https://releases.mattermost.com/desktop/6.1.1/mattermost-desktop-6.1.1-mac-arm64.zip",
+      "installer_url": "https://releases.mattermost.com/desktop/6.1.2/mattermost-desktop-6.1.2-mac-arm64.zip",
       "install_script_ref": "17822dd8",
       "uninstall_script_ref": "efc92f2b",
-      "sha256": "55acdb9898c76f223cf8fd218f67db384b1aebdce14a37e7a42c8a7fe3b1b26c",
+      "sha256": "bdfbf4d23de5b58c59904856ca74c7574e6b640ab36a1038d08ae4379169b98b",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/onedrive/darwin.json
+++ b/ee/maintained-apps/outputs/onedrive/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.051.0316.0004",
+      "version": "26.055.0323.0004",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.051.0316.0004') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.OneDrive' AND version_compare(bundle_short_version, '26.055.0323.0004') < 0);"
       },
-      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.051.0316.0004/universal/OneDrive.pkg",
+      "installer_url": "https://oneclient.sfx.ms/Mac/Installers/26.055.0323.0004/universal/OneDrive.pkg",
       "install_script_ref": "3825df5c",
       "uninstall_script_ref": "605be8f5",
-      "sha256": "d54dca1766fbf452a71ab371f2a7ef93cef4dd01c58fca720e422d7610b00f00",
+      "sha256": "14a3870b9bc09ec2c1d8e3d5c291b22879793c3e8ba11993c37e34f4553aa7df",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/windsurf/darwin.json
+++ b/ee/maintained-apps/outputs/windsurf/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.0.61",
+      "version": "2.0.63",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '2.0.61') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.exafunction.windsurf' AND version_compare(bundle_short_version, '2.0.63') < 0);"
       },
-      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/abcd9c8664da5af505557f3b327b5537400635f2/Windsurf-darwin-arm64-2.0.61.dmg",
+      "installer_url": "https://windsurf-stable.codeiumdata.com/darwin-arm64-dmg/stable/8636ab52872ef59a7227b8f7f386fd30d94b2249/Windsurf-darwin-arm64-2.0.63.dmg",
       "install_script_ref": "c8855980",
       "uninstall_script_ref": "461afb53",
-      "sha256": "53010c8710535ee78f2f28c7afbe94fd8ff2738b0b1b2587c684c42e721dc086",
+      "sha256": "1ee966e6c13d792fa5b6ae980a534f0c81f4155cb8b970f6aaf68b0d3b18c288",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version metadata for maintained macOS applications: Mattermost (6.1.2), OneDrive (26.055.0323.0004), and Windsurf (2.0.63). Each update includes refreshed installer URLs and corresponding checksums to ensure proper installation and security verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->