### PR TITLE
Add Fleet Desktop login item profile

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -54,6 +54,9 @@ controls:
       - path: ../lib/macos/configuration-profiles/enable-gatekeeper.mobileconfig
       - path: ../lib/macos/configuration-profiles/enforce-library-validation.mobileconfig
       - path: ../lib/macos/configuration-profiles/firewall.mobileconfig
+      - path: ../lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig
+        labels_include_any:
+          - "Macs with Fleet Desktop installed"
       - path: ../lib/macos/configuration-profiles/full-disk-access-for-fleetd.mobileconfig
       - path: ../lib/macos/configuration-profiles/google-chrome-managed-bookmarks.mobileconfig
       - path: ../lib/macos/configuration-profiles/google-updater-background-task.mobileconfig

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>AutoLaunchedApplicationDictionary-managed</key>
+			<array>
+				<dict>
+					<key>AuthenticateAsLoginUserShortName</key>
+					<false/>
+					<key>Hide</key>
+					<false/>
+					<key>Path</key>
+					<string>/Applications/Fleet Desktop.app</string>
+				</dict>
+			</array>
+			<key>PayloadDisplayName</key>
+			<string>Managed Login Items</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.loginitems.managed.BDF51B05-C65F-4F70-A6AA-6B6274BC5A97</string>
+			<key>PayloadType</key>
+			<string>com.apple.loginitems.managed</string>
+			<key>PayloadUUID</key>
+			<string>BDF51B05-C65F-4F70-A6AA-6B6274BC5A97</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Fleet Desktop login item</string>
+	<key>PayloadIdentifier</key>
+	<string>com.fleetdm.F831422E-D3E8-4CC9-A55B-A9BC0113237E</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>F831422E-D3E8-4CC9-A55B-A9BC0113237E</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/it-and-security/lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig
@@ -11,7 +11,7 @@
 					<key>AuthenticateAsLoginUserShortName</key>
 					<false/>
 					<key>Hide</key>
-					<false/>
+					<true/>
 					<key>Path</key>
 					<string>/Applications/Fleet Desktop.app</string>
 				</dict>


### PR DESCRIPTION
Introduce a new macOS configuration profile to register /Applications/Fleet Desktop.app as a managed login item so Fleet Desktop auto-launches. Adds it-and-security/lib/macos/configuration-profiles/fleet-desktop-login-item.mobileconfig and includes it in it-and-security/fleets/workstations.yml limited to hosts labeled "Macs with Fleet Desktop installed".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented automatic launch of Fleet Desktop on macOS user login for designated machines.
  * Auto-launch functionality is applied exclusively to computers where Fleet Desktop is already installed.
  * The application launches silently in the background without requiring user authentication.
  * Streamlines fleet management by ensuring Fleet Desktop is always active on startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->