### PR TITLE
Better Apple server URL validation

### DIFF
--- a/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
+++ b/frontend/pages/admin/OrgSettingsPage/cards/Advanced/Advanced.tsx
@@ -55,13 +55,23 @@ const validateFormData = ({
 
   if (!ssoUserURL) {
     delete errors.ssoUserURL;
-  } else if (!validUrl({ url: ssoUserURL })) {
+  } else if (
+    !validUrl({
+      url: ssoUserURL,
+    })
+  ) {
     errors.ssoUserURL = "SSO user URL is not a valid URL";
   }
 
   if (!mdmAppleServerURL) {
     delete errors.mdmAppleServerURL;
-  } else if (!validUrl({ url: mdmAppleServerURL })) {
+  } else if (
+    !validUrl({
+      url: mdmAppleServerURL,
+      allowLocalHost: false,
+      protocols: ["http", "https"],
+    })
+  ) {
     errors.mdmAppleServerURL = "Apple MDM server URL is not a valid URL";
   }
 

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1147,12 +1147,16 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		if err != nil {
 			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must be a valid URL")
 		}
-
-		if parsedURL.Scheme == "" {
+		scheme := strings.ToLower(parsedURL.Scheme)
+		if scheme == "" {
 			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must include a URL scheme (e.g. https://)")
 		}
 
-		if parsedURL.Host == "" {
+		if scheme != "http" && scheme != "https" {
+			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "URL scheme must be http or https")
+		}
+
+		if parsedURL.Hostname() == "" {
 			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must include a host")
 		}
 	}

--- a/server/service/appconfig.go
+++ b/server/service/appconfig.go
@@ -1141,6 +1141,22 @@ func (svc *Service) ModifyAppConfig(ctx context.Context, p []byte, applyOpts fle
 		appConfig.MDM.EndUserAuthentication.SSOProviderSettings
 	serverURLChanged := oldAppConfig.ServerSettings.ServerURL != appConfig.ServerSettings.ServerURL
 	appleMDMUrlChanged := oldAppConfig.MDMUrl() != appConfig.MDMUrl()
+
+	if appleMDMUrlChanged && appConfig.MDM.AppleServerURL != "" {
+		parsedURL, err := url.Parse(appConfig.MDM.AppleServerURL)
+		if err != nil {
+			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must be a valid URL")
+		}
+
+		if parsedURL.Scheme == "" {
+			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must include a URL scheme (e.g. https://)")
+		}
+
+		if parsedURL.Host == "" {
+			return nil, fleet.NewInvalidArgumentError("mdmAppleServerURL", "must include a host")
+		}
+	}
+
 	if (mdmEnableEndUserAuthChanged || mdmSSOSettingsChanged || serverURLChanged || appleMDMUrlChanged) && lic.IsPremium() {
 		if err := svc.EnterpriseOverrides.MDMAppleSyncDEPProfiles(ctx); err != nil {
 			return nil, ctxerr.Wrap(ctx, err, "sync DEP profiles")

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1354,6 +1354,14 @@ func TestMDMConfig(t *testing.T) {
 			expectedError: "mdmAppleServerURL must include a URL scheme",
 		},
 		{
+			name:        "apple MDM server URL invalid protocol",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				AppleServerURL: "ftp://bogus.url.com",
+			},
+			expectedError: "mdmAppleServerURL URL scheme must be http or https",
+		},
+		{
 			name:        "apple MDM server invalid URL",
 			licenseTier: "premium",
 			newMDM: fleet.MDM{

--- a/server/service/appconfig_test.go
+++ b/server/service/appconfig_test.go
@@ -1345,6 +1345,30 @@ func TestMDMConfig(t *testing.T) {
 			},
 			expectedError: `"enable_end_user_authentication" must be set to "true"`,
 		},
+		{
+			name:        "apple MDM server URL no protocol",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				AppleServerURL: "bogus.url.com",
+			},
+			expectedError: "mdmAppleServerURL must include a URL scheme",
+		},
+		{
+			name:        "apple MDM server invalid URL",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				AppleServerURL: "http://[::1]:namedport",
+			},
+			expectedError: "mdmAppleServerURL must be a valid URL",
+		},
+		{
+			name:        "apple MDM server no host",
+			licenseTier: "premium",
+			newMDM: fleet.MDM{
+				AppleServerURL: "http:///path-only",
+			},
+			expectedError: "mdmAppleServerURL must include a host",
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Small PR to improve URL validation for Apple Server URL, frontend now also requires a protocol, and does require a TLD (aka. no localhost).

Backend requires a scheme/protocol, and no empty hostname, we previously did not have these validations in place, which breaks if you don't use a scheme for the URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for MDM Apple Server URL and SSO User URL settings. MDM Apple Server URL now rejects localhost and non-HTTP/HTTPS schemes, and reports clearer errors for malformed URLs to reduce misconfiguration.

* **Tests**
  * Added test cases covering malformed MDM Apple Server URL inputs to ensure validation behaves as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->