### PR TITLE
Cherry-pick: Helm updates from main into 4.84.0 release branch

### DIFF
--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,7 +4,7 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.8.8
+version: v6.9.0
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -476,10 +476,10 @@ spec:
             {{- if .Values.fleet.tls.enabled }}
             scheme: HTTPS
             {{- end }}
-        {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") (include "fleet.additionalCAs.enabled" .) }}
         volumeMounts:
           - name: tmp
             mountPath: /tmp
+        {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") (include "fleet.additionalCAs.enabled" .) }}
           {{- if .Values.fleet.tls.enabled }}
           - name: fleet-tls
             readOnly: true
@@ -540,10 +540,10 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end }}
       serviceAccountName: fleet
-      {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") }}
       volumes:
         - name: tmp
           emptyDir:
+      {{- if or (.Values.fleet.tls.enabled) (.Values.database.tls.enabled) (eq .Values.osquery.logging.statusPlugin "filesystem") (eq .Values.osquery.logging.resultPlugin "filesystem") (include "fleet.additionalCAs.enabled" .) }}
         {{- if .Values.fleet.tls.enabled }}
         - name: fleet-tls
           secret:

--- a/charts/fleet/templates/deployment.yaml
+++ b/charts/fleet/templates/deployment.yaml
@@ -448,7 +448,11 @@ spec:
           capabilities:
             drop: [ALL]
           privileged: false
+          {{- if hasKey .Values.fleet.securityContext "readOnlyRootFilesystem" }}
+          readOnlyRootFilesystem: {{ .Values.fleet.securityContext.readOnlyRootFilesystem }}
+          {{- else }}
           readOnlyRootFilesystem: true
+          {{- end }}
           {{- if .Values.fleet.securityContext.runAsGroup }}
           runAsGroup: {{ int64 .Values.fleet.securityContext.runAsGroup }}
           {{- end }}

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -125,8 +125,9 @@ fleet:
     licenseKey: license-key
   extraVolumes: []
   extraVolumeMounts: []
-  # Currently only passes runAsNonRoot, runAsUser, runAsGroup
+  # Currently only passes readOnlyRootFilesystem, runAsNonRoot, runAsUser, runAsGroup
   securityContext:
+    readOnlyRootFilesystem: true
     runAsNonRoot: true
     runAsUser: 3333
     runAsGroup: 3333


### PR DESCRIPTION
- Allows setting `securityContext.readOnlyRootFilesystem` in `values.yaml`, which is then propagated down to the `deployment.yaml` template
- Update tmp volume mounts to be unconditional
  - Fixes an issue where `fleet.tls.enabled = false`, `databse.tls.enabled = false`, `osquery.logging.statusPlugin != "filesystem"`, `osquery.logging.resultPlugin != "filesystem"`, and `fleet.additionalCAs.enabled = false`, all at once, would lead to exclusion of the `tmp` volume mount and affecting software installer uploads.
- Bump helm chart version from `6.8.10` -> `6.9.0`