### PR TITLE
Add Vulnerabilities exposure dataset

### DIFF
--- a/changes/44124-add-vulnerabilities-chart
+++ b/changes/44124-add-vulnerabilities-chart
@@ -1,0 +1,1 @@
+- Added chart showing host vulnerability exposure to dashboard

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1952,6 +1952,7 @@ func createChartBoundedContext(dbConns *common_mysql.DBConnections, svc fleet.Se
 	// Register all chart types here. The registry is used to validate chart types in the API
 	// and to iterate over all chart types when generating chart data.
 	chartSvc.RegisterDataset(&chart.UptimeDataset{})
+	chartSvc.RegisterDataset(&chart.CVEDataset{})
 	// Create auth middleware for chart bounded context
 	chartAuthMiddleware := func(next endpoint.Endpoint) endpoint.Endpoint {
 		return auth.AuthenticatedUser(svc, next)

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -66,6 +66,12 @@ type DatasetStore interface {
 	// recent host activity.
 	FindRecentlySeenHostIDs(ctx context.Context, since time.Time) ([]uint, error)
 
+	// AffectedHostIDsByCVE returns, for every CVE currently affecting any host,
+	// the slice of host IDs impacted by it. Unresolved-only is implicit in the
+	// underlying joins: a host's software/OS row transitions when it upgrades
+	// past the vulnerable version, so the join naturally stops matching.
+	AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error)
+
 	// RecordBucketData writes one or more entity bitmaps for the given bucket
 	// using the specified sample strategy. See SampleStrategy for semantics.
 	RecordBucketData(

--- a/server/chart/api/chart.go
+++ b/server/chart/api/chart.go
@@ -40,11 +40,10 @@ type Dataset interface {
 	// Name returns the dataset identifier used in the DB and API path.
 	Name() string
 
-	// DefaultResolutionHours returns the default display granularity in hours
-	// (1 for uptime, 24 for CVE). Used when the caller doesn't specify
-	// RequestOpts.Resolution. Unrelated to write-side granularity — all
-	// collectors write at 1h regardless of display resolution; see
-	// SampleStrategy for details.
+	// DefaultResolutionHours returns the default display granularity in hours.
+	// Used when the caller doesn't specify RequestOpts.Resolution. Unrelated
+	// to write-side granularity — all collectors write at 1h regardless of
+	// display resolution; see SampleStrategy for details.
 	DefaultResolutionHours() int
 
 	// SampleStrategy returns how samples combine within and across buckets.

--- a/server/chart/datasets.go
+++ b/server/chart/datasets.go
@@ -38,11 +38,19 @@ func (u *UptimeDataset) Collect(ctx context.Context, store api.DatasetStore, now
 type CVEDataset struct{}
 
 func (c *CVEDataset) Name() string                       { return "cve" }
-func (c *CVEDataset) DefaultResolutionHours() int        { return 24 }
+func (c *CVEDataset) DefaultResolutionHours() int        { return 3 }
 func (c *CVEDataset) SampleStrategy() api.SampleStrategy { return api.SampleStrategySnapshot }
 func (c *CVEDataset) DefaultVisualization() string       { return "line" }
 
-// @todo implement CVE dataset collection.
-func (c *CVEDataset) Collect(_ context.Context, _ api.DatasetStore, _ time.Time) error {
-	return nil
+func (c *CVEDataset) Collect(ctx context.Context, store api.DatasetStore, now time.Time) error {
+	hostIDsByCVE, err := store.AffectedHostIDsByCVE(ctx)
+	if err != nil {
+		return err
+	}
+	bitmaps := make(map[string][]byte, len(hostIDsByCVE))
+	for cve, hostIDs := range hostIDsByCVE {
+		bitmaps[cve] = HostIDsToBlob(hostIDs)
+	}
+	bucketStart := now.UTC().Truncate(time.Hour)
+	return store.RecordBucketData(ctx, c.Name(), bucketStart, time.Hour, c.SampleStrategy(), bitmaps)
 }

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -137,25 +137,25 @@ var trackedCVESoftwareMatchers = []cveSoftwareMatcher{
 	{"kernel-%", []string{"rpm_packages"}},
 }
 
-// AffectedHostIDsByCVE returns host IDs grouped by CVE. It streams two joins
-// (software-level and OS-level vulnerabilities) and merges the results into a
-// single map. Duplicates across sources are harmless — the downstream
+// AffectedHostIDsByCVE returns host IDs grouped by CVE. It runs two joins
+// (software-level and OS-level vulnerabilities) and merges the results into
+// a single map. Duplicates across sources are harmless — the downstream
 // HostIDsToBlob setBit is idempotent.
 func (ds *Datastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error) {
 	result := make(map[string][]uint)
 
-	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
+	if err := collectCVEHostPairs(ctx, ds.reader(ctx), `
 		SELECT sc.cve, hs.host_id
 		FROM software_cve sc
 		JOIN host_software hs ON hs.software_id = sc.software_id`, result); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "stream software CVE host pairs")
+		return nil, ctxerr.Wrap(ctx, err, "collect software CVE host pairs")
 	}
 
-	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
+	if err := collectCVEHostPairs(ctx, ds.reader(ctx), `
 		SELECT osv.cve, hos.host_id
 		FROM operating_system_vulnerabilities osv
 		JOIN host_operating_system hos ON hos.os_id = osv.operating_system_id`, result); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "stream OS CVE host pairs")
+		return nil, ctxerr.Wrap(ctx, err, "collect OS CVE host pairs")
 	}
 
 	return result, nil
@@ -203,7 +203,7 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 	}
 	expanded = ds.rebind(expanded)
 	if err := collectCVEStrings(ctx, ds.reader(ctx), expanded, expandedArgs, set); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE software results")
+		return nil, ctxerr.Wrap(ctx, err, "collect tracked-CVE software results")
 	}
 
 	// OS-side: all OS vulnerabilities at or above the critical threshold.
@@ -214,7 +214,7 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 		JOIN cve_meta cm ON cm.cve = osv.cve
 		WHERE cm.cvss_score >= ?`
 	if err := collectCVEStrings(ctx, ds.reader(ctx), osQuery, []any{criticalCVSS}, set); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE OS results")
+		return nil, ctxerr.Wrap(ctx, err, "collect tracked-CVE OS results")
 	}
 
 	out := make([]string, 0, len(set))
@@ -225,42 +225,38 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 }
 
 // collectCVEStrings runs a single-column SELECT of CVE IDs and inserts each
-// into the provided set. Helper for TrackedCriticalCVEs.
+// into the provided set. Helper for TrackedCriticalCVEs. Uses SelectContext
+// rather than manual rows iteration so sqlx owns the Rows lifecycle (the
+// linter can't prove Close through the QueryerContext interface otherwise).
 func collectCVEStrings(ctx context.Context, q sqlx.QueryerContext, query string, args []any, out map[string]struct{}) error {
-	rows, err := q.QueryxContext(ctx, query, args...)
-	if err != nil {
+	var cves []string
+	if err := sqlx.SelectContext(ctx, q, &cves, query, args...); err != nil {
 		return err
 	}
-	defer rows.Close()
-
-	var cve string
-	for rows.Next() {
-		if err := rows.Scan(&cve); err != nil {
-			return err
-		}
+	for _, cve := range cves {
 		out[cve] = struct{}{}
 	}
-	return rows.Err()
+	return nil
 }
 
-// streamCVEHostPairs runs a query yielding (cve, host_id) pairs and appends
-// host IDs into out under each CVE key.
-func streamCVEHostPairs(ctx context.Context, q sqlx.QueryerContext, query string, out map[string][]uint) error {
-	rows, err := q.QueryxContext(ctx, query)
-	if err != nil {
+// cveHostPair is the row shape for collectCVEHostPairs.
+type cveHostPair struct {
+	CVE    string `db:"cve"`
+	HostID uint   `db:"host_id"`
+}
+
+// collectCVEHostPairs runs a query yielding (cve, host_id) pairs and appends
+// host IDs into out under each CVE key. Uses SelectContext (see
+// collectCVEStrings for the rationale).
+func collectCVEHostPairs(ctx context.Context, q sqlx.QueryerContext, query string, out map[string][]uint) error {
+	var pairs []cveHostPair
+	if err := sqlx.SelectContext(ctx, q, &pairs, query); err != nil {
 		return err
 	}
-	defer rows.Close()
-
-	var cve string
-	var hostID uint
-	for rows.Next() {
-		if err := rows.Scan(&cve, &hostID); err != nil {
-			return err
-		}
-		out[cve] = append(out[cve], hostID)
+	for _, p := range pairs {
+		out[p.CVE] = append(out[p.CVE], p.HostID)
 	}
-	return rows.Err()
+	return nil
 }
 
 // buildHostFilterClauses translates a HostFilter into SQL WHERE clauses for

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -90,6 +90,50 @@ func (ds *Datastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Tim
 	return ids, nil
 }
 
+// AffectedHostIDsByCVE returns host IDs grouped by CVE. It streams two joins
+// (software-level and OS-level vulnerabilities) and merges the results into a
+// single map. Duplicates across sources are harmless — the downstream
+// HostIDsToBlob setBit is idempotent.
+func (ds *Datastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error) {
+	result := make(map[string][]uint)
+
+	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
+		SELECT sc.cve, hs.host_id
+		FROM software_cve sc
+		JOIN host_software hs ON hs.software_id = sc.software_id`, result); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream software CVE host pairs")
+	}
+
+	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
+		SELECT osv.cve, hos.host_id
+		FROM operating_system_vulnerabilities osv
+		JOIN host_operating_system hos ON hos.os_id = osv.operating_system_id`, result); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream OS CVE host pairs")
+	}
+
+	return result, nil
+}
+
+// streamCVEHostPairs runs a query yielding (cve, host_id) pairs and appends
+// host IDs into out under each CVE key.
+func streamCVEHostPairs(ctx context.Context, q sqlx.QueryerContext, query string, out map[string][]uint) error {
+	rows, err := q.QueryxContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var cve string
+	var hostID uint
+	for rows.Next() {
+		if err := rows.Scan(&cve, &hostID); err != nil {
+			return err
+		}
+		out[cve] = append(out[cve], hostID)
+	}
+	return rows.Err()
+}
+
 // buildHostFilterClauses translates a HostFilter into SQL WHERE clauses for
 // the hosts table. Uses "h" as the table alias. Args may contain slices —
 // caller must use sqlx.In to expand them.

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -137,25 +137,25 @@ var trackedCVESoftwareMatchers = []cveSoftwareMatcher{
 	{"kernel-%", []string{"rpm_packages"}},
 }
 
-// AffectedHostIDsByCVE returns host IDs grouped by CVE. It runs two joins
-// (software-level and OS-level vulnerabilities) and merges the results into
-// a single map. Duplicates across sources are harmless — the downstream
+// AffectedHostIDsByCVE returns host IDs grouped by CVE. It streams two joins
+// (software-level and OS-level vulnerabilities) and merges the results into a
+// single map. Duplicates across sources are harmless — the downstream
 // HostIDsToBlob setBit is idempotent.
 func (ds *Datastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error) {
 	result := make(map[string][]uint)
 
-	if err := collectCVEHostPairs(ctx, ds.reader(ctx), `
+	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
 		SELECT sc.cve, hs.host_id
 		FROM software_cve sc
 		JOIN host_software hs ON hs.software_id = sc.software_id`, result); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "collect software CVE host pairs")
+		return nil, ctxerr.Wrap(ctx, err, "stream software CVE host pairs")
 	}
 
-	if err := collectCVEHostPairs(ctx, ds.reader(ctx), `
+	if err := streamCVEHostPairs(ctx, ds.reader(ctx), `
 		SELECT osv.cve, hos.host_id
 		FROM operating_system_vulnerabilities osv
 		JOIN host_operating_system hos ON hos.os_id = osv.operating_system_id`, result); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "collect OS CVE host pairs")
+		return nil, ctxerr.Wrap(ctx, err, "stream OS CVE host pairs")
 	}
 
 	return result, nil
@@ -202,8 +202,8 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 		return nil, ctxerr.Wrap(ctx, err, "expand tracked-CVE software args")
 	}
 	expanded = ds.rebind(expanded)
-	if err := collectCVEStrings(ctx, ds.reader(ctx), expanded, expandedArgs, set); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "collect tracked-CVE software results")
+	if err := streamCVEStrings(ctx, ds.reader(ctx), expanded, expandedArgs, set); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE software results")
 	}
 
 	// OS-side: all OS vulnerabilities at or above the critical threshold.
@@ -213,8 +213,8 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 		FROM operating_system_vulnerabilities osv
 		JOIN cve_meta cm ON cm.cve = osv.cve
 		WHERE cm.cvss_score >= ?`
-	if err := collectCVEStrings(ctx, ds.reader(ctx), osQuery, []any{criticalCVSS}, set); err != nil {
-		return nil, ctxerr.Wrap(ctx, err, "collect tracked-CVE OS results")
+	if err := streamCVEStrings(ctx, ds.reader(ctx), osQuery, []any{criticalCVSS}, set); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE OS results")
 	}
 
 	out := make([]string, 0, len(set))
@@ -224,39 +224,50 @@ func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) 
 	return out, nil
 }
 
-// collectCVEStrings runs a single-column SELECT of CVE IDs and inserts each
-// into the provided set. Helper for TrackedCriticalCVEs. Uses SelectContext
-// rather than manual rows iteration so sqlx owns the Rows lifecycle (the
-// linter can't prove Close through the QueryerContext interface otherwise).
-func collectCVEStrings(ctx context.Context, q sqlx.QueryerContext, query string, args []any, out map[string]struct{}) error {
-	var cves []string
-	if err := sqlx.SelectContext(ctx, q, &cves, query, args...); err != nil {
+// streamCVEStrings runs a single-column SELECT of CVE IDs and inserts each
+// into the provided set. Helper for TrackedCriticalCVEs. Streams rather than
+// using SelectContext so we don't materialize the full result set.
+func streamCVEStrings(ctx context.Context, q sqlx.QueryerContext, query string, args []any, out map[string]struct{}) error {
+	// sqlclosecheck can't see through the QueryerContext interface to verify
+	// Close() is reached. The defer below provides it.
+	rows, err := q.QueryxContext(ctx, query, args...) //nolint:sqlclosecheck
+	if err != nil {
 		return err
 	}
-	for _, cve := range cves {
+	defer rows.Close()
+
+	var cve string
+	for rows.Next() {
+		if err := rows.Scan(&cve); err != nil {
+			return err
+		}
 		out[cve] = struct{}{}
 	}
-	return nil
+	return rows.Err()
 }
 
-// cveHostPair is the row shape for collectCVEHostPairs.
-type cveHostPair struct {
-	CVE    string `db:"cve"`
-	HostID uint   `db:"host_id"`
-}
-
-// collectCVEHostPairs runs a query yielding (cve, host_id) pairs and appends
-// host IDs into out under each CVE key. Uses SelectContext (see
-// collectCVEStrings for the rationale).
-func collectCVEHostPairs(ctx context.Context, q sqlx.QueryerContext, query string, out map[string][]uint) error {
-	var pairs []cveHostPair
-	if err := sqlx.SelectContext(ctx, q, &pairs, query); err != nil {
+// streamCVEHostPairs runs a query yielding (cve, host_id) pairs and appends
+// host IDs into out under each CVE key. Streams rather than materializing the
+// join result, since on a large fleet the (cve, host_id) row count can reach
+// millions.
+func streamCVEHostPairs(ctx context.Context, q sqlx.QueryerContext, query string, out map[string][]uint) error {
+	// sqlclosecheck can't see through the QueryerContext interface to verify
+	// Close() is reached. The defer below provides it.
+	rows, err := q.QueryxContext(ctx, query) //nolint:sqlclosecheck
+	if err != nil {
 		return err
 	}
-	for _, p := range pairs {
-		out[p.CVE] = append(out[p.CVE], p.HostID)
+	defer rows.Close()
+
+	var cve string
+	var hostID uint
+	for rows.Next() {
+		if err := rows.Scan(&cve, &hostID); err != nil {
+			return err
+		}
+		out[cve] = append(out[cve], hostID)
 	}
-	return nil
+	return rows.Err()
 }
 
 // buildHostFilterClauses translates a HostFilter into SQL WHERE clauses for

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -90,6 +90,53 @@ func (ds *Datastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Tim
 	return ids, nil
 }
 
+// TODO(iteration-2): the matcher list and TrackedCriticalCVEs exist only
+// until user-configurable CVE filtering ships on the dashboard. When that
+// lands, delete trackedCVESoftwareMatchers, TrackedCriticalCVEs, its entries
+// on the Datastore/DatasetStore interfaces, and the `if metric == "cve"`
+// branch in the chart service. See change `cve-chart-demo-filter`.
+
+// cveSoftwareMatcher filters `software` rows by a MySQL LIKE pattern and an
+// optional source allowlist. Empty Sources means any source.
+type cveSoftwareMatcher struct {
+	NamePattern string
+	Sources     []string
+}
+
+// trackedCVESoftwareMatchers is the hard-coded curated list of software
+// whose critical CVEs contribute to the CVE chart. Patterns are deliberately
+// broad (trailing `%`) so packaging variants (Chrome Beta/Canary, Firefox
+// ESR/Nightly, kernel metapackages) are absorbed without maintenance.
+// See openspec/changes/archive/*-cve-chart-demo-filter/design.md §1.
+var trackedCVESoftwareMatchers = []cveSoftwareMatcher{
+	// Browsers.
+	{"Google Chrome%", nil},
+	{"Firefox%", nil},
+	{"Mozilla Firefox%", nil},
+	{"Brave Browser%", nil},
+	{"Safari%", []string{"apps"}},
+	{"Opera%", nil},
+
+	// Microsoft Office.
+	{"Microsoft Word%", nil},
+	{"Microsoft Excel%", nil},
+	{"Microsoft PowerPoint%", nil},
+	{"Microsoft Outlook%", nil},
+	{"Microsoft Office%", nil},
+
+	// Adobe.
+	{"Adobe Flash%", nil},
+	{"Shockwave Flash%", nil},
+	{"Adobe Acrobat%", nil},
+
+	// Linux kernel. Debian/Ubuntu metapackages are linux-image-* and
+	// linux-signed-image-*; RHEL/Fedora/Amazon Linux are kernel-* (confirmed
+	// via server/vulnerabilities/osv/analyzer.go rhelKernelPackages).
+	{"linux-image-%", []string{"deb_packages"}},
+	{"linux-signed-image-%", []string{"deb_packages"}},
+	{"kernel-%", []string{"rpm_packages"}},
+}
+
 // AffectedHostIDsByCVE returns host IDs grouped by CVE. It streams two joins
 // (software-level and OS-level vulnerabilities) and merges the results into a
 // single map. Duplicates across sources are harmless — the downstream
@@ -112,6 +159,88 @@ func (ds *Datastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uin
 	}
 
 	return result, nil
+}
+
+// TrackedCriticalCVEs returns the deduplicated set of CVE IDs that are
+// (a) linked to any `software` row matching trackedCVESoftwareMatchers with
+// `cve_meta.cvss_score >= 9.0`, OR (b) present in
+// `operating_system_vulnerabilities` with `cve_meta.cvss_score >= 9.0`.
+//
+// Returns a non-nil empty slice when no CVEs match, so callers can
+// distinguish "filter resolved to empty" from "no filter requested" (nil).
+// See GetSCDData for how empty vs nil is interpreted at the query layer.
+//
+// TODO(iteration-2): replace with user-configurable filtering. See the
+// matcher-list comment above.
+func (ds *Datastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) {
+	const criticalCVSS = 9.0
+	set := make(map[string]struct{})
+
+	// Software-side: build an OR-chained matcher clause. Each matcher adds one
+	// `(name LIKE ? AND source IN (?))` or `name LIKE ?` subclause.
+	softwareArgs := []any{criticalCVSS}
+	matcherClauses := make([]string, 0, len(trackedCVESoftwareMatchers))
+	for _, m := range trackedCVESoftwareMatchers {
+		if len(m.Sources) == 0 {
+			matcherClauses = append(matcherClauses, "s.name LIKE ?")
+			softwareArgs = append(softwareArgs, m.NamePattern)
+		} else {
+			matcherClauses = append(matcherClauses, "(s.name LIKE ? AND s.source IN (?))")
+			softwareArgs = append(softwareArgs, m.NamePattern, m.Sources)
+		}
+	}
+	softwareQuery := `
+		SELECT DISTINCT sc.cve
+		FROM software_cve sc
+		JOIN software s  ON s.id = sc.software_id
+		JOIN cve_meta cm ON cm.cve = sc.cve
+		WHERE cm.cvss_score >= ?
+		  AND (` + strings.Join(matcherClauses, " OR ") + `)`
+
+	expanded, expandedArgs, err := sqlx.In(softwareQuery, softwareArgs...)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "expand tracked-CVE software args")
+	}
+	expanded = ds.rebind(expanded)
+	if err := collectCVEStrings(ctx, ds.reader(ctx), expanded, expandedArgs, set); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE software results")
+	}
+
+	// OS-side: all OS vulnerabilities at or above the critical threshold.
+	// Fleet's OS vuln coverage is already scoped to desktop OSes.
+	const osQuery = `
+		SELECT DISTINCT osv.cve
+		FROM operating_system_vulnerabilities osv
+		JOIN cve_meta cm ON cm.cve = osv.cve
+		WHERE cm.cvss_score >= ?`
+	if err := collectCVEStrings(ctx, ds.reader(ctx), osQuery, []any{criticalCVSS}, set); err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "stream tracked-CVE OS results")
+	}
+
+	out := make([]string, 0, len(set))
+	for cve := range set {
+		out = append(out, cve)
+	}
+	return out, nil
+}
+
+// collectCVEStrings runs a single-column SELECT of CVE IDs and inserts each
+// into the provided set. Helper for TrackedCriticalCVEs.
+func collectCVEStrings(ctx context.Context, q sqlx.QueryerContext, query string, args []any, out map[string]struct{}) error {
+	rows, err := q.QueryxContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	var cve string
+	for rows.Next() {
+		if err := rows.Scan(&cve); err != nil {
+			return err
+		}
+		out[cve] = struct{}{}
+	}
+	return rows.Err()
 }
 
 // streamCVEHostPairs runs a query yielding (cve, host_id) pairs and appends

--- a/server/chart/internal/mysql/charts.go
+++ b/server/chart/internal/mysql/charts.go
@@ -107,7 +107,6 @@ type cveSoftwareMatcher struct {
 // whose critical CVEs contribute to the CVE chart. Patterns are deliberately
 // broad (trailing `%`) so packaging variants (Chrome Beta/Canary, Firefox
 // ESR/Nightly, kernel metapackages) are absorbed without maintenance.
-// See openspec/changes/archive/*-cve-chart-demo-filter/design.md §1.
 var trackedCVESoftwareMatchers = []cveSoftwareMatcher{
 	// Browsers.
 	{"Google Chrome%", nil},

--- a/server/chart/internal/mysql/data.go
+++ b/server/chart/internal/mysql/data.go
@@ -269,7 +269,13 @@ func (ds *Datastore) GetSCDData(
 	lastBucketEnd := endDate.Add(bucketSize)
 	args := []any{dataset, lastBucketEnd, firstBucketStart}
 	var entityClause string
-	if len(entityIDs) > 0 {
+	switch {
+	case entityIDs == nil:
+		// no clause — match every entity for this dataset
+	case len(entityIDs) == 0:
+		// explicit empty set — match nothing; avoids MySQL syntax error from `IN ()`
+		entityClause = " AND 1=0"
+	default:
 		entityClause = " AND entity_id IN (?)"
 		args = append(args, entityIDs)
 	}

--- a/server/chart/internal/mysql/data.go
+++ b/server/chart/internal/mysql/data.go
@@ -36,15 +36,23 @@ func (ds *Datastore) RecordBucketData(
 	strategy api.SampleStrategy,
 	entityBitmaps map[string][]byte,
 ) error {
-	if len(entityBitmaps) == 0 {
-		return nil
-	}
 	bucketStart = bucketStart.UTC()
 
 	switch strategy {
 	case api.SampleStrategyAccumulate:
+		// Accumulate with an empty map has nothing to OR-merge and no prior
+		// state to reconcile — skip the round trip.
+		if len(entityBitmaps) == 0 {
+			return nil
+		}
 		return ds.recordAccumulate(ctx, dataset, bucketStart, bucketSize, entityBitmaps)
 	case api.SampleStrategySnapshot:
+		// Do NOT short-circuit on empty: empty means "no entities are
+		// currently in the tracked state." For snapshot semantics this is a
+		// meaningful write because any previously-open rows for this dataset
+		// need to be closed at bucketStart. recordSnapshot handles empty
+		// input correctly (the "absent entities" branch closes every open
+		// row).
 		return ds.recordSnapshot(ctx, dataset, bucketStart, entityBitmaps)
 	default:
 		return ctxerr.Errorf(ctx, "unknown sample strategy: %s", strategy)

--- a/server/chart/internal/mysql/data.go
+++ b/server/chart/internal/mysql/data.go
@@ -95,6 +95,9 @@ func (ds *Datastore) recordAccumulate(
 			HostBitmap []byte `db:"host_bitmap"`
 		}
 		var rows []row
+		// Using writer here since a stale read would OR-merge against an older
+		// bitmap, then ODKU would overwrite the row with the partial merge — silently
+		// dropping hosts from any sample the replica hadn't replicated yet.
 		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &rows, query, args...); err != nil {
 			return ctxerr.Wrap(ctx, err, "fetch in-bucket bitmaps")
 		}
@@ -151,7 +154,10 @@ func (ds *Datastore) recordSnapshot(
 		ValidFrom  time.Time `db:"valid_from"`
 	}
 	var openRows []openRow
-	if err := sqlx.SelectContext(ctx, ds.writer(ctx), &openRows,
+	// Reader is safe here: the close UPDATE filters by valid_to = sentinel and the
+	// insert uses ODKU on uniq_entity_bucket, so a stale read at worst produces
+	// idempotent re-work (a no-op close or a same-bucket overwrite).
+	if err := sqlx.SelectContext(ctx, ds.reader(ctx), &openRows,
 		`SELECT entity_id, host_bitmap, valid_from
 		 FROM host_scd_data
 		 WHERE dataset = ? AND valid_to = ?`,

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -132,8 +132,7 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 	var entityIDs []string
 	if metric == "cve" {
 		// TODO(iteration-2): replace with user-configurable filter from
-		// RequestOpts when dynamic CVE filtering ships. See change
-		// `cve-chart-demo-filter`.
+		// RequestOpts when dynamic CVE filtering ships.
 		entityIDs, err = s.store.TrackedCriticalCVEs(ctx)
 		if err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "resolve tracked critical CVEs")

--- a/server/chart/internal/service/service.go
+++ b/server/chart/internal/service/service.go
@@ -129,7 +129,21 @@ func (s *Service) GetChartData(ctx context.Context, metric string, opts api.Requ
 		return nil, err
 	}
 
-	data, err := s.store.GetSCDData(ctx, metric, startDate, endDate, bucketSize, dataset.SampleStrategy(), filterMask, nil)
+	var entityIDs []string
+	if metric == "cve" {
+		// TODO(iteration-2): replace with user-configurable filter from
+		// RequestOpts when dynamic CVE filtering ships. See change
+		// `cve-chart-demo-filter`.
+		entityIDs, err = s.store.TrackedCriticalCVEs(ctx)
+		if err != nil {
+			return nil, ctxerr.Wrap(ctx, err, "resolve tracked critical CVEs")
+		}
+	}
+
+	// entityIDs semantics at the storage layer: nil = no filter; non-nil empty
+	// = match nothing (produces zero-valued buckets). Do NOT convert empty to
+	// nil here.
+	data, err := s.store.GetSCDData(ctx, metric, startDate, endDate, bucketSize, dataset.SampleStrategy(), filterMask, entityIDs)
 	if err != nil {
 		return nil, err
 	}

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -60,6 +60,7 @@ type mockDatastore struct {
 	getHostIDsForFilterFunc   func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
 	findRecentlySeenHostIDsFn func(ctx context.Context, since time.Time) ([]uint, error)
 	affectedHostIDsByCVEFn    func(ctx context.Context) (map[string][]uint, error)
+	trackedCriticalCVEsFn     func(ctx context.Context) ([]string, error)
 	recordBucketDataFn        func(ctx context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error
 	recordBucketDataInvoked   bool
 }
@@ -74,6 +75,13 @@ func (m *mockDatastore) FindRecentlySeenHostIDs(ctx context.Context, since time.
 func (m *mockDatastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error) {
 	if m.affectedHostIDsByCVEFn != nil {
 		return m.affectedHostIDsByCVEFn(ctx)
+	}
+	return nil, nil
+}
+
+func (m *mockDatastore) TrackedCriticalCVEs(ctx context.Context) ([]string, error) {
+	if m.trackedCriticalCVEsFn != nil {
+		return m.trackedCriticalCVEsFn(ctx)
 	}
 	return nil, nil
 }
@@ -227,7 +235,7 @@ func TestGetChartDataCVEResolution(t *testing.T) {
 		resolutionStr string
 		bucketSize    time.Duration
 	}{
-		{"default", 0, "daily", 24 * time.Hour},
+		{"default", 0, "3-hour", 3 * time.Hour},
 		{"hourly override", 1, "hourly", time.Hour},
 		{"4-hour override", 4, "4-hour", 4 * time.Hour},
 	} {
@@ -251,6 +259,80 @@ func TestGetChartDataCVEResolution(t *testing.T) {
 			assert.Equal(t, api.SampleStrategySnapshot, gotStrategy)
 		})
 	}
+}
+
+func TestGetChartDataCVEUsesCuratedFilter(t *testing.T) {
+	ds := &mockDatastore{}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+
+	ds.trackedCriticalCVEsFn = func(_ context.Context) ([]string, error) {
+		return []string{"CVE-A", "CVE-B"}, nil
+	}
+	var gotEntityIDs []string
+	ds.getSCDDataFunc = func(_ context.Context, _ string, _, _ time.Time, _ time.Duration, _ api.SampleStrategy, _ []byte, entityIDs []string) ([]api.DataPoint, error) {
+		gotEntityIDs = entityIDs
+		return nil, nil
+	}
+
+	_, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+	require.NoError(t, err)
+	assert.Equal(t, []string{"CVE-A", "CVE-B"}, gotEntityIDs)
+}
+
+func TestGetChartDataCVEEmptySetReturnsZeros(t *testing.T) {
+	ds := &mockDatastore{}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+
+	// Non-nil empty slice — the resolver produced no matches but a filter
+	// was requested. The service MUST pass this through verbatim so the
+	// storage layer's "AND 1=0" path fires.
+	ds.trackedCriticalCVEsFn = func(_ context.Context) ([]string, error) {
+		return []string{}, nil
+	}
+	var gotEntityIDs []string
+	gotEntityIDsIsNil := true
+	ds.getSCDDataFunc = func(_ context.Context, _ string, startDate, endDate time.Time, bucketSize time.Duration, _ api.SampleStrategy, _ []byte, entityIDs []string) ([]api.DataPoint, error) {
+		gotEntityIDs = entityIDs
+		gotEntityIDsIsNil = entityIDs == nil
+		numBuckets := int(endDate.Sub(startDate) / bucketSize)
+		points := make([]api.DataPoint, numBuckets)
+		for i := range points {
+			points[i] = api.DataPoint{Timestamp: startDate.Add(time.Duration(i+1) * bucketSize), Value: 0}
+		}
+		return points, nil
+	}
+
+	resp, err := svc.GetChartData(t.Context(), "cve", api.RequestOpts{Days: 7})
+	require.NoError(t, err)
+	assert.False(t, gotEntityIDsIsNil, "service must pass non-nil empty slice so storage layer emits AND 1=0")
+	assert.Empty(t, gotEntityIDs)
+	require.NotEmpty(t, resp.Data)
+	for _, dp := range resp.Data {
+		assert.Zero(t, dp.Value)
+	}
+}
+
+func TestGetChartDataUptimePassesNilEntityIDs(t *testing.T) {
+	ds := &mockDatastore{}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.UptimeDataset{})
+
+	// Stub TrackedCriticalCVEs so an accidental call would fail loudly.
+	ds.trackedCriticalCVEsFn = func(_ context.Context) ([]string, error) {
+		t.Fatal("uptime path must not call TrackedCriticalCVEs")
+		return nil, nil
+	}
+	gotEntityIDsIsNil := false
+	ds.getSCDDataFunc = func(_ context.Context, _ string, _, _ time.Time, _ time.Duration, _ api.SampleStrategy, _ []byte, entityIDs []string) ([]api.DataPoint, error) {
+		gotEntityIDsIsNil = entityIDs == nil
+		return nil, nil
+	}
+
+	_, err := svc.GetChartData(t.Context(), "uptime", api.RequestOpts{Days: 7})
+	require.NoError(t, err)
+	assert.True(t, gotEntityIDsIsNil, "uptime must pass nil entityIDs — the CVE branch must not leak")
 }
 
 func TestGetChartDataWithHostFilters(t *testing.T) {
@@ -519,7 +601,7 @@ func TestUptimeDatasetMetadata(t *testing.T) {
 func TestCVEDatasetMetadata(t *testing.T) {
 	d := &chart.CVEDataset{}
 	assert.Equal(t, "cve", d.Name())
-	assert.Equal(t, 24, d.DefaultResolutionHours())
+	assert.Equal(t, 3, d.DefaultResolutionHours())
 	assert.Equal(t, api.SampleStrategySnapshot, d.SampleStrategy())
 	assert.Equal(t, "line", d.DefaultVisualization())
 }

--- a/server/chart/internal/service/service_test.go
+++ b/server/chart/internal/service/service_test.go
@@ -59,6 +59,7 @@ type mockDatastore struct {
 	getSCDDataFunc            func(ctx context.Context, dataset string, startDate, endDate time.Time, bucketSize time.Duration, strategy api.SampleStrategy, filterMask []byte, entityIDs []string) ([]api.DataPoint, error)
 	getHostIDsForFilterFunc   func(ctx context.Context, hostFilter *types.HostFilter) ([]uint, error)
 	findRecentlySeenHostIDsFn func(ctx context.Context, since time.Time) ([]uint, error)
+	affectedHostIDsByCVEFn    func(ctx context.Context) (map[string][]uint, error)
 	recordBucketDataFn        func(ctx context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error
 	recordBucketDataInvoked   bool
 }
@@ -66,6 +67,13 @@ type mockDatastore struct {
 func (m *mockDatastore) FindRecentlySeenHostIDs(ctx context.Context, since time.Time) ([]uint, error) {
 	if m.findRecentlySeenHostIDsFn != nil {
 		return m.findRecentlySeenHostIDsFn(ctx, since)
+	}
+	return nil, nil
+}
+
+func (m *mockDatastore) AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error) {
+	if m.affectedHostIDsByCVEFn != nil {
+		return m.affectedHostIDsByCVEFn(ctx)
 	}
 	return nil, nil
 }
@@ -462,6 +470,36 @@ func TestCollectDatasetsUptime(t *testing.T) {
 		assert.Equal(t, api.SampleStrategyAccumulate, strategy)
 		require.Len(t, entityBitmaps, 1)
 		assert.NotEmpty(t, entityBitmaps[""])
+		return nil
+	}
+
+	err := svc.CollectDatasets(t.Context(), now)
+	require.NoError(t, err)
+	assert.True(t, ds.recordBucketDataInvoked)
+}
+
+func TestCollectDatasetsCVE(t *testing.T) {
+	ds := &mockDatastore{}
+	svc := NewService(&mockAuthorizer{}, ds, globalViewer(), nil)
+	svc.RegisterDataset(&chart.CVEDataset{})
+
+	now := time.Date(2026, 4, 8, 14, 37, 0, 0, time.UTC)
+	wantBucketStart := time.Date(2026, 4, 8, 14, 0, 0, 0, time.UTC)
+
+	ds.affectedHostIDsByCVEFn = func(_ context.Context) (map[string][]uint, error) {
+		return map[string][]uint{
+			"CVE-2024-0001": {1, 2, 3},
+			"CVE-2024-0002": {2, 4},
+		}, nil
+	}
+	ds.recordBucketDataFn = func(_ context.Context, dataset string, bucketStart time.Time, bucketSize time.Duration, strategy api.SampleStrategy, entityBitmaps map[string][]byte) error {
+		assert.Equal(t, "cve", dataset)
+		assert.Equal(t, wantBucketStart, bucketStart)
+		assert.Equal(t, time.Hour, bucketSize)
+		assert.Equal(t, api.SampleStrategySnapshot, strategy)
+		require.Len(t, entityBitmaps, 2)
+		assert.NotEmpty(t, entityBitmaps["CVE-2024-0001"])
+		assert.NotEmpty(t, entityBitmaps["CVE-2024-0002"])
 		return nil
 	}
 

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -40,6 +40,15 @@ type Datastore interface {
 	// past the vulnerable version, so the join naturally stops matching.
 	AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error)
 
+	// TrackedCriticalCVEs returns CVE IDs matching the iteration-1 curated
+	// filter: critical (CVSS >= 9.0) CVEs on a hard-coded set of software
+	// titles, unioned with all critical OS vulnerabilities. Returns a non-nil
+	// empty slice when nothing matches — callers pass this to GetSCDData's
+	// entityIDs parameter where nil vs empty have distinct semantics.
+	//
+	// TODO(iteration-2): replace with user-configurable filtering.
+	TrackedCriticalCVEs(ctx context.Context) ([]string, error)
+
 	// RecordBucketData writes one or more entity bitmaps for the given bucket using
 	// the specified sample strategy. See api.SampleStrategy for the semantics of
 	// each strategy.

--- a/server/chart/internal/types/chart.go
+++ b/server/chart/internal/types/chart.go
@@ -34,6 +34,12 @@ type Datastore interface {
 	// recent host activity.
 	FindRecentlySeenHostIDs(ctx context.Context, since time.Time) ([]uint, error)
 
+	// AffectedHostIDsByCVE returns, for every CVE currently affecting any host,
+	// the slice of host IDs impacted by it. Unresolved-only is implicit in the
+	// underlying joins: a host's software/OS row transitions when it upgrades
+	// past the vulnerable version, so the join naturally stops matching.
+	AffectedHostIDsByCVE(ctx context.Context) (map[string][]uint, error)
+
 	// RecordBucketData writes one or more entity bitmaps for the given bucket using
 	// the specified sample strategy. See api.SampleStrategy for the semantics of
 	// each strategy.

--- a/tools/charts-collect/main.go
+++ b/tools/charts-collect/main.go
@@ -7,8 +7,8 @@
 // CVE: fetches per-host vulnerability data, builds per-CVE host bitmaps, and
 // reconciles them into host_scd_data (dataset='cve') as snapshot rows.
 // Unchanged CVEs keep their existing open row; changed bitmaps close the prior
-// row at today's midnight (UTC) and open a new one; intra-day changes
-// overwrite today's row via ODKU.
+// row at the current hour boundary (UTC) and open a new one; same-hour
+// re-runs overwrite the open row via ODKU.
 //
 // Usage:
 //
@@ -245,7 +245,7 @@ func collectCVE(api *apiClient, db *sql.DB) error {
 	}
 	log.Printf("  %d unique CVEs found in %.1fs", len(cveHosts), time.Since(fetchStart).Seconds())
 
-	// Build the desired entity->bitmap map for today's 24h bucket.
+	// Build the desired entity->bitmap map for the current hourly bucket.
 	entityBitmaps := make(map[string][]byte, len(cveHosts))
 	for cve, hosts := range cveHosts {
 		entityBitmaps[cve] = chart.HostIDsToBlob(hosts)


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #43769

# Details

Adds methods to collect data for the `cve` dataset.  As with all sets this is collected at hourly granularity, but unlike the `uptime` set, the `cve` set uses the "snapshot" strategy so that we record at most one change (the most recent) per hour.

For this first iteration, we are _recording_ data for all CVEs (i.e., which hosts were exposed to which CVEs at a given time), but we are only _reporting_ a subset of CVEs for the dashboard chart.  See [this comment](https://github.com/fleetdm/fleet/pull/44124#discussion_r3155554405) for more info.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [X] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [X] Added/updated automated tests
- [X] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually
  - [X] Spot-checked the CVEs chosen by the `trackedCVESoftwareMatchers` and didn't find any outside of the expected
  - [X] With [front-end PR](https://github.com/fleetdm/fleet/pull/44261), generated chart:
<img width="706" height="421" alt="image" src="https://github.com/user-attachments/assets/539d9877-6573-4406-a159-1d2a711a045f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Host vulnerability (CVE) chart added to the dashboard; CVE chart data collection is now active.
  * Critical CVE tracking surfaces high-severity vulnerabilities.

* **Improvements**
  * CVE chart refreshes every 3 hours (was daily) for more timely insights.
  * Snapshot collection reconciles and closes prior data during empty runs to keep charts accurate.
  * CVE queries may produce zero datapoints when no tracked CVEs exist, without affecting other metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->