### PR TITLE
Potential fix for code scanning alert no. 1537: Incorrect conversion between integer types

### DIFF
--- a/server/cron/calendar_cron.go
+++ b/server/cron/calendar_cron.go
@@ -514,7 +514,7 @@ func getBodyTag(ctx context.Context, ds fleet.Datastore, host fleet.HostPolicyMe
 		var policy *calendar.PolicyLiteWithMeta
 		policyAny, ok := policyIDtoPolicy.Load(policyIDs[0])
 		if !ok {
-			id, err := strconv.ParseUint(policyIDs[0], 10, 64)
+			id, err := strconv.ParseUint(policyIDs[0], 10, strconv.IntSize)
 			if err != nil {
 				logger.ErrorContext(ctx, "parse policy id", "err", err)
 				// Do nothing


### PR DESCRIPTION
Potential fix for [https://github.com/fleetdm/fleet/security/code-scanning/1537](https://github.com/fleetdm/fleet/security/code-scanning/1537)

Use `strconv.ParseUint` with the target type bit size for `uint` instead of parsing as 64-bit and narrowing later. The best fix here is to change line 517 in `server/cron/calendar_cron.go` from parsing with bit size `64` to parsing with `strconv.IntSize`, then keep `uint(id)` conversion. This guarantees parsed values always fit `uint` on the current platform and preserves behavior (invalid/out-of-range IDs already return `""` via existing error handling).

Changes needed:
- In `server/cron/calendar_cron.go`, inside `getBodyTag`, update:
  - `strconv.ParseUint(policyIDs[0], 10, 64)` → `strconv.ParseUint(policyIDs[0], 10, strconv.IntSize)`.
- No new imports required (`strconv` already imported).
- No additional methods/definitions required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal ID parsing logic in the calendar scheduling system to be more robust and reduce parsing-related errors; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->