### PR TITLE
Enforce consistent fleet name uniqueness across UI and GitOps (#33557)

### DIFF
--- a/changes/33557-inconsistent-team-name-conflicts
+++ b/changes/33557-inconsistent-team-name-conflicts
@@ -1,1 +1,1 @@
-- Made fleet name uniqueness rules consistent across the UI, API, and GitOps paths. Fleet names must now differ by at least one non-special character (case-insensitive), and conflicts return a 409 error on all code paths.
+- Made fleet name uniqueness rules consistent across the UI, API, and GitOps paths. Fleet names must now differ by more than letter case, and conflicts return a 409 error on all code paths.

--- a/changes/33557-inconsistent-team-name-conflicts
+++ b/changes/33557-inconsistent-team-name-conflicts
@@ -1,0 +1,1 @@
+- Made fleet name uniqueness rules consistent across the UI, API, and GitOps paths. Fleet names must now differ by at least one non-special character (case-insensitive), and conflicts return a 409 Conflict error that names the existing fleet.

--- a/changes/33557-inconsistent-team-name-conflicts
+++ b/changes/33557-inconsistent-team-name-conflicts
@@ -1,1 +1,1 @@
-- Made fleet name uniqueness rules consistent across the UI, API, and GitOps paths. Fleet names must now differ by at least one non-special character (case-insensitive), and conflicts return a 409 Conflict error that names the existing fleet.
+- Made fleet name uniqueness rules consistent across the UI, API, and GitOps paths. Fleet names must now differ by at least one non-special character (case-insensitive), and conflicts return a 409 error on all code paths.

--- a/cmd/fleetctl/fleetctl/gitops.go
+++ b/cmd/fleetctl/fleetctl/gitops.go
@@ -342,6 +342,27 @@ func gitopsCommand() *cli.Command {
 				return fmt.Errorf("global config must be provided alongside %s", noTeamFilename)
 			}
 
+			// Fail fast if two YAML files in this run resolve to the same
+			// team name under MySQL's utf8mb4_unicode_ci collation.
+			seenTeamNames := make(map[string]string, len(configs)) // key -> filename
+			for _, cf := range configs {
+				if cf.IsGlobalConfig || cf.Config.TeamName == nil {
+					continue
+				}
+				name := strings.TrimSpace(*cf.Config.TeamName)
+				key := norm.NFC.String(strings.ToLower(name))
+				if key == "" {
+					continue
+				}
+				if prev, ok := seenTeamNames[key]; ok {
+					return fmt.Errorf(
+						"duplicate fleet names in GitOps files: %q and %q both resolve to the same fleet name. Fleet names must differ by more than letter case.",
+						prev, cf.Filename,
+					)
+				}
+				seenTeamNames[key] = cf.Filename
+			}
+
 			labelMoves, err := computeLabelMoves(labelChanges)
 			if err != nil {
 				return err

--- a/cmd/fleetctl/fleetctl/gitops_test.go
+++ b/cmd/fleetctl/fleetctl/gitops_test.go
@@ -1661,6 +1661,15 @@ func TestGitOpsFullTeam(t *testing.T) {
 		}
 		return nil, &notFoundError{}
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		// Simulate a pre-existing "Conflict" team so renaming into it
+		// triggers the 409 path. excludeID is the current team's id and
+		// wouldn't match the Conflict team anyway.
+		if strings.EqualFold(name, "Conflict") {
+			return &fleet.Team{ID: 999, Name: "Conflict"}, nil
+		}
+		return nil, nil
+	}
 	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
 		if savedTeam != nil && *savedTeam.Filename == filename {
 			return savedTeam, nil
@@ -1903,9 +1912,9 @@ func TestGitOpsFullTeam(t *testing.T) {
 			// Try to change team name again, but this time the new name conflicts with an existing team
 			t.Setenv("TEST_TEAM_NAME", "Conflict")
 			_, err := RunAppNoChecks([]string{"gitops", "-f", gitopsFile, "--dry-run"})
-			require.ErrorContains(t, err, "team name already exists")
+			require.ErrorContains(t, err, `conflicts with existing fleet "Conflict"`)
 			_, err = RunAppNoChecks([]string{"gitops", "-f", gitopsFile})
-			require.ErrorContains(t, err, "team name already exists")
+			require.ErrorContains(t, err, `conflicts with existing fleet "Conflict"`)
 
 			// Now clear the settings
 			t.Setenv("TEST_TEAM_NAME", newTeamName)

--- a/cmd/fleetctl/fleetctl/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils.go
@@ -173,7 +173,7 @@ func setupEmptyGitOpsMocks(ds *mock.Store) {
 		return nil, nil
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, &gitopsTestNotFoundError{}
+		return nil, nil
 	}
 	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
 		return &fleet.TeamLite{}, nil

--- a/cmd/fleetctl/fleetctl/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils.go
@@ -172,6 +172,9 @@ func setupEmptyGitOpsMocks(ds *mock.Store) {
 	ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
 		return nil, nil
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, &gitopsTestNotFoundError{}
+	}
 	ds.TeamLiteFunc = func(ctx context.Context, id uint) (*fleet.TeamLite, error) {
 		return &fleet.TeamLite{}, nil
 	}

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -455,7 +455,7 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 				return *tm, nil
 			}
 		}
-		return nil, &notFoundError{}
+		return nil, nil
 	}
 	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
 		savedTeams[team.Name] = &team

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -446,6 +446,17 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 		}
 		return nil, &notFoundError{}
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		for _, tm := range savedTeams {
+			if (*tm).ID == excludeID {
+				continue
+			}
+			if strings.EqualFold((*tm).Name, name) {
+				return *tm, nil
+			}
+		}
+		return nil, &notFoundError{}
+	}
 	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
 		savedTeams[team.Name] = &team
 		return team, nil

--- a/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
+++ b/cmd/fleetctl/fleetctl/testing_utils/testing_utils.go
@@ -16,6 +16,8 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/docker/go-units"
 	"github.com/fleetdm/fleet/v4/server/config"
 	"github.com/fleetdm/fleet/v4/server/datastore/cached_mysql"
@@ -447,11 +449,16 @@ func SetupFullGitOpsPremiumServer(t *testing.T) (*mock.Store, **fleet.AppConfig,
 		return nil, &notFoundError{}
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		// Match production semantics: both sides get NFC-normalized before
+		// the case-insensitive compare, so two names that only differ by
+		// Unicode composition (e.g., precomposed "é" vs. "e" + combining
+		// acute accent) are treated as equal.
+		needle := norm.NFC.String(name)
 		for _, tm := range savedTeams {
 			if (*tm).ID == excludeID {
 				continue
 			}
-			if strings.EqualFold((*tm).Name, name) {
+			if strings.EqualFold(norm.NFC.String((*tm).Name), needle) {
 				return *tm, nil
 			}
 		}

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12359,7 +12359,7 @@ _Available in Fleet Premium_
 
 | Name | Type   | In   | Description                    |
 | ---- | ------ | ---- | ------------------------------ |
-| name | string | body | **Required.** The fleet's name. |
+| name | string | body | **Required.** The fleet's name. Fleet names must differ by at least one non-special character (case-insensitive). |
 
 #### Example
 
@@ -12370,6 +12370,24 @@ _Available in Fleet Premium_
 ```json
 {
   "name": "workstations"
+}
+```
+
+##### Name conflict response
+
+`Status: 409`
+
+Returned when the requested name only differs from an existing fleet's name by case or collation-equivalent characters (e.g., unicode-normalized accents).
+
+```json
+{
+  "message": "Conflict",
+  "errors": [
+    {
+      "name": "base",
+      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by at least one non-special character (case-insensitive)."
+    }
+  ]
 }
 ```
 
@@ -12428,7 +12446,7 @@ _Available in Fleet Premium_
 | Name                                                    | Type    | In   | Description                                                                                                                                                                                               |
 | ------------------------------------------------------- | ------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                                                      | integer | path | **Required.** The desired fleet's ID. Use `0` for "Unassigned" hosts. **Note:** When using `id=0`, only `webhook_settings.failing_policies_webhook`, `integrations.jira`, and `integrations.zendesk` fields are supported in the request body. |
-| name                                                    | string  | body | The fleet's name.                                                                                                                                                                                          |
+| name                                                    | string  | body | The fleet's name. Fleet names must differ by at least one non-special character (case-insensitive). Renaming a fleet into another fleet's name returns a 409 Conflict error.                                                                                                                                                                                          |
 | host_ids                                                | array    | body | A list of hosts that belong to the fleet.                                                                                                                                                                  |
 | user_ids                                                | array    | body | A list of users on the fleet.                                                                                                                                                             |
 | webhook_settings                                        | object  | body | Webhook settings for the fleet. See [webhook_settings](#webhook-settings2).                                                                                                                                                          |
@@ -12445,6 +12463,24 @@ _Available in Fleet Premium_
 ```json
 {
   "host_ids": [3, 6, 7, 8, 9, 20, 32, 44]
+}
+```
+
+##### Name conflict response
+
+`Status: 409`
+
+Returned when the requested name only differs from another fleet's name by case or collation-equivalent characters. Renaming a fleet to a case variant of its own current name (e.g., `ABC` → `abc`) succeeds.
+
+```json
+{
+  "message": "Conflict",
+  "errors": [
+    {
+      "name": "base",
+      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by at least one non-special character (case-insensitive)."
+    }
+  ]
 }
 ```
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -12359,7 +12359,7 @@ _Available in Fleet Premium_
 
 | Name | Type   | In   | Description                    |
 | ---- | ------ | ---- | ------------------------------ |
-| name | string | body | **Required.** The fleet's name. Fleet names must differ by at least one non-special character (case-insensitive). |
+| name | string | body | **Required.** The fleet's name. Fleet names must differ by more than letter case. |
 
 #### Example
 
@@ -12377,7 +12377,7 @@ _Available in Fleet Premium_
 
 `Status: 409`
 
-Returned when the requested name only differs from an existing fleet's name by case or collation-equivalent characters (e.g., unicode-normalized accents).
+Returned when the requested name only differs from an existing fleet's name by letter case.
 
 ```json
 {
@@ -12385,7 +12385,7 @@ Returned when the requested name only differs from an existing fleet's name by c
   "errors": [
     {
       "name": "base",
-      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by at least one non-special character (case-insensitive)."
+      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by more than letter case."
     }
   ]
 }
@@ -12446,7 +12446,7 @@ _Available in Fleet Premium_
 | Name                                                    | Type    | In   | Description                                                                                                                                                                                               |
 | ------------------------------------------------------- | ------- | ---- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | id                                                      | integer | path | **Required.** The desired fleet's ID. Use `0` for "Unassigned" hosts. **Note:** When using `id=0`, only `webhook_settings.failing_policies_webhook`, `integrations.jira`, and `integrations.zendesk` fields are supported in the request body. |
-| name                                                    | string  | body | The fleet's name. Fleet names must differ by at least one non-special character (case-insensitive). Renaming a fleet into another fleet's name returns a 409 Conflict error.                                                                                                                                                                                          |
+| name                                                    | string  | body | The fleet's name. Fleet names must differ by more than letter case. Renaming a fleet into another fleet's name returns a 409 Conflict error.                                                                                                                                                                                          |
 | host_ids                                                | array    | body | A list of hosts that belong to the fleet.                                                                                                                                                                  |
 | user_ids                                                | array    | body | A list of users on the fleet.                                                                                                                                                             |
 | webhook_settings                                        | object  | body | Webhook settings for the fleet. See [webhook_settings](#webhook-settings2).                                                                                                                                                          |
@@ -12470,7 +12470,7 @@ _Available in Fleet Premium_
 
 `Status: 409`
 
-Returned when the requested name only differs from another fleet's name by case or collation-equivalent characters. Renaming a fleet to a case variant of its own current name (e.g., `ABC` → `abc`) succeeds.
+Returned when the requested name only differs from another fleet's name by letter case. Renaming a fleet to a case variant of its own current name (e.g., `ABC` → `abc`) succeeds.
 
 ```json
 {
@@ -12478,7 +12478,7 @@ Returned when the requested name only differs from another fleet's name by case 
   "errors": [
     {
       "name": "base",
-      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by at least one non-special character (case-insensitive)."
+      "reason": "A fleet named \"Workstations\" already exists. Fleet names must differ by more than letter case."
     }
   ]
 }

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -207,7 +207,7 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 					return team, nil
 				}
 			}
-			return nil, ctxerr.Wrap(ctx, &eeservice.NotFoundError{})
+			return nil, nil
 		}
 		ds.TeamWithExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
 			tm, ok := teamStore[id]

--- a/ee/server/service/mdm_external_test.go
+++ b/ee/server/service/mdm_external_test.go
@@ -198,6 +198,17 @@ func TestGetOrCreatePreassignTeam(t *testing.T) {
 			}
 			return nil, ctxerr.Wrap(ctx, &eeservice.NotFoundError{})
 		}
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			for _, team := range teamStore {
+				if team.ID == excludeID {
+					continue
+				}
+				if strings.EqualFold(team.Name, name) {
+					return team, nil
+				}
+			}
+			return nil, ctxerr.Wrap(ctx, &eeservice.NotFoundError{})
+		}
 		ds.TeamWithExtrasFunc = func(ctx context.Context, id uint) (*fleet.Team, error) {
 			tm, ok := teamStore[id]
 			if !ok {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -94,15 +94,13 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 	}
 
 	conflict, err := svc.ds.TeamConflictsWithName(ctx, *p.Name, 0)
-	switch {
-	case err == nil:
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
+	}
+	if conflict != nil {
 		return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
 			Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictErrMsg),
 		})
-	case fleet.IsNotFound(err):
-		// No conflict; continue.
-	default:
-		return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
 	}
 
 	team.Name = *p.Name
@@ -172,15 +170,13 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 
 		conflict, err := svc.ds.TeamConflictsWithName(ctx, *payload.Name, teamID)
-		switch {
-		case err == nil:
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
+		}
+		if conflict != nil {
 			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
 				Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictErrMsg),
 			})
-		case fleet.IsNotFound(err):
-			// No conflict; continue.
-		default:
-			return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
 		}
 
 		team.Name = *payload.Name
@@ -1176,16 +1172,14 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		// with a different team.
 		if team != nil {
 			conflict, err := svc.ds.TeamConflictsWithName(ctx, spec.Name, team.ID)
-			switch {
-			case err == nil:
+			if err != nil {
+				return nil, err
+			}
+			if conflict != nil {
 				return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
 					"fleet name %q conflicts with existing fleet %q. %s",
 					spec.Name, conflict.Name, teamNameConflictErrMsg,
 				)})
-			case fleet.IsNotFound(err):
-				// No conflict; continue.
-			default:
-				return nil, err
 			}
 		}
 

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -27,6 +27,8 @@ import (
 	"github.com/fleetdm/fleet/v4/server/worker"
 )
 
+const teamNameConflictErrMsg = "Fleet names must differ by at least one non-special character (case-insensitive)."
+
 func obfuscateSecrets(user *fleet.User, teams []*fleet.Team) error {
 	if user == nil {
 		return &authz.Forbidden{}
@@ -63,12 +65,6 @@ func obfuscateSecrets(user *fleet.User, teams []*fleet.Team) error {
 	return nil
 }
 
-// teamNameConflictSuffix is the canonical sentence appended to every 409
-// response from the team-write paths (create, rename, GitOps apply). The
-// frontend substring-matches on "must differ" to surface the backend copy
-// inline on the name field.
-const teamNameConflictSuffix = "Fleet names must differ by at least one non-special character (case-insensitive)."
-
 func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Team, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionWrite); err != nil {
 		return nil, err
@@ -101,7 +97,7 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 	switch {
 	case err == nil:
 		return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
-			Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictSuffix),
+			Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictErrMsg),
 		})
 	case fleet.IsNotFound(err):
 		// No conflict; continue.
@@ -179,7 +175,7 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		switch {
 		case err == nil:
 			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
-				Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictSuffix),
+				Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictErrMsg),
 			})
 		case fleet.IsNotFound(err):
 			// No conflict; continue.
@@ -1125,7 +1121,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		if prev, ok := seenNames[key]; ok {
 			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
 				"fleet names in GitOps batch conflict: %q (filename %q) and %q (filename %q). %s",
-				prev.name, prev.filename, trimmedName, filename, teamNameConflictSuffix,
+				prev.name, prev.filename, trimmedName, filename, teamNameConflictErrMsg,
 			)})
 		}
 		seenNames[key] = seenSpec{name: trimmedName, filename: filename}
@@ -1163,9 +1159,10 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		}
 
 		var team *fleet.Team
-		// If filename is provided, try to find the team by filename first.
-		// This is needed in case the user is trying to modify the team name.
 		filenameProvided := spec.Filename != nil && *spec.Filename != ""
+
+		// Primary key for a GitOps-managed team is its filename. Try that
+		// lookup first.
 		if filenameProvided {
 			team, err = svc.ds.TeamByFilename(ctx, *spec.Filename)
 			if err != nil && !fleet.IsNotFound(err) {
@@ -1173,23 +1170,17 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 			}
 		}
 
-		// With an explicit filename, the spec is bound to a specific file on
-		// disk. A name collision with a *different* team means two files are
-		// fighting over the same name, so flag it as a conflict. When the
-		// filename matched an existing team, excluding its id lets a
-		// case-only self-rename succeed. When no team matched the filename,
-		// excludeID=0 catches any existing team with a colliding name.
-		if filenameProvided {
-			var excludeID uint
-			if team != nil {
-				excludeID = team.ID
-			}
-			conflict, err := svc.ds.TeamConflictsWithName(ctx, spec.Name, excludeID)
+		// If we matched by filename, enforce uniqueness against *other*
+		// teams. Excluding the matched team's id lets a case-only self-rename
+		// ("ABC" → "abc") succeed while still catching renames that collide
+		// with a different team.
+		if team != nil {
+			conflict, err := svc.ds.TeamConflictsWithName(ctx, spec.Name, team.ID)
 			switch {
 			case err == nil:
 				return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
 					"fleet name %q conflicts with existing fleet %q. %s",
-					spec.Name, conflict.Name, teamNameConflictSuffix,
+					spec.Name, conflict.Name, teamNameConflictErrMsg,
 				)})
 			case fleet.IsNotFound(err):
 				// No conflict; continue.
@@ -1204,12 +1195,15 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 			switch {
 			case err == nil:
 				// Matched by collation-aware name lookup. Without a filename
-				// anchoring this spec to a specific file, adopting the spec's
-				// exact-case form would silently rename the team (e.g.,
-				// "ABC" → "abc") and re-introduce the inconsistency this
-				// fix closes. Preserve the DB's canonical name instead —
-				// users who want to rename must supply a filename.
-				spec.Name = team.Name
+				// anchoring this spec to a specific file, adopting the
+				// spec's exact-case form would silently case-rename the team
+				// (e.g., "ABC" → "abc") — re-introducing the inconsistency
+				// this fix closes. Preserve the DB's canonical name unless
+				// the user supplied a filename, which is an explicit claim
+				// that they want to manage (and possibly rename) this team.
+				if !filenameProvided {
+					spec.Name = team.Name
+				}
 			case fleet.IsNotFound(err):
 				create = true
 			default:

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1093,14 +1093,9 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		return nil, err
 	}
 
-	// Detect conflicting names within the incoming batch before hitting the DB.
-	// The key is a lowercased NFC-normalized form, which approximates MySQL's
-	// utf8mb4_unicode_ci collation. Per-spec DB checks below catch any cases
-	// this approximation misses (e.g., ß vs ss, Turkish İ); those would
-	// result in a partial batch apply since ApplyTeamSpecs is not wrapped in
-	// a single transaction.
+	// Try to detect conflicting names within the incoming batch before hitting the DB.
 	type seenSpec struct {
-		name     string // trimmed for stable display
+		name     string
 		filename string
 	}
 	seenNames := make(map[string]seenSpec, len(specs))
@@ -1191,8 +1186,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 				// Matched by collation-aware name lookup. Without a filename
 				// anchoring this spec to a specific file, adopting the
 				// spec's exact-case form would silently case-rename the team
-				// (e.g., "ABC" → "abc") — re-introducing the inconsistency
-				// this fix closes. Preserve the DB's canonical name unless
+				// (e.g., "ABC" → "abc") so we need to preserve the DB's canonical name unless
 				// the user supplied a filename, which is an explicit claim
 				// that they want to manage (and possibly rename) this team.
 				if !filenameProvided {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -27,7 +27,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/worker"
 )
 
-const teamNameConflictErrMsg = "Fleet names must differ by at least one non-special character (case-insensitive)."
+const teamNameConflictErrMsg = "Fleet names must differ by more than letter case."
 
 func obfuscateSecrets(user *fleet.User, teams []*fleet.Team) error {
 	if user == nil {

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -1111,7 +1111,7 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		}
 		if prev, ok := seenNames[key]; ok {
 			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
-				"fleet names in GitOps batch conflict: %q (filename %q) and %q (filename %q). %s",
+				"duplicate fleet names in request: %q (filename %q) and %q (filename %q). %s",
 				prev.name, prev.filename, trimmedName, filename, teamNameConflictErrMsg,
 			)})
 		}
@@ -1191,6 +1191,16 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 				// that they want to manage (and possibly rename) this team.
 				if !filenameProvided {
 					spec.Name = team.Name
+				} else if team.Filename != nil && *team.Filename != "" && *team.Filename != *spec.Filename {
+					// The spec supplied a filename that matched no existing
+					// team, but the team matched by name is already managed
+					// by a different filename.
+					svc.logger.InfoContext(ctx, "GitOps filename changed for existing team",
+						"team_id", team.ID,
+						"team_name", team.Name,
+						"old_filename", *team.Filename,
+						"new_filename", *spec.Filename,
+					)
 				}
 			case fleet.IsNotFound(err):
 				create = true

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -11,6 +11,8 @@ import (
 	"net/url"
 	"strings"
 
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/authz"
@@ -61,6 +63,12 @@ func obfuscateSecrets(user *fleet.User, teams []*fleet.Team) error {
 	return nil
 }
 
+// teamNameConflictSuffix is the canonical sentence appended to every 409
+// response from the team-write paths (create, rename, GitOps apply). The
+// frontend substring-matches on "must differ" to surface the backend copy
+// inline on the name field.
+const teamNameConflictSuffix = "Fleet names must differ by at least one non-special character (case-insensitive)."
+
 func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Team, error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Team{}, fleet.ActionWrite); err != nil {
 		return nil, err
@@ -88,6 +96,19 @@ func (svc *Service) NewTeam(ctx context.Context, p fleet.TeamPayload) (*fleet.Te
 	if fleet.IsReservedTeamName(*p.Name) {
 		return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("%q is a reserved fleet name", *p.Name))
 	}
+
+	conflict, err := svc.ds.TeamConflictsWithName(ctx, *p.Name, 0)
+	switch {
+	case err == nil:
+		return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
+			Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictSuffix),
+		})
+	case fleet.IsNotFound(err):
+		// No conflict; continue.
+	default:
+		return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
+	}
+
 	team.Name = *p.Name
 
 	if p.Description != nil {
@@ -153,6 +174,19 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		if fleet.IsReservedTeamName(*payload.Name) {
 			return nil, fleet.NewInvalidArgumentError("name", fmt.Sprintf("%q is a reserved fleet name", *payload.Name))
 		}
+
+		conflict, err := svc.ds.TeamConflictsWithName(ctx, *payload.Name, teamID)
+		switch {
+		case err == nil:
+			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{
+				Message: fmt.Sprintf("A fleet named %q already exists. %s", conflict.Name, teamNameConflictSuffix),
+			})
+		case fleet.IsNotFound(err):
+			// No conflict; continue.
+		default:
+			return nil, ctxerr.Wrap(ctx, err, "check team name uniqueness")
+		}
+
 		team.Name = *payload.Name
 	}
 	if payload.Description != nil {
@@ -1067,6 +1101,36 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 		return nil, err
 	}
 
+	// Detect conflicting names within the incoming batch before hitting the DB.
+	// The key is a lowercased NFC-normalized form, which approximates MySQL's
+	// utf8mb4_unicode_ci collation. Per-spec DB checks below catch any cases
+	// this approximation misses (e.g., ß vs ss, Turkish İ); those would
+	// result in a partial batch apply since ApplyTeamSpecs is not wrapped in
+	// a single transaction.
+	type seenSpec struct {
+		name     string // trimmed for stable display
+		filename string
+	}
+	seenNames := make(map[string]seenSpec, len(specs))
+	for _, spec := range specs {
+		trimmedName := strings.TrimSpace(spec.Name)
+		key := norm.NFC.String(strings.ToLower(trimmedName))
+		if key == "" {
+			continue
+		}
+		filename := ""
+		if spec.Filename != nil {
+			filename = *spec.Filename
+		}
+		if prev, ok := seenNames[key]; ok {
+			return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
+				"fleet names in GitOps batch conflict: %q (filename %q) and %q (filename %q). %s",
+				prev.name, prev.filename, trimmedName, filename, teamNameConflictSuffix,
+			)})
+		}
+		seenNames[key] = seenSpec{name: trimmedName, filename: filename}
+	}
+
 	appConfig, err := svc.ds.AppConfig(ctx)
 	if err != nil {
 		return nil, err
@@ -1100,25 +1164,37 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 
 		var team *fleet.Team
 		// If filename is provided, try to find the team by filename first.
-		// This is needed in case user is trying to modify the team name.
-		if spec.Filename != nil && *spec.Filename != "" {
+		// This is needed in case the user is trying to modify the team name.
+		filenameProvided := spec.Filename != nil && *spec.Filename != ""
+		if filenameProvided {
 			team, err = svc.ds.TeamByFilename(ctx, *spec.Filename)
 			if err != nil && !fleet.IsNotFound(err) {
 				return nil, err
 			}
-			if team != nil && team.Name != spec.Name {
-				// If user is trying to change team name, check that the new name is not already taken.
-				_, err = svc.ds.TeamByName(ctx, spec.Name)
-				switch {
-				case err == nil:
-					return nil, fleet.NewInvalidArgumentError("name",
-						fmt.Sprintf("cannot change team name from '%s' (filename: %s) to '%s' because team name already exists", team.Name,
-							*spec.Filename, spec.Name))
-				case fleet.IsNotFound(err):
-					// OK
-				default:
-					return nil, err
-				}
+		}
+
+		// With an explicit filename, the spec is bound to a specific file on
+		// disk. A name collision with a *different* team means two files are
+		// fighting over the same name, so flag it as a conflict. When the
+		// filename matched an existing team, excluding its id lets a
+		// case-only self-rename succeed. When no team matched the filename,
+		// excludeID=0 catches any existing team with a colliding name.
+		if filenameProvided {
+			var excludeID uint
+			if team != nil {
+				excludeID = team.ID
+			}
+			conflict, err := svc.ds.TeamConflictsWithName(ctx, spec.Name, excludeID)
+			switch {
+			case err == nil:
+				return nil, ctxerr.Wrap(ctx, &fleet.ConflictError{Message: fmt.Sprintf(
+					"fleet name %q conflicts with existing fleet %q. %s",
+					spec.Name, conflict.Name, teamNameConflictSuffix,
+				)})
+			case fleet.IsNotFound(err):
+				// No conflict; continue.
+			default:
+				return nil, err
 			}
 		}
 
@@ -1127,7 +1203,13 @@ func (svc *Service) ApplyTeamSpecs(ctx context.Context, specs []*fleet.TeamSpec,
 			team, err = svc.ds.TeamByName(ctx, spec.Name)
 			switch {
 			case err == nil:
-				// OK
+				// Matched by collation-aware name lookup. Without a filename
+				// anchoring this spec to a specific file, adopting the spec's
+				// exact-case form would silently rename the team (e.g.,
+				// "ABC" → "abc") and re-introduce the inconsistency this
+				// fix closes. Preserve the DB's canonical name instead —
+				// users who want to rename must supply a filename.
+				spec.Name = team.Name
 			case fleet.IsNotFound(err):
 				create = true
 			default:

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -416,15 +416,15 @@ func TestNewTeamCollationEqualConflict(t *testing.T) {
 		authz: authorizer,
 	}
 
-	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	adminUser := &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}
 	ctx := test.UserContext(context.Background(), adminUser)
 
-	_, err = svc.NewTeam(ctx, fleet.TeamPayload{Name: ptr.String("abc")})
+	_, err = svc.NewTeam(ctx, fleet.TeamPayload{Name: new("abc")})
 	require.Error(t, err)
 	var conflict *fleet.ConflictError
 	require.ErrorAs(t, err, &conflict)
 	require.Contains(t, err.Error(), `"ABC"`)
-	require.Contains(t, err.Error(), "must differ by at least one non-special character")
+	require.Contains(t, err.Error(), "must differ by more than letter case")
 }
 
 // TestModifyTeamCaseOnlyRenameAndConflict covers two ModifyTeam scenarios:
@@ -461,7 +461,7 @@ func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
 		authz: authorizer,
 	}
 
-	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	adminUser := &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}
 	ctx := test.UserContext(context.Background(), adminUser)
 
 	t.Run("case-only self rename succeeds", func(t *testing.T) {
@@ -470,7 +470,7 @@ func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
 			return nil, nil
 		}
 
-		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: ptr.String("abc")})
+		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: new("abc")})
 		require.NoError(t, err)
 		require.NotNil(t, team)
 		require.Equal(t, "abc", team.Name)
@@ -482,13 +482,13 @@ func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
 			return &fleet.Team{ID: 6, Name: "def"}, nil
 		}
 
-		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: ptr.String("DEF")})
+		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: new("DEF")})
 		require.Error(t, err)
 		require.Nil(t, team)
 		var conflict *fleet.ConflictError
 		require.ErrorAs(t, err, &conflict)
 		require.Contains(t, err.Error(), `"def"`)
-		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+		require.Contains(t, err.Error(), "must differ by more than letter case")
 	})
 }
 
@@ -501,7 +501,7 @@ func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
 func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
-	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	adminUser := &fleet.User{ID: 1, GlobalRole: new(fleet.RoleAdmin)}
 	ctx := test.UserContext(context.Background(), adminUser)
 
 	newSvc := func() (*Service, *mock.Store) {
@@ -540,7 +540,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 	t.Run("case-only rename of existing team succeeds and persists new name", func(t *testing.T) {
 		svc, ds := newSvc()
 		filename := "abc.yml"
-		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: ptr.String(filename)}
+		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: new(filename)}
 		ds.TeamByFilenameFunc = func(ctx context.Context, f string) (*fleet.Team, error) {
 			require.Equal(t, filename, f)
 			return existing, nil
@@ -562,7 +562,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		// and SaveTeam is called — otherwise we'd only be asserting that the
 		// conflict check didn't trip.
 		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
-			{Name: "abc", Filename: ptr.String(filename)},
+			{Name: "abc", Filename: new(filename)},
 		}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.Equal(t, 1, conflictCalls, "TeamConflictsWithName must be called once per spec")
@@ -577,7 +577,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		// rename it to "DEF" via the same file, but another team "def"
 		// already exists under a different file. This must 409.
 		svc, ds := newSvc()
-		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: ptr.String("abc.yml")}
+		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: new("abc.yml")}
 		ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
 			return existing, nil
 		}
@@ -591,13 +591,13 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		}
 
 		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
-			{Name: "DEF", Filename: ptr.String("abc.yml")},
+			{Name: "DEF", Filename: new("abc.yml")},
 		}, fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}})
 		require.Error(t, err)
 		var conflict *fleet.ConflictError
 		require.ErrorAs(t, err, &conflict)
 		require.Contains(t, err.Error(), `"def"`)
-		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+		require.Contains(t, err.Error(), "must differ by more than letter case")
 	})
 
 	t.Run("adopt existing team via new filename succeeds", func(t *testing.T) {
@@ -606,7 +606,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		// (possibly taking over management from another YAML file). The
 		// pre-fix behavior was adoption; the fix must not break it.
 		svc, ds := newSvc()
-		existing := &fleet.Team{ID: 12, Name: "Adoptable", Filename: ptr.String("old.yml")}
+		existing := &fleet.Team{ID: 12, Name: "Adoptable", Filename: new("old.yml")}
 		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 			return existing, nil
 		}
@@ -617,7 +617,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		}
 
 		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
-			{Name: "Adoptable", Filename: ptr.String("new.yml")},
+			{Name: "Adoptable", Filename: new("new.yml")},
 		}, fleet.ApplyTeamSpecOptions{})
 		require.NoError(t, err)
 		require.True(t, ds.SaveTeamFuncInvoked, "SaveTeam must be called to adopt the team")
@@ -635,15 +635,15 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		}
 
 		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
-			{Name: "ABC", Filename: ptr.String("foo.yml")},
-			{Name: "abc", Filename: ptr.String("bar.yml")},
+			{Name: "ABC", Filename: new("foo.yml")},
+			{Name: "abc", Filename: new("bar.yml")},
 		}, fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}})
 		require.Error(t, err)
 		var conflict *fleet.ConflictError
 		require.ErrorAs(t, err, &conflict)
 		require.Contains(t, err.Error(), "foo.yml")
 		require.Contains(t, err.Error(), "bar.yml")
-		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+		require.Contains(t, err.Error(), "must differ by more than letter case")
 	})
 
 	t.Run("no-filename spec with collation-equal name preserves DB canonical name", func(t *testing.T) {

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -26,7 +26,7 @@ func TestNewTeamNameValidation(t *testing.T) {
 		return team, nil
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, &notFoundError{}
+		return nil, nil
 	}
 
 	authorizer, err := authz.NewAuthorizer()
@@ -164,7 +164,7 @@ func TestModifyTeamNameValidation(t *testing.T) {
 		return team, nil
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, &notFoundError{}
+		return nil, nil
 	}
 
 	authorizer, err := authz.NewAuthorizer()
@@ -284,7 +284,7 @@ func TestApplyTeamSpecsNameValidation(t *testing.T) {
 		return nil, &notFoundError{}
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, &notFoundError{}
+		return nil, nil
 	}
 
 	authorizer, err := authz.NewAuthorizer()
@@ -467,7 +467,7 @@ func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
 	t.Run("case-only self rename succeeds", func(t *testing.T) {
 		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
 			require.Equal(t, uint(5), excludeID)
-			return nil, &notFoundError{}
+			return nil, nil
 		}
 
 		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: ptr.String("abc")})
@@ -519,7 +519,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 			return nil, &notFoundError{}
 		}
 		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-			return nil, &notFoundError{}
+			return nil, nil
 		}
 
 		mockSvc := &svcmock.Service{}
@@ -550,7 +550,7 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 			conflictCalls++
 			require.Equal(t, uint(7), excludeID,
 				"conflict check must exclude the team matched by filename so a case-only rename succeeds")
-			return nil, &notFoundError{}
+			return nil, nil
 		}
 		var savedTeam *fleet.Team
 		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -25,6 +25,9 @@ func TestNewTeamNameValidation(t *testing.T) {
 		team.ID = 1
 		return team, nil
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, &notFoundError{}
+	}
 
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
@@ -160,6 +163,9 @@ func TestModifyTeamNameValidation(t *testing.T) {
 	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
 		return team, nil
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, &notFoundError{}
+	}
 
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
@@ -277,6 +283,9 @@ func TestApplyTeamSpecsNameValidation(t *testing.T) {
 	ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
 		return nil, &notFoundError{}
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, &notFoundError{}
+	}
 
 	authorizer, err := authz.NewAuthorizer()
 	require.NoError(t, err)
@@ -372,6 +381,268 @@ func TestApplyTeamSpecsNameValidation(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestNewTeamCollationEqualConflict covers the case where the requested name
+// collides with an existing team under MySQL's collation.
+func TestNewTeamCollationEqualConflict(t *testing.T) {
+	ds := new(mock.Store)
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		t.Fatalf("NewTeam should not be called when a conflict is detected")
+		return nil, nil
+	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		require.Equal(t, uint(0), excludeID)
+		return &fleet.Team{ID: 42, Name: "ABC"}, nil
+	}
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+
+	mockSvc := &svcmock.Service{}
+	mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+		return nil
+	}
+
+	svc := &Service{
+		Service: mockSvc,
+		ds:      ds,
+		config: config.FleetConfig{
+			Server: config.ServerConfig{PrivateKey: "something"},
+		},
+		authz: authorizer,
+	}
+
+	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx := test.UserContext(context.Background(), adminUser)
+
+	_, err = svc.NewTeam(ctx, fleet.TeamPayload{Name: ptr.String("abc")})
+	require.Error(t, err)
+	var conflict *fleet.ConflictError
+	require.ErrorAs(t, err, &conflict)
+	require.Contains(t, err.Error(), `"ABC"`)
+	require.Contains(t, err.Error(), "must differ by at least one non-special character")
+}
+
+// TestModifyTeamCaseOnlyRenameAndConflict covers two ModifyTeam scenarios:
+//  1. Case-only self-rename succeeds (the team is excluded from the conflict
+//     check by id).
+//  2. Rename into another team's name returns a ConflictError naming that
+//     team.
+func TestModifyTeamCaseOnlyRenameAndConflict(t *testing.T) {
+	ds := new(mock.Store)
+	ds.TeamWithExtrasFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+		return &fleet.Team{ID: tid, Name: "ABC"}, nil
+	}
+	ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+		return &fleet.AppConfig{}, nil
+	}
+	ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+		return team, nil
+	}
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+
+	mockSvc := &svcmock.Service{}
+	mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+		return nil
+	}
+
+	svc := &Service{
+		Service: mockSvc,
+		ds:      ds,
+		config: config.FleetConfig{
+			Server: config.ServerConfig{PrivateKey: "something"},
+		},
+		authz: authorizer,
+	}
+
+	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx := test.UserContext(context.Background(), adminUser)
+
+	t.Run("case-only self rename succeeds", func(t *testing.T) {
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			require.Equal(t, uint(5), excludeID)
+			return nil, &notFoundError{}
+		}
+
+		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: ptr.String("abc")})
+		require.NoError(t, err)
+		require.NotNil(t, team)
+		require.Equal(t, "abc", team.Name)
+	})
+
+	t.Run("rename into another team's name conflicts", func(t *testing.T) {
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			require.Equal(t, uint(5), excludeID)
+			return &fleet.Team{ID: 6, Name: "def"}, nil
+		}
+
+		team, err := svc.ModifyTeam(ctx, 5, fleet.TeamPayload{Name: ptr.String("DEF")})
+		require.Error(t, err)
+		require.Nil(t, team)
+		var conflict *fleet.ConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.Contains(t, err.Error(), `"def"`)
+		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+	})
+}
+
+// TestApplyTeamSpecsCollationEqualConflict covers the three GitOps scenarios
+// that were inconsistently handled:
+//   - Single-team case-only rename should succeed.
+//   - Cross-file conflict (new filename, colliding name) should return
+//     ConflictError.
+//   - Intra-batch conflict should be detected before any DB writes.
+func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+	ctx := test.UserContext(context.Background(), adminUser)
+
+	newSvc := func() (*Service, *mock.Store) {
+		ds := new(mock.Store)
+		ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+			return &fleet.AppConfig{}, nil
+		}
+		ds.IsEnrollSecretAvailableFunc = func(ctx context.Context, secret string, newB bool, teamID *uint) (bool, error) {
+			return true, nil
+		}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return nil, &notFoundError{}
+		}
+		ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+			return nil, &notFoundError{}
+		}
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			return nil, &notFoundError{}
+		}
+
+		mockSvc := &svcmock.Service{}
+		mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+			return nil
+		}
+		svc := &Service{
+			Service: mockSvc,
+			ds:      ds,
+			config: config.FleetConfig{
+				Server: config.ServerConfig{PrivateKey: "something"},
+			},
+			authz: authorizer,
+		}
+		return svc, ds
+	}
+
+	t.Run("case-only rename of existing team succeeds and persists new name", func(t *testing.T) {
+		svc, ds := newSvc()
+		filename := "abc.yml"
+		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: ptr.String(filename)}
+		ds.TeamByFilenameFunc = func(ctx context.Context, f string) (*fleet.Team, error) {
+			require.Equal(t, filename, f)
+			return existing, nil
+		}
+		conflictCalls := 0
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			conflictCalls++
+			require.Equal(t, uint(7), excludeID,
+				"conflict check must exclude the team matched by filename so a case-only rename succeeds")
+			return nil, &notFoundError{}
+		}
+		var savedTeam *fleet.Team
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			savedTeam = team
+			return team, nil
+		}
+
+		// Run without DryRun so editTeamFromSpec actually rewrites team.Name
+		// and SaveTeam is called — otherwise we'd only be asserting that the
+		// conflict check didn't trip.
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
+			{Name: "abc", Filename: ptr.String(filename)},
+		}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.Equal(t, 1, conflictCalls, "TeamConflictsWithName must be called once per spec")
+		require.True(t, ds.SaveTeamFuncInvoked, "SaveTeam must be called to persist the rename")
+		require.NotNil(t, savedTeam)
+		require.Equal(t, "abc", savedTeam.Name, "rename must persist the spec's new case form")
+		require.Equal(t, uint(7), savedTeam.ID, "rename must target the same team id")
+	})
+
+	t.Run("cross-file conflict returns 409", func(t *testing.T) {
+		svc, ds := newSvc()
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			require.Equal(t, uint(0), excludeID)
+			return &fleet.Team{ID: 9, Name: "ABC"}, nil
+		}
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			t.Fatalf("SaveTeam must not be called when a conflict is detected")
+			return nil, nil
+		}
+		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			t.Fatalf("NewTeam must not be called when a conflict is detected")
+			return nil, nil
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
+			{Name: "abc", Filename: ptr.String("new.yml")},
+		}, fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}})
+		require.Error(t, err)
+		var conflict *fleet.ConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.Contains(t, err.Error(), `"ABC"`)
+		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+	})
+
+	t.Run("intra-batch conflict short-circuits before any DB conflict check", func(t *testing.T) {
+		svc, ds := newSvc()
+		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+			t.Fatalf("TeamConflictsWithName must not be called when the pre-pass catches the conflict (got name=%q, excludeID=%d)", name, excludeID)
+			return nil, nil
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
+			{Name: "ABC", Filename: ptr.String("foo.yml")},
+			{Name: "abc", Filename: ptr.String("bar.yml")},
+		}, fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}})
+		require.Error(t, err)
+		var conflict *fleet.ConflictError
+		require.ErrorAs(t, err, &conflict)
+		require.Contains(t, err.Error(), "foo.yml")
+		require.Contains(t, err.Error(), "bar.yml")
+		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+	})
+
+	t.Run("no-filename spec with collation-equal name preserves DB canonical name", func(t *testing.T) {
+		// Regression: without a filename, a spec whose name is a case variant
+		// of an existing team must NOT silently rename that team. The DB's
+		// canonical form wins; users who want to rename must supply a
+		// filename.
+		svc, ds := newSvc()
+		existing := &fleet.Team{ID: 11, Name: "Workstations"}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			// TeamByName is collation-aware in production, so "workstations"
+			// matches "Workstations" here.
+			return existing, nil
+		}
+		var savedTeam *fleet.Team
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			savedTeam = team
+			return team, nil
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
+			{Name: "workstations"}, // no filename
+		}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked)
+		require.NotNil(t, savedTeam)
+		require.Equal(t, "Workstations", savedTeam.Name,
+			"no-filename spec must preserve the DB's canonical name, not silently case-rename it")
+	})
 }
 
 func TestUpdateTeamMDMDiskEncryption(t *testing.T) {

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -532,7 +533,8 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 			config: config.FleetConfig{
 				Server: config.ServerConfig{PrivateKey: "something"},
 			},
-			authz: authorizer,
+			authz:  authorizer,
+			logger: slog.New(slog.DiscardHandler),
 		}
 		return svc, ds
 	}

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -572,29 +572,59 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		require.Equal(t, uint(7), savedTeam.ID, "rename must target the same team id")
 	})
 
-	t.Run("cross-file conflict returns 409", func(t *testing.T) {
+	t.Run("filename-matched rename into another team's name conflicts", func(t *testing.T) {
+		// Regression: team "ABC" is managed by "abc.yml". User tries to
+		// rename it to "DEF" via the same file, but another team "def"
+		// already exists under a different file. This must 409.
 		svc, ds := newSvc()
+		existing := &fleet.Team{ID: 7, Name: "ABC", Filename: ptr.String("abc.yml")}
+		ds.TeamByFilenameFunc = func(ctx context.Context, filename string) (*fleet.Team, error) {
+			return existing, nil
+		}
 		ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-			require.Equal(t, uint(0), excludeID)
-			return &fleet.Team{ID: 9, Name: "ABC"}, nil
+			require.Equal(t, uint(7), excludeID, "must exclude the filename-matched team")
+			return &fleet.Team{ID: 8, Name: "def"}, nil
 		}
 		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
 			t.Fatalf("SaveTeam must not be called when a conflict is detected")
 			return nil, nil
 		}
-		ds.NewTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
-			t.Fatalf("NewTeam must not be called when a conflict is detected")
-			return nil, nil
-		}
 
 		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
-			{Name: "abc", Filename: ptr.String("new.yml")},
+			{Name: "DEF", Filename: ptr.String("abc.yml")},
 		}, fleet.ApplyTeamSpecOptions{ApplySpecOptions: fleet.ApplySpecOptions{DryRun: true}})
 		require.Error(t, err)
 		var conflict *fleet.ConflictError
 		require.ErrorAs(t, err, &conflict)
-		require.Contains(t, err.Error(), `"ABC"`)
+		require.Contains(t, err.Error(), `"def"`)
 		require.Contains(t, err.Error(), "must differ by at least one non-special character")
+	})
+
+	t.Run("adopt existing team via new filename succeeds", func(t *testing.T) {
+		// Regression for TestIntegrationsEnterpriseGitops: a spec with a new
+		// filename that matches an existing team by name must adopt it
+		// (possibly taking over management from another YAML file). The
+		// pre-fix behavior was adoption; the fix must not break it.
+		svc, ds := newSvc()
+		existing := &fleet.Team{ID: 12, Name: "Adoptable", Filename: ptr.String("old.yml")}
+		ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
+			return existing, nil
+		}
+		var savedTeam *fleet.Team
+		ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			savedTeam = team
+			return team, nil
+		}
+
+		_, err := svc.ApplyTeamSpecs(ctx, []*fleet.TeamSpec{
+			{Name: "Adoptable", Filename: ptr.String("new.yml")},
+		}, fleet.ApplyTeamSpecOptions{})
+		require.NoError(t, err)
+		require.True(t, ds.SaveTeamFuncInvoked, "SaveTeam must be called to adopt the team")
+		require.NotNil(t, savedTeam)
+		require.Equal(t, uint(12), savedTeam.ID)
+		require.NotNil(t, savedTeam.Filename)
+		require.Equal(t, "new.yml", *savedTeam.Filename, "adoption must set the new filename")
 	})
 
 	t.Run("intra-batch conflict short-circuits before any DB conflict check", func(t *testing.T) {

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -209,11 +209,17 @@ const TeamManagementPage = (): JSX.Element => {
               setBackendValidators({
                 name: "A fleet with this name already exists",
               });
-            } else if (errMsg.includes("all teams")) {
+            } else if (
+              errMsg.includes("all teams") ||
+              errMsg.includes("all fleets")
+            ) {
               setBackendValidators({
                 name: `"All fleets" is a reserved fleet name.`,
               });
-            } else if (errMsg.includes("no team")) {
+            } else if (
+              errMsg.includes("no team") ||
+              errMsg.includes("unassigned")
+            ) {
               setBackendValidators({
                 name: `"Unassigned" is a reserved fleet name. Please try another name.`,
               });

--- a/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
+++ b/frontend/pages/admin/TeamManagementPage/TeamManagementPage.tsx
@@ -119,8 +119,11 @@ const TeamManagementPage = (): JSX.Element => {
           refetchTeams();
         })
         .catch((createError: { data: IApiError }) => {
-          const errMsg = createError.data.errors[0].reason.toLowerCase();
-          if (errMsg.includes("duplicate")) {
+          const rawReason = createError.data.errors[0].reason;
+          const errMsg = rawReason.toLowerCase();
+          if (errMsg.includes("must differ")) {
+            setBackendValidators({ name: rawReason });
+          } else if (errMsg.includes("duplicate")) {
             setBackendValidators({
               name: "A fleet with this name already exists",
             });
@@ -198,17 +201,19 @@ const TeamManagementPage = (): JSX.Element => {
           })
           .catch((updateError: { data: IApiError }) => {
             console.error(updateError);
-            if (updateError.data.errors[0].reason.includes("Duplicate")) {
+            const rawReason = updateError.data.errors[0].reason;
+            const errMsg = rawReason.toLowerCase();
+            if (errMsg.includes("must differ")) {
+              setBackendValidators({ name: rawReason });
+            } else if (errMsg.includes("duplicate")) {
               setBackendValidators({
                 name: "A fleet with this name already exists",
               });
-            } else if (
-              updateError.data.errors[0].reason.includes("all teams")
-            ) {
+            } else if (errMsg.includes("all teams")) {
               setBackendValidators({
                 name: `"All fleets" is a reserved fleet name.`,
               });
-            } else if (updateError.data.errors[0].reason.includes("no team")) {
+            } else if (errMsg.includes("no team")) {
               setBackendValidators({
                 name: `"Unassigned" is a reserved fleet name. Please try another name.`,
               });

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -279,6 +279,26 @@ func (ds *Datastore) loadExtrasForTeam(ctx context.Context, team *fleet.Team) (*
 	return team, nil
 }
 
+// TeamConflictsWithName returns a team whose collation-equal name conflicts
+// with the provided name and whose id != excludeID. Returns a notFound error
+// when no conflict exists. Pass excludeID=0 to check against all teams
+// (creation path). The query relies on the utf8mb4_unicode_ci collation, so
+// names that differ only by case or by Unicode-equivalent special characters
+// are considered equal.
+func (ds *Datastore) TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+	// Normalize to match the NFC normalization applied on write (see NewTeam).
+	nameUnicode := norm.NFC.String(name)
+	stmt := `SELECT id, name FROM teams WHERE name = ? AND id != ? LIMIT 1`
+	team := &fleet.Team{}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), team, stmt, nameUnicode, excludeID); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ctxerr.Wrap(ctx, notFound("Fleet").WithName(nameUnicode))
+		}
+		return nil, ctxerr.Wrap(ctx, err, "check team name conflict")
+	}
+	return team, nil
+}
+
 func (ds *Datastore) TeamByFilename(ctx context.Context, filename string) (*fleet.Team, error) {
 	stmt := `
 		SELECT ` + teamColumns + ` FROM teams

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -279,12 +279,6 @@ func (ds *Datastore) loadExtrasForTeam(ctx context.Context, team *fleet.Team) (*
 	return team, nil
 }
 
-// TeamConflictsWithName returns a team whose collation-equal name conflicts
-// with the provided name and whose id != excludeID. Returns a notFound error
-// when no conflict exists. Pass excludeID=0 to check against all teams
-// (creation path). The query relies on the utf8mb4_unicode_ci collation, so
-// names that differ only by case or by Unicode-equivalent special characters
-// are considered equal.
 func (ds *Datastore) TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
 	// Normalize to match the NFC normalization applied on write (see NewTeam).
 	nameUnicode := norm.NFC.String(name)

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -284,13 +284,14 @@ func (ds *Datastore) TeamConflictsWithName(ctx context.Context, name string, exc
 	nameUnicode := norm.NFC.String(name)
 	stmt := `SELECT id, name FROM teams WHERE name = ? AND id != ? LIMIT 1`
 	team := &fleet.Team{}
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), team, stmt, nameUnicode, excludeID); err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, ctxerr.Wrap(ctx, notFound("Fleet").WithName(nameUnicode))
-		}
+	switch err := sqlx.GetContext(ctx, ds.reader(ctx), team, stmt, nameUnicode, excludeID); {
+	case err == nil:
+		return team, nil
+	case errors.Is(err, sql.ErrNoRows):
+		return nil, nil
+	default:
 		return nil, ctxerr.Wrap(ctx, err, "check team name conflict")
 	}
-	return team, nil
 }
 
 func (ds *Datastore) TeamByFilename(ctx context.Context, filename string) (*fleet.Team, error) {

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -962,18 +962,12 @@ func testTeamConflictsWithName(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 	require.Equal(t, reneeCombined.ID, conflict.ID)
 
-	// Deterministic exclude-self under a legacy duplicate pair. The production
-	// schema has a UNIQUE KEY on teams.name under utf8mb4_unicode_ci, so we
-	// cannot create a collation-equal duplicate through NewTeam. Drop the
-	// index for the duration of this sub-check so we actually exercise the
-	// `id != excludeID` branch rather than leave it as unreachable code.
-	_, err = ds.writer(ctx).ExecContext(ctx, `ALTER TABLE teams DROP INDEX idx_name`)
-	require.NoError(t, err)
-	defer func() {
-		_, rerr := ds.writer(ctx).ExecContext(ctx, `ALTER TABLE teams ADD UNIQUE KEY idx_name (name)`)
-		require.NoError(t, rerr)
-	}()
-
+	// Deterministic exclude-self under a legacy collation-equal duplicate
+	// pair. The production schema's unique index is on name_bin (binary
+	// collation), so two rows that differ only by case — e.g., "ABC" and
+	// "abc" — coexist as distinct rows but match each other under the
+	// collation-aware WHERE clause used by this method. This is exactly the
+	// scenario that motivated the excludeID parameter.
 	res, err := ds.writer(ctx).ExecContext(ctx,
 		`INSERT INTO teams (name, description, config) VALUES (?, ?, ?)`,
 		"abc", "", []byte("{}"))

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -927,14 +927,13 @@ func testTeamsNameUnicode(t *testing.T, ds *Datastore) {
 func testTeamConflictsWithName(t *testing.T, ds *Datastore) {
 	ctx := context.Background()
 
-	// No teams exist → notFound for any name.
+	// No teams exist → (nil, nil).
 	conflict, err := ds.TeamConflictsWithName(ctx, "anything", 0)
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err), err)
+	require.NoError(t, err)
 	require.Nil(t, conflict)
 
 	// Create a team and confirm excludeID=0 returns it, excludeID=team.ID
-	// returns notFound.
+	// returns (nil, nil).
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "ABC"})
 	require.NoError(t, err)
 
@@ -944,8 +943,7 @@ func testTeamConflictsWithName(t *testing.T, ds *Datastore) {
 	require.Equal(t, team.ID, conflict.ID)
 
 	conflict, err = ds.TeamConflictsWithName(ctx, "ABC", team.ID)
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err), err)
+	require.NoError(t, err)
 	require.Nil(t, conflict)
 
 	// Collation-equal variants: ASCII case.

--- a/server/datastore/mysql/teams_test.go
+++ b/server/datastore/mysql/teams_test.go
@@ -40,6 +40,7 @@ func TestTeams(t *testing.T) {
 		{"TeamsMDMConfig", testTeamsMDMConfig},
 		{"TestTeamsNameUnicode", testTeamsNameUnicode},
 		{"TestTeamsNameEmoji", testTeamsNameEmoji},
+		{"TestTeamConflictsWithName", testTeamConflictsWithName},
 		{"TestTeamsNameSort", testTeamsNameSort},
 		{"TeamIDsWithSetupExperienceIdPEnabled", testTeamIDsWithSetupExperienceIdPEnabled},
 		{"DefaultTeamConfig", testDefaultTeamConfig},
@@ -921,6 +922,83 @@ func testTeamsNameUnicode(t *testing.T, ds *Datastore) {
 	result, err := ds.TeamByName(context.Background(), equivalentNames[1])
 	assert.NoError(t, err)
 	assert.Equal(t, equivalentNames[0], result.Name)
+}
+
+func testTeamConflictsWithName(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	// No teams exist → notFound for any name.
+	conflict, err := ds.TeamConflictsWithName(ctx, "anything", 0)
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err), err)
+	require.Nil(t, conflict)
+
+	// Create a team and confirm excludeID=0 returns it, excludeID=team.ID
+	// returns notFound.
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "ABC"})
+	require.NoError(t, err)
+
+	conflict, err = ds.TeamConflictsWithName(ctx, "ABC", 0)
+	require.NoError(t, err)
+	require.NotNil(t, conflict)
+	require.Equal(t, team.ID, conflict.ID)
+
+	conflict, err = ds.TeamConflictsWithName(ctx, "ABC", team.ID)
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err), err)
+	require.Nil(t, conflict)
+
+	// Collation-equal variants: ASCII case.
+	conflict, err = ds.TeamConflictsWithName(ctx, "abc", 0)
+	require.NoError(t, err)
+	require.Equal(t, team.ID, conflict.ID)
+
+	// Collation-equal variants: NFC normalization (é written as combined vs.
+	// e + combining acute accent).
+	reneeCombined, err := ds.NewTeam(ctx, &fleet.Team{Name: "Renée"})
+	require.NoError(t, err)
+	reneeDecomposed := "Renée" // e + U+0301 COMBINING ACUTE ACCENT
+	conflict, err = ds.TeamConflictsWithName(ctx, reneeDecomposed, 0)
+	require.NoError(t, err)
+	require.Equal(t, reneeCombined.ID, conflict.ID)
+
+	// Deterministic exclude-self under a legacy duplicate pair. The production
+	// schema has a UNIQUE KEY on teams.name under utf8mb4_unicode_ci, so we
+	// cannot create a collation-equal duplicate through NewTeam. Drop the
+	// index for the duration of this sub-check so we actually exercise the
+	// `id != excludeID` branch rather than leave it as unreachable code.
+	_, err = ds.writer(ctx).ExecContext(ctx, `ALTER TABLE teams DROP INDEX idx_name`)
+	require.NoError(t, err)
+	defer func() {
+		_, rerr := ds.writer(ctx).ExecContext(ctx, `ALTER TABLE teams ADD UNIQUE KEY idx_name (name)`)
+		require.NoError(t, rerr)
+	}()
+
+	res, err := ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO teams (name, description, config) VALUES (?, ?, ?)`,
+		"abc", "", []byte("{}"))
+	require.NoError(t, err)
+	dupID64, err := res.LastInsertId()
+	require.NoError(t, err)
+	dupID := uint(dupID64) //nolint:gosec // test code
+
+	// Excluding the original team's id returns the legacy duplicate...
+	conflict, err = ds.TeamConflictsWithName(ctx, "ABC", team.ID)
+	require.NoError(t, err)
+	require.Equal(t, dupID, conflict.ID)
+
+	// ...and excluding the duplicate's id returns the original.
+	conflict, err = ds.TeamConflictsWithName(ctx, "abc", dupID)
+	require.NoError(t, err)
+	require.Equal(t, team.ID, conflict.ID)
+
+	// Only id and name are populated — this is a hot path so extras are not
+	// loaded.
+	require.NotZero(t, conflict.ID)
+	require.NotEmpty(t, conflict.Name)
+	require.Empty(t, conflict.Description)
+	require.Nil(t, conflict.Users)
+	require.Nil(t, conflict.Secrets)
 }
 
 func testTeamsNameEmoji(t *testing.T, ds *Datastore) {

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -620,6 +620,12 @@ type Datastore interface {
 	TeamByName(ctx context.Context, name string) (*Team, error)
 	// TeamByFilename retrieves the Team by GitOps filename.
 	TeamByFilename(ctx context.Context, filename string) (*Team, error)
+	// TeamConflictsWithName returns a team whose collation-equal name conflicts
+	// with the provided name and whose id != excludeID. Returns a notFound
+	// error when no conflict exists. Pass excludeID=0 to check against all
+	// teams (team creation path). Only id and name are populated on the
+	// returned team — this is a hot path for every team write.
+	TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*Team, error)
 	// ListTeams lists teams with the ordering and filters in the provided options.
 	ListTeams(ctx context.Context, filter TeamFilter, opt ListOptions) ([]*Team, error)
 	// TeamsSummary lists id, name and description for all teams.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -623,8 +623,7 @@ type Datastore interface {
 	// TeamConflictsWithName returns a team whose collation-equal name conflicts
 	// with the provided name and whose id != excludeID. Returns a notFound
 	// error when no conflict exists. Pass excludeID=0 to check against all
-	// teams (team creation path). Only id and name are populated on the
-	// returned team — this is a hot path for every team write.
+	// teams.
 	TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*Team, error)
 	// ListTeams lists teams with the ordering and filters in the provided options.
 	ListTeams(ctx context.Context, filter TeamFilter, opt ListOptions) ([]*Team, error)

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -621,9 +621,8 @@ type Datastore interface {
 	// TeamByFilename retrieves the Team by GitOps filename.
 	TeamByFilename(ctx context.Context, filename string) (*Team, error)
 	// TeamConflictsWithName returns a team whose collation-equal name conflicts
-	// with the provided name and whose id != excludeID. Returns a notFound
-	// error when no conflict exists. Pass excludeID=0 to check against all
-	// teams.
+	// with the provided name and whose id != excludeID, or (nil, nil) when
+	// no such team exists. Pass excludeID=0 to check against all teams.
 	TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*Team, error)
 	// ListTeams lists teams with the ordering and filters in the provided options.
 	ListTeams(ctx context.Context, filter TeamFilter, opt ListOptions) ([]*Team, error)

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -467,6 +467,8 @@ type TeamByNameFunc func(ctx context.Context, name string) (*fleet.Team, error)
 
 type TeamByFilenameFunc func(ctx context.Context, filename string) (*fleet.Team, error)
 
+type TeamConflictsWithNameFunc func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error)
+
 type ListTeamsFunc func(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error)
 
 type TeamsSummaryFunc func(ctx context.Context) ([]*fleet.TeamSummary, error)
@@ -2533,6 +2535,9 @@ type DataStore struct {
 
 	TeamByFilenameFunc        TeamByFilenameFunc
 	TeamByFilenameFuncInvoked bool
+
+	TeamConflictsWithNameFunc        TeamConflictsWithNameFunc
+	TeamConflictsWithNameFuncInvoked bool
 
 	ListTeamsFunc        ListTeamsFunc
 	ListTeamsFuncInvoked bool
@@ -6189,6 +6194,13 @@ func (s *DataStore) TeamByFilename(ctx context.Context, filename string) (*fleet
 	s.TeamByFilenameFuncInvoked = true
 	s.mu.Unlock()
 	return s.TeamByFilenameFunc(ctx, filename)
+}
+
+func (s *DataStore) TeamConflictsWithName(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+	s.mu.Lock()
+	s.TeamConflictsWithNameFuncInvoked = true
+	s.mu.Unlock()
+	return s.TeamConflictsWithNameFunc(ctx, name, excludeID)
 }
 
 func (s *DataStore) ListTeams(ctx context.Context, filter fleet.TeamFilter, opt fleet.ListOptions) ([]*fleet.Team, error) {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1788,7 +1788,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 		Secrets:     []*fleet.EnrollSecret{{Secret: "CASEVAR"}},
 	}
 	r := s.Do("POST", "/api/latest/fleet/teams", teamCaseVariant, http.StatusConflict)
-	require.Contains(t, extractServerErrorText(r.Body), "must differ by at least one non-special character")
+	require.Contains(t, extractServerErrorText(r.Body), "must differ by more than letter case")
 
 	// create a team with reserved team names; should be case-insensitive
 	teamReserved := &fleet.Team{
@@ -1829,13 +1829,13 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 
 	// case-only self-rename is allowed (the team's own id is excluded from
 	// the conflict check).
-	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: ptr.String("RENAMED PADDED")}, http.StatusOK, &tmResp)
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: new("RENAMED PADDED")}, http.StatusOK, &tmResp)
 	require.Equal(t, "RENAMED PADDED", tmResp.Team.Name)
 
 	// renaming into another team's name (the original team created above)
 	// using only case differences must return 409 with the canonical message.
-	r = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: ptr.String(strings.ToUpper(name))}, http.StatusConflict)
-	require.Contains(t, extractServerErrorText(r.Body), "must differ by at least one non-special character")
+	r = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: new(strings.ToUpper(name))}, http.StatusConflict)
+	require.Contains(t, extractServerErrorText(r.Body), "must differ by more than letter case")
 
 	// clean up
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), nil, http.StatusOK)

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1780,6 +1780,16 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	}
 	s.DoJSON("POST", "/api/latest/fleet/teams", team2, http.StatusConflict, &tmResp)
 
+	// create a team whose name only differs by case — must also 409 with the
+	// canonical "must differ" message.
+	teamCaseVariant := &fleet.Team{
+		Name:        strings.ToLower(name),
+		Description: "case variant",
+		Secrets:     []*fleet.EnrollSecret{{Secret: "CASEVAR"}},
+	}
+	r := s.Do("POST", "/api/latest/fleet/teams", teamCaseVariant, http.StatusConflict)
+	require.Contains(t, extractServerErrorText(r.Body), "must differ by at least one non-special character")
+
 	// create a team with reserved team names; should be case-insensitive
 	teamReserved := &fleet.Team{
 		Name:        "no TeAm",
@@ -1787,7 +1797,7 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 		Secrets:     []*fleet.EnrollSecret{{Secret: "foobar"}},
 	}
 
-	r := s.Do("POST", "/api/latest/fleet/teams", teamReserved, http.StatusUnprocessableEntity)
+	r = s.Do("POST", "/api/latest/fleet/teams", teamReserved, http.StatusUnprocessableEntity)
 	require.Contains(t, extractServerErrorText(r.Body), `is a reserved fleet name`)
 
 	teamReserved.Name = "AlL TeaMS"
@@ -1816,6 +1826,16 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	// rename with leading/trailing whitespace — name should be trimmed
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: ptr.String("  Renamed Padded  ")}, http.StatusOK, &tmResp)
 	require.Equal(t, "Renamed Padded", tmResp.Team.Name)
+
+	// case-only self-rename is allowed (the team's own id is excluded from
+	// the conflict check).
+	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: ptr.String("RENAMED PADDED")}, http.StatusOK, &tmResp)
+	require.Equal(t, "RENAMED PADDED", tmResp.Team.Name)
+
+	// renaming into another team's name (the original team created above)
+	// using only case differences must return 409 with the canonical message.
+	r = s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), fleet.TeamPayload{Name: ptr.String(strings.ToUpper(name))}, http.StatusConflict)
+	require.Contains(t, extractServerErrorText(r.Body), "must differ by at least one non-special character")
 
 	// clean up
 	s.Do("DELETE", fmt.Sprintf("/api/latest/fleet/teams/%d", paddedTeamID), nil, http.StatusOK)

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -221,6 +221,9 @@ func TestApplyTeamSpecs(t *testing.T) {
 	svc, ctx := newTestService(t, ds, nil, nil, opts)
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, newNotFoundError()
+	}
 	baseFeatures := fleet.Features{
 		EnableHostUsers:         true,
 		EnableSoftwareInventory: true,
@@ -374,7 +377,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 		for _, tt := range cases {
 			t.Run(tt.name, func(t *testing.T) {
 				ds.TeamByNameFunc = func(ctx context.Context, name string) (*fleet.Team, error) {
-					return &fleet.Team{ID: 123, Config: fleet.TeamConfig{Features: tt.old}}, nil
+					return &fleet.Team{ID: 123, Name: name, Config: fleet.TeamConfig{Features: tt.old}}, nil
 				}
 
 				ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -71,6 +71,9 @@ func TestTeamAuth(t *testing.T) {
 			return &fleet.Team{ID: 2}, nil
 		}
 	}
+	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
+		return nil, &notFoundError{}
+	}
 	ds.ConditionalAccessMicrosoftGetFunc = func(ctx context.Context) (*fleet.ConditionalAccessMicrosoftIntegration, error) {
 		return nil, &notFoundError{}
 	}

--- a/server/service/teams_test.go
+++ b/server/service/teams_test.go
@@ -72,7 +72,7 @@ func TestTeamAuth(t *testing.T) {
 		}
 	}
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, &notFoundError{}
+		return nil, nil
 	}
 	ds.ConditionalAccessMicrosoftGetFunc = func(ctx context.Context) (*fleet.ConditionalAccessMicrosoftIntegration, error) {
 		return nil, &notFoundError{}
@@ -222,7 +222,7 @@ func TestApplyTeamSpecs(t *testing.T) {
 	user := &fleet.User{GlobalRole: ptr.String(fleet.RoleAdmin)}
 	ctx = viewer.NewContext(ctx, viewer.Viewer{User: user})
 	ds.TeamConflictsWithNameFunc = func(ctx context.Context, name string, excludeID uint) (*fleet.Team, error) {
-		return nil, newNotFoundError()
+		return nil, nil
 	}
 	baseFeatures := fleet.Features{
 		EnableHostUsers:         true,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->

**Related issue:** Resolves #33557 

The tems.name column uses utf8mb4_unicode_ci, so names like "ABC" and "abc" compare as equal at the database level. Before this change name collisions were handled in different ways in the UI and in GitOps.

The changes introduced here, consolidates the logic used for detecting name collisions in all code path. All conflicts return 409 with the canonical copy "Fleet names must differ by at least one non-special character (case-insensitive)."

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Team name uniqueness is now consistent across UI, API, and GitOps; case-only differences are not treated as conflicts.
  * Conflicting name attempts now return a consistent HTTP 409 with a clearer conflict message.

* **New Features**
  * Case-only team renames (e.g., "Team" → "TEAM") are allowed.
  * GitOps now pre-validates team names across files and fails early when two files specify names that differ only by case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->