### PR TITLE
🤖 Ignore DEP premium filters on Fleet Free tier

### DIFF
--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -1802,7 +1802,6 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				if err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "get host mdm enrollment times")
 				}
-
 			}
 		}
 	}

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -451,6 +451,12 @@ func (svc *Service) StreamHosts(ctx context.Context, opt fleet.HostListOptions) 
 		opt.MDMBootstrapPackageFilter = nil
 		// including vulnerability details on software is premium-only
 		opt.PopulateSoftwareVulnerabilityDetails = false
+		// the dep profile error filter is premium-only
+		opt.DEPProfileErrorFilter = nil
+		// the dep assign profile response filter is premium-only
+		opt.DEPAssignProfileResponseFilter = nil
+
+		// Missing fleet_id filter?
 	}
 
 	hosts, err := svc.ds.ListHosts(ctx, filter, opt)
@@ -1797,6 +1803,7 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 				if err != nil {
 					return nil, ctxerr.Wrap(ctx, err, "get host mdm enrollment times")
 				}
+
 			}
 		}
 	}
@@ -1863,6 +1870,9 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get conditional access bypass status")
 	}
 	conditionalAccessBypassed := conditionalAccessBypassedAt != nil
+
+	// since dep_profile_error is part of the parent MDM tree
+	// we need to filter it out here
 
 	return &fleet.HostDetail{
 		Host:                          *host,

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -443,6 +443,7 @@ func (svc *Service) StreamHosts(ctx context.Context, opt fleet.HostListOptions) 
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
 	// TODO(Sarah): Are we missing any other filters here?
+	// Fleet ID is not filtered
 	premiumLicense := license.IsPremium(ctx)
 	if !premiumLicense {
 		// the low disk space filter is premium-only
@@ -455,8 +456,6 @@ func (svc *Service) StreamHosts(ctx context.Context, opt fleet.HostListOptions) 
 		opt.DEPProfileErrorFilter = nil
 		// the dep assign profile response filter is premium-only
 		opt.DEPAssignProfileResponseFilter = nil
-
-		// Missing fleet_id filter?
 	}
 
 	hosts, err := svc.ds.ListHosts(ctx, filter, opt)
@@ -1870,9 +1869,6 @@ func (svc *Service) getHostDetails(ctx context.Context, host *fleet.Host, opts f
 		return nil, ctxerr.Wrap(ctx, err, "get conditional access bypass status")
 	}
 	conditionalAccessBypassed := conditionalAccessBypassedAt != nil
-
-	// since dep_profile_error is part of the parent MDM tree
-	// we need to filter it out here
 
 	return &fleet.HostDetail{
 		Host:                          *host,

--- a/server/service/hosts.go
+++ b/server/service/hosts.go
@@ -431,6 +431,19 @@ func (svc *Service) ListHosts(ctx context.Context, opt fleet.HostListOptions) ([
 	return hosts, nil
 }
 
+// sanitizeNonPremiumHostListOptions clears filter fields that are only valid
+// on a Fleet Premium license so that free-tier callers see unfiltered results.
+func sanitizeNonPremiumHostListOptions(isPremium bool, opt *fleet.HostListOptions) {
+	if isPremium {
+		return
+	}
+	opt.LowDiskSpaceFilter = nil
+	opt.MDMBootstrapPackageFilter = nil
+	opt.PopulateSoftwareVulnerabilityDetails = false
+	opt.DEPProfileErrorFilter = nil
+	opt.DEPAssignProfileResponseFilter = nil
+}
+
 func (svc *Service) StreamHosts(ctx context.Context, opt fleet.HostListOptions) (iter.Seq2[*fleet.Host, error], error) {
 	if err := svc.authz.Authorize(ctx, &fleet.Host{}, fleet.ActionList); err != nil {
 		return nil, err
@@ -442,21 +455,8 @@ func (svc *Service) StreamHosts(ctx context.Context, opt fleet.HostListOptions) 
 	}
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
-	// TODO(Sarah): Are we missing any other filters here?
-	// Fleet ID is not filtered
 	premiumLicense := license.IsPremium(ctx)
-	if !premiumLicense {
-		// the low disk space filter is premium-only
-		opt.LowDiskSpaceFilter = nil
-		// the bootstrap package filter is premium-only
-		opt.MDMBootstrapPackageFilter = nil
-		// including vulnerability details on software is premium-only
-		opt.PopulateSoftwareVulnerabilityDetails = false
-		// the dep profile error filter is premium-only
-		opt.DEPProfileErrorFilter = nil
-		// the dep assign profile response filter is premium-only
-		opt.DEPAssignProfileResponseFilter = nil
-	}
+	sanitizeNonPremiumHostListOptions(premiumLicense, &opt)
 
 	hosts, err := svc.ds.ListHosts(ctx, filter, opt)
 	if err != nil {
@@ -732,10 +732,7 @@ func (svc *Service) countHostFromFilters(ctx context.Context, labelID *uint, opt
 	}
 	filter := fleet.TeamFilter{User: vc.User, IncludeObserver: true}
 
-	if !license.IsPremium(ctx) {
-		// the low disk space filter is premium-only
-		opt.LowDiskSpaceFilter = nil
-	}
+	sanitizeNonPremiumHostListOptions(license.IsPremium(ctx), &opt)
 
 	var count int
 	var err error

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -4842,19 +4842,28 @@ func TestListHostsIgnoresPremiumOptions(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
 
-	// Simulate host1 not matching any filters.
-	ds.ListHostsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) ([]*fleet.Host, error) {
-		includeHost1 := opt.LowDiskSpaceFilter == nil &&
-			opt.MDMBootstrapPackageFilter == nil &&
-			opt.DEPProfileErrorFilter == nil &&
-			opt.DEPAssignProfileResponseFilter == nil
+	// filtersActive returns true when any premium filter is set. Host 1 only
+	// appears when no filters are active; host 2 always appears.
+	filtersActive := func(opt fleet.HostListOptions) bool {
+		return opt.LowDiskSpaceFilter != nil ||
+			opt.MDMBootstrapPackageFilter != nil ||
+			opt.DEPProfileErrorFilter != nil ||
+			opt.DEPAssignProfileResponseFilter != nil
+	}
 
+	ds.ListHostsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) ([]*fleet.Host, error) {
 		var hosts []*fleet.Host
-		if includeHost1 {
+		if !filtersActive(opt) {
 			hosts = append(hosts, &fleet.Host{ID: 1})
 		}
 		hosts = append(hosts, &fleet.Host{ID: 2})
 		return hosts, nil
+	}
+	ds.CountHostsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) (int, error) {
+		if filtersActive(opt) {
+			return 1, nil
+		}
+		return 2, nil
 	}
 
 	cases := []struct {
@@ -4877,11 +4886,19 @@ func TestListHostsIgnoresPremiumOptions(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, hosts, 2)
 
+			count, err := svc.CountHosts(freeCtx, nil, tc.opts)
+			require.NoError(t, err)
+			require.Equal(t, 2, count)
+
 			// Premium tier: filter is used and hosts are filtered
 			hosts, err = svc.ListHosts(premiumCtx, tc.opts)
 			require.NoError(t, err)
 			require.Len(t, hosts, 1)
 			require.Equal(t, uint(2), hosts[0].ID)
+
+			count, err = svc.CountHosts(premiumCtx, nil, tc.opts)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
 		})
 	}
 }

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -4842,21 +4842,12 @@ func TestListHostsIgnoresPremiumOptions(t *testing.T) {
 	ds := new(mock.Store)
 	svc, ctx := newTestService(t, ds, nil, nil)
 
-	// Simulate host1 not matching any filters
+	// Simulate host1 not matching any filters.
 	ds.ListHostsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) ([]*fleet.Host, error) {
-		includeHost1 := true
-		if opt.LowDiskSpaceFilter != nil {
-			includeHost1 = false
-		}
-		if opt.MDMBootstrapPackageFilter != nil {
-			includeHost1 = false
-		}
-		if opt.DEPProfileErrorFilter != nil {
-			includeHost1 = false
-		}
-		if opt.DEPAssignProfileResponseFilter != nil {
-			includeHost1 = false
-		}
+		includeHost1 := opt.LowDiskSpaceFilter == nil &&
+			opt.MDMBootstrapPackageFilter == nil &&
+			opt.DEPProfileErrorFilter == nil &&
+			opt.DEPAssignProfileResponseFilter == nil
 
 		var hosts []*fleet.Host
 		if includeHost1 {

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -4837,3 +4837,60 @@ func TestGetHostRecoveryLockPassword(t *testing.T) {
 		assert.Contains(t, err.Error(), "mark recovery lock password viewed")
 	})
 }
+
+func TestListHostsIgnoresPremiumOptions(t *testing.T) {
+	ds := new(mock.Store)
+	svc, ctx := newTestService(t, ds, nil, nil)
+
+	// Simulate host1 not matching any filters
+	ds.ListHostsFunc = func(ctx context.Context, filter fleet.TeamFilter, opt fleet.HostListOptions) ([]*fleet.Host, error) {
+		includeHost1 := true
+		if opt.LowDiskSpaceFilter != nil {
+			includeHost1 = false
+		}
+		if opt.MDMBootstrapPackageFilter != nil {
+			includeHost1 = false
+		}
+		if opt.DEPProfileErrorFilter != nil {
+			includeHost1 = false
+		}
+		if opt.DEPAssignProfileResponseFilter != nil {
+			includeHost1 = false
+		}
+
+		var hosts []*fleet.Host
+		if includeHost1 {
+			hosts = append(hosts, &fleet.Host{ID: 1})
+		}
+		hosts = append(hosts, &fleet.Host{ID: 2})
+		return hosts, nil
+	}
+
+	cases := []struct {
+		name string
+		opts fleet.HostListOptions
+	}{
+		{"LowDiskSpaceFilter", fleet.HostListOptions{LowDiskSpaceFilter: new(32)}},
+		{"MDMBootstrapPackageFilter", fleet.HostListOptions{MDMBootstrapPackageFilter: new(fleet.MDMBootstrapPackageFailed)}},
+		{"DEPProfileErrorFilter", fleet.HostListOptions{DEPProfileErrorFilter: new(true)}},
+		{"DEPAssignProfileResponseFilter", fleet.HostListOptions{DEPAssignProfileResponseFilter: new(fleet.DEPAssignProfileResponseFailed)}},
+	}
+
+	freeCtx := license.NewContext(test.UserContext(ctx, test.UserAdmin), &fleet.LicenseInfo{Tier: fleet.TierFree})
+	premiumCtx := license.NewContext(test.UserContext(ctx, test.UserAdmin), &fleet.LicenseInfo{Tier: fleet.TierPremium})
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Free tier: filter is silently ignored
+			hosts, err := svc.ListHosts(freeCtx, tc.opts)
+			require.NoError(t, err)
+			require.Len(t, hosts, 2)
+
+			// Premium tier: filter is used and hosts are filtered
+			hosts, err = svc.ListHosts(premiumCtx, tc.opts)
+			require.NoError(t, err)
+			require.Len(t, hosts, 1)
+			require.Equal(t, uint(2), hosts[0].ID)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #43826.

Adds code to silently ignore `dep_profile_error` and `dep_assign_profile_response` query parameters similar to other premium only parameters on the list hosts endpoint. This PR does _NOT_ include filtering out the `dep_profile_error` field from the host details object since it doesn't seem like a common pattern to filter out individual fields from a response object, but that can be changed if needed.


# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

### Before fix

On premium:
- UI: can see "AB issue" card 
- UI: can see MDM status with Profile assignment error: failed
- API: can curl `/fleet/hosts?dep_profile_error=true` and get the host
- API: can curl `/fleet/hosts` and see `"dep_profile_error":true` for the failed host
- API: can curl `/fleet/hosts/7` and see `"dep_profile_error": true`
- API: can curl `/fleet/hosts?dep_assign_profile_response=FAILED`

On free:
- UI: can't see "AB issue" card
- UI: can see MDM status pending but no details, api response has `"dep_profile_error": true`
- API: can curl `/fleet/hosts?dep_profile_error=true` and get the host
- API: can curl `/fleet/hosts` and see `"dep_profile_error":true` for the failed host
- API: can curl `/fleet/hosts?dep_assign_profile_response=FAILED`


### After fix

On free:
- API: curl `/fleet/hosts?dep_profile_error=true` and the filter gets ignored
- API: curl `/fleet/hosts?dep_assign_profile_response=FAILED` or other statuses and the filter gets ignored
- API: can curl `/fleet/hosts` to show all hosts and it shows `"dep_profile_error":true` since it is not filtered at the host details level
- API: can curl `/fleet/hosts/7` and see dep_profile_error since it is not filtered at the host details level

```
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_assign_profile_response=FAILED'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8878    0  8878    0     0   144k      0 --:--:-- --:--:-- --:--:--  146k
       5
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_profile_error=true'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8879    0  8879    0     0   298k      0 --:--:-- --:--:-- --:--:--  298k
       5
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8879    0  8879    0     0   283k      0 --:--:-- --:--:-- --:--:--  289k
       5
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_profile_error=true&dep_assign_profile_response=FAILED'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  8879    0  8879    0     0   311k      0 --:--:-- --:--:-- --:--:--  321k
       5
```

On premium:
- Everything works as expected, filters work

```
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_assign_profile_response=FAILED'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1696    0  1696    0     0  58681      0 --:--:-- --:--:-- --:--:-- 60571
       1
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_profile_error=true'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1696    0  1696    0     0  59613      0 --:--:-- --:--:-- --:--:-- 60571
       1
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  9055    0  9055    0     0   355k      0 --:--:-- --:--:-- --:--:--  368k
       5
jonathan@jonathans-macbook-pro:~/fleet$ curl -k -X GET 'https://localhost:8080/api/v1/fleet/hosts?dep_profile_error=true&dep_assign_profile_response=FAILED'   -H "Authorization: Bearer $TOKEN" | wc -l
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1696    0  1696    0     0  60845      0 --:--:-- --:--:-- --:--:-- 62814
       1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Host listing and counts now ignore premium-only filters on non-premium licenses, ensuring consistent results for free-tier users.

* **Tests**
  * Added tests validating that host listing and counting behave differently between free and premium license tiers when premium filters are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->