### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/1password/windows.json
+++ b/ee/maintained-apps/outputs/1password/windows.json
@@ -1,22 +1,22 @@
 {
   "versions": [
     {
-      "version": "8.12.10",
+      "version": "8.12.12",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND publisher = 'Agilebits Inc.' AND version_compare(version, '8.12.12') < 0);"
       },
-      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.10.msi",
+      "installer_url": "https://c.1password.com/dist/1P/win8/1PasswordSetup-8.12.12.msi",
       "install_script_ref": "8959087b",
-      "uninstall_script_ref": "795667d8",
-      "sha256": "fc036ea97efad01df048e7503d21e33e7521c6c39174478ae2122a03d1c6afcd",
+      "uninstall_script_ref": "43b5726e",
+      "sha256": "db118d3aee37ef55d2172a814f50db1941730988f38a06366db8b59ce0264d75",
       "default_categories": [
         "Productivity"
       ]
     }
   ],
   "refs": {
-    "795667d8": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{1D940C01-A867-4D52-AF26-026FD7EB6A41}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n",
+    "43b5726e": "# 1Password Uninstall Script\n# Closes running processes before uninstalling to prevent hangs\n\n$product_code = '{4E29828B-8BA2-452F-91A1-D4294DC6C0A8}'\n$timeoutSeconds = 300  # 5 minute timeout\n\n# Close any running 1Password processes\nGet-Process -Name \"1Password*\" -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue\nStart-Sleep -Seconds 2\n\n# Fleet uninstalls app using product code that's extracted on upload\n$process = Start-Process msiexec -ArgumentList @(\"/quiet\", \"/x\", $product_code, \"/norestart\") -PassThru\n\n# Wait for process with timeout\n$completed = $process.WaitForExit($timeoutSeconds * 1000)\n\nif (-not $completed) {\n    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue\n    Exit 1603  # ERROR_INSTALL_FAILURE\n}\n\n# Check exit code and output result\nif ($process.ExitCode -eq 0) {\n    Write-Output \"Exit 0\"\n    Exit 0\n} else {\n    Write-Output \"Exit $($process.ExitCode)\"\n    Exit $process.ExitCode\n}\n\n",
     "8959087b": "$logFile = \"${env:TEMP}/fleet-install-software.log\"\n\ntry {\n\n$installProcess = Start-Process msiexec.exe `\n  -ArgumentList \"/quiet /norestart /lv ${logFile} /i `\"${env:INSTALLER_PATH}`\"\" `\n  -PassThru -Verb RunAs -Wait\n\nGet-Content $logFile -Tail 500\n\nExit $installProcess.ExitCode\n\n} catch {\n  Write-Host \"Error: $_\"\n  Exit 1\n}\n"
   }
 }

--- a/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
+++ b/ee/maintained-apps/outputs/adobe-acrobat-reader/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "26.001.21431",
+      "version": "26.001.21483",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21431') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND version_compare(version, '26.001.21483') < 0);"
       },
-      "installer_url": "https://ardownload3.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121431/AcroRdrDCx642600121431_MUI.exe",
+      "installer_url": "https://ardownload2.adobe.com/pub/adobe/acrobat/win/AcrobatDC/2600121483/AcroRdrDCx642600121483_MUI.exe",
       "install_script_ref": "7dc0b065",
       "uninstall_script_ref": "3bb10c80",
-      "sha256": "c3270abe8a816a50ffe275888d217da289997eda67debd497de6db394d601917",
+      "sha256": "c7add1e3145b24633e70e9860849f7dcdb5e000734573b4d72547be8137f068a",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/arc/darwin.json
+++ b/ee/maintained-apps/outputs/arc/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.143.2",
+      "version": "1.144.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.143.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'company.thebrowser.Browser' AND version_compare(bundle_short_version, '1.144.0') < 0);"
       },
-      "installer_url": "https://releases.arc.net/release/Arc-1.143.2-79250.zip",
+      "installer_url": "https://releases.arc.net/release/Arc-1.144.0-79514.zip",
       "install_script_ref": "db517fce",
       "uninstall_script_ref": "9fac1341",
-      "sha256": "d06d70a050f40651b761aa733f2c7096eaa396d57e5879f3bc20bbe8cdf90882",
+      "sha256": "292c0a918779160cbda3f5b32457d8dd24cce6e547b3540190ee7e28abf1be20",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/darwin.json
+++ b/ee/maintained-apps/outputs/brave-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.1.89.141",
+      "version": "147.1.89.143",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '147.1.89.141') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.brave.Browser' AND version_compare(bundle_short_version, '147.1.89.143') < 0);"
       },
-      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/189.141/Brave-Browser-arm64.dmg",
+      "installer_url": "https://updates-cdn.bravesoftware.com/sparkle/Brave-Browser/stable-arm64/189.143/Brave-Browser-arm64.dmg",
       "install_script_ref": "415f6786",
       "uninstall_script_ref": "e860eed9",
-      "sha256": "0a75eab9a2131cebf5a25c1d9d713dbc3bb6a24c67dd0e55c3c8fad1510cc32f",
+      "sha256": "1c0a35392a998ca214499c6192d3ec2bf6219bbb1da45c6c661cdb4c16f25ec2",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/brave-browser/windows.json
+++ b/ee/maintained-apps/outputs/brave-browser/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.1.89.137",
+      "version": "147.1.89.143",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '147.1.89.137') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Brave' AND publisher = 'Brave Software Inc' AND version_compare(version, '147.1.89.143') < 0);"
       },
-      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.89.137/BraveBrowserStandaloneSilentSetup.exe",
+      "installer_url": "https://github.com/brave/brave-browser/releases/download/v1.89.143/BraveBrowserStandaloneSilentSetup.exe",
       "install_script_ref": "9a0c2b15",
       "uninstall_script_ref": "30c77f69",
-      "sha256": "6df590d6e0630609036b504af7a56e8c18e9dfc93539f3c17568586f973a7804",
+      "sha256": "2b0bbf35308b99e4f37e560bcc92a0cfb8d5a104884daf1bd1d9713f5ee531f1",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/clion/darwin.json
+++ b/ee/maintained-apps/outputs/clion/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.CLion' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/cpp/CLion-2026.1.1-aarch64.dmg",
       "install_script_ref": "c03a64cb",
       "uninstall_script_ref": "43624c60",
-      "sha256": "0abc7ade315b25b097d7f5c8660db63b177b1f1156981de25e52687f3bf4def0",
+      "sha256": "f26e926e9915750f5067291596c7bd70af0acac5e53e7fcd03d5b2b0b1e1f239",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/clockify/darwin.json
+++ b/ee/maintained-apps/outputs/clockify/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "2.12.3",
+      "version": "2.12.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'coing.ClockifyDesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'coing.ClockifyDesktop' AND version_compare(bundle_short_version, '2.12.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'coing.ClockifyDesktop' AND version_compare(bundle_short_version, '2.12.4') < 0);"
       },
       "installer_url": "https://clockify.me/downloads/ClockifyDesktop.zip",
       "install_script_ref": "f6ef5fd5",

--- a/ee/maintained-apps/outputs/goland/darwin.json
+++ b/ee/maintained-apps/outputs/goland/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.goland' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/go/goland-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/go/goland-2026.1.1-aarch64.dmg",
       "install_script_ref": "ded9cd56",
       "uninstall_script_ref": "b430dd4b",
-      "sha256": "668e3c44cb55530795e78d48998c6d413069e0be198724c3c451702be632ad99",
+      "sha256": "cdf749ad705ab6f025df034c4372e117da0ec68d5d132a3cc2be250a815d9bd2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/granola/darwin.json
+++ b/ee/maintained-apps/outputs/granola/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.147.1",
+      "version": "7.155.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.147.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.granola.app' AND version_compare(bundle_short_version, '7.155.1') < 0);"
       },
-      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.147.1/Granola-7.147.1-mac-universal.dmg",
+      "installer_url": "https://dr2v7l5emb758.cloudfront.net/7.155.1/Granola-7.155.1-mac-universal.dmg",
       "install_script_ref": "f085c17c",
       "uninstall_script_ref": "9f1ed248",
-      "sha256": "e7aeaf8763cedfff240a04880774cea9167d9b357beb71869befe157f7e8d767",
+      "sha256": "7235520aa61a09e6c971e78fb159592863f207451bf8ea58956f05ad4dbd2f3c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/granola/windows.json
+++ b/ee/maintained-apps/outputs/granola/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "7.147.1",
+      "version": "7.155.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.147.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Granola %' AND publisher = 'Granola' AND version_compare(version, '7.155.1') < 0);"
       },
-      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.147.1-win-x64.exe",
+      "installer_url": "https://api.granola.ai/v1/check-for-update/Granola-7.155.1-win-x64.exe",
       "install_script_ref": "3f66ac53",
       "uninstall_script_ref": "a4fab3f5",
-      "sha256": "7679a7e7b0b83f146b9d10316607be975bbe1b76abc57298ed68fcb5f7cf79b1",
+      "sha256": "83fe931c74ea5b6496a0303f5ebf1e6097df88bed8d608075d1b359498d1801c",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-excel/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-excel/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.108",
+      "version": "16.108.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel' AND version_compare(bundle_short_version, '16.108') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Excel' AND version_compare(bundle_short_version, '16.108.1') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Excel_16.108.26041915_Installer.pkg",
       "install_script_ref": "6be6955e",

--- a/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-onenote/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.108",
+      "version": "16.108.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac' AND version_compare(bundle_short_version, '16.108') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.onenote.mac' AND version_compare(bundle_short_version, '16.108.1') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_OneNote_16.108.26041915_Updater.pkg",
       "install_script_ref": "46212383",

--- a/ee/maintained-apps/outputs/microsoft-outlook/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-outlook/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.108",
+      "version": "16.108.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Outlook';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Outlook' AND version_compare(bundle_short_version, '16.108') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Outlook' AND version_compare(bundle_short_version, '16.108.1') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Outlook_16.108.26041915_Installer.pkg",
       "install_script_ref": "fbfafe33",

--- a/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-powerpoint/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.108",
+      "version": "16.108.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint' AND version_compare(bundle_short_version, '16.108') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Powerpoint' AND version_compare(bundle_short_version, '16.108.1') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_PowerPoint_16.108.26041915_Installer.pkg",
       "install_script_ref": "6dfc37ad",

--- a/ee/maintained-apps/outputs/microsoft-word/darwin.json
+++ b/ee/maintained-apps/outputs/microsoft-word/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "16.108",
+      "version": "16.108.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word' AND version_compare(bundle_short_version, '16.108') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.microsoft.Word' AND version_compare(bundle_short_version, '16.108.1') < 0);"
       },
       "installer_url": "https://officecdnmac.microsoft.com/pr/C1297A47-86C4-4C1F-97FA-950631F94777/MacAutoupdate/Microsoft_Word_16.108.26041915_Installer.pkg",
       "install_script_ref": "1daaf52c",

--- a/ee/maintained-apps/outputs/miro/darwin.json
+++ b/ee/maintained-apps/outputs/miro/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "0.11.134",
+      "version": "0.11.139",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard' AND version_compare(bundle_short_version, '0.11.134') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.realtimeboard' AND version_compare(bundle_short_version, '0.11.139') < 0);"
       },
       "installer_url": "https://desktop.miro.com/platforms/darwin-arm64/Install-Miro.dmg",
       "install_script_ref": "319b8ee5",

--- a/ee/maintained-apps/outputs/obs/windows.json
+++ b/ee/maintained-apps/outputs/obs/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "32.1.1",
+      "version": "32.1.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.1.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'OBS Studio' AND publisher = 'OBS Project' AND version_compare(version, '32.1.2') < 0);"
       },
-      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.1.1/OBS-Studio-32.1.1-Windows-x64-Installer.exe",
+      "installer_url": "https://github.com/obsproject/obs-studio/releases/download/32.1.2/OBS-Studio-32.1.2-Windows-x64-Installer.exe",
       "install_script_ref": "8a919fae",
       "uninstall_script_ref": "145a6b76",
-      "sha256": "9b4b643a44154ed8bee5229a4e0c85f6826f76b7e38b1d0d1d7e8b349dfa38e1",
+      "sha256": "94d180c1fc481ccc307b95513f795d088d63ac4f61ad3253c2ac0d94d0844110",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/ollama/darwin.json
+++ b/ee/maintained-apps/outputs/ollama/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.21.1",
+      "version": "0.21.2",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.21.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.ollama' AND version_compare(bundle_short_version, '0.21.2') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.21.1/Ollama-darwin.zip",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.21.2/Ollama-darwin.zip",
       "install_script_ref": "5efcb963",
       "uninstall_script_ref": "f60ddfee",
-      "sha256": "56163f12d8e7a7386812575d2e1073bdd96966ec788df7921fe54dd7d3beb979",
+      "sha256": "52c8856bf6c46beef9664ebab22b327afd6224a418744afa594b70a11587ec15",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/ollama/windows.json
+++ b/ee/maintained-apps/outputs/ollama/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.21.0",
+      "version": "0.21.2",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.21.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Ollama' AND publisher = 'Ollama' AND version_compare(version, '0.21.2') < 0);"
       },
-      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.21.0/OllamaSetup.exe",
+      "installer_url": "https://github.com/ollama/ollama/releases/download/v0.21.2/OllamaSetup.exe",
       "install_script_ref": "e14c71ee",
       "uninstall_script_ref": "3f049b5d",
-      "sha256": "3ab56c0e0a4b2b61e172a1b938fc50b98b0f7ceb4064e9ea81cf3cccb07b0546",
+      "sha256": "4a61eba960b0053e55380198cd996db6eb42b0a99d3a9f5afc930e879b6845cc",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/opera/darwin.json
+++ b/ee/maintained-apps/outputs/opera/darwin.json
@@ -6,10 +6,10 @@
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera';",
         "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.operasoftware.Opera' AND version_compare(bundle_short_version, '130.0') < 0);"
       },
-      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/130.0.5847.82/mac/Opera_130.0.5847.82_Setup.dmg",
+      "installer_url": "https://get.geo.opera.com/pub/opera/desktop/130.0.5847.92/mac/Opera_130.0.5847.92_Setup.dmg",
       "install_script_ref": "21b29a49",
       "uninstall_script_ref": "f3ba65ab",
-      "sha256": "7721d5981fe14eab5e6514a6adfc243b81e8a83fd6ef4616ec598e6693788b54",
+      "sha256": "2dc03afa8e8558b32fe0e2d083a7ead6eb7da684e06a4396d2dd2788287726ad",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/phpstorm/darwin.json
+++ b/ee/maintained-apps/outputs/phpstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.PhpStorm' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webide/PhpStorm-2026.1.1-aarch64.dmg",
       "install_script_ref": "878d0888",
       "uninstall_script_ref": "96ef3e71",
-      "sha256": "5774d022f6981f7f8d996203245c9370eed9c1d77e4cf3f44d21665f9a631213",
+      "sha256": "b66fd4147ff9157d0743f1678d0fc9c3069ffdca4861be23d0dbca95acc1a74f",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.7.5",
+      "version": "12.7.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.7.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.7.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.7.5/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.7.6/osx_arm64",
       "install_script_ref": "d27f3112",
       "uninstall_script_ref": "15e9f11c",
-      "sha256": "fe744db5d516abb4c678cce8651c95c52d399af710178339984831531f69fd7a",
+      "sha256": "a1248b74741d96e38bd48443f6d1aec6ace9e988b13bee4752fe2c7e5be12a14",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.7.5",
+      "version": "12.7.6",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.7.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.7.6') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.7.5/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.7.6/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "0d047ef216d62540c5d68b5a1df822ea94c0fe833800d1a6560f7b060093beb8",
+      "sha256": "939a1412f68b29cf8fab6462421d76c5fe205da0c76be95788232a0e047b2acf",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/protonvpn/darwin.json
+++ b/ee/maintained-apps/outputs/protonvpn/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "6.4.0",
+      "version": "6.5.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonvpn.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonvpn.mac' AND version_compare(bundle_short_version, '6.4.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'ch.protonvpn.mac' AND version_compare(bundle_short_version, '6.5.0') < 0);"
       },
-      "installer_url": "https://vpn.protondownload.com/download/macos/6.4.0/ProtonVPN_mac_v6.4.0.dmg",
+      "installer_url": "https://vpn.protondownload.com/download/macos/6.5.0/ProtonVPN_mac_v6.5.0.dmg",
       "install_script_ref": "dadd799a",
       "uninstall_script_ref": "27bfb4ac",
-      "sha256": "179352ecd36ac4d25c97b8056aa5ad5b107105b57a06da7b732c83a5e80418b4",
+      "sha256": "941e38a4803903175c610fe271c59ca890cead09152d1565d2fcb51ee3cf97ca",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/rubymine/darwin.json
+++ b/ee/maintained-apps/outputs/rubymine/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rubymine' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/ruby/RubyMine-2026.1.1-aarch64.dmg",
       "install_script_ref": "a13041df",
       "uninstall_script_ref": "65b92f82",
-      "sha256": "c43f896268ae74c246082241dcf7fcfa634651124547130387e363ef152b7f3f",
+      "sha256": "50f9c44a8b810b1e7d7b69fc8a74df7becd20a440c1765dea0dc3cdb92d32ae5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rustrover/darwin.json
+++ b/ee/maintained-apps/outputs/rustrover/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rustrover' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/rustrover/RustRover-2026.1.1-aarch64.dmg",
       "install_script_ref": "e4dca375",
       "uninstall_script_ref": "ba2137dc",
-      "sha256": "0de2e4c0aab4d4cdf39abdb26673985c29f4099fb43fd32d582f5b308ccaad51",
+      "sha256": "2bd1b092e771f96576e5f035211c1f0e5a9c2bc5f423f4b3acbed2da21bb21f2",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/spotify/darwin.json
+++ b/ee/maintained-apps/outputs/spotify/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.2.87.415",
+      "version": "1.2.88.483",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client' AND version_compare(bundle_short_version, '1.2.87.415') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.spotify.client' AND version_compare(bundle_short_version, '1.2.88.483') < 0);"
       },
       "installer_url": "https://download.scdn.co/SpotifyARM64.dmg",
       "install_script_ref": "16ad9735",

--- a/ee/maintained-apps/outputs/webstorm/darwin.json
+++ b/ee/maintained-apps/outputs/webstorm/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.WebStorm' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/webstorm/WebStorm-2026.1.1-aarch64.dmg",
       "install_script_ref": "8182ffb0",
       "uninstall_script_ref": "4dacd0a2",
-      "sha256": "411a5679588a8c69b2ce12a4362cfd828df00c593f048b91d9decd062589ed8b",
+      "sha256": "fd6c065e7bd8673f0ccce39081fe0118c44fedc2c8bfc140d652bc36f220b68a",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version tracking for 24+ applications to enable proper recognition of latest releases. Supported apps include 1Password, Brave, Adobe Acrobat Reader, Arc, CLion, Clockify, GoLand, Granola, Microsoft Office apps, Miro, OBS Studio, Ollama, Opera, PhpStorm, Postman, ProtonVPN, RubyMine, RustRover, Spotify, WebStorm, and others. Updated with latest installer URLs and verification checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->