### PR TITLE
Add macOS report to collect default browser

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -139,6 +139,7 @@ policies:
   - path: ../lib/linux/policies/check-fleet-desktop-extension-enabled.yml
 reports:
   - path: ../lib/macos/reports/detect-apple-intelligence.yml
+  - path: ../lib/macos/reports/collect-default-browser.yml
   - path: ../lib/macos/reports/collect-santa-denied-logs.yml
   - path: ../lib/macos/reports/collect-macos-27-incompatible-apps.yml
   - path: ../lib/all/reports/dex-queries.yml

--- a/it-and-security/lib/macos/reports/collect-default-browser.yml
+++ b/it-and-security/lib/macos/reports/collect-default-browser.yml
@@ -1,0 +1,21 @@
+- name: Collect default browser on macOS
+  automations_enabled: false
+  description: Collects the default browser setting for local users on macOS hosts.
+  discard_data: false
+  interval: 604800
+  logging: snapshot
+  observer_can_run: true
+  platform: "darwin"
+  query: |
+    SELECT
+      u.username,
+      b.value AS default_browser
+    FROM users u
+    JOIN plist a
+      ON a.path = u.directory || '/Library/Preferences/com.apple.LaunchServices/com.apple.launchservices.secure.plist'
+    JOIN plist b
+      ON b.path = a.path
+      AND b.rowid = a.rowid + 1
+    WHERE a.subkey = 'LSHandlerContentType'
+      AND a.value = 'com.apple.default-app.web-browser'
+      AND b.subkey = 'LSHandlerRoleAll';


### PR DESCRIPTION
Add a new macOS report (lib/macos/reports/collect-default-browser.yml) and enable it in the it-and-security/fleets/workstations.yml reports list. The report gathers each local user's default web browser by reading LaunchServices plist entries, runs weekly (interval 604800), uses snapshot logging, and is observer-runnable. Automations are disabled by default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a macOS report to collect default browser information, disabled by default with weekly scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->