### PR TITLE
Fixed a race where a host could silently revert to its previous team

### DIFF
--- a/changes/44071-team-transfer-race-with-update-host
+++ b/changes/44071-team-transfer-race-with-update-host
@@ -1,1 +1,1 @@
-- Fixed a race where a host could silently revert to its previous team after an admin team transfer.
+- Fixed a race condition where a host could silently revert to its previous team after an admin team transfer.

--- a/changes/44071-team-transfer-race-with-update-host
+++ b/changes/44071-team-transfer-race-with-update-host
@@ -1,0 +1,1 @@
+- Fixed a race where a host could silently revert to its previous team after an admin team transfer.

--- a/server/datastore/mysql/android_test.go
+++ b/server/datastore/mysql/android_test.go
@@ -1613,9 +1613,10 @@ func testListMDMAndroidProfilesToSendWithExcludeAny(t *testing.T, ds *Datastore)
 	// Set the hosts label_updated_at causing p4-p6 to become applicable to host 1
 	hosts[1].LabelUpdatedAt = time.Now().UTC().Add(time.Second) // just to be extra safe in tests
 	hosts[1].PolicyUpdatedAt = time.Now().UTC()
-	hosts[1].TeamID = &tm.ID
 	err = ds.UpdateHost(ctx, hosts[1])
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&tm.ID, []uint{hosts[1].ID})))
+	hosts[1].TeamID = &tm.ID
 
 	profs, toRemoveProfs, err = ds.ListMDMAndroidProfilesToSend(ctx)
 	require.NoError(t, err)

--- a/server/datastore/mysql/certificate_templates_test.go
+++ b/server/datastore/mysql/certificate_templates_test.go
@@ -994,9 +994,8 @@ func testGetHostCertificateTemplates(t *testing.T, ds *Datastore) {
 	team, err := ds.NewTeam(ctx, &fleet.Team{Name: "Test Team"})
 	require.NoError(t, err)
 
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{h2.ID})))
 	h2.TeamID = &team.ID
-	err = ds.UpdateHost(ctx, h2)
-	require.NoError(t, err)
 
 	// Create a test certificate authority
 	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
@@ -1100,14 +1099,12 @@ func testGetCertificateTemplateForHost(t *testing.T, ds *Datastore) {
 
 	// Create hosts
 	h1 := test.NewHost(t, ds, "host_1", "127.0.0.1", "1", "1", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{h1.ID})))
 	h1.TeamID = &team1.ID
-	err = ds.UpdateHost(ctx, h1)
-	require.NoError(t, err)
 
 	h2 := test.NewHost(t, ds, "host_2", "127.0.0.2", "2", "2", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team2.ID, []uint{h2.ID})))
 	h2.TeamID = &team2.ID
-	err = ds.UpdateHost(ctx, h2)
-	require.NoError(t, err)
 
 	// Create certificate authority
 	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
@@ -1226,9 +1223,8 @@ func testGetHostCertificateTemplateRecord(t *testing.T, ds *Datastore) {
 
 	// Create host
 	h1 := test.NewHost(t, ds, "host_1", "127.0.0.1", "1", "1", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{h1.ID})))
 	h1.TeamID = &team1.ID
-	err = ds.UpdateHost(ctx, h1)
-	require.NoError(t, err)
 
 	// Create certificate authority
 	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
@@ -1337,9 +1333,8 @@ func testResendHostCertificateTemplate(t *testing.T, ds *Datastore) {
 	require.NoError(t, err)
 
 	h1 := test.NewHost(t, ds, "host_1", "127.0.0.1", "1", "1", time.Now())
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{h1.ID})))
 	h1.TeamID = &team1.ID
-	err = ds.UpdateHost(ctx, h1)
-	require.NoError(t, err)
 
 	ca, err := ds.NewCertificateAuthority(ctx, &fleet.CertificateAuthority{
 		Type:      string(fleet.CATypeCustomSCEPProxy),

--- a/server/datastore/mysql/host_certificate_templates_test.go
+++ b/server/datastore/mysql/host_certificate_templates_test.go
@@ -1430,10 +1430,9 @@ func testListCertificateTemplatesForHostsIncludesRemovalAfterTeamTransfer(t *tes
 	}})
 	require.NoError(t, err)
 
-	// Simulate team transfer: move host to Team B using UpdateHost
+	// Simulate team transfer: move host to Team B.
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&setupB.team.ID, []uint{host.ID})))
 	host.TeamID = &setupB.team.ID
-	err = ds.UpdateHost(ctx, host)
-	require.NoError(t, err)
 
 	// Mark Team A template for removal using the datastore method
 	err = ds.SetHostCertificateTemplatesToPendingRemoveForHost(ctx, host.UUID)
@@ -1612,8 +1611,8 @@ func testCertificateTemplateReinstalledAfterTransferBackToOriginalTeam(t *testin
 	require.NotEmpty(t, initialUUID, "initial UUID should not be empty")
 
 	// Transfer to Team B: mark Team A cert for removal, create pending install for Team B
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&setupB.team.ID, []uint{host.ID})))
 	host.TeamID = &setupB.team.ID
-	require.NoError(t, ds.UpdateHost(ctx, host))
 	require.NoError(t, ds.SetHostCertificateTemplatesToPendingRemoveForHost(ctx, host.UUID))
 	_, err = ds.CreatePendingCertificateTemplatesForNewHost(ctx, host.UUID, setupB.team.ID)
 	require.NoError(t, err)
@@ -1632,8 +1631,8 @@ func testCertificateTemplateReinstalledAfterTransferBackToOriginalTeam(t *testin
 	require.NotEqual(t, initialUUID, uuidAfterRemove, "UUID should change when marked for removal")
 
 	// Transfer back to Team A: mark Team B cert for removal, re-create pending install for Team A
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&setupA.team.ID, []uint{host.ID})))
 	host.TeamID = &setupA.team.ID
-	require.NoError(t, ds.UpdateHost(ctx, host))
 	require.NoError(t, ds.SetHostCertificateTemplatesToPendingRemoveForHost(ctx, host.UUID))
 	_, err = ds.CreatePendingCertificateTemplatesForNewHost(ctx, host.UUID, setupA.team.ID)
 	require.NoError(t, err)

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5443,7 +5443,8 @@ func (ds *Datastore) UpdateHostRefetchCriticalQueriesUntil(ctx context.Context, 
 }
 
 // UpdateHost updates most columns of the `hosts` table.
-// It only updates `hosts` table, other additional host information is ignored.
+// It also updates host display-name information in `host_display_names`;
+// other additional host information is ignored.
 //
 // UpdateHost deliberately does NOT write `team_id`. Team membership is an administrative
 // assignment managed by AddHostsToTeam / AddHostsToTeamByFilter / GitOps / the

--- a/server/datastore/mysql/hosts.go
+++ b/server/datastore/mysql/hosts.go
@@ -5442,8 +5442,14 @@ func (ds *Datastore) UpdateHostRefetchCriticalQueriesUntil(ctx context.Context, 
 	return nil
 }
 
-// UpdateHost updates all columns of the `hosts` table.
+// UpdateHost updates most columns of the `hosts` table.
 // It only updates `hosts` table, other additional host information is ignored.
+//
+// UpdateHost deliberately does NOT write `team_id`. Team membership is an administrative
+// assignment managed by AddHostsToTeam / AddHostsToTeamByFilter / GitOps / the
+// enroll-secret path (EnrollOsquery / EnrollOrbit). Writing team_id here would
+// re-open a lost-update race where a stale in-memory host struct (loaded before a
+// concurrent transfer) silently clobbers the admin's assignment. See #44071.
 func (ds *Datastore) UpdateHost(ctx context.Context, host *fleet.Host) error {
 	if host.OrbitNodeKey == nil || *host.OrbitNodeKey == "" {
 		// iOS/iPadOS hosts currently do not use/set orbit_node_key.
@@ -5482,7 +5488,6 @@ func (ds *Datastore) UpdateHost(ctx context.Context, host *fleet.Host) error {
 			distributed_interval = ?,
 			config_tls_refresh = ?,
 			logger_tls_period = ?,
-			team_id = ?,
 			primary_ip = ?,
 			primary_mac = ?,
 			public_ip = ?,
@@ -5530,7 +5535,6 @@ func (ds *Datastore) UpdateHost(ctx context.Context, host *fleet.Host) error {
 				host.DistributedInterval,
 				host.ConfigTLSRefresh,
 				host.LoggerTLSPeriod,
-				host.TeamID,
 				host.PrimaryIP,
 				host.PrimaryMac,
 				host.PublicIP,

--- a/server/datastore/mysql/hosts_test.go
+++ b/server/datastore/mysql/hosts_test.go
@@ -291,6 +291,34 @@ func testUpdateHost(t *testing.T, ds *Datastore, updateHostFunc func(context.Con
 	assert.Nil(t, host.DesktopVersion)
 	assert.Nil(t, host.ScriptsEnabled)
 
+	// Regression for #44071: UpdateHost must not write team_id, so a stale
+	// in-memory struct cannot clobber a concurrent admin team transfer.
+	team, err := ds.NewTeam(context.Background(), &fleet.Team{Name: fmt.Sprintf("%s-team-%d", t.Name(), time.Now().UnixNano())})
+	require.NoError(t, err)
+
+	require.NoError(t, ds.AddHostsToTeam(context.Background(),
+		fleet.NewAddHostsToTeamParams(&team.ID, []uint{host.ID})))
+
+	// The in-memory host still has TeamID=nil (loaded before the transfer).
+	host.TeamID = nil
+	require.NoError(t, updateHostFunc(context.Background(), host))
+
+	reloaded, err := ds.Host(context.Background(), host.ID)
+	require.NoError(t, err)
+	require.NotNil(t, reloaded.TeamID, "UpdateHost must not clobber team_id set by a concurrent transfer")
+	assert.Equal(t, team.ID, *reloaded.TeamID)
+
+	// And the reverse: if the host is transferred off the team while the stale
+	// struct still carries the old team_id, UpdateHost must not resurrect it.
+	require.NoError(t, ds.AddHostsToTeam(context.Background(),
+		fleet.NewAddHostsToTeamParams(nil, []uint{host.ID})))
+	host.TeamID = &team.ID
+	require.NoError(t, updateHostFunc(context.Background(), host))
+
+	reloaded, err = ds.Host(context.Background(), host.ID)
+	require.NoError(t, err)
+	assert.Nil(t, reloaded.TeamID, "UpdateHost must not resurrect a team_id that was cleared by a concurrent transfer")
+
 	p, err := ds.NewPack(context.Background(), &fleet.Pack{
 		Name:    t.Name(),
 		HostIDs: []uint{host.ID},

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -9264,16 +9264,18 @@ func testDeleteTeamCancelsWindowsProfileInstalls(t *testing.T, ds *Datastore) {
 	// Create Windows hosts enrolled in MDM and assigned to the team.
 	host1 := test.NewHost(t, ds, "tw-host1", "tw1", "tw1key", "tw-host1-uuid", time.Now())
 	host1.Platform = "windows"
-	host1.TeamID = &team.ID
 	err = ds.UpdateHost(ctx, host1)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host1.ID})))
+	host1.TeamID = &team.ID
 	windowsEnroll(t, ds, host1)
 
 	host2 := test.NewHost(t, ds, "tw-host2", "tw2", "tw2key", "tw-host2-uuid", time.Now())
 	host2.Platform = "windows"
-	host2.TeamID = &team.ID
 	err = ds.UpdateHost(ctx, host2)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team.ID, []uint{host2.ID})))
+	host2.TeamID = &team.ID
 	windowsEnroll(t, ds, host2)
 
 	// Simulate profiles delivered to both hosts (install + verified).

--- a/server/service/hosts_test.go
+++ b/server/service/hosts_test.go
@@ -1711,34 +1711,38 @@ func TestCleanupExpiredHostsActivities(t *testing.T) {
 	host1 := test.NewHost(t, ds, "team1-host1", "192.168.1.10", "1", "1", team1ExpiredTime)
 	host1.HardwareSerial = "TEAM1_SERIAL1"
 	host1.ComputerName = "Team 1 Computer 1"
-	host1.TeamID = &team1.ID
 	err = ds.UpdateHost(ctx, host1)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{host1.ID})))
+	host1.TeamID = &team1.ID
 
 	host2 := test.NewHost(t, ds, "team1-host2", "192.168.1.11", "2", "2", team1ExpiredTime)
 	host2.HardwareSerial = "TEAM1_SERIAL2"
 	host2.ComputerName = "Team 1 Computer 2"
-	host2.TeamID = &team1.ID
 	err = ds.UpdateHost(ctx, host2)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team1.ID, []uint{host2.ID})))
+	host2.TeamID = &team1.ID
 
 	// Create expired host for Team 2 (use team2ExpiryWindow)
 	team2ExpiredTime := mockClock.Now().Add(-time.Duration(team2ExpiryWindow+1) * 24 * time.Hour)
 	host3 := test.NewHost(t, ds, "team2-host1", "192.168.1.12", "3", "3", team2ExpiredTime)
 	host3.HardwareSerial = "TEAM2_SERIAL1"
 	host3.ComputerName = "Team 2 Computer 1"
-	host3.TeamID = &team2.ID
 	err = ds.UpdateHost(ctx, host3)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team2.ID, []uint{host3.ID})))
+	host3.TeamID = &team2.ID
 
 	// Create expired host for Team 3 (uses global expiry)
 	globalExpiredTime := mockClock.Now().Add(-time.Duration(globalExpiryWindow+1) * 24 * time.Hour)
 	host4 := test.NewHost(t, ds, "team3-host1", "192.168.1.13", "4", "4", globalExpiredTime)
 	host4.HardwareSerial = "TEAM3_SERIAL1"
 	host4.ComputerName = "Team 3 Computer 1"
-	host4.TeamID = &team3.ID
 	err = ds.UpdateHost(ctx, host4)
 	require.NoError(t, err)
+	require.NoError(t, ds.AddHostsToTeam(ctx, fleet.NewAddHostsToTeamParams(&team3.ID, []uint{host4.ID})))
+	host4.TeamID = &team3.ID
 
 	// Create expired host with no team (uses global expiry)
 	host5 := test.NewHost(t, ds, "no-team-host", "192.168.1.14", "5", "5", globalExpiredTime)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44071 

Verified fix in loadtest.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition that could cause hosts to silently revert to a previous team after an admin team transfer.
  * Improved reliability of team-transfer handling to prevent unexpected reversion during certificate/template transfers and device/profile operations.

* **Tests**
  * Added regression tests to ensure team assignments persist correctly across host refreshes and related workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->