### PR TITLE
Website: update CRM helper

### DIFF
--- a/website/api/helpers/salesforce/update-or-create-contact-and-account.js
+++ b/website/api/helpers/salesforce/update-or-create-contact-and-account.js
@@ -362,6 +362,13 @@ module.exports = {
       if(enrichmentData.person && enrichmentData.person.title){
         contactValuesToSet.Title = enrichmentData.person.title;
       }
+      // If no firstName/lastName was provided but enrichment matched a name, use it for the new contact record.
+      if(enrichmentData.person && enrichmentData.person.firstName && !firstName) {
+        firstName = enrichmentData.person.firstName;
+      }
+      if(enrichmentData.person && enrichmentData.person.lastName && !lastName) {
+        lastName = enrichmentData.person.lastName;
+      }
       let salesforceAccountOwnerId;
       if(!enrichmentData.employer || !enrichmentData.employer.emailDomain || !enrichmentData.employer.organization) {
         // Special sacrificial meat cave where the contacts with no organization go.
@@ -468,6 +475,16 @@ module.exports = {
 
 
 
+      // If we don't have a firstName or lastName (from inputs or enrichment), tell Salesforce to save the
+      // record even if its duplicate rules match — otherwise we'd silently update an unrelated "? ?"
+      // contact instead of creating a new one for this person.
+      let createOptions;
+      if(!firstName && !lastName) {
+        createOptions = {
+          headers: { 'Sforce-Duplicate-Rule-Header': 'allowSave=true' }
+        };
+      }
+
       let duplicateContactWasFound = false;
       let newContactRecord = await sails.helpers.flow.build(async ()=>{
         return await salesforceConnection.sobject('Contact')
@@ -477,7 +494,7 @@ module.exports = {
           FirstName: firstName ? firstName : '?',
           LastName: lastName ? lastName : '?',
           ...contactValuesToSet,
-        });
+        }, createOptions);
       })// If Salesforce returns a duplicates_detected error message, use the first duplicate record returned in the error.
       .tolerate({errorCode: 'DUPLICATES_DETECTED'}, (err)=>{
         // Get the first matched duplicate record returned in the error returned by Salesforce.
@@ -539,6 +556,14 @@ module.exports = {
     //  ║ ║╠═╝ ║║╠═╣ ║ ║╣   ║╣ ╔╩╦╝║╚═╗ ║ ║║║║║ ╦  ║  ║ ║║║║ ║ ╠═╣║   ║
     //  ╚═╝╩  ═╩╝╩ ╩ ╩ ╚═╝  ╚═╝╩ ╚═╩╚═╝ ╩ ╩╝╚╝╚═╝  ╚═╝╚═╝╝╚╝ ╩ ╩ ╩╚═╝ ╩
     if(existingContactRecord) {
+      // If the existing contact has a placeholder name and we now have
+      // a real firstName/lastName, overwrite the placeholder. Otherwise leave the existing name alone.
+      if(firstName && existingContactRecord.FirstName === '?') {
+        contactValuesToSet.FirstName = firstName;
+      }
+      if(lastName && existingContactRecord.LastName === '?') {
+        contactValuesToSet.LastName = lastName;
+      }
       // If a description was provided and the contact has a description, prepend the new description to it.
       if(description && existingContactRecord.Description) {
         contactValuesToSet.Description += '\n' + existingContactRecord.Description;

--- a/website/config/custom.js
+++ b/website/config/custom.js
@@ -415,7 +415,7 @@ module.exports.custom = {
     'yahoo.com.br',    'yahoo.com.mx', 'yahoo.com.sg',     'yahoo.de',
     'yahoo.es',        'yahoo.fr',     'yahoo.in',         'yahoo.it',
     'yandex.ru',       'ymail.com',    'zoho.com',         'zonnet.nl',
-    'email.tst',       'de-smet.name',
+    'email.tst',
   ],
 
   // For website signups & "Talk to us" form submissions:
@@ -442,14 +442,13 @@ module.exports.custom = {
     'yahoo.co.uk',
     'yandex.ru',
     'ymail.com',
-    'de-smet.name',
   ],
 
   // For contact form submissions.
   // Note: We're using a separate list for the contact form because we previously allowed signups/license dispenser purchases with a personal email address.
   bannedEmailDomainsForContactFormSubmissions: [
+    'email.tst',
     'example.com',
-    'de-smet.name',
   ],
 
   /***************************************************************************


### PR DESCRIPTION
Closes: https://github.com/fleetdm/fleet/issues/44066

Changes:
- updated the `update-or-create-contact-and-account` helper to:
   - Save potential duplicate contacts with placeholder name values (`? ?`).
   - Use the firstName and lastName values returned by the get-enriched helper if a name is not provided.
   - Update contacts with placeholder name values if a name is provided.
 - Removed a domain from the lists of banned email domains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Salesforce contact creation with automatic name derivation from enrichment data.
  * Improved duplicate detection allowing new contacts to be created with flexible matching rules.
  * Automatic replacement of placeholder names with verified data during contact updates.

* **Chores**
  * Updated email domain blocklists configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->