### PR TITLE
redirect to correct URL, and allow both URLs for MDM SSO SAML validation if set

### DIFF
--- a/changes/41592-eua-broken-with-custom-apple-mdm-url‎
+++ b/changes/41592-eua-broken-with-custom-apple-mdm-url‎
@@ -1,0 +1,1 @@
+- Fixed an issue where if a custom Apple MDM URL was set, SSO for end user auth would fail.

--- a/cmd/fleet/serve.go
+++ b/cmd/fleet/serve.go
@@ -1506,6 +1506,7 @@ func runServeCmd(cmd *cobra.Command, configManager configpkg.Manager, debug, dev
 		if err := apiendpoints.Init(apiHandler); err != nil {
 			panic(fmt.Sprintf("error initializing API endpoints: %v", err))
 		}
+		apiHandler = service.WithMDMSSOCallbackRedirect(svc, logger, apiHandler)
 
 		if serveCSP {
 			// Only injecting this if CSP is turned on since the default security headers add some overhead to each request

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -1012,19 +1012,66 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 		appConfig.MDMUrl(),
 		appConfig.MDMUrl() + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback",
 	}
-	samlProvider, requestID, originalURL, ssoRequestData, err := sso.SAMLProviderFromSession(
-		ctx, sessionID, svc.ssoSessionStore, acsURL, mdmSSOSettings.EntityID, expectedAudiences,
-	)
+	session, err := svc.ssoSessionStore.Fullfill(sessionID)
 	if err != nil {
-		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to create provider from metadata")
+		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "validate request in session")
 	}
 
-	// Parse and verify SAMLResponse (verifies fields, expected IDs and signature).
-	auth, err := sso.ParseAndVerifySAMLResponse(samlProvider, samlResponse, requestID, acsURL)
-	if err != nil {
+	var auth fleet.Auth
+	var ssoErr error
+	if appConfig.MDM.AppleServerURL != "" {
+		// check for both apple server URL and default
+		expectedAudiences = append(expectedAudiences, appConfig.ServerSettings.ServerURL, appConfig.ServerSettings.ServerURL+svc.config.Server.URLPrefix+"/api/v1/fleet/mdm/sso/callback")
+
+		acsURL, err := url.Parse(appConfig.ServerSettings.ServerURL + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback")
+		if err != nil {
+			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse ACS URL with server URL")
+		}
+
+		samlProvider, requestID, authOriginalURL, authSSORequestData, err := sso.SAMLProviderFromSession(
+			ctx, session, acsURL, mdmSSOSettings.EntityID, expectedAudiences,
+		)
+		if err != nil {
+			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to create provider from metadata")
+		}
+
+		// Parse and verify SAMLResponse (verifies fields, expected IDs and signature).
+		// We don't care about the error yet, only if we have no auth and next attempt also errors do we return an error.
+		authAttempt, authErr := sso.ParseAndVerifySAMLResponse(samlProvider, samlResponse, requestID, acsURL)
+
+		if authAttempt != nil {
+			auth = authAttempt
+			originalURL = authOriginalURL
+			ssoRequestData = authSSORequestData
+		} else if authErr != nil {
+			ssoErr = authErr
+		}
+	}
+
+	if auth == nil {
+		samlProvider, requestID, authOriginalURL, authSSORequestData, err := sso.SAMLProviderFromSession(
+			ctx, session, acsURL, mdmSSOSettings.EntityID, expectedAudiences,
+		)
+		if err != nil {
+			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to create provider from metadata")
+		}
+
+		// Parse and verify SAMLResponse (verifies fields, expected IDs and signature).
+		authAttempt, authErr := sso.ParseAndVerifySAMLResponse(samlProvider, samlResponse, requestID, acsURL)
+		if authAttempt != nil {
+			auth = authAttempt
+			originalURL = authOriginalURL
+			ssoRequestData = authSSORequestData
+		} else if authErr != nil {
+			ssoErr = authErr
+		}
+	}
+
+	// if nil after two attempts, return an error.
+	if ssoErr != nil && auth == nil {
 		// We actually don't return 401 to clients and instead return an HTML page with /login?status=error,
 		// but to be consistent we will return fleet.AuthFailedError which is used for unauthorized access.
-		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, fleet.NewAuthFailedError(err.Error()))
+		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, fleet.NewAuthFailedError(ssoErr.Error()))
 	}
 
 	// Store information for automatic account population/creation

--- a/ee/server/service/mdm.go
+++ b/ee/server/service/mdm.go
@@ -991,10 +991,11 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 	}
 
 	serverURL := appConfig.MDMUrl()
-	acsURL, err := url.Parse(serverURL + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback")
+	acsURL, err := url.Parse(serverURL)
 	if err != nil {
 		return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse ACS URL")
 	}
+	acsURL = acsURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
 
 	mdmSSOSettings := appConfig.MDM.EndUserAuthentication.SSOProviderSettings
 
@@ -1009,8 +1010,8 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 
 	expectedAudiences := []string{
 		mdmSSOSettings.EntityID,
-		appConfig.MDMUrl(),
-		appConfig.MDMUrl() + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback",
+		serverURL,
+		acsURL.String(),
 	}
 	session, err := svc.ssoSessionStore.Fullfill(sessionID)
 	if err != nil {
@@ -1021,12 +1022,16 @@ func (svc *Service) mdmSSOHandleCallbackAuth(
 	var ssoErr error
 	if appConfig.MDM.AppleServerURL != "" {
 		// check for both apple server URL and default
-		expectedAudiences = append(expectedAudiences, appConfig.ServerSettings.ServerURL, appConfig.ServerSettings.ServerURL+svc.config.Server.URLPrefix+"/api/v1/fleet/mdm/sso/callback")
-
-		acsURL, err := url.Parse(appConfig.ServerSettings.ServerURL + svc.config.Server.URLPrefix + "/api/v1/fleet/mdm/sso/callback")
+		acsURL, err := url.Parse(appConfig.ServerSettings.ServerURL)
 		if err != nil {
 			return "", "", "", "", sso.SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse ACS URL with server URL")
 		}
+		acsURL = acsURL.JoinPath(svc.config.Server.URLPrefix, "/api/v1/fleet/mdm/sso/callback")
+
+		expectedAudiences = append(expectedAudiences,
+			appConfig.ServerSettings.ServerURL,
+			acsURL.String(),
+		)
 
 		samlProvider, requestID, authOriginalURL, authSSORequestData, err := sso.SAMLProviderFromSession(
 			ctx, session, acsURL, mdmSSOSettings.EntityID, expectedAudiences,

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -63,10 +63,10 @@ func (ds *Datastore) AppConfigUrls(ctx context.Context) (*fleet.AppConfigUrls, e
 	info := &fleet.AppConfigUrls{}
 	var bytes []byte
 	err := sqlx.GetContext(ctx, ds.reader(ctx), &bytes, `SELECT json_value FROM app_config_json LIMIT 1`)
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, ctxerr.Wrap(ctx, err, "selecting app config urls")
 	}
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return &fleet.AppConfigUrls{}, nil
 	}
 

--- a/server/datastore/mysql/app_configs.go
+++ b/server/datastore/mysql/app_configs.go
@@ -59,6 +59,24 @@ func appConfigDB(ctx context.Context, q sqlx.QueryerContext) (*fleet.AppConfig, 
 	return info, nil
 }
 
+func (ds *Datastore) AppConfigUrls(ctx context.Context) (*fleet.AppConfigUrls, error) {
+	info := &fleet.AppConfigUrls{}
+	var bytes []byte
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &bytes, `SELECT json_value FROM app_config_json LIMIT 1`)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, ctxerr.Wrap(ctx, err, "selecting app config urls")
+	}
+	if err == sql.ErrNoRows {
+		return &fleet.AppConfigUrls{}, nil
+	}
+
+	err = json.Unmarshal(bytes, info)
+	if err != nil {
+		return nil, ctxerr.Wrap(ctx, err, "unmarshaling config urls")
+	}
+	return info, nil
+}
+
 func (ds *Datastore) SaveAppConfig(ctx context.Context, info *fleet.AppConfig) error {
 	return ds.withTx(ctx, func(tx sqlx.ExtContext) error {
 		configBytes, err := json.Marshal(info)

--- a/server/fleet/app.go
+++ b/server/fleet/app.go
@@ -289,7 +289,24 @@ type GitOpsConfig struct {
 	Exceptions        GitOpsExceptions `json:"exceptions"`
 }
 
+// Subset of Appconfig to pull out only the serverURL and the MDM.AppleServerURL
+type AppConfigUrls struct {
+	ServerSettings struct {
+		ServerURL string `json:"server_url"`
+	} `json:"server_settings"`
+	MDM struct {
+		AppleServerURL string `json:"apple_server_url"`
+	} `json:"mdm"`
+}
+
 func (c *AppConfig) MDMUrl() string {
+	if c.MDM.AppleServerURL == "" {
+		return c.ServerSettings.ServerURL
+	}
+	return c.MDM.AppleServerURL
+}
+
+func (c *AppConfigUrls) MDMUrl() string {
 	if c.MDM.AppleServerURL == "" {
 		return c.ServerSettings.ServerURL
 	}

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -3208,4 +3208,5 @@ type AccessesMDMConfigAssets interface {
 }
 type GetsAppConfig interface {
 	AppConfig(ctx context.Context) (*AppConfig, error)
+	AppConfigUrls(ctx context.Context) (*AppConfigUrls, error)
 }

--- a/server/fleet/service.go
+++ b/server/fleet/service.go
@@ -523,6 +523,7 @@ type Service interface {
 	AppConfigObfuscated(ctx context.Context) (info *AppConfig, err error)
 	ModifyAppConfig(ctx context.Context, p []byte, applyOpts ApplySpecOptions) (info *AppConfig, err error)
 	SandboxEnabled() bool
+	AppConfigUrls(ctx context.Context) (urls *AppConfigUrls, err error)
 
 	// ApplyEnrollSecretSpec adds and updates the enroll secrets specified in the spec.
 	ApplyEnrollSecretSpec(ctx context.Context, spec *EnrollSecretSpec, applyOpts ApplySpecOptions) error

--- a/server/mdm/apple/apple_apps/api_test.go
+++ b/server/mdm/apple/apple_apps/api_test.go
@@ -197,6 +197,10 @@ func (m *mockDataStore) AppConfig(ctx context.Context) (*fleet.AppConfig, error)
 	return m.appConfig, m.appConfigErr
 }
 
+func (m *mockDataStore) AppConfigUrls(ctx context.Context) (*fleet.AppConfigUrls, error) {
+	return nil, nil
+}
+
 func (m *mockDataStore) InsertMDMConfigAssets(ctx context.Context, assets []fleet.MDMConfigAsset, tx sqlx.ExtContext) error {
 	m.insertMDMConfigAssetsCalled = true
 	return nil

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -25,6 +25,8 @@ var _ fleet.Datastore = (*DataStore)(nil)
 
 type AppConfigFunc func(ctx context.Context) (*fleet.AppConfig, error)
 
+type AppConfigUrlsFunc func(ctx context.Context) (*fleet.AppConfigUrls, error)
+
 type InsertMDMConfigAssetsFunc func(ctx context.Context, assets []fleet.MDMConfigAsset, tx sqlx.ExtContext) error
 
 type InsertOrReplaceMDMConfigAssetFunc func(ctx context.Context, asset fleet.MDMConfigAsset) error
@@ -1880,6 +1882,9 @@ type MDMWindowsAcknowledgeEnrolledDeviceCredentialsFunc func(ctx context.Context
 type DataStore struct {
 	AppConfigFunc        AppConfigFunc
 	AppConfigFuncInvoked bool
+
+	AppConfigUrlsFunc        AppConfigUrlsFunc
+	AppConfigUrlsFuncInvoked bool
 
 	InsertMDMConfigAssetsFunc        InsertMDMConfigAssetsFunc
 	InsertMDMConfigAssetsFuncInvoked bool
@@ -4667,6 +4672,13 @@ func (s *DataStore) AppConfig(ctx context.Context) (*fleet.AppConfig, error) {
 	s.AppConfigFuncInvoked = true
 	s.mu.Unlock()
 	return s.AppConfigFunc(ctx)
+}
+
+func (s *DataStore) AppConfigUrls(ctx context.Context) (*fleet.AppConfigUrls, error) {
+	s.mu.Lock()
+	s.AppConfigUrlsFuncInvoked = true
+	s.mu.Unlock()
+	return s.AppConfigUrlsFunc(ctx)
 }
 
 func (s *DataStore) InsertMDMConfigAssets(ctx context.Context, assets []fleet.MDMConfigAsset, tx sqlx.ExtContext) error {

--- a/server/mock/service/service_mock.go
+++ b/server/mock/service/service_mock.go
@@ -312,6 +312,8 @@ type ModifyAppConfigFunc func(ctx context.Context, p []byte, applyOpts fleet.App
 
 type SandboxEnabledFunc func() bool
 
+type AppConfigUrlsFunc func(ctx context.Context) (urls *fleet.AppConfigUrls, err error)
+
 type ApplyEnrollSecretSpecFunc func(ctx context.Context, spec *fleet.EnrollSecretSpec, applyOpts fleet.ApplySpecOptions) error
 
 type GetEnrollSecretSpecFunc func(ctx context.Context) (*fleet.EnrollSecretSpec, error)
@@ -1354,6 +1356,9 @@ type Service struct {
 
 	SandboxEnabledFunc        SandboxEnabledFunc
 	SandboxEnabledFuncInvoked bool
+
+	AppConfigUrlsFunc        AppConfigUrlsFunc
+	AppConfigUrlsFuncInvoked bool
 
 	ApplyEnrollSecretSpecFunc        ApplyEnrollSecretSpecFunc
 	ApplyEnrollSecretSpecFuncInvoked bool
@@ -3284,6 +3289,13 @@ func (s *Service) SandboxEnabled() bool {
 	s.SandboxEnabledFuncInvoked = true
 	s.mu.Unlock()
 	return s.SandboxEnabledFunc()
+}
+
+func (s *Service) AppConfigUrls(ctx context.Context) (urls *fleet.AppConfigUrls, err error) {
+	s.mu.Lock()
+	s.AppConfigUrlsFuncInvoked = true
+	s.mu.Unlock()
+	return s.AppConfigUrlsFunc(ctx)
 }
 
 func (s *Service) ApplyEnrollSecretSpec(ctx context.Context, spec *fleet.EnrollSecretSpec, applyOpts fleet.ApplySpecOptions) error {

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -264,6 +264,17 @@ func (svc *Service) AppConfigObfuscated(ctx context.Context) (*fleet.AppConfig, 
 	return ac, nil
 }
 
+func (svc *Service) AppConfigUrls(ctx context.Context) (*fleet.AppConfigUrls, error) {
+	// We skip auhtorization, as this is used where we don't have access to it, but that is why we return a subset of AppConfig fields.
+	svc.authz.SkipAuthorization(ctx)
+
+	ac, err := svc.ds.AppConfigUrls(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return ac, nil
+}
+
 // //////////////////////////////////////////////////////////////////////////////
 // Modify AppConfig
 // //////////////////////////////////////////////////////////////////////////////

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -1388,6 +1390,39 @@ func registerMDM(
 		httpmdm.SigLogWithLogger(mdmLogger.With("handler", "cert-extract")))
 	mux.Handle(apple_mdm.MDMPath, otel.WrapHandler(mdmHandler, apple_mdm.MDMPath, fleetConfig))
 	return nil
+}
+
+func WithMDMSSOCallbackRedirect(svc fleet.Service, logger *slog.Logger, next http.Handler) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/mdm/sso/callback") {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Check for custom apple URL set and does not match the current request URL, then do a redirect to the custom URL, where the Cookie is set.
+		appCfg, err := svc.AppConfigUrls(r.Context())
+		if err != nil {
+			logger.ErrorContext(r.Context(), "fetching app config", "err", err)
+			next.ServeHTTP(w, r)
+			return
+		}
+		parsedUrl, err := url.Parse(appCfg.MDMUrl())
+		if err != nil {
+			logger.ErrorContext(r.Context(), "parsing custom Apple MDM URL", "err", err)
+			next.ServeHTTP(w, r)
+			return
+		}
+		reqHost := r.Host
+		if h, _, err := net.SplitHostPort(reqHost); err == nil {
+			reqHost = h
+		}
+		fmt.Printf("Comparing APPLE %s with incoming %s", parsedUrl.Hostname(), reqHost)
+		if !strings.EqualFold(parsedUrl.Hostname(), reqHost) {
+			logger.InfoContext(r.Context(), "redirecting to custom Apple MDM URL for SSO callback")
+			http.Redirect(w, r, appCfg.MDMUrl()+r.URL.Path+"?"+r.URL.RawQuery, http.StatusTemporaryRedirect)
+			return
+		}
+		next.ServeHTTP(w, r)
+	}
 }
 
 func WithMDMEnrollmentMiddleware(svc fleet.Service, logger *slog.Logger, next http.Handler) http.HandlerFunc {

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1394,7 +1394,7 @@ func registerMDM(
 
 func WithMDMSSOCallbackRedirect(svc fleet.Service, logger *slog.Logger, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/mdm/sso/callback") {
+		if !strings.HasSuffix(r.URL.Path, "/fleet/mdm/sso/callback") {
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -1415,10 +1415,13 @@ func WithMDMSSOCallbackRedirect(svc fleet.Service, logger *slog.Logger, next htt
 		if h, _, err := net.SplitHostPort(reqHost); err == nil {
 			reqHost = h
 		}
-		fmt.Printf("Comparing APPLE %s with incoming %s", parsedUrl.Hostname(), reqHost)
+
 		if !strings.EqualFold(parsedUrl.Hostname(), reqHost) {
+			target := *parsedUrl
+			target.Path = r.URL.Path
+			target.RawQuery = r.URL.RawQuery
 			logger.InfoContext(r.Context(), "redirecting to custom Apple MDM URL for SSO callback")
-			http.Redirect(w, r, appCfg.MDMUrl()+r.URL.Path+"?"+r.URL.RawQuery, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, target.String(), http.StatusTemporaryRedirect)
 			return
 		}
 		next.ServeHTTP(w, r)

--- a/server/service/handler.go
+++ b/server/service/handler.go
@@ -1398,6 +1398,13 @@ func WithMDMSSOCallbackRedirect(svc fleet.Service, logger *slog.Logger, next htt
 			next.ServeHTTP(w, r)
 			return
 		}
+		// First check if the cookie is set on the current domain, if it is, just serve as is.
+		_, err := r.Cookie(cookieNameSSOSession)
+		if err == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		// Check for custom apple URL set and does not match the current request URL, then do a redirect to the custom URL, where the Cookie is set.
 		appCfg, err := svc.AppConfigUrls(r.Context())
 		if err != nil {

--- a/server/sso/saml_provider.go
+++ b/server/sso/saml_provider.go
@@ -56,7 +56,7 @@ func SAMLProviderFromConfiguredMetadata(
 }
 
 // SAMLProviderFromSession creates a SAML provider that can validate SAML responses
-// from a valid SSO session (stored in sessionStore).
+// from a valid SSO session.
 func SAMLProviderFromSession(
 	ctx context.Context,
 	session *Session,

--- a/server/sso/saml_provider.go
+++ b/server/sso/saml_provider.go
@@ -59,16 +59,11 @@ func SAMLProviderFromConfiguredMetadata(
 // from a valid SSO session (stored in sessionStore).
 func SAMLProviderFromSession(
 	ctx context.Context,
-	sessionID string,
-	sessionStore SessionStore,
+	session *Session,
 	acsURL *url.URL,
 	entityID string,
 	expectedAudiences []string,
 ) (samlProvider *saml.ServiceProvider, requestID, originalURL string, ssoRequestData SSORequestData, err error) {
-	session, err := sessionStore.Fullfill(sessionID)
-	if err != nil {
-		return nil, "", "", SSORequestData{}, ctxerr.Wrap(ctx, err, "validate request in session")
-	}
 	entityDescriptor, err := ParseMetadata([]byte(session.Metadata))
 	if err != nil {
 		return nil, "", "", SSORequestData{}, ctxerr.Wrap(ctx, err, "failed to parse metadata")


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #41592 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSO failures when a custom Apple MDM URL is configured: callback requests are now redirected to the configured MDM URL when needed, and SAML validation correctly considers the configured MDM/server URLs so authentication succeeds for custom MDM setups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->