### PR TITLE
Fix FD leak in goval_dictionary Analyze (#42741)

### DIFF
--- a/changes/42741-fix-goval-dictionary-fd-leak
+++ b/changes/42741-fix-goval-dictionary-fd-leak
@@ -1,0 +1,1 @@
+* Fixed file descriptor leak in vulnerability processing where deleted goval_dictionary sqlite files were kept open until Fleet server restart.

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -41,7 +41,7 @@ func Analyze(
 	}
 	defer func() {
 		if err := db.Close(); err != nil {
-			logger.Error("failed to close goval dictionary database", "platform", platform, "vuln_path", vulnPath, "err", err)
+			logger.ErrorContext(ctx, "failed to close goval dictionary database", "platform", platform, "vuln_path", vulnPath, "err", err)
 		}
 	}()
 

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -39,7 +39,11 @@ func Analyze(
 	if err != nil {
 		return nil, err
 	}
-	defer func() { _ = db.Close() }()
+	defer func() {
+		if err := db.Close(); err != nil {
+			logger.Error("failed to close goval dictionary database", "platform", platform, "vuln_path", vulnPath, "err", err)
+		}
+	}()
 
 	// For kernel-only platforms (e.g., RHEL), we only scan kernel packages via goval-dictionary.
 	// Non-kernel packages are scanned via regular OVAL processing.  This keeps the testing

--- a/server/vulnerabilities/goval_dictionary/analyzer.go
+++ b/server/vulnerabilities/goval_dictionary/analyzer.go
@@ -39,6 +39,7 @@ func Analyze(
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = db.Close() }()
 
 	// For kernel-only platforms (e.g., RHEL), we only scan kernel packages via goval-dictionary.
 	// Non-kernel packages are scanned via regular OVAL processing.  This keeps the testing

--- a/server/vulnerabilities/goval_dictionary/close_test.go
+++ b/server/vulnerabilities/goval_dictionary/close_test.go
@@ -20,7 +20,9 @@ func TestDatabaseCloseReleasesFileHandle(t *testing.T) {
 		t.Fatalf("create temp: %v", err)
 	}
 	path := tmpFile.Name()
-	tmpFile.Close()
+	if err := tmpFile.Close(); err != nil {
+		t.Fatalf("close temp file: %v", err)
+	}
 	defer os.Remove(path)
 
 	// Seed the goval schema so Verfiy's query succeeds.

--- a/server/vulnerabilities/goval_dictionary/close_test.go
+++ b/server/vulnerabilities/goval_dictionary/close_test.go
@@ -47,6 +47,7 @@ func TestDatabaseCloseReleasesFileHandle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("sql.Open: %v", err)
 	}
+	t.Cleanup(func() { _ = sqlite.Close() })
 	db := Database{sqlite: sqlite}
 
 	// Run a real query to force the pool to allocate a connection on

--- a/server/vulnerabilities/goval_dictionary/close_test.go
+++ b/server/vulnerabilities/goval_dictionary/close_test.go
@@ -1,0 +1,69 @@
+package goval_dictionary
+
+import (
+	"database/sql"
+	"os"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// TestDatabaseCloseReleasesFileHandle is the regression test for the
+// FD leak in fleetdm/fleet#42741. It exercises the exact lifecycle
+// that Analyze depends on: open the sqlite file, run a goval-style
+// query (which forces the connection pool to allocate a real file
+// descriptor), then Close (which must drain the pool so the FD is
+// released before the next vuln refresh atomically replaces the file).
+func TestDatabaseCloseReleasesFileHandle(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "repro42741*.sqlite3")
+	if err != nil {
+		t.Fatalf("create temp: %v", err)
+	}
+	path := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(path)
+
+	// Seed the goval schema so Verfiy's query succeeds.
+	seed, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("seed open: %v", err)
+	}
+	schema := `
+		CREATE TABLE packages (id INTEGER, name TEXT, version TEXT, arch TEXT, definition_id INTEGER);
+		CREATE TABLE definitions (id INTEGER);
+		CREATE TABLE advisories (id INTEGER, definition_id INTEGER);
+		CREATE TABLE cves (id INTEGER, cve_id TEXT, advisory_id INTEGER);`
+	if _, err := seed.Exec(schema); err != nil {
+		t.Fatalf("seed schema: %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed close: %v", err)
+	}
+
+	// Open the file the way LoadDb does in production.
+	sqlite, err := sql.Open("sqlite3", path)
+	if err != nil {
+		t.Fatalf("sql.Open: %v", err)
+	}
+	db := Database{sqlite: sqlite}
+
+	// Run a real query to force the pool to allocate a connection on
+	// the sqlite file. Matches db.Eval's behavior inside Analyze.
+	if err := db.Verfiy(); err != nil {
+		t.Fatalf("Verfiy: %v", err)
+	}
+	if n := sqlite.Stats().OpenConnections; n < 1 {
+		t.Fatalf("query should have opened a pool connection, got %d", n)
+	}
+
+	// This is the fix: Close must drain the pool so the FD is released.
+	if err := db.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if n := sqlite.Stats().OpenConnections; n != 0 {
+		t.Fatalf("Close did not drain pool, got %d open connections", n)
+	}
+	if err := sqlite.Ping(); err == nil {
+		t.Fatal("pool still accepting queries after Close; expected error")
+	}
+}

--- a/server/vulnerabilities/goval_dictionary/close_test.go
+++ b/server/vulnerabilities/goval_dictionary/close_test.go
@@ -25,7 +25,7 @@ func TestDatabaseCloseReleasesFileHandle(t *testing.T) {
 	}
 	defer os.Remove(path)
 
-	// Seed the goval schema so Verfiy's query succeeds.
+	// Seed the goval schema so Verify's query succeeds.
 	seed, err := sql.Open("sqlite3", path)
 	if err != nil {
 		t.Fatalf("seed open: %v", err)

--- a/server/vulnerabilities/goval_dictionary/database.go
+++ b/server/vulnerabilities/goval_dictionary/database.go
@@ -101,3 +101,11 @@ func (db Database) Eval(ctx context.Context, software []fleet.Software, logger *
 
 	return vulnerabilities
 }
+
+// Close releases the underlying sqlite database connection pool.
+func (db Database) Close() error {
+	if db.sqlite == nil {
+		return nil
+	}
+	return db.sqlite.Close()
+}


### PR DESCRIPTION
**Related issue:** Resolves #42741

## Problem
`goval_dictionary.Analyze` opened a `*sql.DB` via `LoadDb` but never closed it. `pkg/download/download.go` atomically renames the goval sqlite on each refresh, unlinking the old inode while the pool still held FDs on it. lsof showed them as `(deleted)`, accumulating over days until Fleet server restart.

## Fix
- New `Database.Close()` that delegates to the underlying `*sql.DB`.
- `defer func() { _ = db.Close() }()` in `Analyze` right after `LoadDb`.

## How this was tested
- New unit test `TestDatabaseCloseReleasesFileHandle` opens a file-backed sqlite, runs a query to force a pool connection, then asserts Close drains the pool and blocks further queries.
- `go test ./server/vulnerabilities/goval_dictionary/...` passes.
- Standalone Go program reproduced the leak mechanism: `sql.Open` + query + unlink left the FD on the orphaned inode; adding Close released it.

## Confidence and QA
~90% confident. I did not reproduce end-to-end through Fleet's vuln cron locally (the analyzer never entered its query loop; likely `HostIDsByOSVersion` hadn't populated for the Rocky test host). Reviewer: flag anything that drops your confidence. @xpkoala for QA after merge: please exercise in a production-like env with enrolled RHEL hosts and confirm no `(deleted)` FDs after goval refreshes.

# Checklist for submitter
- [x] Changes file added for user-visible changes in `changes/` (`changes/42741-fix-goval-dictionary-fd-leak`).
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (N/A, no new input paths).
- [x] Timeouts are implemented and retries are limited to avoid infinite loops (N/A, no new network calls).
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes (N/A, no endpoint changes).

## Testing
- [x] Added/updated automated tests
- [x] Where appropriate, automated tests simulate multiple hosts and test for host isolation (N/A, package-level unit test).
- [ ] QA'd all new/changed functionality manually (pending, post-merge by @xpkoala).

## Database migrations
- [x] Checked schema for modified tables for auto-updating timestamp columns (N/A, no schema changes).
- [x] Confirmed timestamp updates are acceptable (N/A, no schema changes).
- [x] Ensured correct collation is explicitly set for character columns (N/A, no schema changes).

## New Fleet configuration settings
- [x] Setting(s) is/are explicitly excluded from GitOps (N/A, no new settings).

## fleetd/orbit/Fleet Desktop
- [x] Verified compatibility with the latest released version of Fleet (N/A, server-only change).
- [x] If the change applies to only one platform, confirmed `runtime.GOOS` is used (N/A).
- [x] Verified fleetd runs on macOS, Linux and Windows (N/A, server-only change).
- [x] Verified auto-update works (N/A, server-only change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a file-descriptor leak in vulnerability processing so deleted SQLite database files are properly closed without requiring a server restart, improving stability and resource usage.

* **Tests**
  * Added a regression test to ensure database handles are released after close.

* **Documentation**
  * Documented the fix for the file-descriptor leak.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->