### PR TITLE
Website: Update partners form, update action input validation

### DIFF
--- a/website/api/controllers/deliver-deal-registration-submission.js
+++ b/website/api/controllers/deliver-deal-registration-submission.js
@@ -10,13 +10,13 @@ module.exports = {
   inputs: {
     submittersFirstName: {type: 'string', required: true},
     submittersLastName: {type: 'string', required: true},
-    submittersEmailAddress: {type: 'string', isEmail: true,},
+    submittersEmailAddress: {type: 'string', isEmail: true, required: true},
     submittersOrganization: {type: 'string', required: true},
     submitterIsExistingPartner: {type: 'string', required: true},
 
     customersOrganization: {type: 'string', required: true},
     customersName: {type: 'string', required: true},
-    customersEmailAddress: {type: 'string', isEmail: true,},
+    customersEmailAddress: {type: 'string', isEmail: true, required: true},
 
     dealStage: {type: 'string', required: true},
     expectedClose: {type: 'string', required: true},
@@ -30,14 +30,21 @@ module.exports = {
 
   exits: {
     success: {description: 'A deal registration email was successfully sent.'},
+    invalidEmailDomain: {
+      description: 'This email address is on a denylist of domains and was not delivered.',
+      responseType: 'badRequest'
+    },
   },
 
 
   fn: async function (inputs) {
+    let emailDomain = inputs.submittersEmailAddress.split('@')[1];
+    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
+      throw 'invalidEmailDomain';
+    }
     if(!sails.config.custom.dealRegistrationContactEmailAddress){
       throw new Error('Missing config variable! Please set sails.config.custom.dealRegistrationContactEmailAddress to be the email address of the person who receives deal registration submissions.');
     }
-
     let emailTemplateData = _.omit(inputs, ['platforms', 'useCase']);
 
 

--- a/website/api/controllers/deliver-partner-registration-submission.js
+++ b/website/api/controllers/deliver-partner-registration-submission.js
@@ -12,7 +12,7 @@ module.exports = {
     submittersLastName: { type: 'string', required: true },
     submittersEmailAddress: { type: 'string', required: true, isEmail: true },
     submittersOrganization: { type: 'string', required: true },
-    partnerType: { type: 'string', required: true },
+    partnerType: { type: 'string', required: true, isIn: ['reseller', 'integrations'] },
     partnerWebsite: { type: 'string', required: true },
     partnerCountry: { type: 'string', required: true },
     notes: {type: 'string', required: true },
@@ -26,7 +26,6 @@ module.exports = {
   exits: {
     success: {description: 'A partner registration email was successfully sent.'},
     missingInput: {description: 'The form submission is missing a required input', responseType: 'badRequest'},
-    invalidPartnerType: {description: 'This form submission has an unexpectedValue', responseType: 'badRequest'},
     invalidEmailDomain: {
       description: 'This email address is on a denylist of domains and was not delivered.',
       responseType: 'badRequest'
@@ -63,9 +62,6 @@ module.exports = {
     };
     emailTemplateData.goal = partnerTypeFriendlyNameValuesByFormValue[inputs.partnerType];
 
-    if(!emailTemplateData.goal) {
-      throw 'invalidPartnerType';
-    }
     // Default to sending these to the configured fromEmailAddress
     let toEmail = sails.config.custom.fromEmailAddress;
     if(inputs.partnerType === 'reseller') {

--- a/website/api/controllers/deliver-partner-registration-submission.js
+++ b/website/api/controllers/deliver-partner-registration-submission.js
@@ -26,7 +26,7 @@ module.exports = {
   exits: {
     success: {description: 'A partner registration email was successfully sent.'},
     missingInput: {description: 'The form submission is missing a required input', responseType: 'badRequest'},
-    unexpectedValue: {description: 'This form submission has an unexpectedValue', responseType: 'badRequest'},
+    invalidPartnerType: {description: 'This form submission has an unexpectedValue', responseType: 'badRequest'},
     invalidEmailDomain: {
       description: 'This email address is on a denylist of domains and was not delivered.',
       responseType: 'badRequest'
@@ -64,7 +64,7 @@ module.exports = {
     emailTemplateData.goal = partnerTypeFriendlyNameValuesByFormValue[inputs.partnerType];
 
     if(!emailTemplateData.goal) {
-      throw 'unexpectedValue';
+      throw 'invalidPartnerType';
     }
     // Default to sending these to the configured fromEmailAddress
     let toEmail = sails.config.custom.fromEmailAddress;

--- a/website/api/controllers/deliver-partner-registration-submission.js
+++ b/website/api/controllers/deliver-partner-registration-submission.js
@@ -26,10 +26,19 @@ module.exports = {
   exits: {
     success: {description: 'A partner registration email was successfully sent.'},
     missingInput: {description: 'The form submission is missing a required input', responseType: 'badRequest'},
+    unexpectedValue: {description: 'This form submission has an unexpectedValue', responseType: 'badRequest'},
+    invalidEmailDomain: {
+      description: 'This email address is on a denylist of domains and was not delivered.',
+      responseType: 'badRequest'
+    },
   },
 
 
   fn: async function (inputs) {
+    let emailDomain = inputs.submittersEmailAddress.split('@')[1];
+    if(_.includes(sails.config.custom.bannedEmailDomainsForWebsiteSubmissions, emailDomain.toLowerCase())){
+      throw 'invalidEmailDomain';
+    }
     if(!sails.config.custom.dealRegistrationContactEmailAddress){
       throw new Error('Missing config variable! Please set sails.config.custom.dealRegistrationContactEmailAddress to be the email address of the person who receives deal registration submissions.');
     }
@@ -53,6 +62,10 @@ module.exports = {
       'integrations': 'Build integrations with Fleet'
     };
     emailTemplateData.goal = partnerTypeFriendlyNameValuesByFormValue[inputs.partnerType];
+
+    if(!emailTemplateData.goal) {
+      throw 'unexpectedValue';
+    }
     // Default to sending these to the configured fromEmailAddress
     let toEmail = sails.config.custom.fromEmailAddress;
     if(inputs.partnerType === 'reseller') {

--- a/website/api/controllers/deliver-webinar-access-request.js
+++ b/website/api/controllers/deliver-webinar-access-request.js
@@ -10,7 +10,7 @@ module.exports = {
   inputs: {
     firstName: {type: 'string', required: true },
     lastName: {type: 'string', required: true },
-    emailAddress: {type: 'string', required: true },
+    emailAddress: {type: 'string', required: true, isEmail: true, },
     webinarName: {type: 'string', required: true },
   },
 

--- a/website/api/controllers/deliver-whitepaper-download-request.js
+++ b/website/api/controllers/deliver-whitepaper-download-request.js
@@ -10,7 +10,7 @@ module.exports = {
   inputs: {
     firstName: {type: 'string', required: true },
     lastName: {type: 'string', required: true },
-    emailAddress: {type: 'string', required: true },
+    emailAddress: {type: 'string', required: true, isEmail: true },
     whitepaperName: {type: 'string', required: true },
   },
 

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -414,11 +414,13 @@ module.exports.custom = {
     'yahoo.co.uk',     'yahoo.com',    'yahoo.com.ar',     'yahoo.com.au',
     'yahoo.com.br',    'yahoo.com.mx', 'yahoo.com.sg',     'yahoo.de',
     'yahoo.es',        'yahoo.fr',     'yahoo.in',         'yahoo.it',
-    'yandex.ru',       'ymail.com',    'zoho.com',         'zonnet.nl'
+    'yandex.ru',       'ymail.com',    'zoho.com',         'zonnet.nl',
+    'email.tst',
   ],
 
   // For website signups & "Talk to us" form submissions:
   bannedEmailDomainsForWebsiteSubmissions: [
+    'email.tst',
     'example.com',
     'gmail.com',
     'hotmail.ca',
@@ -439,7 +441,7 @@ module.exports.custom = {
     'yahoo.com',
     'yahoo.co.uk',
     'yandex.ru',
-    'ymail.com'
+    'ymail.com',
   ],
 
   // For contact form submissions.

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -184,7 +184,7 @@
             <div class="invalid-feedback" v-if="formErrors.submittersOrganization">Please enter the name of your organization.</div>
           </div>
           <div class="form-group">
-            <label purpose="checkbox-group-label">How will you work with Fleet?</label>
+            <label purpose="checkbox-group-label">How will you work with Fleet? *</label>
             <label purpose="form-option" class="form-control" :class="[partnerFormData.partnerType === 'reseller' ? 'selected' : '']">
               <input type="radio" v-model.trim="partnerFormData.partnerType" value="reseller" >
               <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
@@ -197,17 +197,17 @@
             </label>
           </div>
           <div class="form-group">
-            <label for="partner-website">Website</label>
+            <label for="partner-website">Website *</label>
             <input class="form-control" id="partner-website" :class="[formErrors.partnerWebsite ? 'is-invalid' : '']"  v-model.trim="partnerFormData.partnerWebsite" >
-            <div class="invalid-feedback" v-if="formErrors.partnerWebsite">Please select an option.</div>
+            <div class="invalid-feedback" v-if="formErrors.partnerWebsite">Please provide your website.</div>
           </div>
           <div class="form-group">
-            <label for="partner-country">Country</label>
+            <label for="partner-country">Country *</label>
             <input class="form-control" id="partner-country" :class="[formErrors.partnerCountry ? 'is-invalid' : '']"  v-model.trim="partnerFormData.partnerCountry" >
-            <div class="invalid-feedback" v-if="formErrors.partnerCountry">Please select an option.</div>
+            <div class="invalid-feedback" v-if="formErrors.partnerCountry">Please provide your country.</div>
           </div>
           <div v-if="partnerFormData.partnerType === 'reseller'">
-            <label purpose="checkbox-group-label" for="partner-services-offered">Services offered</label>
+            <label purpose="checkbox-group-label" for="partner-services-offered">Services offered *</label>
             <div class="form-group" :class="[formErrors.servicesOffered ? 'is-invalid' : '']">
               <div purpose="input-group">
                 <label purpose="custom-checkbox-label" for="device-management" @click="clickSelectCustomCheckbox()">
@@ -234,7 +234,7 @@
               </div>
             </div>
             <div class="form-group">
-              <label for="partner-number-of-hosts">Approx. endpoints managed</label>
+              <label for="partner-number-of-hosts">Approx. endpoints managed *</label>
               <select class="form-control custom-select" v-model.trim="partnerFormData.numberOfHosts" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']">
                 <option :value="undefined">Select</option>
                 <option value="1 - 100">1 - 100</option>
@@ -248,7 +248,7 @@
           </div>
           <div v-else>
             <div class="form-group">
-              <label for="partner-service-description">Which best describes your services?</label>
+              <label for="partner-service-description">Which best describes your services? *</label>
               <select class="form-control custom-select" id="partner-service-description" v-model.trim="partnerFormData.servicesCategory" :class="[formErrors.servicesCategory ? 'is-invalid' : '']">
                 <option :value="undefined">Select</option>
                 <option value="Security">Security</option>
@@ -264,11 +264,11 @@
           </div>
           <div class="form-group">
             <div purpose="form-label" v-if="partnerFormData.partnerType === 'reseller'">
-              <label for="notes">Tell us about your services or customers</label>
+              <label for="notes">Tell us about your services or customers *</label>
               <p>E.g., types of customers, deployments, or services you offer.</p>
             </div>
             <div purpose="form-label"  v-else>
-              <label for="notes">Tell us about your integration</label>
+              <label for="notes">Tell us about your integration *</label>
               <p>E.g., data integration, product integration, or co-marketing.</p>
             </div>
             <textarea class="form-control" :class="[formErrors.notes ? 'is-invalid' : '']" id="notes" type="textarea" v-model.trim="partnerFormData.notes" >
@@ -305,31 +305,31 @@
           <div class="row">
             <div class="col-12 col-sm-6 pr-sm-2">
               <div class="form-group">
-                <label for="submitter-first-name">First name</label>
+                <label for="submitter-first-name">First name *</label>
                 <input class="form-control" id="submitter-first-name" type="text"  :class="[formErrors.partnersFirstName ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.submittersFirstName" autocomplete="first-name">
                 <div class="invalid-feedback" v-if="formErrors.submittersFirstName">Please enter your first name.</div>
               </div>
             </div>
             <div class="col-12 col-sm-6 pl-sm-2">
               <div class="form-group">
-                <label for="submitter-last-name">Last name</label>
+                <label for="submitter-last-name">Last name *</label>
                 <input class="form-control" id="submitter-last-name" type="text"  :class="[formErrors.submittersLastName ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.submittersLastName" autocomplete="last-name">
                 <div class="invalid-feedback" v-if="formErrors.submittersLastName">Please enter your last name.</div>
               </div>
             </div>
           </div>
           <div class="form-group">
-            <label for="submitters-email-address">Email</label>
+            <label for="submitters-email-address">Email *</label>
             <input class="form-control" id="submitters-email-address"  :class="[formErrors.submittersEmailAddress ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.submittersEmailAddress">
             <div class="invalid-feedback" v-if="formErrors.submittersEmailAddress" focus-first>This doesn’t appear to be a valid email address</div>
           </div>
           <div class="form-group">
-            <label for="submitters-organization">Company</label>
+            <label for="submitters-organization">Company *</label>
             <input class="form-control" id="submitters-organization" type="text"  :class="[formErrors.submittersOrganization ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.submittersOrganization">
             <div class="invalid-feedback" v-if="formErrors.submittersOrganization">Please enter the name of your organization.</div>
           </div>
           <div class="form-group" :class="[formErrors.submitterIsExistingPartner ? 'is-invalid' : '']" >
-            <strong>Are you an existing Fleet partner</strong>
+            <strong>Are you an existing Fleet partner *</strong>
             <label purpose="form-option" class="form-control" :class="[dealRegistrationFormData.submitterIsExistingPartner === 'yes' ? 'selected' : '']">
               <input type="radio" v-model.trim="dealRegistrationFormData.submitterIsExistingPartner" value="yes" >
               <span purpose="custom-radio"><span purpose="custom-radio-selected"></span></span>
@@ -350,17 +350,17 @@
         <div purpose="form-section">
           <h3>Customer details</h3>
           <div class="form-group">
-            <label for="customer-organization">Company</label>
+            <label for="customer-organization">Company *</label>
             <input class="form-control" id="customer-organization"  :class="[formErrors.customersOrganization ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.customersOrganization">
             <div class="invalid-feedback" v-if="formErrors.customersOrganization" focus-first>Please enter the customer's company</div>
           </div>
           <div class="form-group">
-            <label for="customer-name">Contact name</label>
+            <label for="customer-name">Contact name *</label>
             <input class="form-control" id="customer-name" type="text"  :class="[formErrors.customersName ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.customersName" autocomplete="first-name">
             <div class="invalid-feedback" v-if="formErrors.customersName">Please enter the customer's name.</div>
           </div>
           <div class="form-group">
-            <label for="customers-email-address">Contact email</label>
+            <label for="customers-email-address">Contact email *</label>
             <input class="form-control" id="customers-email-address"  :class="[formErrors.customersEmailAddress ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.customersEmailAddress">
             <div class="invalid-feedback" v-if="formErrors.customersEmailAddress" focus-first>This doesn’t appear to be a valid email address</div>
           </div>
@@ -369,7 +369,7 @@
         <div purpose="form-section">
           <h3>Deal qualification</h3>
           <div class="form-group">
-            <label for="deal-stage">Deal stage</label>
+            <label for="deal-stage">Deal stage *</label>
             <select class="form-control custom-select" id="deal-stage"  :class="[formErrors.dealStage ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.dealStage">
               <option :value="undefined">Select</option>
               <option value="Identified">Identified</option>
@@ -380,7 +380,7 @@
             <div class="invalid-feedback" v-if="formErrors.dealStage" focus-first>Please select a deal stage</div>
           </div>
           <div class="form-group">
-            <label for="expected-close">Expected close</label>
+            <label for="expected-close">Expected close *</label>
             <select class="form-control custom-select" id="expected-close" :class="[formErrors.expectedClose ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.expectedClose">
               <option :value="undefined">Select</option>
               <option value="< 1 month">< 1 month</option>
@@ -391,7 +391,7 @@
             <div class="invalid-feedback" v-if="formErrors.expectedClose" focus-first>Please select an option</div>
           </div>
           <div class="form-group">
-            <label for="reseller-number-of-devices">Estimated number of devices</label>
+            <label for="reseller-number-of-devices">Estimated number of devices *</label>
             <select class="form-control custom-select" :class="[formErrors.numberOfHosts ? 'is-invalid' : '']" v-model.trim="dealRegistrationFormData.numberOfHosts">
               <option :value="undefined">Select</option>
               <option value="1 - 100">1 - 100</option>
@@ -403,7 +403,7 @@
           </div>
 
 
-          <label purpose="checkbox-group-label" for="deal-reg-platforms">Platforms</label>
+          <label purpose="checkbox-group-label" for="deal-reg-platforms">Platforms *</label>
           <div purpose="checkbox-group" class="form-group d-flex flex-column" :class="[formErrors.platforms ? 'is-invalid' : '']">
               <label purpose="custom-checkbox-label" for="apple" @click="clickSelectCustomCheckbox()">
                 <span purpose="custom-checkbox" :class="[dealRegistrationFormData.platforms.apple ? 'checked' : '']" ><span purpose="custom-checkbox-check"></span></span>
@@ -428,7 +428,7 @@
               <div class="invalid-feedback" v-if="formErrors.platforms" focus-first>Please select an option</div>
           </div>
 
-          <label purpose="checkbox-group-label" for="deal-reg-use-case">Use case</label>
+          <label purpose="checkbox-group-label" for="deal-reg-use-case">Use case *</label>
         <div purpose="checkbox-group" class="form-group d-flex flex-column" :class="[formErrors.useCase ? 'is-invalid' : '']">
             <label purpose="custom-checkbox-label" for="mdm" @click="clickSelectCustomCheckbox()">
               <span purpose="custom-checkbox" :class="[dealRegistrationFormData.useCase.mdm ? 'checked' : '']" ><span purpose="custom-checkbox-check"></span></span>
@@ -444,7 +444,7 @@
           </div>
 
           <div class="form-group">
-            <label for="deal-notes">Additional notes</label>
+            <label for="deal-notes">Additional notes *</label>
             <textarea class="form-control" id="deal-notes" type="textarea" :class="[formErrors.notes ? 'is-invalid' : '']"  v-model.trim="dealRegistrationFormData.notes"></textarea>
             <div class="invalid-feedback" v-if="formErrors.notes" focus-first>Please provide more information</div>
           </div>

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -276,7 +276,7 @@
             <div class="invalid-feedback">Please provide more information</div>
           </div>
         </div>
-        <cloud-error v-if="cloudError === 'invalidEmailDomain'">
+        <cloud-error purpose="cloud-error" v-if="cloudError === 'invalidEmailDomain'">
           <p>
             Please enter your work email address.
           </p>
@@ -449,7 +449,7 @@
             <div class="invalid-feedback" v-if="formErrors.notes" focus-first>Please provide more information</div>
           </div>
         </div>
-        <cloud-error v-if="cloudError === 'invalidEmailDomain'">
+        <cloud-error purpose="cloud-error" v-if="cloudError === 'invalidEmailDomain'">
           <p>
             Please enter your work email address.
           </p>

--- a/website/views/pages/partners.ejs
+++ b/website/views/pages/partners.ejs
@@ -276,7 +276,12 @@
             <div class="invalid-feedback">Please provide more information</div>
           </div>
         </div>
-        <cloud-error purpose="cloud-error" v-if="cloudError"></cloud-error>
+        <cloud-error v-if="cloudError === 'invalidEmailDomain'">
+          <p>
+            Please enter your work email address.
+          </p>
+        </cloud-error>
+        <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>
         <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="!cloudError">Submit</ajax-button>
         <ajax-button purpose="submit-button" type="button" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="cloudError" @click="clickResetForm()">Try again</ajax-button>
       </ajax-form>
@@ -444,7 +449,12 @@
             <div class="invalid-feedback" v-if="formErrors.notes" focus-first>Please provide more information</div>
           </div>
         </div>
-        <cloud-error purpose="cloud-error" v-if="cloudError"></cloud-error>
+        <cloud-error v-if="cloudError === 'invalidEmailDomain'">
+          <p>
+            Please enter your work email address.
+          </p>
+        </cloud-error>
+        <cloud-error purpose="cloud-error" v-else-if="cloudError"></cloud-error>
         <p class="small">By submitting you agree to our <a href="/legal/privacy">privacy policy</a> and <a href="/terms">terms of service</a>.</p>
         <ajax-button purpose="submit-button" spinner="true" type="submit" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="!cloudError">Submit</ajax-button>
         <ajax-button purpose="submit-button" type="button" :syncing="syncing" class="btn btn-block btn-lg btn-primary mt-4" v-if="cloudError" @click="clickResetForm()">Try again</ajax-button>


### PR DESCRIPTION
Changes:
- Updated the input validation and added an invalidEmailDomain exit to the deliver-deal-registration-submission and deliver-partner-registration-submission actions
- Updated the input validation in the deliver-whitepaper-download-request and deliver-webinar-access-request actions
- Added error messages to the forms on the partners page for the added exits
- Updated the `bannedEmailDomainsForCSRSigning` and `bannedEmailDomainsForWebsiteSubmissions` config values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Blocked submissions from restricted email domains with a clear error response and a prompt to use a work email.
* **Bug Fixes**
  * Strengthened email-format and required-field validation across registration and request forms.
  * Restricted partner registration type options to accepted values.
* **Chores**
  * Added a domain to the denylist used for website submissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->