### PR TITLE
mark 12075 MDMErrorDomain as Profile not found

### DIFF
--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -97,9 +97,14 @@ func IsRecoveryLockPasswordMismatchError(chain []mdm.ErrorChain) bool {
 //
 // Known error signature:
 // - MDMClientError (89): "Profile with identifier '...' not found."
+// - MDMErrorDomain (12075): "The profile '...' is not installed."
 func IsProfileNotFoundError(chain []mdm.ErrorChain) bool {
 	for _, e := range chain {
 		if e.ErrorDomain == "MDMClientError" && e.ErrorCode == 89 {
+			return true
+		}
+
+		if e.ErrorDomain == "MDMErrorDomain" && e.ErrorCode == 12075 {
 			return true
 		}
 	}

--- a/server/mdm/apple/util.go
+++ b/server/mdm/apple/util.go
@@ -95,7 +95,7 @@ func IsRecoveryLockPasswordMismatchError(chain []mdm.ErrorChain) bool {
 // was not found on the device. When this error occurs during a RemoveProfile
 // command, it means the profile is already absent — the desired outcome.
 //
-// Known error signature:
+// Known error signatures:
 // - MDMClientError (89): "Profile with identifier '...' not found."
 // - MDMErrorDomain (12075): "The profile '...' is not installed."
 func IsProfileNotFoundError(chain []mdm.ErrorChain) bool {

--- a/server/mdm/apple/util_test.go
+++ b/server/mdm/apple/util_test.go
@@ -86,6 +86,35 @@ func TestIsProfileNotFoundError(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "MDMErrorDomain 12075 - profile not installed",
+			chain: []mdm.ErrorChain{
+				{ErrorCode: 12075, ErrorDomain: "MDMErrorDomain", USEnglishDescription: "The profile 'com.example' is not installed."},
+			},
+			expected: true,
+		},
+		{
+			name: "different MDMErrorDomain code",
+			chain: []mdm.ErrorChain{
+				{ErrorCode: 12076, ErrorDomain: "MDMErrorDomain", USEnglishDescription: "Some other error"},
+			},
+			expected: false,
+		},
+		{
+			name: "different error domain with code 12075",
+			chain: []mdm.ErrorChain{
+				{ErrorCode: 12075, ErrorDomain: "SomeOtherDomain", USEnglishDescription: "Some error"},
+			},
+			expected: false,
+		},
+		{
+			name: "profile not installed in chain with other errors",
+			chain: []mdm.ErrorChain{
+				{ErrorCode: 100, ErrorDomain: "SomeOtherDomain", USEnglishDescription: "First error"},
+				{ErrorCode: 12075, ErrorDomain: "MDMErrorDomain", USEnglishDescription: "The profile 'com.example' is not installed."},
+			},
+			expected: true,
+		},
 	}
 
 	for _, tt := range cases {


### PR DESCRIPTION
An additional case spotted on iPhones like the 89 error code shown on Mac.

That we want to see as a valid profile removal

```xml
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
	<key>CommandUUID</key>
	<string>0c53ebff-93cf-4599-853c-db6b582ff929</string>
	<key>ErrorChain</key>
	<array>
		<dict>
			<key>ErrorCode</key>
			<integer>12075</integer>
			<key>ErrorDomain</key>
			<string>MDMErrorDomain</string>
			<key>LocalizedDescription</key>
			<string>The profile âFleet.WiFiâ is not installed.</string>
			<key>USEnglishDescription</key>
			<string>The profile âFleet.WiFiâ is not installed.</string>
		</dict>
	</array>
	<key>Status</key>
	<string>Error</string>
	<key>UDID</key>
	<string>REDACTED</string>
</dict>
</plist>
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of "profile not found" cases in Apple MDM by recognizing an additional error signature, reducing missed detections.
* **Tests**
  * Added unit tests covering the new signature, negative cases, and mixed error chains to ensure reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->