### PR TITLE
🤖 Fix GitOps leaving duplicate software installer rows 

### DIFF
--- a/changes/43738-duplicate-installers
+++ b/changes/43738-duplicate-installers
@@ -1,0 +1,1 @@
+- Fixed a bug where custom package installers were not removed when adding an FMA for the same title via GitOps, which caused setup experience to install duplicate software.

--- a/server/datastore/mysql/setup_experience.go
+++ b/server/datastore/mysql/setup_experience.go
@@ -304,6 +304,8 @@ LEFT JOIN
 WHERE
 	si.global_or_team_id = ?
 AND
+	si.is_active = TRUE
+AND
 	st.id IN (%s)
 `, titleIDQuestionMarks)
 

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -3,6 +3,7 @@ package mysql
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -35,6 +36,7 @@ func TestSetupExperience(t *testing.T) {
 		{"TestEnqueueSetupExperienceItemsWindows", testEnqueueSetupExperienceItemsWindows},
 		{"EnqueueSetupExperienceItemsWithDisplayName", testEnqueueSetupExperienceItemsWithDisplayName},
 		{"UpdateStatusGuardsTerminalStates", testUpdateStatusGuardsTerminalStates},
+		{"SetSetupExperienceTitlesOnlyMarksActiveInstaller", testSetSetupExperienceTitlesOnlyMarksActiveInstaller},
 	}
 
 	for _, c := range cases {
@@ -1997,4 +1999,104 @@ func testGetSetupExperienceScriptByID(t *testing.T, ds *Datastore) {
 	b, err := ds.GetAnyScriptContents(ctx, gotScript.ScriptContentID)
 	require.NoError(t, err)
 	require.Equal(t, script.ScriptContents, string(b))
+}
+
+// testSetSetupExperienceTitlesOnlyMarksActiveInstaller verifies that when a
+// title has multiple cached FMA installer versions, SetSetupExperienceSoftwareTitles
+// only sets install_during_setup=true on the active one. Previously an
+// inactive/cached row could also get marked, which would cause it to be picked
+// up by setup experience if the FMA were later rolled back to that version.
+func testSetSetupExperienceTitlesOnlyMarksActiveInstaller(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_setup_exp_active"})
+	require.NoError(t, err)
+
+	fma, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "pkg_active",
+		Slug:             "pkg_active",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.pkg_active",
+	})
+	require.NoError(t, err)
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("file contents"), t.TempDir)
+	require.NoError(t, err)
+
+	// Create two cached FMA versions via successive GitOps runs. v1.0 ends
+	// up inactive, v2.0 active.
+	for i, version := range []string{"1.0", "2.0"} {
+		err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
+			{
+				FleetMaintainedAppID: &fma.ID,
+				Title:                "pkg_active",
+				Source:               "apps",
+				Platform:             "darwin",
+				PreInstallQuery:      "SELECT 1",
+				InstallScript:        "echo install",
+				PostInstallScript:    "echo post install",
+				UninstallScript:      "echo uninstall",
+				InstallerFile:        tfr,
+				StorageID:            fmt.Sprintf("storage_%d", i),
+				Filename:             "pkg_active.pkg",
+				Version:              version,
+				UserID:               user.ID,
+				ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+				InstallDuringSetup:   new(false),
+				SelfService:          false,
+				TeamID:               &team.ID,
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	// Grab the two installer IDs so we can assert per-row.
+	type row struct {
+		ID       uint `db:"id"`
+		Active   bool `db:"is_active"`
+		InSetup  bool `db:"install_during_setup"`
+		TitleID  uint `db:"title_id"`
+		Version  string
+	}
+	var rows []row
+	tmFilter := fleet.TeamFilter{User: test.UserAdmin, TeamID: &team.ID}
+	titles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: &team.ID, Platform: "darwin", AvailableForInstall: true}, tmFilter)
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+	titleID := titles[0].ID
+
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, tx, &rows, `
+			SELECT id, is_active, install_during_setup, title_id, version
+			FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ?
+			ORDER BY version ASC
+		`, team.ID, titleID)
+	})
+	require.Len(t, rows, 2, "expected 2 cached FMA versions")
+	require.False(t, rows[0].Active, "v1.0 should be inactive")
+	require.True(t, rows[1].Active, "v2.0 should be active")
+
+	// Sanity: neither row has install_during_setup set yet (BatchSet was
+	// called with InstallDuringSetup=false).
+	require.False(t, rows[0].InSetup)
+	require.False(t, rows[1].InSetup)
+
+	// Add the title to setup experience.
+	err = ds.SetSetupExperienceSoftwareTitles(ctx, "darwin", team.ID, []uint{titleID})
+	require.NoError(t, err)
+
+	// Re-read: only the active (v2.0) row should have install_during_setup=true.
+	rows = nil
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, tx, &rows, `
+			SELECT id, is_active, install_during_setup, title_id, version
+			FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ?
+			ORDER BY version ASC
+		`, team.ID, titleID)
+	})
+	require.Len(t, rows, 2)
+	require.False(t, rows[0].InSetup, "cached inactive v1.0 must not be marked install_during_setup")
+	require.True(t, rows[1].InSetup, "active v2.0 should be marked install_during_setup")
 }

--- a/server/datastore/mysql/setup_experience_test.go
+++ b/server/datastore/mysql/setup_experience_test.go
@@ -3,7 +3,6 @@ package mysql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -2001,11 +2000,6 @@ func testGetSetupExperienceScriptByID(t *testing.T, ds *Datastore) {
 	require.Equal(t, script.ScriptContents, string(b))
 }
 
-// testSetSetupExperienceTitlesOnlyMarksActiveInstaller verifies that when a
-// title has multiple cached FMA installer versions, SetSetupExperienceSoftwareTitles
-// only sets install_during_setup=true on the active one. Previously an
-// inactive/cached row could also get marked, which would cause it to be picked
-// up by setup experience if the FMA were later rolled back to that version.
 func testSetSetupExperienceTitlesOnlyMarksActiveInstaller(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
@@ -2025,7 +2019,7 @@ func testSetSetupExperienceTitlesOnlyMarksActiveInstaller(t *testing.T, ds *Data
 
 	// Create two cached FMA versions via successive GitOps runs. v1.0 ends
 	// up inactive, v2.0 active.
-	for i, version := range []string{"1.0", "2.0"} {
+	for _, version := range []string{"1.0", "2.0"} {
 		err = ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{
 			{
 				FleetMaintainedAppID: &fma.ID,
@@ -2037,7 +2031,7 @@ func testSetSetupExperienceTitlesOnlyMarksActiveInstaller(t *testing.T, ds *Data
 				PostInstallScript:    "echo post install",
 				UninstallScript:      "echo uninstall",
 				InstallerFile:        tfr,
-				StorageID:            fmt.Sprintf("storage_%d", i),
+				StorageID:            "storage_id",
 				Filename:             "pkg_active.pkg",
 				Version:              version,
 				UserID:               user.ID,
@@ -2052,11 +2046,11 @@ func testSetSetupExperienceTitlesOnlyMarksActiveInstaller(t *testing.T, ds *Data
 
 	// Grab the two installer IDs so we can assert per-row.
 	type row struct {
-		ID       uint `db:"id"`
-		Active   bool `db:"is_active"`
-		InSetup  bool `db:"install_during_setup"`
-		TitleID  uint `db:"title_id"`
-		Version  string
+		ID      uint `db:"id"`
+		Active  bool `db:"is_active"`
+		InSetup bool `db:"install_during_setup"`
+		TitleID uint `db:"title_id"`
+		Version string
 	}
 	var rows []row
 	tmFilter := fleet.TeamFilter{User: test.UserAdmin, TeamID: &team.ID}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2888,12 +2888,8 @@ WHERE
 			// For FMA installers: determine the active version, then evict old versions
 			// (protecting the active one from eviction).
 			if installer.FleetMaintainedAppID != nil {
-				// If this title previously had a custom (non-FMA) installer, it
-				// would otherwise remain alongside the new FMA rows with
-				// is_active = 1, causing setup experience to enqueue the app
-				// twice (see issue #43738). Re-point any policies that
-				// referenced the custom installer to the new FMA row, then
-				// delete the stale custom row(s).
+				// Re-point policies from any non-FMA installers for this title
+				// to the new FMA installer.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (
@@ -2903,6 +2899,9 @@ WHERE
 				`, installerID, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
 				}
+				// Delete previous non-FMA installers for this title — unlike
+				// FMA installers, custom installers are not retained for the
+				// version pinning feature.
 				if _, err := tx.ExecContext(ctx, `
 					DELETE FROM software_installers
 					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2899,9 +2899,8 @@ WHERE
 				`, installerID, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
 				}
-				// Delete previous non-FMA installers for this title — unlike
-				// FMA installers, custom installers are not retained for the
-				// version pinning feature.
+				// Delete previous custom installer for this title since they shouldn't
+				// be kept for rollback.
 				if _, err := tx.ExecContext(ctx, `
 					DELETE FROM software_installers
 					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2290,6 +2290,7 @@ WHERE
   title_id NOT IN (?)
 `
 
+	// ORDER BY is_active DESC, id DESC makes existing[0] the previously-active row.
 	const checkExistingInstaller = `
 SELECT
 	id,
@@ -2305,6 +2306,7 @@ FROM
 WHERE
 	global_or_team_id = ?	AND
 	title_id = ?
+ORDER BY is_active DESC, id DESC
 `
 
 	const insertNewOrEditedInstaller = `

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -1169,6 +1169,11 @@ func (ds *Datastore) DeleteSoftwareInstaller(ctx context.Context, id uint) error
 		}
 		activateAffectedHostIDs = affectedHostIDs
 
+		if _, err := tx.ExecContext(ctx, `DELETE FROM software_title_display_names WHERE (software_title_id, team_id) IN
+			(SELECT title_id, global_or_team_id FROM software_installers WHERE id = ?)`, id); err != nil {
+			return ctxerr.Wrap(ctx, err, "delete software title display name for installer being deleted")
+		}
+
 		// allow delete only if install_during_setup is false
 		res, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ? AND install_during_setup = 0`, id)
 		if err != nil {
@@ -1457,12 +1462,6 @@ func (ds *Datastore) runInstallerUpdateSideEffectsInTransaction(ctx context.Cont
 	  			WHERE software_installer_id = ? AND status IS NOT NULL AND host_deleted_at IS NULL`, installerID)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "hide existing install counts")
-		}
-
-		_, err = tx.ExecContext(ctx, `DELETE FROM software_title_display_names WHERE (software_title_id, team_id) IN
-			(SELECT title_id, global_or_team_id FROM software_installers WHERE id = ?)`, installerID)
-		if err != nil {
-			return nil, ctxerr.Wrap(ctx, err, "delete software title display name that matches installer")
 		}
 	}
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2863,8 +2863,6 @@ WHERE
 				return ctxerr.Wrapf(ctx, err, "load id of new/edited installer with name %q", installer.Filename)
 			}
 
-			// Installer rows to delete after running side effects (so
-			// upcoming_activities aren't left with NULL installer IDs).
 			var installerIDsToDelete []uint
 
 			// For non-FMA (custom) packages, enforce one installer per title per team.
@@ -2974,8 +2972,7 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "setting active installer for %q", installer.Filename)
 				}
 
-				// Re-point policies from any non-FMA installers for this title
-				// to the active FMA installer.
+				// Re-point policies from any non-FMA installers for this title to the active FMA installer.
 				if _, err := tx.ExecContext(ctx, `
 					UPDATE policies SET software_installer_id = ?
 					WHERE software_installer_id IN (
@@ -2985,8 +2982,7 @@ WHERE
 				`, activeInstallerID, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
 				}
-				// Mark previous custom installers for this title for deletion;
-				// they shouldn't be kept for rollback.
+				// Mark previous custom package installers for this title for deletion;
 				for _, e := range existing {
 					if e.FleetMaintainedAppID == nil {
 						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
@@ -3117,7 +3113,7 @@ WHERE
 				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
 			}
 
-			// Run side effects and delete unnecessary installers.
+			// Perform side effects and delete unnecessary installers.
 			for _, id := range installerIDsToDelete {
 				affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true)
 				if err != nil {

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2356,6 +2356,7 @@ ON DUPLICATE KEY UPDATE
   user_email = VALUES(user_email),
   url = VALUES(url),
   install_during_setup = COALESCE(?, install_during_setup),
+  fleet_maintained_app_id = VALUES(fleet_maintained_app_id),
   is_active = VALUES(is_active),
   http_etag = VALUES(http_etag),
   patch_query = VALUES(patch_query)
@@ -2982,9 +2983,9 @@ WHERE
 				`, activeInstallerID, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
 				}
-				// Mark previous custom package installers for this title for deletion;
+				// Mark previous custom package installers for this title for deletion.
 				for _, e := range existing {
-					if e.FleetMaintainedAppID == nil {
+					if e.FleetMaintainedAppID == nil && e.InstallerID != installerID {
 						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
 					}
 				}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2294,6 +2294,7 @@ WHERE
 	const checkExistingInstaller = `
 SELECT
 	id,
+	fleet_maintained_app_id,
 	storage_id != ? is_package_modified,
 	install_script_content_id != ? OR uninstall_script_content_id != ? OR pre_install_query != ? OR
 	COALESCE(post_install_script_content_id != ? OR
@@ -2763,9 +2764,10 @@ WHERE
 
 			// pull existing installer state if it exists so we can diff for side effects post-update
 			type existingInstallerUpdateCheckResult struct {
-				InstallerID        uint `db:"id"`
-				IsPackageModified  bool `db:"is_package_modified"`
-				IsMetadataModified bool `db:"is_metadata_modified"`
+				InstallerID          uint  `db:"id"`
+				FleetMaintainedAppID *uint `db:"fleet_maintained_app_id"`
+				IsPackageModified    bool  `db:"is_package_modified"`
+				IsMetadataModified   bool  `db:"is_metadata_modified"`
 			}
 			var existing []existingInstallerUpdateCheckResult
 			err = sqlx.SelectContext(ctx, tx, &existing, checkExistingInstaller, wasUpdatedArgs...)
@@ -2861,6 +2863,10 @@ WHERE
 				return ctxerr.Wrapf(ctx, err, "load id of new/edited installer with name %q", installer.Filename)
 			}
 
+			// Installer rows to delete after running side effects (so
+			// upcoming_activities aren't left with NULL installer IDs).
+			var installerIDsToDelete []uint
+
 			// For non-FMA (custom) packages, enforce one installer per title per team.
 			// With the unique constraint on (global_or_team_id, title_id, version),
 			// a version change inserts a new row instead of replacing — clean up the old one.
@@ -2877,11 +2883,10 @@ WHERE
 				`, installerID, globalOrTeamID, titleID, installerID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies for old versions of custom installer %q", installer.Filename)
 				}
-				if _, err := tx.ExecContext(ctx, `
-					DELETE FROM software_installers
-					WHERE global_or_team_id = ? AND title_id = ? AND id != ?
-				`, globalOrTeamID, titleID, installerID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "clean up old versions of custom installer %q", installer.Filename)
+				for _, e := range existing {
+					if e.InstallerID != installerID {
+						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
+					}
 				}
 			}
 
@@ -2953,17 +2958,10 @@ WHERE
 						return ctxerr.Wrapf(ctx, err, "re-point policies for evicted FMA versions of %q", installer.Filename)
 					}
 
-					stmt, args, err := sqlx.In(
-						`DELETE FROM software_installers WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NOT NULL AND id NOT IN (?)`,
-						globalOrTeamID,
-						titleID,
-						keepIDs,
-					)
-					if err != nil {
-						return ctxerr.Wrap(ctx, err, "build FMA eviction query")
-					}
-					if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
-						return ctxerr.Wrapf(ctx, err, "evict old FMA versions for %q", installer.Filename)
+					for _, e := range existing {
+						if e.FleetMaintainedAppID != nil && !keepSet[e.InstallerID] {
+							installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
+						}
 					}
 				}
 
@@ -2987,13 +2985,12 @@ WHERE
 				`, activeInstallerID, globalOrTeamID, titleID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
 				}
-				// Delete previous custom installer for this title since they shouldn't
-				// be kept for rollback.
-				if _, err := tx.ExecContext(ctx, `
-					DELETE FROM software_installers
-					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
-				`, globalOrTeamID, titleID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "delete custom installer replaced by FMA %q", installer.Filename)
+				// Mark previous custom installers for this title for deletion;
+				// they shouldn't be kept for rollback.
+				for _, e := range existing {
+					if e.FleetMaintainedAppID == nil {
+						installerIDsToDelete = append(installerIDsToDelete, e.InstallerID)
+					}
 				}
 			}
 
@@ -3118,6 +3115,19 @@ WHERE
 					return ctxerr.Wrapf(ctx, err, "processing installer with name %q", installer.Filename)
 				}
 				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
+			}
+
+			// Run side effects and delete unnecessary installers.
+			for _, id := range installerIDsToDelete {
+				affectedHostIDs, err := ds.runInstallerUpdateSideEffectsInTransaction(ctx, tx, id, true, true)
+				if err != nil {
+					return ctxerr.Wrapf(ctx, err, "side effects for replaced installer id %d for %q", id, installer.Filename)
+				}
+				activateAffectedHostIDs = append(activateAffectedHostIDs, affectedHostIDs...)
+
+				if _, err := tx.ExecContext(ctx, `DELETE FROM software_installers WHERE id = ?`, id); err != nil {
+					return ctxerr.Wrapf(ctx, err, "delete replaced installer id %d for %q", id, installer.Filename)
+				}
 			}
 		}
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2888,26 +2888,6 @@ WHERE
 			// For FMA installers: determine the active version, then evict old versions
 			// (protecting the active one from eviction).
 			if installer.FleetMaintainedAppID != nil {
-				// Re-point policies from any non-FMA installers for this title
-				// to the new FMA installer.
-				if _, err := tx.ExecContext(ctx, `
-					UPDATE policies SET software_installer_id = ?
-					WHERE software_installer_id IN (
-						SELECT id FROM software_installers
-						WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
-					)
-				`, installerID, globalOrTeamID, titleID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
-				}
-				// Delete previous custom installer for this title since they shouldn't
-				// be kept for rollback.
-				if _, err := tx.ExecContext(ctx, `
-					DELETE FROM software_installers
-					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
-				`, globalOrTeamID, titleID); err != nil {
-					return ctxerr.Wrapf(ctx, err, "delete custom installer replaced by FMA %q", installer.Filename)
-				}
-
 				// Determine which installer should be "active" for this FMA+team.
 				// If RollbackVersion is specified, find the cached installer with that version;
 				// otherwise default to the newest (just inserted/updated).
@@ -2994,6 +2974,26 @@ WHERE
 					WHERE global_or_team_id = ? AND fleet_maintained_app_id = ?
 				`, activeInstallerID, globalOrTeamID, installer.FleetMaintainedAppID); err != nil {
 					return ctxerr.Wrapf(ctx, err, "setting active installer for %q", installer.Filename)
+				}
+
+				// Re-point policies from any non-FMA installers for this title
+				// to the active FMA installer.
+				if _, err := tx.ExecContext(ctx, `
+					UPDATE policies SET software_installer_id = ?
+					WHERE software_installer_id IN (
+						SELECT id FROM software_installers
+						WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+					)
+				`, activeInstallerID, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
+				}
+				// Delete previous custom installer for this title since they shouldn't
+				// be kept for rollback.
+				if _, err := tx.ExecContext(ctx, `
+					DELETE FROM software_installers
+					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+				`, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "delete custom installer replaced by FMA %q", installer.Filename)
 				}
 			}
 

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -2888,6 +2888,28 @@ WHERE
 			// For FMA installers: determine the active version, then evict old versions
 			// (protecting the active one from eviction).
 			if installer.FleetMaintainedAppID != nil {
+				// If this title previously had a custom (non-FMA) installer, it
+				// would otherwise remain alongside the new FMA rows with
+				// is_active = 1, causing setup experience to enqueue the app
+				// twice (see issue #43738). Re-point any policies that
+				// referenced the custom installer to the new FMA row, then
+				// delete the stale custom row(s).
+				if _, err := tx.ExecContext(ctx, `
+					UPDATE policies SET software_installer_id = ?
+					WHERE software_installer_id IN (
+						SELECT id FROM software_installers
+						WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+					)
+				`, installerID, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "re-point policies from replaced custom installer to FMA %q", installer.Filename)
+				}
+				if _, err := tx.ExecContext(ctx, `
+					DELETE FROM software_installers
+					WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+				`, globalOrTeamID, titleID); err != nil {
+					return ctxerr.Wrapf(ctx, err, "delete custom installer replaced by FMA %q", installer.Filename)
+				}
+
 				// Determine which installer should be "active" for this FMA+team.
 				// If RollbackVersion is specified, find the cached installer with that version;
 				// otherwise default to the newest (just inserted/updated).

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4612,10 +4612,9 @@ func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {
 	})
 }
 
-// testCustomToFMAInstallerReplacement regresses issue #43738: when a title
-// that previously had a custom (non-FMA) installer is replaced by an FMA
-// installer via GitOps, the stale custom row used to remain with is_active=1,
-// causing setup experience to enqueue the app twice.
+// testCustomToFMAInstallerReplacement verifies that when a title's custom
+// installer is replaced by an FMA installer via GitOps, the stale custom
+// row is cleaned up and policies are re-pointed to the new FMA row.
 func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -60,6 +60,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
 		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
+		{"BatchSetFMACancelsPendingOnActiveRow", testBatchSetFMACancelsPendingOnActiveRow},
 	}
 
 	for _, c := range cases {
@@ -4612,9 +4613,6 @@ func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {
 	})
 }
 
-// testCustomToFMAInstallerReplacement verifies that when a title's custom
-// installer is replaced by an FMA installer via GitOps, the stale custom
-// row is cleaned up and policies are re-pointed to the new FMA row.
 func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	ctx := t.Context()
 	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
@@ -4963,4 +4961,76 @@ func testGetInstallerByTeamAndURL(t *testing.T, ds *Datastore) {
 	assert.Equal(t, "active_hash", existing.StorageID, "must return the active installer, not the inactive duplicate")
 	require.NotNil(t, existing.HTTPETag)
 	assert.Equal(t, etag, *existing.HTTPETag)
+}
+
+func testBatchSetFMACancelsPendingOnActiveRow(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_fma_ordering"})
+	require.NoError(t, err)
+	host := test.NewHost(t, ds, "host_fma_ordering", "1", "hostkey_fma_ordering", "hostuuid_fma_ordering", time.Now())
+
+	fma, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "pkg_ord",
+		Slug:             "pkg_ord",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.pkg_ord",
+	})
+	require.NoError(t, err)
+
+	basePayload := func(version, storageID, installScript string) *fleet.UploadSoftwareInstallerPayload {
+		tfr, err := fleet.NewTempFileReader(strings.NewReader(storageID), t.TempDir)
+		require.NoError(t, err)
+		return &fleet.UploadSoftwareInstallerPayload{
+			FleetMaintainedAppID: &fma.ID,
+			Title:                "pkg_ord",
+			Source:               "apps",
+			Platform:             "darwin",
+			PreInstallQuery:      "SELECT 1",
+			InstallScript:        installScript,
+			PostInstallScript:    "echo post",
+			UninstallScript:      "echo uninstall",
+			InstallerFile:        tfr,
+			StorageID:            storageID,
+			Filename:             "pkg_ord.pkg",
+			Version:              version,
+			UserID:               user.ID,
+			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+			TeamID:               &team.ID,
+		}
+	}
+
+	// v1.0 first (active), then v2.0 (active, v1 demoted to inactive cache).
+	require.NoError(t, ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{basePayload("1.0", "storage_v1", "echo v1")}))
+	require.NoError(t, ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{basePayload("2.0", "storage_v2", "echo v2")}))
+
+	var v2ID uint
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &v2ID, `
+			SELECT id FROM software_installers
+			WHERE global_or_team_id = ? AND version = ? AND is_active = 1
+		`, team.ID, "2.0")
+	})
+
+	_, err = ds.InsertSoftwareInstallRequest(ctx, host.ID, v2ID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
+	var pending int
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &pending, `
+			SELECT COUNT(*) FROM software_install_upcoming_activities
+			WHERE software_installer_id = ?
+		`, v2ID)
+	})
+	require.Equal(t, 1, pending)
+
+	require.NoError(t, ds.BatchSetSoftwareInstallers(ctx, &team.ID, []*fleet.UploadSoftwareInstallerPayload{basePayload("2.0", "storage_v2_updated", "echo v2 updated")}))
+
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &pending, `
+			SELECT COUNT(*) FROM software_install_upcoming_activities
+			WHERE software_installer_id = ?
+		`, v2ID)
+	})
+	require.Zero(t, pending, "re-submitting the active FMA version must cancel its pending installs")
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4730,6 +4730,81 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	require.NotNil(t, policyAfter.SoftwareInstallerID)
 	require.Equal(t, metadata.InstallerID, *policyAfter.SoftwareInstallerID)
 	require.NotEqual(t, customInstallerID, *policyAfter.SoftwareInstallerID)
+
+	// Same-version case: custom installer and incoming FMA share a version
+	// string. ON DUPLICATE KEY UPDATE on (team, title, version) upserts in
+	// place; the row must be converted to FMA, not deleted.
+	team2, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_custom_to_fma_same_version"})
+	require.NoError(t, err)
+
+	fma2, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "pkg2",
+		Slug:             "pkg2",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.pkg2",
+	})
+	require.NoError(t, err)
+
+	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:              "pkg2",
+		Source:             "apps",
+		Platform:           "darwin",
+		PreInstallQuery:    "SELECT 1",
+		InstallScript:      "echo install",
+		PostInstallScript:  "echo post install",
+		UninstallScript:    "echo uninstall",
+		InstallerFile:      tfr,
+		StorageID:          "storageid_custom2",
+		Filename:           "pkg2.pkg",
+		Version:            "1.0",
+		UserID:             user.ID,
+		ValidatedLabels:    &fleet.LabelIdentsWithScope{},
+		InstallDuringSetup: new(true),
+		TeamID:             new(team2.ID),
+	})
+	require.NoError(t, err)
+
+	err = ds.BatchSetSoftwareInstallers(ctx, new(team2.ID), []*fleet.UploadSoftwareInstallerPayload{
+		{
+			FleetMaintainedAppID: new(fma2.ID),
+			Title:                "pkg2",
+			Source:               "apps",
+			Platform:             "darwin",
+			PreInstallQuery:      "SELECT 1",
+			InstallScript:        "echo install",
+			PostInstallScript:    "echo post install",
+			UninstallScript:      "echo uninstall",
+			InstallerFile:        tfr,
+			StorageID:            "storageid_fma2",
+			Filename:             "pkg2_fma.pkg",
+			Version:              "1.0", // same version as the custom installer
+			UserID:               user.ID,
+			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+			InstallDuringSetup:   new(true),
+			TeamID:               new(team2.ID),
+		},
+	})
+	require.NoError(t, err)
+
+	tmFilter2 := fleet.TeamFilter{User: test.UserAdmin, TeamID: new(team2.ID)}
+	titles2, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: new(team2.ID), Platform: "darwin", AvailableForInstall: true}, tmFilter2)
+	require.NoError(t, err)
+	require.Len(t, titles2, 1, "exactly one installer row should remain after same-version custom\u2192FMA upsert")
+
+	var installerRows []struct {
+		FMAID    *uint `db:"fleet_maintained_app_id"`
+		IsActive bool  `db:"is_active"`
+	}
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, tx, &installerRows, `
+			SELECT fleet_maintained_app_id, is_active FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ?
+		`, team2.ID, titles2[0].ID)
+	})
+	require.Len(t, installerRows, 1)
+	require.NotNil(t, installerRows[0].FMAID, "row should have been converted to FMA via ON DUPLICATE KEY UPDATE")
+	require.Equal(t, fma2.ID, *installerRows[0].FMAID)
+	require.True(t, installerRows[0].IsActive)
 }
 
 func testGetInstallerByTeamAndURL(t *testing.T, ds *Datastore) {

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4633,7 +4633,7 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	// Seed a custom installer for title "pkg1".
-	customInstallerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+	customInstallerID, titleID, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		Title:              "pkg1",
 		Source:             "apps",
 		Platform:           "darwin",
@@ -4663,7 +4663,25 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	// GitOps run: same title, now an FMA payload.
+	// Seed a display name for the title so we can verify it's updated in
+	// place (rather than deleted + re-inserted) when the batch sets a new
+	// display name.
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		_, err := tx.ExecContext(ctx, `
+			INSERT INTO software_title_display_names (team_id, software_title_id, display_name)
+			VALUES (?, ?, ?)
+		`, team.ID, titleID, "Initial Name")
+		return err
+	})
+	var initialDisplayNameID uint
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &initialDisplayNameID, `
+			SELECT id FROM software_title_display_names
+			WHERE team_id = ? AND software_title_id = ?
+		`, team.ID, titleID)
+	})
+
+	// GitOps run: same title, now an FMA payload with a display name.
 	err = ds.BatchSetSoftwareInstallers(ctx, new(team.ID), []*fleet.UploadSoftwareInstallerPayload{
 		{
 			FleetMaintainedAppID: new(fma.ID),
@@ -4682,6 +4700,7 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
 			InstallDuringSetup:   new(true),
 			SelfService:          true,
+			DisplayName:          "Cool Package",
 			TeamID:               new(team.ID),
 		},
 	})
@@ -4730,6 +4749,21 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	require.NotNil(t, policyAfter.SoftwareInstallerID)
 	require.Equal(t, metadata.InstallerID, *policyAfter.SoftwareInstallerID)
 	require.NotEqual(t, customInstallerID, *policyAfter.SoftwareInstallerID)
+
+	// The display name from the batch payload must survive the side-effect
+	// cleanup. The display_name row should be UPDATEd in place (same id),
+	// not DELETEd and re-INSERTed.
+	displayName, err := ds.getSoftwareTitleDisplayName(ctx, team.ID, titles[0].ID)
+	require.NoError(t, err)
+	require.Equal(t, "Cool Package", displayName)
+	var afterDisplayNameID uint
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &afterDisplayNameID, `
+			SELECT id FROM software_title_display_names
+			WHERE team_id = ? AND software_title_id = ?
+		`, team.ID, titles[0].ID)
+	})
+	require.Equal(t, initialDisplayNameID, afterDisplayNameID, "display_name row should be upserted in place, not deleted and re-inserted")
 
 	// Same-version case: custom installer and incoming FMA share a version
 	// string. ON DUPLICATE KEY UPDATE on (team, title, version) upserts in

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -4777,7 +4777,7 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	})
 	require.NoError(t, err)
 
-	_, _, err = ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+	customInstallerID2, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
 		Title:              "pkg2",
 		Source:             "apps",
 		Platform:           "darwin",
@@ -4824,16 +4824,18 @@ func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
 	require.Len(t, titles2, 1, "exactly one installer row should remain after same-version custom\u2192FMA upsert")
 
 	var installerRows []struct {
+		ID       uint  `db:"id"`
 		FMAID    *uint `db:"fleet_maintained_app_id"`
 		IsActive bool  `db:"is_active"`
 	}
 	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
 		return sqlx.SelectContext(ctx, tx, &installerRows, `
-			SELECT fleet_maintained_app_id, is_active FROM software_installers
+			SELECT id, fleet_maintained_app_id, is_active FROM software_installers
 			WHERE global_or_team_id = ? AND title_id = ?
 		`, team2.ID, titles2[0].ID)
 	})
 	require.Len(t, installerRows, 1)
+	require.Equal(t, customInstallerID2, installerRows[0].ID, "row should be updated in place, not deleted+re-inserted")
 	require.NotNil(t, installerRows[0].FMAID, "row should have been converted to FMA via ON DUPLICATE KEY UPDATE")
 	require.Equal(t, fma2.ID, *installerRows[0].FMAID)
 	require.True(t, installerRows[0].IsActive)

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -58,6 +58,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"AddSoftwareTitleToMatchingSoftware", testAddSoftwareTitleToMatchingSoftware},
 		{"FleetMaintainedAppInstallerUpdates", testFleetMaintainedAppInstallerUpdates},
 		{"RepointCustomPackagePolicyToNewInstaller", testRepointPolicyToNewInstaller},
+		{"CustomToFMAInstallerReplacement", testCustomToFMAInstallerReplacement},
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
 	}
 
@@ -4609,6 +4610,127 @@ func testRepointPolicyToNewInstaller(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, metadata.InstallerID, *policyAfterUpdate.SoftwareInstallerID)
 	})
+}
+
+// testCustomToFMAInstallerReplacement regresses issue #43738: when a title
+// that previously had a custom (non-FMA) installer is replaced by an FMA
+// installer via GitOps, the stale custom row used to remain with is_active=1,
+// causing setup experience to enqueue the app twice.
+func testCustomToFMAInstallerReplacement(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	user := test.NewUser(t, ds, "Alice", "alice@example.com", true)
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "team_custom_to_fma"})
+	require.NoError(t, err)
+
+	fma, err := ds.UpsertMaintainedApp(ctx, &fleet.MaintainedApp{
+		Name:             "pkg1",
+		Slug:             "pkg1",
+		Platform:         "darwin",
+		UniqueIdentifier: "fleet.pkg1",
+	})
+	require.NoError(t, err)
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("file contents"), t.TempDir)
+	require.NoError(t, err)
+
+	// Seed a custom installer for title "pkg1".
+	customInstallerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		Title:              "pkg1",
+		Source:             "apps",
+		Platform:           "darwin",
+		PreInstallQuery:    "SELECT 1",
+		InstallScript:      "echo install",
+		PostInstallScript:  "echo post install",
+		UninstallScript:    "echo uninstall",
+		InstallerFile:      tfr,
+		StorageID:          "storageid_custom",
+		Filename:           "pkg1.pkg",
+		Version:            "1.0",
+		UserID:             user.ID,
+		ValidatedLabels:    &fleet.LabelIdentsWithScope{},
+		InstallDuringSetup: new(true),
+		SelfService:        false,
+		TeamID:             new(team.ID),
+	})
+	require.NoError(t, err)
+
+	// Attach a policy to the custom installer so we also exercise the
+	// policy re-point on deletion (policies.software_installer_id FK has no
+	// ON DELETE CASCADE).
+	policy, err := ds.NewTeamPolicy(ctx, team.ID, &user.ID, fleet.PolicyPayload{
+		Name:                "p_custom_to_fma",
+		Query:               "SELECT 1;",
+		SoftwareInstallerID: &customInstallerID,
+	})
+	require.NoError(t, err)
+
+	// GitOps run: same title, now an FMA payload.
+	err = ds.BatchSetSoftwareInstallers(ctx, new(team.ID), []*fleet.UploadSoftwareInstallerPayload{
+		{
+			FleetMaintainedAppID: new(fma.ID),
+			Title:                "pkg1",
+			Source:               "apps",
+			Platform:             "darwin",
+			PreInstallQuery:      "SELECT 1 DIFFERENT",
+			InstallScript:        "echo install 2",
+			PostInstallScript:    "echo post install 2",
+			UninstallScript:      "echo uninstall 2",
+			InstallerFile:        tfr,
+			StorageID:            "storageid_fma",
+			Filename:             "pkg1_fma.pkg",
+			Version:              "2.0",
+			UserID:               user.ID,
+			ValidatedLabels:      &fleet.LabelIdentsWithScope{},
+			InstallDuringSetup:   new(true),
+			SelfService:          true,
+			TeamID:               new(team.ID),
+		},
+	})
+	require.NoError(t, err)
+
+	tmFilter := fleet.TeamFilter{User: test.UserAdmin, TeamID: new(team.ID)}
+	titles, _, _, err := ds.ListSoftwareTitles(ctx, fleet.SoftwareTitleListOptions{TeamID: new(team.ID), Platform: "darwin", AvailableForInstall: true}, tmFilter)
+	require.NoError(t, err)
+	require.Len(t, titles, 1)
+
+	// The old custom row (fleet_maintained_app_id IS NULL) must be gone.
+	var customRows int
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &customRows, `
+			SELECT COUNT(*) FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ? AND fleet_maintained_app_id IS NULL
+		`, team.ID, titles[0].ID)
+	})
+	require.Zero(t, customRows, "stale custom installer row was not cleaned up after FMA replacement")
+
+	// Exactly one active installer remains for the title, and it's the FMA.
+	var activeCount int
+	var activeFMAID *uint
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &activeCount, `
+			SELECT COUNT(*) FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ? AND is_active = 1
+		`, team.ID, titles[0].ID)
+	})
+	require.Equal(t, 1, activeCount)
+	ExecAdhocSQL(t, ds, func(tx sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, tx, &activeFMAID, `
+			SELECT fleet_maintained_app_id FROM software_installers
+			WHERE global_or_team_id = ? AND title_id = ? AND is_active = 1
+		`, team.ID, titles[0].ID)
+	})
+	require.NotNil(t, activeFMAID)
+	require.Equal(t, fma.ID, *activeFMAID)
+
+	// The policy that pointed at the deleted custom installer must have
+	// been re-pointed to the new FMA row, not dropped/nulled.
+	metadata, err := ds.GetSoftwareInstallerMetadataByTeamAndTitleID(ctx, new(team.ID), titles[0].ID, false)
+	require.NoError(t, err)
+	policyAfter, err := ds.TeamPolicy(ctx, team.ID, policy.ID)
+	require.NoError(t, err)
+	require.NotNil(t, policyAfter.SoftwareInstallerID)
+	require.Equal(t, metadata.InstallerID, *policyAfter.SoftwareInstallerID)
+	require.NotEqual(t, customInstallerID, *policyAfter.SoftwareInstallerID)
 }
 
 func testGetInstallerByTeamAndURL(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43738 #43884

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

- Before the fix, switching from custom package to FMA via GitOps created two software installer rows and duplicate setup experience installers (the setup experience page said "2 software items will be installed during setup" even though only one was selected.
- After the fix, switching from custom package to FMA via GitOps deleted the old installer and left only one row with the correct FMA. In setup experience, only one instance of the software was installed.
- Added a custom package (obsidian) and a policy with a software install automation for it, then applied gitops and replaced obsidian with the FMA version and the policy with the FMA slug, and it redirected the policy to the new installer. 
- Adding setup experience software will only set `install_during_setup=1` on the active FMA, and not on installer rows with `is_active=0`
<img width="1222" height="558" alt="image" src="https://github.com/user-attachments/assets/ace5922a-63ec-4591-b615-1a8534a70805" />
<img width="1173" height="483" alt="image" src="https://github.com/user-attachments/assets/05c7c718-4f4a-4549-bbf1-1e1d6dae75d0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevent duplicate installs by ensuring only active installers are considered during setup; remove or replace custom installers when a managed (fleet‑maintained) installer is added, repointing policies to the active installer and canceling now-obsolete pending setup actions.
* **Tests**
  * Added tests covering active-installer selection, custom→managed installer replacement, policy repointing, display-name preservation, and cancellation of pending setup activities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->