### PR TITLE
Fix unreleased bug where workstations is not selected on controls page

### DIFF
--- a/frontend/hooks/useTeamIdParam.tests.ts
+++ b/frontend/hooks/useTeamIdParam.tests.ts
@@ -35,6 +35,17 @@ describe("preferredOrLowestIdFleet", () => {
     });
   });
 
+  it("matches case-insensitively", () => {
+    const fleets = [
+      { id: 1, name: "Alpha" },
+      { id: 4, name: "WORKSTATIONS" },
+    ];
+    expect(preferredOrLowestIdFleet(fleets)).toEqual({
+      id: 4,
+      name: "WORKSTATIONS",
+    });
+  });
+
   it("falls back to lowest ID when no Workstations fleet exists", () => {
     const fleets = [
       { id: 10, name: "Zebra" },

--- a/frontend/hooks/useTeamIdParam.tests.ts
+++ b/frontend/hooks/useTeamIdParam.tests.ts
@@ -1,0 +1,53 @@
+import { preferredOrLowestIdFleet } from "./useTeamIdParam";
+
+describe("preferredOrLowestIdFleet", () => {
+  it('returns "Workstations" when present', () => {
+    const fleets = [
+      { id: 1, name: "Alpha" },
+      { id: 2, name: "Workstations" },
+      { id: 3, name: "Zebra" },
+    ];
+    expect(preferredOrLowestIdFleet(fleets)).toEqual({
+      id: 2,
+      name: "Workstations",
+    });
+  });
+
+  it('returns "💻 Workstations" (emoji variant) when present', () => {
+    const fleets = [
+      { id: 1, name: "Alpha" },
+      { id: 3, name: "💻 Workstations" },
+    ];
+    expect(preferredOrLowestIdFleet(fleets)).toEqual({
+      id: 3,
+      name: "💻 Workstations",
+    });
+  });
+
+  it("prefers plain over emoji when both exist (first match wins)", () => {
+    const fleets = [
+      { id: 5, name: "Workstations" },
+      { id: 2, name: "💻 Workstations" },
+    ];
+    expect(preferredOrLowestIdFleet(fleets)).toEqual({
+      id: 5,
+      name: "Workstations",
+    });
+  });
+
+  it("falls back to lowest ID when no Workstations fleet exists", () => {
+    const fleets = [
+      { id: 10, name: "Zebra" },
+      { id: 3, name: "Charlie" },
+      { id: 7, name: "Mike" },
+    ];
+    expect(preferredOrLowestIdFleet(fleets)).toEqual({
+      id: 3,
+      name: "Charlie",
+    });
+  });
+
+  it("returns undefined for an empty array", () => {
+    expect(preferredOrLowestIdFleet([])).toBeUndefined();
+  });
+});

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -190,9 +190,7 @@ const getUserTeams = ({
  *  otherwise fall back to the fleet with the lowest ID. */
 const preferredOrLowestIdFleet = (fleets: ITeamSummary[]) => {
   const workstations = fleets.find(
-    (t) =>
-      t.name === "Workstations" ||
-      t.name === "\u{1F4BB} Workstations" // 💻 Workstations
+    (t) => t.name === "Workstations" || t.name === "\u{1F4BB} Workstations"
   );
   return workstations ?? sortBy(fleets, (t) => t.id)[0];
 };
@@ -245,9 +243,7 @@ const getDefaultTeam = ({
     }
 
     if (!defaultTeam) {
-      const realFleets = userTeams.filter(
-        (t) => t.id > APP_CONTEXT_NO_TEAM_ID
-      );
+      const realFleets = userTeams.filter((t) => t.id > APP_CONTEXT_NO_TEAM_ID);
       defaultTeam =
         realFleets.length > 0
           ? preferredOrLowestIdFleet(realFleets)

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -186,6 +186,17 @@ const getUserTeams = ({
     : filterUserTeamsByRole(currentUser.teams, permittedAccessByTeamRole);
 };
 
+/** Prefer a fleet named "Workstations" (with or without emoji prefix),
+ *  otherwise fall back to the fleet with the lowest ID. */
+const preferredOrLowestIdFleet = (fleets: ITeamSummary[]) => {
+  const workstations = fleets.find(
+    (t) =>
+      t.name === "Workstations" ||
+      t.name === "\u{1F4BB} Workstations" // 💻 Workstations
+  );
+  return workstations ?? sortBy(fleets, (t) => t.id)[0];
+};
+
 const getDefaultTeam = ({
   currentUser,
   includeAllTeams,
@@ -226,20 +237,31 @@ const getDefaultTeam = ({
           (t) => t.id > APP_CONTEXT_NO_TEAM_ID
         );
         if (realFleets.length > 0) {
-          defaultTeam = sortBy(realFleets, (t) => t.id)[0];
+          defaultTeam = preferredOrLowestIdFleet(realFleets);
         } else {
           defaultTeam = userTeams.find((t) => t.id === APP_CONTEXT_NO_TEAM_ID);
         }
       }
     }
 
-    return defaultTeam || userTeams.find((t) => t.id > APP_CONTEXT_NO_TEAM_ID);
+    if (!defaultTeam) {
+      const realFleets = userTeams.filter(
+        (t) => t.id > APP_CONTEXT_NO_TEAM_ID
+      );
+      defaultTeam =
+        realFleets.length > 0
+          ? preferredOrLowestIdFleet(realFleets)
+          : undefined;
+    }
+    return defaultTeam;
   }
 
   return (
     userTeams.find((t) => permissions.isTeamAdmin(currentUser, t.id)) ||
     userTeams.find((t) => permissions.isTeamMaintainer(currentUser, t.id)) ||
-    userTeams.find((t) => t.id > APP_CONTEXT_NO_TEAM_ID)
+    preferredOrLowestIdFleet(
+      userTeams.filter((t) => t.id > APP_CONTEXT_NO_TEAM_ID)
+    )
   );
 };
 

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -188,7 +188,7 @@ const getUserTeams = ({
 
 /** Prefer a fleet named "Workstations" (with or without emoji prefix),
  *  otherwise fall back to the fleet with the lowest ID. */
-const preferredOrLowestIdFleet = (fleets: ITeamSummary[]) => {
+export const preferredOrLowestIdFleet = (fleets: ITeamSummary[]) => {
   const workstations = fleets.find(
     (t) => t.name === "Workstations" || t.name === "\u{1F4BB} Workstations"
   );

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -186,12 +186,14 @@ const getUserTeams = ({
     : filterUserTeamsByRole(currentUser.teams, permittedAccessByTeamRole);
 };
 
-/** Prefer a fleet named "Workstations" (with or without emoji prefix),
- *  otherwise fall back to the fleet with the lowest ID. */
+// Prefer a fleet named "Workstations" (with or without emoji prefix),
+// otherwise fall back to the fleet with the lowest ID.
 export const preferredOrLowestIdFleet = (fleets: ITeamSummary[]) => {
-  const workstations = fleets.find(
-    (t) => t.name === "Workstations" || t.name === "\u{1F4BB} Workstations"
-  );
+  const name = "workstations";
+  const workstations = fleets.find((t) => {
+    const lower = t.name.toLowerCase();
+    return lower === name || lower === `\u{1F4BB} ${name}`;
+  });
   return workstations ?? sortBy(fleets, (t) => t.id)[0];
 };
 

--- a/frontend/hooks/useTeamIdParam.ts
+++ b/frontend/hooks/useTeamIdParam.ts
@@ -211,6 +211,8 @@ const getDefaultTeam = ({
   if (!currentUser || !userTeams?.length) {
     return undefined;
   }
+  const realFleets = userTeams.filter((t) => t.id > APP_CONTEXT_NO_TEAM_ID);
+
   if (permissions.isOnGlobalTeam(currentUser)) {
     let defaultTeam: ITeamSummary | undefined;
     if (isPrimoMode) {
@@ -230,10 +232,7 @@ const getDefaultTeam = ({
         defaultTeam = userTeams.find((t) => t.id === APP_CONTEXT_ALL_TEAMS_ID);
       }
       if (!defaultTeam && includeNoTeam) {
-        // prefer the real fleet with the lowest ID over "Unassigned"
-        const realFleets = userTeams.filter(
-          (t) => t.id > APP_CONTEXT_NO_TEAM_ID
-        );
+        // prefer a real fleet over "Unassigned"
         if (realFleets.length > 0) {
           defaultTeam = preferredOrLowestIdFleet(realFleets);
         } else {
@@ -242,22 +241,13 @@ const getDefaultTeam = ({
       }
     }
 
-    if (!defaultTeam) {
-      const realFleets = userTeams.filter((t) => t.id > APP_CONTEXT_NO_TEAM_ID);
-      defaultTeam =
-        realFleets.length > 0
-          ? preferredOrLowestIdFleet(realFleets)
-          : undefined;
-    }
-    return defaultTeam;
+    return defaultTeam || preferredOrLowestIdFleet(realFleets);
   }
 
   return (
     userTeams.find((t) => permissions.isTeamAdmin(currentUser, t.id)) ||
     userTeams.find((t) => permissions.isTeamMaintainer(currentUser, t.id)) ||
-    preferredOrLowestIdFleet(
-      userTeams.filter((t) => t.id > APP_CONTEXT_NO_TEAM_ID)
-    )
+    preferredOrLowestIdFleet(realFleets)
   );
 };
 


### PR DESCRIPTION
Addresses https://github.com/fleetdm/fleet/issues/43525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default fleet/team selection to prefer "Workstations" (including the "💻 Workstations" emoji variant), and to fall back to the lowest-ID real fleet when no preferred fleet exists.
* **Tests**
  * Added unit tests validating preferred selection, emoji-name handling, case-insensitive matching, fallback to lowest-ID fleet, and empty-list behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->