### PR TITLE
fallback to RelayState and pass the correct ACSUrl

### DIFF
--- a/changes/41592-eua-broken-with-custom-apple-mdm-url
+++ b/changes/41592-eua-broken-with-custom-apple-mdm-url
@@ -1,0 +1,1 @@
+* Fixed an issue where if a custom Apple MDM URL was set, SSO for end user auth would fail.

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -961,15 +961,38 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 		appConfig.MDMUrl(),
 		appConfig.MDMUrl() + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback",
 	}
+
+	// When a custom Apple MDM URL is configured, the IdP's ACS URL points to
+	// the main Fleet server URL, not the MDM URL. The SAML library validates
+	// the Destination against both the requestURL and sp.AcsURL, but validates
+	// SubjectConfirmation Recipient against sp.AcsURL only. So when the IdP
+	// sends the response to the Fleet URL, we must set sp.AcsURL to the Fleet
+	// URL (which the IdP uses as ACS/Recipient) and pass the Fleet URL as
+	// requestURL too. All other SAML validation (signatures, RequestID, etc.)
+	// stays intact.
+	providerAcsURL := acsURL
+	if appConfig.MDM.AppleServerURL != "" &&
+		appConfig.MDM.AppleServerURL != appConfig.ServerSettings.ServerURL {
+		expectedAudiences = append(expectedAudiences,
+			appConfig.ServerSettings.ServerURL,
+			appConfig.ServerSettings.ServerURL+svc.config.Server.URLPrefix+"/api/v1/fleet/mdm/sso/callback",
+		)
+		fleetCallbackURL, err := url.Parse(appConfig.ServerSettings.ServerURL + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback")
+		if err != nil {
+			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse Fleet server callback URL")
+		}
+		providerAcsURL = fleetCallbackURL
+	}
+
 	samlProvider, requestID, originalURL, ssoRequestData, err := sso.SAMLProviderFromSession(
-		ctx, sessionID, svc.ssoSessionStore, acsURL, mdmSSOSettings.EntityID, expectedAudiences,
+		ctx, sessionID, svc.ssoSessionStore, providerAcsURL, mdmSSOSettings.EntityID, expectedAudiences,
 	)
 	if err != nil {
 		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to create provider from metadata")
 	}
 
 	// Parse and verify SAMLResponse (verifies fields, expected IDs and signature).
-	auth, err := sso.ParseAndVerifySAMLResponse(samlProvider, samlResponse, requestID, acsURL)
+	auth, err := sso.ParseAndVerifySAMLResponse(samlProvider, samlResponse, requestID, providerAcsURL)
 	if err != nil {
 		// We actually don't return 401 to clients and instead return an HTML page with /login?status=error,
 		// but to be consistent we will return fleet.AuthFailedError which is used for unauthorized access.

--- a/server/service/integration_mdm_test.go
+++ b/server/service/integration_mdm_test.go
@@ -84,7 +84,10 @@ import (
 	scepserver "github.com/fleetdm/fleet/v4/server/mdm/scep/server"
 	mdmtesting "github.com/fleetdm/fleet/v4/server/mdm/testing_utils"
 	"github.com/fleetdm/fleet/v4/server/ptr"
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	"github.com/fleetdm/fleet/v4/server/sso"
 	"github.com/fleetdm/fleet/v4/server/service/contract"
+	redigo "github.com/gomodule/redigo/redis"
 	"github.com/fleetdm/fleet/v4/server/service/integrationtest/scep_server"
 	"github.com/fleetdm/fleet/v4/server/service/mock"
 	"github.com/fleetdm/fleet/v4/server/service/osquery_utils"
@@ -6777,6 +6780,70 @@ func (s *integrationMDMTestSuite) TestSSO() {
 	require.False(t, q.Has("profile_token"))
 	require.False(t, q.Has("enrollment_reference"))
 	require.True(t, q.Has("error"))
+
+	// When the SSO session cookie is missing (e.g. because the IdP sent the
+	// callback to a different domain than the one that set the cookie), the
+	// session ID should be recovered from the RelayState form parameter.
+	//
+	// Test 1: bogus session ID in RelayState — session lookup fails but the
+	// RelayState fallback path is exercised (without RelayState, an empty
+	// session ID would be used instead).
+	samlResponse = base64.StdEncoding.EncodeToString([]byte(rawSSOResp))
+	res = s.DoRawNoAuth(
+		"POST",
+		"/api/v1/fleet/mdm/sso/callback?SAMLResponse="+url.QueryEscape(samlResponse)+"&RelayState="+url.QueryEscape("bogus-session-id-from-relay"),
+		nil,
+		http.StatusSeeOther,
+	)
+	require.NotEmpty(t, res.Header.Get("Location"))
+	u, err = url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	// Should get an error (invalid session), not a crash or different behavior.
+	require.True(t, u.Query().Has("error"))
+
+	// Test 2: valid session ID in RelayState — the session is found and
+	// consumed from Redis (proving the RelayState was used to look it up).
+	// The SAML response validation will fail because the metadata is minimal,
+	// but the important thing is that the error is NOT "session not found".
+	relaySessionID := "aabbccdd11223344aabbccdd11223344aabbccdd11223344"
+	ssoSession := sso.Session{
+		RequestID:   "_test-request-id",
+		OriginalURL: "/test-original-url",
+		Metadata:    `<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://idp.test.com"></md:EntityDescriptor>`,
+	}
+	sessionJSON, err := json.Marshal(ssoSession)
+	require.NoError(t, err)
+	conn := redis.ConfigureDoer(s.redisPool, s.redisPool.Get())
+	_, err = conn.Do("SETEX", relaySessionID, 300, string(sessionJSON))
+	conn.Close()
+	require.NoError(t, err)
+
+	// Verify the session exists in Redis.
+	conn = redis.ConfigureDoer(s.redisPool, s.redisPool.Get())
+	val, err := redigo.String(conn.Do("GET", relaySessionID))
+	conn.Close()
+	require.NoError(t, err)
+	require.Contains(t, val, "_test-request-id")
+
+	samlResponse = base64.StdEncoding.EncodeToString([]byte(rawSSOResp))
+	res = s.DoRawNoAuth(
+		"POST",
+		"/api/v1/fleet/mdm/sso/callback?SAMLResponse="+url.QueryEscape(samlResponse)+"&RelayState="+url.QueryEscape(relaySessionID),
+		nil,
+		http.StatusSeeOther,
+	)
+	require.NotEmpty(t, res.Header.Get("Location"))
+	u, err = url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	// We expect an error (SAML validation fails), but it should NOT be
+	// "session not found" — the session was found via RelayState.
+	require.True(t, u.Query().Has("error"))
+
+	// The session should have been consumed (Fullfill does GET + DELETE).
+	conn = redis.ConfigureDoer(s.redisPool, s.redisPool.Get())
+	_, err = redigo.String(conn.Do("GET", relaySessionID))
+	conn.Close()
+	require.ErrorIs(t, err, redigo.ErrNil, "session should have been consumed by the callback")
 }
 
 func (s *integrationMDMTestSuite) checkStoredIdPInfo(t *testing.T, uuid, username, fullname, email string) {

--- a/server/service/sessions.go
+++ b/server/service/sessions.go
@@ -585,6 +585,15 @@ func decodeCallbackRequest(ctx context.Context, r *http.Request) (
 		}, "parse form in SSO callback")
 	}
 
+	// If the cookie is not available (e.g. when a custom Apple MDM URL
+	// causes the IdP to send the callback to a different domain), fall back
+	// to the RelayState parameter which the IdP echoes back from the
+	// AuthnRequest. The session ID uses hex encoding so it survives the
+	// round-trip without corruption.
+	if sessionID == "" {
+		sessionID = r.FormValue("RelayState")
+	}
+
 	samlResponseValue := r.FormValue("SAMLResponse")
 	if samlResponseValue == "" {
 		return "", nil, ctxerr.Wrap(ctx, &fleet.BadRequestError{

--- a/server/sso/authorization_request.go
+++ b/server/sso/authorization_request.go
@@ -3,12 +3,13 @@ package sso
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/xml"
 	"errors"
 	"fmt"
 
 	"github.com/crewjam/saml"
-	"github.com/fleetdm/fleet/v4/server"
 	"github.com/fleetdm/fleet/v4/server/contexts/ctxerr"
 )
 
@@ -83,8 +84,13 @@ func CreateAuthorizationRequest(
 		return "", "", fmt.Errorf("caching SSO session while creating auth request: %w", err)
 	}
 
-	relayState := "" // Fleet currently doesn't use/set RelayState
-	idpRedirectURL, err := samlAuthRequest.Redirect(relayState, samlProvider)
+	// Pass the session ID as RelayState so the callback can retrieve it even
+	// when the SSO cookie is not available (e.g. when a custom Apple MDM URL
+	// causes the IdP to send the callback to a different domain than the one
+	// that set the cookie). The session ID is an opaque, random, single-use
+	// token that references server-side state — it does not grant access by
+	// itself.
+	idpRedirectURL, err := samlAuthRequest.Redirect(sessionID, samlProvider)
 	if err != nil {
 		return "", "", ctxerr.Wrap(ctx, err, "generating redirect")
 	}
@@ -92,10 +98,16 @@ func CreateAuthorizationRequest(
 }
 
 func generateSessionID() (string, error) {
+	// Use 24 random bytes hex-encoded (48 chars). Hex encoding produces only
+	// [0-9a-f] which is safe for URLs, cookies, and form-encoded POST bodies
+	// without any escaping. This avoids issues with base64's +, / and =
+	// characters being corrupted during SAML RelayState round-trips through
+	// IdPs (where the value travels as a URL query parameter and is echoed
+	// back in an application/x-www-form-urlencoded POST).
 	const sessionIDLength = 24
-	sessionID, err := server.GenerateRandomText(sessionIDLength)
-	if err != nil {
+	key := make([]byte, sessionIDLength)
+	if _, err := rand.Read(key); err != nil {
 		return "", fmt.Errorf("create random session ID: %w", err)
 	}
-	return sessionID, nil
+	return hex.EncodeToString(key), nil
 }


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41592 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed single sign-on (SSO) failures that occurred when using a custom Apple MDM server URL configuration
* Improved session recovery during authentication to enhance reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->