### PR TITLE
Fix MDM status modal for non-ABM Apple hosts

### DIFF
--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -476,10 +476,12 @@ const MDMStatusModal = ({
       {renderMDMStatus()}
       {isPremiumTier &&
         isAppleDevice &&
-        // Only render the modal if this host has an actual host_dep_assignment entry,
-        // in which case we expect there to be data to render. While loading, keep
-        // the section visible so renderProfileAssignmentList can show its spinner.
+        // Only render the profile assignment section if this host has an actual
+        // host_dep_assignment entry, in which case we expect there to be data to
+        // render. While loading or on query error, keep the section visible so
+        // renderProfileAssignmentList can show its spinner or DataError.
         (isLoadingDepAssignment ||
+          isDepAssignmentError ||
           depAssignmentData?.host_dep_assignment) &&
         renderProfileAssignment()}
       {renderFooter()}

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -306,9 +306,12 @@ const MDMStatusModal = ({
     }
 
     if (
+      // Only show the error if there is a DEP assignment error OR if the data contains the host_dep_assignment(meaning we
+      // expect the host to be in DEP) but there's no dep_device(meaning Apple returned nothing). If host_dep_assignment is
+      // not present the device isn't expected to be in DEP
       isDepAssignmentError ||
-      !depAssignmentData?.host_dep_assignment ||
-      !depAssignmentData?.dep_device
+      !depAssignmentData ||
+      (depAssignmentData?.host_dep_assignment && !depAssignmentData?.dep_device)
     ) {
       return (
         <DataError
@@ -471,7 +474,14 @@ const MDMStatusModal = ({
   return (
     <Modal title="MDM status" className={baseClass} onExit={onExit}>
       {renderMDMStatus()}
-      {isPremiumTier && isAppleDevice && renderProfileAssignment()}
+      {isPremiumTier &&
+        isAppleDevice &&
+        // Only render the modal if this host has an actual host_dep_assignment entry,
+        // in which case we expect there to be data to render. While loading, keep
+        // the section visible so renderProfileAssignmentList can show its spinner.
+        (isLoadingDepAssignment ||
+          depAssignmentData?.host_dep_assignment) &&
+        renderProfileAssignment()}
       {renderFooter()}
     </Modal>
   );


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43824

Unreleased bug so no changes file

# Checklist for submitter

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DEP assignment error detection in the MDM status modal so missing data is recognized correctly, reducing spurious error messages.
  * Updated profile assignment visibility: the profile assignment section now appears only when relevant enrollment data is loading, has an error, or is present, preventing it from showing in inappropriate contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->