### PR TITLE
Fix overflow issue on report's descriptions

### DIFF
--- a/frontend/pages/hosts/details/HostReportsTab/_styles.scss
+++ b/frontend/pages/hosts/details/HostReportsTab/_styles.scss
@@ -118,6 +118,7 @@
     font-size: $xx-small;
     color: $ui-fleet-black-75;
     margin: $pad-xsmall 0 0;
+    overflow-wrap: anywhere;
   }
 
   &__clipped-badge {

--- a/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
+++ b/frontend/pages/queries/details/QueryDetailsPage/_styles.scss
@@ -1,6 +1,10 @@
 .query-details-page {
   @include vertical-page-layout;
 
+  &__query-description {
+    overflow-wrap: anywhere;
+  }
+
   &__title-bar {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44025

Updated overflow CSS rules so that a single long word doesn't overflow the report description component.

<img width="1498" height="625" alt="image" src="https://github.com/user-attachments/assets/eb74307a-6fc9-4c2b-8879-4e878873db73" />

<img width="1910" height="361" alt="image" src="https://github.com/user-attachments/assets/232fb8d2-66d3-433f-8947-936916a16f37" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

## Testing

- [X] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved text wrapping behavior for host report and query description content to prevent overflow and ensure proper display within their containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->