### PR TITLE
Website: exclude whitepaper articles from blog category page

### DIFF
--- a/website/api/controllers/articles/view-articles.js
+++ b/website/api/controllers/articles/view-articles.js
@@ -36,7 +36,7 @@ module.exports = {
     if (category === 'articles') {
       // If the category is `/articles` we'll show all articles
       articles = sails.config.builtStaticContent.markdownPages.filter((page)=>{
-        if(_.startsWith(page.htmlId, 'articles') && !_.startsWith(page.url, '/guides')) {
+        if(_.startsWith(page.htmlId, 'articles') && !_.startsWith(page.url, '/guides') && !_.startsWith(page.url, '/whitepapers')) {
           return page;
         }
       });


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/43953

Changes:
- Updated the article category template page's view action to exclude whitepaper articles from the "Blog" category

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected article categorization by excluding whitepaper content from the articles section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->