### PR TITLE
Don't refetch "change management" settings page on focus

### DIFF
--- a/changes/43977-fix-chg-mgmt-focus-issue
+++ b/changes/43977-fix-chg-mgmt-focus-issue
@@ -1,0 +1,1 @@
+- Fixed issue where the "Change Management" form would reset when the page lost and regained focus.

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -75,6 +75,7 @@ const ChangeManagement = () => {
     Error,
     IConfig
   >(["integrations"], () => configAPI.loadAll(), {
+    refetchOnWindowFocus: false,
     onSuccess: (data) => {
       const {
         gitops: {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43977

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [ ] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - Repro'd issue on main
  - Verified on this branch that dirtying the form and then focusing elsewhere / refocusing on page doesn't lose changes.

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where the Change Management form would reset upon losing and regaining page focus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->