### PR TITLE
Allow building fleetd package with local osqueryd build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -686,20 +686,39 @@ restore: $(SNAPSHOT_BINARY)
 # To generate an osquery bundle for a unreleased change in osquery in a pull request
 # (e.g. https://github.com/osquery/osquery/pull/8815):
 # make osqueryd-app-tar-gz pr=8815 out-path=.
+#
+# To generate an osquery bundle from a locally built osqueryd executable:
+# make osqueryd-app-tar-gz osqueryd_path=/path/to/osqueryd out-path=.
 osqueryd-app-tar-gz:
 ifneq ($(shell uname), Darwin)
 	@echo "Makefile target osqueryd-app-tar-gz is only supported on macOS"
 	@exit 1
 endif
-ifdef pr
+ifdef osqueryd_path
+	$(eval TMP_DIR := $(shell mktemp -d))
+	@if [ ! -f "$(osqueryd_path)" ]; then \
+		echo "Error: osqueryd executable not found at $(osqueryd_path)"; \
+		rm -rf $(TMP_DIR); \
+		exit 1; \
+	fi
+	mkdir -p $(TMP_DIR)/osquery.app/Contents/MacOS
+	mkdir -p $(TMP_DIR)/osquery.app/Contents/Resources
+	cp "$(osqueryd_path)" $(TMP_DIR)/osquery.app/Contents/MacOS/osqueryd
+	chmod +x $(TMP_DIR)/osquery.app/Contents/MacOS/osqueryd
+	@OSQUERY_VERSION=$$("$(osqueryd_path)" --version | awk '{print $$NF}') && \
+		printf '<?xml version="1.0" encoding="UTF-8"?>\n<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n<plist version="1.0">\n<dict>\n\t<key>CFBundleIdentifier</key>\n\t<string>io.osquery.agent</string>\n\t<key>CFBundleName</key>\n\t<string>osquery</string>\n\t<key>CFBundleExecutable</key>\n\t<string>osqueryd</string>\n\t<key>CFBundleVersion</key>\n\t<string>%s</string>\n\t<key>CFBundleShortVersionString</key>\n\t<string>%s</string>\n\t<key>CFBundleInfoDictionaryVersion</key>\n\t<string>6.0</string>\n\t<key>CFBundlePackageType</key>\n\t<string>APPL</string>\n\t<key>CFBundleSignature</key>\n\t<string>????</string>\n\t<key>LSMinimumSystemVersion</key>\n\t<string>10.14</string>\n</dict>\n</plist>\n' "$$OSQUERY_VERSION" "$$OSQUERY_VERSION" > $(TMP_DIR)/osquery.app/Contents/Info.plist
+	$(TMP_DIR)/osquery.app/Contents/MacOS/osqueryd --version
+	tar czf $(out-path)/osqueryd.app.tar.gz -C $(TMP_DIR) osquery.app
+	rm -rf $(TMP_DIR)
+else ifdef pr
 	$(eval TMP_DIR := $(shell mktemp -d))
 	@echo "Fetching macos_unsigned_tgz_universal artifact from osquery/osquery PR $(pr)..."
 	@PR_SHA=$$(gh pr view -R osquery/osquery $(pr) --json headRefOid -q .headRefOid) && \
 		echo "PR head SHA: $$PR_SHA" && \
 		RUN_IDS=$$(gh api "repos/osquery/osquery/actions/runs?head_sha=$$PR_SHA" \
-			-q '[.workflow_runs[] | select(.conclusion == "success") | .id] | .[]') && \
+			-q '[.workflow_runs[] | .id] | .[]') && \
 		if [ -z "$$RUN_IDS" ]; then \
-			echo "Error: no successful workflow runs found for PR $(pr)"; \
+			echo "Error: no workflow runs found for PR $(pr)"; \
 			rm -rf $(TMP_DIR); \
 			exit 1; \
 		fi && \

--- a/tools/tuf/test/README.md
+++ b/tools/tuf/test/README.md
@@ -154,6 +154,15 @@ make osqueryd-app-tar-gz pr=8815 out-path=.
 ./tools/tuf/test/push_target.sh macos-app osqueryd osqueryd.app.tar.gz 5.23.0
 ```
 
+E.g. to add a custom `osqueryd` version built locally:
+```sh
+# Generate osqueryd app bundle from a locally built osqueryd executable.
+make osqueryd-app-tar-gz osqueryd_path=/path/to/osqueryd out-path=.
+
+# Push the osqueryd target as a new version.
+./tools/tuf/test/push_target.sh macos-app osqueryd osqueryd.app.tar.gz 5.23.0
+```
+
 E.g. to add a new version of `desktop` for macOS:
 ```sh
 source ./tools/tuf/test/load_orbit_version_vars.sh


### PR DESCRIPTION
Ease testing locally built osquery on macOS (bundled with fleetd).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for packaging locally built osqueryd binaries into osquery.app tarballs on macOS with automatic validation and cleanup.

* **Improvements**
  * Enhanced PR artifact download workflow for improved artifact retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->