### PR TITLE
Website: update build-static-content script to be compatible with Node versions under 20

### DIFF
--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -771,7 +771,7 @@ module.exports = {
                   } else {
                     let parsedVideoUrl;
                     try {
-                      parsedVideoUrl = require('URL').parse(embeddedMetadata.webinarEmbeddedVideoUrl);
+                      parsedVideoUrl = require('url').parse(embeddedMetadata.webinarEmbeddedVideoUrl);
                     } catch(err) {
                       throw new Error(`Failed compiling markdown content: A webinar article has an invalid "webinarEmbeddedVideoUrl" value (${embeddedMetadata.webinarEmbeddedVideoUrl}) at ${path.join(topLvlRepoPath, pageSourcePath)}. Please change this value to be a valid URL of the webinar recording with no query strings.`, err);
                     }

--- a/website/scripts/build-static-content.js
+++ b/website/scripts/build-static-content.js
@@ -771,7 +771,7 @@ module.exports = {
                   } else {
                     let parsedVideoUrl;
                     try {
-                      parsedVideoUrl = URL.parse(embeddedMetadata.webinarEmbeddedVideoUrl);
+                      parsedVideoUrl = require('URL').parse(embeddedMetadata.webinarEmbeddedVideoUrl);
                     } catch(err) {
                       throw new Error(`Failed compiling markdown content: A webinar article has an invalid "webinarEmbeddedVideoUrl" value (${embeddedMetadata.webinarEmbeddedVideoUrl}) at ${path.join(topLvlRepoPath, pageSourcePath)}. Please change this value to be a valid URL of the webinar recording with no query strings.`, err);
                     }


### PR DESCRIPTION
Changes:
- Updated the `URL.parse` in build-static-content to be `require('URL').parse()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webinar video URL parsing for greater reliability. Existing behavior remains: parse failures still produce errors and video links containing query strings are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->