### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/darwin.json
+++ b/ee/maintained-apps/outputs/1password/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "8.12.10",
+      "version": "8.12.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password' AND version_compare(bundle_short_version, '8.12.12') < 0);"
       },
       "installer_url": "https://downloads.1password.com/mac/1Password.pkg",
       "install_script_ref": "90335256",

--- a/ee/maintained-apps/outputs/deepl/darwin.json
+++ b/ee/maintained-apps/outputs/deepl/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.4.14340455",
+      "version": "26.4.24484530",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.linguee.DeepLCopyTranslator';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.linguee.DeepLCopyTranslator' AND version_compare(bundle_short_version, '26.4.14340455') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.linguee.DeepLCopyTranslator' AND version_compare(bundle_short_version, '26.4.24484530') < 0);"
       },
-      "installer_url": "https://www.deepl.com/macos/download/26.4/14340455/DeepL.dmg",
+      "installer_url": "https://www.deepl.com/macos/download/26.4/24484530/DeepL.dmg",
       "install_script_ref": "1be7ff80",
       "uninstall_script_ref": "eb9e017a",
-      "sha256": "9342b5c492d76f2327001da5806fc688fcd752f5317667d63150fac50201dc3b",
+      "sha256": "8f8febe6e72ccb4dd7806a6dbfffd2051e3d90159f91231df71b005bb0f13c21",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/firefox/darwin.json
+++ b/ee/maintained-apps/outputs/firefox/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "149.0.2",
+      "version": "150.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '149.0.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '150.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/149.0.2/mac/en-US/Firefox%20149.0.2.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/150.0/mac/en-US/Firefox%20150.0.dmg",
       "install_script_ref": "b24d8cf6",
       "uninstall_script_ref": "741d2eac",
-      "sha256": "3c4f90c4d8e52ded2ab3c173323d57c9f2943b448d05cb68f938760bb56d524f",
+      "sha256": "203667ff6b0920f89973d477b1394d99b4b78807a613914c97bb1b3200e6da1b",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/firefox@esr/darwin.json
+++ b/ee/maintained-apps/outputs/firefox@esr/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "140.9.1",
+      "version": "140.10.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.9.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.mozilla.firefox' AND version_compare(bundle_short_version, '140.10.0') < 0);"
       },
-      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.9.1esr/mac/en-US/Firefox%20140.9.1esr.dmg",
+      "installer_url": "https://download-installer.cdn.mozilla.net/pub/firefox/releases/140.10.0esr/mac/en-US/Firefox%20140.10.0esr.dmg",
       "install_script_ref": "b24d8cf6",
       "uninstall_script_ref": "5cdaad2e",
-      "sha256": "abc094c780cdfcf7b4762f5a9c97332b18b59b63c98cda9b54b088a0fca43bf4",
+      "sha256": "b2c4ab15cbadbe95c0d9532e8178a2088298fd5a7b57b63f697cb284846e3015",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.161.1",
+      "version": "1.162.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.161.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.162.2') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.161.1.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.162.2.0/Grammarly.dmg",
       "install_script_ref": "962d8d13",
       "uninstall_script_ref": "7b5a67c7",
-      "sha256": "bafcd6ea392c7f2368cf6cc52f20375fe70cfcba869e4f773f9f1bd0978221b7",
+      "sha256": "2c8171d340819c76a92b53987cef4ae73eeb0cd96848e8967932eab5c6a35402",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated metadata and configurations for supported macOS applications: 1Password (8.12.12), DeepL (26.4.24484530), Firefox (150.0), Firefox ESR (140.10.0), and Grammarly Desktop (1.162.2). These maintenance updates include refreshed package integrity checksums, revised installation resource paths, adjusted version verification thresholds, and comprehensive deployment configuration updates to better support the latest application releases across managed systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->