### PR TITLE
Improved Windows MDM profiles summary performance

### DIFF
--- a/changes/42545-windows-mdm-profile-summary-performance
+++ b/changes/42545-windows-mdm-profile-summary-performance
@@ -1,0 +1,1 @@
+- Improved Fleet server performance for the Windows MDM profiles summary and host OS settings filter queries by replacing correlated subqueries with a single aggregation pass.

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -1762,44 +1762,14 @@ AND (
 	// construct the WHERE for windows
 	whereWindows = `hmdm.is_server = 0`
 	paramsWindows := []any{}
-	subqueryFailed, paramsFailed, err := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	// profilesStatus does one aggregation pass over host_mdm_windows_profiles
+	// per host (correlated on h.uuid) instead of the previous four correlated
+	// EXISTS (with nested NOT EXISTS). See windowsHostProfileStatusSubquery.
+	profilesStatus, profilesStatusArgs, err := windowsHostProfileStatusSubquery("profiles_")
 	if err != nil {
 		return "", nil, err
 	}
-	paramsWindows = append(paramsWindows, paramsFailed...)
-	subqueryPending, paramsPending, err := subqueryHostsMDMWindowsOSSettingsStatusPending()
-	if err != nil {
-		return "", nil, err
-	}
-	paramsWindows = append(paramsWindows, paramsPending...)
-	subqueryVerifying, paramsVerifying, err := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
-	if err != nil {
-		return "", nil, err
-	}
-	paramsWindows = append(paramsWindows, paramsVerifying...)
-	subqueryVerified, paramsVerified, err := subqueryHostsMDMWindowsOSSettingsStatusVerified()
-	if err != nil {
-		return "", nil, err
-	}
-	paramsWindows = append(paramsWindows, paramsVerified...)
-
-	profilesStatus := fmt.Sprintf(`
-        CASE WHEN EXISTS (%s) THEN
-            'profiles_failed'
-        WHEN EXISTS (%s) THEN
-            'profiles_pending'
-        WHEN EXISTS (%s) THEN
-            'profiles_verifying'
-        WHEN EXISTS (%s) THEN
-            'profiles_verified'
-        ELSE
-            ''
-        END`,
-		subqueryFailed,
-		subqueryPending,
-		subqueryVerifying,
-		subqueryVerified,
-	)
+	paramsWindows = append(paramsWindows, profilesStatusArgs...)
 
 	bitlockerStatus := `''`
 	if diskEncryptionConfig.Enabled {

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1784,13 +1784,13 @@ type statusCounts struct {
 }
 
 func getMDMWindowsStatusCountsProfilesOnlyDB(ctx context.Context, ds *Datastore, teamID *uint) ([]statusCounts, error) {
-	reserved := mdm.ListFleetReservedWindowsProfileNames()
-	args := []any{
-		fleet.MDMDeliveryFailed, reserved,
-		fleet.MDMDeliveryPending, reserved,
-		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying, reserved,
-		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerified, reserved,
+	profilesStatus, profilesStatusArgs, err := windowsHostProfileStatusSubquery("")
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "windows host profile status subquery")
 	}
+
+	args := make([]any, 0, len(profilesStatusArgs)+1)
+	args = append(args, profilesStatusArgs...)
 
 	teamFilter := "h.team_id IS NULL"
 	if teamID != nil && *teamID > 0 {
@@ -1798,49 +1798,34 @@ func getMDMWindowsStatusCountsProfilesOnlyDB(ctx context.Context, ds *Datastore,
 		args = append(args, *teamID)
 	}
 
-	// Rather than up to four correlated EXISTS (three with nested NOT EXISTS)
-	// evaluated per host, we do a single aggregation pass over
-	// host_mdm_windows_profiles per host via the PK(host_uuid, profile_uuid)
-	// prefix, then classify each host's status. See
-	// windowsHostProfileStatusSubquery for the priority equivalence argument.
+	// profilesStatus is a correlated scalar subquery that does one aggregation
+	// pass over host_mdm_windows_profiles per host (via the PK(host_uuid,
+	// profile_uuid) prefix) and resolves directly to one of
+	// 'failed'|'pending'|'verifying'|'verified'|''. It replaces the previous
+	// four correlated EXISTS (three with a nested NOT EXISTS) with a single
+	// PK range scan per outer row. The outer SELECT/FROM/WHERE/GROUP BY shape
+	// is preserved verbatim so row-level counts (including duplicate enrolled
+	// rows in mdm_windows_enrollments, if any) match the prior implementation.
 	stmt := fmt.Sprintf(`
 SELECT
-    CASE
-        WHEN failed_count    > 0 THEN 'failed'
-        WHEN pending_count   > 0 THEN 'pending'
-        WHEN verifying_count > 0 THEN 'verifying'
-        WHEN verified_count  > 0 THEN 'verified'
-        ELSE ''
-    END AS final_status,
+    (%s) AS final_status,
     SUM(1) AS count
-FROM (
-    SELECT
-        h.id,
-        SUM(CASE WHEN hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS failed_count,
-        SUM(CASE WHEN (hmwp.status IS NULL OR hmwp.status = ?) AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS pending_count,
-        SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS verifying_count,
-        SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS verified_count
-    FROM hosts h
+FROM
+    hosts h
     JOIN host_mdm hmdm ON h.id = hmdm.host_id
     JOIN mdm_windows_enrollments mwe ON h.uuid = mwe.host_uuid
-    LEFT JOIN host_mdm_windows_profiles hmwp ON h.uuid = hmwp.host_uuid
-    WHERE
-        mwe.device_state = '%s' AND
-        h.platform = 'windows' AND
-        hmdm.is_server = 0 AND
-        hmdm.enrolled = 1 AND
-        %s
-    GROUP BY h.id
-) per_host
-GROUP BY final_status`,
+WHERE
+    mwe.device_state = '%s' AND
+    h.platform = 'windows' AND
+    hmdm.is_server = 0 AND
+    hmdm.enrolled = 1 AND
+    %s
+GROUP BY
+    final_status`,
+		profilesStatus,
 		microsoft_mdm.MDMDeviceStateEnrolled,
 		teamFilter,
 	)
-
-	stmt, args, err := sqlx.In(stmt, args...)
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "expand IN clauses for windows mdm profile status counts")
-	}
 
 	var counts []statusCounts
 	err = sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1680,99 +1680,61 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfileByTeamAndName(ctx context.Cont
 	})
 }
 
-func subqueryHostsMDMWindowsOSSettingsStatusFailed() (string, []interface{}, error) {
-	sql := `
-            SELECT
-                1 FROM host_mdm_windows_profiles hmwp
-            WHERE
-                h.uuid = hmwp.host_uuid
-                AND hmwp.status = ?
-                AND hmwp.profile_name NOT IN(?)`
-	args := []interface{}{
-		fleet.MDMDeliveryFailed,
-		mdm.ListFleetReservedWindowsProfileNames(),
+// windowsHostProfileStatusSubquery returns a correlated SQL scalar subquery
+// that resolves to one of `<statusPrefix>failed`, `<statusPrefix>pending`,
+// `<statusPrefix>verifying`, `<statusPrefix>verified`, or ” for the host
+// identified by h.uuid in the outer query.
+//
+// The subquery does a single aggregation pass over host_mdm_windows_profiles
+// via the PK(host_uuid, profile_uuid) prefix, replacing four correlated
+// EXISTS (three of which contain a nested NOT EXISTS). This takes per-host
+// evaluations down from up to seven PK range scans to one.
+//
+// The returned SQL does NOT include outer parentheses; callers wrap in
+// `(...)` as needed for the context (scalar subquery or CASE switch).
+//
+// Priority logic and its equivalence to the original EXISTS/NOT-EXISTS
+// version:
+//   - failed: any non-reserved profile has status='failed'.
+//   - pending: any non-reserved profile has status NULL or 'pending'.
+//   - verifying: at least one non-reserved install-type profile has
+//     status='verifying'. The original additionally required "no install-type
+//     non-reserved profile with status NULL or not in (verifying,verified)".
+//     At this CASE branch we already know failed=0 and pending=0, so no
+//     profile has status NULL/pending/failed; since profile status is always
+//     one of {NULL,pending,failed,verifying,verified}, that leaves only
+//     verifying and verified for install-type rows, so the extra clause is
+//     automatically satisfied.
+//   - verified: at least one non-reserved install-type profile has
+//     status='verified' and no install verifying exists (enforced by the
+//     earlier verifying branch).
+func windowsHostProfileStatusSubquery(statusPrefix string) (string, []any, error) {
+	reserved := mdm.ListFleetReservedWindowsProfileNames()
+
+	sql := fmt.Sprintf(`
+        SELECT CASE
+            WHEN SUM(CASE WHEN hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) > 0
+                THEN '%sfailed'
+            WHEN SUM(CASE WHEN (hmwp.status IS NULL OR hmwp.status = ?) AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) > 0
+                THEN '%spending'
+            WHEN SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) > 0
+                THEN '%sverifying'
+            WHEN SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) > 0
+                THEN '%sverified'
+            ELSE ''
+        END
+        FROM host_mdm_windows_profiles hmwp
+        WHERE hmwp.host_uuid = h.uuid`,
+		statusPrefix, statusPrefix, statusPrefix, statusPrefix,
+	)
+
+	args := []any{
+		fleet.MDMDeliveryFailed, reserved,
+		fleet.MDMDeliveryPending, reserved,
+		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying, reserved,
+		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerified, reserved,
 	}
 
-	return sqlx.In(sql, args...)
-}
-
-func subqueryHostsMDMWindowsOSSettingsStatusPending() (string, []interface{}, error) {
-	sql := `
-            SELECT
-                1 FROM host_mdm_windows_profiles hmwp
-            WHERE
-                h.uuid = hmwp.host_uuid
-                AND (hmwp.status IS NULL OR hmwp.status = ?)
-				AND hmwp.profile_name NOT IN(?)
-                AND NOT EXISTS (
-                    SELECT
-                        1 FROM host_mdm_windows_profiles hmwp2
-                    WHERE (h.uuid = hmwp2.host_uuid
-                        AND hmwp2.status = ?
-                        AND hmwp2.profile_name NOT IN(?)))`
-	args := []interface{}{
-		fleet.MDMDeliveryPending,
-		mdm.ListFleetReservedWindowsProfileNames(),
-		fleet.MDMDeliveryFailed,
-		mdm.ListFleetReservedWindowsProfileNames(),
-	}
-	return sqlx.In(sql, args...)
-}
-
-func subqueryHostsMDMWindowsOSSettingsStatusVerifying() (string, []interface{}, error) {
-	sql := `
-            SELECT
-                1 FROM host_mdm_windows_profiles hmwp
-            WHERE
-                h.uuid = hmwp.host_uuid
-                AND hmwp.operation_type = ?
-                AND hmwp.status = ?
-                AND hmwp.profile_name NOT IN(?)
-                AND NOT EXISTS (
-                    SELECT
-                        1 FROM host_mdm_windows_profiles hmwp2
-                    WHERE (h.uuid = hmwp2.host_uuid
-                        AND hmwp2.operation_type = ?
-                        AND hmwp2.profile_name NOT IN(?)
-                        AND(hmwp2.status IS NULL
-                            OR hmwp2.status NOT IN(?))))`
-
-	args := []interface{}{
-		fleet.MDMOperationTypeInstall,
-		fleet.MDMDeliveryVerifying,
-		mdm.ListFleetReservedWindowsProfileNames(),
-		fleet.MDMOperationTypeInstall,
-		mdm.ListFleetReservedWindowsProfileNames(),
-		[]interface{}{fleet.MDMDeliveryVerifying, fleet.MDMDeliveryVerified},
-	}
-	return sqlx.In(sql, args...)
-}
-
-func subqueryHostsMDMWindowsOSSettingsStatusVerified() (string, []interface{}, error) {
-	sql := `
-            SELECT
-                1 FROM host_mdm_windows_profiles hmwp
-            WHERE
-                h.uuid = hmwp.host_uuid
-                AND hmwp.operation_type = ?
-                AND hmwp.status = ?
-                AND hmwp.profile_name NOT IN(?)
-                AND NOT EXISTS (
-                    SELECT
-                        1 FROM host_mdm_windows_profiles hmwp2
-                    WHERE (h.uuid = hmwp2.host_uuid
-                        AND hmwp2.operation_type = ?
-                        AND hmwp2.profile_name NOT IN(?)
-                        AND(hmwp2.status IS NULL
-                            OR hmwp2.status != ?)))`
-	args := []interface{}{
-		fleet.MDMOperationTypeInstall,
-		fleet.MDMDeliveryVerified,
-		mdm.ListFleetReservedWindowsProfileNames(),
-		fleet.MDMOperationTypeInstall,
-		mdm.ListFleetReservedWindowsProfileNames(),
-		fleet.MDMDeliveryVerified,
-	}
 	return sqlx.In(sql, args...)
 }
 
@@ -1822,27 +1784,13 @@ type statusCounts struct {
 }
 
 func getMDMWindowsStatusCountsProfilesOnlyDB(ctx context.Context, ds *Datastore, teamID *uint) ([]statusCounts, error) {
-	var args []interface{}
-	subqueryFailed, subqueryFailedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusFailed()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusFailed")
+	reserved := mdm.ListFleetReservedWindowsProfileNames()
+	args := []any{
+		fleet.MDMDeliveryFailed, reserved,
+		fleet.MDMDeliveryPending, reserved,
+		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerifying, reserved,
+		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerified, reserved,
 	}
-	args = append(args, subqueryFailedArgs...)
-	subqueryPending, subqueryPendingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusPending()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusPending")
-	}
-	args = append(args, subqueryPendingArgs...)
-	subqueryVerifying, subqueryVeryingingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerifying")
-	}
-	args = append(args, subqueryVeryingingArgs...)
-	subqueryVerified, subqueryVerifiedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerified()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerified")
-	}
-	args = append(args, subqueryVerifiedArgs...)
 
 	teamFilter := "h.team_id IS NULL"
 	if teamID != nil && *teamID > 0 {
@@ -1850,40 +1798,49 @@ func getMDMWindowsStatusCountsProfilesOnlyDB(ctx context.Context, ds *Datastore,
 		args = append(args, *teamID)
 	}
 
+	// Rather than up to four correlated EXISTS (three with nested NOT EXISTS)
+	// evaluated per host, we do a single aggregation pass over
+	// host_mdm_windows_profiles per host via the PK(host_uuid, profile_uuid)
+	// prefix, then classify each host's status. See
+	// windowsHostProfileStatusSubquery for the priority equivalence argument.
 	stmt := fmt.Sprintf(`
 SELECT
     CASE
-        WHEN EXISTS (%s) THEN
-            'failed'
-        WHEN EXISTS (%s) THEN
-            'pending'
-        WHEN EXISTS (%s) THEN
-            'verifying'
-        WHEN EXISTS (%s) THEN
-            'verified'
-        ELSE
-            ''
+        WHEN failed_count    > 0 THEN 'failed'
+        WHEN pending_count   > 0 THEN 'pending'
+        WHEN verifying_count > 0 THEN 'verifying'
+        WHEN verified_count  > 0 THEN 'verified'
+        ELSE ''
     END AS final_status,
     SUM(1) AS count
-FROM
-    hosts h
+FROM (
+    SELECT
+        h.id,
+        SUM(CASE WHEN hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS failed_count,
+        SUM(CASE WHEN (hmwp.status IS NULL OR hmwp.status = ?) AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS pending_count,
+        SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS verifying_count,
+        SUM(CASE WHEN hmwp.operation_type = ? AND hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) AS verified_count
+    FROM hosts h
     JOIN host_mdm hmdm ON h.id = hmdm.host_id
     JOIN mdm_windows_enrollments mwe ON h.uuid = mwe.host_uuid
-WHERE
-    mwe.device_state = '%s' AND
-    h.platform = 'windows' AND
-    hmdm.is_server = 0 AND
-    hmdm.enrolled = 1 AND
-    %s
-GROUP BY
-    final_status`,
-		subqueryFailed,
-		subqueryPending,
-		subqueryVerifying,
-		subqueryVerified,
+    LEFT JOIN host_mdm_windows_profiles hmwp ON h.uuid = hmwp.host_uuid
+    WHERE
+        mwe.device_state = '%s' AND
+        h.platform = 'windows' AND
+        hmdm.is_server = 0 AND
+        hmdm.enrolled = 1 AND
+        %s
+    GROUP BY h.id
+) per_host
+GROUP BY final_status`,
 		microsoft_mdm.MDMDeviceStateEnrolled,
 		teamFilter,
 	)
+
+	stmt, args, err := sqlx.In(stmt, args...)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "expand IN clauses for windows mdm profile status counts")
+	}
 
 	var counts []statusCounts
 	err = sqlx.SelectContext(ctx, ds.reader(ctx), &counts, stmt, args...)
@@ -1894,54 +1851,19 @@ GROUP BY
 }
 
 func getMDMWindowsStatusCountsProfilesAndBitLockerDB(ctx context.Context, ds *Datastore, teamID *uint, bitLockerPINRequired bool) ([]statusCounts, error) {
-	var args []interface{}
-	subqueryFailed, subqueryFailedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusFailed()
+	profilesStatus, profilesStatusArgs, err := windowsHostProfileStatusSubquery("profiles_")
 	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusFailed")
+		return nil, ctxerr.Wrap(ctx, err, "windows host profile status subquery")
 	}
-	args = append(args, subqueryFailedArgs...)
-	subqueryPending, subqueryPendingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusPending()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusPending")
-	}
-	args = append(args, subqueryPendingArgs...)
-	subqueryVerifying, subqueryVeryingingArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerifying()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerifying")
-	}
-	args = append(args, subqueryVeryingingArgs...)
-	subqueryVerified, subqueryVerifiedArgs, err := subqueryHostsMDMWindowsOSSettingsStatusVerified()
-	if err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "subqueryHostsMDMWindowsOSSettingsStatusVerified")
-	}
-	args = append(args, subqueryVerifiedArgs...)
 
-	profilesStatus := fmt.Sprintf(`
-        CASE WHEN EXISTS (%s) THEN
-            'profiles_failed'
-        WHEN EXISTS (%s) THEN
-            'profiles_pending'
-        WHEN EXISTS (%s) THEN
-            'profiles_verifying'
-        WHEN EXISTS (%s) THEN
-            'profiles_verified'
-        ELSE
-            ''
-        END`,
-		subqueryFailed,
-		subqueryPending,
-		subqueryVerifying,
-		subqueryVerified,
-	)
+	args := make([]any, 0, len(profilesStatusArgs)+1)
+	args = append(args, profilesStatusArgs...)
 
 	teamFilter := "h.team_id IS NULL"
 	if teamID != nil && *teamID > 0 {
 		teamFilter = "h.team_id = ?"
 		args = append(args, *teamID)
 	}
-	bitlockerJoin := `
-    LEFT JOIN host_disk_encryption_keys hdek ON hdek.host_id = h.id
-    LEFT JOIN host_disks hd ON hd.host_id = h.id`
 
 	bitlockerStatus := fmt.Sprintf(`
             CASE WHEN (%s) THEN
@@ -1964,9 +1886,14 @@ func getMDMWindowsStatusCountsProfilesAndBitLockerDB(ctx context.Context, ds *Da
 		ds.whereBitLockerStatus(ctx, fleet.DiskEncryptionFailed, bitLockerPINRequired),
 	)
 
+	// profilesStatus is a scalar subquery that does one aggregation pass over
+	// host_mdm_windows_profiles per host (correlated on h.uuid). It replaces
+	// the original four correlated EXISTS (with nested NOT EXISTS) that each
+	// scanned the same rows independently. bitlockerStatus stays row-based
+	// (cheap predicates over hmdm/hdek/hd) and is evaluated per branch.
 	stmt := fmt.Sprintf(`
 SELECT
-    CASE (SELECT (%s) FROM hosts h2 WHERE h2.id = h.id)
+    CASE (%s)
     WHEN 'profiles_failed' THEN
         'failed'
     WHEN 'profiles_pending' THEN (
@@ -2008,7 +1935,8 @@ FROM
     hosts h
     JOIN host_mdm hmdm ON h.id = hmdm.host_id
     JOIN mdm_windows_enrollments mwe ON h.uuid = mwe.host_uuid
-    %s
+    LEFT JOIN host_disk_encryption_keys hdek ON hdek.host_id = h.id
+    LEFT JOIN host_disks hd ON hd.host_id = h.id
 WHERE
     mwe.device_state = '%s' AND
     h.platform = 'windows' AND
@@ -2022,7 +1950,6 @@ GROUP BY
 		bitlockerStatus,
 		bitlockerStatus,
 		bitlockerStatus,
-		bitlockerJoin,
 		microsoft_mdm.MDMDeviceStateEnrolled,
 		teamFilter,
 	)

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -1682,36 +1682,31 @@ func (ds *Datastore) DeleteMDMWindowsConfigProfileByTeamAndName(ctx context.Cont
 
 // windowsHostProfileStatusSubquery returns a correlated SQL scalar subquery
 // that resolves to one of `<statusPrefix>failed`, `<statusPrefix>pending`,
-// `<statusPrefix>verifying`, `<statusPrefix>verified`, or ” for the host
+// `<statusPrefix>verifying`, `<statusPrefix>verified`, or '<empty>' for the host
 // identified by h.uuid in the outer query.
 //
 // The subquery does a single aggregation pass over host_mdm_windows_profiles
-// via the PK(host_uuid, profile_uuid) prefix, replacing four correlated
-// EXISTS (three of which contain a nested NOT EXISTS). This takes per-host
-// evaluations down from up to seven PK range scans to one.
+// via the PK(host_uuid, profile_uuid) prefix.
 //
 // The returned SQL does NOT include outer parentheses; callers wrap in
 // `(...)` as needed for the context (scalar subquery or CASE switch).
 //
-// Priority logic and its equivalence to the original EXISTS/NOT-EXISTS
-// version:
+// Priority logic:
 //   - failed: any non-reserved profile has status='failed'.
 //   - pending: any non-reserved profile has status NULL or 'pending'.
 //   - verifying: at least one non-reserved install-type profile has
-//     status='verifying'. The original additionally required "no install-type
-//     non-reserved profile with status NULL or not in (verifying,verified)".
+//     status='verifying'.
 //     At this CASE branch we already know failed=0 and pending=0, so no
 //     profile has status NULL/pending/failed; since profile status is always
 //     one of {NULL,pending,failed,verifying,verified}, that leaves only
-//     verifying and verified for install-type rows, so the extra clause is
-//     automatically satisfied.
+//     verifying and verified for install-type rows.
 //   - verified: at least one non-reserved install-type profile has
 //     status='verified' and no install verifying exists (enforced by the
 //     earlier verifying branch).
 func windowsHostProfileStatusSubquery(statusPrefix string) (string, []any, error) {
 	reserved := mdm.ListFleetReservedWindowsProfileNames()
 
-	sql := fmt.Sprintf(`
+	stmt := fmt.Sprintf(`
         SELECT CASE
             WHEN SUM(CASE WHEN hmwp.status = ? AND hmwp.profile_name NOT IN (?) THEN 1 ELSE 0 END) > 0
                 THEN '%sfailed'
@@ -1735,7 +1730,7 @@ func windowsHostProfileStatusSubquery(statusPrefix string) (string, []any, error
 		fleet.MDMOperationTypeInstall, fleet.MDMDeliveryVerified, reserved,
 	}
 
-	return sqlx.In(sql, args...)
+	return sqlx.In(stmt, args...)
 }
 
 func (ds *Datastore) GetMDMWindowsProfilesSummary(ctx context.Context, teamID *uint) (*fleet.MDMProfilesSummary, error) {
@@ -1872,10 +1867,7 @@ func getMDMWindowsStatusCountsProfilesAndBitLockerDB(ctx context.Context, ds *Da
 	)
 
 	// profilesStatus is a scalar subquery that does one aggregation pass over
-	// host_mdm_windows_profiles per host (correlated on h.uuid). It replaces
-	// the original four correlated EXISTS (with nested NOT EXISTS) that each
-	// scanned the same rows independently. bitlockerStatus stays row-based
-	// (cheap predicates over hmdm/hdek/hd) and is evaluated per branch.
+	// host_mdm_windows_profiles per host (correlated on h.uuid).
 	stmt := fmt.Sprintf(`
 SELECT
     CASE (%s)

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -6,12 +6,14 @@ import (
 	"database/sql"
 	"encoding/xml"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/fleetdm/fleet/v4/pkg/optjson"
 	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/mdm"
 	"github.com/fleetdm/fleet/v4/server/mdm/apple/mobileconfig"
 	microsoft_mdm "github.com/fleetdm/fleet/v4/server/mdm/microsoft"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -45,6 +47,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestSetOrReplaceMDMWindowsConfigProfile", testSetOrReplaceMDMWindowsConfigProfile},
 		{"TestMDMWindowsDiskEncryption", testMDMWindowsDiskEncryption},
 		{"TestMDMWindowsProfilesSummary", testMDMWindowsProfilesSummary},
+		{"TestMDMWindowsProfilesSummaryEnumeration", testMDMWindowsProfilesSummaryEnumeration},
 		{"TestBatchSetMDMWindowsProfiles", testBatchSetMDMWindowsProfiles},
 		{"TestMDMWindowsProfileLabels", testMDMWindowsProfileLabels},
 		{"TestMDMWindowsSaveResponse", testSaveResponse},
@@ -4619,4 +4622,176 @@ func testMDMWindowsUnenrollCleansUpProfiles(t *testing.T, ds *Datastore) {
 	winProfs, err = ds.GetHostMDMWindowsProfiles(ctx, host.UUID)
 	require.NoError(t, err)
 	require.Empty(t, winProfs)
+}
+
+// testMDMWindowsProfilesSummaryEnumeration exhaustively enumerates every
+// possible (status, operation_type, reserved) shape a host_mdm_windows_profiles
+// row can take and exercises every 0-, 1-, and 2-profile host configuration
+// through GetMDMWindowsProfilesSummary.
+//
+// The input universe is finite and small: status is FK-constrained to
+// {NULL, failed, pending, verifying, verified} (5 values) and operation_type
+// is FK-constrained to {NULL, install, remove} (3 values); a profile is either
+// reserved or non-reserved (2). Per row that is 30 shapes; for 2-profile hosts
+// we enumerate all 30x30 = 900 ordered pairs, plus 30 single-profile cases,
+// plus one zero-profile case.
+func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Keep us on the profiles-only summary path (no BitLocker branches).
+	ac, err := ds.AppConfig(ctx)
+	require.NoError(t, err)
+	ac.MDM.EnableDiskEncryption = optjson.SetBool(false)
+	require.NoError(t, ds.SaveAppConfig(ctx, ac))
+
+	type profileShape struct {
+		status        *fleet.MDMDeliveryStatus
+		operationType *fleet.MDMOperationType
+		reserved      bool
+	}
+
+	var shapes []profileShape
+	statuses := []*fleet.MDMDeliveryStatus{
+		nil,
+		&fleet.MDMDeliveryFailed,
+		&fleet.MDMDeliveryPending,
+		&fleet.MDMDeliveryVerifying,
+		&fleet.MDMDeliveryVerified,
+	}
+	// MDMOperationType constants are untyped until bound to a local var, so we
+	// materialize pointers here.
+	opInstall := fleet.MDMOperationTypeInstall
+	opRemove := fleet.MDMOperationTypeRemove
+	opTypes := []*fleet.MDMOperationType{
+		nil,
+		&opInstall,
+		&opRemove,
+	}
+	for _, s := range statuses {
+		for _, o := range opTypes {
+			for _, r := range []bool{false, true} {
+				shapes = append(shapes, profileShape{status: s, operationType: o, reserved: r})
+			}
+		}
+	}
+	require.Len(t, shapes, len(statuses)*len(opTypes)*2)
+
+	// expectedFinalStatus implements the pre-refactor EXISTS/NOT-EXISTS logic
+	// literally so we can validate the new aggregation-based query against it.
+	expectedFinalStatus := func(profiles []profileShape) string {
+		isNonReserved := func(p profileShape) bool { return !p.reserved }
+		isNonReservedInstall := func(p profileShape) bool {
+			return !p.reserved && p.operationType != nil && *p.operationType == fleet.MDMOperationTypeInstall
+		}
+		anyMatch := func(xs []profileShape, pred func(profileShape) bool) bool {
+			return slices.ContainsFunc(xs, pred)
+		}
+
+		// EXISTS(non-reserved row with status='failed')
+		if anyMatch(profiles, func(p profileShape) bool {
+			return isNonReserved(p) && p.status != nil && *p.status == fleet.MDMDeliveryFailed
+		}) {
+			return "failed"
+		}
+		// EXISTS(non-reserved row with status IS NULL OR status='pending')
+		if anyMatch(profiles, func(p profileShape) bool {
+			return isNonReserved(p) && (p.status == nil || *p.status == fleet.MDMDeliveryPending)
+		}) {
+			return "pending"
+		}
+		// EXISTS(non-reserved install row with status='verifying')
+		// AND NOT EXISTS(non-reserved install row with status NULL or status NOT IN (verifying, verified))
+		hasVerifying := anyMatch(profiles, func(p profileShape) bool {
+			return isNonReservedInstall(p) && p.status != nil && *p.status == fleet.MDMDeliveryVerifying
+		})
+		verifyingBlocker := anyMatch(profiles, func(p profileShape) bool {
+			return isNonReservedInstall(p) && (p.status == nil ||
+				(*p.status != fleet.MDMDeliveryVerifying && *p.status != fleet.MDMDeliveryVerified))
+		})
+		if hasVerifying && !verifyingBlocker {
+			return "verifying"
+		}
+		// EXISTS(non-reserved install row with status='verified')
+		// AND NOT EXISTS(non-reserved install row with status NULL or status != 'verified')
+		hasVerified := anyMatch(profiles, func(p profileShape) bool {
+			return isNonReservedInstall(p) && p.status != nil && *p.status == fleet.MDMDeliveryVerified
+		})
+		verifiedBlocker := anyMatch(profiles, func(p profileShape) bool {
+			return isNonReservedInstall(p) && (p.status == nil || *p.status != fleet.MDMDeliveryVerified)
+		})
+		if hasVerified && !verifiedBlocker {
+			return "verified"
+		}
+		return ""
+	}
+
+	// Build every configuration: 0-, 1-, and 2-profile.
+	var cases [][]profileShape
+	cases = append(cases, nil)
+	for _, a := range shapes {
+		cases = append(cases, []profileShape{a})
+	}
+	for _, a := range shapes {
+		for _, b := range shapes {
+			cases = append(cases, []profileShape{a, b})
+		}
+	}
+	require.Len(t, cases, 1+len(shapes)+len(shapes)*len(shapes))
+
+	// Tally the expected bucket counts for the final assertion.
+	var expected fleet.MDMProfilesSummary
+	for _, c := range cases {
+		switch expectedFinalStatus(c) {
+		case "failed":
+			expected.Failed++
+		case "pending":
+			expected.Pending++
+		case "verifying":
+			expected.Verifying++
+		case "verified":
+			expected.Verified++
+		}
+	}
+
+	// Insert one Windows host per case (all on the global "no team" scope so
+	// the summary query's `h.team_id IS NULL` branch covers them), then insert
+	// its profile rows.
+	const nonReservedName = "enum-test-profile"
+	reservedName := mdm.FleetWindowsOSUpdatesProfileName
+	now := time.Now()
+	for caseIdx, c := range cases {
+		hostUUID := fmt.Sprintf("enum-host-%04d", caseIdx)
+		h := test.NewHost(t, ds, hostUUID, "1.1.1.1", hostUUID, hostUUID, now, test.WithPlatform("windows"))
+		require.NoError(t, ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "https://example.com", false, fleet.WellKnownMDMFleet, "", false))
+		windowsEnroll(t, ds, h)
+
+		for i, p := range c {
+			profUUID := fmt.Sprintf("%s-p%d", hostUUID, i)
+			commandUUID := fmt.Sprintf("cmd-%s", profUUID)
+			name := nonReservedName
+			if p.reserved {
+				name = reservedName
+			}
+			var statusArg any
+			if p.status != nil {
+				statusArg = string(*p.status)
+			}
+			var opTypeArg any
+			if p.operationType != nil {
+				opTypeArg = string(*p.operationType)
+			}
+			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+				_, err := q.ExecContext(ctx,
+					`INSERT INTO host_mdm_windows_profiles (host_uuid, profile_uuid, profile_name, status, operation_type, command_uuid) VALUES (?, ?, ?, ?, ?, ?)`,
+					hostUUID, profUUID, name, statusArg, opTypeArg, commandUUID)
+				return err
+			})
+		}
+	}
+
+	got, err := ds.GetMDMWindowsProfilesSummary(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	require.Equalf(t, expected, *got,
+		"aggregate bucket counts diverged from reference implementation over %d enumerated configurations", len(cases))
 }

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -4683,28 +4683,25 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 		isNonReservedInstall := func(p profileShape) bool {
 			return !p.reserved && p.operationType != nil && *p.operationType == fleet.MDMOperationTypeInstall
 		}
-		anyMatch := func(xs []profileShape, pred func(profileShape) bool) bool {
-			return slices.ContainsFunc(xs, pred)
-		}
 
 		// EXISTS(non-reserved row with status='failed')
-		if anyMatch(profiles, func(p profileShape) bool {
+		if slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReserved(p) && p.status != nil && *p.status == fleet.MDMDeliveryFailed
 		}) {
 			return "failed"
 		}
 		// EXISTS(non-reserved row with status IS NULL OR status='pending')
-		if anyMatch(profiles, func(p profileShape) bool {
+		if slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReserved(p) && (p.status == nil || *p.status == fleet.MDMDeliveryPending)
 		}) {
 			return "pending"
 		}
 		// EXISTS(non-reserved install row with status='verifying')
 		// AND NOT EXISTS(non-reserved install row with status NULL or status NOT IN (verifying, verified))
-		hasVerifying := anyMatch(profiles, func(p profileShape) bool {
+		hasVerifying := slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReservedInstall(p) && p.status != nil && *p.status == fleet.MDMDeliveryVerifying
 		})
-		verifyingBlocker := anyMatch(profiles, func(p profileShape) bool {
+		verifyingBlocker := slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReservedInstall(p) && (p.status == nil ||
 				(*p.status != fleet.MDMDeliveryVerifying && *p.status != fleet.MDMDeliveryVerified))
 		})
@@ -4713,10 +4710,10 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 		}
 		// EXISTS(non-reserved install row with status='verified')
 		// AND NOT EXISTS(non-reserved install row with status NULL or status != 'verified')
-		hasVerified := anyMatch(profiles, func(p profileShape) bool {
+		hasVerified := slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReservedInstall(p) && p.status != nil && *p.status == fleet.MDMDeliveryVerified
 		})
-		verifiedBlocker := anyMatch(profiles, func(p profileShape) bool {
+		verifiedBlocker := slices.ContainsFunc(profiles, func(p profileShape) bool {
 			return isNonReservedInstall(p) && (p.status == nil || *p.status != fleet.MDMDeliveryVerified)
 		})
 		if hasVerified && !verifiedBlocker {
@@ -4738,10 +4735,25 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 	}
 	require.Len(t, cases, 1+len(shapes)+len(shapes)*len(shapes))
 
-	// Tally the expected bucket counts for the final assertion.
+	// Map "<bucket>" -> OSSettingsFilter for the per-host membership check.
+	bucketFilter := map[string]fleet.OSSettingsStatus{
+		"failed":    fleet.OSSettingsFailed,
+		"pending":   fleet.OSSettingsPending,
+		"verifying": fleet.OSSettingsVerifying,
+		"verified":  fleet.OSSettingsVerified,
+	}
+
+	// Tally expected bucket counts (for the summary assertion) and expected
+	// host membership per bucket (for the filter assertion). The membership
+	// check defends against regressions that swap two configurations between
+	// buckets while preserving aggregate counts.
 	var expected fleet.MDMProfilesSummary
-	for _, c := range cases {
-		switch expectedFinalStatus(c) {
+	expectedHostsByBucket := map[fleet.OSSettingsStatus][]uint{}
+	expectedBucketByCase := make([]string, len(cases))
+	for i, c := range cases {
+		bucket := expectedFinalStatus(c)
+		expectedBucketByCase[i] = bucket
+		switch bucket {
 		case "failed":
 			expected.Failed++
 		case "pending":
@@ -4755,7 +4767,8 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 
 	// Insert one Windows host per case (all on the global "no team" scope so
 	// the summary query's `h.team_id IS NULL` branch covers them), then insert
-	// its profile rows.
+	// its profile rows. Track each host's expected bucket by ID for the
+	// per-host membership assertion below.
 	const nonReservedName = "enum-test-profile"
 	reservedName := mdm.FleetWindowsOSUpdatesProfileName
 	now := time.Now()
@@ -4764,6 +4777,10 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 		h := test.NewHost(t, ds, hostUUID, "1.1.1.1", hostUUID, hostUUID, now, test.WithPlatform("windows"))
 		require.NoError(t, ds.SetOrUpdateMDMData(ctx, h.ID, false, true, "https://example.com", false, fleet.WellKnownMDMFleet, "", false))
 		windowsEnroll(t, ds, h)
+
+		if filter, ok := bucketFilter[expectedBucketByCase[caseIdx]]; ok {
+			expectedHostsByBucket[filter] = append(expectedHostsByBucket[filter], h.ID)
+		}
 
 		for i, p := range c {
 			profUUID := fmt.Sprintf("%s-p%d", hostUUID, i)
@@ -4789,9 +4806,32 @@ func testMDMWindowsProfilesSummaryEnumeration(t *testing.T, ds *Datastore) {
 		}
 	}
 
+	// 1) Aggregate bucket counts via GetMDMWindowsProfilesSummary.
 	got, err := ds.GetMDMWindowsProfilesSummary(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equalf(t, expected, *got,
 		"aggregate bucket counts diverged from reference implementation over %d enumerated configurations", len(cases))
+
+	// 2) Per-host membership via ListHosts with OSSettingsFilter. This
+	//    catches regressions that preserve aggregate counts but swap two
+	//    hosts between buckets, and also exercises filterHostsByOSSettingsStatus
+	//    (the host-list path uses the same windowsHostProfileStatusSubquery
+	//    helper but a different outer query).
+	teamFilter := fleet.TeamFilter{User: test.UserAdmin}
+	for _, filter := range []fleet.OSSettingsStatus{
+		fleet.OSSettingsFailed,
+		fleet.OSSettingsPending,
+		fleet.OSSettingsVerifying,
+		fleet.OSSettingsVerified,
+	} {
+		gotHosts, err := ds.ListHosts(ctx, teamFilter, fleet.HostListOptions{OSSettingsFilter: filter})
+		require.NoError(t, err)
+		gotIDs := make([]uint, 0, len(gotHosts))
+		for _, h := range gotHosts {
+			gotIDs = append(gotIDs, h.ID)
+		}
+		require.ElementsMatchf(t, expectedHostsByBucket[filter], gotIDs,
+			"per-host membership mismatch for OSSettingsFilter=%s", filter)
+	}
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44050 

Original query like:
```sql
SELECT
    CASE
        WHEN EXISTS (
            SELECT 1 FROM host_mdm_windows_profiles hmwp
            WHERE h.uuid = hmwp.host_uuid
              AND hmwp.status = 'failed'                              -- fleet.MDMDeliveryFailed
              AND hmwp.profile_name NOT IN (<reserved_names>)
        ) THEN 'failed'
        WHEN EXISTS (
            SELECT 1 FROM host_mdm_windows_profiles hmwp
            WHERE h.uuid = hmwp.host_uuid
              AND (hmwp.status IS NULL OR hmwp.status = 'pending')    -- fleet.MDMDeliveryPending
              AND hmwp.profile_name NOT IN (<reserved_names>)
              AND NOT EXISTS (
                  SELECT 1 FROM host_mdm_windows_profiles hmwp2
                  WHERE h.uuid = hmwp2.host_uuid
                    AND hmwp2.status = 'failed'
                    AND hmwp2.profile_name NOT IN (<reserved_names>)
              )
        ) THEN 'pending'
        WHEN EXISTS (
            SELECT 1 FROM host_mdm_windows_profiles hmwp
            WHERE h.uuid = hmwp.host_uuid
              AND hmwp.operation_type = 'install'                     -- fleet.MDMOperationTypeInstall
              AND hmwp.status = 'verifying'                           -- fleet.MDMDeliveryVerifying
              AND hmwp.profile_name NOT IN (<reserved_names>)
              AND NOT EXISTS (
                  SELECT 1 FROM host_mdm_windows_profiles hmwp2
                  WHERE h.uuid = hmwp2.host_uuid
                    AND hmwp2.operation_type = 'install'
                    AND hmwp2.profile_name NOT IN (<reserved_names>)
                    AND (hmwp2.status IS NULL
                         OR hmwp2.status NOT IN ('verifying', 'verified'))
              )
        ) THEN 'verifying'
        WHEN EXISTS (
            SELECT 1 FROM host_mdm_windows_profiles hmwp
            WHERE h.uuid = hmwp.host_uuid
              AND hmwp.operation_type = 'install'
              AND hmwp.status = 'verified'                            -- fleet.MDMDeliveryVerified
              AND hmwp.profile_name NOT IN (<reserved_names>)
              AND NOT EXISTS (
                  SELECT 1 FROM host_mdm_windows_profiles hmwp2
                  WHERE h.uuid = hmwp2.host_uuid
                    AND hmwp2.operation_type = 'install'
                    AND hmwp2.profile_name NOT IN (<reserved_names>)
                    AND (hmwp2.status IS NULL OR hmwp2.status != 'verified')
              )
        ) THEN 'verified'
        ELSE ''
    END AS final_status,
    SUM(1) AS count
FROM
    hosts h
    JOIN host_mdm hmdm                 ON h.id   = hmdm.host_id
    JOIN mdm_windows_enrollments mwe   ON h.uuid = mwe.host_uuid
WHERE
    mwe.device_state = 'enrolled'      -- microsoft_mdm.MDMDeviceStateEnrolled
    AND h.platform = 'windows'
    AND hmdm.is_server = 0
    AND hmdm.enrolled = 1
    AND <team_filter>
GROUP BY
    final_status;
```

New query like:
```sql
SELECT
    (
        SELECT CASE
            WHEN SUM(CASE WHEN hmwp.status = 'failed'
                           AND hmwp.profile_name NOT IN (<reserved_names>)
                          THEN 1 ELSE 0 END) > 0
                THEN 'failed'
            WHEN SUM(CASE WHEN (hmwp.status IS NULL OR hmwp.status = 'pending')
                           AND hmwp.profile_name NOT IN (<reserved_names>)
                          THEN 1 ELSE 0 END) > 0
                THEN 'pending'
            WHEN SUM(CASE WHEN hmwp.operation_type = 'install'
                           AND hmwp.status = 'verifying'
                           AND hmwp.profile_name NOT IN (<reserved_names>)
                          THEN 1 ELSE 0 END) > 0
                THEN 'verifying'
            WHEN SUM(CASE WHEN hmwp.operation_type = 'install'
                           AND hmwp.status = 'verified'
                           AND hmwp.profile_name NOT IN (<reserved_names>)
                          THEN 1 ELSE 0 END) > 0
                THEN 'verified'
            ELSE ''
        END
        FROM host_mdm_windows_profiles hmwp
        WHERE hmwp.host_uuid = h.uuid
    ) AS final_status,
    SUM(1) AS count
FROM
    hosts h
    JOIN host_mdm hmdm                 ON h.id   = hmdm.host_id
    JOIN mdm_windows_enrollments mwe   ON h.uuid = mwe.host_uuid
WHERE
    mwe.device_state = 'enrolled'
    AND h.platform = 'windows'
    AND hmdm.is_server = 0
    AND hmdm.enrolled = 1
    AND <team_filter>
GROUP BY
    final_status;
```

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests

- [x] QA'd all new/changed functionality manually

For unreleased bug fixes in a release candidate, one of:

- [x] Alerted the release DRI if additional load testing is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized Windows MDM profile summary and host OS settings filtering for faster, lower-cost server queries.

* **Tests**
  * Added an exhaustive verification test covering all Windows MDM profile permutations to ensure correct status bucketing and host membership.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->