### PR TITLE
Reworked Windows profile delete batching

### DIFF
--- a/changes/42545-windows-profile-delete-batching
+++ b/changes/42545-windows-profile-delete-batching
@@ -1,0 +1,1 @@
+* Improved the performance of deleting Windows MDM configuration profiles at scale by collapsing the per-profile update loop into a single batched statement that spans multiple profiles per chunk.

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -21,10 +21,15 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
-// windowsMDMProfileDeleteBatchSize is the number of hosts to process per
-// batch when enqueuing <Delete> commands and updating host profile rows
-// during profile deletion.
-const windowsMDMProfileDeleteBatchSize = 5000
+// windowsMDMProfileDeleteBatchSize is the number of rows to process per batch
+// when enqueuing <Delete> commands, resolving enrollment IDs, and updating
+// host profile rows during profile deletion.
+//
+// 10,000 stays well under MySQL's 65,535 placeholder limit on every caller
+// (the densest caller is the batched UPDATE with tuple IN + CASE per profile,
+// which tops out near ~20,000 placeholders at this batch size) and matches
+// the batch sizes used elsewhere in Fleet for host-table bulk ops.
+const windowsMDMProfileDeleteBatchSize = 10000
 
 func isWindowsHostConnectedToFleetMDM(ctx context.Context, q sqlx.QueryerContext, h *fleet.Host) (bool, error) {
 	var unused string
@@ -1474,25 +1479,71 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 	// Update host-profile rows only for profiles that had delete commands enqueued.
 	// This covers both install rows (being flipped to remove) and remove+NULL rows
 	// (being given a command_uuid and set to pending).
+	//
+	// Flatten (host_uuid, profile_uuid, cmd_uuid) triples across all profiles and
+	// batch them into a single UPDATE per batch. Each batch can span multiple
+	// profiles, with a CASE mapping each row's profile_uuid to its command_uuid.
+	// The WHERE clause uses a tuple IN on (host_uuid, profile_uuid), which matches
+	// the PK and lets the optimizer perform direct PK point lookups. This avoids
+	// the previous per-profile loop, which under-utilized batches when profiles
+	// affected fewer than batchSize hosts.
+	type pendingRemoveRow struct {
+		hostUUID    string
+		profileUUID string
+		cmdUUID     string
+	}
+	var rows []pendingRemoveRow
 	for profUUID, target := range enqueuedTargets {
-		if err := common_mysql.BatchProcessSimple(target.hostUUIDs, windowsMDMProfileDeleteBatchSize, func(batch []string) error {
-			upStmt, upArgs, err := sqlx.In(
-				`UPDATE host_mdm_windows_profiles
-				SET operation_type = ?, status = ?, command_uuid = ?, detail = ''
-				WHERE profile_uuid = ? AND host_uuid IN (?)`,
-				fleet.MDMOperationTypeRemove, fleet.MDMDeliveryPending, target.cmdUUID,
-				profUUID, batch,
-			)
-			if err != nil {
-				return ctxerr.Wrap(ctx, err, "building IN for phase 2 update")
-			}
-			if _, err := tx.ExecContext(ctx, upStmt, upArgs...); err != nil {
-				return ctxerr.Wrap(ctx, err, "updating host profiles to remove")
-			}
-			return nil
-		}); err != nil {
-			return err
+		for _, hostUUID := range target.hostUUIDs {
+			rows = append(rows, pendingRemoveRow{
+				hostUUID:    hostUUID,
+				profileUUID: profUUID,
+				cmdUUID:     target.cmdUUID,
+			})
 		}
+	}
+
+	if err := common_mysql.BatchProcessSimple(rows, windowsMDMProfileDeleteBatchSize, func(batch []pendingRemoveRow) error {
+		// Collect the profile_uuid -> cmd_uuid mapping needed by this batch. Most
+		// batches span 1 to N profiles; we only need one CASE arm per distinct
+		// profile in the batch.
+		profileCmds := make(map[string]string)
+		for _, r := range batch {
+			profileCmds[r.profileUUID] = r.cmdUUID
+		}
+
+		var sb strings.Builder
+		sb.WriteString(`UPDATE host_mdm_windows_profiles
+			SET operation_type = ?,
+			    status = ?,
+			    detail = '',
+			    command_uuid = CASE profile_uuid`)
+		args := make([]any, 0, 2+2*len(profileCmds)+2*len(batch))
+		args = append(args, fleet.MDMOperationTypeRemove, fleet.MDMDeliveryPending)
+		for profUUID, cmdUUID := range profileCmds {
+			sb.WriteString(" WHEN ? THEN ?")
+			args = append(args, profUUID, cmdUUID)
+		}
+		// ELSE command_uuid is defensive: WHERE restricts the update to rows
+		// whose profile_uuid is present in profileCmds, so in practice every
+		// updated row matches a WHEN arm.
+		sb.WriteString(` ELSE command_uuid END
+			WHERE (host_uuid, profile_uuid) IN (`)
+		for i, r := range batch {
+			if i > 0 {
+				sb.WriteByte(',')
+			}
+			sb.WriteString("(?,?)")
+			args = append(args, r.hostUUID, r.profileUUID)
+		}
+		sb.WriteByte(')')
+
+		if _, err := tx.ExecContext(ctx, sb.String(), args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "updating host profiles to remove")
+		}
+		return nil
+	}); err != nil {
+		return err
 	}
 
 	return nil

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -25,10 +25,16 @@ import (
 // when enqueuing <Delete> commands, resolving enrollment IDs, and updating
 // host profile rows during profile deletion.
 //
-// 10,000 stays well under MySQL's 65,535 placeholder limit on every caller
-// (the densest caller is the batched UPDATE with tuple IN + CASE per profile,
-// which tops out near ~20,000 placeholders at this batch size) and matches
-// the batch sizes used elsewhere in Fleet for host-table bulk ops.
+// 10,000 stays under MySQL's 65,535 placeholder limit on every caller. The
+// densest caller is the batched UPDATE with tuple IN + CASE per profile in
+// cancelWindowsHostInstallsForDeletedMDMProfiles, whose placeholder count is
+//
+//	2 (constants) + 2*distinctProfilesInBatch (CASE arms) + 2*rowsInBatch (IN)
+//
+// At batchSize=10,000 the realistic case (tens of profiles × many hosts each)
+// is ~20,000 placeholders, and the worst case (up to 10,000 distinct profiles
+// sharing a 10,000-row batch) is 40,002, still well under 65,535. The value
+// also matches the batch sizes used elsewhere in Fleet for host-table bulk ops.
 const windowsMDMProfileDeleteBatchSize = 10000
 
 func isWindowsHostConnectedToFleetMDM(ctx context.Context, q sqlx.QueryerContext, h *fleet.Host) (bool, error) {
@@ -1487,13 +1493,24 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 	// the PK and lets the optimizer perform direct PK point lookups. This avoids
 	// the previous per-profile loop, which under-utilized batches when profiles
 	// affected fewer than batchSize hosts.
+	//
+	// Profile UUIDs are iterated in sorted order so that the generated SQL text
+	// (IN-tuple order within a batch and CASE-arm order) is deterministic across
+	// runs; that keeps MySQL plan-cache entries and observability query digests
+	// stable.
 	type pendingRemoveRow struct {
 		hostUUID    string
 		profileUUID string
 		cmdUUID     string
 	}
-	var rows []pendingRemoveRow
-	for profUUID, target := range enqueuedTargets {
+	sortedProfUUIDs := slices.Sorted(maps.Keys(enqueuedTargets))
+	totalRows := 0
+	for _, profUUID := range sortedProfUUIDs {
+		totalRows += len(enqueuedTargets[profUUID].hostUUIDs)
+	}
+	rows := make([]pendingRemoveRow, 0, totalRows)
+	for _, profUUID := range sortedProfUUIDs {
+		target := enqueuedTargets[profUUID]
 		for _, hostUUID := range target.hostUUIDs {
 			rows = append(rows, pendingRemoveRow{
 				hostUUID:    hostUUID,
@@ -1511,6 +1528,7 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 		for _, r := range batch {
 			profileCmds[r.profileUUID] = r.cmdUUID
 		}
+		sortedBatchProfUUIDs := slices.Sorted(maps.Keys(profileCmds))
 
 		var sb strings.Builder
 		sb.WriteString(`UPDATE host_mdm_windows_profiles
@@ -1520,9 +1538,9 @@ func (ds *Datastore) cancelWindowsHostInstallsForDeletedMDMProfiles(
 			    command_uuid = CASE profile_uuid`)
 		args := make([]any, 0, 2+2*len(profileCmds)+2*len(batch))
 		args = append(args, fleet.MDMOperationTypeRemove, fleet.MDMDeliveryPending)
-		for profUUID, cmdUUID := range profileCmds {
+		for _, profUUID := range sortedBatchProfUUIDs {
 			sb.WriteString(" WHEN ? THEN ?")
-			args = append(args, profUUID, cmdUUID)
+			args = append(args, profUUID, profileCmds[profUUID])
 		}
 		// ELSE command_uuid is defensive: WHERE restricts the update to rows
 		// whose profile_uuid is present in profileCmds, so in practice every

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -54,6 +54,7 @@ func TestMDMWindows(t *testing.T) {
 		{"TestResendWindowsMDMCommand", testResendWindowsMDMCommand},
 		{"TestDeleteProfileLocURIProtection", testDeleteProfileLocURIProtection},
 		{"TestEditProfileDeletesRemovedLocURIs", testEditProfileDeletesRemovedLocURIs},
+		{"TestBatchDeleteMultipleWindowsProfiles", testBatchDeleteMultipleWindowsProfiles},
 		{"TestMDMWindowsUnenrollCleansUpProfiles", testMDMWindowsUnenrollCleansUpProfiles},
 	}
 
@@ -1968,6 +1969,58 @@ func windowsEnroll(t *testing.T, ds fleet.Datastore, h *fleet.Host) string {
 	err := ds.MDMWindowsInsertEnrolledDevice(ctx, d1)
 	require.NoError(t, err)
 	return d1.MDMDeviceID
+}
+
+// windowsProfileUUIDByName returns the profile_uuid of a Windows config profile
+// identified by its (unique) name.
+func windowsProfileUUIDByName(t *testing.T, ds *Datastore, name string) string {
+	t.Helper()
+	var u string
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(t.Context(), q, &u,
+			`SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = ?`, name)
+	})
+	return u
+}
+
+// installWindowsProfilesAsVerified simulates a successful prior install of each
+// profile on each host by inserting operation_type=install, status=verified rows
+// via BulkUpsertMDMWindowsHostProfiles.
+func installWindowsProfilesAsVerified(t *testing.T, ds *Datastore, hostUUIDs, profileUUIDs []string) {
+	t.Helper()
+	verified := fleet.MDMDeliveryVerified
+	var payloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload
+	for _, hUUID := range hostUUIDs {
+		for _, pUUID := range profileUUIDs {
+			payloads = append(payloads, &fleet.MDMWindowsBulkUpsertHostProfilePayload{
+				ProfileUUID:   pUUID,
+				ProfileName:   "test",
+				HostUUID:      hUUID,
+				CommandUUID:   uuid.NewString(),
+				OperationType: fleet.MDMOperationTypeInstall,
+				Status:        &verified,
+				Checksum:      []byte{0},
+			})
+		}
+	}
+	require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(t.Context(), payloads))
+}
+
+// rawWindowsDeleteCommandForHostProfile returns the raw SyncML of the queued
+// <Delete> command for a (host, profile) pair by joining host_mdm_windows_profiles
+// (operation_type=remove) to windows_mdm_commands via command_uuid. Returns empty
+// bytes if no such command is queued.
+func rawWindowsDeleteCommandForHostProfile(t *testing.T, ds *Datastore, hostUUID, profileUUID string) []byte {
+	t.Helper()
+	var raw []byte
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(t.Context(), q, &raw,
+			`SELECT wc.raw_command FROM windows_mdm_commands wc
+			 JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
+			 WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = ?`,
+			hostUUID, profileUUID, fleet.MDMOperationTypeRemove)
+	})
+	return raw
 }
 
 func testMDMWindowsProfileManagement(t *testing.T, ds *Datastore) {
@@ -4344,37 +4397,16 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 	profB := &fleet.MDMWindowsConfigProfile{Name: "profB", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/Y</LocURI></Target><Data>2</Data></Item></Replace>`)}
 
 	// Insert both profiles.
-	var profAUUID, profBUUID string
 	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profA, profB}, nil)
 		return err
 	})
 	require.NoError(t, err)
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &profAUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profA'`)
-	})
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &profBUUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'profB'`)
-	})
+	profAUUID := windowsProfileUUIDByName(t, ds, "profA")
+	profBUUID := windowsProfileUUIDByName(t, ds, "profB")
 
 	// Simulate both profiles installed on both hosts.
-	verified := fleet.MDMDeliveryVerified
-	var hostProfilePayloads []*fleet.MDMWindowsBulkUpsertHostProfilePayload
-	for _, hUUID := range []string{h1.UUID, h2.UUID} {
-		for _, pUUID := range []string{profAUUID, profBUUID} {
-			hostProfilePayloads = append(hostProfilePayloads, &fleet.MDMWindowsBulkUpsertHostProfilePayload{
-				ProfileUUID:   pUUID,
-				ProfileName:   "test",
-				HostUUID:      hUUID,
-				CommandUUID:   uuid.NewString(),
-				OperationType: fleet.MDMOperationTypeInstall,
-				Status:        &verified,
-				Checksum:      []byte{0},
-			})
-		}
-	}
-	err = ds.BulkUpsertMDMWindowsHostProfiles(ctx, hostProfilePayloads)
-	require.NoError(t, err)
+	installWindowsProfilesAsVerified(t, ds, []string{h1.UUID, h2.UUID}, []string{profAUUID, profBUUID})
 
 	t.Run("shared LocURI not deleted when other profile uses it", func(t *testing.T) {
 		t.Cleanup(func() {
@@ -4390,13 +4422,7 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 
 		// Verify the delete command on BOTH hosts.
 		for _, h := range []*fleet.Host{h1, h2} {
-			var rawCmd []byte
-			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-				return sqlx.GetContext(ctx, q, &rawCmd,
-					`SELECT wc.raw_command FROM windows_mdm_commands wc
-					JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
-					WHERE hwp.host_uuid = ? AND hwp.operation_type = 'remove'`, h.UUID)
-			})
+			rawCmd := rawWindowsDeleteCommandForHostProfile(t, ds, h.UUID, profAUUID)
 			require.NotEmpty(t, rawCmd, "host %s should have a delete command", h.Hostname)
 			rawStr := string(rawCmd)
 			assert.Contains(t, rawStr, "./Device/X", "host %s: should delete LocURI X", h.Hostname)
@@ -4423,13 +4449,8 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		})
 		require.NoError(t, err)
 
-		var profA2UUID, profB2UUID string
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profA2UUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'ls-profA'`)
-		})
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profB2UUID, `SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE name = 'ls-profB'`)
-		})
+		profA2UUID := windowsProfileUUIDByName(t, ds, "ls-profA")
+		profB2UUID := windowsProfileUUIDByName(t, ds, "ls-profB")
 
 		// Create a label and make profB label-scoped to it.
 		scopeLabel, err := ds.NewLabel(ctx, &fleet.Label{Name: "locuri-scope-label", Query: ""})
@@ -4524,18 +4545,10 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 			return err
 		})
 		require.NoError(t, err)
-		var profUUID string
-		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-			return sqlx.GetContext(ctx, q, &profUUID,
-				`SELECT profile_uuid FROM mdm_windows_configuration_profiles WHERE team_id = 0 AND name = 'no-team-prof'`)
-		})
+		profUUID := windowsProfileUUIDByName(t, ds, "no-team-prof")
 
 		// Both hosts start with the profile installed and verified.
-		verified := fleet.MDMDeliveryVerified
-		require.NoError(t, ds.BulkUpsertMDMWindowsHostProfiles(ctx, []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
-			{ProfileUUID: profUUID, ProfileName: "n", HostUUID: h1.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
-			{ProfileUUID: profUUID, ProfileName: "n", HostUUID: h2.UUID, CommandUUID: uuid.NewString(), OperationType: fleet.MDMOperationTypeInstall, Status: &verified, Checksum: []byte{0}},
-		}))
+		installWindowsProfilesAsVerified(t, ds, []string{h1.UUID, h2.UUID}, []string{profUUID})
 
 		// Move h2 out of no-team; replicate the post-move reconciliation the
 		// service layer does so h2's row flips to operation=remove, status=NULL.
@@ -4574,14 +4587,7 @@ func testDeleteProfileLocURIProtection(t *testing.T, ds *Datastore) {
 		// and that the destination-team profile with the same LocURI did
 		// not spuriously protect ./Device/Z from the no-team deletion.
 		for _, h := range []*fleet.Host{h1, h2} {
-			var rawCmd []byte
-			ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-				return sqlx.GetContext(ctx, q, &rawCmd,
-					`SELECT wc.raw_command FROM windows_mdm_commands wc
-					JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
-					WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = 'remove'`,
-					h.UUID, profUUID)
-			})
+			rawCmd := rawWindowsDeleteCommandForHostProfile(t, ds, h.UUID, profUUID)
 			require.NotEmpty(t, rawCmd, "host %s should have a queued <Delete>", h.Hostname)
 			assert.Contains(t, string(rawCmd), "./Device/Z")
 		}
@@ -4707,6 +4713,94 @@ func testEditProfileDeletesRemovedLocURIs(t *testing.T, ds *Datastore) {
 			}
 		}
 	})
+}
+
+// testBatchDeleteMultipleWindowsProfiles exercises the multi-profile delete path in
+// cancelWindowsHostInstallsForDeletedMDMProfiles via a single batchSetMDMWindowsProfilesDB
+// call that removes several profiles at once. This hits the CASE-mapped multi-profile
+// UPDATE on host_mdm_windows_profiles (one statement, many profiles, one command_uuid
+// per profile) and verifies that each profile's rows receive the correct, distinct
+// command_uuid.
+func testBatchDeleteMultipleWindowsProfiles(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	h1 := test.NewHost(t, ds, "host-multi-del-1", "10.0.0.10", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
+	windowsEnroll(t, ds, h1)
+	h2 := test.NewHost(t, ds, "host-multi-del-2", "10.0.0.11", uuid.NewString(), uuid.NewString(), time.Now(), test.WithPlatform("windows"))
+	windowsEnroll(t, ds, h2)
+
+	profA := &fleet.MDMWindowsConfigProfile{Name: "multi-del-A", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/A</LocURI></Target><Data>1</Data></Item></Replace>`)}
+	profB := &fleet.MDMWindowsConfigProfile{Name: "multi-del-B", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/B</LocURI></Target><Data>1</Data></Item></Replace>`)}
+	profC := &fleet.MDMWindowsConfigProfile{Name: "multi-del-C", SyncML: []byte(`<Replace><Item><Target><LocURI>./Device/C</LocURI></Target><Data>1</Data></Item></Replace>`)}
+
+	err := ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{profA, profB, profC}, nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	profAUUID := windowsProfileUUIDByName(t, ds, "multi-del-A")
+	profBUUID := windowsProfileUUIDByName(t, ds, "multi-del-B")
+	profCUUID := windowsProfileUUIDByName(t, ds, "multi-del-C")
+
+	// Mark all three profiles as verified-installed on both hosts, so phase-2
+	// cleanup has to generate <Delete> commands and flip the rows to remove+pending.
+	installWindowsProfilesAsVerified(t, ds,
+		[]string{h1.UUID, h2.UUID},
+		[]string{profAUUID, profBUUID, profCUUID})
+
+	// Delete ALL THREE profiles in a single batch-set call by passing an empty new set.
+	// This drives cancelWindowsHostInstallsForDeletedMDMProfiles with >1 profile, which
+	// is precisely the code path the new multi-profile batched UPDATE targets.
+	err = ds.withTx(ctx, func(tx sqlx.ExtContext) error {
+		_, err := ds.batchSetMDMWindowsProfilesDB(ctx, tx, nil, []*fleet.MDMWindowsConfigProfile{}, nil)
+		return err
+	})
+	require.NoError(t, err)
+
+	// 2 hosts × 3 profiles = 6 rows, each flipped to remove+pending with a
+	// non-empty command_uuid and empty detail.
+	type row struct {
+		OperationType string `db:"operation_type"`
+		Status        string `db:"status"`
+		Detail        string `db:"detail"`
+		CommandUUID   string `db:"command_uuid"`
+	}
+	var rows []row
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &rows,
+			`SELECT operation_type, status, detail, command_uuid
+			 FROM host_mdm_windows_profiles
+			 WHERE host_uuid IN (?, ?)
+			 ORDER BY host_uuid, profile_uuid`, h1.UUID, h2.UUID)
+	})
+	require.Len(t, rows, 6)
+	for _, r := range rows {
+		assert.Equal(t, string(fleet.MDMOperationTypeRemove), r.OperationType)
+		assert.Equal(t, string(fleet.MDMDeliveryPending), r.Status)
+		assert.Empty(t, r.Detail)
+		assert.NotEmpty(t, r.CommandUUID)
+	}
+
+	// For every (host, profile), follow the command_uuid on the flipped row
+	// through to windows_mdm_commands and assert the raw SyncML targets THAT
+	// profile's specific LocURI. This catches CASE mis-assignment (profA's
+	// command_uuid cross-wired to profB's Delete command) and an unintended
+	// ELSE-clause fire (command_uuid unchanged, not in windows_mdm_commands).
+	profLocURIs := map[string]string{
+		profAUUID: "./Device/A",
+		profBUUID: "./Device/B",
+		profCUUID: "./Device/C",
+	}
+	for _, hUUID := range []string{h1.UUID, h2.UUID} {
+		for profUUID, wantLocURI := range profLocURIs {
+			raw := rawWindowsDeleteCommandForHostProfile(t, ds, hUUID, profUUID)
+			require.NotEmpty(t, raw, "host %s profile %s: no Delete command queued", hUUID, profUUID)
+			assert.Contains(t, string(raw), wantLocURI,
+				"host %s profile %s: command should target %s, not another profile's LocURI",
+				hUUID, profUUID, wantLocURI)
+		}
+	}
 }
 
 // testMDMWindowsUnenrollCleansUpProfiles verifies that pending profile rows are cleaned up when a

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -2008,19 +2008,22 @@ func installWindowsProfilesAsVerified(t *testing.T, ds *Datastore, hostUUIDs, pr
 
 // rawWindowsDeleteCommandForHostProfile returns the raw SyncML of the queued
 // <Delete> command for a (host, profile) pair by joining host_mdm_windows_profiles
-// (operation_type=remove) to windows_mdm_commands via command_uuid. Returns empty
-// bytes if no such command is queued.
+// (operation_type=remove) to windows_mdm_commands via command_uuid. Returns nil
+// if no such command is queued, so callers can assert with a descriptive message.
 func rawWindowsDeleteCommandForHostProfile(t *testing.T, ds *Datastore, hostUUID, profileUUID string) []byte {
 	t.Helper()
-	var raw []byte
+	var raws [][]byte
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(t.Context(), q, &raw,
+		return sqlx.SelectContext(t.Context(), q, &raws,
 			`SELECT wc.raw_command FROM windows_mdm_commands wc
 			 JOIN host_mdm_windows_profiles hwp ON hwp.command_uuid = wc.command_uuid
 			 WHERE hwp.host_uuid = ? AND hwp.profile_uuid = ? AND hwp.operation_type = ?`,
 			hostUUID, profileUUID, fleet.MDMOperationTypeRemove)
 	})
-	return raw
+	if len(raws) == 0 {
+		return nil
+	}
+	return raws[0]
 }
 
 func testMDMWindowsProfileManagement(t *testing.T, ds *Datastore) {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42545

This rework does not significantly improve the worst case performance, but it does improve some cases (like lower number of hosts with a lot of profiles).

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [x] Added/updated automated tests
- [x] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved batch deletion for Windows MDM configuration profiles to handle very large-scale cleanup with fewer database updates.
  * Replaced per-profile update loops with multi-profile batched updates to reduce update overhead and improve determinism.
* **Tests**
  * Added tests validating multi-profile batch delete behavior and ensuring each queued delete command is correctly targeted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->