### PR TITLE
Fix testing utils

### DIFF
--- a/server/service/testing_utils.go
+++ b/server/service/testing_utils.go
@@ -44,6 +44,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/contexts/license"
 	"github.com/fleetdm/fleet/v4/server/datastore/cached_mysql"
 	"github.com/fleetdm/fleet/v4/server/datastore/filesystem"
+	"github.com/fleetdm/fleet/v4/server/datastore/mysql"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis"
 	"github.com/fleetdm/fleet/v4/server/datastore/redis/redistest"
 	"github.com/fleetdm/fleet/v4/server/dev_mode"
@@ -78,13 +79,31 @@ import (
 	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/fleetdm/fleet/v4/server/test"
 	"github.com/go-kit/kit/endpoint"
+	kithttp "github.com/go-kit/kit/transport/http"
 	"github.com/google/uuid"
+	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/throttled/throttled/v2"
 	"github.com/throttled/throttled/v2/store/memstore"
 	"google.golang.org/api/androidmanagement/v1"
 )
+
+// stubActivityRoutes returns a HandlerRoutesFunc that registers placeholder routes
+// matching the activity bounded context endpoints listed in the API endpoints catalog.
+// Used by tests that run against a mock datastore where the real bounded context
+// cannot be wired up. Handlers return 501 so accidental use is obvious.
+func stubActivityRoutes() endpointer.HandlerRoutesFunc {
+	return func(r *mux.Router, _ []kithttp.ServerOption) {
+		stub := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "activity endpoint not wired up in this test", http.StatusNotImplemented)
+		})
+		for _, v := range []string{"v1", "latest"} {
+			r.Handle("/api/"+v+"/fleet/activities", stub).Methods("GET")
+			r.Handle("/api/"+v+"/fleet/hosts/{id:[0-9]+}/activities", stub).Methods("GET")
+		}
+	}
+}
 
 func newTestService(t *testing.T, ds fleet.Datastore, rs fleet.QueryResultStore, lq fleet.LiveQueryStore, opts ...*TestServerOpts) (fleet.Service, context.Context) {
 	return newTestServiceWithConfig(t, ds, config.TestConfig(), rs, lq, opts...)
@@ -467,6 +486,19 @@ type TestServerOpts struct {
 }
 
 func RunServerForTestsWithDS(t *testing.T, ds fleet.Datastore, opts ...*TestServerOpts) (map[string]fleet.User, *httptest.Server) {
+	// Derive activity DBConns from the unwrapped datastore before any caching layer
+	// wraps it, so RunServerForTestsWithServiceWithDS can register real activity
+	// routes even when opts[0].DBConns wasn't provided explicitly. The type
+	// assertion in RunServerForTestsWithServiceWithDS would otherwise fail against
+	// the cached_mysql wrapper and silently fall back to stub routes.
+	if mysqlDS, ok := ds.(*mysql.Datastore); ok {
+		if len(opts) == 0 {
+			opts = append(opts, &TestServerOpts{})
+		}
+		if opts[0].DBConns == nil {
+			opts[0].DBConns = mysql.TestDBConnections(t, mysqlDS)
+		}
+	}
 	if len(opts) > 0 && opts[0].EnableCachedDS {
 		ds = cached_mysql.New(ds)
 	}
@@ -496,18 +528,28 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		logger = opts[0].Logger
 	}
 
+	var extraFeatureRoutes []endpointer.HandlerRoutesFunc
 	if len(opts) > 0 {
 		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, android_service.GetRoutes(svc, opts[0].androidModule))
 	}
 
-	// Add activity routes if DBConns is provided
+	// Add activity routes. DBConns may be passed explicitly; otherwise derive them
+	// from the datastore so activity endpoints are registered for every integration
+	// test (the API endpoints catalog requires them).
+	var activityDBConns *common_mysql.DBConnections
 	if len(opts) > 0 && opts[0].DBConns != nil {
+		activityDBConns = opts[0].DBConns
+	} else if mysqlDS, ok := ds.(*mysql.Datastore); ok {
+		activityDBConns = mysql.TestDBConnections(t, mysqlDS)
+	}
+	var activityRoutes endpointer.HandlerRoutesFunc
+	if activityDBConns != nil {
 		legacyAuthorizer, err := authz.NewAuthorizer()
 		require.NoError(t, err)
 		activityAuthorizer := authz.NewAuthorizerAdapter(legacyAuthorizer)
 		activityACLAdapter := activityacl.NewFleetServiceAdapter(svc)
 		activitySvc, activityRoutesFn := activity_bootstrap.New(
-			opts[0].DBConns,
+			activityDBConns,
 			activityAuthorizer,
 			activityACLAdapter,
 			logger,
@@ -516,7 +558,16 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 		activityAuthMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint {
 			return auth.AuthenticatedUser(svc, next)
 		}
-		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, activityRoutesFn(activityAuthMiddleware))
+		activityRoutes = activityRoutesFn(activityAuthMiddleware)
+	} else {
+		// No real DB available (e.g. mock-based unit tests). Register stub handlers
+		// so the API endpoints catalog check still passes.
+		activityRoutes = stubActivityRoutes()
+	}
+	if len(opts) > 0 {
+		opts[0].FeatureRoutes = append(opts[0].FeatureRoutes, activityRoutes)
+	} else {
+		extraFeatureRoutes = append(extraFeatureRoutes, activityRoutes)
 	}
 
 	var mdmPusher nanomdm_push.Pusher
@@ -611,6 +662,7 @@ func RunServerForTestsWithServiceWithDS(t *testing.T, ctx context.Context, ds fl
 	if len(opts) > 0 && len(opts[0].FeatureRoutes) > 0 {
 		featureRoutes = opts[0].FeatureRoutes
 	}
+	featureRoutes = append(featureRoutes, extraFeatureRoutes...)
 	var extra []ExtraHandlerOption
 	extra = append(extra, WithLoginRateLimit(throttled.PerMin(1000)))
 


### PR DESCRIPTION
Fixes testing issues arising from the fact that we added routes to the api_endoints.yml file that are not on the main router (they're in separate modules), so our sanity check for "do all the documented routes actually exist" fails.  This is 100% 🤖 generated but the general idea is "match the promise the catalog makes at the level where that promise is verifiable".