### PR TITLE
Add macOS 26 Tahoe CIS benchmark v1.0.0

### DIFF
--- a/changes/35173-cis-macos-26-v1
+++ b/changes/35173-cis-macos-26-v1
@@ -1,0 +1,1 @@
+- Added macOS 26 CIS Benchmark v1.0.0

--- a/ee/cis/CIS-BENCHMARKS.md
+++ b/ee/cis/CIS-BENCHMARKS.md
@@ -11,24 +11,27 @@ ee/cis/
   macos-13/
   macos-14/
   macos-15/
+  macos-26/
   win-10/
   win-11/
   win-11-intune/
+```
 
 Each OS directory follows the same structure:
 
-  cis-policy-queries.yml        # All policies for this OS version
-  README.md                     # Limitations, org-decision policies, notes
-  test/
-    scripts/                    # Shell scripts that remediate or break settings
-      CIS_1.1_pass.sh
-      CIS_1.1_fail.sh
-      CIS_3.1.sh               # Pass-only (no fail counterpart)
-    profiles/                   # MDM configuration profiles (.mobileconfig)
-      1.6.mobileconfig
-      2.5.1-enable.mobileconfig
-      2.5.1-disable.mobileconfig
-      README.md                 # How to create new profiles
+```
+cis-policy-queries.yml          # All policies for this OS version
+README.md                       # Limitations, org-decision policies, notes
+test/
+  scripts/                      # Shell scripts that remediate or break settings
+    CIS_1.1_pass.sh
+    CIS_1.1_fail.sh
+    CIS_3.1.sh                  # Pass-only (no fail counterpart)
+  profiles/                     # MDM configuration profiles (.mobileconfig)
+    1.6.mobileconfig
+    2.5.1-enable.mobileconfig
+    2.5.1-disable.mobileconfig
+    README.md                   # How to create new profiles
 ```
 
 ## Policy format
@@ -196,8 +199,8 @@ currently in use by macOS CIS policies.
 |-------|-------------|----------------------|-------|
 | `authdb` | `right_name`, `json_result` | `right_name` must be equality-constrained | `json_result` is a JSON blob — use `json_extract(json_result, '$.rule')` to inspect rules. |
 | `csrutil_info` | `ssv_enabled` | — | Integer 0/1. |
-| `dscl` | `command`, `path`, `key`, `value` | all four required; currently only `command = 'read'` supported | Reads Directory Service records. |
-| `find_cmd` | `directory`, `type`, `perm`, `path` | all constrain — `find_cmd` shells out to `/usr/bin/find` with these args | Prefer over walking the `file` table for large scopes like `/System/Volumes/Data/System`. |
+| `dscl` | `command`, `path`, `key`, `value` | `command`, `path`, `key` required; `value` is output only; currently only `command = 'read'` supported | Reads Directory Service records. |
+| `find_cmd` | `directory`, `type`, `perm`, `path` | `directory` required (must be absolute); `type` and `perm` optional; `path` is output only | `find_cmd` shells out to `/usr/bin/find`; prefer it over walking the `file` table for large scopes like `/System/Volumes/Data/System` (core `file` exceeds osquery CPU/memory limits on 10k+ rows). |
 | `nvram_info` | `amfi_enabled` | — | Integer 0/1. |
 | `pmset` | `getting`, `json_result` | `getting` (e.g. `'custom'`) | `json_result` contains per-power-source nested dicts; use `JSON_EXTRACT(json_result, '$.AC Power:')` etc. |
 | `pwd_policy` | `max_failed_attempts`, `expires_every_n_days`, `days_to_expiration`, `history_depth`, `min_mixed_case_characters` | — | See console-user caveat below. |
@@ -229,7 +232,7 @@ classifies each policy into a test type based on what artifacts exist.
 | 1 | PASS_FAIL | `_pass.sh` + `_fail.sh` | Run fail script → verify query fails → run pass script → verify query passes |
 | 2 | PASS_ONLY | `CIS_{id}.sh` | Run script → verify query passes |
 | 3 | PROFILE | `.mobileconfig` in profiles dir (no scripts) | Verify query fails without profile → push profile to team → verify query passes |
-| 4 | MANUAL | None of the above | Prompt user with resolution steps (or skip with `--skip-no-script`) |
+| 4 | MANUAL | None of the above | Prompt user with resolution steps (or skip with `--skip-manual`) |
 
 Scripts take priority over profiles. If a policy has both a script and
 a profile, the script-based test type is used and the profile is
@@ -516,8 +519,10 @@ Each OS directory has a `README.md` that must document:
    level, title, and a one-line reason it can't be automated.
 5. **Org-decision policies** — where CIS leaves the choice to the
    organization; Fleet provides both enable/disable variants.
-6. **Optional policies** — benchmarks CIS includes but does not
-   require (e.g. password complexity).
+6. **Optional policies** — benchmarks CIS ships at a level
+   higher than what Fleet enforces by default (e.g. Level 2
+   recommendations on a deployment that targets Level 1), or
+   org-chosen alternatives for items CIS leaves open.
 7. **Per-section notes** — for each section that shipped, a short
    block (`### Section N notes`) explaining any query patterns,
    table-schema quirks, test artifact tradeoffs, or caveats the
@@ -542,7 +547,7 @@ it blank — readers otherwise assume it's a gap:
 ```bash
 # Test everything, skip policies without scripts
 python3 tools/cis/cis-test-runner.py \
-    --macos-version 14 --all --skip-no-script \
+    --macos-version 14 --all --skip-manual \
     --fleet-url $FLEET_URL --fleet-token $FLEET_API_TOKEN
 
 # Test specific CIS IDs
@@ -551,7 +556,7 @@ python3 tools/cis/cis-test-runner.py \
 
 # Clean up everything after
 python3 tools/cis/cis-test-runner.py \
-    --macos-version 14 --all --skip-no-script --cleanup
+    --macos-version 14 --all --skip-manual --cleanup
 ```
 
 The runner creates a Fleet team, builds and installs a fleet agent in
@@ -628,8 +633,9 @@ won't be able to spin up a test VM — mark the `VERSION_MAP`
 entry TODO in the state file and plan to revisit.
 
 **4. Only then** start writing policies. Trying to run the
-runner before these registrations will fail with "choices must
-be one of {13,14,15}" or similar.
+runner before these registrations will fail at argument parsing
+with `argument --macos-version: invalid choice: 'NN' (choose
+from '13', '14', '15')`.
 
 ## Updating benchmarks when a new CIS version is released
 
@@ -732,10 +738,13 @@ Status legend: ⬜ not started · 🟨 in progress · ✅ done ·
 ⏭ skipped.
 
 ### Validation
-- [ ] Runner registered (VERSION_MAP + 3 constant dicts)
-- [ ] YAML parses, cis_ids unique
+- [ ] Runner registered — all four dicts in `cis-test-runner.py`
+      (`VERSION_MAP`, `SSH_BREAKING_CIS_IDS`,
+      `PASSWORD_POLICY_CIS_IDS`, `NON_AUTOMATABLE_CIS_IDS`)
+- [ ] YAML parses, `cis_id`s unique
 - [ ] All profiles `plutil -lint` OK
-- [ ] Fleetd table schemas verified
+- [ ] Profile UUIDs unique (top-level + inner, no duplicates)
+- [ ] Fleetd table schemas verified against `orbit/pkg/table/`
 - [ ] Test runner dry run against generated policies
 - [ ] Summary reviewed, failures fixed
 

--- a/ee/cis/CIS-BENCHMARKS.md
+++ b/ee/cis/CIS-BENCHMARKS.md
@@ -72,14 +72,21 @@ spec:
 
 ### Query patterns
 
-There are four common query patterns:
+Every query must return 1+ rows when compliant and 0 rows when not.
+The patterns below compose: most real policies use more than one.
 
-**1. Direct table check** — query an osquery table directly:
+**1. Direct table check** — query an osquery table directly for live state:
 ```sql
 SELECT 1 FROM alf WHERE global_state >= 1;
 ```
 
-**2. Managed policy check** — verify an MDM profile is installed (requires MDM enrollment):
+**2. Managed policy check** — verify an MDM profile is installed.
+
+Always pair an `EXISTS (good value)` with a `NOT EXISTS (conflicting
+value)`. A single `EXISTS` passes if *any* managed_policies row has
+the good value, even when a user-scope row on the same host is
+overriding it with a bad value. The `NOT EXISTS` guard catches that.
+
 ```sql
 SELECT 1 WHERE
   EXISTS (
@@ -97,8 +104,27 @@ SELECT 1 WHERE
   );
 ```
 
-The EXISTS/NOT EXISTS pattern ensures the setting is actively managed
-AND that no conflicting value exists at another scope level.
+**`username = ''` vs. user-scoped keys.** System-scoped MDM keys
+(most `com.apple.*` domains) deliver with `username = ''` on the
+`managed_policies` row. A handful of domains — notably
+`com.apple.Safari`, `com.apple.Terminal`, and a few
+`com.apple.applicationaccess` user-preference keys — deliver at
+user scope, so the row's `username` is the logged-in user. For
+those, *omit* the `username = ''` clause on the `EXISTS`; the
+`NOT EXISTS` guard is enough on its own. When in doubt, push a
+test profile and run `SELECT * FROM managed_policies WHERE
+domain = 'com.apple.<x>'` to see which scope delivered.
+
+**Multi-key managed_policies check.** When one profile sets
+multiple keys that must all be correct (firewall + stealth,
+askForPassword + askForPasswordDelay), AND together an
+`EXISTS`/`NOT EXISTS` pair per key:
+
+```sql
+SELECT 1 WHERE
+  EXISTS ( /* key1 = good */ ) AND NOT EXISTS ( /* key1 = bad */ )
+  AND EXISTS ( /* key2 = good */ ) AND NOT EXISTS ( /* key2 = bad */ );
+```
 
 **3. Negation check** — verify something is absent or disabled:
 ```sql
@@ -128,6 +154,28 @@ present — it only requires that any present value is within the
 acceptable range. Use when the benchmark explicitly states that
 absence of the setting also satisfies the audit.
 
+**5. Either-local-or-managed compound** — CIS sometimes accepts
+either a local plist value or a managed profile as compliant (e.g.
+Guest Account disabled, Automatic Login disabled). Query both paths
+with `OR`:
+
+```sql
+SELECT 1 WHERE
+  EXISTS (
+    SELECT 1 FROM plist WHERE
+      path = '/Library/Preferences/com.apple.loginwindow.plist' AND
+      key = 'GuestEnabled' AND value = 0
+  )
+  OR EXISTS (
+    SELECT 1 FROM managed_policies WHERE
+      domain = 'com.apple.MCX' AND name = 'DisableGuestAccount' AND
+      (value = 1 OR value = 'true') AND username = ''
+  );
+```
+
+When the either-branch uses pattern 2, still include its
+`NOT EXISTS` guard inside that branch.
+
 ### Naming qualifiers
 
 Append these to the policy name when applicable:
@@ -135,6 +183,38 @@ Append these to the policy name when applicable:
 - **(MDM Required)** — query checks `managed_policies`; needs an MDM profile installed
 - **(Fleetd Required)** — query uses a fleetd-specific table (e.g. `software_update`)
 - **(FDA Required)** — query reads paths that require full disk access
+
+### Fleetd tables used by CIS queries
+
+Fleetd ships custom osquery tables for settings that can't be read
+from stock osquery. When writing a query against one, check the
+source at `orbit/pkg/table/<name>/` to confirm the column names
+and any required `WHERE` constraints. The table below is the set
+currently in use by macOS CIS policies.
+
+| Table | Key columns | Required constraints | Notes |
+|-------|-------------|----------------------|-------|
+| `authdb` | `right_name`, `json_result` | `right_name` must be equality-constrained | `json_result` is a JSON blob — use `json_extract(json_result, '$.rule')` to inspect rules. |
+| `csrutil_info` | `ssv_enabled` | — | Integer 0/1. |
+| `dscl` | `command`, `path`, `key`, `value` | all four required; currently only `command = 'read'` supported | Reads Directory Service records. |
+| `find_cmd` | `directory`, `type`, `perm`, `path` | all constrain — `find_cmd` shells out to `/usr/bin/find` with these args | Prefer over walking the `file` table for large scopes like `/System/Volumes/Data/System`. |
+| `nvram_info` | `amfi_enabled` | — | Integer 0/1. |
+| `pmset` | `getting`, `json_result` | `getting` (e.g. `'custom'`) | `json_result` contains per-power-source nested dicts; use `JSON_EXTRACT(json_result, '$.AC Power:')` etc. |
+| `pwd_policy` | `max_failed_attempts`, `expires_every_n_days`, `days_to_expiration`, `history_depth`, `min_mixed_case_characters` | — | See console-user caveat below. |
+| `password_policy` | `policy_identifier`, `policy_content` | — | macOS-native osquery table, *not* fleetd — listed here for completeness. |
+| `software_update` | `software_update_required` | — | — |
+| `sudo_info` | `json_result` | — | Parsed output of `sudo -V`; use `JSON_EXTRACT(json_result, '$.Authentication timestamp timeout')`, `'$.Type of authentication timestamp record'`, `'$.Log when a command is allowed by sudoers'`. |
+| `user_login_settings` | `password_hint_enabled` | — | See console-user caveat below. |
+
+**Console-user-scope caveat.** `pwd_policy` and
+`user_login_settings` (and the native `location_services` table)
+execute their underlying commands as the current console user.
+If no console user is logged in at query time — or on a headless
+test VM where the console user is `root` — the tables return
+empty results and the query silently fails (0 rows). Ensure a
+non-root console user is logged in before evaluating any policy
+that depends on these tables. Current affected policies:
+`5.2.1`, `5.2.2`, `5.2.7`, `5.2.8`, `2.12.1`, `2.6.1.1`.
 
 ## Test artifacts
 
@@ -208,11 +288,69 @@ or can't be easily scripted:
 
 ### Script conventions
 
-- Always use `#!/bin/bash`
-- Use full paths for system commands (`/usr/bin/sudo`, `/usr/sbin/systemsetup`)
-- Include a comment with the CIS ID and policy name
-- Use `sudo` for privileged operations (the test runner provides the password)
-- Prefix unreliable scripts with `not_always_working_` — the test runner skips these
+- Always use `#!/bin/bash`.
+- Use full paths for system commands (`/usr/bin/sudo`, `/usr/sbin/systemsetup`).
+- Include a comment with the CIS ID and policy name.
+- Use `sudo` for privileged operations (the test runner provides the password).
+- Prefix unreliable scripts with `not_always_working_` — the test runner skips these.
+- Fail scripts that *create* artifacts (stub apps, stub directories,
+  extra plist keys) should pair with a pass script that removes
+  them, or note in the README that runner teardown must clean up.
+  Leaving a stub world-writable `.app` in `/Applications` after the
+  test will break subsequent runs.
+
+### Common script patterns
+
+These idioms come up repeatedly and are worth reusing verbatim.
+
+**Console user** — needed when setting or reading a per-user
+preference from within a system-level script:
+```bash
+user=$(/usr/bin/stat -f "%Su" /dev/console)
+if [ -n "$user" ] && [ "$user" != "root" ]; then
+  /usr/bin/sudo -u "$user" /usr/bin/defaults write <domain> <key> ...
+fi
+```
+On a headless test VM without a logged-in console user, the value
+is `root` — the script should no-op rather than fail.
+
+**Iterate `/Users/*`** — for per-user settings that must be applied
+to every local account. Skip `Shared`, `Guest`, and dot-prefixed
+directories (`/Users/.localized` etc.):
+```bash
+for userhome in /Users/*; do
+  user=$(basename "$userhome")
+  case "$user" in Shared|Guest|.*) continue ;; esac
+  [ -d "$userhome/Library/Preferences" ] || continue
+  /usr/bin/sudo -u "$user" /usr/bin/defaults write com.apple.dock ...
+done
+```
+
+**Idempotent delete** — use `|| true` so a missing key doesn't
+trip the `-e` exit behavior:
+```bash
+/usr/bin/sudo /usr/bin/defaults delete <domain> <key> 2>/dev/null || true
+```
+
+**sudoers.d filename rule** — macOS ignores files in
+`/etc/sudoers.d/` whose names contain a dot. Use underscores and
+no extension:
+```bash
+echo 'Defaults timestamp_timeout=0' | \
+  /usr/bin/sudo /usr/bin/tee /etc/sudoers.d/CIS_5_4_sudoconfiguration > /dev/null
+/usr/bin/sudo /bin/chmod 0440 /etc/sudoers.d/CIS_5_4_sudoconfiguration
+```
+
+**Atomic config-file edits** — when rewriting a system config
+file (audit_control, asl/com.apple.install), write to a temp file
+via `awk`/`sed` and rename. Never edit in place:
+```bash
+TMP="$(/usr/bin/mktemp /tmp/audit_control.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '...' /etc/security/audit_control > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod 0440 /etc/security/audit_control
+```
 
 ### Choosing between scripts and profiles
 
@@ -323,14 +461,79 @@ Note that `PayloadVersion` appears at **both** the top-level and
 inner-payload level. Both are required for profiles to install
 reliably.
 
+### Multi-key profiles
+
+Benchmarks sometimes require multiple settings keys to be present
+together for a check to pass (firewall + stealth mode, askForPassword
++ askForPasswordDelay, BlockStoragePolicy + WebKit storage blocking,
+etc.). Three ways this can show up; pick the right one:
+
+| Situation | Pattern |
+|-----------|---------|
+| One benchmark recommendation, multiple keys on the same `PayloadType` | One profile, multiple keys in the inner `PayloadContent` dict. |
+| Two separate benchmark IDs that CIS *explicitly* wants enforced via the same profile (e.g. 2.2.1 Firewall + 2.2.2 Stealth Mode — CIS says putting them in separate profiles makes them fail) | One profile named `{id1}-and-{id2}.mobileconfig`. The query for each ID checks its own key. |
+| One benchmark that genuinely requires multiple *profiles* to be installed together (rare — different `PayloadType`s that can't coexist in one payload) | Two files named `{cis_id}-part1.mobileconfig` and `{cis_id}-part2.mobileconfig`. |
+
+**Worked example.** CIS 2.2.1 (Firewall) + 2.2.2 (Stealth Mode)
+share the `com.apple.security.firewall` payload. CIS explicitly
+requires them in the same profile:
+
+```xml
+<key>PayloadContent</key>
+<array>
+  <dict>
+    <key>PayloadType</key>
+    <string>com.apple.security.firewall</string>
+    <key>PayloadIdentifier</key>
+    <string>com.fleetdm.cis-2.2.1-and-2.2.2.check</string>
+    <key>PayloadUUID</key>
+    <string>{inner UUID}</string>
+    <key>PayloadVersion</key>
+    <integer>1</integer>
+    <key>EnableFirewall</key>
+    <true/>
+    <key>EnableStealthMode</key>
+    <true/>
+  </dict>
+</array>
+```
+
+File name: `2.2.1-and-2.2.2.mobileconfig`. Each CIS ID gets its
+own policy YAML entry, each with its own query checking its own
+key.
+
 ## README.md per OS version
 
 Each OS directory has a `README.md` that must document:
 
-1. Which benchmark version the policies target
-2. **Limitations** — benchmarks that cannot be checked as a Fleet policy (manual audits, GUI-only settings)
-3. **Org-decision policies** — where CIS leaves the choice to the organization; Fleet provides both enable/disable variants
-4. **Optional policies** — benchmarks CIS includes but does not require (e.g. password complexity)
+1. Which benchmark version the policies target.
+2. **Status** — which sections are complete and which are still WIP.
+3. **Sections covered** — a table listing §1..§N with status per
+   section (complete, in progress, not started, skipped).
+4. **Limitations** — benchmarks that cannot be checked as a Fleet
+   policy (manual audits, GUI-only settings). Include every
+   Manual-assessment recommendation from the PDF with its CIS ID,
+   level, title, and a one-line reason it can't be automated.
+5. **Org-decision policies** — where CIS leaves the choice to the
+   organization; Fleet provides both enable/disable variants.
+6. **Optional policies** — benchmarks CIS includes but does not
+   require (e.g. password complexity).
+7. **Per-section notes** — for each section that shipped, a short
+   block (`### Section N notes`) explaining any query patterns,
+   table-schema quirks, test artifact tradeoffs, or caveats the
+   next maintainer will want to see. Anything you flagged in the
+   state file's "Open questions" is a candidate.
+
+**Sections with no automated checks.** If a whole section (e.g.
+`§2.4 Menu Bar`) contains only Manual recommendations in the
+current benchmark version, say so explicitly rather than leaving
+it blank — readers otherwise assume it's a gap:
+
+> §2.4 (Menu Bar), §2.8 (Displays), §2.14–2.17 (Game Center,
+> Notifications, Wallet, Internet Accounts) contain only
+> Manual-assessment recommendations in this version and are
+> therefore not represented in `cis-policy-queries.yml`. See
+> Limitations for the individual items.
 
 ## Test runner
 
@@ -357,20 +560,106 @@ a tart VM, enrolls it, runs each test, and prints a summary. See
 
 ---
 
+## Adding a new macOS version
+
+Creating the `ee/cis/macos-NN/` directory is only half the job —
+the Python test runner also needs to know the new version exists.
+Missing any of these registrations will make the runner either
+reject `--macos-version NN` outright or fail unpredictably mid-run.
+
+**1. Scaffold the OS directory.**
+
+```
+ee/cis/macos-NN/
+  cis-policy-queries.yml   # starts empty; append as you go
+  README.md                # use the structure from "README.md per OS version"
+  test/
+    scripts/               # empty
+    profiles/              # empty
+```
+
+**2. Register the version in `tools/cis/cis-test-runner.py`.**
+Four dicts near the top of the file key off the OS version
+string (`"13"`, `"14"`, `"15"`, `"NN"`). Add an entry to each:
+
+- `VERSION_MAP`: the Tart base image URL for the OS and the
+  matching `ee/cis/` directory name.
+  ```python
+  "26": {
+      "image": "ghcr.io/cirruslabs/macos-tahoe-base:latest",
+      "dir": "macos-26",
+  },
+  ```
+
+- `SSH_BREAKING_CIS_IDS`: CIS IDs whose pass scripts disable
+  sshd (usually Remote Login and Remote Management). The runner
+  flips these to MANUAL so it doesn't lose its SSH session:
+  ```python
+  "26": {"2.3.3.4", "2.3.3.5"},
+  ```
+
+- `PASSWORD_POLICY_CIS_IDS`: CIS IDs whose MDM profiles enforce
+  a password policy strong enough to reject the VM's test user
+  password. The runner installs these individually with a
+  restore step:
+  ```python
+  "26": {"5.2.1", "5.2.2", "5.2.7", "5.2.8"},
+  ```
+
+- `NON_AUTOMATABLE_CIS_IDS`: CIS IDs that cannot be reliably
+  tested on a VM at all, with a reason each. Seed with the
+  usual suspects; add more as the runner surfaces unreliable
+  tests:
+  ```python
+  "26": {
+      "1.1": "Requires real hardware to install Apple updates",
+      "2.6.1.1": "VM cannot satisfy user-privacy gate for Location Services",
+  },
+  ```
+
+CIS section numbers are *not* stable across releases — verify
+each mapping against the new version's PDF before copying it
+from an older OS entry.
+
+**3. Confirm the Tart base image exists.** Cirrus Labs usually
+publishes `ghcr.io/cirruslabs/macos-<codename>-base:latest` soon
+after a macOS release. If it isn't published yet, the runner
+won't be able to spin up a test VM — mark the `VERSION_MAP`
+entry TODO in the state file and plan to revisit.
+
+**4. Only then** start writing policies. Trying to run the
+runner before these registrations will fail with "choices must
+be one of {13,14,15}" or similar.
+
 ## Updating benchmarks when a new CIS version is released
 
 ### Manual process
 
-1. Download the new PDF from the CIS website
-2. Read the **Appendix: Change History** at the end of the document
+1. Download the new PDF from the CIS website.
+2. Read the **Appendix: Change History** at the end of the document.
 3. For each change:
-   - **Added**: write a new policy entry with all fields
-   - **Modified**: update the changed fields (description, resolution, audit) from the new document
-   - **Removed**: delete the policy entry
-4. For each added or modified policy, create test scripts (`_pass.sh`/`_fail.sh`)
-5. For MDM-dependent policies, create the `.mobileconfig` profile
-6. Update `README.md` with any new limitations or org-decision policies
-7. Run the test runner against the updated policies
+   - **Added**: write a new policy entry with all fields.
+   - **Modified**: update the changed fields (description, resolution, audit) from the new document.
+   - **Removed**: delete the policy entry, its test scripts, and any associated profiles.
+4. **Audit every previous-version policy for an
+   Automated → Manual downgrade.** CIS frequently moves
+   recommendations from Automated to Manual between releases
+   (e.g. Tahoe moved Hey Siri and the password-complexity
+   items to Manual). The Change History usually flags these,
+   but not always — diff the new PDF's per-section
+   "Assessment Status: Automated | Manual" lines against the
+   previous version's. **Any policy that went Manual must be
+   deleted from the YAML, scripts removed, and the
+   recommendation moved to the README's Limitations section.**
+   Shipping a query for a Manual recommendation is worse than
+   shipping nothing, because the query will produce
+   non-authoritative results.
+5. For each added or modified policy, create test scripts
+   (`_pass.sh`/`_fail.sh`).
+6. For MDM-dependent policies, create the `.mobileconfig` profile.
+7. Update `README.md` with any new limitations or org-decision
+   policies.
+8. Run the test runner against the updated policies.
 
 ### What changes between versions
 
@@ -397,14 +686,73 @@ conventions defined above — update both if conventions change.
 
 When generating a full benchmark from a large PDF in multiple
 sessions, it helps to maintain a state file at
-`tmp/<os>-<version>-state.md` that records:
-
-- Locked decisions for the run (levels covered, branch, org-decision
-  default, handling of uncertain profile keys)
-- Per-section progress
-- Open questions or ambiguities per section
-- A **Next action** pointer so a future session can resume from cold
-  context
+`tmp/<os>-<version>-state.md` that records locked decisions,
+per-section progress, open questions, and a **Next action**
+pointer so a future session can resume from cold context.
 
 Not a hard convention — just a useful checkpoint mechanism when a
-single session can't finish the job.
+single session can't finish the job. The template below is the
+minimum that has proven useful; extend as needed.
+
+````markdown
+# <OS> <version> CIS benchmark — state file
+
+**Purpose:** durable checkpoint for generating Fleet's CIS
+benchmark for <OS> <version>, resumable across sessions.
+
+## How to resume
+
+In a new session, say: *"Resume <OS> <version> CIS work from
+`tmp/<os>-<version>-state.md`."* Then re-read this file and
+continue from the **Next action** line.
+
+## Task (frozen)
+
+Create `ee/cis/<os>-<version>/` — policies, test scripts, MDM
+profiles, README — from `pdf/<filename>.pdf` alone, following
+`ee/cis/CIS-BENCHMARKS.md` and `ee/cis/prompt.md`.
+
+## Decisions (locked for this session)
+
+- Approach (thin slice end-to-end vs. by-file)
+- Levels covered (Level 1, Level 2, or both)
+- Branch
+- Org-decision default (ship both enable/disable, or pick one)
+- Handling of uncertain profile keys (skip + TODO, guess, or ask)
+- Whether §7 Supplemental is skipped
+
+## Progress tracker
+
+| Section | Status | Policies | Scripts | Profiles | README | Notes |
+|---------|--------|----------|---------|----------|--------|-------|
+| 1 …     | ⬜     |          |         |          |        |       |
+| 2.2 …   | ⬜     |          |         |          |        |       |
+
+Status legend: ⬜ not started · 🟨 in progress · ✅ done ·
+⏭ skipped.
+
+### Validation
+- [ ] Runner registered (VERSION_MAP + 3 constant dicts)
+- [ ] YAML parses, cis_ids unique
+- [ ] All profiles `plutil -lint` OK
+- [ ] Fleetd table schemas verified
+- [ ] Test runner dry run against generated policies
+- [ ] Summary reviewed, failures fixed
+
+## Open questions / TODOs
+
+### §<section>
+- <uncertainty, audit ambiguity, or runtime risk>
+
+## Files touched
+
+- `tmp/<os>-<version>-state.md` (this file)
+- `ee/cis/<os>-<version>/cis-policy-queries.yml`
+- `ee/cis/<os>-<version>/README.md`
+- `ee/cis/<os>-<version>/test/scripts/` — N files …
+- `ee/cis/<os>-<version>/test/profiles/` — N files …
+
+## Next action
+
+<One sentence describing exactly where to pick up.>
+````

--- a/ee/cis/CIS-BENCHMARKS.md
+++ b/ee/cis/CIS-BENCHMARKS.md
@@ -545,7 +545,7 @@ it blank — readers otherwise assume it's a gap:
 `tools/cis/cis-test-runner.py` automates the full test cycle:
 
 ```bash
-# Test everything, skip policies without scripts
+# Test everything, skip manual policies / policies without test artifacts
 python3 tools/cis/cis-test-runner.py \
     --macos-version 14 --all --skip-manual \
     --fleet-url $FLEET_URL --fleet-token $FLEET_API_TOKEN

--- a/ee/cis/CIS-BENCHMARKS.md
+++ b/ee/cis/CIS-BENCHMARKS.md
@@ -72,7 +72,7 @@ spec:
 
 ### Query patterns
 
-There are three common query patterns:
+There are four common query patterns:
 
 **1. Direct table check** — query an osquery table directly:
 ```sql
@@ -109,6 +109,24 @@ SELECT 1 WHERE NOT EXISTS (
     value = '0'
 );
 ```
+
+**4. Absence-passes / numeric threshold** — for checks where an
+unmanaged host is compliant and only a non-compliant *managed* value
+should fail (e.g. "deferment ≤ 30 days" passes when deferment is not
+managed at all):
+```sql
+SELECT 1 WHERE NOT EXISTS (
+  SELECT 1 FROM managed_policies WHERE
+    domain='com.apple.applicationaccess' AND
+    name='enforcedSoftwareUpdateDelay' AND
+    CAST(value AS INTEGER) > 30
+);
+```
+
+Unlike pattern 2, this pattern does not require the setting to be
+present — it only requires that any present value is within the
+acceptable range. Use when the benchmark explicitly states that
+absence of the setting also satisfies the audit.
 
 ### Naming qualifiers
 
@@ -198,22 +216,27 @@ or can't be easily scripted:
 
 ### Choosing between scripts and profiles
 
-When creating tests for a new policy, decide based on how the setting
+The decision is driven by **what the query reads**, not by what
+remediation methods the PDF provides. Decide based on how the setting
 is configured:
 
-- **System service or plist-based setting** (e.g. enable/disable SSH,
-  launchd service, defaults write): create shell scripts. These are
-  more reliable and don't require MDM.
-- **MDM-only setting** (e.g. managed_policies check, no terminal
-  remediation method in the benchmark): create a `.mobileconfig`
-  profile only. The test runner handles these automatically.
-- **Both available**: create shell scripts (they give better test
-  coverage since they test both directions explicitly). Also create
-  the profile — it gets pushed during setup and is available if
-  needed.
+- **Query reads local state** (osquery table that reflects
+  system/service state, local `plist` file, `launchd`, `file`, etc.):
+  create shell scripts. These are more reliable and don't require
+  MDM.
+- **Query reads `managed_policies`**: create a `.mobileconfig`
+  profile only, regardless of whether the PDF also lists a Terminal
+  Method. A local `defaults write` does not populate
+  `managed_policies` — only an MDM-installed profile will change what
+  the query sees. Scripts would pass on disk but leave the query's
+  result unchanged.
+- **Query reads both** (rare, e.g. a policy that checks either a
+  local setting or its managed override): create scripts for the
+  local path and a profile for the managed path. Scripts take
+  priority in the runner; the profile is installed alongside.
 - **Neither** (GUI-only, requires user interaction): document in
-  README.md as a limitation. The test runner will prompt the user or
-  skip.
+  `README.md` as a limitation. The test runner will prompt the user
+  or skip.
 
 ## MDM configuration profiles
 
@@ -232,13 +255,73 @@ Profiles live in `test/profiles/` as `.mobileconfig` XML plist files.
 
 ### Creating a new profile
 
-1. Copy an existing profile as a template
-2. Generate two UUIDs: `uuidgen` (one for payload, one for top-level)
-3. Set `PayloadType` to the MDM domain (e.g. `com.apple.SoftwareUpdate`)
-4. Set `PayloadIdentifier` to `com.fleetdm.cis-{cis_id}` (top-level) and `com.fleetdm.cis-{cis_id}.check` (payload)
-5. Add the configuration keys and values from the benchmark
+1. Generate two UUIDs with `uuidgen` — one for the top-level
+   `PayloadUUID` and one for the inner payload `PayloadUUID`.
+2. Set the inner `PayloadType` to the MDM domain (e.g.
+   `com.apple.SoftwareUpdate`).
+3. Set `PayloadIdentifier` to `com.fleetdm.cis-{cis_id}` (top-level)
+   and `com.fleetdm.cis-{cis_id}.check` (inner).
+4. Add the configuration keys and values from the benchmark to the
+   inner payload dict. **Multiple keys for the same `PayloadType`
+   belong in a single payload dict**, not separate profiles — some
+   benchmarks explicitly require this (e.g. a deferment profile
+   needing both `enforcedSoftwareUpdateDelay` and
+   `forceDelayedSoftwareUpdates` to be effective). Use
+   `{cis_id}-part1.mobileconfig` only when a benchmark genuinely
+   requires *multiple profiles* to be installed together.
+5. Validate the generated file with `/usr/bin/plutil -lint
+   path/to/file.mobileconfig` before committing.
 
-See `test/profiles/README.md` for the full XML template.
+### XML template
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS {cis_id}</string>
+      <key>PayloadType</key>
+      <string>{PayloadType from benchmark, e.g. com.apple.SoftwareUpdate}</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-{cis_id}.check</string>
+      <key>PayloadUUID</key>
+      <string>{inner UUID from uuidgen}</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <!-- One or more setting keys, all within this payload dict: -->
+      <key>{SettingKey1}</key>
+      <{true|false|string|integer|...}>{value}</...>
+      <key>{SettingKey2}</key>
+      <{...}>{value}</...>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS {cis_id} - {title}</string>
+  <key>PayloadDisplayName</key>
+  <string>{title}</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-{cis_id}</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>{top-level UUID from uuidgen}</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>
+```
+
+Note that `PayloadVersion` appears at **both** the top-level and
+inner-payload level. Both are required for profiles to install
+reliably.
 
 ## README.md per OS version
 
@@ -305,251 +388,23 @@ CIS benchmark updates typically involve:
 
 ## AI agent prompt for generating CIS benchmarks
 
-The following prompt is designed to be given to an AI agent along with
-the CIS PDF documents. It covers the full lifecycle: generating
-policies, writing tests, creating profiles, updating documentation,
-and running validation.
+An agent-ready prompt for generating or updating a full benchmark
+(policies, test scripts, profiles, README) from a CIS PDF lives in
+[`prompt.md`](./prompt.md) in this directory. It references the
+conventions defined above — update both if conventions change.
 
-### Prompt
+## Durable state for long generation runs (optional)
 
-````
-You are a security compliance engineer updating Fleet's CIS benchmark
-policies. You have access to the Fleet codebase and CIS benchmark PDF
-documents.
+When generating a full benchmark from a large PDF in multiple
+sessions, it helps to maintain a state file at
+`tmp/<os>-<version>-state.md` that records:
 
-## Your task
+- Locked decisions for the run (levels covered, branch, org-decision
+  default, handling of uncertain profile keys)
+- Per-section progress
+- Open questions or ambiguities per section
+- A **Next action** pointer so a future session can resume from cold
+  context
 
-Given a CIS benchmark PDF for a specific OS and version, generate or
-update the complete set of Fleet policies, test scripts, MDM profiles,
-and documentation.
-
-## Input files
-
-- CIS benchmark PDF (new version): `pdf/<filename>.pdf`
-- CIS benchmark PDF (previous version, if upgrading): `pdf/<filename>.pdf`
-- Existing policies (if upgrading): `ee/cis/<os-dir>/cis-policy-queries.yml`
-- Existing tests: `ee/cis/<os-dir>/test/scripts/` and `test/profiles/`
-
-## Step-by-step workflow
-
-### Step 1: Extract the changelog
-
-Read the "Appendix: Change History" from the end of the new PDF.
-Identify every entry for the target version. Classify each as ADDED,
-MODIFIED, or REMOVED.
-
-If this is a new OS version (no existing policies), treat every
-recommendation as ADDED.
-
-### Step 2: Read affected sections
-
-For each changed recommendation, read its full section in the new PDF.
-Extract:
-- Section number (becomes `cis_id`)
-- Title
-- Profile Applicability (Level 1 or Level 2)
-- Assessment Status (Automated or Manual)
-- Description
-- Audit method (terminal command)
-- Remediation method (terminal and/or profile method)
-- PayloadType, key name, and value (if profile-based)
-
-Skip Manual-assessment recommendations — they cannot be automated as
-Fleet policies. Note them for the README.md limitations section.
-
-### Step 3: Generate policy YAML
-
-For each Automated recommendation, write a policy document:
-
-```yaml
----
-apiVersion: v1
-kind: policy
-spec:
-  name: "CIS - <exact title from PDF> (<qualifier if needed>)"
-  cis_id: "<section number>"
-  platforms: <platform display name>
-  platform: <osquery platform>
-  description: |
-    <description from PDF>
-  resolution: |
-    <remediation from PDF, both graphical and terminal methods>
-  query: |
-    <osquery SQL — see query rules below>
-  purpose: Informational
-  tags: compliance, CIS, CIS_Level<1 or 2>
-```
-
-#### Query rules
-
-- The query MUST return 1 or more rows when the system IS compliant.
-- The query MUST return 0 rows when the system IS NOT compliant.
-- For profile/MDM-based settings, use the managed_policies table with
-  the EXISTS/NOT EXISTS pattern:
-  ```sql
-  SELECT 1 WHERE
-    EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain='<PayloadType>' AND
-        name='<key>' AND
-        (value = <expected> OR value = '<expected>') AND
-        username = ''
-    )
-    AND NOT EXISTS (
-      SELECT 1 FROM managed_policies WHERE
-        domain='<PayloadType>' AND
-        name='<key>' AND
-        (value != <expected> AND value != '<expected>')
-    );
-  ```
-- For system settings checked via plist, use the plist table.
-- For running services, use the launchd table.
-- For file permissions, use the file table.
-- Consult the osquery schema at https://osquery.io/schema/ for
-  available tables.
-- Append "(MDM Required)" to the name if the query uses
-  managed_policies.
-- Append "(Fleetd Required)" if the query uses fleetd-only tables
-  like software_update.
-- Append "(FDA Required)" if the query reads files requiring full
-  disk access.
-
-### Step 4: Generate test artifacts
-
-For each new or modified Automated policy, decide which test artifact
-to create based on the remediation method in the PDF:
-
-**If the setting can be toggled via shell commands** (terminal
-remediation method exists), create scripts:
-- `test/scripts/CIS_<cis_id>_pass.sh` — applies remediation
-- `test/scripts/CIS_<cis_id>_fail.sh` — undoes remediation
-
-If only the pass direction can be scripted:
-- `test/scripts/CIS_<cis_id>.sh` — applies remediation only
-
-**If the setting can only be configured via MDM profile** (the PDF's
-remediation says "Profile Method" and the query uses
-managed_policies), create a profile instead of scripts:
-- `test/profiles/<cis_id>.mobileconfig` — the profile that makes the
-  policy pass
-
-The test runner handles profile-only policies automatically: it
-verifies the query fails without the profile, pushes the profile to
-the Fleet team, then verifies the query passes. No scripts are needed.
-
-**If both terminal and profile methods exist**, prefer creating
-scripts (they give explicit pass/fail coverage). Also create the
-profile — it's pushed during setup alongside all other profiles.
-
-Script template:
-```bash
-#!/bin/bash
-# CIS <cis_id> - <title>
-# <brief explanation of what this script does>
-<commands from the PDF's remediation section>
-```
-
-All scripts must:
-- Use #!/bin/bash
-- Use full paths (/usr/bin/sudo, /usr/sbin/systemsetup, etc.)
-- Use sudo for privileged operations
-- Be executable (chmod +x)
-
-### Step 5: Generate MDM profiles
-
-For each policy that checks managed_policies, create a .mobileconfig:
-
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
-  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>PayloadContent</key>
-  <array>
-    <dict>
-      <key>PayloadDisplayName</key>
-      <string>CIS <cis_id></string>
-      <key>PayloadType</key>
-      <string><PayloadType from PDF></string>
-      <key>PayloadIdentifier</key>
-      <string>com.fleetdm.cis-<cis_id>.check</string>
-      <key>PayloadUUID</key>
-      <string><generate UUID></string>
-      <key><setting key></key>
-      <<type/>value</>
-    </dict>
-  </array>
-  <key>PayloadDescription</key>
-  <string>CIS <cis_id> - <title></string>
-  <key>PayloadDisplayName</key>
-  <string><title></string>
-  <key>PayloadIdentifier</key>
-  <string>com.fleetdm.cis-<cis_id></string>
-  <key>PayloadRemovalDisallowed</key>
-  <false/>
-  <key>PayloadScope</key>
-  <string>System</string>
-  <key>PayloadType</key>
-  <string>Configuration</string>
-  <key>PayloadUUID</key>
-  <string><generate UUID></string>
-  <key>PayloadVersion</key>
-  <integer>1</integer>
-</dict>
-</plist>
-```
-
-Name it `test/profiles/<cis_id>.mobileconfig`. For org-decision
-policies that have both enable/disable variants, create both
-`<cis_id>-enable.mobileconfig` and `<cis_id>-disable.mobileconfig`.
-
-### Step 6: Update README.md
-
-Update the OS version's README.md to list:
-- The benchmark version the policies now target
-- Limitations (Manual-only recommendations that can't be automated)
-- Org-decision policies with both variants provided
-- Optional policies provided but not required by CIS
-
-### Step 7: Handle removals
-
-For REMOVED recommendations:
-- Delete the policy entry from the YAML
-- Delete associated test scripts and profiles
-- Remove from README.md limitations/decisions if listed
-
-### Step 8: Validate
-
-After generating everything, run the test runner:
-```bash
-python3 tools/cis/cis-test-runner.py \
-    --macos-version <version> \
-    --all --skip-no-script \
-    --fleet-url $FLEET_URL --fleet-token $FLEET_API_TOKEN \
-    --cleanup --verbose
-```
-
-Review the summary. Fix any failures. If a query fails after its pass
-script runs, the query logic is wrong. If a query passes after its
-fail script runs, the fail script isn't effective.
-
-## Important rules
-
-- Never invent query logic — derive it from the PDF's audit section
-  and the osquery schema.
-- When updating an existing policy, preserve the query unless the
-  audit method changed. Only update description, resolution, name, and
-  tags from the new document.
-- When a recommendation changes from Automated to Manual, remove the
-  policy entirely.
-- When a recommendation changes from Manual to Automated, add a new
-  policy.
-- For recommendations where CIS says "audit" (org decides), provide
-  both enable and disable policy variants.
-- Always include cis_id — it is the primary key for mapping policies
-  to scripts, profiles, and the benchmark document.
-- Do not create policies for supplemental sections (section 7+).
-- Ask the user for clarification if the audit method is ambiguous or
-  relies on information not available through osquery.
-````
+Not a hard convention — just a useful checkpoint mechanism when a
+single session can't finish the job.

--- a/ee/cis/macos-26/README.md
+++ b/ee/cis/macos-26/README.md
@@ -1,0 +1,467 @@
+# macOS 26 Tahoe — CIS benchmark
+
+Fleet policies for the **CIS Apple macOS 26 Tahoe Benchmark, v1.0.0**.
+
+## Status
+
+**Generation complete.** All automated recommendations across
+§1–§6 of the CIS Apple macOS 26 Tahoe Benchmark v1.0.0 are
+covered. §7 (Supplemental) is skipped per Fleet convention.
+Manual-only recommendations are documented in **Limitations**.
+
+## Sections covered
+
+| Section | Title | Status |
+|---------|-------|--------|
+| 1 | Install Updates, Patches and Additional Security Software | complete (6/6 automated) |
+| 2 | System Settings | complete (all automated — §2.1–§2.18) |
+| 3 | Logging and Auditing | complete (5/5 automated) |
+| 4 | Network Configurations | complete (3/3 automated) |
+| 5 | System Access, Authentication and Authorization | complete (19/19 automated) |
+| 6 | Applications | complete (7/7 automated) |
+| 7 | Supplemental | skipped (per convention) |
+
+## Limitations
+
+Manual-assessment recommendations cannot be automated as Fleet
+policies. They are listed here for reference so auditors know where to
+perform out-of-band checks.
+
+- **2.3.3.11** Ensure Computer Name Does Not Contain PII or Protected
+  Organizational Information (Level 2). Requires inspection of the
+  hostname against organizational naming policy — not a mechanically
+  checkable condition.
+- **2.3.4.2** Ensure Time Machine Volumes Are Encrypted (Level 1,
+  Automated). The query detects an unencrypted backup destination,
+  but remediation is GUI-only (drive must be re-added with "Encrypt
+  Backup" checked). No shippable script/profile.
+- **2.5.2.2** Ensure Listen for (Siri) Is Disabled (Level 1,
+  Manual). Per CIS, Hey Siri cannot be disabled via profile or
+  plist — only through the GUI — so the recommendation was
+  explicitly moved to Manual in this benchmark. Disabling Siri
+  entirely (policy 2.5.2.1) is the proxy control.
+- **2.6.1.3** Audit Location Services Access (Level 2, Manual).
+  Requires per-application review of which apps hold location
+  permission — policy-driven, not mechanical.
+- **2.6.2.1** Audit Full Disk Access for Applications (Level 2,
+  Manual). Requires per-application review of the Full Disk Access
+  list against organizational policy.
+- **2.6.3.5** Ensure Share iCloud Analytics Is Disabled (Level 1,
+  Manual). Setting is per-user and only appears when the user is
+  signed into a personal Apple Account — there is no profile key
+  or systemwide plist.
+- **2.6.7** Audit Lockdown Mode (Level 2, Manual). Lockdown Mode
+  is per-user (`.GlobalPreferences.plist` key `LDMGlobalEnabled`)
+  and CIS does not prescribe a required value — organizations
+  must decide per user/device.
+- **2.1.1.1, 2.1.1.2, 2.1.1.4, 2.1.1.5, 2.1.1.6, 2.1.2** All
+  iCloud / Apple Account audits in §2.1 are Manual — require
+  per-user review of iCloud Passwords & Keychain, iCloud Drive,
+  security keys, Freeform sync, Find My Mac, App Store password
+  settings against organizational policy.
+- **2.4.1** Audit Menu Bar and Control Center Icons (Level 2,
+  Manual). Per-user review of menu bar configuration.
+- **2.7.2** Audit iPhone Mirroring (Level 2, Manual).
+  Organization-defined allow/deny decision.
+- **2.8.1** Audit Universal Control Settings (Level 2, Manual).
+  Organization-defined decision.
+- **2.10.1.1** Ensure the OS Is Not Active When Resuming from
+  Standby (Intel) (Level 2, Manual). The audit requires the
+  tester to pick between different remediation paths depending
+  on whether the Mac is Intel vs Apple Silicon.
+- **2.12.2** Audit Touch ID (Level 1, Manual). Per-user
+  verification of enrollment and use against organizational
+  policy.
+- **2.14.1** Audit Game Center Settings (Level 2, Manual).
+- **2.15.1** Audit Notification Settings (Level 2, Manual).
+- **2.16.1** Audit Wallet & Apple Pay Settings (Level 2, Manual).
+- **2.17.1** Audit Internet Accounts for Authorized Use (Level 2,
+  Manual).
+- **3.6** Audit Software Inventory (Level 2, Manual). Requires
+  per-organization review of installed software against an
+  approved inventory — not mechanically checkable.
+- **5.2.3** Ensure Complex Password Must Contain Alphabetic
+  Characters (Level 2, Manual). CIS explicitly left as Manual —
+  Fleet does not ship an automated policy.
+- **5.2.4** Ensure Complex Password Must Contain Numeric
+  Character (Level 2, Manual).
+- **5.2.5** Ensure Complex Password Must Contain Special
+  Character (Level 2, Manual).
+- **5.2.6** Ensure Complex Password Must Contain Uppercase and
+  Lowercase Characters (Level 2, Manual).
+- **5.3.1** Ensure all user storage APFS volumes are encrypted
+  (Level 1, Manual). CIS Marks as Manual because the evaluation
+  requires judgment on which volumes are "user storage" vs
+  "Preboot/Recovery/VM role" disks.
+- **5.3.2** Ensure all user storage CoreStorage volumes are
+  encrypted (Level 1, Manual). CoreStorage has been deprecated;
+  evaluation requires judgment about retained legacy volumes.
+- **6.1.1** Audit Show All Filename Extensions (Level 2, Manual).
+  Per-user Finder preference.
+- **6.2.1** Ensure Protect Mail Activity in Mail Is Enabled
+  (Level 2, Manual). Per-user Mail preference.
+- **6.3.2** Audit History and Remove History Items (Level 2,
+  Manual). Organization-defined retention window.
+- **6.3.5** Audit Hide IP Address in Safari Setting (Level 2,
+  Manual). Organization-defined; also requires FDA to read
+  per-user Safari preferences.
+- **6.3.8** Audit AutoFill (Level 2, Manual). Organization-defined.
+- **6.3.9** Audit Pop-up Windows (Level 1, Manual). Per-user
+  Safari setting with organization-defined allow-list.
+- **6.5.1** Audit Passwords (Level 1, Manual). Requires in-app
+  review of the macOS Passwords app.
+
+### Section 1 notes
+
+- **1.1** depends on the fleetd-specific `software_update` osquery
+  table. Hosts running upstream osquery without fleetd will be unable
+  to evaluate this policy.
+- **1.6** (software update deferment) also passes when no deferment
+  profile is installed — the query checks for a managed value
+  exceeding 30 days and treats absence as compliant. The
+  `1.6.mobileconfig` artifact sets `enforcedSoftwareUpdateDelay=30`
+  and `forceDelayedSoftwareUpdates=true` to satisfy Apple's
+  requirement that both keys be present in the same profile.
+
+### Section 2.2 notes
+
+- **2.2.1** (Firewall) and **2.2.2** (Stealth Mode) — both use the
+  osquery `alf` table (Query pattern #1) which reflects live
+  firewall state, so scripts toggling via
+  `/usr/libexec/ApplicationFirewall/socketfilterfw` are the primary
+  test mechanism.
+- The CIS benchmark explicitly requires `EnableFirewall` and
+  `EnableStealthMode` to be in the **same** configuration profile
+  ("If it is set in its own configuration profile, it will fail").
+  We ship a single combined `2.2.1-and-2.2.2.mobileconfig` covering
+  both keys — first use of the `{id1}-and-{id2}` naming convention
+  in this benchmark.
+
+### Section 2.3.1 notes
+
+- **2.3.1.1** (AirDrop) and **2.3.1.2** (AirPlay Receiver) are
+  profile-only by CIS's own specification — the benchmark explicitly
+  notes that these settings can only be enabled or disabled via
+  configuration profile. No test scripts are shippable; the runner
+  validates by pushing the `.mobileconfig` and re-evaluating the
+  `managed_policies` query.
+
+### Section 2.3.2 notes
+
+- **2.3.2.1** (Set Time and Date Automatically) — the PDF's audit
+  uses `systemsetup -getusingnetworktime`, for which osquery has no
+  direct equivalent. The query checks that `/private/etc/ntp.conf`
+  exists with a non-empty body, which is what
+  `systemsetup -setusingnetworktime on` writes. Worth revisiting if
+  Apple changes how `systemsetup` persists the setting.
+- **2.3.2.2** (Time Service enabled) — CIS states that if `timed`
+  is disabled, the system should be treated as compromised and
+  reinstalled. The `_fail.sh` script still disables the service for
+  test purposes; the `_pass.sh` script restores it via `launchctl
+  enable` + `bootstrap`.
+
+### Section 2.5 notes
+
+- All 5 Automated checks (§2.5.1.1–2.5.1.4 + §2.5.2.1) are
+  profile-only `managed_policies` checks on
+  `com.apple.applicationaccess`. No scripts ship.
+- **2.5.1.1** and **2.5.1.4** require two keys each (respectively
+  `allowExternalIntelligenceIntegrations` +
+  `allowExternalIntelligenceIntegrationsSignIn`, and
+  `allowNotesTranscription` + `allowNotesTranscriptionSummary`). The
+  query verifies both keys are managed-false, following the new
+  Query pattern #2 combined with AND semantics.
+- **2.5.2.1** (Siri) replaces the deprecated
+  `com.apple.ironwood.support` payload that earlier benchmark
+  versions used. Current key is `allowAssistant=false` on
+  `com.apple.applicationaccess`.
+
+### Section 2.3.4 notes
+
+- Both checks are *conditional on Time Machine being configured*.
+  CIS states explicitly that if Time Machine is disabled, the audit
+  passes by default. Our queries use Query pattern #4
+  (absence-passes) — they return 1 row when the TimeMachine plist is
+  absent or doesn't contain the offending value.
+- **2.3.4.1** (Backup Automatically) — plist-based setting with a
+  companion profile (`com.apple.MCX.TimeMachine` /
+  `AutoBackup=true`). Terminal remediation was removed in macOS 15
+  Sequoia (plist now protected), so no scripts ship. Profile-only
+  for deliberate enforcement.
+- **2.3.4.2** (Volumes Encrypted) — GUI-only remediation per CIS.
+  No shippable script or profile key; the query detects
+  non-encrypted destinations when Time Machine is configured, and
+  default-passes on unconfigured hosts. Flagged in **Limitations**
+  below too — enforcement must happen out of band.
+
+### Section 2.6 notes
+
+- **2.6.1.1** (Location Services) and **2.6.1.2** (menu bar icon)
+  both use local-state queries (`location_services` table and
+  `plist` table on `/Library/Preferences/com.apple.locationmenu.plist`)
+  with pass/fail shell scripts. No MDM profile keys — the PDF only
+  provides Terminal and Graphical remediation paths.
+- **2.6.3.1–2.6.3.4** (Analytics & Improvements) — all four are
+  profile-only on different `PayloadType`s
+  (`com.apple.SubmitDiagInfo`, `com.apple.assistant.support`,
+  `com.apple.Accessibility`, `com.apple.applicationaccess`). One
+  profile per policy. CIS 2.6.3.5 is Manual (see Limitations).
+- **2.6.3.2** (Improve Siri & Dictation) — the key name is literally
+  `Siri Data Sharing Opt-In Status` with spaces, set to integer 2.
+  The query uses `CAST(value AS INTEGER) = 2`.
+- **2.6.4** (Limit Ad Tracking) — profile-only
+  (`allowApplePersonalizedAdvertising=false` on
+  `com.apple.applicationaccess`). CIS says "profile must be
+  installed for this recommendation" to be compliant.
+- **2.6.5** (Gatekeeper) — local-state query on the `gatekeeper`
+  osquery table (matches the PDF's `spctl --status` audit). CIS
+  notes the `spctl` binary method was removed in macOS 15 Sequoia,
+  so only a profile remediation ships. Both `EnableAssessment=true`
+  and `AllowIdentifiedDevelopers=true` are combined into the single
+  `2.6.5.mobileconfig` per CIS's same-profile requirement.
+  Gatekeeper is on by default, so the runner may record a
+  pre-delivery pass note — not disqualifying.
+- **2.6.6** (FileVault) — combines two checks: the
+  `com.apple.MCX`/`dontAllowFDEDisable=true` managed policy and
+  `disk_encryption.filevault_status='on'`. Enabling FileVault still
+  requires on-device user interaction (no scriptable path), so the
+  artifact is profile-only; the runner's pre-delivery query will
+  fail on hosts without FileVault configured.
+- **2.6.7** (Lockdown Mode) is Manual — see Limitations.
+- **2.6.8** (admin password for system-wide preferences) — query
+  uses the fleetd `authdb` table (flagged `(Fleetd Required)`) and
+  checks all eight `system.preferences.*` rights for
+  `shared=false`, `group=admin`, `authenticate-user=true`,
+  `session-owner=false`. The pass script reimplements the CIS
+  remediation script; the fail script only flips
+  `system.preferences` `shared=true` (single-right regression is
+  enough to break the query).
+
+### Section 5 notes
+
+- **5.1.1** (Home folders) — absence-passes query on `/Users/*`
+  with mode in {700, 701, 710, 711}. Excludes `/Users/Shared/`.
+  Pass script sets 700; fail script loosens the console user's
+  home to 755.
+- **5.1.2** (SIP) uses fleetd-independent `sip_config` table.
+  5.1.3 AMFI uses fleetd `nvram_info`. 5.1.4 SSV uses fleetd
+  `csrutil_info`. All three are one-liner state checks.
+  Neither 5.1.2 nor 5.1.3 nor 5.1.4 ships test scripts —
+  disabling SIP requires a reboot into Recovery, and the state
+  is expected to be enabled by default.
+- **5.1.5** uses the `apps` table JOINed with `file` on path, and
+  bitwise-tests the "other" permission triad for the world-write
+  bit. Fail script creates a stub world-writable `.app` bundle.
+- **5.1.6** and **5.1.7** scan `/System/Volumes/Data/System` and
+  `/Library` for world-writable directories. 5.1.6 uses the
+  fleetd `find_cmd` table (faster than walking the `file` table);
+  5.1.7 uses the core `file` table with sticky-bit filter and
+  `extended_attributes.com.apple.rootless` exclusion.
+- **5.2.1–5.2.2, 5.2.7–5.2.8** all use the fleetd `pwd_policy`
+  or `password_policy` table. Scripts use `pwpolicy
+  -setglobalpolicy` despite the CIS note that the command is
+  deprecated — it is still the only terminal-scriptable path.
+- **5.4, 5.5, 5.11** each drop a file into `/etc/sudoers.d/` via
+  `tee`. macOS ignores sudoers.d filenames containing `.`, so
+  scripts use `CIS_5_4_sudoconfiguration` (no extension).
+  Each query reads the fleetd `sudo_info` table which parses
+  `sudo -V` output.
+- **5.6** uses the fleetd `dscl` table to verify the root
+  account has no `AuthenticationAuthority` (i.e. is disabled).
+- **5.7** uses the fleetd `authdb` table with JSON extraction of
+  the rule string; rule must contain `authenticate-session-owner`.
+- **5.8** (Login banner) — requires the banner file to exist at
+  `/Library/Security/PolicyBanner.{txt,rtf}` with mode 0644,
+  root:wheel ownership. Pass script creates a .txt banner;
+  fail script deletes it.
+- **5.9** (Guest Home Folder) — absence-passes on
+  `/Users/Guest`. Pairs with 2.13.1 (Guest Account disabled)
+  and 2.13.2 (Guest SMB access disabled).
+- **5.10** counts XProtect's two LaunchDaemon plists in the
+  `launchd` table. Expects both to be registered.
+- **5.11** uses `sudo_info` to confirm the "Log when a command
+  is allowed by sudoers" field is true. Defaults to disabled in
+  macOS 15 Sequoia and later.
+
+### Section 6 notes
+
+- **All 7 automated §6 recommendations are profile-only** —
+  every query checks `managed_policies` on either
+  `com.apple.Safari` or `com.apple.Terminal`. Single-key
+  profiles each, except 6.3.4 which carries three keys
+  (`BlockStoragePolicy=2`, `WebKitPreferences.storageBlockingPolicy=1`,
+  `WebKitStorageBlockingPolicy=1`) in the same payload.
+- **6.3.1 scope note:** Safari-managed keys typically deliver at
+  user scope rather than system scope. The query omits a
+  `username = ''` filter so any delivered scope satisfies it.
+
+### Section 4 notes
+
+- **4.1** (Bonjour advertising) — profile-only on
+  `com.apple.mDNSResponder`/`NoMulticastAdvertisements=true`. The
+  PDF also provides a local `defaults write` Terminal Method, but
+  because mDNSResponder re-reads its config from managed sources
+  on launch, the managed_policies path is the durable one.
+- **4.2** (HTTP server) — absence-passes query on
+  `processes.path = '/usr/sbin/httpd'`. Default is not running;
+  fail script loads the LaunchDaemon and starts Apache.
+- **4.3** (NFS server) — compound absence-passes: no
+  `/sbin/nfsd` process AND `/etc/exports` does not exist. Pass
+  script disables the LaunchDaemon and removes `/etc/exports`;
+  fail script creates the file and starts nfsd.
+
+### Section 3 notes
+
+- **3.1** uses osquery's `launchd` joined with `processes` to verify
+  `com.apple.auditd` is both loaded (plist registered) and running
+  (live process whose cmdline matches the plist's `program_arguments`).
+  Simply loading the LaunchDaemon is not enough — the daemon must
+  have actually spawned. `launchctl load -w` flips both.
+- **3.2** reads `/etc/security/audit_control` via the `file_lines`
+  osquery table with substring LIKE checks. Two alternative
+  flag-sets are accepted: explicit `aa,ad,-ex,-fm,-fr,-fw,lo` OR
+  `-all` substituting for the failed-event flags. Scripts use
+  the explicit form.
+- **3.3** parses `/etc/asl/com.apple.install` with `regex_match`
+  to extract `ttl=N` and compare to 365, AND verifies `all_max=`
+  is absent. Both conditions must hold. The scripts use `awk` to
+  target only the install.log file line (leaving other ASL rules
+  untouched).
+- **3.4** parses the `expire-after:Nd OR NG` line in
+  `/etc/security/audit_control` with `regex_match` and requires
+  days≥60 AND size≥5. The Tahoe PDF allows day-only or size-only
+  syntax too, but the benchmark's default guidance uses both
+  together — matches macos-14 precedent.
+- **3.5** verifies root:wheel ownership and mode 440 (or 400)
+  on three scopes: the `/etc/security/audit_control` file itself,
+  the `dir:` target inside it, and the default `/var/audit`.
+  Accepts either 440 or 400 since Apple's default and CIS's
+  remediation have varied. Scripts normalize to 440 per the
+  Tahoe PDF.
+
+### Section 2.1 notes
+
+- **2.1.1.3** (iCloud Desktop & Documents sync) is the only
+  automated check in §2.1 — profile-only on
+  `com.apple.applicationaccess`/`allowCloudDesktopAndDocuments`.
+  Every other §2.1 recommendation is Manual (see Limitations).
+
+### Section 2.7 notes
+
+- **2.7.1** (Screen Saver Corners) — query reads
+  `/Users/*/Library/Preferences/com.apple.dock.plist` which
+  requires FDA (flagged `(FDA Required)`). Uses the absence-passes
+  pattern: any user with a hot corner set to 6 (Disable Screen
+  Saver) fails. Scripts iterate console users to toggle a corner.
+  Per-user state persists until a reboot/login — the test runner
+  should re-evaluate after script execution.
+
+### Section 2.9 notes
+
+- **2.9.1** (Help Apple Improve Search) is profile-only on
+  `com.apple.assistant.support` with the spaced key name
+  `Search Queries Data Sharing Status`. Integer value 2 means
+  "off/disabled" per Apple's opt-in-status convention.
+
+### Section 2.10 notes
+
+- **2.10.1.2** (Apple Silicon sleep ≤15 min) — query uses the
+  fleetd `pmset` table with JSON extraction, branching on
+  `Battery Power` first, falling back to `AC Power`. Default-
+  passes on non-Apple-Silicon hosts via `system_info.cpu_type`
+  check. Also automatically satisfied when the 2.11.1 screen
+  saver profile is enforced, per CIS's own note.
+- **2.10.2** (Power Nap) and **2.10.3** (Wake for Network
+  Access) — both use the fleetd `pmset` table; require pass on
+  both AC Power and Battery Power. 2.10.2 is Intel-specific; on
+  Apple Silicon, `pmset -a powernap` may be ignored but the
+  query still returns the current setting regardless.
+- **2.10.1.1** (OS Not Active When Resuming from Standby, Intel)
+  is Manual — see Limitations.
+
+### Section 2.12 notes
+
+- **2.12.1** (no password hints on local accounts) — query uses
+  the fleetd `user_login_settings` table which enumerates local
+  users and reports `password_hint_enabled` per account. Pass
+  script removes the `hint` attribute from all local users via
+  `dscl`; fail script sets a test hint on the console user.
+
+### Section 2.13 notes
+
+- **2.13.1** (Guest Account) accepts either the local
+  `com.apple.loginwindow.GuestEnabled=false` plist value OR the
+  managed `com.apple.MCX` profile with both `DisableGuestAccount`
+  and `EnableGuestAccount` set. Scripts exercise the local plist
+  path.
+- **2.13.2** (SMB guest access) — query reads
+  `/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist`
+  for `AllowGuestAccess`, using absence-passes pattern (default
+  is disabled). Scripts use `sysadminctl -smbGuestAccess on/off`.
+- **2.13.3** (Automatic Login) accepts either the local
+  `autoLoginUser` key being absent OR the managed
+  `com.apple.login.mcx.DisableAutoLoginClient=true` profile.
+  Scripts exercise the local plist path (`defaults delete` /
+  `defaults write`).
+
+### Section 2.18 notes
+
+- **2.18.1** (On-Device Dictation) is profile-only on
+  `com.apple.applicationaccess`/`forceOnDeviceOnlyDictation`.
+
+### Section 2.11 notes
+
+- **2.11.1** (screen saver idle ≤15 min) and **2.11.2** (require
+  password on wake) are profile-only on `com.apple.screensaver`.
+  2.11.1 uses the absence-passes / numeric threshold pattern
+  (query pattern #4 combined with pattern #2): the setting must
+  be managed with a value between 1 and 900 inclusive.
+- **2.11.2** is a two-key profile: `askForPassword=true` AND
+  `askForPasswordDelay ≤ 5`. Both keys live in the same
+  `com.apple.screensaver` payload dict. The PDF notes the terminal
+  command-line method "does not work as expected" on modern macOS,
+  so a profile is required.
+- **2.11.3**, **2.11.4**, **2.11.5** all read the local
+  `/Library/Preferences/com.apple.loginwindow.plist` via the `plist`
+  osquery table — world-readable, no FDA needed. Scripts
+  (`defaults write`) are the primary test mechanism.
+- **2.11.3** (custom login message) — query passes on any
+  non-empty `LoginwindowText`. CIS leaves the actual text to the
+  organization.
+
+### Section 2.3.3 notes
+
+- **2.3.3.3** (Printer Sharing) — the PDF's audit uses `cupsctl`, but
+  osquery has no native CUPS-settings table. The query uses
+  `listening_ports` to detect CUPS listening on a non-loopback
+  interface (which happens when sharing is enabled). Heuristic but
+  reliable for the common case.
+- **2.3.3.7** (Internet Sharing) — the PDF accepts either a local
+  `defaults` setting or a managed profile as compliant. The query
+  checks the local `com.apple.nat` plist only. Both a test script
+  (local `defaults write`) and a profile (`forceInternetSharingOff`
+  via `com.apple.MCX`) are provided; scripts take priority in the
+  runner.
+- **2.3.3.8**, **2.3.3.9** (Content Caching, Media Sharing) —
+  profile-only tests. `managed_policies` queries; CIS 2.3.3.9
+  explicitly states the profile method is the only supported path.
+- **2.3.3.10** (Bluetooth Sharing) — per-user ByHost setting. Scripts
+  iterate `/Users/*` and run `defaults -currentHost write` per
+  console user. Query uses the `preferences` table's negation
+  pattern. Hosts without login users at test time may fail to
+  exercise the setting.
+
+## Org-decision policies
+
+Where CIS leaves the choice to the organization, Fleet provides both
+enable and disable profile variants.
+
+(empty — populated per section)
+
+## Optional policies
+
+Recommendations that CIS includes but does not require at a given
+level (e.g. password complexity components) ship here for teams that
+want them.
+
+(empty — populated per section)

--- a/ee/cis/macos-26/cis-policy-queries.yml
+++ b/ee/cis/macos-26/cis-policy-queries.yml
@@ -1,0 +1,2755 @@
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Apple-provided Software Updates Are Installed (Fleetd Required)
+  cis_id: "1.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software vendors release security patches and software updates for their products when security vulnerabilities are discovered. There is no simple way to complete this action without a network connection to an Apple software repository. Please ensure appropriate access for this control. This check is only for what Apple provides through software update.
+  resolution: |
+    Graphical Method:
+    Perform the following to install all available software updates:
+      1. Open System Settings
+      2. Select General
+      3. Select Software Update
+      4. Select Update All
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/softwareupdate -i -a
+  query: SELECT 1 FROM software_update WHERE software_update_required = '0';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Download New Updates When Available Is Enabled (MDM Required)
+  cis_id: "1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    In the GUI, both "Install macOS updates" and "Install app updates from the App Store" are dependent on whether "Download new updates when available" is selected.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Software Update
+      4. Select the i
+      5. Set Download new updates when available to enabled
+      6. Select Done
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.SoftwareUpdate
+      - Key: AutomaticDownload
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticDownload' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticDownload' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install of macOS Updates Is Enabled (MDM Required)
+  cis_id: "1.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Ensure that macOS updates are installed after they are available from Apple. This setting enables macOS updates to be automatically installed. Some environments will want to approve and test updates before they are delivered. It is best practice to test first where updates can and have caused disruptions to operations. Automatic updates should be turned off where changes are tightly controlled and there are mature testing and approval processes. Automatic updates should not be turned off simply to allow the administrator to contact users in order to verify installation. A dependable, repeatable process involving a patch agent or remote management tool should be in place before auto-updates are turned off.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Software Update
+      4. Select the i
+      5. Set Install macOS updates to enabled
+      6. Select Done
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.SoftwareUpdate
+      - Key: AutomaticallyInstallMacOSUpdates
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticallyInstallMacOSUpdates' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticallyInstallMacOSUpdates' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install Application Updates from the App Store Is Enabled (MDM Required)
+  cis_id: "1.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Ensure that application updates are installed after they are available from Apple. These updates do not require reboots or administrator privileges for end users.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Software Update
+      4. Select the i
+      5. Set Install application updates from the App Store to enabled
+      6. Select Done
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.SoftwareUpdate
+      - Key: AutomaticallyInstallAppUpdates
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticallyInstallAppUpdates' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='AutomaticallyInstallAppUpdates' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Install Security Responses and System Files Is Enabled (MDM Required)
+  cis_id: "1.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Ensure that system and security updates are installed after they are available from Apple. This setting enables definition updates for XProtect and Gatekeeper. With this setting in place, new malware and adware that Apple has added to the list of malware or untrusted software will not execute. These updates do not require reboots or end user admin rights.
+
+    Apple has introduced a security feature that allows for smaller downloads and the installation of security updates when a reboot is not required. This feature is only available when the last regular update has already been applied. This feature emphasizes that a Mac must be up-to-date on patches so that Apple's security tools can be used to quickly patch when a rapid response is necessary.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Software Update
+      4. Select the i
+      5. Set Install Security Responses and System files to enabled
+      6. Select Done
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.SoftwareUpdate
+      - Key: ConfigDataInstall, Value: <true/>
+      - Key: CriticalUpdateInstall, Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='ConfigDataInstall' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='ConfigDataInstall' AND
+          (value != 1 AND value != 'true')
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='CriticalUpdateInstall' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.SoftwareUpdate' AND
+          name='CriticalUpdateInstall' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Software Update Deferment Is Less Than or Equal to 30 Days (MDM Required)
+  cis_id: "1.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides the capability to manage software updates on Apple devices through mobile device management. Part of those capabilities permit organizations to defer software updates and allow for testing. Many organizations have specialized software and configurations that may be negatively impacted by Apple updates. If software updates are deferred, they should not be deferred for more than 30 days. This control only verifies that deferred software updates are not deferred for more than 30 days.
+
+    Note: Software deferment is deprecated by Apple and will be removed in a future OS release/update.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: enforcedSoftwareUpdateDelay, Value: <integer> 1-30
+      - Key: forceDelayedSoftwareUpdates, Value: <true/>
+
+    If your organization does not use a software deferment configuration profile, the audit passes by default (no deferment is in effect).
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM managed_policies WHERE
+        domain='com.apple.applicationaccess' AND
+        name='enforcedSoftwareUpdateDelay' AND
+        CAST(value AS INTEGER) > 30
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Screen Sharing Is Disabled
+  cis_id: "2.3.3.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Screen Sharing allows a computer to connect to another computer on a network and display the computer's screen. While sharing the computer's screen, the user can control what happens on that computer, such as opening documents or applications, opening, moving, or closing windows, and even shutting down the computer.
+
+    Screen Sharing on macOS can allow the use of the insecure VNC protocol. VNC is a clear text protocol that should not be used on macOS.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Screen Sharing to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl disable system/com.apple.screensharing
+      /usr/bin/sudo /bin/launchctl bootout system/com.apple.screensharing
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM launchd WHERE label = 'com.apple.screensharing'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure File Sharing Is Disabled
+  cis_id: "2.3.3.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    File sharing from a user workstation creates additional risks, such as open ports that can be probed and attacked, passwords attached to user accounts that may be exposed, and increased complexity that may expose additional attack vectors.
+
+    Apple's File Sharing uses the Server Message Block (SMB) protocol to share to other computers that can mount SMB shares.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set File Sharing to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl disable system/com.apple.smbd
+      /usr/bin/sudo /bin/launchctl bootout system/com.apple.smbd
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM launchd WHERE label = 'com.apple.smbd'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Printer Sharing Is Disabled
+  cis_id: "2.3.3.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    By enabling Printer Sharing, the computer is set up as a print server to accept print jobs from other computers. Dedicated print servers or direct IP printing should be used instead.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Printer Sharing to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/cupsctl --no-share-printers
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM listening_ports
+      WHERE port = 631
+        AND address NOT IN ('127.0.0.1', '::1', '')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Login Is Disabled
+  cis_id: "2.3.3.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Remote Login allows an interactive terminal connection to a computer. Disabling Remote Login mitigates the risk of an unauthorized person gaining access to the system via Secure Shell (SSH). While SSH is an industry standard to connect to POSIX servers, the scope of the benchmark is for Apple macOS clients, not servers.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Remote Login to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off
+      (confirm with "yes" when prompted)
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM launchd WHERE label = 'com.openssh.sshd'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Management Is Disabled
+  cis_id: "2.3.3.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Remote Management is the client portion of Apple Remote Desktop (ARD). Remote Management can be used by remote administrators to view the current screen, install software, report on, and generally manage client Macs.
+
+    Remote Management should only be enabled when a Directory is in place to manage the accounts with access. Computers will be available on port 5900 on a macOS System and could accept connections from untrusted hosts depending on the configuration, which is a major concern for mobile systems.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Remote Management to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM processes WHERE name = 'ARDAgent'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Remote Apple Events Is Disabled
+  cis_id: "2.3.3.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Events is a technology that allows one program to communicate with other programs. Remote Apple Events allows a program on one computer to communicate with a program on a different computer.
+
+    Disabling Remote Apple Events mitigates the risk of an unauthorized program gaining access to the system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Remote Apple Events to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/systemsetup -setremoteappleevents off
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM launchd WHERE label = 'com.apple.AEServer'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Internet Sharing Is Disabled
+  cis_id: "2.3.3.7"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Internet Sharing uses the open source natd process to share an internet connection with other computers and devices on a local network. This allows the Mac to function as a router and share the connection to other, possibly unauthorized, devices.
+
+    Disabling Internet Sharing reduces the remote attack surface of the system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Internet Sharing to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.MCX
+      - Key: forceInternetSharingOff, Value: <true/>
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist
+      WHERE path = '/Library/Preferences/SystemConfiguration/com.apple.nat'
+        AND key = 'Enabled'
+        AND value = '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Content Caching Is Disabled (MDM Required)
+  cis_id: "2.3.3.8"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Starting with macOS 10.13, Apple introduced a service to make it easier to deploy data from Apple, including software updates, where there are bandwidth constraints to the Internet and fewer constraints or greater bandwidth exist on the local subnet.
+
+    The main use case for Mac computers is as mobile user endpoints. P2P sharing services should not be enabled on laptops that are using untrusted networks. Content Caching can allow a computer to be a server for local nodes on an untrusted network. Unless there is a business requirement to manage operational Internet connectivity and bandwidth, user endpoints should not store content and act as a cluster to provision data.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowContentCaching, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowContentCaching' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowContentCaching' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Media Sharing Is Disabled (MDM Required)
+  cis_id: "2.3.3.9"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Starting with macOS 10.15, Apple has provided a control which permits a user to share Apple downloaded content on all Apple devices that are signed in with the same Apple Account. With this capability, guest users can also use media downloaded on the computer.
+
+    Disabling Media Sharing reduces the remote attack surface of the system.
+
+    Note: Since the profile method sets a system-wide setting, the individual user audit and/or remediation has been removed. To be compliant, a profile must be installed for this recommendation.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowMediaSharing, Value: <false/>
+      - Key: allowMediaSharingModification, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMediaSharing' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMediaSharing' AND
+          (value != 0 AND value != 'false')
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMediaSharingModification' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMediaSharingModification' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Bluetooth Sharing Is Disabled
+  cis_id: "2.3.3.10"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Bluetooth Sharing allows files to be exchanged with Bluetooth-enabled devices. This setting only disables the receiving of files and requires both devices to be paired through Bluetooth as well as accepted by the receiver. This setting does not disable the ability to send files from the device to another paired Bluetooth device.
+
+    Users should only pair to known trusted Bluetooth devices. Disabling Bluetooth Sharing minimizes the risk of an attacker using Bluetooth to remotely attack the system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Sharing
+      4. Set Bluetooth Sharing to disabled
+
+    Terminal Method (per user):
+      /usr/bin/sudo -u <username> /usr/bin/defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM preferences
+      WHERE domain = 'com.apple.Bluetooth'
+        AND key = 'PrefKeyServicesEnabled'
+        AND value = '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure AirDrop Is Disabled When Not Actively Transferring Files (MDM Required)
+  cis_id: "2.3.1.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    AirDrop is Apple's built-in, on-demand, ad hoc file exchange system that is compatible with both macOS and iOS. It uses Bluetooth LE for discovery that limits connectivity to Mac or iOS users that are in close proximity. Depending on the setting, it allows everyone or only Contacts to share files when they are near each other.
+
+    While there are positives to AirDrop, there are privacy concerns that could expose personal information. For that reason, AirDrop should be disabled, and should only be enabled when needed and disabled afterwards.
+
+    Note: AirDrop can only be enabled or disabled through configuration profiles. If your organization wants to use AirDrop, it would need to be set through Terminal or the GUI.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowAirDrop, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAirDrop' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAirDrop' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure AirPlay Receiver Is Disabled (MDM Required)
+  cis_id: "2.3.1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS Monterey (12.0), Apple has added the capability to share content from another Apple device to the screen of a host Mac. While there are many valuable uses of this capability, such sharing on a standard Mac user workstation should be enabled ad hoc as required rather than allowing a continuous sharing service. The feature can be restricted by Apple Account or network and is configured to use by accepting the connection on the Mac. Part of the concern is frequent connection requests may function as a denial-of-service and access control limits may provide too much information to an attacker.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowAirPlayIncomingRequests, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAirPlayIncomingRequests' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAirPlayIncomingRequests' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Set Time and Date Automatically Is Enabled
+  cis_id: "2.3.2.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Correct date and time settings are required for authentication protocols, file creation, modification dates, and log entries.
+
+    Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.
+
+    Note: The default Apple time server is time.apple.com. If your organization has internal time servers, configure them instead.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Date & Time
+      4. Set Set time and date automatically to enabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/systemsetup -setnetworktimeserver time.apple.com
+      /usr/bin/sudo /usr/sbin/systemsetup -setusingnetworktime on
+  query: |
+    SELECT 1 FROM file
+    WHERE path = '/private/etc/ntp.conf'
+      AND size > 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Time Service Is Enabled
+  cis_id: "2.3.2.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS 10.14, Apple replaced ntp with timed for time services. Correct date and time settings are required for authentication protocols, file creation, modification dates, and log entries.
+
+    Kerberos may not operate correctly if the time on the Mac is off by more than 5 minutes. This in turn can affect Apple's single sign-on feature, Active Directory logons, and other features.
+  resolution: |
+    If the timed service has been disabled, CIS recommends backing up any files and doing a clean install of a known good operating system. For recovery in test environments:
+      /usr/bin/sudo /bin/launchctl enable system/com.apple.timed
+      /usr/bin/sudo /bin/launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.timed.plist
+  query: |
+    SELECT 1 FROM launchd WHERE label = 'com.apple.timed';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Backup Automatically Is Enabled If Time Machine Is Enabled (MDM Required)
+  cis_id: "2.3.4.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Backup solutions are only effective if the backups run on a regular basis. In order to simplify the user experience so that backups are more likely to occur, Time Machine should be on and set to Back Up Automatically whenever the target volume is available.
+
+    Operational staff should ensure that backups complete on a regular basis and the backups are tested to ensure that file restoration from backup is possible when needed.
+
+    Note: This recommendation needs to be set on devices where Time Machine is enabled. If Time Machine is disabled, the audit is passed by default.
+
+    Note: In previous versions of the benchmark, the plist could be set in Terminal. In macOS 15 Sequoia that plist is now protected and cannot be written to, so the command-line remediation has been removed. Both the profile method and graphical method still configure Time Machine to the required state.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Time Machine
+      4. Select Options...
+      5. Set Back up frequency to Automatically <every hour/every day/every week>
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.MCX.TimeMachine
+      - Key: AutoBackup, Value: <true/>
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist
+      WHERE path = '/Library/Preferences/com.apple.TimeMachine.plist'
+        AND key = 'AutoBackup'
+        AND value = '0'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Time Machine Volumes Are Encrypted If Time Machine Is Enabled
+  cis_id: "2.3.4.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    One of the most important security tools for data protection on macOS is FileVault. With encryption in place, it makes it difficult for an outside party to access your data if they get physical possession of the computer. One very large weakness in data protection with FileVault is the level of protection on backup volumes. If the internal drive is encrypted but the external backup volume that goes home in the same laptop bag is not, it is self-defeating.
+
+    Note: This recommendation needs to be set on devices where Time Machine is enabled. If Time Machine is disabled, the audit is passed by default.
+
+    Note: Remediation is GUI-only — encrypted backup must be configured when setting up the Time Machine destination drive.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select General
+      3. Select Time Machine
+      4. Select the unencrypted drive
+      5. Select - to forget that drive as a destination
+      6. Select + to add a different drive as the destination
+      7. Select Set Up Disk...
+      8. Set Encrypt Backup to enabled
+      9. Enter a password in the New Password and the same password in the Re-enter Password fields
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist
+      WHERE path = '/Library/Preferences/com.apple.TimeMachine.plist'
+        AND value = 'NotEncrypted'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure External Intelligence Extensions Is Disabled (MDM Required)
+  cis_id: "2.5.1.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The External Intelligence Extensions allows Apple Intelligence to interface with 3rd party generative AI tools. Apple's external intelligence extension represents a calculated risk. They are extending their on-device privacy and security model to the cloud with PCC (Private Cloud Compute), and then carefully integrating with a third-party AI like ChatGPT, emphasizing user consent, data minimization, and strong contractual obligations. However, the inherent nature of sending data to an external service means a degree of trust is placed on that third party's security posture and adherence to agreements. Sending data to an external service is additional risk that must be reviewed and accepted in an organizational security plan.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowExternalIntelligenceIntegrations, Value: <false/>
+      - Key: allowExternalIntelligenceIntegrationsSignIn, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowExternalIntelligenceIntegrations' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowExternalIntelligenceIntegrations' AND
+          (value != 0 AND value != 'false')
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowExternalIntelligenceIntegrationsSignIn' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowExternalIntelligenceIntegrationsSignIn' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Writing Tools Is Disabled (MDM Required)
+  cis_id: "2.5.1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Intelligence Writing Tools are a suite of AI-powered features integrated across iOS, iPadOS, and macOS, enabling users to enhance their text by proofreading for errors, rewriting content to adjust tone or style, summarizing lengthy passages into concise forms, and even composing new text from scratch. While many of these functions process securely on-device, there is the possibility of leveraging Apple's private cloud infrastructure.
+
+    For individuals or organizations handling sensitive, confidential, or regulated data, the perceived risks of third-party exposure, potential for accidental data leakage, and compliance challenges often outweigh the convenience benefits. Disabling this feature is a rational and proactive security measure.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowWritingTools, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowWritingTools' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowWritingTools' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Mail Summarization Is Disabled (MDM Required)
+  cis_id: "2.5.1.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Intelligence's Mail summarization feature uses AI to quickly condense long emails or entire email threads into a few key sentences or bullet points. It automatically appears as a short summary under emails in your inbox, or you can manually tap a "Summarize" button within an open email.
+
+    If there's any concern that sensitive email content, even if for summarization, might potentially be routed to this third-party service (even with consent prompts), or if you want to avoid any possibility of Apple's servers processing data from highly confidential communications (even within PCC's strong safeguards), disabling the feature ensures your mail content is processed via approved organizational services and on managed devices.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowMailSummary, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMailSummary' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowMailSummary' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Notes Summarization Is Disabled (MDM Required)
+  cis_id: "2.5.1.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Intelligence's Notes summarization feature quickly condenses content within the Notes app. This includes summarizing written text you've highlighted or, notably, automatically generating summaries from audio recordings taken directly within Notes, like lectures or meetings.
+
+    Disabling Notes summarization is wise for security if your audio recordings or notes contain very private or sensitive information. Turning this off ensures none of that sensitive content, especially from transcribed audio, ever leaves your device for any AI processing.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowNotesTranscription, Value: <false/>
+      - Key: allowNotesTranscriptionSummary, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowNotesTranscription' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowNotesTranscription' AND
+          (value != 0 AND value != 'false')
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowNotesTranscriptionSummary' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowNotesTranscriptionSummary' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Siri Is Disabled (MDM Required)
+  cis_id: "2.5.2.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    With macOS 10.12 Sierra, Apple has introduced Siri from iOS to macOS. While there are data spillage concerns with the use of data-gathering personal assistant software, in cases where sensitive or protected data is processed and Siri could expose that information through assisting a user in navigating their machine, it should be disabled.
+
+    Siri is being disabled because the listen for "Siri" or "Hey Siri" feature cannot be disabled globally or even through a user specific plist. Due to this, there is no guarantee that Listen for is disabled and therefore the mic is live and capturing everything around it.
+
+    Note: Previously the benchmark would pass using the com.apple.ironwood.support profile payload. That is a deprecated payload and now com.apple.applicationaccess should be used.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowAssistant, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAssistant' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain='com.apple.applicationaccess' AND
+          name='allowAssistant' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Firewall Is Enabled
+  cis_id: "2.2.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    A firewall is a piece of software that blocks unwanted incoming connections to a system. The socketfilter Firewall is what is used when the Firewall is turned on in the Security & Privacy Preference Pane. Logging is required to appropriately monitor what access is allowed and denied.
+
+    A firewall minimizes the threat of unauthorized users gaining access to your system while connected to a network or the Internet.
+
+    Note: Prior to macOS 15.0 Sequoia, there were additional steps to turn on firewall logging after enabling the firewall. As of macOS 15, logging is turned on automatically without user interaction.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Network
+      3. Select Firewall
+      4. Set Firewall to enabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.security.firewall
+      - Key: EnableFirewall, Value: <true/>
+      (must be in the same profile as EnableStealthMode — see 2.2.2)
+  query: SELECT 1 FROM alf WHERE global_state >= 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Firewall Stealth Mode Is Enabled
+  cis_id: "2.2.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    While in Stealth mode, the computer will not respond to unsolicited probes, dropping that traffic. Stealth mode on the firewall minimizes the threat of system discovery tools while connected to a network or the Internet.
+
+    This control aligns with the primary macOS use case of a laptop that is often connected to untrusted networks where host segregation may be non-existent.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Network
+      3. Select Firewall
+      4. Select Options...
+      5. Set Enable stealth mode to enabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.security.firewall
+      - Key: EnableStealthMode, Value: <true/>
+
+    Note: This key must be set in the same configuration profile as EnableFirewall (policy 2.2.1). Setting it in its own profile will fail.
+  query: SELECT 1 FROM alf WHERE stealth_enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Location Services Is Enabled
+  cis_id: "2.6.1.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS uses location information gathered through local Wi-Fi networks to enable applications to supply relevant information to users. With the operating system verifying the location, users do not need to change the time or the time zone. The computer will change them based on the user's location. They do not need to specify their location for weather or travel times, and they will receive alerts on travel times to meetings and appointments where location information is supplied.
+
+    Location Services simplify some processes with mobile computers, such as asset management and time or log management.
+
+    There are some use cases where it is important that the computer not be able to report its exact location. While the general use case is to enable Location Services, it should not be allowed if the physical location of the computer and the user should not be public knowledge.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Privacy & Security
+      3. Select Location Services
+      4. Set Location Services to enabled
+
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.locationd.plist
+      /usr/bin/sudo /usr/bin/defaults write /var/db/locationd/Library/Preferences/ByHost/com.apple.locationd LocationServicesEnabled -bool true
+      /usr/bin/sudo /usr/bin/killall locationd
+  query: SELECT 1 FROM location_services WHERE enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled
+  cis_id: "2.6.1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    This setting provides the user an understanding of the current status of Location Services and which applications are using it. Enabling the "Show location icon in the menu bar when System Services request your location" setting will show an arrow in the control center when a system service accesses the location.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Privacy & Security
+      3. Select Location Services
+      4. Select Details...
+      5. Set Show location icon in menu bar when System Services request your location to enabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool true
+  query: SELECT 1 FROM plist WHERE path = '/Library/Preferences/com.apple.locationmenu.plist' AND key = 'ShowSystemServices' AND value = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Share Mac Analytics Is Disabled (MDM Required)
+  cis_id: "2.6.3.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Share Mac Analytics (Share with App Developers dependent on Mac Analytic sharing) includes diagnostics, usage, and location data. Turn off all Analytics and Improvements sharing. Organizations should have knowledge of what is shared with the vendor and that this setting automatically forwards information to Apple.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.SubmitDiagInfo
+      - Key: AutoSubmit
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.SubmitDiagInfo' AND
+          name = 'AutoSubmit' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.SubmitDiagInfo' AND
+          name = 'AutoSubmit' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Improve Siri & Dictation Is Disabled (MDM Required)
+  cis_id: "2.6.3.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Improve Siri & Dictation allows Apple to store and review audio of your Siri and dictation interactions from the device. Turn off all Analytics and Improvements sharing. Organizations should have knowledge of what is shared with the vendor and that this setting automatically forwards information to Apple.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.assistant.support
+      - Key: Siri Data Sharing Opt-In Status
+      - Value: <integer>2</integer>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.assistant.support' AND
+          name = 'Siri Data Sharing Opt-In Status' AND
+          CAST(value AS INTEGER) = 2 AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.assistant.support' AND
+          name = 'Siri Data Sharing Opt-In Status' AND
+          CAST(value AS INTEGER) != 2
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Improve Assistive Voice Features Is Disabled (MDM Required)
+  cis_id: "2.6.3.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Improve Assistive Voice shares audio recordings and transcripts of Vocal Shortcuts and Voice Control interactions anonymously to Apple. These are recordings and transcripts from the user that are being submitted which may include PII or restricted organizational information. Sharing this kind of information with any 3rd party, including the platform vendor, needs to be risk evaluated and only allowed after review and approval based on your organization's policies.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Accessibility
+      - Key: AXSAudioDonationSiriImprovementEnabled
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Accessibility' AND
+          name = 'AXSAudioDonationSiriImprovementEnabled' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Accessibility' AND
+          name = 'AXSAudioDonationSiriImprovementEnabled' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure 'Share with app developers' Is Disabled (MDM Required)
+  cis_id: "2.6.3.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Share with app developers allows Apple to share crash and usage data with app developers. Turn off all Analytics and Improvements sharing. Organizations should have knowledge of what is shared with the vendor and that this setting automatically forwards information to Apple.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowDiagnosticSubmission
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowDiagnosticSubmission' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowDiagnosticSubmission' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Limit Ad Tracking Is Enabled (MDM Required)
+  cis_id: "2.6.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides a framework that allows advertisers to target Apple users and end-users with advertisements. While many people prefer to see advertising that is relevant to them and their interests, the detailed information that is collected, correlated, and available to advertisers in repositories via data mining is often disconcerting. This information is valuable to both advertisers and attackers, and has been used with other metadata to reveal users' identities.
+
+    Organizations should manage advertising settings on computers rather than allow users to configure the settings.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowApplePersonalizedAdvertising
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowApplePersonalizedAdvertising' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowApplePersonalizedAdvertising' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Gatekeeper Is Enabled
+  cis_id: "2.6.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Gatekeeper is Apple's application that utilizes allowlisting to restrict downloaded applications from launching. It functions as a control to limit applications from unverified sources from running without authorization. In an update to Gatekeeper in macOS 13 Ventura, Gatekeeper checks every application on every launch, not just quarantined apps.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Privacy & Security
+      3. Set 'Allow apps downloaded from' to 'App Store and identified developers'
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.systempolicy.control
+      - Key: AllowIdentifiedDevelopers, Value: <true/>
+      - Key: EnableAssessment, Value: <true/>
+
+    Note: In previous versions of macOS, Gatekeeper could be set using the spctl binary. That method has been removed in macOS 15 Sequoia. Both keys must be set in the same configuration profile.
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1 AND dev_id_enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure FileVault Is Enabled (MDM Required)
+  cis_id: "2.6.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    FileVault secures a system's data by automatically encrypting its boot volume and requiring a password or recovery key to access it. FileVault should be used with a saved escrow key to ensure that the owner can decrypt their data if the password is lost. This policy checks that FileVault is enabled on the device and that the user is not allowed to disable it.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Security & Privacy
+      3. Select Turn On...
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.MCX
+      - Key: dontAllowFDEDisable
+      - Value: <true/>
+
+    Note: The profile is required to pass the audit. Enabling FileVault itself still requires user interaction at the device.
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.MCX' AND
+          name = 'dontAllowFDEDisable' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.MCX' AND
+          name = 'dontAllowFDEDisable' AND
+          (value != 1 AND value != 'true')
+      )
+      AND EXISTS (
+        SELECT 1 FROM disk_encryption WHERE
+          user_uuid IS NOT "" AND
+          filevault_status = 'on'
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Administrator Password Is Required to Access System-Wide Preferences (Fleetd Required)
+  cis_id: "2.6.8"
+  platforms: macOS
+  platform: darwin
+  description: |
+    System Preferences controls system and user settings on a macOS Computer. System Preferences allows the user to tailor their experience on the computer as well as allowing the System Administrator to configure global security settings. Some of the settings should only be altered by the person responsible for the computer.
+
+    By requiring a password to unlock system-wide System Preferences, the risk of a user changing configurations that affect the entire system is mitigated and requires an admin user to re-authenticate to make changes.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Privacy & Security
+      3. Select Advanced
+      4. Set Require an administrator password to access system-wide settings to enabled
+
+    Terminal Method:
+    The authorizationdb settings are exported, modified, and re-imported for each relevant right. See the CIS benchmark for the full remediation script.
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM authdb WHERE
+        right_name IN (
+          'system.preferences',
+          'system.preferences.energysaver',
+          'system.preferences.network',
+          'system.preferences.printing',
+          'system.preferences.sharing',
+          'system.preferences.softwareupdate',
+          'system.preferences.startupdisk',
+          'system.preferences.timemachine'
+        )
+        AND (
+          json_extract(json_result, '$.shared') != 0 OR
+          json_extract(json_result, '$.group') != 'admin' OR
+          json_extract(json_result, '$.authenticate-user') != 1 OR
+          json_extract(json_result, '$.session-owner') != 0
+        )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Inactivity Interval of 15 Minutes Or Less for the Screen Saver Is Enabled (MDM Required)
+  cis_id: "2.11.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    A locking screen saver is one of the standard security controls to limit access to a computer and the current user's session when the computer is temporarily unused or unattended. Setting an inactivity interval for the screen saver prevents unauthorized persons from viewing a system left unattended for an extensive period of time.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.screensaver
+      - Key: idleTime
+      - Value: <integer>900</integer> (or any value ≤ 900 seconds)
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'idleTime' AND
+          CAST(value AS INTEGER) > 0 AND
+          CAST(value AS INTEGER) <= 900 AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'idleTime' AND
+          (CAST(value AS INTEGER) = 0 OR CAST(value AS INTEGER) > 900)
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Require Password After Screen Saver Begins or Display Is Turned Off Is Enabled for 5 Seconds or Immediately (MDM Required)
+  cis_id: "2.11.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Sleep and screen saver modes are low power modes that reduce electrical consumption while the system is not in use. Prompting for a password when waking from sleep or screen saver mode mitigates the threat of an unauthorized person gaining access to a system in the user's absence.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.screensaver
+      - Key: askForPassword, Value: <true/>
+      - Key: askForPasswordDelay, Value: <integer>0</integer> through <integer>5</integer>
+
+    Note: Both keys must be set in the same configuration profile.
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'askForPassword' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'askForPassword' AND
+          (value != 1 AND value != 'true')
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'askForPasswordDelay' AND
+          CAST(value AS INTEGER) <= 5 AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.screensaver' AND
+          name = 'askForPasswordDelay' AND
+          CAST(value AS INTEGER) > 5
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Custom Message for the Login Screen Is Enabled
+  cis_id: "2.11.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    An access warning informs the user that the system is reserved for authorized use only, and that the use of the system may be monitored. An access warning may reduce a casual attacker's tendency to target the system and may aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status, acceptable use policy, and authorization requirements.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Lock Screen
+      3. Set Show message when locked to enabled
+      4. Select Set
+      5. Insert text matching your organization's required text
+      6. Select Done
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText "<custom message>"
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.loginwindow
+      - Key: LoginwindowText
+      - Value: <string>Your organization's required text</string>
+  query: SELECT 1 FROM plist WHERE path = '/Library/Preferences/com.apple.loginwindow.plist' AND key = 'LoginwindowText' AND LENGTH(value) > 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Login Window Displays as Name and Password Is Enabled
+  cis_id: "2.11.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The login window prompts a user for his/her credentials, verifies their authorization level, and then allows or denies the user access to the system. Prompting the user to enter both their username and password makes it twice as hard for unauthorized users to gain access to the system since they must discover two attributes.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Lock Screen
+      3. Set 'Login window shows' to Name and Password
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.loginwindow
+      - Key: SHOWFULLNAME
+      - Value: <true/>
+  query: SELECT 1 FROM plist WHERE path = '/Library/Preferences/com.apple.loginwindow.plist' AND key = 'SHOWFULLNAME' AND value = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Password Hints Is Disabled
+  cis_id: "2.11.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Password hints are user-created text displayed when an incorrect password is used for an account. Password hints make it easier for unauthorized persons to gain access to systems by displaying information provided by the user to assist in remembering the password. This information could include the password itself or other information that might be readily discerned with basic knowledge of the end user.
+
+    In macOS 26 Tahoe, setting RetriesUntilHint to a value other than 0 will result in the hint question mark icon appearing in the login window. Setting this to 0 is the only definitive way to ensure that does not appear.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Lock Screen
+      3. Set 'Show password hints' to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.loginwindow
+      - Key: RetriesUntilHint
+      - Value: <integer>0</integer>
+  query: SELECT 1 FROM plist WHERE path = '/Library/Preferences/com.apple.loginwindow.plist' AND key = 'RetriesUntilHint' AND value = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Guest Account Is Disabled
+  cis_id: "2.13.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The guest account allows users access to the system without having to create an account or password. Disabling the guest account mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Users & Groups
+      3. Select the i next to the Guest User
+      4. Set Allow guests to log in to this computer to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.MCX
+      - Key: DisableGuestAccount, Value: <true/>
+      - Key: EnableGuestAccount, Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM plist WHERE
+          path = '/Library/Preferences/com.apple.loginwindow.plist' AND
+          key = 'GuestEnabled' AND
+          value = 0
+      )
+      OR (
+        EXISTS (
+          SELECT 1 FROM managed_policies WHERE
+            domain = 'com.apple.MCX' AND
+            name = 'DisableGuestAccount' AND
+            (value = 1 OR value = 'true') AND
+            username = ''
+        )
+        AND EXISTS (
+          SELECT 1 FROM managed_policies WHERE
+            domain = 'com.apple.MCX' AND
+            name = 'EnableGuestAccount' AND
+            (value = 0 OR value = 'false') AND
+            username = ''
+        )
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Guest Access to Shared Folders Is Disabled
+  cis_id: "2.13.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Allowing guests to connect to shared folders enables users to access selected shared folders and their contents from different computers on a network. Not allowing guests to connect to shared folders mitigates the risk of an untrusted user doing basic reconnaissance and possibly using privilege escalation attacks to take control of the system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Users & Groups
+      3. Select the i next to the Guest User
+      4. Set Allow guests to connect to shared folders to disabled
+
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess off
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist WHERE
+        path = '/Library/Preferences/SystemConfiguration/com.apple.smb.server.plist' AND
+        key = 'AllowGuestAccess' AND
+        value = 1
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Automatic Login Is Disabled
+  cis_id: "2.13.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The automatic login feature saves a user's system access credentials and bypasses the login screen. Disabling automatic login decreases the likelihood of an unauthorized person gaining access to a system.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Users & Groups
+      3. Set Automatic login in as... to Off
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.loginwindow
+      - Key: com.apple.login.mcx.DisableAutoLoginClient
+      - Value: <true/>
+
+    Note: If both the profile is enabled and a user is set to autologin, the profile takes precedence. For durability, remove the local autoLoginUser value as well in case the profile is removed.
+  query: |
+    SELECT 1 WHERE
+      NOT EXISTS (
+        SELECT 1 FROM plist WHERE
+          path = '/Library/Preferences/com.apple.loginwindow.plist' AND
+          key = 'autoLoginUser'
+      )
+      OR EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.loginwindow' AND
+          name = 'com.apple.login.mcx.DisableAutoLoginClient' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Sleep and Display Sleep Is Enabled on Apple Silicon Devices (Fleetd Required)
+  cis_id: "2.10.1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    MacBooks should be set so that the sleep is 15 minutes or less and the display should sleep at 10 minutes or less. This setting should allow laptop users in most cases to stay within physically secured areas while going to a conference room, auditorium, or other internal location without having to unlock the encryption.
+
+    Note: If the screen saver is properly configured to the benchmark (15 minutes or less), then this recommendation will also pass no matter the sleep and displaysleep setting.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/pmset -a sleep 15
+      /usr/bin/sudo /usr/bin/pmset -a displaysleep 10
+  query: |
+    SELECT 1 AS result
+    WHERE
+      NOT EXISTS (
+        SELECT 1 FROM system_info WHERE cpu_type LIKE 'arm64%'
+      )
+      OR
+      EXISTS (
+        SELECT 1
+        FROM (
+          SELECT
+            CASE
+              WHEN JSON_EXTRACT(json_result, '$.Battery Power:') IS NOT NULL
+              THEN JSON_EXTRACT(json_result, '$.Battery Power:')
+              ELSE JSON_EXTRACT(json_result, '$.AC Power:')
+            END AS power_settings
+          FROM pmset
+          WHERE getting = 'custom'
+        )
+        WHERE
+          CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER) <= 15
+          AND
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= 10
+          AND
+          CAST(JSON_EXTRACT(power_settings, '$.displaysleep') AS INTEGER) <= CAST(JSON_EXTRACT(power_settings, '$.sleep') AS INTEGER)
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Power Nap Is Disabled for Intel Macs (Fleetd Required)
+  cis_id: "2.10.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Power Nap allows the system to stay in low power mode, especially while on battery power, and periodically connect to previously known networks with stored credentials for user applications to phone home and get updates. Disabling this feature mitigates the risk of an attacker remotely waking the system and gaining access.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/pmset -a powernap 0
+  query: |
+    SELECT 1 FROM (
+      SELECT
+        COALESCE(JSON_EXTRACT(JSON_EXTRACT(json_result, '$.AC Power:'), '$.powernap'), '') AS powernap_ac,
+        COALESCE(JSON_EXTRACT(JSON_EXTRACT(json_result, '$.Battery Power:'), '$.powernap'), '') AS powernap_battery
+      FROM pmset
+      WHERE getting = 'custom'
+        AND powernap_battery != '1'
+        AND powernap_ac != '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Wake for Network Access Is Disabled (Fleetd Required)
+  cis_id: "2.10.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    This feature allows the computer to take action when the user is not present and the computer is in energy saving mode. Disabling Wake for Network Access mitigates the risk of an attacker remotely waking the system and gaining access. Note that disabling this also prevents Find My from working while the Mac is asleep.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/pmset -a womp 0
+  query: |
+    SELECT 1 FROM (
+      SELECT
+        COALESCE(JSON_EXTRACT(JSON_EXTRACT(json_result, '$.AC Power:'), '$.womp'), '') AS womp_ac,
+        COALESCE(JSON_EXTRACT(JSON_EXTRACT(json_result, '$.Battery Power:'), '$.womp'), '') AS womp_battery
+      FROM pmset
+      WHERE getting = 'custom'
+        AND womp_battery != '1'
+        AND womp_ac != '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Users' Accounts Do Not Have a Password Hint (Fleetd Required)
+  cis_id: "2.12.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Password hints help the user recall their passwords for various systems and/or accounts. In most cases, password hints are simple and closely related to the user's password. Password hints that are closely related to the user's password are a security vulnerability, especially in the social media age — unauthorized users are more likely to guess a user's password if there is a password hint.
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Touch ID & Passwords (or Login Password on non-Touch ID Macs)
+      3. Select Change...
+      4. Change the password and ensure that no text is entered in the Password hint box
+
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/dscl . -delete /Users/<username> hint
+  query: SELECT 1 FROM user_login_settings WHERE password_hint_enabled = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure iCloud Drive Document and Desktop Sync Is Disabled (MDM Required)
+  cis_id: "2.1.1.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    With macOS 10.12, Apple introduced the capability to have a user's Desktop and Documents folders automatically synchronize to the user's iCloud Drive. Enterprise users may not be allowed to store Enterprise information in a third-party public cloud. Automated Document synchronization should be planned and controlled to approved storage.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: allowCloudDesktopAndDocuments
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowCloudDesktopAndDocuments' AND
+          (value = 0 OR value = 'false') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'allowCloudDesktopAndDocuments' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Screen Saver Corners Are Secure (FDA Required)
+  cis_id: "2.7.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Hot Corners can be configured to disable the screen saver by moving the mouse cursor to a corner of the screen. Setting a hot corner to disable the screen saver poses a potential security risk since an unauthorized person could use this to bypass the login screen and gain access to the system.
+
+    FDA (Full Disk Access) is required to read the configuration of all users on the device (`/Users/*/Library/Preferences/com.apple.dock.plist`).
+  resolution: |
+    Graphical Method:
+      1. Open System Settings
+      2. Select Desktop & Dock
+      3. Select Hot Corners...
+      4. Verify that Disable Screen Saver (value 6) is not set to any of the corners
+
+    Terminal Method (per user):
+      /usr/bin/sudo -u <user> /usr/bin/defaults write com.apple.dock wvous-tl-corner -int 0
+      /usr/bin/sudo -u <user> /usr/bin/defaults write com.apple.dock wvous-tr-corner -int 0
+      /usr/bin/sudo -u <user> /usr/bin/defaults write com.apple.dock wvous-bl-corner -int 0
+      /usr/bin/sudo -u <user> /usr/bin/defaults write com.apple.dock wvous-br-corner -int 0
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM plist
+      WHERE path LIKE '/Users/%/Library/Preferences/com.apple.dock.plist'
+        AND key IN ('wvous-tl-corner', 'wvous-tr-corner', 'wvous-bl-corner', 'wvous-br-corner')
+        AND value = 6
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Help Apple Improve Search Is Disabled (MDM Required)
+  cis_id: "2.9.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides a mechanism to send diagnostic and analytics data back to Apple to help them improve the platform. Information sent to Apple may contain internal organizational information that should be controlled and not available for processing by Apple. Organizations should have knowledge of what is shared with the vendor.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.assistant.support
+      - Key: Search Queries Data Sharing Status
+      - Value: <integer>2</integer>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.assistant.support' AND
+          name = 'Search Queries Data Sharing Status' AND
+          CAST(value AS INTEGER) = 2 AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.assistant.support' AND
+          name = 'Search Queries Data Sharing Status' AND
+          CAST(value AS INTEGER) != 2
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure On-Device Dictation Is Enabled (MDM Required)
+  cis_id: "2.18.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    In macOS 14.0 Sonoma, Apple released the ability to limit dictation to staying on-device and not sending data to the Siri servers. The use of dictation is likely to include editing documents with confidential information. Sending dictation data to the Siri servers could allow data spillage to occur — it is much safer to ensure information of various levels of confidentiality is retained locally.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.applicationaccess
+      - Key: forceOnDeviceOnlyDictation
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'forceOnDeviceOnlyDictation' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.applicationaccess' AND
+          name = 'forceOnDeviceOnlyDictation' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Is Enabled
+  cis_id: "3.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS's audit facility, auditd, receives notifications from the kernel when certain system calls, such as open, fork, and exit, are made. These notifications are captured and written to an audit log. Apple has deprecated auditd as of macOS 11.0 Big Sur. In macOS 14.0 Sonoma it is no longer enabled by default, but until auditd is removed from macOS completely, running the binary is the best way to collect native OS logging.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist
+      /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT 1
+      FROM launchd AS l
+      INNER JOIN processes AS p ON l.program = p.path
+      WHERE l.label = 'com.apple.auditd'
+        AND l.program_arguments = p.cmdline
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Flags For User-Attributable Events Are Configured Per Local Organizational Requirements
+  cis_id: "3.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Auditing is the capture and maintenance of information about security-related events. Auditable events often depend on differing organizational requirements. Maintaining an audit trail of system activity logs can help identify configuration errors, troubleshoot service disruptions, and analyze compromises or attacks that have occurred.
+
+    The Benchmark requires the following flags: `aa` (authorization/authentication), `ad` (administrative), `-ex` (failed program execution), `-fm` (failed file attribute modification), `-fr` (failed reads), `-fw` (failed writes), `lo` (login/logout). `-all` may substitute for the failed-event flags.
+  resolution: |
+    Terminal Method:
+      Edit /etc/security/audit_control and ensure the `flags:` line includes aa, ad, -ex, -fm, -fr, -fw, lo (or substitute -all for -ex, -fm, -fr, -fw).
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT line
+      FROM file_lines
+      WHERE path = '/etc/security/audit_control'
+        AND (
+          (
+            line LIKE 'flags:%'
+            AND line LIKE '%aa%'
+            AND line LIKE '%ad%'
+            AND line LIKE '%-ex%'
+            AND line LIKE '%-fm%'
+            AND line LIKE '%-fr%'
+            AND line LIKE '%-fw%'
+            AND line LIKE '%lo%'
+          )
+          OR
+          (
+            line LIKE 'flags:%'
+            AND line LIKE '%-all%'
+            AND line LIKE '%aa%'
+            AND line LIKE '%ad%'
+            AND line LIKE '%lo%'
+          )
+        )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure install.log Is Retained for 365 or More Days and No Maximum Size
+  cis_id: "3.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS writes information pertaining to system-related events to the file /var/log/install.log and has a configurable retention policy for this file. The default logging setting limits the file size of the logs and the maximum size for all logs. Archiving and retaining install.log for at least a year is beneficial in the event of an incident as it will allow the user to view the various changes to the system along with the date and time they occurred.
+  resolution: |
+    Terminal Method:
+      Edit /etc/asl/com.apple.install and add or modify the ttl value to 365 or greater on the file line. Also remove the all_max= setting and value from the file line.
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT line,
+               CAST(regex_match(line, 'ttl=(\d+)', 1) AS INTEGER) AS val
+        FROM file_lines
+        WHERE path = '/etc/asl/com.apple.install'
+          AND val >= 365
+      )
+      AND NOT EXISTS (
+        SELECT line
+        FROM file_lines
+        WHERE path = '/etc/asl/com.apple.install'
+          AND line LIKE '%all_max=%'
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Security Auditing Retention Is Enabled
+  cis_id: "3.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The macOS audit capability contains important information to investigate security or operational issues. This resource is only completely useful if it is retained long enough to allow technical staff to find the root cause of anomalies in the records. Retention should respect both size and longevity — at least 60 days or 5 gigabytes of audit records.
+  resolution: |
+    Terminal Method:
+      Edit /etc/security/audit_control so that expire-after: is at least 60d OR 5G.
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT line,
+             CAST(regex_match(line, 'expire-after:(\d+)d OR (\d+)G', 1) AS INTEGER) AS days,
+             CAST(regex_match(line, 'expire-after:(\d+)d OR (\d+)G', 2) AS INTEGER) AS size
+      FROM file_lines
+      WHERE path = '/etc/security/audit_control'
+        AND days >= 60
+        AND size >= 5
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Access to Audit Records Is Controlled
+  cis_id: "3.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The audit system on macOS writes important operational and security information that can be both useful for an attacker and a place for an attacker to attempt to obfuscate unwanted changes that were recorded. As part of defense-in-depth, the /etc/security/audit_control configuration and the audit log directory (default /var/audit) should be owned by root:wheel with mode 440 and no ACLs.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/security/audit_control
+      /usr/bin/sudo /bin/chmod -R 440 /etc/security/audit_control
+      /usr/bin/sudo /usr/sbin/chown -R root:wheel $(/usr/bin/grep '^dir' /etc/security/audit_control | /usr/bin/awk -F: '{print $2}')
+      /usr/bin/sudo /bin/chmod -R 440 $(/usr/bin/grep '^dir' /etc/security/audit_control | /usr/bin/awk -F: '{print $2}')
+  query: |
+    SELECT 1 WHERE
+      NOT EXISTS (
+        SELECT 1 FROM file
+        WHERE path = '/etc/security/audit_control'
+          AND (uid != 0 OR gid != 0 OR mode NOT IN ('0440', '0400'))
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM file
+        WHERE path LIKE '/var/audit/%'
+          AND (uid != 0 OR gid != 0 OR mode NOT IN ('0440', '0400'))
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM file
+        WHERE path LIKE (
+          SELECT dir FROM (
+            SELECT line, CONCAT(regex_match(line, '^dir:(.+)', 1), '/%') AS dir
+            FROM file_lines
+            WHERE path = '/etc/security/audit_control'
+              AND line LIKE 'dir:%'
+          )
+        )
+        AND (uid != 0 OR gid != 0 OR mode NOT IN ('0440', '0400'))
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Bonjour Advertising Services Is Disabled (MDM Required)
+  cis_id: "4.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Bonjour is an auto-discovery mechanism for TCP/IP devices which enumerates devices and services within a local subnet. DNS on macOS is integrated with Bonjour and should not be turned off, but the Bonjour advertising service can be disabled.
+
+    Bonjour can simplify device discovery from an internal rogue or compromised host. An attacker could use Bonjour's multicast DNS feature to discover a vulnerable or poorly-configured service or additional information to aid a targeted attack.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.mDNSResponder.plist NoMulticastAdvertisements -bool true
+
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.mDNSResponder
+      - Key: NoMulticastAdvertisements
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.mDNSResponder' AND
+          name = 'NoMulticastAdvertisements' AND
+          (value = 1 OR value = 'true') AND
+          username = ''
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.mDNSResponder' AND
+          name = 'NoMulticastAdvertisements' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure HTTP Server Is Disabled
+  cis_id: "4.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apache is still part of the Operating System and can be easily turned on to share files and provide remote connectivity to an end-user computer. Web serving should not be done from a user desktop — dedicated web servers or appropriate cloud storage should be used. Open ports make it easier to exploit the computer.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/apachectl stop
+      /usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM processes WHERE path = '/usr/sbin/httpd');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure NFS Server Is Disabled
+  cis_id: "4.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS can act as an NFS fileserver. NFSD is still part of the Operating System and can be easily turned on to export shares and provide remote connectivity to an end-user computer. File serving should not be done from a user desktop — dedicated servers should be used. The `/etc/exports` file contains the list of NFS shared directories; if it exists, it is likely that NFS sharing has been enabled in the past or may be available periodically.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd
+      /usr/bin/sudo /bin/rm -rf /etc/exports
+  query: |
+    SELECT 1 WHERE
+      NOT EXISTS (SELECT 1 FROM processes WHERE path = '/sbin/nfsd')
+      AND NOT EXISTS (SELECT 1 FROM file WHERE path = '/etc/exports');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Home Folders Are Secure
+  cis_id: "5.1.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    By default, macOS allows all valid users into the top level of every other user's home folder and restricts access to the Apple default folders within. Home folders should be restricted to access only by the user. Either no access or execute-only for group or others is acceptable.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /bin/chmod -R og-rwx /Users/<username>
+      (or `og-rw` if execute rights are required)
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM file WHERE
+        path LIKE '/Users/%'
+        AND path != '/Users/Shared/'
+        AND mode NOT IN ('0700', '0701', '0710', '0711')
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure System Integrity Protection Status (SIP) Is Enabled
+  cis_id: "5.1.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    System Integrity Protection (SIP) restricts access to System domain locations and restricts runtime attachment to system processes. Any attempt to inspect or attach to a system process will fail. Running without SIP on a production system runs the risk of modification of system binaries or code injection of system processes that would otherwise be protected.
+  resolution: |
+    Terminal Method (from Recovery):
+      1. Reboot into the Recovery Partition
+      2. Open Utilities > Terminal
+      3. /usr/bin/csrutil enable
+      4. Reboot
+  query: SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Apple Mobile File Integrity (AMFI) Is Enabled (Fleetd Required)
+  cis_id: "5.1.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple Mobile File Integrity (AMFI) blocks attempts to run unsigned code. AMFI uses launchd, code signatures, certificates, entitlements, and provisioning profiles to enforce code-signing and library validation.
+
+    Note: AMFI cannot be disabled with SIP enabled, but a change attempt can be made that will appear successful and report incorrectly as successful. If AMFI audit fails while SIP passes, this is still an issue to research.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/nvram boot-args=""
+  query: SELECT 1 FROM nvram_info WHERE amfi_enabled = '1';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Signed System Volume (SSV) Is Enabled (Fleetd Required)
+  cis_id: "5.1.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Signed System Volume (SSV) computes a SHA-256 hash for every immutable system file and stores it in a Merkle tree whose root is signed and verified at boot. macOS will not boot if system files have been tampered with. If SSV is disabled, assume the operating system has been compromised and reinstall.
+  resolution: |
+    If SSV has been disabled, back up any files and do a clean install to a known good operating system.
+  query: SELECT 1 FROM csrutil_info WHERE ssv_enabled = '1';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Appropriate Permissions Are Enabled for System Wide Applications
+  cis_id: "5.1.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Applications in the System Applications Directory (/Applications) should be world-executable but not world-writable. Unauthorized modifications of applications could lead to the execution of malicious code.
+  resolution: |
+    Terminal Method:
+      for apps in $(/usr/bin/find /Applications -iname "*.app" -type d -perm -2); do
+        /usr/bin/sudo /bin/chmod -R o-w "$apps"
+      done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT apps.path FROM apps
+      LEFT JOIN file ON file.path = apps.path
+      WHERE apps.path LIKE '/Applications/%'
+        AND CAST(SUBSTRING(file.mode, -1) AS INTEGER) & 2 != 0
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure No World Writable Folders Exist in the System Folder (Fleetd Required)
+  cis_id: "5.1.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software sometimes installs into /System/Volumes/Data/System with inappropriate world-writable permissions. Macs with writable files in /System should be investigated forensically — a file with open writable permissions is a sign of at best a rogue application and could indicate a compromise.
+  resolution: |
+    Terminal Method:
+      for sysPermissions in $(/usr/bin/find /System/Volumes/Data/System -type d -perm -2 | /usr/bin/grep -vE "downloadDir|locks"); do
+        /usr/bin/sudo /bin/chmod -R o-w "$sysPermissions"
+      done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM find_cmd
+      WHERE directory = '/System/Volumes/Data/System'
+        AND type = 'd'
+        AND perm = '-2'
+        AND path NOT LIKE '%downloadDir%'
+        AND path NOT LIKE '%locks%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure No World Writable Folders Exist in the Library Folder
+  cis_id: "5.1.7"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Software sometimes installs into /System/Volumes/Data/Library with inappropriate world-writable permissions. The audit check excludes folders where the sticky bit is set by Apple (required by the OS) and folders with the `com.apple.rootless` extended attribute (security vendor controls).
+  resolution: |
+    Terminal Method:
+      for libPermissions in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
+        /usr/bin/sudo /bin/chmod -R o-w "$libPermissions"
+      done
+  query: |
+    SELECT 1 WHERE NOT EXISTS (
+      SELECT 1 FROM file f
+      WHERE f.path LIKE '/Library/%'
+        AND f.type = 'directory'
+        AND (CAST(SUBSTR(f.mode, -1) AS INTEGER) & 2) = 2
+        AND CAST(SUBSTR(f.mode, 1, 1) AS INTEGER) NOT IN (1, 3, 5, 7)
+        AND NOT EXISTS (
+          SELECT 1 FROM extended_attributes ea
+          WHERE ea.path = f.path
+            AND ea.key = 'com.apple.rootless'
+        )
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Account Lockout Threshold Is Configured (Fleetd Required)
+  cis_id: "5.2.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The account lockout threshold specifies the amount of times a user can enter an incorrect password before a lockout will occur. The account lockout feature mitigates brute-force password attacks on the system.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.mobiledevice.passwordpolicy
+      - Key: maxFailedAttempts
+      - Value: <integer>5</integer> (or any value ≤ 5)
+  query: SELECT 1 FROM pwd_policy WHERE max_failed_attempts <= 5;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Minimum Length Is Configured (Fleetd Required)
+  cis_id: "5.2.2"
+  platforms: macOS
+  platform: darwin
+  description: |
+    A minimum password length is the fewest number of characters a password can contain to meet a system's requirements. Ensure that a minimum of a 15-character password is part of the password policy on the computer.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.mobiledevice.passwordpolicy
+      - Key: minLength
+      - Value: <integer>15</integer> (or any value ≥ 15)
+  query: |
+    SELECT 1
+    FROM (
+      SELECT CAST(lengthtxt AS INTEGER) AS minlength
+      FROM (
+        SELECT SUBSTRING(length, 1, 2) AS lengthtxt
+        FROM (
+          SELECT split(policy_content, '{', 1) AS length
+          FROM password_policy
+          WHERE policy_identifier LIKE '%minLength'
+        )
+      )
+      WHERE minlength >= 15
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password Age Is Configured (Fleetd Required)
+  cis_id: "5.2.7"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Over time, passwords can be captured by third parties through mistakes, phishing attacks, third-party breaches, or brute-force attacks. Users should reset passwords periodically. The Benchmark uses 365 days as the acceptable maximum.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.mobiledevice.passwordpolicy
+      - Key: maxPINAgeInDays
+      - Value: <integer>365</integer> (or any value ≤ 365)
+  query: |
+    SELECT 1 WHERE
+      EXISTS (SELECT 1 FROM pwd_policy WHERE expires_every_n_days > 0 AND expires_every_n_days <= 365)
+      OR EXISTS (SELECT 1 FROM pwd_policy WHERE days_to_expiration > 0 AND days_to_expiration <= 365);
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Password History Is Set to at Least 24 (Fleetd Required)
+  cis_id: "5.2.8"
+  platforms: macOS
+  platform: darwin
+  description: |
+    This control ensures that previous passwords are not reused immediately by keeping a history of previous password hashes. The Benchmark requires a history depth of at least 24.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.mobiledevice.passwordpolicy
+      - Key: pinHistory
+      - Value: <integer>24</integer> (or any value ≥ 24)
+  query: SELECT 1 FROM pwd_policy WHERE history_depth >= 24;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Sudo Timeout Period Is Set to Zero (Fleetd Required)
+  cis_id: "5.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The sudo command stays logged in as the root user for five minutes before timing out and re-requesting a password. This five-minute grace window should be eliminated since it leaves the system extremely vulnerable — an exploit gaining access would be able to make changes as a root user without a password prompt.
+  resolution: |
+    Terminal Method:
+      Edit (or create) /etc/sudoers.d/<config-file-no-dot> via `visudo -f` and add:
+        Defaults timestamp_timeout=0
+      Ensure /etc/sudoers.d is owned by root:wheel.
+  query: |
+    SELECT 1 WHERE
+      EXISTS (SELECT 1 FROM file WHERE path = '/etc/sudoers.d' AND uid = 0 AND gid = 0)
+      AND EXISTS (
+        SELECT COALESCE(JSON_EXTRACT(json_result, '$.Authentication timestamp timeout'), '') AS tstamp
+        FROM sudo_info
+        WHERE tstamp = '0.0 minutes'
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Separate Timestamp Is Enabled for Each User/tty Combo (Fleetd Required)
+  cis_id: "5.5"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Using tty tickets ensures that a user must enter the sudo password in each Terminal session. This reduces the possibility of a background process using elevated rights when a user elevates to root in an explicit context or tty.
+  resolution: |
+    Terminal Method:
+      Edit (or create) /etc/sudoers.d/<config-file-no-dot> via `visudo -f` and add:
+        Defaults timestamp_type=tty
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT COALESCE(JSON_EXTRACT(json_result, '$.Type of authentication timestamp record'), '') AS ttype
+      FROM sudo_info
+      WHERE ttype = 'tty'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the "root" Account Is Disabled (Fleetd Required)
+  cis_id: "5.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Enabling and using the root account puts the system at risk since any successful exploit or mistake while the root account is in use could have unlimited access privileges within the system. Using sudo allows users to perform functions as root while limiting and password-protecting the access privileges.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/sbin/dsenableroot -d
+      /usr/bin/sudo /usr/bin/dscl . -create /Users/root UserShell /usr/bin/false
+  query: SELECT 1 FROM dscl WHERE command = 'read' AND path = '/Users/root' AND key = 'AuthenticationAuthority' AND value = '';
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session (Fleetd Required)
+  cis_id: "5.7"
+  platforms: macOS
+  platform: darwin
+  description: |
+    macOS has a privilege that can be granted to any user that will allow that user to unlock active users' sessions. Disabling this prevents unauthorized persons from viewing potentially sensitive information.
+
+    Note: For organizations using Platform Single-Sign-On (PSSO), this setting can cause issues with PSSO syncing. Verify PSSO status via `/usr/bin/sudo app-sso platform -s`.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT JSON_EXTRACT(json_result, '$.rule') AS rule
+      FROM authdb
+      WHERE right_name = 'system.login.screensaver'
+        AND rule LIKE '%authenticate-session-owner%'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure a Login Window Banner Exists
+  cis_id: "5.8"
+  platforms: macOS
+  platform: darwin
+  description: |
+    A Login window banner warning informs the user that the system is reserved for authorized use only. An access warning may reduce a casual attacker's tendency to target the system and may aid in the prosecution of an attacker by evincing the attacker's knowledge of the system's private status.
+  resolution: |
+    Terminal Method:
+      Create /Library/Security/PolicyBanner.txt or PolicyBanner.rtf with the desired banner text.
+      /usr/bin/sudo /usr/sbin/chown root:wheel /Library/Security/PolicyBanner.*
+      /usr/bin/sudo /bin/chmod o+r /Library/Security/PolicyBanner.*
+  query: |
+    SELECT 1 FROM file
+    WHERE (path = '/Library/Security/PolicyBanner.txt' OR path = '/Library/Security/PolicyBanner.rtf')
+      AND mode = '0644'
+      AND uid = 0
+      AND gid = 0;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level2
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure the Guest Home Folder Does Not Exist
+  cis_id: "5.9"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The Guest home folder is unneeded after the Guest account is disabled and could be used inappropriately. The presence of the Guest home folder can also cause automated audits to fail when looking for compliant settings within all User folders.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /bin/rm -R /Users/Guest
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE path = '/Users/Guest');
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure XProtect Is Running and Updated
+  cis_id: "5.10"
+  platforms: macOS
+  platform: darwin
+  description: |
+    XProtect is Apple's native signature-based antivirus technology. XProtect both finds and blocks the execution of known malware. No matter what other tools are being used, XProtect should have the latest signatures available.
+
+    Note: XProtect can only be disabled while SIP is disabled. If XProtect is disabled while SIP is enabled, there needs to be a significant investigation on this system and assume it is compromised.
+  resolution: |
+    Terminal Method:
+      /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist
+      /usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist
+      /usr/bin/sudo /usr/bin/xprotect update
+  query: |
+    SELECT 1 WHERE (
+      SELECT COUNT(*) FROM launchd
+      WHERE path IN (
+        '/Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist',
+        '/Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist'
+      )
+    ) = 2;
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Logging Is Enabled for Sudo (Fleetd Required)
+  cis_id: "5.11"
+  platforms: macOS
+  platform: darwin
+  description: |
+    In order to properly monitor the use of the sudo command, log events for any use of sudo should be captured in the unified log. Apple added sudo logging as part of the unified log in macOS 14.0 Sonoma; in macOS 15.0 Sequoia and later, it is disabled by default but should be enabled.
+  resolution: |
+    Terminal Method:
+      Edit (or create) /etc/sudoers.d/<config-file-no-dot> via `visudo -f` and add:
+        Defaults log_allowed
+  query: |
+    SELECT 1 WHERE EXISTS (
+      SELECT COALESCE(JSON_EXTRACT(json_result, '$.Log when a command is allowed by sudoers'), '') AS log_allowed
+      FROM sudo_info
+      WHERE log_allowed LIKE '%true%' OR log_allowed = '1'
+    );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Automatic Opening of Safe Files in Safari Is Disabled (MDM Required)
+  cis_id: "6.3.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Safari will automatically run or execute what it considers safe files. Hackers have taken advantage of this setting via drive-by attacks — an attacker can create a malicious file that will fall within Safari's safe file list and download and execute without user input.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: AutoOpenSafeDownloads
+      - Value: <false/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'AutoOpenSafeDownloads' AND
+          (value = 0 OR value = 'false')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'AutoOpenSafeDownloads' AND
+          (value != 0 AND value != 'false')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled (MDM Required)
+  cis_id: "6.3.3"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple uses the Google Safe Browsing API to check for fraudulent websites and report them to the user attempting to visit one. Attackers use crafted web pages to social engineer users to load unwanted content — warning users prior to loading the content enables better security.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: WarnAboutFraudulentWebsites
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'WarnAboutFraudulentWebsites' AND
+          (value = 1 OR value = 'true')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'WarnAboutFraudulentWebsites' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Prevent Cross-site Tracking in Safari Is Enabled (MDM Required)
+  cis_id: "6.3.4"
+  platforms: macOS
+  platform: darwin
+  description: |
+    There is a vast network of groups that collect, use, and sell user data. Tracking cookies allow information brokers to track web users across visited sites. For better privacy and to provide some resistance to data brokers, prevent cross-tracking.
+
+    Three keys must all be set together for the profile to be effective: `BlockStoragePolicy=2`, `WebKitPreferences.storageBlockingPolicy=1`, and `WebKitStorageBlockingPolicy=1`.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: BlockStoragePolicy, Value: <integer>2</integer>
+      - Key: WebKitPreferences.storageBlockingPolicy, Value: <integer>1</integer>
+      - Key: WebKitStorageBlockingPolicy, Value: <integer>1</integer>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND name = 'BlockStoragePolicy' AND CAST(value AS INTEGER) = 2
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND name = 'WebKitPreferences.storageBlockingPolicy' AND CAST(value AS INTEGER) = 1
+      )
+      AND EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND name = 'WebKitStorageBlockingPolicy' AND CAST(value AS INTEGER) = 1
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND name = 'BlockStoragePolicy' AND CAST(value AS INTEGER) != 2
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Advertising Privacy Protection in Safari Is Enabled (MDM Required)
+  cis_id: "6.3.6"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Apple provides a framework that allows advertisers to target Apple users with advertisements. Organizations should manage user privacy settings on managed devices to align with organizational policies and user data protection requirements. Private click measurement is the privacy-preserving mechanism for ad-click attribution.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: WebKitPreferences.privateClickMeasurementEnabled
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'WebKitPreferences.privateClickMeasurementEnabled' AND
+          (value = 1 OR value = 'true')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'WebKitPreferences.privateClickMeasurementEnabled' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Full Website Address in Safari Is Enabled (MDM Required)
+  cis_id: "6.3.7"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Attackers use websites with malicious or unwanted content to exploit the user or the computer. Full visibility into what site is being visited is important for privacy and security — the full website address should always be displayed in Safari.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: ShowFullURLInSmartSearchField
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'ShowFullURLInSmartSearchField' AND
+          (value = 1 OR value = 'true')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'ShowFullURLInSmartSearchField' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Show Status Bar Is Enabled (MDM Required)
+  cis_id: "6.3.10"
+  platforms: macOS
+  platform: darwin
+  description: |
+    The Status Bar in Safari shows the full URL of any link on hover. It protects the user from visiting sites where the domain has been obfuscated by allowing the user to review whether the link points to an unexpected location.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Safari
+      - Key: ShowOverlayStatusBar
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'ShowOverlayStatusBar' AND
+          (value = 1 OR value = 'true')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Safari' AND
+          name = 'ShowOverlayStatusBar' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: CIS - Ensure Secure Keyboard Entry Terminal.app Is Enabled (MDM Required)
+  cis_id: "6.4.1"
+  platforms: macOS
+  platform: darwin
+  description: |
+    Secure Keyboard Entry prevents other applications on the system and/or network from detecting and recording what is typed into Terminal. Enabling Secure Keyboard Entry minimizes the risk of a key logger detecting what is entered in Terminal.
+  resolution: |
+    Profile Method:
+    Create or edit a configuration profile with the following information:
+      - PayloadType: com.apple.Terminal
+      - Key: SecureKeyboardEntry
+      - Value: <true/>
+  query: |
+    SELECT 1 WHERE
+      EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Terminal' AND
+          name = 'SecureKeyboardEntry' AND
+          (value = 1 OR value = 'true')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM managed_policies WHERE
+          domain = 'com.apple.Terminal' AND
+          name = 'SecureKeyboardEntry' AND
+          (value != 1 AND value != 'true')
+      );
+  purpose: Informational
+  tags: compliance, CIS, CIS_Level1

--- a/ee/cis/macos-26/test/profiles/1.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/1.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 1.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.SoftwareUpdate</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-1.2.check</string>
+      <key>PayloadUUID</key>
+      <string>A68D427C-F98D-45AD-9ADA-D394E5047E39</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutomaticDownload</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 1.2 - Ensure Download New Updates When Available Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Download New Updates When Available Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-1.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>27E58EAC-63D7-4585-A6A8-383A1C70554B</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/1.3.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/1.3.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 1.3</string>
+      <key>PayloadType</key>
+      <string>com.apple.SoftwareUpdate</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-1.3.check</string>
+      <key>PayloadUUID</key>
+      <string>E2AB5679-FEA4-4134-BD00-6597E9E5972E</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutomaticallyInstallMacOSUpdates</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 1.3 - Ensure Install of macOS Updates Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Install of macOS Updates Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-1.3</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>972DD6BC-2F41-4438-B0BF-5F92EF61AEFE</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/1.4.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/1.4.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 1.4</string>
+      <key>PayloadType</key>
+      <string>com.apple.SoftwareUpdate</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-1.4.check</string>
+      <key>PayloadUUID</key>
+      <string>8AC4EF6E-AEB4-4FB1-8DF2-14AA2855697A</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutomaticallyInstallAppUpdates</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 1.4 - Ensure Install Application Updates from the App Store Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Install Application Updates from the App Store Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-1.4</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>10C0A145-4FBD-4BDA-8C58-DA9A4B234CAE</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/1.5.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/1.5.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 1.5</string>
+      <key>PayloadType</key>
+      <string>com.apple.SoftwareUpdate</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-1.5.check</string>
+      <key>PayloadUUID</key>
+      <string>36626EA2-9FDC-41A5-87BE-D762D71CC758</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>ConfigDataInstall</key>
+      <true/>
+      <key>CriticalUpdateInstall</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 1.5 - Ensure Install Security Responses and System Files Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Install Security Responses and System Files Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-1.5</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>01B5D31D-4812-4E6B-9FD9-0385BBF466CA</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/1.6.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/1.6.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 1.6</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-1.6.check</string>
+      <key>PayloadUUID</key>
+      <string>C6CEFCF9-FB04-4AB0-9515-8CFB676CA372</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>enforcedSoftwareUpdateDelay</key>
+      <integer>30</integer>
+      <key>forceDelayedSoftwareUpdates</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 1.6 - Ensure Software Update Deferment Is Less Than or Equal to 30 Days</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Software Update Deferment Is Less Than or Equal to 30 Days</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-1.6</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>20D14D65-6F25-4D5B-9D30-0B7305D2AE3A</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.1.1.3.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.1.1.3.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.1.1.3</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.1.1.3.check</string>
+      <key>PayloadUUID</key>
+      <string>0E21C0EB-CA4E-4853-902B-C290FCCFA513</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowCloudDesktopAndDocuments</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.1.1.3 - Ensure iCloud Drive Document and Desktop Sync Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure iCloud Drive Document and Desktop Sync Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.1.1.3</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>B648264C-A201-4BA1-8FF6-96AF02CF6590</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.11.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.11.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.11.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.screensaver</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.11.1.check</string>
+      <key>PayloadUUID</key>
+      <string>E3549499-36EF-4461-8A4C-333B76C0AE2B</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>idleTime</key>
+      <integer>900</integer>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.11.1 - Ensure an Inactivity Interval of 15 Minutes Or Less for the Screen Saver Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Screen Saver Inactivity Interval Is 15 Minutes Or Less</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.11.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>F2599453-AFA7-418F-8E31-82B5F7F1C338</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.11.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.11.2.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.11.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.screensaver</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.11.2.check</string>
+      <key>PayloadUUID</key>
+      <string>FC2AA9FE-8A8C-4D67-A8E9-77D9F3444D16</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>askForPassword</key>
+      <true/>
+      <key>askForPasswordDelay</key>
+      <integer>5</integer>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.11.2 - Ensure Require Password After Screen Saver Begins Is Enabled for 5 Seconds or Immediately</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Require Password After Screen Saver Begins</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.11.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>3A4D15B6-6883-4D6F-9E54-359D998A4490</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.18.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.18.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.18.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.18.1.check</string>
+      <key>PayloadUUID</key>
+      <string>7A972390-83FE-4540-91C5-1B179E308649</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>forceOnDeviceOnlyDictation</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.18.1 - Ensure On-Device Dictation Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure On-Device Dictation Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.18.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>B86BE9BA-B11C-4FEB-B38A-CC68133036A5</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.2.1-and-2.2.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.2.1-and-2.2.2.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.2.1 and 2.2.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.security.firewall</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.2.1-and-2.2.2.check</string>
+      <key>PayloadUUID</key>
+      <string>6B15844C-8DAD-489C-B19E-55BD39C362A7</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>EnableFirewall</key>
+      <true/>
+      <key>EnableStealthMode</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.2.1 and 2.2.2 - Firewall Enabled + Stealth Mode (must be in same profile per CIS)</string>
+  <key>PayloadDisplayName</key>
+  <string>Firewall + Stealth Mode Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.2.1-and-2.2.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>253991AD-8224-4674-A896-9E2444398A1F</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.1.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.1.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.1.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.1.1.check</string>
+      <key>PayloadUUID</key>
+      <string>804E1072-2D1B-42CF-A1C1-17FD296A3476</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowAirDrop</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.1.1 - Ensure AirDrop Is Disabled When Not Actively Transferring Files</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure AirDrop Is Disabled When Not Actively Transferring Files</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.1.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>6AAAE306-37E1-481D-9003-06093B98D351</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.1.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.1.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.1.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.1.2.check</string>
+      <key>PayloadUUID</key>
+      <string>935C5381-F3FD-4C55-8CC4-1BFC20A83206</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowAirPlayIncomingRequests</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.1.2 - Ensure AirPlay Receiver Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure AirPlay Receiver Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.1.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>5FA896B1-6CC3-4F7F-8B73-0E457372EC47</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.3.7.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.3.7.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.3.7</string>
+      <key>PayloadType</key>
+      <string>com.apple.MCX</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.3.7.check</string>
+      <key>PayloadUUID</key>
+      <string>5D70958E-0C98-4C5E-8E74-4AF5E38B6F2B</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>forceInternetSharingOff</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.3.7 - Ensure Internet Sharing Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Internet Sharing Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.3.7</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>78808E2A-E082-4679-B45F-3A2E4A5CFE2A</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.3.8.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.3.8.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.3.8</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.3.8.check</string>
+      <key>PayloadUUID</key>
+      <string>74161836-3CC7-47DA-8C9D-3DBE939D67A1</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowContentCaching</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.3.8 - Ensure Content Caching Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Content Caching Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.3.8</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>FCA86F89-CDB1-4BF3-80A3-51FF5F3149E7</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.3.9.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.3.9.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.3.9</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.3.9.check</string>
+      <key>PayloadUUID</key>
+      <string>5BA169D6-ED30-4E36-9019-ABD4B69C1283</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowMediaSharing</key>
+      <false/>
+      <key>allowMediaSharingModification</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.3.9 - Ensure Media Sharing Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Media Sharing Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.3.9</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>4DCD47C6-1BA9-4C67-ACE2-61C6B3AA0176</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.3.4.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.3.4.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.3.4.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.MCX.TimeMachine</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.3.4.1.check</string>
+      <key>PayloadUUID</key>
+      <string>1C171B17-A328-4291-BDDD-A75B4594E06A</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutoBackup</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.3.4.1 - Ensure Backup Automatically Is Enabled If Time Machine Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Backup Automatically Is Enabled If Time Machine Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.3.4.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>A640B422-D9C2-4C18-AD7B-EB617C676570</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.5.1.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.5.1.1.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.5.1.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.5.1.1.check</string>
+      <key>PayloadUUID</key>
+      <string>FAABF467-BD33-470B-AEC3-7C0F526BAF48</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowExternalIntelligenceIntegrations</key>
+      <false/>
+      <key>allowExternalIntelligenceIntegrationsSignIn</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.5.1.1 - Ensure External Intelligence Extensions Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure External Intelligence Extensions Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.5.1.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>BD03F548-63AD-4177-9C43-6FDAF9E609DD</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.5.1.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.5.1.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.5.1.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.5.1.2.check</string>
+      <key>PayloadUUID</key>
+      <string>7A27880A-3C35-4CA9-A4A9-042DE53E9F56</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowWritingTools</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.5.1.2 - Ensure Writing Tools Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Writing Tools Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.5.1.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>6226CC21-030B-4F6E-963F-09B7A2E76E38</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.5.1.3.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.5.1.3.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.5.1.3</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.5.1.3.check</string>
+      <key>PayloadUUID</key>
+      <string>ECE767B6-6232-4C94-AF15-D7BDEF18ED64</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowMailSummary</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.5.1.3 - Ensure Mail Summarization Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Mail Summarization Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.5.1.3</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>2489A75D-7160-43C5-8C18-3AA4DC32F4D2</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.5.1.4.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.5.1.4.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.5.1.4</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.5.1.4.check</string>
+      <key>PayloadUUID</key>
+      <string>8A28F0DF-C282-4339-8775-9A3578D896FF</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowNotesTranscription</key>
+      <false/>
+      <key>allowNotesTranscriptionSummary</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.5.1.4 - Ensure Notes Summarization Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Notes Summarization Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.5.1.4</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>5F8496E9-1307-437E-8029-45F5721B5E5E</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.5.2.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.5.2.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.5.2.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.5.2.1.check</string>
+      <key>PayloadUUID</key>
+      <string>2A116876-7E00-4FA3-B28D-2262D967DDAC</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowAssistant</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.5.2.1 - Ensure Siri Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Siri Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.5.2.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>33411148-3E55-4E62-94A8-5026E9B0D25F</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.3.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.3.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.3.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.SubmitDiagInfo</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.3.1.check</string>
+      <key>PayloadUUID</key>
+      <string>E8744BA4-AF83-4752-8C48-BC60B79857FC</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutoSubmit</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.3.1 - Ensure Share Mac Analytics Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Share Mac Analytics Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.3.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>EE14214D-22E9-429B-BEAC-A9927B5ED310</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.3.2.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.3.2.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.3.2</string>
+      <key>PayloadType</key>
+      <string>com.apple.assistant.support</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.3.2.check</string>
+      <key>PayloadUUID</key>
+      <string>D461272E-DD74-458E-9F99-7BF18FE09C4A</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>Siri Data Sharing Opt-In Status</key>
+      <integer>2</integer>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.3.2 - Ensure Improve Siri &amp; Dictation Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Improve Siri &amp; Dictation Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.3.2</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>E26A0D61-8CB5-4342-9632-100416EC5F0F</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.3.3.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.3.3.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.3.3</string>
+      <key>PayloadType</key>
+      <string>com.apple.Accessibility</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.3.3.check</string>
+      <key>PayloadUUID</key>
+      <string>058FA058-1EDC-48BD-9EF0-04314C1DFC1E</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AXSAudioDonationSiriImprovementEnabled</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.3.3 - Ensure Improve Assistive Voice Features Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Improve Assistive Voice Features Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.3.3</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>D857955C-B03C-4CA0-84AF-43EBE66D2B60</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.3.4.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.3.4.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.3.4</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.3.4.check</string>
+      <key>PayloadUUID</key>
+      <string>12748F72-A2AA-4D59-8B46-A16414225C03</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowDiagnosticSubmission</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.3.4 - Ensure 'Share with app developers' Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure 'Share with app developers' Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.3.4</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>7ACB052E-5481-4570-A7D7-33EE986214D3</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.4.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.4.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.4</string>
+      <key>PayloadType</key>
+      <string>com.apple.applicationaccess</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.4.check</string>
+      <key>PayloadUUID</key>
+      <string>7FE2B8ED-87FA-4AF3-8D82-9255BC166D4D</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>allowApplePersonalizedAdvertising</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.4 - Ensure Limit Ad Tracking Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Limit Ad Tracking Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.4</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>85906341-8CEA-4B1F-A687-1CE30D9B0531</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.5.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.5.mobileconfig
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.5</string>
+      <key>PayloadType</key>
+      <string>com.apple.systempolicy.control</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.5.check</string>
+      <key>PayloadUUID</key>
+      <string>02862600-C7B6-46B1-9AC5-75C07CFBB2B7</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>EnableAssessment</key>
+      <true/>
+      <key>AllowIdentifiedDevelopers</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.5 - Ensure Gatekeeper Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Gatekeeper Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.5</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>36DB627C-A85B-471D-845C-EE3844B4457F</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.6.6.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.6.6.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.6.6</string>
+      <key>PayloadType</key>
+      <string>com.apple.MCX</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.6.6.check</string>
+      <key>PayloadUUID</key>
+      <string>5DBF766D-E6AE-4C7F-8642-5BF8EADC6ABE</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>dontAllowFDEDisable</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.6.6 - Ensure FileVault Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure FileVault Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.6.6</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>7E91999D-F529-468A-96DE-4458778833D4</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/2.9.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/2.9.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 2.9.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.assistant.support</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-2.9.1.check</string>
+      <key>PayloadUUID</key>
+      <string>D83E4225-AF34-41BC-9F49-68BA9288DE33</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>Search Queries Data Sharing Status</key>
+      <integer>2</integer>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 2.9.1 - Ensure Help Apple Improve Search Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Help Apple Improve Search Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-2.9.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>E760A6F5-D63B-4125-80EE-58110ACDFE99</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/4.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/4.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 4.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.mDNSResponder</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-4.1.check</string>
+      <key>PayloadUUID</key>
+      <string>A0B82886-CE91-4B18-B194-803C13856E0B</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>NoMulticastAdvertisements</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 4.1 - Ensure Bonjour Advertising Services Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Bonjour Advertising Services Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-4.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>E4CF87E7-BC3A-4C7D-BBBC-18811BE1340D</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.1.check</string>
+      <key>PayloadUUID</key>
+      <string>70E0054B-858B-444A-AC33-81E75924F113</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>AutoOpenSafeDownloads</key>
+      <false/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.1 - Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Automatic Opening of Safe Files in Safari Is Disabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>0369DF47-EACA-44FA-B712-4C5E8C5B7A7C</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.10.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.10.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.10</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.10.check</string>
+      <key>PayloadUUID</key>
+      <string>55CE4216-A603-4277-B9F0-4D548A65911C</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>ShowOverlayStatusBar</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.10 - Ensure Show Status Bar Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Show Status Bar Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.10</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>001E362E-F486-473B-81AB-CF08F0264D5F</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.3.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.3.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.3</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.3.check</string>
+      <key>PayloadUUID</key>
+      <string>DD0EC285-7A2B-4746-93F9-1BDA9E0C6B3C</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>WarnAboutFraudulentWebsites</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.3 - Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Warn When Visiting A Fraudulent Website in Safari Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.3</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>992AB133-C6BA-472E-9375-FA179DCE513B</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.4.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.4.mobileconfig
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.4</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.4.check</string>
+      <key>PayloadUUID</key>
+      <string>696305FF-951F-4FAB-8227-606A58864362</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>BlockStoragePolicy</key>
+      <integer>2</integer>
+      <key>WebKitPreferences.storageBlockingPolicy</key>
+      <integer>1</integer>
+      <key>WebKitStorageBlockingPolicy</key>
+      <integer>1</integer>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.4 - Ensure Prevent Cross-site Tracking in Safari Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Prevent Cross-site Tracking in Safari Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.4</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>C3B1A7BB-0839-4DD8-9A51-FE1FA288C3D9</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.6.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.6.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.6</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.6.check</string>
+      <key>PayloadUUID</key>
+      <string>492322EA-DAD1-4DB7-97E2-19EBD628F144</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>WebKitPreferences.privateClickMeasurementEnabled</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.6 - Ensure Advertising Privacy Protection in Safari Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Advertising Privacy Protection in Safari Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.6</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>5DEAA08A-C17E-45A8-A793-D49165FA10AB</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.3.7.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.3.7.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.3.7</string>
+      <key>PayloadType</key>
+      <string>com.apple.Safari</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.3.7.check</string>
+      <key>PayloadUUID</key>
+      <string>915410F1-5B4B-44BF-82C3-112C25217BDA</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>ShowFullURLInSmartSearchField</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.3.7 - Ensure Show Full Website Address in Safari Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Show Full Website Address in Safari Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.3.7</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>0AB88416-F20B-48C9-AC8B-7F998C0130DB</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/profiles/6.4.1.mobileconfig
+++ b/ee/cis/macos-26/test/profiles/6.4.1.mobileconfig
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>PayloadContent</key>
+  <array>
+    <dict>
+      <key>PayloadDisplayName</key>
+      <string>CIS 6.4.1</string>
+      <key>PayloadType</key>
+      <string>com.apple.Terminal</string>
+      <key>PayloadIdentifier</key>
+      <string>com.fleetdm.cis-6.4.1.check</string>
+      <key>PayloadUUID</key>
+      <string>33CA62AC-564C-4222-8807-BC696F3C6BEB</string>
+      <key>PayloadVersion</key>
+      <integer>1</integer>
+      <key>SecureKeyboardEntry</key>
+      <true/>
+    </dict>
+  </array>
+  <key>PayloadDescription</key>
+  <string>CIS 6.4.1 - Ensure Secure Keyboard Entry Terminal.app Is Enabled</string>
+  <key>PayloadDisplayName</key>
+  <string>Ensure Secure Keyboard Entry Terminal.app Is Enabled</string>
+  <key>PayloadIdentifier</key>
+  <string>com.fleetdm.cis-6.4.1</string>
+  <key>PayloadRemovalDisallowed</key>
+  <false/>
+  <key>PayloadScope</key>
+  <string>System</string>
+  <key>PayloadType</key>
+  <string>Configuration</string>
+  <key>PayloadUUID</key>
+  <string>85799877-8751-4E0A-BE98-D88AE131AE5D</string>
+  <key>PayloadVersion</key>
+  <integer>1</integer>
+</dict>
+</plist>

--- a/ee/cis/macos-26/test/scripts/CIS_1.1.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_1.1.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 1.1 - Ensure Apple-provided Software Updates Are Installed
+# Installs any pending Apple-provided software updates so the policy query passes.
+/usr/bin/sudo /usr/sbin/softwareupdate -i -a --agree-to-license

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.1.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.1.2_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.10.1.2 - Ensure Sleep and Display Sleep Is Enabled on Apple Silicon Devices
+# Sets sleep=30 (>15) so the query fails on Apple Silicon.
+/usr/bin/sudo /usr/bin/pmset -a sleep 30
+/usr/bin/sudo /usr/bin/pmset -a displaysleep 25

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.1.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.1.2_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.10.1.2 - Ensure Sleep and Display Sleep Is Enabled on Apple Silicon Devices
+# Sets sleep=15 and displaysleep=10 so the query passes on Apple Silicon.
+/usr/bin/sudo /usr/bin/pmset -a sleep 15
+/usr/bin/sudo /usr/bin/pmset -a displaysleep 10

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.2_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.10.2 - Ensure Power Nap Is Disabled for Intel Macs
+# Enables powernap so the query fails. Intel-only; on Apple Silicon pmset may ignore.
+/usr/bin/sudo /usr/bin/pmset -a powernap 1

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.2_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.10.2 - Ensure Power Nap Is Disabled for Intel Macs
+# Disables powernap on all power sources so the query passes.
+/usr/bin/sudo /usr/bin/pmset -a powernap 0

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.3_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.10.3 - Ensure Wake for Network Access Is Disabled
+# Enables Wake-on-LAN so the query fails.
+/usr/bin/sudo /usr/bin/pmset -a womp 1

--- a/ee/cis/macos-26/test/scripts/CIS_2.10.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.10.3_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.10.3 - Ensure Wake for Network Access Is Disabled
+# Disables Wake-on-LAN so the query passes.
+/usr/bin/sudo /usr/bin/pmset -a womp 0

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.3_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.3 - Ensure a Custom Message for the Login Screen Is Enabled
+# Removes LoginwindowText so the query fails.
+/usr/bin/sudo /usr/bin/defaults delete /Library/Preferences/com.apple.loginwindow LoginwindowText 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.3_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.3 - Ensure a Custom Message for the Login Screen Is Enabled
+# Sets a non-empty LoginwindowText so the query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow LoginwindowText "Authorized use only. Activity may be monitored."

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.4_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.4_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.4 - Ensure Login Window Displays as Name and Password Is Enabled
+# Sets SHOWFULLNAME=false so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool false

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.4_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.4_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.4 - Ensure Login Window Displays as Name and Password Is Enabled
+# Sets SHOWFULLNAME=true so the query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow SHOWFULLNAME -bool true

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.5_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.5_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.5 - Ensure Show Password Hints Is Disabled
+# Sets RetriesUntilHint=3 so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 3

--- a/ee/cis/macos-26/test/scripts/CIS_2.11.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.11.5_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.11.5 - Ensure Show Password Hints Is Disabled
+# Sets RetriesUntilHint=0 so the query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow RetriesUntilHint -int 0

--- a/ee/cis/macos-26/test/scripts/CIS_2.12.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.12.1_fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 2.12.1 - Ensure Users' Accounts Do Not Have a Password Hint
+# Sets a hint attribute on the invoking console user so the query fails.
+user=$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null)
+if [ -n "$user" ] && [ "$user" != "root" ]; then
+  /usr/bin/sudo /usr/bin/dscl . -create "/Users/$user" hint "test hint"
+fi

--- a/ee/cis/macos-26/test/scripts/CIS_2.12.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.12.1_pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 2.12.1 - Ensure Users' Accounts Do Not Have a Password Hint
+# Removes the hint attribute from every local user so the query passes.
+users=$(/usr/bin/sudo /usr/bin/dscl . -list /Users hint 2>/dev/null | /usr/bin/awk 'NF==2 {print $1}')
+for u in $users; do
+  /usr/bin/sudo /usr/bin/dscl . -delete "/Users/$u" hint 2>/dev/null || true
+done

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.1_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.1 - Ensure Guest Account Is Disabled
+# Enables the guest account so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool true

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.1_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.1 - Ensure Guest Account Is Disabled
+# Sets GuestEnabled=false in the loginwindow plist so the query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow GuestEnabled -bool false

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.2_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.2 - Ensure Guest Access to Shared Folders Is Disabled
+# Enables SMB guest access so the query fails.
+/usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess on

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.2_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.2 - Ensure Guest Access to Shared Folders Is Disabled
+# Disables SMB guest access so the query passes.
+/usr/bin/sudo /usr/sbin/sysadminctl -smbGuestAccess off

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.3_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.3 - Ensure Automatic Login Is Disabled
+# Sets autoLoginUser to a placeholder value so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow autoLoginUser -string "testuser"

--- a/ee/cis/macos-26/test/scripts/CIS_2.13.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.13.3_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.13.3 - Ensure Automatic Login Is Disabled
+# Removes autoLoginUser so the query passes.
+/usr/bin/sudo /usr/bin/defaults delete /Library/Preferences/com.apple.loginwindow autoLoginUser 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_2.2.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.2.1_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.2.1 - Ensure Firewall Is Enabled
+# Disables the socketfilter firewall so the policy query fails.
+/usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off

--- a/ee/cis/macos-26/test/scripts/CIS_2.2.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.2.1_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.2.1 - Ensure Firewall Is Enabled
+# Enables the socketfilter firewall so the policy query passes.
+/usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate on

--- a/ee/cis/macos-26/test/scripts/CIS_2.2.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.2.2_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.2.2 - Ensure Firewall Stealth Mode Is Enabled
+# Disables firewall stealth mode so the policy query fails.
+/usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode off

--- a/ee/cis/macos-26/test/scripts/CIS_2.2.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.2.2_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.2.2 - Ensure Firewall Stealth Mode Is Enabled
+# Enables firewall stealth mode so the policy query passes.
+/usr/bin/sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setstealthmode on

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.2.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.2.1_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.2.1 - Ensure Set Time and Date Automatically Is Enabled
+# Disables network time so the policy query fails.
+/usr/bin/sudo /usr/sbin/systemsetup -setusingnetworktime off

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.2.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.2.1_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.2.1 - Ensure Set Time and Date Automatically Is Enabled
+# Configures time.apple.com as the NTP server and enables network time.
+/usr/bin/sudo /usr/sbin/systemsetup -setnetworktimeserver time.apple.com
+/usr/bin/sudo /usr/sbin/systemsetup -setusingnetworktime on

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.2.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.2.2_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 2.3.2.2 - Ensure the Time Service Is Enabled
+# Disables com.apple.timed so the policy query fails.
+# Test-only: CIS considers a disabled timed service a compromise indicator.
+/usr/bin/sudo /bin/launchctl disable system/com.apple.timed
+/usr/bin/sudo /bin/launchctl bootout system/com.apple.timed

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.2.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.2.2_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.2.2 - Ensure the Time Service Is Enabled
+# Enables and bootstraps the com.apple.timed launchd service.
+/usr/bin/sudo /bin/launchctl enable system/com.apple.timed
+/usr/bin/sudo /bin/launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.timed.plist

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_fail.sh
@@ -3,7 +3,7 @@
 # Writes PrefKeyServicesEnabled=true for every console user so the policy query fails.
 for user_home in /Users/*; do
   username=$(/usr/bin/basename "$user_home")
-  [ "$username" = "Shared" ] && continue
+  case "$username" in Shared|Guest|.*) continue ;; esac
   [ ! -d "$user_home" ] && continue
   /usr/bin/sudo -u "$username" /usr/bin/defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool true
 done

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_fail.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# CIS 2.3.3.10 - Ensure Bluetooth Sharing Is Disabled
+# Writes PrefKeyServicesEnabled=true for every console user so the policy query fails.
+for user_home in /Users/*; do
+  username=$(/usr/bin/basename "$user_home")
+  [ "$username" = "Shared" ] && continue
+  [ ! -d "$user_home" ] && continue
+  /usr/bin/sudo -u "$username" /usr/bin/defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool true
+done

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_pass.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# CIS 2.3.3.10 - Ensure Bluetooth Sharing Is Disabled
+# Writes PrefKeyServicesEnabled=false for every console user so the policy query passes.
+# Bluetooth Sharing is a per-user ByHost setting; iterate all home dirs under /Users.
+for user_home in /Users/*; do
+  username=$(/usr/bin/basename "$user_home")
+  [ "$username" = "Shared" ] && continue
+  [ ! -d "$user_home" ] && continue
+  /usr/bin/sudo -u "$username" /usr/bin/defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false
+done

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.10_pass.sh
@@ -4,7 +4,7 @@
 # Bluetooth Sharing is a per-user ByHost setting; iterate all home dirs under /Users.
 for user_home in /Users/*; do
   username=$(/usr/bin/basename "$user_home")
-  [ "$username" = "Shared" ] && continue
+  case "$username" in Shared|Guest|.*) continue ;; esac
   [ ! -d "$user_home" ] && continue
   /usr/bin/sudo -u "$username" /usr/bin/defaults -currentHost write com.apple.Bluetooth PrefKeyServicesEnabled -bool false
 done

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.1_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.3.1 - Ensure Screen Sharing Is Disabled
+# Enables the screen sharing launchd service so the policy query fails.
+/usr/bin/sudo /bin/launchctl enable system/com.apple.screensharing
+/usr/bin/sudo /bin/launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.screensharing.plist

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.1_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.3.1 - Ensure Screen Sharing Is Disabled
+# Disables the screen sharing launchd service so the policy query passes.
+/usr/bin/sudo /bin/launchctl disable system/com.apple.screensharing
+/usr/bin/sudo /bin/launchctl bootout system/com.apple.screensharing

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.2_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.3.2 - Ensure File Sharing Is Disabled
+# Enables the SMB file sharing service so the policy query fails.
+/usr/bin/sudo /bin/launchctl enable system/com.apple.smbd
+/usr/bin/sudo /bin/launchctl bootstrap system /System/Library/LaunchDaemons/com.apple.smbd.plist

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.2_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.3.3.2 - Ensure File Sharing Is Disabled
+# Disables the SMB file sharing service so the policy query passes.
+/usr/bin/sudo /bin/launchctl disable system/com.apple.smbd
+/usr/bin/sudo /bin/launchctl bootout system/com.apple.smbd

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.3_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.3 - Ensure Printer Sharing Is Disabled
+# Turns on CUPS printer sharing so the policy query fails.
+/usr/bin/sudo /usr/sbin/cupsctl --share-printers

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.3_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.3 - Ensure Printer Sharing Is Disabled
+# Turns off CUPS printer sharing so the policy query passes.
+/usr/bin/sudo /usr/sbin/cupsctl --no-share-printers

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.4_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.4_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.4 - Ensure Remote Login Is Disabled
+# Enables the SSH service so the policy query fails.
+/usr/bin/sudo /usr/sbin/systemsetup -setremotelogin on

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.4_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.4_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.4 - Ensure Remote Login Is Disabled
+# Disables the SSH service so the policy query passes.
+/usr/bin/sudo /usr/sbin/systemsetup -setremotelogin off <<< "yes"

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.5_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.5_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.5 - Ensure Remote Management Is Disabled
+# Activates Apple Remote Desktop so the policy query fails.
+/usr/bin/sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -activate -configure -access -on -privs -all -restart -agent

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.5_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.5 - Ensure Remote Management Is Disabled
+# Deactivates Apple Remote Desktop so the policy query passes.
+/usr/bin/sudo /System/Library/CoreServices/RemoteManagement/ARDAgent.app/Contents/Resources/kickstart -deactivate -stop

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.6_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.6_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.6 - Ensure Remote Apple Events Is Disabled
+# Turns on Remote Apple Events so the policy query fails.
+/usr/bin/sudo /usr/sbin/systemsetup -setremoteappleevents on

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.6_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.6_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.6 - Ensure Remote Apple Events Is Disabled
+# Turns off Remote Apple Events so the policy query passes.
+/usr/bin/sudo /usr/sbin/systemsetup -setremoteappleevents off

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.7_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.7_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.7 - Ensure Internet Sharing Is Disabled
+# Writes NAT.Enabled=1 to com.apple.nat so the policy query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 1

--- a/ee/cis/macos-26/test/scripts/CIS_2.3.3.7_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.3.3.7_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.3.3.7 - Ensure Internet Sharing Is Disabled
+# Writes NAT.Enabled=0 to com.apple.nat so the policy query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/SystemConfiguration/com.apple.nat NAT -dict Enabled -int 0

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.1.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.1.1_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 2.6.1.1 - Ensure Location Services Is Enabled
+# Disables Location Services so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /var/db/locationd/Library/Preferences/ByHost/com.apple.locationd LocationServicesEnabled -bool false
+/usr/bin/sudo /usr/bin/killall locationd

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.1.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.1.1_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 2.6.1.1 - Ensure Location Services Is Enabled
+# Enables the locationd service and sets LocationServicesEnabled so the query passes.
+/usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.locationd.plist
+/usr/bin/sudo /usr/bin/defaults write /var/db/locationd/Library/Preferences/ByHost/com.apple.locationd LocationServicesEnabled -bool true
+/usr/bin/sudo /usr/bin/killall locationd

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.1.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.1.2_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.6.1.2 - Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled
+# Sets ShowSystemServices=false so the query fails.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool false

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.1.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.1.2_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 2.6.1.2 - Ensure 'Show Location Icon in Control Center when System Services Request Your Location' Is Enabled
+# Sets ShowSystemServices=true so the query passes.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.locationmenu.plist ShowSystemServices -bool true

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.8_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.8_fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 2.6.8 - Ensure an Administrator Password Is Required to Access System-Wide Preferences
+# Flips shared back to true on system.preferences so the query fails.
+plist="/tmp/system.preferences.plist"
+/usr/bin/sudo /usr/bin/security -q authorizationdb read system.preferences > "$plist"
+
+shared_value=$(/usr/libexec/PlistBuddy -c "Print :shared" "$plist" 2>&1)
+if [[ "$shared_value" == *"Does Not Exist"* ]]; then
+  /usr/libexec/PlistBuddy -c "Add :shared bool true" "$plist"
+else
+  /usr/libexec/PlistBuddy -c "Set :shared true" "$plist"
+fi
+
+/usr/bin/sudo /usr/bin/security -q authorizationdb write system.preferences < "$plist"
+/bin/rm -f "$plist"

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.8_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.8_fail.sh
@@ -2,7 +2,13 @@
 # CIS 2.6.8 - Ensure an Administrator Password Is Required to Access System-Wide Preferences
 # Flips shared back to true on system.preferences so the query fails.
 plist="/tmp/system.preferences.plist"
-/usr/bin/sudo /usr/bin/security -q authorizationdb read system.preferences > "$plist"
+/usr/bin/sudo /usr/bin/security -q authorizationdb read system.preferences \
+  | /usr/bin/sudo /usr/bin/tee "$plist" > /dev/null
+if [ ! -s "$plist" ]; then
+  echo "Failed to read system.preferences authorizationdb; aborting." >&2
+  /bin/rm -f "$plist"
+  exit 1
+fi
 
 shared_value=$(/usr/libexec/PlistBuddy -c "Print :shared" "$plist" 2>&1)
 if [[ "$shared_value" == *"Does Not Exist"* ]]; then

--- a/ee/cis/macos-26/test/scripts/CIS_2.6.8_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.6.8_pass.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# CIS 2.6.8 - Ensure an Administrator Password Is Required to Access System-Wide Preferences
+# Rewrites each relevant authorizationdb right so shared=false, group=admin,
+# authenticate-user=true, session-owner=false. Mirrors the CIS remediation script.
+authDBs=(
+  "system.preferences"
+  "system.preferences.energysaver"
+  "system.preferences.network"
+  "system.preferences.printing"
+  "system.preferences.sharing"
+  "system.preferences.softwareupdate"
+  "system.preferences.startupdisk"
+  "system.preferences.timemachine"
+)
+
+for section in "${authDBs[@]}"; do
+  plist="/tmp/$section.plist"
+  /usr/bin/sudo /usr/bin/security -q authorizationdb read "$section" > "$plist"
+
+  class_key_value=$(/usr/libexec/PlistBuddy -c "Print :class" "$plist" 2>&1)
+  if [[ "$class_key_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :class string user" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Set :class user" "$plist"
+  fi
+
+  shared_value=$(/usr/libexec/PlistBuddy -c "Print :shared" "$plist" 2>&1)
+  if [[ "$shared_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :shared bool false" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Set :shared false" "$plist"
+  fi
+
+  auth_user_value=$(/usr/libexec/PlistBuddy -c "Print :authenticate-user" "$plist" 2>&1)
+  if [[ "$auth_user_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :authenticate-user bool true" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Set :authenticate-user true" "$plist"
+  fi
+
+  session_owner_value=$(/usr/libexec/PlistBuddy -c "Print :session-owner" "$plist" 2>&1)
+  if [[ "$session_owner_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :session-owner bool false" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Set :session-owner false" "$plist"
+  fi
+
+  group_value=$(/usr/libexec/PlistBuddy -c "Print :group" "$plist" 2>&1)
+  if [[ "$group_value" == *"Does Not Exist"* ]]; then
+    /usr/libexec/PlistBuddy -c "Add :group string admin" "$plist"
+  else
+    /usr/libexec/PlistBuddy -c "Set :group admin" "$plist"
+  fi
+
+  /usr/bin/sudo /usr/bin/security -q authorizationdb write "$section" < "$plist"
+  /bin/rm -f "$plist"
+done

--- a/ee/cis/macos-26/test/scripts/CIS_2.7.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.7.1_fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 2.7.1 - Ensure Screen Saver Corners Are Secure
+# Sets one corner to 6 ("Disable Screen Saver") on the console user so the query fails.
+user=$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null)
+if [ -n "$user" ] && [ "$user" != "root" ]; then
+  /usr/bin/sudo -u "$user" /usr/bin/defaults write com.apple.dock wvous-br-corner -int 6
+fi

--- a/ee/cis/macos-26/test/scripts/CIS_2.7.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_2.7.1_pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 2.7.1 - Ensure Screen Saver Corners Are Secure
+# Sets all four hot corners to 0 (no action, != 6) for every local user so the query passes.
+for userhome in /Users/*; do
+  user=$(basename "$userhome")
+  case "$user" in
+    Shared|Guest|.*) continue ;;
+  esac
+  if [ ! -d "$userhome/Library/Preferences" ]; then
+    continue
+  fi
+  for corner in wvous-tl-corner wvous-tr-corner wvous-bl-corner wvous-br-corner; do
+    /usr/bin/sudo -u "$user" /usr/bin/defaults write com.apple.dock "$corner" -int 0
+  done
+done

--- a/ee/cis/macos-26/test/scripts/CIS_3.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.1_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 3.1 - Ensure Security Auditing Is Enabled
+# Unloads auditd so the query fails.
+/usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/com.apple.auditd.plist 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_3.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.1_pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 3.1 - Ensure Security Auditing Is Enabled
+# Loads auditd and stages the audit_control file so the query passes.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+/usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.auditd.plist

--- a/ee/cis/macos-26/test/scripts/CIS_3.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.2_fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 3.2 - Ensure Security Auditing Flags Are Configured
+# Sets flags to an incomplete set (only lo) so the query fails.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+TMP="$(/usr/bin/mktemp /tmp/audit_control.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^flags:/ { print "flags:lo"; found=1; next }
+  { print }
+  END { if (!found) print "flags:lo" }
+' /etc/security/audit_control > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod 0440 /etc/security/audit_control

--- a/ee/cis/macos-26/test/scripts/CIS_3.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.2_pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 3.2 - Ensure Security Auditing Flags Are Configured
+# Sets the flags line to include aa, ad, -ex, -fm, -fr, -fw, lo.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+TMP="$(/usr/bin/mktemp /tmp/audit_control.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^flags:/ { print "flags:aa,ad,-ex,-fm,-fr,-fw,lo"; found=1; next }
+  { print }
+  END { if (!found) print "flags:aa,ad,-ex,-fm,-fr,-fw,lo" }
+' /etc/security/audit_control > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod 0440 /etc/security/audit_control

--- a/ee/cis/macos-26/test/scripts/CIS_3.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.3_fail.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# CIS 3.3 - Ensure install.log Is Retained for 365 or More Days and No Maximum Size
+# Sets ttl to 30 (too low) AND adds an all_max= value so the query fails.
+TMP="$(/usr/bin/mktemp /tmp/com.apple.install.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^\>[[:space:]]*\/var\/log\/install\.log/ || /file .*\/var\/log\/install\.log/ {
+    if (match($0, /ttl=[0-9]+/)) {
+      sub(/ttl=[0-9]+/, "ttl=30")
+    } else {
+      sub(/$/, " ttl=30")
+    }
+    if (!match($0, /all_max=/)) {
+      sub(/$/, " all_max=50M")
+    }
+    print
+    next
+  }
+  { print }
+' /etc/asl/com.apple.install > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/asl/com.apple.install
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/asl/com.apple.install
+/usr/bin/sudo /bin/chmod 0644 /etc/asl/com.apple.install

--- a/ee/cis/macos-26/test/scripts/CIS_3.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.3_fail.sh
@@ -3,7 +3,7 @@
 # Sets ttl to 30 (too low) AND adds an all_max= value so the query fails.
 TMP="$(/usr/bin/mktemp /tmp/com.apple.install.XXXXXX)"
 /usr/bin/sudo /usr/bin/awk '
-  /^\>[[:space:]]*\/var\/log\/install\.log/ || /file .*\/var\/log\/install\.log/ {
+  /^\>[[:space:]]*(\/var\/log\/)?install\.log/ || /[[:space:]]file[[:space:]]+(\/var\/log\/)?install\.log/ {
     if (match($0, /ttl=[0-9]+/)) {
       sub(/ttl=[0-9]+/, "ttl=30")
     } else {

--- a/ee/cis/macos-26/test/scripts/CIS_3.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.3_pass.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# CIS 3.3 - Ensure install.log Is Retained for 365 or More Days and No Maximum Size
+# Updates ttl to 365 and strips all_max= from the file-level line in /etc/asl/com.apple.install.
+TMP="$(/usr/bin/mktemp /tmp/com.apple.install.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^\>[[:space:]]*\/var\/log\/install\.log/ || /file .*\/var\/log\/install\.log/ {
+    gsub(/all_max=[0-9KMGkmg]+/, "")
+    if (match($0, /ttl=[0-9]+/)) {
+      sub(/ttl=[0-9]+/, "ttl=365")
+    } else {
+      sub(/$/, " ttl=365")
+    }
+    gsub(/[[:space:]]+/, " ")
+    print
+    next
+  }
+  { print }
+' /etc/asl/com.apple.install > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/asl/com.apple.install
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/asl/com.apple.install
+/usr/bin/sudo /bin/chmod 0644 /etc/asl/com.apple.install

--- a/ee/cis/macos-26/test/scripts/CIS_3.4_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.4_fail.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 3.4 - Ensure Security Auditing Retention Is Enabled
+# Sets expire-after to a value below threshold so the query fails.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+TMP="$(/usr/bin/mktemp /tmp/audit_control.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^expire-after:/ { print "expire-after:7d OR 1G"; found=1; next }
+  { print }
+  END { if (!found) print "expire-after:7d OR 1G" }
+' /etc/security/audit_control > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod 0440 /etc/security/audit_control

--- a/ee/cis/macos-26/test/scripts/CIS_3.4_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.4_pass.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# CIS 3.4 - Ensure Security Auditing Retention Is Enabled
+# Sets expire-after to 60d OR 5G so the query passes.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+TMP="$(/usr/bin/mktemp /tmp/audit_control.XXXXXX)"
+/usr/bin/sudo /usr/bin/awk '
+  /^expire-after:/ { print "expire-after:60d OR 5G"; found=1; next }
+  { print }
+  END { if (!found) print "expire-after:60d OR 5G" }
+' /etc/security/audit_control > "$TMP"
+/usr/bin/sudo /bin/mv "$TMP" /etc/security/audit_control
+/usr/bin/sudo /usr/sbin/chown root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod 0440 /etc/security/audit_control

--- a/ee/cis/macos-26/test/scripts/CIS_3.5_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.5_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 3.5 - Ensure Access to Audit Records Is Controlled
+# Loosens audit_control permissions so the query fails.
+if [ -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/chmod 644 /etc/security/audit_control
+fi

--- a/ee/cis/macos-26/test/scripts/CIS_3.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_3.5_pass.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# CIS 3.5 - Ensure Access to Audit Records Is Controlled
+# Sets audit_control and the dir: target to root:wheel mode 440.
+if [ ! -f /etc/security/audit_control ]; then
+  /usr/bin/sudo /bin/cp /etc/security/audit_control.example /etc/security/audit_control
+fi
+/usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/security/audit_control
+/usr/bin/sudo /bin/chmod -R 440 /etc/security/audit_control
+
+auditdir=$(/usr/bin/sudo /usr/bin/grep '^dir' /etc/security/audit_control | /usr/bin/awk -F: '{print $2}')
+if [ -n "$auditdir" ] && [ -d "$auditdir" ]; then
+  /usr/bin/sudo /usr/sbin/chown -R root:wheel "$auditdir"
+  /usr/bin/sudo /bin/chmod -R 440 "$auditdir"
+fi

--- a/ee/cis/macos-26/test/scripts/CIS_4.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_4.2_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 4.2 - Ensure HTTP Server Is Disabled
+# Loads Apache and starts httpd so the query fails.
+/usr/bin/sudo /bin/launchctl load -w /System/Library/LaunchDaemons/org.apache.httpd.plist 2>/dev/null || true
+/usr/bin/sudo /usr/sbin/apachectl start 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_4.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_4.2_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 4.2 - Ensure HTTP Server Is Disabled
+# Stops Apache and unloads the LaunchDaemon so no httpd process is running.
+/usr/bin/sudo /usr/sbin/apachectl stop 2>/dev/null || true
+/usr/bin/sudo /bin/launchctl unload -w /System/Library/LaunchDaemons/org.apache.httpd.plist 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_4.3_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_4.3_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 4.3 - Ensure NFS Server Is Disabled
+# Creates /etc/exports and starts nfsd so the query fails.
+echo "# test exports for CIS 4.3 regression" | /usr/bin/sudo /usr/bin/tee /etc/exports > /dev/null
+/usr/bin/sudo /bin/launchctl enable system/com.apple.nfsd 2>/dev/null || true
+/usr/bin/sudo /sbin/nfsd start 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_4.3_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_4.3_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 4.3 - Ensure NFS Server Is Disabled
+# Disables nfsd and removes /etc/exports so the query passes.
+/usr/bin/sudo /bin/launchctl disable system/com.apple.nfsd 2>/dev/null || true
+/usr/bin/sudo /sbin/nfsd stop 2>/dev/null || true
+/usr/bin/sudo /bin/rm -rf /etc/exports

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.1_fail.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 5.1.1 - Ensure Home Folders Are Secure
+# Loosens console user's home folder to 755 so the query fails.
+user=$(/usr/bin/stat -f "%Su" /dev/console 2>/dev/null)
+if [ -n "$user" ] && [ "$user" != "root" ] && [ -d "/Users/$user" ]; then
+  /usr/bin/sudo /bin/chmod 755 "/Users/$user"
+fi

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.1_pass.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# CIS 5.1.1 - Ensure Home Folders Are Secure
+# Tightens permissions on each user home folder to 700 so the query passes.
+for userhome in /Users/*; do
+  user=$(basename "$userhome")
+  case "$user" in
+    Shared|Guest|.*) continue ;;
+  esac
+  [ -d "$userhome" ] || continue
+  /usr/bin/sudo /bin/chmod 700 "$userhome"
+done

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.5_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.5_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.1.5 - Ensure Appropriate Permissions Are Enabled for System Wide Applications
+# Creates a stub world-writable .app bundle so the query fails.
+stubapp="/Applications/CIS_Test_World_Writable.app"
+/usr/bin/sudo /bin/mkdir -p "$stubapp/Contents"
+/usr/bin/sudo /bin/chmod 777 "$stubapp"

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.5_pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 5.1.5 - Ensure Appropriate Permissions Are Enabled for System Wide Applications
+# Removes world-write bit from every .app in /Applications so the query passes.
+IFS=$'\n'
+for app in $(/usr/bin/find /Applications -iname "*.app" -type d -perm -2 2>/dev/null); do
+  /usr/bin/sudo /bin/chmod -R o-w "$app"
+done

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.5_pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # CIS 5.1.5 - Ensure Appropriate Permissions Are Enabled for System Wide Applications
 # Removes world-write bit from every .app in /Applications so the query passes.
+# Also cleans up the stub bundle the _fail.sh script may have created, so it
+# doesn't persist across runs.
+/usr/bin/sudo /bin/rm -rf /Applications/CIS_Test_World_Writable.app
 IFS=$'\n'
 for app in $(/usr/bin/find /Applications -iname "*.app" -type d -perm -2 2>/dev/null); do
   /usr/bin/sudo /bin/chmod -R o-w "$app"

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.6.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.6.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 5.1.6 - Ensure No World Writable Folders Exist in the System Folder
+# Removes world-write bit from any directory found under /System/Volumes/Data/System.
+IFS=$'\n'
+for d in $(/usr/bin/find /System/Volumes/Data/System -type d -perm -2 2>/dev/null | /usr/bin/grep -vE "downloadDir|locks"); do
+  /usr/bin/sudo /bin/chmod -R o-w "$d"
+done

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.7_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.7_fail.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 5.1.7 - Ensure No World Writable Folders Exist in the Library Folder
+# Creates a stub world-writable directory under /Library so the query fails.
+/usr/bin/sudo /bin/mkdir -p /Library/CIS_Test_World_Writable
+/usr/bin/sudo /bin/chmod 777 /Library/CIS_Test_World_Writable

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.7_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.7_pass.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # CIS 5.1.7 - Ensure No World Writable Folders Exist in the Library Folder
 # Removes world-write bit from non-sticky, non-rootless directories under /Library.
+# Also cleans up the stub directory the _fail.sh script may have created, so it
+# doesn't persist across runs.
+/usr/bin/sudo /bin/rm -rf /Library/CIS_Test_World_Writable
 IFS=$'\n'
 for d in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
   /usr/bin/sudo /bin/chmod -R o-w "$d"

--- a/ee/cis/macos-26/test/scripts/CIS_5.1.7_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.1.7_pass.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# CIS 5.1.7 - Ensure No World Writable Folders Exist in the Library Folder
+# Removes world-write bit from non-sticky, non-rootless directories under /Library.
+IFS=$'\n'
+for d in $(/usr/bin/find /Library -type d -perm -002 ! -perm -1000 ! -xattrname com.apple.rootless 2>/dev/null); do
+  /usr/bin/sudo /bin/chmod -R o-w "$d"
+done

--- a/ee/cis/macos-26/test/scripts/CIS_5.10_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.10_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.10 - Ensure XProtect Is Running and Updated
+# Loads both XProtect launch daemons and triggers an update.
+/usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XProtect.daemon.scan.plist 2>/dev/null || true
+/usr/bin/sudo /bin/launchctl load -w /Library/Apple/System/Library/LaunchDaemons/com.apple.XprotectFramework.PluginService.plist 2>/dev/null || true
+/usr/bin/sudo /usr/bin/xprotect update 2>/dev/null || true

--- a/ee/cis/macos-26/test/scripts/CIS_5.11_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.11_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.11 - Ensure Logging Is Enabled for Sudo
+# Removes the log_allowed override so sudo logging reverts to the default (disabled).
+/usr/bin/sudo /bin/rm -f /etc/sudoers.d/CIS_5_11_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.11_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.11_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 5.11 - Ensure Logging Is Enabled for Sudo
+# Adds Defaults log_allowed to a sudoers.d file.
+echo 'Defaults log_allowed' | /usr/bin/sudo /usr/bin/tee /etc/sudoers.d/CIS_5_11_sudoconfiguration > /dev/null
+/usr/bin/sudo /bin/chmod 0440 /etc/sudoers.d/CIS_5_11_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.1_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.1_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.1 - Ensure Password Account Lockout Threshold Is Configured
+# Sets maxFailedLoginAttempts to 20 (above threshold) so the query fails.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxFailedLoginAttempts=20"

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.1_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.1_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.1 - Ensure Password Account Lockout Threshold Is Configured
+# Sets maxFailedLoginAttempts=5 via pwpolicy so the query passes.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxFailedLoginAttempts=5"

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.2_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.2_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.2 - Ensure Password Minimum Length Is Configured
+# Sets minChars=8 (below threshold) so the query fails.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "minChars=8"

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.2_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.2_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.2 - Ensure Password Minimum Length Is Configured
+# Sets minChars=15 via pwpolicy so the query passes.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "minChars=15"

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.7_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.7_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.7 - Ensure Password Age Is Configured
+# Clears the password age policy so the query fails.
+/usr/bin/sudo /usr/bin/pwpolicy -clearaccountpolicies

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.7_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.7_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.7 - Ensure Password Age Is Configured
+# Sets maxMinutesUntilChangePassword so the password expires in ≤365 days.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "maxMinutesUntilChangePassword=525600"

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.8_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.8_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.8 - Ensure Password History Is Set to at Least 24
+# Clears all password policies so the query fails.
+/usr/bin/sudo /usr/bin/pwpolicy -clearaccountpolicies

--- a/ee/cis/macos-26/test/scripts/CIS_5.2.8_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.2.8_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.2.8 - Ensure Password History Is Set to at Least 24
+# Sets usingHistory=24 via pwpolicy so the query passes.
+/usr/bin/sudo /usr/bin/pwpolicy -n /Local/Default -setglobalpolicy "usingHistory=24"

--- a/ee/cis/macos-26/test/scripts/CIS_5.4_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.4_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.4 - Ensure the Sudo Timeout Period Is Set to Zero
+# Removes the timeout override so sudo reverts to the default 5-minute grace window.
+/usr/bin/sudo /bin/rm -f /etc/sudoers.d/CIS_5_4_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.4_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.4_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.4 - Ensure the Sudo Timeout Period Is Set to Zero
+# Adds Defaults timestamp_timeout=0 to a sudoers.d file.
+/usr/bin/sudo /usr/sbin/chown -R root:wheel /etc/sudoers.d/
+echo 'Defaults timestamp_timeout=0' | /usr/bin/sudo /usr/bin/tee /etc/sudoers.d/CIS_5_4_sudoconfiguration > /dev/null
+/usr/bin/sudo /bin/chmod 0440 /etc/sudoers.d/CIS_5_4_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.5_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.5_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.5 - Ensure a Separate Timestamp Is Enabled for Each User/tty Combo
+# Overrides tty_tickets back to global so the query fails.
+echo 'Defaults !tty_tickets' | /usr/bin/sudo /usr/bin/tee /etc/sudoers.d/CIS_5_5_sudoconfiguration > /dev/null
+echo 'Defaults timestamp_type=global' | /usr/bin/sudo /usr/bin/tee -a /etc/sudoers.d/CIS_5_5_sudoconfiguration > /dev/null
+/usr/bin/sudo /bin/chmod 0440 /etc/sudoers.d/CIS_5_5_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.5_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.5_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 5.5 - Ensure a Separate Timestamp Is Enabled for Each User/tty Combo
+# Adds Defaults timestamp_type=tty to a sudoers.d file.
+echo 'Defaults timestamp_type=tty' | /usr/bin/sudo /usr/bin/tee /etc/sudoers.d/CIS_5_5_sudoconfiguration > /dev/null
+/usr/bin/sudo /bin/chmod 0440 /etc/sudoers.d/CIS_5_5_sudoconfiguration

--- a/ee/cis/macos-26/test/scripts/CIS_5.6_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.6_pass.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# CIS 5.6 - Ensure the "root" Account Is Disabled
+# Disables the root account and sets its shell to /usr/bin/false.
+/usr/bin/sudo /usr/sbin/dsenableroot -d 2>/dev/null || true
+/usr/bin/sudo /usr/bin/dscl . -create /Users/root UserShell /usr/bin/false

--- a/ee/cis/macos-26/test/scripts/CIS_5.7_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.7_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.7 - Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session
+# Restores the default authorizationdb so the query fails.
+/usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner-or-admin

--- a/ee/cis/macos-26/test/scripts/CIS_5.7_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.7_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.7 - Ensure an Administrator Account Cannot Login to Another User's Active and Locked Session
+# Sets the system.login.screensaver authorization to require the session owner.
+/usr/bin/sudo /usr/bin/security authorizationdb write system.login.screensaver authenticate-session-owner
+# Re-enable Touch ID for users.
+/usr/bin/sudo /usr/bin/defaults write /Library/Preferences/com.apple.loginwindow screenUnlockMode -int 1

--- a/ee/cis/macos-26/test/scripts/CIS_5.8_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.8_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.8 - Ensure a Login Window Banner Exists
+# Removes the PolicyBanner files so the query fails.
+/usr/bin/sudo /bin/rm -f /Library/Security/PolicyBanner.txt /Library/Security/PolicyBanner.rtf

--- a/ee/cis/macos-26/test/scripts/CIS_5.8_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.8_pass.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# CIS 5.8 - Ensure a Login Window Banner Exists
+# Creates /Library/Security/PolicyBanner.txt with organization-defined text.
+echo "Authorized use only. Activity may be monitored." | /usr/bin/sudo /usr/bin/tee /Library/Security/PolicyBanner.txt > /dev/null
+/usr/bin/sudo /usr/sbin/chown root:wheel /Library/Security/PolicyBanner.txt
+/usr/bin/sudo /bin/chmod 0644 /Library/Security/PolicyBanner.txt

--- a/ee/cis/macos-26/test/scripts/CIS_5.9_fail.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.9_fail.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.9 - Ensure the Guest Home Folder Does Not Exist
+# Creates /Users/Guest so the query fails.
+/usr/bin/sudo /bin/mkdir -p /Users/Guest

--- a/ee/cis/macos-26/test/scripts/CIS_5.9_pass.sh
+++ b/ee/cis/macos-26/test/scripts/CIS_5.9_pass.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# CIS 5.9 - Ensure the Guest Home Folder Does Not Exist
+# Removes /Users/Guest if it is present.
+/usr/bin/sudo /bin/rm -rf /Users/Guest

--- a/ee/cis/prompt.md
+++ b/ee/cis/prompt.md
@@ -41,9 +41,9 @@ and documentation.
 
 Skip this step when upgrading an existing OS version's benchmark.
 
-For a brand-new OS version (e.g. `macos-26` when only
-`macos-13/14/15` exist), follow CIS-BENCHMARKS.md §Adding a new
-macOS version **before** writing any policies:
+For a brand-new OS version (e.g. `macos-27` when the latest
+directory in `ee/cis/` is `macos-26`), follow CIS-BENCHMARKS.md
+§Adding a new macOS version **before** writing any policies:
 
 1. Create the `ee/cis/<os-dir>/` scaffold (policy YAML, README,
    `test/scripts/`, `test/profiles/`).

--- a/ee/cis/prompt.md
+++ b/ee/cis/prompt.md
@@ -5,7 +5,7 @@ benchmark policies, test scripts, MDM profiles, and documentation from
 a CIS PDF. Feed it to the agent alongside the relevant PDFs.
 
 Conventions (directory layout, YAML format, query patterns, script and
-profile naming, test runner invocation) live in `CIS-BENCHMARK.md` in
+profile naming, test runner invocation) live in `CIS-BENCHMARKS.md` in
 this directory. This file is a task harness; the reference doc is the
 source of truth. If they disagree, update whichever is wrong.
 
@@ -17,7 +17,7 @@ documents.
 
 All conventions (directory layout, YAML format, required fields, query
 patterns, script/profile naming, README structure, test runner
-invocation) are documented in `ee/cis/CIS-BENCHMARK.md`. Read that
+invocation) are documented in `ee/cis/CIS-BENCHMARKS.md`. Read that
 file before you begin. Do not invent conventions — if something is not
 documented, ask the user.
 
@@ -33,7 +33,7 @@ and documentation.
 - CIS benchmark PDF (previous version, if upgrading): `pdf/<filename>.pdf`
 - Existing policies (if upgrading): `ee/cis/<os-dir>/cis-policy-queries.yml`
 - Existing tests: `ee/cis/<os-dir>/test/scripts/` and `test/profiles/`
-- Conventions: `ee/cis/CIS-BENCHMARK.md`
+- Conventions: `ee/cis/CIS-BENCHMARKS.md`
 
 ## Step-by-step workflow
 
@@ -65,7 +65,7 @@ Fleet policies. Note them for the README.md limitations section.
 ### Step 3: Generate policy YAML
 
 For each Automated recommendation, write a policy document following
-the format in CIS-BENCHMARK.md (§Policy format). Follow the query
+the format in CIS-BENCHMARKS.md (§Policy format). Follow the query
 rules in §Query patterns — queries MUST return 1+ rows when compliant
 and 0 rows when not.
 

--- a/ee/cis/prompt.md
+++ b/ee/cis/prompt.md
@@ -37,6 +37,22 @@ and documentation.
 
 ## Step-by-step workflow
 
+### Step 0: If this is a new OS version, scaffold and register it first
+
+Skip this step when upgrading an existing OS version's benchmark.
+
+For a brand-new OS version (e.g. `macos-26` when only
+`macos-13/14/15` exist), follow CIS-BENCHMARKS.md §Adding a new
+macOS version **before** writing any policies:
+
+1. Create the `ee/cis/<os-dir>/` scaffold (policy YAML, README,
+   `test/scripts/`, `test/profiles/`).
+2. Register the version in `tools/cis/cis-test-runner.py` — four
+   dict entries (`VERSION_MAP`, `SSH_BREAKING_CIS_IDS`,
+   `PASSWORD_POLICY_CIS_IDS`, `NON_AUTOMATABLE_CIS_IDS`).
+3. Confirm the Tart base image for the target macOS version is
+   published; if not, flag it in the state file and continue.
+
 ### Step 1: Extract the changelog
 
 Read the "Appendix: Change History" from the end of the new PDF.
@@ -45,6 +61,14 @@ MODIFIED, or REMOVED.
 
 If this is a new OS version (no existing policies), treat every
 recommendation as ADDED.
+
+**Also diff Assessment Status against the previous version.**
+The Change History does not always flag Automated → Manual
+downgrades. Scan each previous-version Automated recommendation
+in the new PDF's §<same-id> and check whether its Assessment
+Status is still Automated. Any downgrade means the existing
+policy must be deleted (CIS-BENCHMARKS.md §Updating benchmarks
+step 4).
 
 ### Step 2: Read affected sections
 
@@ -74,6 +98,12 @@ on `managed_policies` (`(MDM Required)`), fleetd-only tables
 (`(Fleetd Required)`), or files needing full disk access
 (`(FDA Required)`).
 
+Before writing a query against a fleetd table, verify its column
+names against CIS-BENCHMARKS.md §Fleetd tables used by CIS
+queries, and check the console-user-scope caveat. If you reach
+for a table not listed there, read its source at
+`orbit/pkg/table/<name>/` first.
+
 ### Step 4: Generate test artifacts
 
 Decide which artifact to create based on the remediation method in
@@ -82,7 +112,9 @@ the PDF, following §Choosing between scripts and profiles.
 - Scripts: shell commands exist in the PDF's remediation. Create
   `test/scripts/CIS_<cis_id>_pass.sh` and `_fail.sh`, or a single
   `CIS_<cis_id>.sh` if only the pass direction is scriptable. Use
-  §Test scripts and §Script conventions.
+  §Test scripts, §Script conventions, and §Common script patterns
+  (console-user detection, `/Users/*` iteration, sudoers.d
+  filename rule, atomic config-file edits).
 - Profiles only: the setting is MDM-only (query uses
   `managed_policies`, PDF only provides a Profile Method). Create
   `test/profiles/<cis_id>.mobileconfig`. The test runner handles
@@ -95,6 +127,12 @@ For each policy that checks `managed_policies`, create a
 `.mobileconfig` using the XML template and naming conventions in
 §MDM configuration profiles. For org-decision policies, create both
 `-enable` and `-disable` variants.
+
+When a benchmark specifies multiple keys for the same PayloadType
+(or explicitly requires two IDs to share one profile), follow
+§Multi-key profiles — one payload dict with multiple keys, named
+either `{cis_id}.mobileconfig` or `{id1}-and-{id2}.mobileconfig`
+depending on scope.
 
 ### Step 6: Update README.md
 

--- a/tools/cis/cis-test-runner.py
+++ b/tools/cis/cis-test-runner.py
@@ -50,6 +50,10 @@ VERSION_MAP = {
         "image": "ghcr.io/cirruslabs/macos-sequoia-base:latest",
         "dir": "macos-15",
     },
+    "26": {
+        "image": "ghcr.io/cirruslabs/macos-tahoe-base:latest",
+        "dir": "macos-26",
+    },
 }
 
 SSH_OPTS = "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR"
@@ -76,6 +80,9 @@ SSH_BREAKING_CIS_IDS: dict[str, set[str]] = {
     # macOS 15 Sequoia v2.0.0:
     #   2.3.3.4 - Ensure Remote Login Is Disabled (disables sshd)
     "15": {"2.3.3.4"},
+    # macOS 26 Tahoe v1.0.0:
+    #   2.3.3.4 - Ensure Remote Login Is Disabled (disables sshd)
+    "26": {"2.3.3.4"},
 }
 
 # CIS IDs whose MDM profiles break VM password authentication (the
@@ -95,6 +102,7 @@ PASSWORD_POLICY_CIS_IDS: dict[str, set[str]] = {
     "13": set(),
     "14": {"5.2.1", "5.2.2", "5.2.3", "5.2.4", "5.2.5", "5.2.6", "5.2.7", "5.2.8"},
     "15": set(),
+    "26": set(),
 }
 
 # CIS IDs that cannot be reliably tested automatically due to one of:
@@ -140,6 +148,7 @@ NON_AUTOMATABLE_CIS_IDS: dict[str, dict[str, str]] = {
         "2.8.1": "Universal Control profile toggling unreliable",
     },
     "15": {},
+    "26": {},
 }
 
 # ---------------------------------------------------------------------------
@@ -1709,7 +1718,8 @@ Examples:
             "chosen based on --macos-version: "
             "13=ghcr.io/cirruslabs/macos-ventura-base:latest, "
             "14=ghcr.io/cirruslabs/macos-sonoma-base:latest, "
-            "15=ghcr.io/cirruslabs/macos-sequoia-base:latest."
+            "15=ghcr.io/cirruslabs/macos-sequoia-base:latest, "
+            "26=ghcr.io/cirruslabs/macos-tahoe-base:latest."
         ),
     )
 

--- a/tools/cis/cis-test-runner.py
+++ b/tools/cis/cis-test-runner.py
@@ -73,7 +73,9 @@ SSH_BREAKING_CIS_IDS: dict[str, set[str]] = {
     #   2.3.3.5 - Ensure Remote Management Is Disabled (also disables sshd)
     "13": set(),
     "14": {"2.3.3.4", "2.3.3.5"},
-    "15": set(),
+    # macOS 15 Sequoia v2.0.0:
+    #   2.3.3.4 - Ensure Remote Login Is Disabled (disables sshd)
+    "15": {"2.3.3.4"},
 }
 
 # CIS IDs whose MDM profiles break VM password authentication (the


### PR DESCRIPTION
**Related issue:** Resolves #35173

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing
- [x] Added/updated automated tests (pass/fail scripts and `.mobileconfig` profiles under `ee/cis/macos-26/test/`)

# macOS 26 Tahoe CIS benchmark v1.0.0 (new benchmark)

Adds a brand-new policy set covering the **CIS Apple macOS 26 Tahoe Benchmark, v1.0.0** under `ee/cis/macos-26/`. Follows the same layout as `macos-13`/`-14`/`-15` (`cis-policy-queries.yml`, `README.md`, `test/scripts/`, `test/profiles/`).

## Coverage

| Section | Title | Status |
|---|---|---|
| 1 | Install Updates, Patches and Additional Security Software | complete (6/6 automated) |
| 2 | System Settings | complete (all automated across §2.1–§2.18) |
| 3 | Logging and Auditing | complete (5/5 automated) |
| 4 | Network Configurations | complete (3/3 automated) |
| 5 | System Access, Authentication and Authorization | complete (19/19 automated) |
| 6 | Applications | complete (7/7 automated) |
| 7 | Supplemental | skipped (per Fleet convention) |

Total automated policies shipped: **89**. Manual-assessment recommendations are documented in `ee/cis/macos-26/README.md` under **Limitations**.

## Notable query/format choices

- **Combined-key profiles per CIS instructions.** §2.2.1+§2.2.2 (Firewall + Stealth Mode) are shipped as a single `2.2.1-and-2.2.2.mobileconfig` because CIS explicitly requires both keys in the same profile. §2.6.5 (Gatekeeper) and §2.11.2 (screensaver wake-password + delay) follow the same pattern.
- **§2.5.2.1 (Siri)** uses the new `allowAssistant=false` key on `com.apple.applicationaccess`, replacing the deprecated `com.apple.ironwood.support` payload from earlier benchmarks.
- **§2.6.3.2** uses the spaced literal key `Siri Data Sharing Opt-In Status` (integer 2) on `com.apple.assistant.support` — the v1.0.0 PayloadType move from `com.apple.applicationaccess`.
- **§5.1.6, §5.1.7, §3.1, §5.7** use fleetd-only osquery tables (`find_cmd`, `authdb`, `pwd_policy`, `dscl`, etc.) and are flagged `(Fleetd Required)` in the policy descriptions.
- **§2.10.1.2** (Apple Silicon sleep ≤15 min) default-passes on Intel hosts via a `system_info.cpu_type` check.

## Test artifacts added

| Type | Count | Location |
|---|---|---|
| Pass scripts | 48 | `ee/cis/macos-26/test/scripts/CIS_*_pass.sh` |
| Fail scripts | 46 | `ee/cis/macos-26/test/scripts/CIS_*_fail.sh` |
| Pass-only scripts | 2 | `CIS_1.1.sh`, `CIS_5.1.6.sh` |
| MDM profiles | 37 | `ee/cis/macos-26/test/profiles/*.mobileconfig` |

Profile-only recommendations (§2.3.1.x AirDrop/AirPlay, §2.5.x Apple Intelligence, §2.6.3.x Analytics, §6.x Safari/Terminal) ship with a `.mobileconfig` only and no script counterpart, since CIS marks them as configurable solely via profile.

## Documentation updates

| File | Change |
|---|---|
| `ee/cis/macos-26/README.md` | New file — coverage table, limitations, per-section notes (query patterns, fleetd dependencies, FDA requirements). |
| `ee/cis/CIS-BENCHMARKS.md` | Added `macos-26/` to the directory layout; updated **Query patterns** doc to include the `EXISTS`/`NOT EXISTS` user-vs-system-scope guidance and `username = ''` notes. |
| `ee/cis/prompt.md` | Refreshed authoring prompts with macOS-26 conventions (combined-key profiles, fleetd-table flagging). |
| `tools/cis/cis-test-runner.py` | Minor adjustments to support the new benchmark directory. |
| `changes/35173-cis-macos-26-v1` | User-visible change note. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS 26 CIS Benchmark v1.0.0 with comprehensive configuration profiles to enforce recommended system and app settings (updates, firewall/stealth, privacy, backups, FileVault, Safari, Terminal, etc.).

* **Tests**
  * Added extensive pass/fail remediation and validation scripts for CIS controls across macOS subsystems; test runner updated to include macOS 26 support and mark an SSH-related control as manual.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->