### PR TITLE
Make labels on the host detail page render horizontally

### DIFF
--- a/frontend/pages/hosts/details/cards/Labels/Labels.tsx
+++ b/frontend/pages/hosts/details/cards/Labels/Labels.tsx
@@ -28,11 +28,11 @@ const Labels = ({
     .filter((label: ILabel) => label.label_type !== "builtin")
     .map((label: ILabel) => {
       return (
-        <li className="list__item" key={label.id}>
+        <li className={`${baseClass}__list-item`} key={label.id}>
           <Button
             onClick={() => onLabelClick(label)}
             variant="pill"
-            className="list__button"
+            className={`${baseClass}__list-button`}
           >
             <TooltipTruncatedText value={label.name} />
           </Button>
@@ -52,7 +52,7 @@ const Labels = ({
           No labels are associated with this host.
         </p>
       ) : (
-        <ul className="list">{labelItems}</ul>
+        <ul className={`${baseClass}__list`}>{labelItems}</ul>
       )}
     </Card>
   );

--- a/frontend/pages/hosts/details/cards/Labels/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Labels/_styles.scss
@@ -1,14 +1,18 @@
 .host-labels-card {
   @include vertical-card-layout;
 
-  .list {
+  &__list {
     display: flex;
+    flex-direction: row;
     flex-wrap: wrap;
     gap: $pad-small;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
 
-    .list__item {
-      margin-bottom: 0;
-    }
+  &__list-item {
+    margin-bottom: 0;
   }
 
   .button,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43914 

Make labels on the host detail page render horizontally

<img width="1856" height="1076" alt="image" src="https://github.com/user-attachments/assets/dc6f21f2-0ee9-49f0-87cc-88202127824b" />


# Checklist for submitter

## Testing

- [X] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refactored internal CSS styling for the host labels card component to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->