### PR TITLE
Update macOS 15 to CIS Benchmark 2.0.0

### DIFF
--- a/changes/35171-macos-15-cis-2.0.0
+++ b/changes/35171-macos-15-cis-2.0.0
@@ -1,0 +1,1 @@
+- Updated macOS 15 CIS benchmark to include v2.0.0 changes

--- a/ee/cis/macos-15/README.md
+++ b/ee/cis/macos-15/README.md
@@ -26,7 +26,7 @@ CIS has left the parameters of the following checks up to the benchmark implemen
 Fleet has provided both an "enabled" and "disabled" version of these benchmarks. When both policies are added, at least one will fail. Once your organization has made a decision, you can delete one or the other policy.
 The policy will be appended with a `-enabled` or `-disabled` label, such as `2.1.1.1-enabled`.
 
-- 2.1.1.1 Audit iCloud Keychain
+- 2.1.1.1 Audit iCloud Passwords & Keychain
 - 2.1.1.2 Audit iCloud Drive
 - 2.5.1 Audit Siri
 - 2.8.1 Audit Universal Control

--- a/ee/cis/macos-15/README.md
+++ b/ee/cis/macos-15/README.md
@@ -1,6 +1,6 @@
 # macOS 15 Sequoia benchmark
 
-Fleet's policies have been written against v1.1.0 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
+Fleet's policies have been written against v2.0.0 of the benchmark. You can refer to the [CIS website](https://www.cisecurity.org/cis-benchmarks) for full details about this version.
 
 For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com/docs/using-fleet/cis-benchmarks) documentation.
 
@@ -8,14 +8,16 @@ For requirements and usage details, see the [CIS Benchmarks](https://fleetdm.com
 
 The following CIS benchmarks cannot be checked with a policy in Fleet:
 1. 2.1.2 Audit App Store Password Settings
-2. 2.3.3.12 Ensure Computer Name Does Not Contain PII or Protected Organizational Information
-3. 2.6.6 Audit Lockdown Mode
-4. 2.11.2 Audit Touch ID and Wallet & Apple Pay Settings
-5. 2.13.1 Audit Passwords System Preference Setting
-6. 2.14.1 Audit Notification & Focus Settings
-7. 3.7 Audit Software Inventory
-8. 6.2.1 Ensure Protect Mail Activity in Mail Is Enabled
-9. 2.6.3.5 Ensure Share iCloud Analytics Is Disabled (manual)
+2. 2.3.3.11 Ensure Computer Name Does Not Contain PII or Protected Organizational Information
+3. 2.4.1 Audit Menu Bar and Control Center Icons
+4. 2.6.7 Audit Lockdown Mode
+5. 2.12.2 Audit Touch ID
+6. 2.16.1 Audit Wallet & Apple Pay Settings
+7. 2.15.1 Audit Notification Settings
+8. 3.6 Audit Software Inventory
+9. 6.1.1 Audit Show All Filename Extensions
+10. 6.2.1 Ensure Protect Mail Activity in Mail Is Enabled
+11. 2.6.3.5 Ensure Share iCloud Analytics Is Disabled
 
 ### Checks that require decision
 

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -251,8 +251,8 @@ spec:
   platform: darwin
   description: |
     The iCloud Passwords & Keychain is Apple's synchronization service that works with Apple Accounts to synchronize password, passkey, and credit card information across macOS, iOS, iPadOS. The capability allows users to use synced password, passkey, and credit card information in either macOS, iOS, or iPadOS for use in Safari and other applications.
-    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on Enterprise-managed computer.
-    When using personal Apple Accounts and credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
+    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on enterprise-managed computers.
+    When using personal Apple Accounts, credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
     Rationale:
     Ensure that iCloud Passwords and Keychain usage aligns with organizational requirements, taking into account whether personal or managed Apple Accounts are being utilized.
     Impact:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -297,7 +297,7 @@ spec:
     Rationale:
     Ensure that iCloud Passwords and Keychain usage aligns with organizational requirements, taking into account whether personal or managed Apple Accounts are being utilized.
     Impact:
-    When iCloud Passwords & Keychain is turned off, password, passkey, and credit card information are no longer synchronized across devices signed in with the same Apple Account. Passwords, passkeys, and credit card information can still be stored locally and accessed through the Passwords and Keychain apps, even when iCloud Passwords & Keychain is turned off.
+    When iCloud Passwords & Keychain is enabled, password, passkey, and credit card information are synchronized across devices signed in with the same Apple Account. This may result in those items being stored in Apple's cloud and accessible across the user's Apple devices and applications that use iCloud Keychain.
   resolution: |
     The administrator should configure this via MDM profile.
     Ask your administrator to deploy a profile with the following configuration:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -2,7 +2,8 @@
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure All Apple-provided Software Is Current (Fleetd Required)
+  name: CIS - Ensure Apple-provided Software Updates Are Installed (Fleetd Required)
+  cis_id: "1.1"
   platforms: macOS
   platform: darwin
   description: |
@@ -11,10 +12,14 @@ spec:
   resolution: |
     Graphical Method:
     Perform the following to install all available software updates:
-      1. Open System Settings 
+      1. Open System Settings
       2. Select General
       3. Select Software Update
       4. Select Update All
+    Terminal Method:
+    Run the following command to install all available updates:
+      /usr/bin/sudo /usr/sbin/softwareupdate -i -a
+    If an update listed by `softwareupdate -l` requires a restart, attach the `-R` flag to force a system restart.
   query: SELECT 1 FROM software_update WHERE software_update_required = '0';
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
@@ -159,6 +164,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: CIS - Ensure Software Update Deferment Is Less Than or Equal to 30 Days (MDM Required)
+  cis_id: "1.6"
   platforms: macOS
   platform: darwin
   description: |
@@ -168,6 +174,7 @@ spec:
     and configurations that may be negatively impacted by Apple updates. If software
     updates are deferred, they should not be deferred for more than 30 days.
     This control only verifies that deferred software updates are not deferred for more than 30 days.
+    Note: Software deferment is deprecated by Apple and will be removed in a future OS release/update.
   resolution: "Ask your system administrator to deploy an MDM profile configures update deferment to a value of 30 days or less."
   query: |
     SELECT 1 WHERE 
@@ -402,6 +409,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: CIS - Ensure AirDrop Is Disabled (MDM Required)
+  cis_id: "2.3.1.1"
   platforms: macOS
   platform: darwin
   description: |
@@ -413,20 +421,22 @@ spec:
       1. The PayloadType string is com.apple.applicationaccess
       2. The key to include is allowAirDrop
       3. The key must be set to <false/>
+    Note: AirDrop can only be enabled or disabled through configuration profiles. If your
+    organization wants to use AirDrop, it would need to be set through Terminal or the GUI.
   query: |
-    SELECT 1 WHERE 
+    SELECT 1 WHERE
       EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAirDrop' AND 
+        SELECT 1 FROM managed_policies WHERE
+            domain='com.apple.applicationaccess' AND
+            name='allowAirDrop' AND
             (value = 0 OR value = 'false')
         )
       AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='allowAirDrop' AND 
+        SELECT 1 FROM managed_policies WHERE
+            domain='com.apple.applicationaccess' AND
+            name='allowAirDrop' AND
             (value != 0 AND value != 'false')
-        );  
+        );
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
@@ -613,14 +623,16 @@ apiVersion: v1
 kind: policy
 spec:
   name: CIS - Ensure Remote Login Is Disabled
+  cis_id: "2.3.3.4"
   platforms: macOS
   platform: darwin
   description: |
-    Remote Login allows an interactive terminal session to a computer.
-    The SSH server built into macOS should not be enabled on a standard user computer,
-    particularly one that changes locations and IP addresses.
-    A standard user that runs local applications, including email, web browser,
-    and productivity tools, should not use the same device as a server
+    Remote Login allows an interactive terminal connection to a computer.
+    Disabling Remote Login mitigates the risk of an unauthorized person gaining access
+    to the system via Secure Shell (SSH). The SSH server built into macOS should not be
+    enabled on a standard user computer, particularly one that changes locations and IP
+    addresses. A standard user that runs local applications, including email, web
+    browser, and productivity tools, should not use the same device as a server.
 
   resolution: |
     Graphical Method:
@@ -628,6 +640,10 @@ spec:
     2. Select General
     3. Select Sharing
     4. Set Remote Login to disabled
+    Terminal Method:
+    Run the following command to disable Remote Login:
+      /usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off
+    Note: This command will disable the service as well as stop it running in time.
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT * FROM plist WHERE
@@ -913,77 +929,6 @@ spec:
     UNION
     SELECT 'time machines destinations with encryption with automatic backup' as output
     FROM (SELECT COUNT(*) as c FROM time_machine_destinations WHERE encryption <> 'Encrypted') t2 WHERE t2.c = 0;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Show Wi-Fi status in Menu Bar Is Enabled (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    The Wi-Fi status in the menu bar indicates if the system's wireless internet capabilities are enabled.
-    If so, the system will scan for available wireless networks in order to connect.
-    Enabling "Show Wi-Fi status in menu bar" is a security awareness method that helps mitigate public area
-    wireless exploits by making the user aware of their wireless connectivity status.
-  resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Wi-Fi status in the menu bar.
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The `PayloadType` string is `com.apple.controlcenter`.
-    2. The key to include is `WiFi`.
-    3. The key must be set to `<integer>18</integer>`.
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.controlcenter' AND 
-            name='WiFi' AND 
-            value = 18
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.controlcenter' AND 
-            name='WiFi' AND 
-            value != 18
-        );  
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: lucasmrod
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Show Bluetooth Status in Menu Bar Is Enabled (MDM Required)
-  platforms: macOS
-  platform: darwin
-  description: |
-    Enabling "Show Bluetooth status in menu bar" is a security awareness method that
-    helps understand the current state of Bluetooth, including whether it is enabled,
-    discoverable, what paired devices exist, and what paired devices are currently active.
-  resolution: |
-    Automated method:
-    Ask your system administrator to deploy an MDM profile that enables the Bluetooth status in the menu bar.
-    Ask your administrator to deploy a profile with the following configuration:
-    1. The `PayloadType` string is `com.apple.controlcenter`.
-    2. The key to include is `Bluetooth`.
-    3. The key must be set to `<integer>18</integer>`.
-  query: |
-    SELECT 1 WHERE 
-      EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.controlcenter' AND 
-            name='Bluetooth' AND 
-            value = 18
-        )
-      AND NOT EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.controlcenter' AND 
-            name='Bluetooth' AND 
-            value != 18
-        );  
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
@@ -1808,6 +1753,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: CIS - Ensure Sending Diagnostic and Usage Data to Apple Is Disabled (MDM Required)
+  cis_id: "2.6.3.1, 2.6.3.2, 2.6.3.3, 2.6.3.4"
   platforms: macOS
   platform: darwin
   description: Checks that Sending Diagnostic and Usage Data to Apple Is Disabled.
@@ -1844,9 +1790,9 @@ spec:
             (value = 0 OR value = 'false')
         )
       AND EXISTS (
-        SELECT 1 FROM managed_policies WHERE 
-            domain='com.apple.applicationaccess' AND 
-            name='Siri Data Sharing Opt-In Status' AND 
+        SELECT 1 FROM managed_policies WHERE
+            domain='com.apple.assistant.support' AND
+            name='Siri Data Sharing Opt-In Status' AND
             value = 2
         )
       AND NOT EXISTS (
@@ -3024,43 +2970,6 @@ spec:
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: lucasmrod
----
-apiVersion: v1
-kind: policy
-spec:
-  name: CIS - Ensure Show All Filename Extensions Setting is Enabled
-  platforms: macOS
-  platform: darwin
-  description: |
-    A filename extension is a suffix added to a base filename that indicates the
-    base filename's file format. This is intended for any user that logs into
-    the GUI and has a home folder and not for service accounts. For the audit,
-    we will continue to verify that every account with a home folder has
-    filename extensions enabled.
-    Visible filename extensions allow the user to identify the file type and the
-    application it is associated with which leads to quick identification of
-    misrepresented malicious files.
-  resolution: |
-    Automated method:
-    Ask your administrator to deploy a script that runs the following command
-    for each user:
-    /usr/bin/sudo -u <username> /usr/bin/defaults write \
-    /Users/<username>/Library/Preferences/.GlobalPreferences.plist AppleShowAllExtensions -bool true
-  query: |
-    SELECT 1 WHERE NOT EXISTS (
-      SELECT 1 FROM users AS u
-      LEFT JOIN (
-        SELECT * FROM plist WHERE
-          path LIKE '/Users/%/Library/Preferences/.GlobalPreferences.plist' AND
-          key = 'AppleShowAllExtensions' AND
-          value = '1') AS p
-      ON p.path = CONCAT(u.directory, '/Library/Preferences/.GlobalPreferences.plist')
-        WHERE u.directory LIKE '/Users/%' AND
-        p.value IS NULL
-    );
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: artemist-work, getvictor
 ---
 apiVersion: v1
 kind: policy

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -148,6 +148,9 @@ spec:
     updates are deferred, they should not be deferred for more than 30 days.
     This control only verifies that deferred software updates are not deferred for more than 30 days.
     Note: Software deferment is deprecated by Apple and will be removed in a future OS release/update.
+    Rationale:
+    Apple software updates almost always include security updates. Attackers evaluate updates to create exploit code in order to attack unpatched systems. The longer a system remains unpatched, the greater an exploit possibility exists in which there are publicly reported vulnerabilities.
+    Software updates being deferred are specifically referring to OS updates and not either major upgrades (ex. upgrading from macOS 15.0 to macOS 26) or applications from the App Store.
   resolution: "Ask your system administrator to deploy an MDM profile configures update deferment to a value of 30 days or less."
   query: |
     SELECT 1 WHERE 
@@ -631,10 +634,15 @@ spec:
         path = '/var/db/com.apple.xpc.launchd/disabled.plist' AND
         key = 'com.openssh.sshd' AND
         value = '0'
+    )
+    AND NOT EXISTS (
+      SELECT 1 FROM processes WHERE path = '/usr/sbin/sshd'
     );
-  # We are not using the launchd table because it does not check if services
-  # are disabled via disabled.plist, which the preference pane uses whenever
-  # a service is disabled after it has been enabled in the past.
+  # The plist check catches services toggled off via the preference pane
+  # (which the launchd table does not reflect). The processes check catches
+  # the v2.0.0 audit's "service not running at the time of audit" requirement,
+  # which the plist check alone misses when SSH is started outside the
+  # preference pane.
   purpose: Informational
   tags: compliance, CIS, CIS_Level1
   contributors: artemist-work

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -406,7 +406,8 @@ spec:
       2. The key to include is allowAirDrop
       3. The key must be set to <false/>
     Note: AirDrop can only be enabled or disabled through configuration profiles. If your
-    organization wants to use AirDrop, it would need to be set through Terminal or the GUI.
+    organization allows AirDrop, that policy must be set through MDM; users may then use
+    the GUI to transfer files if AirDrop is permitted.
   query: |
     SELECT 1 WHERE
       EXISTS (

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -292,8 +292,8 @@ spec:
   platform: darwin
   description: |
     The iCloud Passwords & Keychain is Apple's synchronization service that works with Apple Accounts to synchronize password, passkey, and credit card information across macOS, iOS, iPadOS. The capability allows users to use synced password, passkey, and credit card information in either macOS, iOS, or iPadOS for use in Safari and other applications.
-    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on Enterprise-managed computer.
-    When using personal Apple Accounts and credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
+    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on an Enterprise-managed computer.
+    When using personal Apple Accounts, credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
     Rationale:
     Ensure that iCloud Passwords and Keychain usage aligns with organizational requirements, taking into account whether personal or managed Apple Accounts are being utilized.
     Impact:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -106,33 +106,6 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure XProtect Is Running and Updated
-  platforms: macOS
-  platform: darwin
-  description: |
-    XProtect is Apple's native signature-based antivirus technology. XProtect both finds and blocks the execution of known malware. There are many AV and Endpoint Threat Detection and Response (ETDR) tools available for Mac OS. The native Apple provisioned tool looks for specific known malware and is completely integrated into the OS. No matter what other tools are being used, XProtect should have the latest signatures available.
-  resolution: |
-        Ask your system administrator to deploy a script that will configure:
-        /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist
-        /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist
-        /usr/bin/sudo /usr/bin/xprotect update
-  query: |
-      SELECT 1
-      WHERE (
-          SELECT COUNT(*)
-          FROM launchd
-          WHERE path IN (
-              '/Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist',
-              '/Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist'
-          )
-      ) = 2;
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level1
-  contributors: defensivedepth, getvictor
----
-apiVersion: v1
-kind: policy
-spec:
   name: CIS - Ensure Install Security Responses and System Files Is Enabled (MDM Required)
   platforms: macOS
   platform: darwin
@@ -269,14 +242,18 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure iCloud Keychain is disabled (if your org policy is to disable it) (MDM Required)
+  name: CIS - Ensure iCloud Passwords & Keychain is disabled (if your org policy is to disable it) (MDM Required)
+  cis_id: "2.1.1.1"
   platforms: macOS
   platform: darwin
   description: |
-    The iCloud keychain is Apple's password manager that works with macOS and iOS. The capability allows users to store passwords in either iOS or macOS for use in Safari on both platforms and other iOS-integrated applications. The most pervasive use is driven by iOS use rather than macOS. The passwords stored in a macOS keychain on an Enterprise-managed computer could be stored in Apple's cloud and then be available on a personal computer using the same account. The stored passwords could be for organizational as well as for personal accounts.
-    If passwords are no longer being used as organizational tokens, they are not in scope for iCloud keychain storage.
+    The iCloud Passwords & Keychain is Apple's synchronization service that works with Apple Accounts to synchronize password, passkey, and credit card information across macOS, iOS, iPadOS. The capability allows users to use synced password, passkey, and credit card information in either macOS, iOS, or iPadOS for use in Safari and other applications.
+    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on Enterprise-managed computer.
+    When using personal Apple Accounts and credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
     Rationale:
-    Ensure that the iCloud keychain is used consistently with organizational requirements.
+    Ensure that iCloud Passwords and Keychain usage aligns with organizational requirements, taking into account whether personal or managed Apple Accounts are being utilized.
+    Impact:
+    When iCloud Passwords & Keychain is turned off, password, passkey, and credit card information are no longer synchronized across devices signed in with the same Apple Account. Passwords, passkeys, and credit card information can still be stored locally and accessed through the Passwords and Keychain apps, even when iCloud Passwords & Keychain is turned off.
   resolution: |
     The administrator should configure this via MDM profile.
     Ask your administrator to deploy a profile with the following configuration:
@@ -306,14 +283,18 @@ spec:
 apiVersion: v1
 kind: policy
 spec:
-  name: CIS - Ensure iCloud Keychain is enabled (if your org policy is to enable it) (MDM Required)
+  name: CIS - Ensure iCloud Passwords & Keychain is enabled (if your org policy is to enable it) (MDM Required)
+  cis_id: "2.1.1.1"
   platforms: macOS
   platform: darwin
   description: |
-    The iCloud keychain is Apple's password manager that works with macOS and iOS. The capability allows users to store passwords in either iOS or macOS for use in Safari on both platforms and other iOS-integrated applications. The most pervasive use is driven by iOS use rather than macOS. The passwords stored in a macOS keychain on an Enterprise-managed computer could be stored in Apple's cloud and then be available on a personal computer using the same account. The stored passwords could be for organizational as well as for personal accounts.
-    If passwords are no longer being used as organizational tokens, they are not in scope for iCloud keychain storage.
+    The iCloud Passwords & Keychain is Apple's synchronization service that works with Apple Accounts to synchronize password, passkey, and credit card information across macOS, iOS, iPadOS. The capability allows users to use synced password, passkey, and credit card information in either macOS, iOS, or iPadOS for use in Safari and other applications.
+    The password, passkey, and credit card information stored on macOS in the keychain is stored in Apple's cloud, including on Enterprise-managed computer.
+    When using personal Apple Accounts and credentials may include both enterprise-related and personal data, depending on user behavior and account usage patterns.
     Rationale:
-    Ensure that the iCloud keychain is used consistently with organizational requirements.
+    Ensure that iCloud Passwords and Keychain usage aligns with organizational requirements, taking into account whether personal or managed Apple Accounts are being utilized.
+    Impact:
+    When iCloud Passwords & Keychain is turned off, password, passkey, and credit card information are no longer synchronized across devices signed in with the same Apple Account. Passwords, passkeys, and credit card information can still be stored locally and accessed through the Passwords and Keychain apps, even when iCloud Passwords & Keychain is turned off.
   resolution: |
     The administrator should configure this via MDM profile.
     Ask your administrator to deploy a profile with the following configuration:

--- a/ee/cis/macos-15/cis-policy-queries.yml
+++ b/ee/cis/macos-15/cis-policy-queries.yml
@@ -627,7 +627,7 @@ spec:
     Terminal Method:
     Run the following command to disable Remote Login:
       /usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off
-    Note: This command will disable the service as well as stop it running in time.
+    Note: This command disables Remote Login and stops the SSH service immediately.
   query: |
     SELECT 1 WHERE NOT EXISTS (
       SELECT * FROM plist WHERE

--- a/ee/cis/macos-15/test/profiles/1.6.mobileconfig
+++ b/ee/cis/macos-15/test/profiles/1.6.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 1.6</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-1.6.check</string>
+			<key>PayloadUUID</key>
+			<string>5D4092DE-AD70-4A5D-9915-0B9D78CA9416</string>
+			<key>enforcedSoftwareUpdateDelay</key>
+			<integer>30</integer>
+			<key>forceDelayedSoftwareUpdates</key>
+			<true/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>CIS 1.6 - Ensure Software Update Deferment Is Less Than or Equal to 30 Days</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Software Update Deferment Is Less Than or Equal to 30 Days</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-1.6</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>C64260FA-A009-4CE0-BCC9-E6579566764F</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-15/test/profiles/2.3.1.1.mobileconfig
+++ b/ee/cis/macos-15/test/profiles/2.3.1.1.mobileconfig
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 2.3.1.1</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.3.1.1.check</string>
+			<key>PayloadUUID</key>
+			<string>20061ECB-DF7D-4B67-9337-331258FD9F5C</string>
+			<key>allowAirDrop</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>CIS 2.3.1.1 - Ensure AirDrop Is Disabled When Not Actively Transferring Files</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure AirDrop Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.3.1.1</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>EE6781F3-308D-48E9-98D3-0CD32EC92AE5</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-15/test/profiles/2.6.3.2.mobileconfig
+++ b/ee/cis/macos-15/test/profiles/2.6.3.2.mobileconfig
@@ -30,7 +30,7 @@
 		</dict>
 		<dict>
 			<key>PayloadDisplayName</key>
-			<string>CIS 2.6.3.1 - allowDiagnosticSubmission</string>
+			<string>CIS 2.6.3.4 - allowDiagnosticSubmission</string>
 			<key>PayloadType</key>
 			<string>com.apple.applicationaccess</string>
 			<key>PayloadIdentifier</key>

--- a/ee/cis/macos-15/test/profiles/2.6.3.2.mobileconfig
+++ b/ee/cis/macos-15/test/profiles/2.6.3.2.mobileconfig
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 2.6.3.2 - Siri data sharing</string>
+			<key>PayloadType</key>
+			<string>com.apple.assistant.support</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.3.2.siri-opt-in</string>
+			<key>PayloadUUID</key>
+			<string>33062252-8F54-427F-8064-1334194BEB84</string>
+			<key>Siri Data Sharing Opt-In Status</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 2.6.3.1 - Share Mac Analytics (AutoSubmit)</string>
+			<key>PayloadType</key>
+			<string>com.apple.SubmitDiagInfo</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.3.2.autosubmit</string>
+			<key>PayloadUUID</key>
+			<string>3832AE34-B669-4920-97B9-B6EEEF0FA589</string>
+			<key>AutoSubmit</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 2.6.3.1 - allowDiagnosticSubmission</string>
+			<key>PayloadType</key>
+			<string>com.apple.applicationaccess</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.3.2.diag-submission</string>
+			<key>PayloadUUID</key>
+			<string>FE1CFE38-152C-4540-A6D1-A88B452716AE</string>
+			<key>allowDiagnosticSubmission</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>PayloadDisplayName</key>
+			<string>CIS 2.6.3.3 - Assistive voice donation</string>
+			<key>PayloadType</key>
+			<string>com.apple.Accessibility</string>
+			<key>PayloadIdentifier</key>
+			<string>com.fleetdm.cis-2.6.3.2.assistive-voice</string>
+			<key>PayloadUUID</key>
+			<string>A583F8D8-B330-4C4F-BE7F-7CB2C14777AC</string>
+			<key>AXSAudioDonationSiriImprovementEnabled</key>
+			<false/>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>CIS 2.6.3.x - Disable diagnostic and Siri data sharing to Apple. Covers the four managed_policies keys required by Fleet's combined 'Ensure Sending Diagnostic and Usage Data to Apple Is Disabled' policy.</string>
+	<key>PayloadDisplayName</key>
+	<string>Ensure Sending Diagnostic and Usage Data to Apple Is Disabled</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.cis-2.6.3.2</string>
+	<key>PayloadRemovalDisallowed</key>
+	<false/>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>1E5C9607-4C07-4785-91D4-35713386C645</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_fail.sh
+++ b/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.4 - Ensure Remote Login Is Disabled
+# Enables SSH so the policy query fails.
+/usr/bin/sudo /usr/sbin/systemsetup -setremotelogin on

--- a/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_fail.sh
+++ b/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_fail.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # CIS 2.3.3.4 - Ensure Remote Login Is Disabled
 # Enables SSH so the policy query fails.
-/usr/bin/sudo /usr/sbin/systemsetup -setremotelogin on
+/usr/bin/printf 'yes\n' | /usr/bin/sudo /usr/sbin/systemsetup -setremotelogin on

--- a/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_pass.sh
+++ b/ee/cis/macos-15/test/scripts/CIS_2.3.3.4_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.4 - Ensure Remote Login Is Disabled
+# Disables SSH so the policy query passes.
+/usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off <<< "yes"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #35171

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually



# macOS 15 CIS benchmark v1.1.0 → v2.0.0 change set

## Policy changes

| CIS ID | Policy name (new) | Change type | Effect |
|---|---|---|---|
| 1.1 | CIS - Ensure Apple-provided Software Updates Are Installed (Fleetd Required) | Modified | Renamed from "Ensure All Apple-provided Software Is Current"; resolution expanded with terminal `softwareupdate -i -a` method; `cis_id` added. Query unchanged (still uses fleetd's `software_update` table). |
| 1.6 | CIS - Ensure Software Update Deferment Is Less Than or Equal to 30 Days (MDM Required) | Modified | Added Apple-deprecation note to description; `cis_id` added. Query unchanged. |
| 1.7 | CIS - Ensure XProtect Is Running and Updated | Removed | Deleted — v2.0.0 removed 1.7 from the numbered benchmark and moved it to Supplemental section 7.4. Per authoring outline, Fleet does not track section 7+ recommendations. |
| 2.1.1.1 | CIS - Ensure iCloud Passwords & Keychain is enabled/disabled (MDM Required) | Modified | Renamed from "iCloud Keychain" to match v2.0.0's "Audit iCloud Passwords & Keychain"; Description, Rationale, and Impact Statement updated from the new PDF; `cis_id` added to both enable/disable variants. Query unchanged (`allowCloudKeychainSync` key is the same). |
| 2.3.1.1 | CIS - Ensure AirDrop Is Disabled (MDM Required) | Modified | Added note to resolution stating AirDrop can only be toggled via configuration profile; `cis_id` added. Query unchanged. |
| 2.3.3.4 | CIS - Ensure Remote Login Is Disabled | Modified | Description rewritten to match v2.0.0 text; terminal remediation (`systemsetup -setremotelogin off`) added to resolution; `cis_id` added. Query unchanged (still checks `disabled.plist`). |
| 2.6.3.1, 2.6.3.2, 2.6.3.3, 2.6.3.4 | CIS - Ensure Sending Diagnostic and Usage Data to Apple Is Disabled (MDM Required) | Modified | **Query change**: Siri Data Sharing Opt-In Status check moved from `com.apple.applicationaccess` → `com.apple.assistant.support` domain to track v2.0.0's new PayloadType; `cis_id` added (combined). |
| 2.4.1 | CIS - Ensure Show Wi-Fi status in Menu Bar Is Enabled (MDM Required) | Removed | Deleted — recommendation removed in v2.0.0. |
| 2.4.2 | CIS - Ensure Show Bluetooth Status in Menu Bar Is Enabled (MDM Required) | Removed | Deleted — recommendation removed in v2.0.0 (replaced by Manual 2.4.1 "Audit Menu Bar and Control Center Icons"). |
| 6.1.1 | CIS - Ensure Show All Filename Extensions Setting is Enabled | Removed | Deleted — recommendation downgraded to Manual in v2.0.0. |

Policy count: 113 → 109.

## Test artifacts added

| Target CIS ID | File | Type | Notes |
|---|---|---|---|
| 2.3.3.4 | `ee/cis/macos-15/test/scripts/CIS_2.3.3.4_pass.sh` | pass script | `systemsetup -setremotelogin off` |
| 2.3.3.4 | `ee/cis/macos-15/test/scripts/CIS_2.3.3.4_fail.sh` | fail script | `systemsetup -setremotelogin on` |
| 1.6 | `ee/cis/macos-15/test/profiles/1.6.mobileconfig` | MDM profile | Sets `enforcedSoftwareUpdateDelay=30`, `forceDelayedSoftwareUpdates=true` |
| 2.3.1.1 | `ee/cis/macos-15/test/profiles/2.3.1.1.mobileconfig` | MDM profile | Sets `allowAirDrop=false` |
| 2.6.3.2 | `ee/cis/macos-15/test/profiles/2.6.3.2.mobileconfig` | MDM profile | Four payloads covering the combined Fleet query: Siri opt-in (new v2.0.0 domain), AutoSubmit, allowDiagnosticSubmission, AXSAudioDonationSiriImprovementEnabled |

No test added for 1.1 — query depends on live OS update state (fleetd `software_update` table) and cannot be toggled by a script or profile.

No test added for 2.1.1.1 — it is an org-decision Audit recommendation (Fleet ships both enable and disable variants); one of the two policies fails by construction regardless of system state.

## Documentation updates

| File | Change |
|---|---|
| `ee/cis/macos-15/README.md` | Benchmark version bumped v1.1.0 → v2.0.0. Limitations list renumbered to v2.0.0 section numbers; added 2.4.1 (new "Audit Menu Bar and Control Center Icons") and 6.1.1 (now Manual "Audit Show All Filename Extensions"). Org-decision entry renamed from "Audit iCloud Keychain" to "Audit iCloud Passwords & Keychain" to match v2.0.0 terminology. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated macOS 15 CIS benchmark changelog to v2.0.0.

* **Updates**
  * Renamed several policies for clarity, added CIS ID mappings, clarified scope/impact and enhanced remediation and compliance notes.

* **New Features**
  * Added configuration profiles to enforce software update deferment, disable AirDrop, and disable diagnostic/data sharing.

* **Tests**
  * Added pass/fail verification scripts for Remote Login.

* **Removed**
  * Removed outdated policies (XProtect, Wi‑Fi/Bluetooth menu items, filename extensions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->