### PR TITLE
Fleet UI: Correct copy message to 24 hours, generic message 

### DIFF
--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/HostMdmStatusCell.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { DEFAULT_EMPTY_CELL_VALUE } from "utilities/constants";
+import paths from "router/paths";
 import Icon from "components/Icon";
+import CustomLink from "components/CustomLink";
 import NotSupported from "components/NotSupported";
 import TooltipWrapper from "components/TooltipWrapper";
 import { IHost } from "interfaces/host";
@@ -9,7 +11,7 @@ const baseClass = "host-mdm-status-cell";
 
 const HostMdmStatusCell = ({
   row: {
-    original: { mdm, platform },
+    original: { id, mdm, platform },
   },
   cell: { value },
 }: {
@@ -31,8 +33,13 @@ const HostMdmStatusCell = ({
         <TooltipWrapper
           tipContent={
             <span className="tooltip__tooltip-text">
-              Fleet hit Apple&apos;s API rate limit when preparing the macOS
-              Setup Assistant for this host. Fleet will try again every hour.
+              Migration or new Mac setup won&apos;t work. There&apos;s an issue
+              with this host&apos;s Apple Business (AB) profile assignment.{" "}
+              <CustomLink
+                url={`${paths.HOST_DETAILS(id)}?show_mdm_status=true`}
+                text="View details"
+                variant="tooltip-link"
+              />
             </span>
           }
           position="top"

--- a/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/HostsPageConfig.tsx
@@ -99,7 +99,7 @@ export const hostSelectStatuses = (isPremiumTier: boolean) => {
   const premiumStatuses = [
     {
       disabled: false,
-      label: "Pending",
+      label: "Pending hosts",
       value: "pending",
       helpText: "Hosts pending enrollment.",
     },

--- a/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/components/HostsFilterBlock/HostsFilterBlock.tsx
@@ -666,7 +666,8 @@ const HostsFilterBlock = ({
             <>
               Migration or new Mac setup won&apos;t work. Fleet hit Apple&apos;s
               API rate limit when preparing the macOS Setup Assistant for these
-              hosts. Fleet will try again every hour.
+              hosts. Fleet will try again within 24 hours of each host&apos;s
+              last throttled response.
             </>
           );
         case "NOT_ACCESSIBLE":

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -241,6 +241,12 @@ const HostDetailsPage = ({
   const [showMDMStatusModal, setShowMDMStatusModal] = useState(
     location.query.show_mdm_status === "true"
   );
+  // Sync MDM status modal state when the query param changes while mounted
+  // (e.g., browser back/forward navigation).
+  useEffect(() => {
+    setShowMDMStatusModal(location.query.show_mdm_status === "true");
+  }, [location.query.show_mdm_status]);
+
   const [showClearPasscodeModal, setShowClearPasscodeModal] = useState(false);
 
   // General-use updating state
@@ -684,8 +690,18 @@ const HostDetailsPage = ({
   }, [showLocationModal, setShowLocationModal]);
 
   const toggleMDMStatusModal = useCallback(() => {
-    setShowMDMStatusModal(!showMDMStatusModal);
-  }, [showMDMStatusModal, setShowMDMStatusModal]);
+    setShowMDMStatusModal((prev) => {
+      const closing = prev;
+      // When closing, strip ?show_mdm_status=true so that refreshing or
+      // sharing the URL won't reopen the modal. Opening never adds the param
+      // — it's only set by external deep-links.
+      if (closing && location.query.show_mdm_status === "true") {
+        const { show_mdm_status: _, ...rest } = location.query;
+        router.replace({ pathname: location.pathname, query: rest });
+      }
+      return !prev;
+    });
+  }, [location, router]);
 
   const toggleClearPasscodeModal = useCallback(() => {
     setShowClearPasscodeModal(!showClearPasscodeModal);

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -165,6 +165,7 @@ interface IHostDetailsProps {
       order_key?: string;
       order_direction?: "asc" | "desc";
       fleet_id?: string;
+      show_mdm_status?: string;
     };
     search?: string;
   };
@@ -237,7 +238,9 @@ const HostDetailsPage = ({
   const [showLocationModal, setShowLocationModal] = useState<
     boolean | undefined
   >(false);
-  const [showMDMStatusModal, setShowMDMStatusModal] = useState(false);
+  const [showMDMStatusModal, setShowMDMStatusModal] = useState(
+    location.query.show_mdm_status === "true"
+  );
   const [showClearPasscodeModal, setShowClearPasscodeModal] = useState(false);
 
   // General-use updating state

--- a/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
+++ b/frontend/pages/hosts/details/modals/MDMStatusModal/MDMStatusModal.tsx
@@ -97,7 +97,7 @@ const getProfileStatusUI = (raw?: string | null) => {
   return PROFILE_STATUS_UI_MAP[label] ?? PROFILE_STATUS_UI_MAP[""];
 };
 
-const getThrottleCopy = (responseUpdatedAt?: string | null) => {
+export const getThrottleCopy = (responseUpdatedAt?: string | null) => {
   if (!responseUpdatedAt) {
     return "when available.";
   }


### PR DESCRIPTION
## Issue
Closes #39063 

## Description

TODO 


## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MDM status modal can be opened via URL parameter on host details; supports browser navigation.

* **Bug Fixes**
  * Clarified MDM error messaging to reflect Apple Business profile assignment issues.
  * Updated throttling guidance to indicate retries occur within 24 hours (per host).

* **UI Improvements**
  * Added links from MDM error tooltips to host details.
  * Renamed "Pending" filter label to "Pending hosts" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->