### PR TITLE
Update disk encryption enforcement details for Windows

### DIFF
--- a/articles/enforce-disk-encryption.md
+++ b/articles/enforce-disk-encryption.md
@@ -10,7 +10,9 @@ When disk encryption is enforced, hosts' disk encryption keys will be stored in 
 
 For macOS hosts that automatically enroll, end users are forced to enable disk encryption during Setup Assistant. For hosts that manually enroll, end users are forced to enable disk encryption the next time they log out and log back in. For both enroll methods, end users can't defer. 
 
-For Windows, currently disk encryption is enforced on the C: volume (default system/OS drive) only on hosts with a [TPM chip](https://support.microsoft.com/en-us/topic/what-s-a-trusted-platform-module-tpm-705f241d-025d-4470-80c5-4feeb24fa1ee). For Linux, encryption requires end user interaction.
+For Windows, currently, disk encryption is enforced on the C: volume (default system/OS drive) only on hosts with a [TPM chip](https://support.microsoft.com/en-us/topic/what-s-a-trusted-platform-module-tpm-705f241d-025d-4470-80c5-4feeb24fa1ee). BitLocker PIN can only be enforced on hosts that do not have the C: volume already encrypted.
+
+For Linux, encryption requires end user interaction.
 
 ## Enforce disk encryption
 

--- a/articles/enforce-disk-encryption.md
+++ b/articles/enforce-disk-encryption.md
@@ -12,7 +12,7 @@ For macOS hosts that automatically enroll, end users are forced to enable disk e
 
 For Windows, currently, disk encryption is enforced on the C: volume (default system/OS drive) only on hosts with a [TPM chip](https://support.microsoft.com/en-us/topic/what-s-a-trusted-platform-module-tpm-705f241d-025d-4470-80c5-4feeb24fa1ee). BitLocker PIN can only be enforced on hosts that do not have the C: volume already encrypted.
 
-For Linux, encryption requires end user interaction.
+For Linux, encryption requires end user interaction. [Learn more](#enforce-disk-encryption-on-linux).
 
 ## Enforce disk encryption
 


### PR DESCRIPTION
Added information about BitLocker PIN enforcement for Windows hosts with existing C: volume encryption.

**Related issue:** Resolves #42318