### PR TITLE
Windows MDM osquery-perf fix

### DIFF
--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1440,13 +1440,6 @@ func (a *agent) runWindowsMDMLoop() {
 				CmdID:   fleet.CmdID{Value: uuid.NewString()},
 			})
 		}
-		// If Fleet's initial response contained only <Status> acks (no Install/Delete/Exec for us
-		// to ack), there is nothing left to send. Fleet rejects a SyncML body with zero protocol
-		// commands as "invalid SyncML body: no SyncML protocol commands", so end the session here
-		// like a real Windows client would.
-		if !a.winMDMClient.HasQueuedResponses() {
-			continue
-		}
 		if _, err := a.winMDMClient.SendResponse(); err != nil {
 			log.Printf("MDM send response request failed: %s", err)
 			a.stats.IncrementMDMErrors()

--- a/cmd/osquery-perf/agent.go
+++ b/cmd/osquery-perf/agent.go
@@ -1440,6 +1440,13 @@ func (a *agent) runWindowsMDMLoop() {
 				CmdID:   fleet.CmdID{Value: uuid.NewString()},
 			})
 		}
+		// If Fleet's initial response contained only <Status> acks (no Install/Delete/Exec for us
+		// to ack), there is nothing left to send. Fleet rejects a SyncML body with zero protocol
+		// commands as "invalid SyncML body: no SyncML protocol commands", so end the session here
+		// like a real Windows client would.
+		if !a.winMDMClient.HasQueuedResponses() {
+			continue
+		}
 		if _, err := a.winMDMClient.SendResponse(); err != nil {
 			log.Printf("MDM send response request failed: %s", err)
 			a.stats.IncrementMDMErrors()

--- a/pkg/mdm/mdmtest/windows.go
+++ b/pkg/mdm/mdmtest/windows.go
@@ -375,7 +375,7 @@ func (c *TestWindowsMDMClient) AppendResponse(op fleet.SyncMLCmd) {
 }
 
 // HasQueuedResponses reports whether any command responses have been queued via AppendResponse
-// and not yet flushed by a SendResponse call.
+// and not yet cleared by the next management request.
 func (c *TestWindowsMDMClient) HasQueuedResponses() bool {
 	return len(c.queuedCommandResponses) > 0
 }

--- a/pkg/mdm/mdmtest/windows.go
+++ b/pkg/mdm/mdmtest/windows.go
@@ -374,6 +374,12 @@ func (c *TestWindowsMDMClient) AppendResponse(op fleet.SyncMLCmd) {
 	c.queuedCommandResponses[op.CmdID.Value] = op
 }
 
+// HasQueuedResponses reports whether any command responses have been queued via AppendResponse
+// and not yet flushed by a SendResponse call.
+func (c *TestWindowsMDMClient) HasQueuedResponses() bool {
+	return len(c.queuedCommandResponses) > 0
+}
+
 func (c *TestWindowsMDMClient) GetCurrentMsgID() (string, error) {
 	msgID, err := c.lastManagementResp.GetMessageID()
 	if err != nil {

--- a/pkg/mdm/mdmtest/windows.go
+++ b/pkg/mdm/mdmtest/windows.go
@@ -302,6 +302,18 @@ func (c *TestWindowsMDMClient) shouldAuth(req *fleet.SyncML) (bool, *string) {
 }
 
 func (c *TestWindowsMDMClient) SendResponse() (map[string]fleet.ProtoCmdOperation, error) {
+	// A real Windows client does not POST a message that contains only a SyncHdr Status ack and
+	// no protocol commands. Per [MS-MDM] §2.2.7.8 (Status):
+	//   "when a client creates a message containing only a successful Status in a SyncHdr,
+	//    the entire message MUST NOT be sent."
+	// (https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-mdm/36b1a4d9-fd93-48ce-b865-6a9d396c52a4)
+	// This is the same section that limits Status-on-Status to auth-renegotiation edge cases, so
+	// when Fleet's response contained only <Status> acks, the client has nothing to send back.
+	// Fleet also rejects such a body with "invalid SyncML body: no SyncML protocol commands"
+	if len(c.queuedCommandResponses) == 0 {
+		return nil, nil
+	}
+
 	// Get SessionID
 	sessionID, err := c.lastManagementResp.GetSessionID()
 	if err != nil {
@@ -372,12 +384,6 @@ func (c *TestWindowsMDMClient) hashedCredentials() string {
 // AppendResponse sets a response for a specific command UUID.
 func (c *TestWindowsMDMClient) AppendResponse(op fleet.SyncMLCmd) {
 	c.queuedCommandResponses[op.CmdID.Value] = op
-}
-
-// HasQueuedResponses reports whether any command responses have been queued via AppendResponse
-// and not yet cleared by the next management request.
-func (c *TestWindowsMDMClient) HasQueuedResponses() bool {
-	return len(c.queuedCommandResponses) > 0
 }
 
 func (c *TestWindowsMDMClient) GetCurrentMsgID() (string, error) {


### PR DESCRIPTION
The previous fix #43940 was incomplete and caused a regression. This is the complete fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a validation error occurring during Windows mobile device synchronization by preventing unnecessary status-only messages from being sent to the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->