### PR TITLE
Fleet UI: Manage local accounts host details page followup

### DIFF
--- a/frontend/components/Modal/Modal.tsx
+++ b/frontend/components/Modal/Modal.tsx
@@ -12,6 +12,9 @@ export interface IModalProps {
   title: string | JSX.Element;
   children: React.ReactNode;
   onExit: () => void;
+  /** Called when the user presses Enter. Avoid using this on modals that
+   * contain forms, reveal/copy controls, or other elements where Enter has
+   * its own meaning — it will conflict with keyboard navigation. */
   onEnter?: () => void;
   /**     medium 650px, large 800px, xlarge 850px, auto auto-width
    * @default "medium"

--- a/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
+++ b/frontend/pages/DashboardPage/cards/ActivityFeed/GlobalActivityItem/GlobalActivityItem.tsx
@@ -516,13 +516,13 @@ const TAGGED_TEMPLATES = {
     return (
       <>
         {" "}
-        enabled managed local accounts for hosts assigned to the{" "}
+        enabled managed local accounts for{" "}
         {activity.details?.team_name ? (
           <>
-            <b>{activity.details.team_name}</b> fleet.
+            hosts assigned to the <b>{activity.details.team_name}</b> fleet.
           </>
         ) : (
-          "hosts with no fleet."
+          "unassigned hosts."
         )}
       </>
     );
@@ -531,13 +531,13 @@ const TAGGED_TEMPLATES = {
     return (
       <>
         {" "}
-        disabled managed local accounts for hosts assigned to the{" "}
+        disabled managed local accounts for{" "}
         {activity.details?.team_name ? (
           <>
-            <b>{activity.details.team_name}</b> fleet.
+            hosts assigned to the <b>{activity.details.team_name}</b> fleet.
           </>
         ) : (
-          "hosts with no fleet."
+          "unassigned hosts."
         )}
       </>
     );

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/HostActionsDropdown.tests.tsx
@@ -1933,48 +1933,85 @@ describe("Host Actions Dropdown", () => {
       ).not.toBeInTheDocument();
     });
 
-    it.each(["pending", "failed"])(
-      "disables the action with 'still being created' tooltip when status is %s",
-      async (status) => {
-        const render = createCustomRenderer({
-          context: {
-            app: {
-              isGlobalAdmin: true,
-              isPremiumTier: true,
-              currentUser: createMockUser(),
-            },
+    it("disables the action with 'still being created' tooltip when status is pending", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            isPremiumTier: true,
+            currentUser: createMockUser(),
           },
-        });
+        },
+      });
 
-        const { user } = render(
-          <HostActionsDropdown
-            hostTeamId={null}
-            onSelect={noop}
-            hostStatus="online"
-            hostMdmEnrollmentStatus="On (automatic)"
-            hostMdmDeviceStatus="unlocked"
-            hostScriptsEnabled
-            isConnectedToFleetMdm
-            hostPlatform="darwin"
-            isManagedLocalAccountEnabled
-            managedAccountStatus={status}
-          />
-        );
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus="On (automatic)"
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+          isConnectedToFleetMdm
+          hostPlatform="darwin"
+          isManagedLocalAccountEnabled
+          managedAccountStatus="pending"
+        />
+      );
 
-        await user.click(screen.getByText("Actions"));
+      await user.click(screen.getByText("Actions"));
 
-        const option = screen.getByText("Show managed account");
-        expect(option).toBeInTheDocument();
-        expect(option).toHaveAttribute("aria-disabled", "true");
+      const option = screen.getByText("Show managed account");
+      expect(option).toBeInTheDocument();
+      expect(option).toHaveAttribute("aria-disabled", "true");
 
-        await user.hover(option);
-        await waitFor(() => {
-          expect(
-            screen.getByText(/The managed account is still being/i)
-          ).toBeInTheDocument();
-        });
-      }
-    );
+      await user.hover(option);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/The managed account is still being/i)
+        ).toBeInTheDocument();
+      });
+    });
+
+    it("disables the action with 'failed' tooltip when status is failed", async () => {
+      const render = createCustomRenderer({
+        context: {
+          app: {
+            isGlobalAdmin: true,
+            isPremiumTier: true,
+            currentUser: createMockUser(),
+          },
+        },
+      });
+
+      const { user } = render(
+        <HostActionsDropdown
+          hostTeamId={null}
+          onSelect={noop}
+          hostStatus="online"
+          hostMdmEnrollmentStatus="On (automatic)"
+          hostMdmDeviceStatus="unlocked"
+          hostScriptsEnabled
+          isConnectedToFleetMdm
+          hostPlatform="darwin"
+          isManagedLocalAccountEnabled
+          managedAccountStatus="failed"
+        />
+      );
+
+      await user.click(screen.getByText("Actions"));
+
+      const option = screen.getByText("Show managed account");
+      expect(option).toBeInTheDocument();
+      expect(option).toHaveAttribute("aria-disabled", "true");
+
+      await user.hover(option);
+      await waitFor(() => {
+        expect(
+          screen.getByText(/The managed account failed to be/i)
+        ).toBeInTheDocument();
+      });
+    });
 
     it("disables the action with 'next enrollment' tooltip when status is null (no record)", async () => {
       const render = createCustomRenderer({

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -636,15 +636,20 @@ const modifyOptions = (
     );
     if (managedAccountOption) {
       managedAccountOption.disabled = true;
-      if (
-        managedAccountStatus === "pending" ||
-        managedAccountStatus === "failed"
-      ) {
+      if (managedAccountStatus === "pending") {
         managedAccountOption.tooltipContent = (
           <>
             The managed account is still being
             <br />
             created.
+          </>
+        );
+      } else if (managedAccountStatus === "failed") {
+        managedAccountOption.tooltipContent = (
+          <>
+            The managed account failed to be
+            <br />
+            created. It will retry at the next enrollment.
           </>
         );
       } else {

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1625,7 +1625,12 @@ const HostDetailsPage = ({
           {showManagedAccountModal && host && (
             <ManagedAccountModal
               hostId={host.id}
-              onCancel={() => setShowManagedAccountModal(false)}
+              onCancel={() => {
+                setShowManagedAccountModal(false);
+                // Opening the modal triggers a "viewed managed account"
+                // activity server-side, so refetch to show it in the feed.
+                refetchPastActivities();
+              }}
             />
           )}
           {showBootstrapPackageModal &&

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
@@ -45,7 +45,6 @@ const ManagedAccountModal = ({
     <Modal
       title="Managed account"
       onExit={onCancel}
-      onEnter={onCancel}
       className={baseClass}
     >
       {isLoading && <Spinner />}

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/ManagedAccountModal/ManagedAccountModal.tsx
@@ -42,11 +42,7 @@ const ManagedAccountModal = ({
   );
 
   return (
-    <Modal
-      title="Managed account"
-      onExit={onCancel}
-      className={baseClass}
-    >
+    <Modal title="Managed account" onExit={onCancel} className={baseClass}>
       {isLoading && <Spinner />}
       {managedAccountError ? (
         <DataError />


### PR DESCRIPTION
## Issue
Closes #31741 

## Description
Follow-up post-review
- Separate failed tooltip on disable state (If the product team has specific copy for the failed state, this can be adjusted)
- Massage activity for unassigned hosts to read better
- Refetch activity feed on close so users will see the viewed activity in past activity immediately
- On enter won't close modal for people viewing the password using keyboard navigation on the show button



## Testing

- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Modal component now supports an optional Enter key handler.

* **Bug Fixes**
  * Improved activity feed text clarity for managed account operations.
  * Activity feed now properly updates after dismissing the managed account modal.
  * Tooltip messaging distinguishes between pending and failed managed account statuses.

* **Tests**
  * Expanded test coverage for managed account status-specific tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->