### PR TITLE
FE: Clean up lint warnings part III

### DIFF
--- a/frontend/components/forms/fields/Checkbox/Checkbox.tsx
+++ b/frontend/components/forms/fields/Checkbox/Checkbox.tsx
@@ -53,7 +53,6 @@ const Checkbox = (props: ICheckboxProps) => {
     labelTooltipClickable = false,
     iconTooltipContent,
     isLeftLabel,
-    helpText,
     enableEnterToCheck = false,
   } = props;
 

--- a/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareAddPage/SoftwareAppStore/SoftwareAppStoreAndroid/SoftwareAppStoreAndroid.tsx
@@ -1,6 +1,5 @@
 import React, { useContext, useState } from "react";
 import { InjectedRouter } from "react-router";
-import axios from "axios";
 import PATHS from "router/paths";
 
 import { NotificationContext } from "context/notification";
@@ -8,18 +7,13 @@ import { AppContext } from "context/app";
 import softwareAPI from "services/entities/software";
 
 import PremiumFeatureMessage from "components/PremiumFeatureMessage";
-import CategoriesEndUserExperienceModal from "pages/SoftwarePage/components/modals/CategoriesEndUserExperienceModal";
 import { ISoftwareAndroidFormData } from "pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm";
 
 import { getPathWithQueryParams } from "utilities/url";
 import SoftwareAndroidForm from "pages/SoftwarePage/components/forms/SoftwareAndroidForm";
 import { getErrorMessage } from "./helpers";
-import { ADD_SOFTWARE_ERROR_PREFIX } from "../../helpers";
 
 const baseClass = "software-app-store-android";
-
-const AMAPI_BASE_URL = "https://androidmanagement.googleapis.com/v1/";
-const ENTERPRISE_ID = "<your_enterprise_id>"; // Set this appropriately
 
 interface ISoftwareAppStoreProps {
   currentTeamId: number;
@@ -34,10 +28,6 @@ const SoftwareAppStoreAndroid = ({
   const { isPremiumTier } = useContext(AppContext);
 
   const [isLoading, setIsLoading] = useState(false);
-  const [
-    showPreviewEndUserExperience,
-    setShowPreviewEndUserExperience,
-  ] = useState(false);
 
   const goBackToSoftwareTitles = (showAvailableForInstallOnly = false) => {
     const queryParams = {
@@ -46,10 +36,6 @@ const SoftwareAppStoreAndroid = ({
     };
 
     router.push(getPathWithQueryParams(PATHS.SOFTWARE_TITLES, queryParams));
-  };
-
-  const onClickPreviewEndUserExperience = () => {
-    setShowPreviewEndUserExperience(!showPreviewEndUserExperience);
   };
 
   const onAddSoftware = async (formData: ISoftwareAndroidFormData) => {
@@ -62,14 +48,12 @@ const SoftwareAppStoreAndroid = ({
     try {
       const {
         software_title_id: softwareAppStoreTitleId,
-        // Maybe this will return name and can render success message with the name?
         name: softwareTitleName,
       } = await softwareAPI.addAppStoreApp(currentTeamId, formData);
 
       renderFlash(
         "success",
         <>
-          {/* <strong>{appApiRes.data.name}</strong> successfully added. */}
           <strong>{softwareTitleName || "Android app"}</strong> successfully
           added.
         </>,
@@ -101,15 +85,8 @@ const SoftwareAppStoreAndroid = ({
         <SoftwareAndroidForm
           onSubmit={onAddSoftware}
           onCancel={goBackToSoftwareTitles}
-          onClickPreviewEndUserExperience={onClickPreviewEndUserExperience}
           isLoading={isLoading}
         />
-        {showPreviewEndUserExperience && (
-          <CategoriesEndUserExperienceModal
-            source="android_apps"
-            onCancel={onClickPreviewEndUserExperience}
-          />
-        )}
       </div>
     );
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/EditConfigurationModal.tsx
@@ -107,10 +107,7 @@ const EditConfigurationModal = ({
       refetchSoftwareTitle();
       onExit();
     } catch (e) {
-      renderFlash(
-        "error",
-        getErrorMessage(e, softwareInstaller as IAppStoreApp)
-      );
+      renderFlash("error", getErrorMessage(e));
     }
     setIsUpdatingConfiguration(false);
   };

--- a/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/helpers.tsx
+++ b/frontend/pages/SoftwarePage/SoftwareTitleDetailsPage/EditConfigurationModal/helpers.tsx
@@ -1,16 +1,12 @@
 import React from "react";
-import { isAxiosError } from "axios";
 
 import { getErrorReason } from "interfaces/errors";
-import { IAppStoreApp, ISoftwarePackage } from "interfaces/software";
-
-import { generateSecretErrMsg } from "pages/SoftwarePage/helpers";
 
 const DEFAULT_ERROR_MESSAGE =
   "Couldn't update configuration. Please try again.";
 
 // eslint-disable-next-line import/prefer-default-export
-export const getErrorMessage = (err: unknown, software: IAppStoreApp) => {
+export const getErrorMessage = (err: unknown) => {
   const reason = getErrorReason(err);
 
   if (

--- a/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
+++ b/frontend/pages/SoftwarePage/components/forms/SoftwareAndroidForm/SoftwareAndroidForm.tsx
@@ -45,7 +45,6 @@ interface ISoftwareAndroidFormProps {
   onSubmit: (formData: ISoftwareAndroidFormData) => void;
   isLoading?: boolean;
   onCancel: () => void;
-  onClickPreviewEndUserExperience: () => void;
 }
 
 const SoftwareAndroidForm = ({
@@ -53,7 +52,6 @@ const SoftwareAndroidForm = ({
   onSubmit,
   isLoading = false,
   onCancel,
-  onClickPreviewEndUserExperience,
 }: ISoftwareAndroidFormProps) => {
   const { gitOpsModeEnabled } = useGitOpsMode("software");
 

--- a/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
+++ b/frontend/pages/SoftwarePage/components/tables/SoftwareVulnerabilitiesTable/SoftwareVulnerabilitiesTable.tsx
@@ -11,7 +11,7 @@ import PATHS from "router/paths";
 
 import { AppContext } from "context/app";
 import { ISoftwareVulnerability } from "interfaces/software";
-import { CONTACT_FLEET_LINK, GITHUB_NEW_ISSUE_LINK } from "utilities/constants";
+import { CONTACT_FLEET_LINK } from "utilities/constants";
 import { DisplayPlatform } from "interfaces/platform";
 import { getPathWithQueryParams } from "utilities/url";
 import TableContainer from "components/TableContainer";

--- a/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/RenameTeamModal.tests.tsx
+++ b/frontend/pages/admin/TeamManagementPage/components/RenameTeamModal/RenameTeamModal.tests.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { screen } from "@testing-library/react";
 import { createCustomRenderer } from "test/test-utils";
 import userEvent from "@testing-library/user-event";
 

--- a/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
+++ b/frontend/pages/hosts/components/TransferHostModal/TransferHostModal.tests.tsx
@@ -2,7 +2,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import paths from "router/paths";
 
 import TransferHostModal from "./TransferHostModal";
 

--- a/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
+++ b/frontend/pages/hosts/details/HostQueryReport/HostQueryReport.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useContext, useState } from "react";
 import { useQuery } from "react-query";
-import { browserHistory, InjectedRouter, Link } from "react-router";
+import { browserHistory, InjectedRouter } from "react-router";
 import { Params } from "react-router/lib/Router";
 import PATHS from "router/paths";
 import { AppContext } from "context/app";

--- a/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
+++ b/frontend/pages/hosts/details/cards/HostSummary/HostSummary.tsx
@@ -24,10 +24,7 @@ import DataSet from "components/DataSet";
 import StatusIndicator from "components/StatusIndicator";
 import IssuesIndicator from "pages/hosts/components/IssuesIndicator";
 
-import {
-  DATE_FNS_FORMAT_STRINGS,
-  DEFAULT_EMPTY_CELL_VALUE,
-} from "utilities/constants";
+import { DATE_FNS_FORMAT_STRINGS } from "utilities/constants";
 
 import OSSettingsIndicator from "./OSSettingsIndicator";
 import BootstrapPackageIndicator from "./BootstrapPackageIndicator/BootstrapPackageIndicator";

--- a/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
+++ b/frontend/pages/queries/edit/components/EditQueryForm/EditQueryForm.tsx
@@ -18,11 +18,7 @@ import PATHS from "router/paths";
 import { AppContext } from "context/app";
 import { QueryContext } from "context/query";
 
-import {
-  addGravatarUrlToResource,
-  getCustomDropdownOptions,
-  secondsToDhms,
-} from "utilities/helpers";
+import { getCustomDropdownOptions, secondsToDhms } from "utilities/helpers";
 
 import {
   FREQUENCY_DROPDOWN_OPTIONS,
@@ -47,7 +43,6 @@ import labelsAPI, {
   ILabelsSummaryResponse,
 } from "services/entities/labels";
 
-import Avatar from "components/Avatar";
 import SQLEditor from "components/SQLEditor";
 import {
   validateQuery,
@@ -58,7 +53,6 @@ import RevealButton from "components/buttons/RevealButton";
 import Checkbox from "components/forms/fields/Checkbox";
 // @ts-ignore
 import Dropdown from "components/forms/fields/Dropdown";
-import DataSet from "components/DataSet";
 import Slider from "components/forms/fields/Slider";
 import TooltipWrapper from "components/TooltipWrapper";
 import Spinner from "components/Spinner";
@@ -179,7 +173,6 @@ const EditQueryForm = ({
     setEditingExistingQuery,
   } = useContext(QueryContext);
   const {
-    currentUser,
     isOnlyObserver,
     isGlobalObserver,
     isTeamMaintainerOrTeamAdmin,
@@ -191,7 +184,6 @@ const EditQueryForm = ({
     config,
     isPremiumTier,
     isFreeTier,
-    currentTeam,
   } = useContext(AppContext);
 
   const isExistingQuery = !!queryIdForEdit;


### PR DESCRIPTION
## Description
- More lint fixes to reduce the number of lint-js warnings on github ci
- Third of many PRs, this just cleaned up 20 warnings of unused variables
  - 461 --> 343 warnings left to clean up


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed end-user preview functionality from the Android software configuration flow.
  * Simplified configuration error handling so displayed error text no longer depends on installer context.

* **Chores**
  * Cleaned up unused imports/constants and removed unreachable/commented snippets across several frontend pages.

* **Tests**
  * Minor test import cleanups (no behavioral changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->