### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/connect-fonts/darwin.json
+++ b/ee/maintained-apps/outputs/connect-fonts/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "28.1.2",
+      "version": "28.1.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion' AND version_compare(bundle_short_version, '28.1.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.extensis.SuitcaseFusion' AND version_compare(bundle_short_version, '28.1.3') < 0);"
       },
-      "installer_url": "https://bin.extensis.com/ConnectFonts-M-28-1-2.dmg",
+      "installer_url": "https://bin.extensis.com/ConnectFonts-M-28-1-3.dmg",
       "install_script_ref": "e2e807f7",
       "uninstall_script_ref": "879ff30b",
-      "sha256": "dfd4a8ea4f9a6f2c84c76a4f24f42cdf88615099fac6b0b43bc90fe8ccb53469",
+      "sha256": "2ccf7731b7cea564b8bc86f9da7d116dd9b189adf2e33e17009601a7170c3812",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/discord/darwin.json
+++ b/ee/maintained-apps/outputs/discord/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.0.386",
+      "version": "0.0.387",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.386') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.hnc.Discord' AND version_compare(bundle_short_version, '0.0.387') < 0);"
       },
-      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.386/Discord.dmg",
+      "installer_url": "https://dl.discordapp.net/apps/osx/0.0.387/Discord.dmg",
       "install_script_ref": "dac37ced",
       "uninstall_script_ref": "8ed76f08",
-      "sha256": "a01cf51f325bb95f4f9dd2ca96f9c1a03f547ac00c4e2034164835508cd8a04d",
+      "sha256": "1fe39dc2dd91cb70b5f8e32155dafd3e30173a723cbe6b1491204bf1d89e6a47",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/zotero/darwin.json
+++ b/ee/maintained-apps/outputs/zotero/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "9.0",
+      "version": "9.0.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '9.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.zotero.zotero' AND version_compare(bundle_short_version, '9.0.1') < 0);"
       },
-      "installer_url": "https://download.zotero.org/client/release/9.0/Zotero-9.0.dmg",
+      "installer_url": "https://download.zotero.org/client/release/9.0.1/Zotero-9.0.1.dmg",
       "install_script_ref": "53036bac",
       "uninstall_script_ref": "24de4c91",
-      "sha256": "2ac2a826ac1632ec6f81b668d9cd34fb8f78f92f57ecdeb2e0d6b481769ac32e",
+      "sha256": "c7dce69eea9d837d7ed5f0a3462059f943bdaa6c5a561c0113a723b390871711",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS package metadata for Connect Fonts (version 28.1.3), Discord (version 0.0.387), and Zotero (version 9.0.1).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->