### PR TITLE
Update why-fleet.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,6 +72,7 @@ go.mod @fleetdm/go
 /docs/Contributing/product-groups/orchestration/understanding-host-vitals.md @sharon-fdm @sgress454 @getvictor # software ingestion is security & compliance
 /docs/REST\ API/rest-api.md                             @rachaelshaw # « REST API reference documentation
 /docs/Contributing/reference                            @rachaelshaw
+/docs/Get\ started/why-fleet.md                         @mike-j-thomas
 /render.yaml                                            @edwardsb
 /it-and-security                                        @allenhouchins
 /articles/what-api-endpoints-to-expose-to-the-public-internet.md @rfairburn @BCTBB # « Infra: active notification of changes to IP Allowlists

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -1,32 +1,32 @@
 # Why Fleet
 
-Fleet is an open-source device management platform for Linux, macOS, Windows, Chromebooks, and iOS devices (BYOD or corporate owned.)
+Fleet is an open-source device management platform for macOS, Linux, Windows, Chromebooks, iOS, and Android devices (BYOD or corporate-owned).
 
 ## What's it for?
 
-Fleet gives IT and security teams a single system to secure and maintain all their computing devices. You can enforce MDM policies, patch vulnerabilities, deploy software, and verify device state—all from one place, across every platform your organization uses.
+Fleet gives you a single system to secure and maintain all your computing devices over the air. You can do MDM, patch stuff, deploy software, and verify anything–all from one place, across every OS and device your organization uses.
 
 Fleet is open source, and free features will always be free.
 
 ## Is it any good?
 
-Fleet is used in production by IT and security teams managing thousands to hundreds of thousands of devices. Many deployments support tens of thousands of hosts. A few large organizations manage 400,000+.
+Fleet is used in production by IT and security teams managing thousands of devices. Many deployments support tens of thousands, and a few large organizations manage 400,000 or more.
 
-- **Get what you need:** Fleet works directly with data and events from the native operating system, down to the bare metal. Strong diagnostics mean you can investigate errors on end-user devices, pull accurate evidence for audits, and answer security questions without waiting days for a report. Fleet is also modular—turn off features you don't use.
-- **Out of the box:** Ready-to-use integrations exist for [most common tools](https://fleetdm.com/integrations). Build custom workflows with the REST API, webhook events, and the fleetctl command-line tool. Or govern your entire fleet with infrastructure as code using [GitOps](https://fleetdm.com/docs/configuration/yaml-files). Fleet also ships an MCP server, so you can drive device management workflows from AI-powered chat interfaces like Claude or Copilot. Want to get hands-on? We run [free GitOps workshops globally](https://fleetdm.com/gitops-workshop).
+- **Get what you need:** Fleet works directly with data and events from the native operating system, down to the bare metal. Strong diagnostics let you investigate errors on end-user devices and collect accurate audit evidence in minutes. It’s also modular. (You can turn off features you are not using.)
+- **Out of the box:** Ready-to-use integrations exist for [most common tools](https://fleetdm.com/integrations). You can become a power user in the GUI or govern your fleet with [infrastructure-as-code](https://fleetdm.com/docs/configuration/yaml-files) or your favorite [AI tool](https://fleetdm.com/webinars/beyond-the-hype-practical-ai-for-device-management). You can also build custom workflows with the REST API, webhook events, MCP server, and the fleetctl command-line tool. 
 - **Good neighbors:** Fleet is independent and open by design. We helped [create osquery](https://fleetdm.com/handbook/company#history) and remain committed to improving it.
 - **Free as in free:** The free version of Fleet will [always be free](https://fleetdm.com/pricing). Fleet is independently backed and actively maintained with the help of many contributors.
 
 ## Scope transparency
 
-Fleet is transparent about what it can and can't see. IT and security teams can verify exactly how the agent works. End users can see what the agent is capable of and what kinds of data their company chooses to collect.
+Fleet is transparent about what it can and can't see. You can verify exactly how the agent works. End users can see what the agent is capable of and what kinds of data their company chooses to collect.
 
 Fleet is designed to collect only the data needed to manage and secure devices: things like user accounts, device health, installed software, and security settings. It isn't built to log private activity such as keystrokes, emails, or webcams.
 
-Fleet supports this across macOS, Windows, Linux, iOS, Android, and beyond. This way, users and teams share the same understanding of how devices are monitored and secured.
+This way, all users share the same understanding of how devices are monitored and secured.
 
 ## Ready to get started?
 
-[Install Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) on your own server, or [let us host it](https://fleetdm.com/register) for you. Enroll your devices, and you're set.
+[Install Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) on your own server, or [let us host it](https://fleetdm.com/pricing) for you. Enroll your devices, and you're set.
 
 <meta name="pageOrderInSection" value="100">

--- a/docs/Get started/why-fleet.md
+++ b/docs/Get started/why-fleet.md
@@ -4,31 +4,29 @@ Fleet is an open-source device management platform for Linux, macOS, Windows, Ch
 
 ## What's it for?
 
-Managing computers today is getting harder. You have to juggle a mix of operating systems and devices, with a bunch of middleman vendors in between. 
-
-Fleet makes things easier by giving you a single system to secure and maintain all your computing devices over the air. You can do MDM, patch stuff, and verify anything—all from one system. It's like having a universal remote control for all your organization's computers.
+Fleet gives IT and security teams a single system to secure and maintain all their computing devices. You can enforce MDM policies, patch vulnerabilities, deploy software, and verify device state—all from one place, across every platform your organization uses.
 
 Fleet is open source, and free features will always be free.
 
 ## Is it any good?
 
-Fleet is used in production by IT and security teams with thousands of laptops and servers. Many deployments support tens of thousands of hosts, and a few large organizations manage deployments as large as 400,000+ hosts.
+Fleet is used in production by IT and security teams managing thousands to hundreds of thousands of devices. Many deployments support tens of thousands of hosts. A few large organizations manage 400,000+.
 
-- **Get what you need:** Fleet lets you work directly with [data](https://fleetdm.com/integrations) and events from the native operating system. It lets you go all the way down to the bare metal. It’s also modular. (You can turn off features you are not using.)
-- **Out of the box:** Ready-to-use integrations exist for the [most common tools](https://fleetdm.com/integrations). You can also build custom workflows with the REST API, webhook events, and the fleetctl command line tool. Or go all in and govern computers [with GitOps](https://github.com/fleetdm/fleet-gitops).
-- **Good neighbors:** We think tools should be as easy as possible for everyone to understand. We helped [create osquery](https://fleetdm.com/handbook/company#history), and we are committed to improving it.
-- **Free as in free:** The free version of Fleet will [always be free](https://fleetdm.com/pricing). Fleet is independently backed and actively maintained with the help of many amazing contributors.
+- **Get what you need:** Fleet works directly with data and events from the native operating system, down to the bare metal. Strong diagnostics mean you can investigate errors on end-user devices, pull accurate evidence for audits, and answer security questions without waiting days for a report. Fleet is also modular—turn off features you don't use.
+- **Out of the box:** Ready-to-use integrations exist for [most common tools](https://fleetdm.com/integrations). Build custom workflows with the REST API, webhook events, and the fleetctl command-line tool. Or govern your entire fleet with infrastructure as code using [GitOps](https://fleetdm.com/docs/configuration/yaml-files). Fleet also ships an MCP server, so you can drive device management workflows from AI-powered chat interfaces like Claude or Copilot. Want to get hands-on? We run [free GitOps workshops globally](https://fleetdm.com/gitops-workshop).
+- **Good neighbors:** Fleet is independent and open by design. We helped [create osquery](https://fleetdm.com/handbook/company#history) and remain committed to improving it.
+- **Free as in free:** The free version of Fleet will [always be free](https://fleetdm.com/pricing). Fleet is independently backed and actively maintained with the help of many contributors.
 
 ## Scope transparency
 
-With Fleet, transparency is built in. IT and security teams can verify exactly how the agent works. End users can see what the agent is capable of and what kinds of data their company chooses to collect.
+Fleet is transparent about what it can and can't see. IT and security teams can verify exactly how the agent works. End users can see what the agent is capable of and what kinds of data their company chooses to collect.
 
-Fleet is designed to collect only the data needed to manage and secure devices—things like user accounts, device health, installed software, and security settings. It isn’t built to log private activity such as keystrokes, emails, or webcams.
+Fleet is designed to collect only the data needed to manage and secure devices: things like user accounts, device health, installed software, and security settings. It isn't built to log private activity such as keystrokes, emails, or webcams.
 
-This way, users and teams share the same understanding of how devices are monitored and secured—on macOS, Windows, Linux, Chromebooks, and beyond.
+Fleet supports this across macOS, Windows, Linux, iOS, Android, and beyond. This way, users and teams share the same understanding of how devices are monitored and secured.
 
 ## Ready to get started?
 
-Deploying Fleet is easy. [Install it](https://fleetdm.com/docs/deploy/deploy-fleet) on a server, or [we can host it](https://fleetdm.com/register) for you. Enroll your devices, and you're set.
+[Install Fleet](https://fleetdm.com/docs/deploy/deploy-fleet) on your own server, or [let us host it](https://fleetdm.com/register) for you. Enroll your devices, and you're set.
 
 <meta name="pageOrderInSection" value="100">


### PR DESCRIPTION
Updates why-fleet.md to better reflect how Fleet is used today.

Resolves https://docs.google.com/document/d/1rroNFfb8j8zGJdkZX1wUKuzXv3Kh-VNlFeN7P8kTtT8/edit?usp=sharing

Changes:

- Removed "Managing computers today is getting harder," the middleman framing, and the universal remote analogy from "What's it for?"
- Added diagnostics and audit use cases to "Get what you need."
- Called out IaC/GitOps directly in "Out of the box," with a link to the YAML files configuration docs.
- Added a mention of the Fleet MCP server and AI-powered chat workflows in "Out of the box."
- Added a link to GitOps workshops in "Out of the box," where IaC is introduced.
- Trimmed "Good neighbors" to its core point: Fleet is independent, open by design, and committed to osquery.
- Removed the extra dashes from "Scope transparency."
- De-emphasized Chromebooks in "Scope transparency" in favor of iOS and Android.
- Simplified the "Ready to get started?" section; removed the push toward "Get a demo."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review configuration for documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->