### PR TITLE
Add AWS VPN Client for macOS to testing and QA

### DIFF
--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -51,7 +51,13 @@ policies:
 reports:
 software:
   packages:
-    # Linux apps
+  
   fleet_maintained_apps:
+    - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
+      self_service: true
+      labels_include_any:
+        - "IdP group: SAML-aws-vpn"
+      categories:
+        - Utilities
     # macOS apps
     # Windows apps


### PR DESCRIPTION
Added AWS VPN Client for macOS to fleet maintained apps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS VPN Client for macOS is now available through self-service deployment for designated user groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->