### PR TITLE
Use UTC time for osv processing

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -496,7 +496,7 @@ func checkOSVVulnerabilities(
 
 	var now time.Time
 	if !config.DisableDataSync {
-		now = time.Now()
+		now = time.Now().UTC()
 	}
 
 	if !config.DisableDataSync {


### PR DESCRIPTION
**Related issue:** Resolves #39900

## Testing
- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:
- [x] Confirmed that the fix is not expected to adversely impact load test results
- [x] Alerted the release DRI if additional load testing is needed



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for OS vulnerability data synchronization to use UTC timezone when synchronization is enabled, ensuring consistent timing behavior across different system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->