### PR TITLE
Cherry-pick: Use UTC time for osv processing

### DIFF
--- a/cmd/fleet/cron.go
+++ b/cmd/fleet/cron.go
@@ -496,7 +496,7 @@ func checkOSVVulnerabilities(
 
 	var now time.Time
 	if !config.DisableDataSync {
-		now = time.Now()
+		now = time.Now().UTC()
 	}
 
 	if !config.DisableDataSync {


### PR DESCRIPTION
**Related issue:** #39900
**Original PR:** #43889
