### PR TITLE
Bugfix: escape characters not supported in JSON when resolving variables 

### DIFF
--- a/changes/43955-gitops-escape-json-in-vars
+++ b/changes/43955-gitops-escape-json-in-vars
@@ -1,0 +1,1 @@
+- Automatically escape JSON special characters in GitOps variables used in `.json` configuration profiles (Apple DDM declarations and Android profiles).

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3942,11 +3942,12 @@ func (s *enterpriseIntegrationGitopsTestSuite) TestJSONConfigurationProfileEscap
 	const (
 		declIdentifier     = "com.fleetdm.json.escape.test"
 		secretPasswordName = "JSON_ESCAPE_PASSWORD"
+
+		// Values contain characters that break naive JSON string interpolation
+		// (double quote, backslash, and XML-significant chars for completeness).
+		secretPasswordValue = `custom"password\tag&<>` //nolint:gosec // G101: test fixture, not a credential
+		apiKeyValue         = `my"api&key\v`           //nolint:gosec // G101: test fixture, not a credential
 	)
-	// Values contain characters that break naive JSON string interpolation
-	// (double quote, backslash, and XML-significant chars for completeness).
-	const secretPasswordValue = `custom"password\tag&<>` //nolint:gosec // G101: test fixture, not a credential
-	const apiKeyValue = `my"api&key\v`                   //nolint:gosec // G101: test fixture, not a credential
 
 	t.Setenv("FLEET_SECRET_"+secretPasswordName, secretPasswordValue)
 	t.Setenv("API_KEY", apiKeyValue)

--- a/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
+++ b/cmd/fleetctl/integrationtest/gitops/gitops_enterprise_integration_test.go
@@ -3928,6 +3928,107 @@ reports:
 		"secret should be stored as the raw value (not XML-escaped)")
 }
 
+// TestJSONConfigurationProfileEscaping covers issue #38013 — JSON profiles
+// (Apple DDM declarations) must have variable values JSON-escaped at expansion
+// time, while the underlying secret is still stored on the server unescaped.
+func (s *enterpriseIntegrationGitopsTestSuite) TestJSONConfigurationProfileEscaping() {
+	t := s.T()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	user := s.createGitOpsUser(t)
+	fleetctlConfig := s.createFleetctlConfig(t, user)
+
+	const (
+		declIdentifier     = "com.fleetdm.json.escape.test"
+		secretPasswordName = "JSON_ESCAPE_PASSWORD"
+	)
+	// Values contain characters that break naive JSON string interpolation
+	// (double quote, backslash, and XML-significant chars for completeness).
+	const secretPasswordValue = `custom"password\tag&<>` //nolint:gosec // G101: test fixture, not a credential
+	const apiKeyValue = `my"api&key\v`                   //nolint:gosec // G101: test fixture, not a credential
+
+	t.Setenv("FLEET_SECRET_"+secretPasswordName, secretPasswordValue)
+	t.Setenv("API_KEY", apiKeyValue)
+	t.Setenv("FLEET_URL", s.Server.URL)
+
+	declPath := filepath.Join(tempDir, "decl.json")
+	declBody := fmt.Sprintf(`{
+		"Type": "com.apple.configuration.management.test",
+		"Identifier": %q,
+		"Payload": {
+			"Password": "$FLEET_SECRET_%s",
+			"ApiKey": "$API_KEY"
+		}
+	}`, declIdentifier, secretPasswordName)
+	require.NoError(t, os.WriteFile(declPath, []byte(declBody), 0o644)) //nolint:gosec
+
+	gitopsConfig := fmt.Sprintf(`
+org_settings:
+  server_settings:
+    server_url: %s
+  org_info:
+    org_name: Fleet
+  secrets:
+    - secret: json_escape_test_secret
+agent_options:
+controls:
+  macos_settings:
+    custom_settings:
+      - path: %s
+policies:
+reports:
+`, s.Server.URL, declPath)
+
+	configPath := filepath.Join(tempDir, "gitops.yml")
+	require.NoError(t, os.WriteFile(configPath, []byte(gitopsConfig), 0o644)) //nolint:gosec
+
+	// Before the fix, this run would fail with
+	// "Declaration profiles should include valid JSON."
+	_ = fleetctl.RunAppForTest(t, []string{"gitops", "--config", fleetctlConfig.Name(), "-f", configPath})
+
+	// Retrieve the stored declaration by listing profiles and matching on identifier.
+	profs, _, err := s.DS.ListMDMConfigProfiles(ctx, nil, fleet.ListOptions{})
+	require.NoError(t, err)
+	var declUUID string
+	for _, p := range profs {
+		if p.Platform == "darwin" && p.Identifier == declIdentifier {
+			declUUID = p.ProfileUUID
+			break
+		}
+	}
+	require.NotEmpty(t, declUUID, "uploaded declaration should be listed")
+
+	decl, err := s.DS.GetMDMAppleDeclaration(ctx, declUUID)
+	require.NoError(t, err)
+	stored := string(decl.RawJSON)
+
+	// Stored bytes must be valid JSON — this is the regression guard for #38013.
+	var parsed map[string]any
+	require.NoError(t, json.Unmarshal(decl.RawJSON, &parsed),
+		"stored declaration must be valid JSON")
+
+	// $FLEET_SECRET_* placeholder must be stored literally; it is expanded
+	// server-side at delivery time so secrets are never double-encoded.
+	assert.Contains(t, stored, "$FLEET_SECRET_"+secretPasswordName,
+		"stored declaration should still contain the FLEET_SECRET_ placeholder")
+
+	// $API_KEY must be JSON-escaped: `"` → `\"`, `\` → `\\`.
+	payload, ok := parsed["Payload"].(map[string]any)
+	require.True(t, ok, "Payload should be an object")
+	assert.Equal(t, apiKeyValue, payload["ApiKey"],
+		"ApiKey should round-trip to the raw env var value after JSON parse")
+	assert.NotContains(t, stored, "$API_KEY",
+		"stored declaration should not contain the unexpanded $API_KEY reference")
+
+	// The custom secret must be stored raw so server-side expansion doesn't double-encode it.
+	dbSecrets, err := s.DS.GetSecretVariables(ctx, []string{secretPasswordName})
+	require.NoError(t, err)
+	require.Len(t, dbSecrets, 1)
+	assert.Equal(t, secretPasswordValue, dbSecrets[0].Value,
+		"secret should be stored as the raw value (not JSON-escaped)")
+}
+
 // TestGitOpsSoftwareWithEnvVarInstalledByPolicy tests that a software package
 // with an environment variable in the URL can be referenced by a policy to be
 // installed automatically.

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -533,7 +533,7 @@ The dollar sign (`$`) can be escaped so it's not considered a variable by using 
 
 In XML, certain characters (`&`, `<`, `>`, `"`, `'`) must be escaped because they have special meanings in the markup language. GitHub and GitLab environment variables, as well as Fleet's reserved variables, will be automatically escaped when used in a `.mobileconfig` configuration profile. For example, `&` will become `&amp;`.
 
-JSON configuration profiles (Apple DDM declarations and Android profiles) require characters like `"`, `\`, and control characters to be escaped inside string values. GitHub/GitLab environment variables, custom variables (`$FLEET_SECRET_*`), and Fleet's reserved variables (`$FLEET_VAR_*`) are automatically JSON-escaped when expanded inside a JSON profile, so you can reference them directly without pre-escaping. Custom variable values are stored on the server unescaped so they are not double-encoded when the profile is delivered to a host.
+In JSON, certain characters (`"`, `\`, and control characters) must be escaped because they have special meanings in the data format. GitHub and GitLab environment variables, as well as Fleet's reserved variables, will be automatically escaped when used in a `.json` configuration profile (Apple DDM declaration or Android profile). For example, `"` will become `\"`.
 
 If certificate authority (CA) variables (ex. `$FLEET_VAR_DIGICERT_DATA_<CA_NAME>`) don't exist, GitOps dry runs will succeed but GitOps runs will fail.
 

--- a/docs/Configuration/yaml-files.md
+++ b/docs/Configuration/yaml-files.md
@@ -533,6 +533,8 @@ The dollar sign (`$`) can be escaped so it's not considered a variable by using 
 
 In XML, certain characters (`&`, `<`, `>`, `"`, `'`) must be escaped because they have special meanings in the markup language. GitHub and GitLab environment variables, as well as Fleet's reserved variables, will be automatically escaped when used in a `.mobileconfig` configuration profile. For example, `&` will become `&amp;`.
 
+JSON configuration profiles (Apple DDM declarations and Android profiles) require characters like `"`, `\`, and control characters to be escaped inside string values. GitHub/GitLab environment variables, custom variables (`$FLEET_SECRET_*`), and Fleet's reserved variables (`$FLEET_VAR_*`) are automatically JSON-escaped when expanded inside a JSON profile, so you can reference them directly without pre-escaping. Custom variable values are stored on the server unescaped so they are not double-encoded when the profile is delivered to a host.
+
 If certificate authority (CA) variables (ex. `$FLEET_VAR_DIGICERT_DATA_<CA_NAME>`) don't exist, GitOps dry runs will succeed but GitOps runs will fail.
 
 To hide variable values in the API and UI, you can use Fleet's [custom variables](https://fleetdm.com/guides/secrets-in-scripts-and-configuration-profiles#gitops).

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -315,17 +315,25 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 
 	s = escapeString(s, preventEscapingPrefix)
 	exclusionZones := getExclusionZones(s)
-	documentIsXML := strings.HasPrefix(strings.TrimSpace(s), "<") // We need to be more aggressive here, to also escape XML in Windows profiles which does not begin with <?xml
+	trimmed := strings.TrimSpace(s)
+	documentIsXML := strings.HasPrefix(trimmed, "<") // We need to be more aggressive here, to also escape XML in Windows profiles which does not begin with <?xml
+	documentIsJSON := strings.HasPrefix(trimmed, "{")
 
-	escapeXMLValues := func(value string, env string) (string, error) {
-		// Escape XML special characters
-		var b strings.Builder
-		xmlErr := xml.EscapeText(&b, []byte(value))
-		if xmlErr != nil {
-			return "", fmt.Errorf("failed to XML escape fleet secret %s", env)
+	escapeValue := func(value string, env string) (string, error) {
+		switch {
+		case documentIsJSON:
+			// Escape JSON special characters so the value is safe to embed inside
+			// a JSON string literal (Apple DDM declarations, Android profiles).
+			return jsonEscapeString(value), nil
+		case documentIsXML:
+			var b strings.Builder
+			if xmlErr := xml.EscapeText(&b, []byte(value)); xmlErr != nil {
+				return "", fmt.Errorf("failed to XML escape fleet secret %s", env)
+			}
+			return b.String(), nil
+		default:
+			return value, nil
 		}
-		value = b.String()
-		return value, nil
 	}
 
 	var err *multierror.Error
@@ -342,16 +350,12 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 				// Expand secrets for client-side validation
 				v, ok := lookupEnv(env)
 				if ok {
-					if !documentIsXML {
-						return v, true
-					}
-
-					v, xmlErr := escapeXMLValues(v, env)
-					if xmlErr != nil {
-						err = multierror.Append(err, xmlErr)
+					escaped, escErr := escapeValue(v, env)
+					if escErr != nil {
+						err = multierror.Append(err, escErr)
 						return "", false
 					}
-					return v, true
+					return escaped, true
 				}
 				// If secret not found, leave as-is for server to handle
 				return "", false
@@ -378,16 +382,12 @@ func expandEnv(s string, secretMode secretHandling) (string, error) {
 			err = multierror.Append(err, fmt.Errorf("environment variable %q not set", env))
 			return "", false
 		}
-		if !documentIsXML {
-			return v, true
-		}
-
-		v, xmlErr := escapeXMLValues(v, env)
-		if xmlErr != nil {
-			err = multierror.Append(err, xmlErr)
+		escaped, escErr := escapeValue(v, env)
+		if escErr != nil {
+			err = multierror.Append(err, escErr)
 			return "", false
 		}
-		return v, true
+		return escaped, true
 	})
 	if err != nil {
 		return "", err
@@ -451,6 +451,18 @@ func LookupEnvSecrets(s string, secretsMap map[string]string) error {
 		return err
 	}
 	return nil
+}
+
+// jsonEscapeString returns the JSON-escaped interior of a string value
+// (without surrounding quotes), suitable for embedding inside a JSON string.
+func jsonEscapeString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// json.Marshal on a string should never fail, but return the
+		// original string as a fallback.
+		return s
+	}
+	return string(b[1 : len(b)-1])
 }
 
 var escapePattern = regexp.MustCompile(`(\\+\$)`)

--- a/pkg/spec/spec_test.go
+++ b/pkg/spec/spec_test.go
@@ -293,6 +293,83 @@ Missing: $FLEET_SECRET_MISSING`
 	assert.Equal(t, expectedXML, string(xmlResult))
 }
 
+// TestExpandEnvJSONDocument verifies that env vars and FLEET_SECRET_ vars
+// expanded inside JSON documents are JSON-string-escaped, not XML-escaped.
+func TestExpandEnvJSONDocument(t *testing.T) {
+	testutils.SaveEnv(t)
+
+	t.Run("env var JSON-escaped", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("API_KEY", `a"b\c`)
+		input := `{"key":"$API_KEY"}`
+		got, err := ExpandEnv(input)
+		require.NoError(t, err)
+
+		var parsed map[string]string
+		require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+		assert.Equal(t, `a"b\c`, parsed["key"])
+	})
+
+	t.Run("FLEET_SECRET_ JSON-escaped when expanded", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("FLEET_SECRET_PWD", `p"<&'d`)
+		input := []byte(`{"pwd":"$FLEET_SECRET_PWD"}`)
+		got, err := ExpandEnvBytesIncludingSecrets(input)
+		require.NoError(t, err)
+
+		var parsed map[string]string
+		require.NoError(t, json.Unmarshal(got, &parsed))
+		assert.Equal(t, `p"<&'d`, parsed["pwd"])
+	})
+
+	t.Run("FLEET_SECRET_ left as placeholder when ignored", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("FLEET_SECRET_PWD", `whatever`)
+		input := []byte(`{"pwd":"$FLEET_SECRET_PWD"}`)
+		got, err := ExpandEnvBytesIgnoreSecrets(input)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"pwd":"$FLEET_SECRET_PWD"}`, string(got))
+	})
+
+	t.Run("FLEET_VAR_ left for server regardless of format", func(t *testing.T) {
+		os.Clearenv()
+		input := []byte(`{"v":"$FLEET_VAR_HOST_HARDWARE_SERIAL"}`)
+		got, err := ExpandEnvBytesIgnoreSecrets(input)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"v":"$FLEET_VAR_HOST_HARDWARE_SERIAL"}`, string(got))
+	})
+
+	t.Run("leading whitespace still detected as JSON", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("API_KEY", `"quoted"`)
+		input := "\n  " + `{"key":"$API_KEY"}`
+		got, err := ExpandEnv(input)
+		require.NoError(t, err)
+
+		var parsed map[string]string
+		require.NoError(t, json.Unmarshal([]byte(got), &parsed))
+		assert.Equal(t, `"quoted"`, parsed["key"])
+	})
+
+	t.Run("XML still XML-escapes (regression guard)", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("API_KEY", `a&b<c`)
+		input := `<Add>$API_KEY</Add>`
+		got, err := ExpandEnv(input)
+		require.NoError(t, err)
+		assert.Equal(t, `<Add>a&amp;b&lt;c</Add>`, got)
+	})
+
+	t.Run("plain text neither escapes nor corrupts", func(t *testing.T) {
+		os.Clearenv()
+		t.Setenv("API_KEY", `a"b&c<d>`)
+		input := `hello $API_KEY world`
+		got, err := ExpandEnv(input)
+		require.NoError(t, err)
+		assert.Equal(t, `hello a"b&c<d> world`, got)
+	})
+}
+
 func TestGetExclusionZones(t *testing.T) {
 	// Test with a small dedicated fixture where exact byte positions are stable
 	t.Run("testdata/policies/policies.yml", func(t *testing.T) {

--- a/server/datastore/mysql/secret_variables.go
+++ b/server/datastore/mysql/secret_variables.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/xml"
 	"errors"
 	"fmt"
@@ -355,9 +356,11 @@ func (ds *Datastore) expandEmbeddedSecrets(ctx context.Context, document string)
 		return "", nil, fleet.MissingSecretsError{MissingSecrets: missingSecrets}
 	}
 
-	// Check if document is XML
-	// We need to be more aggressive here, to also escape XML in Windows profiles which does not begin with <?xml
-	documentIsXML := strings.HasPrefix(strings.TrimSpace(document), "<")
+	// Detect document format so we can escape the secret value appropriately.
+	// XML detection is aggressive because Windows profiles do not begin with <?xml.
+	trimmed := strings.TrimSpace(document)
+	documentIsXML := strings.HasPrefix(trimmed, "<")
+	documentIsJSON := strings.HasPrefix(trimmed, "{")
 
 	expanded := fleet.MaybeExpand(document, func(s string, startPos, endPos int) (string, bool) {
 		if !strings.HasPrefix(s, fleet.ServerSecretPrefix) {
@@ -365,8 +368,10 @@ func (ds *Datastore) expandEmbeddedSecrets(ctx context.Context, document string)
 		}
 		val, ok := secretMap[strings.TrimPrefix(s, fleet.ServerSecretPrefix)]
 
-		if documentIsXML {
-			// Escape XML special characters
+		switch {
+		case documentIsJSON:
+			val = jsonEscapeString(val)
+		case documentIsXML:
 			var b strings.Builder
 			err = xml.EscapeText(&b, []byte(val))
 			if err != nil {
@@ -379,6 +384,18 @@ func (ds *Datastore) expandEmbeddedSecrets(ctx context.Context, document string)
 	})
 
 	return expanded, secrets, nil
+}
+
+// jsonEscapeString returns the JSON-escaped interior of a string value
+// (without surrounding quotes), suitable for embedding inside a JSON string.
+func jsonEscapeString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// json.Marshal on a string should never fail, but return the
+		// original string as a fallback.
+		return s
+	}
+	return string(b[1 : len(b)-1])
 }
 
 func (ds *Datastore) ExpandEmbeddedSecretsAndUpdatedAt(ctx context.Context, document string) (string, *time.Time, error) {
@@ -485,8 +502,10 @@ func (ds *Datastore) ExpandHostSecrets(ctx context.Context, document string, enr
 		}
 	}
 
-	// Check if document is XML (same logic as expandEmbeddedSecrets)
-	documentIsXML := strings.HasPrefix(strings.TrimSpace(document), "<")
+	// Detect document format (same logic as expandEmbeddedSecrets)
+	trimmed := strings.TrimSpace(document)
+	documentIsXML := strings.HasPrefix(trimmed, "<")
+	documentIsJSON := strings.HasPrefix(trimmed, "{")
 
 	// Expand the placeholders
 	expanded := fleet.MaybeExpand(document, func(s string, startPos, endPos int) (string, bool) {
@@ -499,8 +518,10 @@ func (ds *Datastore) ExpandHostSecrets(ctx context.Context, document string, enr
 			return "", false
 		}
 
-		if documentIsXML {
-			// Escape XML special characters to prevent malformed output
+		switch {
+		case documentIsJSON:
+			val = jsonEscapeString(val)
+		case documentIsXML:
 			var b strings.Builder
 			if err := xml.EscapeText(&b, []byte(val)); err != nil {
 				return "", false

--- a/server/datastore/mysql/secret_variables_test.go
+++ b/server/datastore/mysql/secret_variables_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -167,7 +168,9 @@ This document contains a secret not stored in the database.
 Hello doc${FLEET_SECRET_INVALID}. $FLEET_SECRET_ALSO_INVALID
 `
 
-	xmlValidSecret := `<?xml>${FLEET_SECRET_VALID_XML}</xml>` //nolint:gosec // G101: test fixture, not a credential
+	xmlValidSecret := `<?xml>${FLEET_SECRET_VALID_XML}</xml>`                  //nolint:gosec // G101: test fixture, not a credential
+	jsonValidSecret := `{"pwd":"${FLEET_SECRET_VALID_JSON}"}`                  //nolint:gosec // G101: test fixture, not a credential
+	jsonValidSecretWhitespace := "\n  " + `{"pwd":"$FLEET_SECRET_VALID_JSON"}` //nolint:gosec // G101: test fixture, not a credential
 
 	ctx := t.Context()
 
@@ -175,6 +178,7 @@ Hello doc${FLEET_SECRET_INVALID}. $FLEET_SECRET_ALSO_INVALID
 		"VALID":      "testValue1",
 		"ALSO_VALID": "testValue2",
 		"VALID_XML":  "<tag>value & more</tag>",
+		"VALID_JSON": `p"<&'\d`,
 	}
 
 	secrets := make([]fleet.SecretVariable, 0, len(secretMap))
@@ -209,6 +213,19 @@ Hello doc${FLEET_SECRET_INVALID}. $FLEET_SECRET_ALSO_INVALID
 	require.NoError(t, err)
 	expectedXMLExpansion := `<?xml>&lt;tag&gt;value &amp; more&lt;/tag&gt;</xml>`
 	require.Equal(t, expectedXMLExpansion, expanded)
+
+	// JSON documents get JSON-escaped secret values so the result remains valid JSON.
+	expanded, err = ds.ExpandEmbeddedSecrets(ctx, jsonValidSecret)
+	require.NoError(t, err)
+	var parsed map[string]string
+	require.NoError(t, json.Unmarshal([]byte(expanded), &parsed))
+	require.Equal(t, `p"<&'\d`, parsed["pwd"])
+
+	// Leading whitespace before the opening brace should still be detected as JSON.
+	expanded, err = ds.ExpandEmbeddedSecrets(ctx, jsonValidSecretWhitespace)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(expanded)), &parsed))
+	require.Equal(t, `p"<&'\d`, parsed["pwd"])
 }
 
 func testExpandHostSecrets(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #38013 

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

See https://drive.google.com/file/d/1zeFNLuf_rT5FWzDiYyL2_hbIBW2neba-/view?usp=drive_link

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GitOps variables in JSON configuration profiles (Apple DDM declarations and Android profiles) are now automatically escaped for JSON special characters, ensuring proper handling of sensitive values.

* **Tests**
  * Added JSON configuration profile escaping validation to the enterprise GitOps integration test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->