### PR TITLE
Cherry pick to 4.84: Don't refetch "change management" settings page on focus (#44054)

### DIFF
--- a/changes/43977-fix-chg-mgmt-focus-issue
+++ b/changes/43977-fix-chg-mgmt-focus-issue
@@ -1,0 +1,1 @@
+- Fixed issue where the "Change Management" form would reset when the page lost and regained focus.

--- a/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
+++ b/frontend/pages/admin/IntegrationsPage/cards/ChangeManagement/ChangeManagement.tsx
@@ -76,6 +76,7 @@ const ChangeManagement = () => {
     Error,
     IConfig
   >(["integrations"], () => configAPI.loadAll(), {
+    refetchOnWindowFocus: false,
     onSuccess: (data) => {
       const {
         gitops: {


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43977

(cherry picked from commit fe66e3fd084be940827d9cca18c4a5eca7cfe3ff)

