### PR TITLE
Fleet UI: Users page disable checkboxes not meeting requirements

### DIFF
--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -83,9 +83,7 @@ export interface IMdmConfig {
     macos_manual_agent_install: boolean | null;
     require_all_software_macos: boolean | null;
     lock_end_user_info: boolean | null;
-  };
-  macos_setup: {
-    enable_managed_local_account?: boolean;
+    enable_create_local_admin_account?: boolean;
   };
   macos_migration: IMacOsMigrationSettings;
   windows_updates: {

--- a/frontend/interfaces/config.ts
+++ b/frontend/interfaces/config.ts
@@ -85,6 +85,9 @@ export interface IMdmConfig {
     lock_end_user_info: boolean | null;
     enable_create_local_admin_account?: boolean;
   };
+  macos_setup?: {
+    enable_managed_local_account?: boolean;
+  };
   macos_migration: IMacOsMigrationSettings;
   windows_updates: {
     deadline_days: number | null;

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -67,9 +67,7 @@ export interface ITeam extends ITeamSummary {
       macos_manual_agent_install: boolean | null;
       require_all_software_macos: boolean | null;
       lock_end_user_info: boolean | null;
-    };
-    macos_setup: {
-      enable_managed_local_account?: boolean;
+      enable_create_local_admin_account?: boolean;
     };
     windows_updates: {
       deadline_days: number | null;

--- a/frontend/interfaces/team.ts
+++ b/frontend/interfaces/team.ts
@@ -69,6 +69,9 @@ export interface ITeam extends ITeamSummary {
       lock_end_user_info: boolean | null;
       enable_create_local_admin_account?: boolean;
     };
+    macos_setup?: {
+      enable_managed_local_account?: boolean;
+    };
     windows_updates: {
       deadline_days: number | null;
       grace_period_days: number | null;

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -9,7 +9,7 @@ import { ITeamConfig } from "interfaces/team";
 
 import SectionHeader from "components/SectionHeader/SectionHeader";
 import Spinner from "components/Spinner";
-import GenericMsgWithNavButton from "components/GenericMsgWithNavButton";
+
 import CustomLink from "components/CustomLink";
 import { LEARN_MORE_ABOUT_BASE_LINK } from "utilities/constants";
 
@@ -129,22 +129,13 @@ const Users = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
     const mdmConfig = globalConfig.mdm;
     return (
       <SetupExperienceContentContainer>
-        {!isIdPConfigured(mdmConfig) ? (
-          <GenericMsgWithNavButton
-            header="Require end user authentication during setup"
-            info="Connect Fleet to your identity provider (IdP) to get started."
-            buttonText="Connect"
-            router={router}
-            path={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
-          />
-        ) : (
-          <UsersForm
-            currentTeamId={currentTeamId}
-            defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
-            defaultLockEndUserInfo={defaultLockEndUserInfo}
-            defaultEnableManagedLocalAccount={defaultEnableManagedLocalAccount}
-          />
-        )}
+        <UsersForm
+          currentTeamId={currentTeamId}
+          defaultIsEndUserAuthEnabled={defaultIsEndUserAuthEnabled}
+          defaultLockEndUserInfo={defaultLockEndUserInfo}
+          defaultEnableManagedLocalAccount={defaultEnableManagedLocalAccount}
+          isIdPConfigured={isIdPConfigured(mdmConfig)}
+        />
       </SetupExperienceContentContainer>
     );
   };

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -30,11 +30,15 @@ const getEnabledManagedLocalAccount = (
 
   if (currentTeamId === 0) {
     return (
-      globalConfig?.mdm?.macos_setup?.enable_managed_local_account ?? false
+      globalConfig?.mdm?.setup_experience?.enable_create_local_admin_account ??
+      false
     );
   }
 
-  return teamConfig?.mdm?.macos_setup?.enable_managed_local_account ?? false;
+  return (
+    teamConfig?.mdm?.setup_experience?.enable_create_local_admin_account ??
+    false
+  );
 };
 
 const getEnabledEndUserAuth = (

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
@@ -10,10 +10,25 @@ describe("UsersForm", () => {
     defaultIsEndUserAuthEnabled: false,
     defaultLockEndUserInfo: false,
     defaultEnableManagedLocalAccount: false,
+    isIdPConfigured: true,
   };
 
   const render = createCustomRenderer({
     withBackendMock: true,
+  });
+
+  const renderWithMdmEnabled = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: { isMacMdmEnabledAndConfigured: true },
+    },
+  });
+
+  const renderWithMdmDisabled = createCustomRenderer({
+    withBackendMock: true,
+    context: {
+      app: { isMacMdmEnabledAndConfigured: false },
+    },
   });
 
   it("renders the end user authentication and managed local account checkboxes", () => {
@@ -82,5 +97,74 @@ describe("UsersForm", () => {
     render(<UsersForm {...defaultProps} />);
     const saveButtons = screen.getAllByRole("button", { name: "Save" });
     expect(saveButtons).toHaveLength(1);
+  });
+
+  describe("disabled states", () => {
+    it("disables end user authentication checkbox when IdP is not configured", () => {
+      render(<UsersForm {...defaultProps} isIdPConfigured={false} />);
+      expect(
+        screen.getByRole("checkbox", { name: "End user authentication" })
+      ).toBeDisabled();
+    });
+
+    it("enables end user authentication checkbox when IdP is configured", () => {
+      render(<UsersForm {...defaultProps} isIdPConfigured />);
+      expect(
+        screen.getByRole("checkbox", { name: "End user authentication" })
+      ).toBeEnabled();
+    });
+
+    it("disables lock end user info when IdP is not configured", () => {
+      render(
+        <UsersForm
+          {...defaultProps}
+          isIdPConfigured={false}
+          defaultIsEndUserAuthEnabled
+        />
+      );
+      expect(
+        screen.getByRole("checkbox", { name: "Lock end user info" })
+      ).toBeDisabled();
+    });
+
+    it("does not allow toggling end user auth when IdP is not configured", async () => {
+      const { user } = render(
+        <UsersForm {...defaultProps} isIdPConfigured={false} />
+      );
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: "End user authentication",
+      });
+      await user.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+    });
+
+    it("disables managed local account checkbox when Apple MDM is not configured", () => {
+      renderWithMdmDisabled(<UsersForm {...defaultProps} />);
+      expect(
+        screen.getByRole("checkbox", { name: "Managed local account" })
+      ).toBeDisabled();
+    });
+
+    it("enables managed local account checkbox when Apple MDM is configured", () => {
+      renderWithMdmEnabled(<UsersForm {...defaultProps} />);
+      expect(
+        screen.getByRole("checkbox", { name: "Managed local account" })
+      ).toBeEnabled();
+    });
+
+    it("does not allow toggling managed local account when Apple MDM is not configured", async () => {
+      const { user } = renderWithMdmDisabled(
+        <UsersForm {...defaultProps} />
+      );
+
+      const checkbox = screen.getByRole("checkbox", {
+        name: "Managed local account",
+      });
+      await user.click(checkbox);
+
+      expect(checkbox).not.toBeChecked();
+    });
   });
 });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
@@ -104,14 +104,14 @@ describe("UsersForm", () => {
       render(<UsersForm {...defaultProps} isIdPConfigured={false} />);
       expect(
         screen.getByRole("checkbox", { name: "End user authentication" })
-      ).toBeDisabled();
+      ).toHaveAttribute("aria-disabled", "true");
     });
 
     it("enables end user authentication checkbox when IdP is configured", () => {
       render(<UsersForm {...defaultProps} isIdPConfigured />);
       expect(
         screen.getByRole("checkbox", { name: "End user authentication" })
-      ).toBeEnabled();
+      ).toHaveAttribute("aria-disabled", "false");
     });
 
     it("disables lock end user info when IdP is not configured", () => {
@@ -124,7 +124,7 @@ describe("UsersForm", () => {
       );
       expect(
         screen.getByRole("checkbox", { name: "Lock end user info" })
-      ).toBeDisabled();
+      ).toHaveAttribute("aria-disabled", "true");
     });
 
     it("does not allow toggling end user auth when IdP is not configured", async () => {
@@ -144,14 +144,14 @@ describe("UsersForm", () => {
       renderWithMdmDisabled(<UsersForm {...defaultProps} />);
       expect(
         screen.getByRole("checkbox", { name: "Managed local account" })
-      ).toBeDisabled();
+      ).toHaveAttribute("aria-disabled", "true");
     });
 
     it("enables managed local account checkbox when Apple MDM is configured", () => {
       renderWithMdmEnabled(<UsersForm {...defaultProps} />);
       expect(
         screen.getByRole("checkbox", { name: "Managed local account" })
-      ).toBeEnabled();
+      ).toHaveAttribute("aria-disabled", "false");
     });
 
     it("does not allow toggling managed local account when Apple MDM is not configured", async () => {

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
@@ -155,9 +155,7 @@ describe("UsersForm", () => {
     });
 
     it("does not allow toggling managed local account when Apple MDM is not configured", async () => {
-      const { user } = renderWithMdmDisabled(
-        <UsersForm {...defaultProps} />
-      );
+      const { user } = renderWithMdmDisabled(<UsersForm {...defaultProps} />);
 
       const checkbox = screen.getByRole("checkbox", {
         name: "Managed local account",

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -18,6 +18,7 @@ interface IUsersFormProps {
   defaultIsEndUserAuthEnabled: boolean;
   defaultLockEndUserInfo: boolean;
   defaultEnableManagedLocalAccount: boolean;
+  isIdPConfigured: boolean;
 }
 
 const UsersForm = ({
@@ -25,10 +26,11 @@ const UsersForm = ({
   defaultIsEndUserAuthEnabled,
   defaultLockEndUserInfo,
   defaultEnableManagedLocalAccount,
+  isIdPConfigured,
 }: IUsersFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
-  const gitOpsModeEnabled = useContext(AppContext).config?.gitops
-    .gitops_mode_enabled;
+  const { config, isMacMdmEnabledAndConfigured } = useContext(AppContext);
+  const gitOpsModeEnabled = config?.gitops.gitops_mode_enabled;
 
   const [isEndUserAuthEnabled, setEndUserAuthEnabled] = useState(
     defaultIsEndUserAuthEnabled
@@ -91,27 +93,48 @@ const UsersForm = ({
   return (
     <div className={baseClass}>
       <form onSubmit={onClickSave}>
-        <Checkbox
-          disabled={gitOpsModeEnabled}
-          value={isEndUserAuthEnabled}
-          onChange={onToggleEndUserAuth}
-          helpText={
-            <span>
-              End users are required to authenticate with your{" "}
-              <CustomLink
-                url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
-                text="identity provider (IdP)"
-              />{" "}
-              when setting up new hosts.
-            </span>
+        <TooltipWrapper
+          tipContent={
+            !isIdPConfigured ? (
+              <span>
+                Connect Fleet to your{" "}
+                <CustomLink
+                  url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
+                  text="identity provider (IdP)"
+                  variant="tooltip-link"
+                />
+                <br />
+                to get started.
+              </span>
+            ) : undefined
           }
+          disableTooltip={isIdPConfigured}
+          underline={false}
+          position="left"
+          showArrow
         >
-          End user authentication
-        </Checkbox>
+          <Checkbox
+            disabled={gitOpsModeEnabled || !isIdPConfigured}
+            value={isEndUserAuthEnabled}
+            onChange={onToggleEndUserAuth}
+            helpText={
+              <span>
+                End users are required to authenticate with your{" "}
+                <CustomLink
+                  url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
+                  text="identity provider (IdP)"
+                />{" "}
+                when setting up new hosts.
+              </span>
+            }
+          >
+            End user authentication
+          </Checkbox>
+        </TooltipWrapper>
         {isEndUserAuthEnabled && (
           <div className={`${baseClass}__advanced-options`}>
             <Checkbox
-              disabled={gitOpsModeEnabled}
+              disabled={gitOpsModeEnabled || !isIdPConfigured}
               onChange={onChangeLockEndUserInfo}
               value={lockEndUserInfo}
             >
@@ -133,22 +156,50 @@ const UsersForm = ({
             </Checkbox>
           </div>
         )}
-        <Checkbox
-          disabled={gitOpsModeEnabled}
-          value={enableManagedLocalAccount}
-          onChange={onToggleManagedLocalAccount}
-          helpText={
-            <span>
-              Fleet generates a user (_fleetadmin) and unique password for each
-              host, accessible in <b>Host details</b> &gt;{" "}
-              <b>Show managed account</b>.
-            </span>
+        <TooltipWrapper
+          tipContent={
+            !isMacMdmEnabledAndConfigured ? (
+              <span>
+                To use this feature, first enable{" "}
+                <CustomLink
+                  url={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}
+                  text="Apple MDM"
+                  variant="tooltip-link"
+                />
+                .
+              </span>
+            ) : undefined
           }
+          disableTooltip={!!isMacMdmEnabledAndConfigured}
+          underline={false}
+          position="left"
+          showArrow
         >
-          <TooltipWrapper tipContent="Creates a hidden managed local admin account for remote troubleshooting on macOS hosts.">
-            Managed local account
-          </TooltipWrapper>
-        </Checkbox>
+          <Checkbox
+            disabled={gitOpsModeEnabled || !isMacMdmEnabledAndConfigured}
+            value={enableManagedLocalAccount}
+            onChange={onToggleManagedLocalAccount}
+            helpText={
+              <span>
+                Fleet generates a user (_fleetadmin) and unique password for
+                each host, accessible in <b>Host details</b> &gt;{" "}
+                <b>Show managed account</b>.
+              </span>
+            }
+          >
+            <TooltipWrapper
+              tipContent={
+                <>
+                  Creates a hidden managed local admin account for
+                  <br />
+                  remote troubleshooting on macOS hosts.
+                </>
+              }
+            >
+              Managed local account
+            </TooltipWrapper>
+          </Checkbox>
+        </TooltipWrapper>
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
             <Button

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -70,7 +70,8 @@ const UsersForm = ({
     setEnableManagedLocalAccount(newCheckVal);
   };
 
-  const onClickSave = async () => {
+  const onClickSave = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
     setIsUpdating(true);
     const canLockEndUserInfo = isEndUserAuthEnabled && lockEndUserInfo;
 

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -97,14 +97,13 @@ const UsersForm = ({
           tipContent={
             !isIdPConfigured ? (
               <span>
-                Connect Fleet to your{" "}
+                To enable, first connect Fleet to your{" "}
                 <CustomLink
                   url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
                   text="identity provider (IdP)"
                   variant="tooltip-link"
                 />
-                <br />
-                to get started.
+                .
               </span>
             ) : undefined
           }
@@ -160,7 +159,7 @@ const UsersForm = ({
           tipContent={
             !isMacMdmEnabledAndConfigured ? (
               <span>
-                To use this feature, first enable{" "}
+                To enable, first turn on{" "}
                 <CustomLink
                   url={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}
                   text="Apple MDM"

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -97,7 +97,9 @@ const UsersForm = ({
           tipContent={
             !isIdPConfigured ? (
               <span>
-                To enable, first connect Fleet to your{" "}
+                To enable, first connect Fleet to
+                <br />
+                your{" "}
                 <CustomLink
                   url={PATHS.ADMIN_INTEGRATIONS_SSO_END_USERS}
                   text="identity provider (IdP)"

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -340,7 +340,9 @@ const canShowManagedAccount = (config: IHostActionConfigOptions) => {
   if (hostPlatform !== "darwin") return false;
   if (!isConnectedToFleetMdm) return false;
   if (!isAutomaticDeviceEnrollment(hostMdmEnrollmentStatus)) return false;
-  if (!isManagedLocalAccountEnabled && !config.managedAccountStatus) return false;
+  if (!isManagedLocalAccountEnabled && !config.managedAccountStatus) {
+    return false;
+  }
   return isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
 };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostActionsDropdown/helpers.tsx
@@ -340,7 +340,7 @@ const canShowManagedAccount = (config: IHostActionConfigOptions) => {
   if (hostPlatform !== "darwin") return false;
   if (!isConnectedToFleetMdm) return false;
   if (!isAutomaticDeviceEnrollment(hostMdmEnrollmentStatus)) return false;
-  if (!isManagedLocalAccountEnabled) return false;
+  if (!isManagedLocalAccountEnabled && !config.managedAccountStatus) return false;
   return isGlobalAdmin || isGlobalMaintainer || isTeamAdmin || isTeamMaintainer;
 };
 

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1034,8 +1034,7 @@ const HostDetailsPage = ({
           false
         }
         isManagedLocalAccountEnabled={
-          mdmConfig?.setup_experience?.enable_create_local_admin_account ??
-          false
+          mdmConfig?.macos_setup?.enable_managed_local_account ?? false
         }
         managedAccountStatus={
           host.mdm.os_settings?.managed_local_account?.status

--- a/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
+++ b/frontend/pages/hosts/details/HostDetailsPage/HostDetailsPage.tsx
@@ -1034,7 +1034,8 @@ const HostDetailsPage = ({
           false
         }
         isManagedLocalAccountEnabled={
-          mdmConfig?.macos_setup?.enable_managed_local_account ?? false
+          mdmConfig?.setup_experience?.enable_create_local_admin_account ??
+          false
         }
         managedAccountStatus={
           host.mdm.os_settings?.managed_local_account?.status


### PR DESCRIPTION
## Issue
Closes #42946 

## Description
- Two different checkboxes have two different requirements
- Initially we were removing the EUA requirement that was already existing so the user can get to this page
- But I think it's better that the user isn't allowed to interact with checkboxes that will fail because it's missing setting requirements
- Added disabled states to each checkbox based on their respective requirement with tooltips both following the "To [action], first [verb] [thing]." pattern"

## Screenshots


https://github.com/user-attachments/assets/48777009-709c-4725-bf99-6b083fe6ec1e


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [ ] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional flag to enable local admin account creation during setup experience
  * Added UI tooltips guiding users to configure IdP and Apple MDM when required

* **Bug Fixes**
  * Improved managed account eligibility logic on Apple hosts to properly consider account status

* **Tests**
  * Added test coverage for form field availability behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->