### PR TITLE
Relaunch apps via open as console user

### DIFF
--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -543,7 +543,7 @@ const quitApplicationFunc = `quit_application() {
 
   local console_user
   console_user=$(stat -f "%Su" /dev/console)
-  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+  if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
     echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
     return
   fi
@@ -587,7 +587,7 @@ const quitAndTrackApplicationFunc = `quit_and_track_application() {
 
   local console_user
   console_user=$(stat -f "%Su" /dev/console)
-  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+  if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
     echo "Not logged into a non-root GUI; skipping quitting application ID '$bundle_id'."
     eval "export $var_name=0"
     return
@@ -648,9 +648,14 @@ const relaunchApplicationFunc = `relaunch_application() {
 
   # Launch the app in the logged-in user's GUI session. Apps launched by root
   # won't register with the user's Dock/GUI, so run 'open' as the console user.
+  # Use 'launchctl asuser' to bootstrap into the console user's Mach namespace
+  # and GUI session — 'sudo -u' alone doesn't do this, which can cause
+  # LSOpenURLsWithRole() failures even when 'open' exits 0.
   local open_status=0
   if [[ $EUID -eq 0 ]]; then
-    sudo -u "$console_user" open -b "$bundle_id" >/dev/null 2>&1 || open_status=$?
+    local console_uid
+    console_uid=$(id -u "$console_user")
+    /bin/launchctl asuser "$console_uid" sudo -u "$console_user" open -b "$bundle_id" >/dev/null 2>&1 || open_status=$?
   else
     open -b "$bundle_id" >/dev/null 2>&1 || open_status=$?
   fi

--- a/ee/maintained-apps/ingesters/homebrew/scripts.go
+++ b/ee/maintained-apps/ingesters/homebrew/scripts.go
@@ -621,6 +621,11 @@ const quitAndTrackApplicationFunc = `quit_and_track_application() {
 
 // relaunchApplicationFunc relaunches an application if it was running before installation.
 // Checks the APP_WAS_RUNNING_<bundle_id> environment variable set by quitAndTrackApplicationFunc.
+// The install script runs as root, but GUI apps must be launched in the logged-in
+// user's session (not root's) to appear in the user's Dock/GUI. We therefore use
+// 'sudo -u "$console_user" open' rather than 'osascript ... to activate', since
+// the latter fails when launching an app that isn't already running from a root
+// context.
 const relaunchApplicationFunc = `relaunch_application() {
   local bundle_id="$1"
   local var_name="APP_WAS_RUNNING_$(echo "$bundle_id" | tr '.-' '__')"
@@ -634,15 +639,23 @@ const relaunchApplicationFunc = `relaunch_application() {
 
   local console_user
   console_user=$(stat -f "%Su" /dev/console)
-  if [[ $EUID -eq 0 && "$console_user" == "root" ]]; then
+  if [[ -z "$console_user" || "$console_user" == "root" || "$console_user" == "loginwindow" ]]; then
     echo "Not logged into a non-root GUI; skipping relaunching application ID '$bundle_id'."
     return
   fi
 
   echo "Relaunching application '$bundle_id'..."
 
-  # Try to launch the application
-  if osascript -e "tell application id \"$bundle_id\" to activate" >/dev/null 2>&1; then
+  # Launch the app in the logged-in user's GUI session. Apps launched by root
+  # won't register with the user's Dock/GUI, so run 'open' as the console user.
+  local open_status=0
+  if [[ $EUID -eq 0 ]]; then
+    sudo -u "$console_user" open -b "$bundle_id" >/dev/null 2>&1 || open_status=$?
+  else
+    open -b "$bundle_id" >/dev/null 2>&1 || open_status=$?
+  fi
+
+  if [[ $open_status -eq 0 ]]; then
     echo "Application '$bundle_id' relaunched successfully."
   else
     echo "Failed to relaunch application '$bundle_id'."


### PR DESCRIPTION
This pull request updates the application quit and relaunch logic in the Homebrew ingester scripts to more robustly detect valid GUI user sessions and improve how applications are relaunched after installation. The main improvements ensure that actions are only attempted when a real user is logged in, and that relaunching applications works reliably in the correct user context, especially when running as root.

**User session validation:**
* The checks for a valid GUI session in `quit_application`, `quit_and_track_application`, and `relaunch_application` have been expanded to skip actions if the console user is empty, `root`, or `loginwindow`, preventing attempts to interact with the GUI when no real user is logged in. [[1]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97L546-R546) [[2]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97L590-R590) [[3]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97L637-R663)

**Application relaunch improvements:**
* The `relaunch_application` logic now uses `launchctl asuser` with `sudo -u` to launch the application in the correct user's GUI session, ensuring that the app appears in the user's Dock and GUI, even when the script runs as root. This replaces the previous approach of using `osascript`, which could fail in root contexts. [[1]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97R624-R628) [[2]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97L637-R663)
* Additional comments were added to explain why these changes are necessary and how the new approach works. [[1]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97R624-R628) [[2]](diffhunk://#diff-a9df2db484fcbb560d62c43f94c4bcc2d26dcf68066c9e7cc2bffad6f124ce97L637-R663)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable app relaunch after installations, reducing failures when GUI apps are reinstalled.
  * Avoids attempting to quit or relaunch when no active console user is present (including the system login window), preventing unintended actions.
  * Uses a more robust method to launch apps in the user GUI session and reports success based on the launcher outcome for clearer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->