### PR TITLE
Fix handling of cross-team stale Windows MDM profiles after host movement

### DIFF
--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1355,26 +1355,30 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 	locURIToProtectingProfiles := make(map[string][]string)
 	if len(profileUUIDs) > 0 {
 		// Query profile UUIDs and SyncML from profiles in the same team that
-		// are NOT being deleted.
+		// are NOT being deleted. Failures here must not be swallowed: an empty
+		// activeLocURIs would make every LocURI look safe to delete and could
+		// undo settings still enforced by remaining profiles.
 		const activeProfilesStmt = `
 			SELECT profile_uuid, syncml FROM mdm_windows_configuration_profiles
 			WHERE team_id = ? AND profile_uuid NOT IN (?)`
-		apStmt, apArgs, apErr := sqlx.In(activeProfilesStmt, profTeamID, profileUUIDs)
-		if apErr == nil {
-			var activeProfiles []struct {
-				ProfileUUID string `db:"profile_uuid"`
-				SyncML      []byte `db:"syncml"`
-			}
-			if err := sqlx.SelectContext(ctx, tx, &activeProfiles, apStmt, apArgs...); err == nil {
-				for _, ap := range activeProfiles {
-					// Substitute SCEP variable so LocURIs are compared on
-					// resolved paths, consistent with the deleted profile side.
-					resolved := fleet.FleetVarSCEPWindowsCertificateIDRegexp.ReplaceAll(ap.SyncML, []byte(ap.ProfileUUID))
-					for _, uri := range fleet.ExtractLocURIsFromProfileBytes(resolved) {
-						activeLocURIs[uri] = struct{}{}
-						locURIToProtectingProfiles[uri] = append(locURIToProtectingProfiles[uri], ap.ProfileUUID)
-					}
-				}
+		apStmt, apArgs, err := sqlx.In(activeProfilesStmt, profTeamID, profileUUIDs)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building IN for active profiles LocURI protection")
+		}
+		var activeProfiles []struct {
+			ProfileUUID string `db:"profile_uuid"`
+			SyncML      []byte `db:"syncml"`
+		}
+		if err := sqlx.SelectContext(ctx, tx, &activeProfiles, apStmt, apArgs...); err != nil {
+			return ctxerr.Wrap(ctx, err, "selecting active profiles for LocURI protection")
+		}
+		for _, ap := range activeProfiles {
+			// Substitute SCEP variable so LocURIs are compared on
+			// resolved paths, consistent with the deleted profile side.
+			resolved := fleet.FleetVarSCEPWindowsCertificateIDRegexp.ReplaceAll(ap.SyncML, []byte(ap.ProfileUUID))
+			for _, uri := range fleet.ExtractLocURIsFromProfileBytes(resolved) {
+				activeLocURIs[uri] = struct{}{}
+				locURIToProtectingProfiles[uri] = append(locURIToProtectingProfiles[uri], ap.ProfileUUID)
 			}
 		}
 	}

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1203,10 +1203,14 @@ WHERE
 }
 
 func (ds *Datastore) DeleteMDMWindowsConfigProfile(ctx context.Context, profileUUID string) error {
-	// SyncML bytes are needed to generate <Delete> commands.
-	var syncML []byte
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &syncML,
-		`SELECT syncml FROM mdm_windows_configuration_profiles WHERE profile_uuid = ?`, profileUUID); err != nil {
+	// SyncML bytes and team ID are needed to generate <Delete> commands and
+	// scope the LocURI protection set to the profile's team.
+	var profile struct {
+		TeamID uint   `db:"team_id"`
+		SyncML []byte `db:"syncml"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &profile,
+		`SELECT team_id, syncml FROM mdm_windows_configuration_profiles WHERE profile_uuid = ?`, profileUUID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ctxerr.Wrap(ctx, notFound("MDMWindowsProfile").WithName(profileUUID))
 		}
@@ -1218,8 +1222,8 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfile(ctx context.Context, profileU
 			return err
 		}
 
-		profileContents := map[string][]byte{profileUUID: syncML}
-		if err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, []string{profileUUID}, profileContents); err != nil {
+		profileContents := map[string][]byte{profileUUID: profile.SyncML}
+		if err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, profile.TeamID, []string{profileUUID}, profileContents); err != nil {
 			return err
 		}
 
@@ -1246,16 +1250,18 @@ func deleteMDMWindowsConfigProfile(ctx context.Context, tx sqlx.ExtContext, prof
 //   - Phase 2: For rows that were sent (non-NULL status + install), generate SyncML
 //     <Delete> commands and enqueue them, then mark the rows for removal.
 //
-// IMPORTANT: All profileUUIDs must belong to the same team. The LocURI protection
-// set is built by querying all active profiles for the affected team(s). If profiles
-// from multiple teams were passed, a profile in team A could suppress deletes for
-// hosts in team B (over-protection), because the protection set would be the union
-// across teams rather than scoped per-team. All current callers (DeleteMDMWindowsConfigProfile,
-// DeleteMDMWindowsConfigProfileByTeamAndName, batchSetMDMWindowsProfilesDB) operate
-// on a single team.
+// profTeamID is the team the deleted profiles belong to (0 for "No team"/Unassigned).
+// It is passed by the caller rather than derived from the hosts table because
+// host_mdm_windows_profiles rows can reference profile UUIDs from a host's
+// previous team after the host has been moved (the rows stay marked for removal
+// until the reconciler dispatches <Delete> commands). Deriving the team from
+// those rows would return the host's current team, not the profile's team.
+// The team is used to scope the LocURI protection set built from OTHER active
+// profiles; without a fixed team scope, a profile in one team could spuriously
+// suppress deletes for hosts whose rows happen to join to a different team.
 func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 	ctx context.Context, tx sqlx.ExtContext,
-	profileUUIDs []string, profileContents map[string][]byte,
+	profTeamID uint, profileUUIDs []string, profileContents map[string][]byte,
 ) error {
 	if len(profileUUIDs) == 0 {
 		return nil
@@ -1348,45 +1354,25 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 	// so pass 2 can check per-host applicability.
 	locURIToProtectingProfiles := make(map[string][]string)
 	if len(profileUUIDs) > 0 {
-		// Get team IDs for the profiles being deleted. Use the hosts table
-		// with a single query instead of one per host.
-		teamIDStmt, teamIDArgs, err := sqlx.In(
-			`SELECT DISTINCT COALESCE(h.team_id, 0) FROM hosts h
-			JOIN host_mdm_windows_profiles hwp ON hwp.host_uuid = h.uuid
-			WHERE hwp.profile_uuid IN (?)`, profileUUIDs)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building IN for team ID lookup")
-		}
-		var teamIDs []uint
-		if err := sqlx.SelectContext(ctx, tx, &teamIDs, teamIDStmt, teamIDArgs...); err != nil {
-			return ctxerr.Wrap(ctx, err, "selecting team IDs for LocURI protection")
-		}
-		if len(teamIDs) > 1 {
-			// All callers must operate on a single team. If multiple teams are
-			// found, the LocURI protection set would be the union across teams,
-			// letting a profile in team A suppress deletes for hosts in team B.
-			return ctxerr.Errorf(ctx, "cancelWindowsHostInstallsForDeletedMDMProfiles: expected profiles from 1 team, got %d", len(teamIDs))
-		}
-		if len(teamIDs) > 0 {
-			// Query profile UUIDs and SyncML from profiles NOT being deleted.
-			const activeProfilesStmt = `
-				SELECT profile_uuid, syncml FROM mdm_windows_configuration_profiles
-				WHERE team_id IN (?) AND profile_uuid NOT IN (?)`
-			apStmt, apArgs, apErr := sqlx.In(activeProfilesStmt, teamIDs, profileUUIDs)
-			if apErr == nil {
-				var activeProfiles []struct {
-					ProfileUUID string `db:"profile_uuid"`
-					SyncML      []byte `db:"syncml"`
-				}
-				if err := sqlx.SelectContext(ctx, tx, &activeProfiles, apStmt, apArgs...); err == nil {
-					for _, ap := range activeProfiles {
-						// Substitute SCEP variable so LocURIs are compared on
-						// resolved paths, consistent with the deleted profile side.
-						resolved := fleet.FleetVarSCEPWindowsCertificateIDRegexp.ReplaceAll(ap.SyncML, []byte(ap.ProfileUUID))
-						for _, uri := range fleet.ExtractLocURIsFromProfileBytes(resolved) {
-							activeLocURIs[uri] = struct{}{}
-							locURIToProtectingProfiles[uri] = append(locURIToProtectingProfiles[uri], ap.ProfileUUID)
-						}
+		// Query profile UUIDs and SyncML from profiles in the same team that
+		// are NOT being deleted.
+		const activeProfilesStmt = `
+			SELECT profile_uuid, syncml FROM mdm_windows_configuration_profiles
+			WHERE team_id = ? AND profile_uuid NOT IN (?)`
+		apStmt, apArgs, apErr := sqlx.In(activeProfilesStmt, profTeamID, profileUUIDs)
+		if apErr == nil {
+			var activeProfiles []struct {
+				ProfileUUID string `db:"profile_uuid"`
+				SyncML      []byte `db:"syncml"`
+			}
+			if err := sqlx.SelectContext(ctx, tx, &activeProfiles, apStmt, apArgs...); err == nil {
+				for _, ap := range activeProfiles {
+					// Substitute SCEP variable so LocURIs are compared on
+					// resolved paths, consistent with the deleted profile side.
+					resolved := fleet.FleetVarSCEPWindowsCertificateIDRegexp.ReplaceAll(ap.SyncML, []byte(ap.ProfileUUID))
+					for _, uri := range fleet.ExtractLocURIsFromProfileBytes(resolved) {
+						activeLocURIs[uri] = struct{}{}
+						locURIToProtectingProfiles[uri] = append(locURIToProtectingProfiles[uri], ap.ProfileUUID)
 					}
 				}
 			}
@@ -1686,7 +1672,7 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfileByTeamAndName(ctx context.Cont
 		}
 
 		profileContents := map[string][]byte{profile.ProfileUUID: profile.SyncML}
-		return ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, []string{profile.ProfileUUID}, profileContents)
+		return ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, globalOrTeamID, []string{profile.ProfileUUID}, profileContents)
 	})
 }
 
@@ -2923,7 +2909,7 @@ ON DUPLICATE KEY UPDATE
 
 	// Step 4: Cancel pending installs and enqueue <Delete> commands for delivered profiles.
 	if len(deletedProfileUUIDs) > 0 {
-		if err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, deletedProfileUUIDs, deletedProfileContents); err != nil {
+		if err := ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, profTeamID, deletedProfileUUIDs, deletedProfileContents); err != nil {
 			return false, ctxerr.Wrap(ctx, err, "cancel installs of deleted profiles")
 		}
 	}

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -53,7 +53,6 @@ func TestMDMWindows(t *testing.T) {
 		{"TestGetWindowsMDMCommandsForResending", testGetWindowsMDMCommandsForResending},
 		{"TestResendWindowsMDMCommand", testResendWindowsMDMCommand},
 		{"TestDeleteProfileLocURIProtection", testDeleteProfileLocURIProtection},
-		{"TestDeleteProfileAfterHostMovedTeams", testDeleteProfileAfterHostMovedTeams},
 		{"TestEditProfileDeletesRemovedLocURIs", testEditProfileDeletesRemovedLocURIs},
 		{"TestMDMWindowsUnenrollCleansUpProfiles", testMDMWindowsUnenrollCleansUpProfiles},
 	}
@@ -4384,139 +4383,72 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		assert.True(t, h2HasX, "h2: should delete X")
 		assert.True(t, h2HasY, "h2: should delete Y (profB doesn't apply, not in label scope)")
 	})
-}
 
-// testDeleteProfileAfterHostMovedTeams reproduces the scenario where a Windows
-// profile is deleted from the "No team" fleet after some of the hosts that
-// had it applied have been moved to a different team. The moved hosts still
-// carry host_mdm_windows_profiles rows for the original profile (now marked
-// for removal pending <Delete> dispatch). Previously the deletion path
-// derived the team from those stale rows via a JOIN against hosts and
-// rejected the operation with a 500 when it saw multiple teams.
-func testDeleteProfileAfterHostMovedTeams(t *testing.T, ds *Datastore) {
-	ctx := t.Context()
-
-	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "destination-team"})
-	require.NoError(t, err)
-
-	hStay := test.NewHost(t, ds, "host-stay", "10.0.0.10", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
-	windowsEnroll(t, ds, hStay)
-	hMoved := test.NewHost(t, ds, "host-moved", "10.0.0.11", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
-	windowsEnroll(t, ds, hMoved)
-
-	// Insert two profiles in "No team": one we will delete, one that stays.
-	profToDelete := &fleet.MDMWindowsConfigProfile{Name: "profDelete", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Delete/Me</LocURI></Target><Data>1</Data></Item></Replace>`)}
-	profToKeep := &fleet.MDMWindowsConfigProfile{Name: "profKeep", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Keep/Me</LocURI></Target><Data>1</Data></Item></Replace>`)}
-	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-		_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToDelete, profToKeep}, nil)
-		return err
-	})
-	require.NoError(t, err)
-
-	var profToDeleteUUID, profToKeepUUID string
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &profToDeleteUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profDelete'`)
-	})
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &profToKeepUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profKeep'`)
-	})
-
-	// Simulate both profiles already applied to both hosts while both were in "No team".
-	verified := fleet.MDMDeliveryVerified
-	var payloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload
-	for _, hUUID := range []string{hStay.UUID, hMoved.UUID} {
-		for _, pUUID := range []string{profToDeleteUUID, profToKeepUUID} {
-			payloads = append(payloads, &fleet.MDMWindowsBulkUpsertHostProfilePayload{
-				ProfileUUID:   pUUID,
-				ProfileName:   "n",
-				HostUUID:      hUUID,
-				CommandUUID:   uuid.NewString(),
-				OperationType: fleet.MDMOperationTypeInstall,
-				Status:        &verified,
-				Checksum:      []byte{0},
-			})
-		}
-	}
-	require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, payloads))
-
-	// Move hMoved into the destination team. The datastore method updates
-	// hosts.team_id but leaves host_mdm_windows_profiles alone. The service
-	// layer then marks the stale rows for removal. Replicate that here.
-	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{hMoved.ID})))
-	_, err = ds.BulkSetPendingMDMHostProfiles(ctx, []uint{hMoved.ID}, nil, nil, nil)
-	require.NoError(t, err)
-
-	// Sanity check: hMoved's rows for the no-team profiles are now marked for removal.
-	var movedRemoveCount int
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &movedRemoveCount,
-			`SELECT COUNT(*) FROM host_mdm_windows_profiles
-			 WHERE host_uuid = ? AND operation_type = 'remove' AND status IS NULL`, hMoved.UUID)
-	})
-	require.Equal(t, 2, movedRemoveCount, "expected hMoved to have pending-remove rows for the no-team profiles")
-
-	t.Run("DeleteMDMWindowsConfigProfile succeeds across stale cross-team rows", func(t *testing.T) {
-		require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, profToDeleteUUID))
-
-		// A <Delete> command should have been enqueued for the host that stayed.
-		var stayCmd []byte
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &stayCmd,
-				`SELECT wc.raw_command FROM windows_mdm_commands wc
-				JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
-				WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
-				hStay.UUID, profToDeleteUUID)
+	// Reproduces the regression where deleting a no-team profile failed with
+	// "expected profiles from 1 team, got 2" because some hosts that once had
+	// the profile had since been moved to a different team. Their stale
+	// host_mdm_windows_profiles rows (marked remove+NULL by the team move)
+	// made the pre-fix team lookup return two teams from its hosts JOIN.
+	t.Run("stale rows from moved host do not block delete", func(t *testing.T) {
+		t.Cleanup(func() {
+			TruncateTables(t, ds, "host_mdm_windows_profiles", "windows_mdm_command_queue", "windows_mdm_commands", "mdm_windows_configuration_profiles")
 		})
-		require.NotEmpty(t, stayCmd)
-		assert.Contains(t, string(stayCmd), "./Device/Delete/Me")
 
-		// The moved host's row was already remove+NULL from the team move; the
-		// deletion path should have upgraded it to a queued <Delete> command.
-		var movedCmd []byte
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &movedCmd,
-				`SELECT wc.raw_command FROM windows_mdm_commands wc
-				JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
-				WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
-				hMoved.UUID, profToDeleteUUID)
-		})
-		require.NotEmpty(t, movedCmd, "moved host should have a queued <Delete> command even though it is now in a different team")
-		assert.Contains(t, string(movedCmd), "./Device/Delete/Me")
-	})
-
-	t.Run("batchSetMDMWindowsProfilesDB succeeds across stale cross-team rows", func(t *testing.T) {
-		// Re-apply profToDelete to both hosts so batchSet can delete it again.
-		// (The previous subtest queued removes; reset state.)
-		TruncateTables(t, ds, "host_mdm_windows_profiles", "windows_mdm_command_queue", "windows_mdm_commands", "mdm_windows_configuration_profiles")
-
+		prof := &fleet.MDMWindowsConfigProfile{Name: "no-team-prof", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Z</LocURI></Target><Data>1</Data></Item></Replace>`)}
 		err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToDelete, profToKeep}, nil)
+			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{prof}, nil)
 			return err
 		})
 		require.NoError(t, err)
+		var profUUID string
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profToDeleteUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profDelete'`)
-		})
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profToKeepUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profKeep'`)
+			return sqlx.GetContext(ctx, q, &profUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'no-team-prof'`)
 		})
 
-		// Stay host: install+verified. Moved host: remove+NULL (pending <Delete>).
-		removeNull := (*fleet.MDMDeliveryStatus)(nil)
-		stayPayloads := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
-			{ProfileUUID: profToDeleteUUID, ProfileName: "n", HostUUID: hStay.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
-			{ProfileUUID: profToKeepUUID, ProfileName: "n", HostUUID: hStay.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
-			{ProfileUUID: profToDeleteUUID, ProfileName: "n", HostUUID: hMoved.UUID, CommandUUID: "", OperationType: fleet.MDMOperationTypeRemove, Status: removeNull, Checksum: []byte{0}},
-			{ProfileUUID: profToKeepUUID, ProfileName: "n", HostUUID: hMoved.UUID, CommandUUID: "", OperationType: fleet.MDMOperationTypeRemove, Status: removeNull, Checksum: []byte{0}},
-		}
-		require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, stayPayloads))
+		// Both hosts start with the profile installed and verified.
+		verified := fleet.MDMDeliveryVerified
+		require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{ProfileUUID: profUUID, ProfileName: "n", HostUUID: h1.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
+			{ProfileUUID: profUUID, ProfileName: "n", HostUUID: h2.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
+		}))
 
-		// Simulate GitOps: drop profToDelete from "No team".
+		// Move h2 out of no-team; replicate the post-move reconciliation the
+		// service layer does so h2's row flips to operation=remove, status=NULL.
+		team, err := ds.NewTeam(ctx, &fleet.Team{Name: "moved-host-destination"})
+		require.NoError(t, err)
+		require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{h2.ID})))
+		_, err = ds.BulkSetPendingMDMHostProfiles(ctx, []uint{h2.ID}, nil, nil, nil)
+		require.NoError(t, err)
+		// Restore h2 to no-team at the end so the next subtest starts clean.
+		t.Cleanup(func() {
+			_ = ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(nil, []uint{h2.ID}))
+		})
+
+		// GitOps path: submit an empty profile set for no-team, which deletes
+		// the remaining profile. Pre-fix this returned 500; the moved host's
+		// stale row made the team lookup see both no-team and the new team.
 		err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
-			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToKeep}, nil)
+			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{}, nil)
 			return err
 		})
-		require.NoError(t, err, "batchSet should succeed even when moved hosts have stale rows for the deleted profile")
+		require.NoError(t, err)
+
+		// Both hosts should now have a queued <Delete>: h1 as the direct
+		// consequence of the deletion, h2 because phase 2 upgrades the
+		// already remove+NULL row to a concrete command. This also proves
+		// offline moved hosts still receive the removal on next check-in.
+		for _, h := range []*fleet.Host{h1, h2} {
+			var rawCmd []byte
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				return sqlx.GetContext(ctx, q, &rawCmd,
+					`SELECT wc.raw_command FROM windows_mdm_commands wc
+					JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
+					WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
+					h.UUID, profUUID)
+			})
+			require.NotEmpty(t, rawCmd, "host %s should have a queued <Delete>", h.Hostname)
+			assert.Contains(t, string(rawCmd), "./Device/Z")
+		}
 	})
 }
 

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -53,6 +53,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestGetWindowsMDMCommandsForResending", testGetWindowsMDMCommandsForResending},
 		{"TestResendWindowsMDMCommand", testResendWindowsMDMCommand},
 		{"TestDeleteProfileLocURIProtection", testDeleteProfileLocURIProtection},
+		{"TestDeleteProfileAfterHostMovedTeams", testDeleteProfileAfterHostMovedTeams},
 		{"TestEditProfileDeletesRemovedLocURIs", testEditProfileDeletesRemovedLocURIs},
 		{"TestMDMWindowsUnenrollCleansUpProfiles", testMDMWindowsUnenrollCleansUpProfiles},
 	}
@@ -4382,6 +4383,140 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		}
 		assert.True(t, h2HasX, "h2: should delete X")
 		assert.True(t, h2HasY, "h2: should delete Y (profB doesn't apply, not in label scope)")
+	})
+}
+
+// testDeleteProfileAfterHostMovedTeams reproduces the scenario where a Windows
+// profile is deleted from the "No team" fleet after some of the hosts that
+// had it applied have been moved to a different team. The moved hosts still
+// carry host_mdm_windows_profiles rows for the original profile (now marked
+// for removal pending <Delete> dispatch). Previously the deletion path
+// derived the team from those stale rows via a JOIN against hosts and
+// rejected the operation with a 500 when it saw multiple teams.
+func testDeleteProfileAfterHostMovedTeams(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "destination-team"})
+	require.NoError(t, err)
+
+	hStay := test.NewHost(t, ds, "host-stay", "10.0.0.10", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
+	windowsEnroll(t, ds, hStay)
+	hMoved := test.NewHost(t, ds, "host-moved", "10.0.0.11", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
+	windowsEnroll(t, ds, hMoved)
+
+	// Insert two profiles in "No team": one we will delete, one that stays.
+	profToDelete := &fleet.MDMWindowsConfigProfile{Name: "profDelete", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Delete/Me</LocURI></Target><Data>1</Data></Item></Replace>`)}
+	profToKeep := &fleet.MDMWindowsConfigProfile{Name: "profKeep", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Keep/Me</LocURI></Target><Data>1</Data></Item></Replace>`)}
+	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToDelete, profToKeep}, nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	var profToDeleteUUID, profToKeepUUID string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &profToDeleteUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profDelete'`)
+	})
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &profToKeepUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profKeep'`)
+	})
+
+	// Simulate both profiles already applied to both hosts while both were in "No team".
+	verified := fleet.MDMDeliveryVerified
+	var payloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload
+	for _, hUUID := range []string{hStay.UUID, hMoved.UUID} {
+		for _, pUUID := range []string{profToDeleteUUID, profToKeepUUID} {
+			payloads = append(payloads, &fleet.MDMWindowsBulkUpsertHostProfilePayload{
+				ProfileUUID:   pUUID,
+				ProfileName:   "n",
+				HostUUID:      hUUID,
+				CommandUUID:   uuid.NewString(),
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &verified,
+				Checksum:      []byte{0},
+			})
+		}
+	}
+	require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, payloads))
+
+	// Move hMoved into the destination team. The datastore method updates
+	// hosts.team_id but leaves host_mdm_windows_profiles alone. The service
+	// layer then marks the stale rows for removal. Replicate that here.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{hMoved.ID})))
+	_, err = ds.BulkSetPendingMDMHostProfiles(ctx, []uint{hMoved.ID}, nil, nil, nil)
+	require.NoError(t, err)
+
+	// Sanity check: hMoved's rows for the no-team profiles are now marked for removal.
+	var movedRemoveCount int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &movedRemoveCount,
+			`SELECT COUNT(*) FROM host_mdm_windows_profiles
+			 WHERE host_uuid = ? AND operation_type = 'remove' AND status IS NULL`, hMoved.UUID)
+	})
+	require.Equal(t, 2, movedRemoveCount, "expected hMoved to have pending-remove rows for the no-team profiles")
+
+	t.Run("DeleteMDMWindowsConfigProfile succeeds across stale cross-team rows", func(t *testing.T) {
+		require.NoError(t, ds.DeleteMDMWindowsConfigProfile(ctx, profToDeleteUUID))
+
+		// A <Delete> command should have been enqueued for the host that stayed.
+		var stayCmd []byte
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &stayCmd,
+				`SELECT wc.raw_command FROM windows_mdm_commands wc
+				JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
+				WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
+				hStay.UUID, profToDeleteUUID)
+		})
+		require.NotEmpty(t, stayCmd)
+		assert.Contains(t, string(stayCmd), "./Device/Delete/Me")
+
+		// The moved host's row was already remove+NULL from the team move; the
+		// deletion path should have upgraded it to a queued <Delete> command.
+		var movedCmd []byte
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &movedCmd,
+				`SELECT wc.raw_command FROM windows_mdm_commands wc
+				JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
+				WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
+				hMoved.UUID, profToDeleteUUID)
+		})
+		require.NotEmpty(t, movedCmd, "moved host should have a queued <Delete> command even though it is now in a different team")
+		assert.Contains(t, string(movedCmd), "./Device/Delete/Me")
+	})
+
+	t.Run("batchSetMDMWindowsProfilesDB succeeds across stale cross-team rows", func(t *testing.T) {
+		// Re-apply profToDelete to both hosts so batchSet can delete it again.
+		// (The previous subtest queued removes; reset state.)
+		TruncateTables(t, ds, "host_mdm_windows_profiles", "windows_mdm_command_queue", "windows_mdm_commands", "mdm_windows_configuration_profiles")
+
+		err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToDelete, profToKeep}, nil)
+			return err
+		})
+		require.NoError(t, err)
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &profToDeleteUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profDelete'`)
+		})
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			return sqlx.GetContext(ctx, q, &profToKeepUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profKeep'`)
+		})
+
+		// Stay host: install+verified. Moved host: remove+NULL (pending <Delete>).
+		removeNull := (*fleet.MDMDeliveryStatus)(nil)
+		stayPayloads := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+			{ProfileUUID: profToDeleteUUID, ProfileName: "n", HostUUID: hStay.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
+			{ProfileUUID: profToKeepUUID, ProfileName: "n", HostUUID: hStay.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
+			{ProfileUUID: profToDeleteUUID, ProfileName: "n", HostUUID: hMoved.UUID, CommandUUID: "", OperationType: fleet.MDMOperationTypeRemove, Status: removeNull, Checksum: []byte{0}},
+			{ProfileUUID: profToKeepUUID, ProfileName: "n", HostUUID: hMoved.UUID, CommandUUID: "", OperationType: fleet.MDMOperationTypeRemove, Status: removeNull, Checksum: []byte{0}},
+		}
+		require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, stayPayloads))
+
+		// Simulate GitOps: drop profToDelete from "No team".
+		err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profToKeep}, nil)
+			return err
+		})
+		require.NoError(t, err, "batchSet should succeed even when moved hosts have stale rows for the deleted profile")
 	})
 }
 

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -4386,9 +4386,7 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 
 	// Reproduces the regression where deleting a no-team profile failed with
 	// "expected profiles from 1 team, got 2" because some hosts that once had
-	// the profile had since been moved to a different team. Their stale
-	// host_mdm_windows_profiles rows (marked remove+NULL by the team move)
-	// made the pre-fix team lookup return two teams from its hosts JOIN.
+	// the profile had since been moved to a different team.
 	t.Run("stale rows from moved host do not block delete", func(t *testing.T) {
 		t.Cleanup(func() {
 			TruncateTables(t, ds, "host_mdm_windows_profiles", "windows_mdm_command_queue", "windows_mdm_commands", "mdm_windows_configuration_profiles")
@@ -4402,7 +4400,8 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		var profUUID string
 		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'no-team-prof'`)
+			return sqlx.GetContext(ctx, q, &profUUID,
+				`SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE team_id = 0 AND name = 'no-team-prof'`)
 		})
 
 		// Both hosts start with the profile installed and verified.
@@ -4424,9 +4423,18 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 			_ = ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(nil, []uint{h2.ID}))
 		})
 
+		// Insert a destination-team profile with the same LocURI. If LocURI
+		// protection ever leaks across teams, this would be treated as a
+		// protector for the no-team delete and the <Delete> would be empty.
+		destTeamProf := &fleet.MDMWindowsConfigProfile{Name: "dest-team-prof", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Z</LocURI></Target><Data>2</Data></Item></Replace>`)}
+		err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, &team.ID, []*fleet.MDMWindowsConfigProfile{destTeamProf}, nil)
+			return err
+		})
+		require.NoError(t, err)
+
 		// GitOps path: submit an empty profile set for no-team, which deletes
-		// the remaining profile. Pre-fix this returned 500; the moved host's
-		// stale row made the team lookup see both no-team and the new team.
+		// the remaining profile.
 		err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 			_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{}, nil)
 			return err
@@ -4436,7 +4444,9 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		// Both hosts should now have a queued <Delete>: h1 as the direct
 		// consequence of the deletion, h2 because phase 2 upgrades the
 		// already remove+NULL row to a concrete command. This also proves
-		// offline moved hosts still receive the removal on next check-in.
+		// offline moved hosts still receive the removal on next check-in,
+		// and that the destination-team profile with the same LocURI did
+		// not spuriously protect ./Device/Z from the no-team deletion.
 		for _, h := range []*fleet.Host{h1, h2} {
 			var rawCmd []byte
 			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {

--- a/server/datastore/mysql/teams.go
+++ b/server/datastore/mysql/teams.go
@@ -239,7 +239,7 @@ func (ds *Datastore) enqueueWindowsDeleteCommandsForTeam(ctx context.Context, ti
 			profileContents[r.ProfileUUID] = r.SyncML
 		}
 
-		return ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, profileUUIDs, profileContents)
+		return ds.cancelWindowsHostInstallsForDeletedMDMProfiles(ctx, tx, tid, profileUUIDs, profileContents)
 	})
 }
 


### PR DESCRIPTION
Unreleased bug
- Added team scoping to LocURI protection for profile deletion.
- Addressed stale MDM profile rows when hosts transfer between teams.
- Improved test coverage for Windows MDM profile deletion scenarios.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #33418

# Checklist for submitter

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows MDM profile deletion so devices moved between teams are correctly cleaned up and receive removal commands, preventing stale profile configurations from persisting.
  * Added a regression test ensuring deletion of no-team profiles isn’t blocked by leftover host-profile rows or by profiles in other teams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->