### PR TITLE
Update class on exceptions field to fix padding

### DIFF
--- a/changes/43070-fix-exceptions-padding
+++ b/changes/43070-fix-exceptions-padding
@@ -1,0 +1,1 @@
+- Fixed padding between GitOps exceptions checkboxes

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -227,7 +227,7 @@ const ChangeManagement = () => {
               Exceptions
             </TooltipWrapper>
           </div>
-          <div>
+          <div className="form-field">
             <Checkbox
               onChange={onInputChange}
               name="exceptLabels"


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43070

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [X] QA'd all new/changed functionality manually

### Before
<img width="200" height="177" alt="image" src="https://github.com/user-attachments/assets/aa40fe1c-9390-4b4e-accd-3b9cb58dcac4" />

### After
<img width="274" height="193" alt="image" src="https://github.com/user-attachments/assets/afda7d66-b4ce-4884-a922-2b3604280237" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed padding between GitOps exceptions checkboxes in the Change Management section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->