### PR TITLE
Cherry-pick: Bump Alpine base image to 3.23.4 to resolve openssl/musl/zlib CVEs (#43671)

### DIFF
--- a/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
+++ b/infrastructure/loadtesting/terraform/docker/loadtest.Dockerfile
@@ -21,7 +21,7 @@ RUN cd /go/fleet/cmd/osquery-perf/software-library && \
     sqlite3 software.db "SELECT COUNT(*) FROM software;" && \
     echo "Successfully generated software.db ($(du -h software.db | cut -f1))"
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="Fleet Developers"
 
 # Create FleetDM group and user

--- a/server/mdm/scep/Dockerfile
+++ b/server/mdm/scep/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 
 COPY ./scepclient-linux-amd64 /usr/bin/scepclient
 COPY ./scepserver-linux-amd64 /usr/bin/scepserver

--- a/tools/fleet-docker/Dockerfile
+++ b/tools/fleet-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="Fleet Developers"
 
 RUN apk --update add ca-certificates

--- a/tools/mdm/migration/mdmproxy/Dockerfile
+++ b/tools/mdm/migration/mdmproxy/Dockerfile
@@ -3,7 +3,7 @@ ARG TAG
 RUN apk update && apk add --no-cache git
 RUN git clone -b $TAG --depth=1 --no-tags --progress --no-recurse-submodules https://github.com/fleetdm/fleet.git && cd /go/fleet/tools/mdm/migration/mdmproxy && go build .
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 LABEL maintainer="Fleet Developers"
 
 RUN apk update && apk add --no-cache tini


### PR DESCRIPTION
Cherry-picks #44097 into the 4.84.0 release candidate branch.

Resolves #43671 for the 4.84.0 release.

See #44097 for full context, CVE list, and verification that `sha256:5b10f432...` is the multi-arch manifest list digest for `alpine:3.23.4`.