### PR TITLE
Adding changes for Fleet v4.84.0 (#43092)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,114 @@
+## Fleet 4.84.0 (Apr 24, 2026)
+
+### IT Admins
+- Added support for Entra conditional access to Windows devices.
+- Added ability to pin Fleet-maintained apps to a specific major version in GitOps.
+- Implemented ACME for MDM protocol communication, and hardware device attestation.
+- Added `GET /api/v1/fleet/hosts/{id}/reports` endpoint (also accessible as `/hosts/{id}/queries`) that lists the query reports associated with a specific host.
+- Added support for `labels_include_all` conditional scoping for software installers and apps.
+- Added validation for software install, uninstall, and post-install scripts.
+- Added ability to specify custom patch policy query in an FMA manifest.
+- Added ability to re-send Android certificates to a specific host.
+- Added Reports tab to Host details page.
+- Allowed specifying a Fleet-Maintained App (FMA) as a policy software automation in GitOps.
+- Added support for running python scripts on macOS and Linux.
+- Added automatic retry (up to 3 times) when the Android agent reports a certificate install failure.
+- Added activity logging when a certificate is installed or fails to install on an Android host.
+- Enabled the host activity card on the Android host details page.
+- Switched Fleet-maintained apps serving location from GitHub to https://maintained-apps.fleetdm.com/manifests. **NOTE:** If you limit outbound Fleet server traffic, make sure it can access the new FMA manifests location.
+- Increased automatic retry limit for failed Apple (macOS, iOS, iPadOS) configuration profiles from 1 to 3. Windows profiles remain at 1 retry.
+- Added a new `disk_space` fleetd table for macOS that reports available disk space including purgeable storage, matching the value shown in Finder's "Get Info" dialog and System Settings → General → Storage.
+- Added configuration profile deletion when a Windows configuration profile is deleted or a host moves teams via SyncML `<Delete>` commands, bringing Windows profile removal to parity with macOS.
+- Added support for outputting VPP policy automations in `fleetctl generate-gitops`.
+- Added logging of profile names alongside MDM commands installing or removing them.
+- Added indication in the UI when a profile command was deferred via `NotNow` status.
+- Added activity when setup experience is canceled due to software install failure.
+- Added cancel activities for each VPP app install skipped due to setup experience cancellation, and switched "failed" activity to "canceled" for package-based software installs in the same situation.
+- Added install failure activity when VPP installs fail due to licensing issues during setup experience.
+
+### Security Engineers
+- Added vulnerability detection for Microsoft 365 Apps and Office products on Windows.
+- Added OSV data source for Ubuntu vulnerability scanning.
+- Added automatic rotation of Mac recovery lock passwords 1 hour after the password is viewed via the API.
+- Updated ingestion/CVE logic to support JetBrains software with 2 version numbers, like WebStorm 2025.1
+- Addressed false positive vulnerabilities (CVE-2019-17201, CVE-2019-17202) reported for Admin By Request on macOS and Linux hosts. These CVEs are Windows-specific.
+- Generated correct CPE from malformed ipswitch whatsup CPE, ensuring applicable CVEs are matched.
+- Added software source to ecosystem matching to help prevent non-deterministic CPE selection when multiple vendors exist for the same product.
+
+### Other improvements and bug fixes
+- Upped the default limit for the software batch endpoint, from 1MiB to 25MiB.
+- Added `FLEET_MDM_CERTIFICATE_PROFILES_LIMIT` server config option to throttle the number of CA certificate profile installations per reconciler cycle, preventing CA server overload in large deployments.
+- Added banner to Add software page to inform users that Android web apps require Google Chrome.
+- Enabled Windows MDM in `fleetctl preview` by auto-generating WSTEP certificates on startup.
+- Used the same templates for `fleetctl new` and new instance initialization.
+- Added "API time" to GitOps output on API errors.
+- Allowed clearing Windows OS update deadline and grace period fields to remove enforcement.
+- Updated ordering of setup experience software to take display names into account.
+- Updated iOS/iPadOS refetch logic to slowly clear out old/stale results.
+- Increased the default SSO session validity period from 5 to 15 minutes.
+- Improved performance of distributed read endpoint by reducing mutex contention in shouldUpdate using sync.RWMutex instead of sync.Mutex.
+- Allowed OTEL service name to be overridden with standard OTEL_SERVICE_NAME env var.
+- Revised which versions Fleet tests MySQL against to remove 8.0.39 and add 8.0.42.
+- Allowed typing whitespace on Settings > Integrations > SSO > End users form.
+- Removed incorrect `report` key from get/create/modify API responses.
+- Added `(query_id, has_data, host_id, last_fetched)` index on query_results.
+- Improved database query performance for the Host Details > Reports page by adding a `has_data` virtual generated column to `query_results`.
+- Made sure that fleet names are trimmed and validate to prevent whitespace-only or padded names across API, gitops, frontend, and existing data.
+- Hid host details > reports in the UI from platforms that do not support scheduled reporting.
+- Updated GitOps label functionality to allow omitting the `hosts:` key under a manual label to mean "preserve existing host membership", rather than removing all hosts.
+- Added Flatcar Container Linux and CoreOS to the list of recognized Linux platforms, fixing host detail queries (IP address, disk space, etc.) not being sent to hosts running these distributions.
+- Updated the default fleet selected when navigating to the dashboard and to controls.
+- Reduced redundant database queries during policy result submission by computing flipping policies once per host check-in instead of multiple times.
+- Reduced redundant database calls in the osquery distributed query results hot path by pre-loading configuration (AppConfig, HostFeatures, TeamMDMConfig, conditional access) once per request instead of once per detail query result.
+- Updated UI to use new multiplatform API keys.
+- Activated warnings for deprecated API parameters, API URLs, fleetctl commands and fleetctl command options.
+- Updated the Request Certificate API to return the proper PEM header for PKCS #7 certificates returned by EST CAs.
+- Added "Learn more" link on End User Authentication section.
+- Moved Apple MDM worker to a faster cron, and started sending profiles on Post DEP enrollment job, to speed up initial macOS setup.
+- Optimized `PolicyQueriesForHost` and `ListPoliciesForHost` SQL queries by replacing correlated subqueries with a single aggregated LEFT JOIN for label-based policy scoping, reducing query time by ~77% at scale.
+- Improved VPP install failure messaging to explain verification timeouts in Host details and My device install details.
+- Refactored large anonymous functions into named functions to improve nil-safety static analysis coverage.
+- Renamed "Custom settings" to "Configuration profiles" in Fleet UI.
+- Added description to UI to help users understand which fleet a policy belongs to during add/edit.
+- Updated Fleet-maintained apps to overwrite software title names on sync and when adding an FMA installer.
+- Improved Fleet server performance for the Windows MDM profiles summary and host OS settings filter queries by replacing correlated subqueries with a single aggregation pass.
+- Improved Windows MDM server performance at scale by reducing redundant database queries during device check-ins.
+- Updated go to 1.26.1
+- Fixed a server panic when uploading a Windows MDM profile to a fleet on a free license.
+- Fixed MSRC vulnerability scanning to differentiate between Windows Server Core and full desktop installations, preventing false positive/negative CVEs caused by non-deterministic product matching.
+- Fixed GitOps policy software resolution failing when URL lookup doesn't match, by falling back to hash-based lookup.
+- Fixed GitOps failing to delete a certificate authority when certificate templates still reference it in fleet configs.
+- Fixed duplicate text in error message when script validation fails when adding a custom package.
+- Fixed issue where the `include_available_for_install` query param wasn't being applied correctly to the `GET /api/latest/fleet/hosts/{id}/software` endpoint.
+- Fixed disk encryption key modal to not show stale key when switching between hosts.
+- Fixed SCIM user not associating with host when IdP username was set before the SCIM user was created.
+- Fixed  Google Drive version not matching upstream.
+- Fixed bug that cleared the MDM lock state if an "idle" message was received right after the lock ACK.
+- Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.
+- Fixed fleetd installation failure on macOS when installing it through Host details page > Software > Library as a Custom package.
+- Fixed a bug where SQL queries using table aliases (e.g., `FROM mounts m`) incorrectly reported no compatible platforms.
+- Fixed `fleetctl gitops` failing with "No available VPP Token" when assigning VPP apps alongside a new team.
+- Fixed a bug where OS versions were not populated in vulnerability details for OS-only vulnerabilities (e.g., macOS CVEs).
+- Fixed a TOCTOU-related issue when checking before deleting last admin.
+- Fixed database locking issues on the policy_membership table by batching cleanup DELETE operations and moving them outside the primary GitOps apply transaction.
+- Fixed success message on Android software configuration to reference software display name when applicable.
+- Fixed a bug where Android host certificate template records were not cleared when a device unenrolled, causing stale certificate statuses after re-enrollment.
+- Fixed a bug where the organization logo URL entered during setup was only saved for dark backgrounds and not for light backgrounds.
+- Fixed an issue where setup experience items (software to install) were not enqueued for Linux distributions that did not report a "platform-like" value, e.g. Arch Linux and Omarchy.
+- Fixed a bug where filtering hosts by software version for a software version not present on the selected team returned nil software instead of a lightweight report of the software.
+- Fixed Fleet's usage of the incorrectly spelled 'vulnerabities' in favor of 'vulnerabilities' in MSRC bulletins.
+- Fixed nondeterministic CPE matching when multiple CPE candidates share the same product name.
+- Fixed a bug where Windows hosts with an empty `display_version` in the database would get 0 CVEs from MSRC vulnerability scanning.
+- Fixed a bug where `fleetctl generate-gitops` failed if a Fleet-maintained app was associated to a software title with a different name (e.g. names with different versions).
+- Fixed `fleetctl generate-gitops` failing to include VPP fleet assignments.
+- Fixed query results table deduplicating rows when query data contains an `id` column, and fixed `id` column header and cell styling.
+- Fixed missing underline on "Reports" nav item when active in top navigation.
+- Fixed bug where adding a patch policy for a new installer in the UI caused gitops runs that didn't include that installer to fail.
+- Fixed browser back button requiring an extra click to leave the Policies and Reports pages.
+- Fixed a bug where Fleet continued to show a stale Recovery Lock password after a macOS host left MDM, by soft-deleting the stored password whenever the host leaves MDM (re-enrollment, CheckOut, admin unenroll, or a periodic sweep of hosts osquery reports as unenrolled) and hiding the password on the host details page until the host is enrolled again.
+- Fixed an issue where silent migration status would persist even after re-enrolling the device normally, causing SCEP renewal to fail.
+- Fixed issue where the "Change Management" form would reset when the page lost and regained focus.
+
 ## Fleet 4.83.2 (Apr 13, 2026)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@
 - Fixed issue where the `include_available_for_install` query param wasn't being applied correctly to the `GET /api/latest/fleet/hosts/{id}/software` endpoint.
 - Fixed disk encryption key modal to not show stale key when switching between hosts.
 - Fixed SCIM user not associating with host when IdP username was set before the SCIM user was created.
-- Fixed  Google Drive version not matching upstream.
+- Fixed Google Drive version not matching upstream.
 - Fixed bug that cleared the MDM lock state if an "idle" message was received right after the lock ACK.
 - Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.
 - Fixed fleetd installation failure on macOS when installing it through Host details page > Software > Library as a Custom package.

--- a/changes/14827-prevent-TOCTOU-last-admin
+++ b/changes/14827-prevent-TOCTOU-last-admin
@@ -1,1 +1,0 @@
-* Fixed a TOCTOU related issue when checking before deleting last admin.

--- a/changes/29657-custom-settings-configuration-profiles
+++ b/changes/29657-custom-settings-configuration-profiles
@@ -1,1 +1,0 @@
-Renamed "Custom settings" to "Configuration profiles" in Fleet UI.

--- a/changes/31289-acme-for-mdm-protocol
+++ b/changes/31289-acme-for-mdm-protocol
@@ -1,1 +1,0 @@
-* Implemented ACME for MDM protocol communication, and hardware device attestation.

--- a/changes/32126-macos-fleetd-reinstall
+++ b/changes/32126-macos-fleetd-reinstall
@@ -1,1 +1,0 @@
-* Fixed fleetd installation failure on macOS when installing it through Host details page > Software > Library as a Custom package.

--- a/changes/32662-include-correct-cpe
+++ b/changes/32662-include-correct-cpe
@@ -1,1 +1,0 @@
-- Generate correct CPE from malformed ipswitch whatsup CPE, ensuring applicable CVEs are matched.

--- a/changes/32773-preview-windows-mdm
+++ b/changes/32773-preview-windows-mdm
@@ -1,1 +1,0 @@
-* Enabled Windows MDM in `fleetctl preview` by auto-generating WSTEP certificates on startup.

--- a/changes/33106-fix-generate-gitops-vpp
+++ b/changes/33106-fix-generate-gitops-vpp
@@ -1,1 +1,0 @@
-- Fixed `fleetctl generate-gitops` failing to include VPP fleet assignments.

--- a/changes/33418-windows-mdm-profile-deletion
+++ b/changes/33418-windows-mdm-profile-deletion
@@ -1,1 +1,0 @@
-* When a Windows configuration profile is deleted or a host moves teams, Fleet now sends SyncML `<Delete>` commands to remove the settings from the device, bringing Windows profile removal to parity with macOS.

--- a/changes/34288-setup-experience-cancel-activity
+++ b/changes/34288-setup-experience-cancel-activity
@@ -1,3 +1,0 @@
-- Added activity when setup experience is canceled due to software install failure
-- Added cancel activities for each VPP app install skipped due to setup experience cancellation, and switched "failed" activity to "canceled" for package-based software installs in the same situation
-- Added install failure activity when VPP installs fail due to licensing issues during setup experience

--- a/changes/34433-speedup-macos-profile-delivery
+++ b/changes/34433-speedup-macos-profile-delivery
@@ -1,1 +1,0 @@
-- Moved Apple MDM worker to a faster cron, and started sending profiles on Post DEP enrollment job, to speed up initial macOS setup.

--- a/changes/34667-scim-user-host-emails-association
+++ b/changes/34667-scim-user-host-emails-association
@@ -1,1 +1,0 @@
-* Fixed SCIM user not associating with host when IdP username was set before the SCIM user was created.

--- a/changes/34950-nano-tables-cleanup
+++ b/changes/34950-nano-tables-cleanup
@@ -1,1 +1,0 @@
-* Updated iOS/iPadOS refetch logic to slowly clear out old/stale results

--- a/changes/35067-windows-pro-missing-vulnerabilities
+++ b/changes/35067-windows-pro-missing-vulnerabilities
@@ -1,1 +1,0 @@
-* Fixed a bug where Windows hosts with an empty `display_version` in the database would get 0 CVEs from MSRC vulnerability scanning.

--- a/changes/35467-detail-query-config-preload
+++ b/changes/35467-detail-query-config-preload
@@ -1,1 +1,0 @@
-* Reduced redundant database calls in the osquery distributed query results hot path by pre-loading configuration (AppConfig, HostFeatures, TeamMDMConfig, conditional access) once per request instead of once per detail query result.

--- a/changes/35484-improve-policy_membership-contention
+++ b/changes/35484-improve-policy_membership-contention
@@ -1,1 +1,0 @@
-* Fixed database locking issues on the policy_membership table by batching cleanup DELETE operations and moving them outside the primary GitOps apply transaction.

--- a/changes/36312-trim-spaces-from-fleets-names
+++ b/changes/36312-trim-spaces-from-fleets-names
@@ -1,1 +1,0 @@
-* Made sure that fleet names are trimmed and validate to prevent whitespace-only or padded names across API, gitops, frontend, and existing data.

--- a/changes/36643-fix-back-button-policies-reports
+++ b/changes/36643-fix-back-button-policies-reports
@@ -1,1 +1,0 @@
-* Fixed browser back button requiring an extra click to leave the Policies and Reports pages.

--- a/changes/36751-add-fmas-to-policy-automation
+++ b/changes/36751-add-fmas-to-policy-automation
@@ -1,1 +1,0 @@
-- Allow specifying a Fleet-Maintained App (FMA) as a policy software automation in GitOps

--- a/changes/36799-macos-disk-space-purgeable
+++ b/changes/36799-macos-disk-space-purgeable
@@ -1,1 +1,0 @@
-* Added a new `disk_space` fleetd table for macOS that reports available disk space including purgeable storage, matching the value shown in Finder's "Get Info" dialog and System Settings → General → Storage.

--- a/changes/37323-jetbrains-cve
+++ b/changes/37323-jetbrains-cve
@@ -1,1 +1,0 @@
-* Updated ingestion/CVE logic to support JetBrains software with 2 version numbers, like WebStorm 2025.1

--- a/changes/37546-android-certificate-install-activity
+++ b/changes/37546-android-certificate-install-activity
@@ -1,3 +1,0 @@
-- Added automatic retry (up to 3 times) when the Android agent reports a certificate install failure.
-- Added activity logging when a certificate is installed or fails to install on an Android host.
-- Enabled the host activity card on the Android host details page.

--- a/changes/37556-resend-android-certs
+++ b/changes/37556-resend-android-certs
@@ -1,1 +1,0 @@
-- Added ability to re-send Android certificates to a specific host

--- a/changes/38002-throttle-ca-certificate-profiles
+++ b/changes/38002-throttle-ca-certificate-profiles
@@ -1,1 +1,0 @@
-- Added `FLEET_MDM_CERTIFICATE_PROFILES_LIMIT` server config option to throttle the number of CA certificate profile installations per reconciler cycle, preventing CA server overload in large deployments.

--- a/changes/38036-gitops-ca-delete-order
+++ b/changes/38036-gitops-ca-delete-order
@@ -1,1 +1,0 @@
-* Fixed GitOps failing to delete a certificate authority when certificate templates still reference it in fleet configs.

--- a/changes/38041-entra-windows-conditional-access
+++ b/changes/38041-entra-windows-conditional-access
@@ -1,1 +1,0 @@
-* Added support for Entra conditional access to Windows devices.

--- a/changes/38793-python-scripts
+++ b/changes/38793-python-scripts
@@ -1,1 +1,0 @@
-- Added support for running python scripts on macOS and Linux

--- a/changes/38929-reports-tab
+++ b/changes/38929-reports-tab
@@ -1,1 +1,0 @@
-- Fleet UI: Hide host details > reports from platforms that do not support scheduled reporting

--- a/changes/38988-fma-pin-major-version
+++ b/changes/38988-fma-pin-major-version
@@ -1,1 +1,0 @@
-- Added ability to pin Fleet-maintained apps to a specific major version in GitOps.

--- a/changes/39066-vpp-timeout-install-details
+++ b/changes/39066-vpp-timeout-install-details
@@ -1,1 +1,0 @@
-- Improved VPP install failure messaging to explain verification timeouts in Host details and My device install details.

--- a/changes/39082-setup-logo-light-background
+++ b/changes/39082-setup-logo-light-background
@@ -1,1 +1,0 @@
-* Fixed a bug where the organization logo URL entered during setup was only saved for dark backgrounds and not for light backgrounds.

--- a/changes/39190-display-sw-version-filter
+++ b/changes/39190-display-sw-version-filter
@@ -1,2 +1,0 @@
-- Fixed a bug where filtering hosts by software version for a software version not present on the selected team returned nil software instead of a lightweight report of the software
-- Fixed the UI bug the above caused

--- a/changes/39308-team-ca-read-access
+++ b/changes/39308-team-ca-read-access
@@ -1,1 +1,0 @@
-* Fixed team maintainers, admins, and GitOps users being unable to add certificate templates due to missing read access to certificate authorities.

--- a/changes/39316-winoffice-vulnerability-detection
+++ b/changes/39316-winoffice-vulnerability-detection
@@ -1,1 +1,0 @@
-* Added vulnerability detection for Microsoft 365 Apps and Office products on Windows.

--- a/changes/39842-generate-gitops-bug
+++ b/changes/39842-generate-gitops-bug
@@ -1,1 +1,0 @@
-- Fixed a bug where `fleetctl generate-gitops` failed if a Fleet-maintained app was associated to a software title with a different name (e.g. names with different versions).

--- a/changes/39899-deterministic-cpe-matching
+++ b/changes/39899-deterministic-cpe-matching
@@ -1,1 +1,0 @@
-* Fixed nondeterministic CPE matching when multiple CPE candidates share the same product name.

--- a/changes/39968-sso-validity-increase-default
+++ b/changes/39968-sso-validity-increase-default
@@ -1,1 +1,0 @@
-Increased the default SSO session validity period from 5 to 15 minutes.

--- a/changes/40015-activate-deprecation-warnings
+++ b/changes/40015-activate-deprecation-warnings
@@ -1,1 +1,0 @@
-- Activated warnings for deprecated API parameters, API URLs, fleetctl commands and fleetctl command options.

--- a/changes/40050-server-core-msrc-differentiation
+++ b/changes/40050-server-core-msrc-differentiation
@@ -1,1 +1,0 @@
-* Fixed MSRC vulnerability scanning to differentiate between Windows Server Core and full desktop installations, preventing false positive/negative CVEs caused by non-deterministic product matching.

--- a/changes/40057-osv-vulns
+++ b/changes/40057-osv-vulns
@@ -1,1 +1,0 @@
-* Use OSV data source for Ubuntu vulnerability scanning.

--- a/changes/40117-fix-sql-table-alias-platform-detection
+++ b/changes/40117-fix-sql-table-alias-platform-detection
@@ -1,1 +1,0 @@
-- Fixed a bug where SQL queries using table aliases (e.g., `FROM mounts m`) incorrectly reported no compatible platforms.

--- a/changes/40137-update-default-fleet
+++ b/changes/40137-update-default-fleet
@@ -1,1 +1,0 @@
-- Updated the default fleet selected when navigating to the dashboard and to Controls

--- a/changes/40177-config-profile-name-status
+++ b/changes/40177-config-profile-name-status
@@ -1,2 +1,0 @@
-* Added logging of profile names alongside MDM commands installing or removing them
-* Added indication in the UI when a profile command was deferred ("NotNow" status)

--- a/changes/40581-os-versions-vuln-details
+++ b/changes/40581-os-versions-vuln-details
@@ -1,1 +1,0 @@
-* Fixed a bug where OS versions were not populated in vulnerability details for OS-only vulnerabilities (e.g., macOS CVEs).

--- a/changes/40715-allow-whitespace-end-users-form
+++ b/changes/40715-allow-whitespace-end-users-form
@@ -1,1 +1,0 @@
-* Allow typing whitespace on Settings > Integrations > SSO > End users form.

--- a/changes/40751-google-drive-brew-version
+++ b/changes/40751-google-drive-brew-version
@@ -1,1 +1,0 @@
-- Fix Google Drive version not matching upstream

--- a/changes/40785-fix-gitops-vpp-token-assignment
+++ b/changes/40785-fix-gitops-vpp-token-assignment
@@ -1,1 +1,0 @@
-- Fixed `fleetctl gitops` failing with "No available VPP Token" when assigning VPP apps alongside a new team.

--- a/changes/40841-gitops-sw-upload-error
+++ b/changes/40841-gitops-sw-upload-error
@@ -1,1 +1,0 @@
-- Fixed GitOps policy software resolution failing when URL lookup doesn't match, by falling back to hash-based lookup.

--- a/changes/40910-correct-request-certificate-pem
+++ b/changes/40910-correct-request-certificate-pem
@@ -1,1 +1,0 @@
-* Updated the Request Certificate API to return the proper PEM header for PKCS #7 certificates returned by EST CAs

--- a/changes/40972-policy-description
+++ b/changes/40972-policy-description
@@ -1,1 +1,0 @@
-- Fleet UI: Added description to help users understand which fleet a policy belongs during add/edit

--- a/changes/41324-support-labels-include-all-for-installers
+++ b/changes/41324-support-labels-include-all-for-installers
@@ -1,1 +1,0 @@
-- Added support for `labels_include_all` conditional scoping for software installers and apps.

--- a/changes/41409-use-fleetctl-new-templates-as-starter-lib
+++ b/changes/41409-use-fleetctl-new-templates-as-starter-lib
@@ -1,1 +1,0 @@
-- Use the same templates for `fleetctl new` and new instance initialization

--- a/changes/41484-fix-windows-mdm-profile-upload-panic
+++ b/changes/41484-fix-windows-mdm-profile-upload-panic
@@ -1,1 +1,0 @@
-- Fixed a server panic when uploading a Windows/Apple/Android MDM profile to a fleet on a free license (fleets are a premium feature).

--- a/changes/41500-validate-scripts
+++ b/changes/41500-validate-scripts
@@ -1,1 +1,0 @@
-- Added validation for software install, uninstall, and post-install scripts.

--- a/changes/41534-host-details-reports-api-end-point
+++ b/changes/41534-host-details-reports-api-end-point
@@ -1,1 +1,0 @@
-*  Added GET /api/v1/fleet/hosts/{id}/reports endpoint (also accessible as /hosts/{id}/queries) that lists the query reports associated with a specific host.

--- a/changes/41540-host-details-reports-db-optimizations
+++ b/changes/41540-host-details-reports-db-optimizations
@@ -1,2 +1,0 @@
-* Improved database query performance for the Host Details > Reports page by adding a `has_data` virtual generated column to `query_results`.
-* Added `(query_id, has_data, host_id, last_fetched)` index on query_results.

--- a/changes/41542-android-cert-resend-backend
+++ b/changes/41542-android-cert-resend-backend
@@ -1,1 +1,0 @@
-- Add backend to resend Android certificates

--- a/changes/41586-admin-by-request-false-positive
+++ b/changes/41586-admin-by-request-false-positive
@@ -1,1 +1,0 @@
-* Fixed false positive vulnerabilities (CVE-2019-17201, CVE-2019-17202) reported for Admin By Request on macOS and Linux hosts. These CVEs are Windows-specific.

--- a/changes/41601-use-multiplatform-names-in-front-end
+++ b/changes/41601-use-multiplatform-names-in-front-end
@@ -1,1 +1,0 @@
-- Updated frontend to use new multiplatform API keys

--- a/changes/41603-fix-query-responses
+++ b/changes/41603-fix-query-responses
@@ -1,1 +1,0 @@
-- Removed incorrect `report` key from get/create/modify API responses.

--- a/changes/41631-not-installed
+++ b/changes/41631-not-installed
@@ -1,2 +1,0 @@
-- Fixed issue where the `include_available_for_install` query param wasn't being applied correctly
-to the `GET /api/latest/fleet/hosts/{id}/software` endpoint.

--- a/changes/41636-typo-in-msrc-json
+++ b/changes/41636-typo-in-msrc-json
@@ -1,1 +1,0 @@
-- Fixed Fleet's usage of the incorrectly spelled 'vulnerabities' in favor of 'vulnerabilities' in MSRC bulletins

--- a/changes/41644-improve-cpe-matching
+++ b/changes/41644-improve-cpe-matching
@@ -1,1 +1,0 @@
-* Added software source to ecosystem matching to help prevent non-deterministic CPE selection when multiple vendors exist for the same product.

--- a/changes/41670-auto-rotate-recovery-lock
+++ b/changes/41670-auto-rotate-recovery-lock
@@ -1,1 +1,0 @@
-- Added automatic rotation of Mac recovery lock passwords 1 hour after the password is viewed via the API.

--- a/changes/41672-allow-omitting-manual-hosts-label
+++ b/changes/41672-allow-omitting-manual-hosts-label
@@ -1,1 +1,0 @@
-- Updated GitOps label functionality to allow omitting the `hosts:` key under a manual label to mean "preserve existing host membership", rather than removing all hosts.

--- a/changes/41710-overwrite-software-title
+++ b/changes/41710-overwrite-software-title
@@ -1,1 +1,0 @@
-- Updated Fleet-maintained apps to overwrite software title names on sync and when adding an FMA installer.

--- a/changes/41741-order
+++ b/changes/41741-order
@@ -1,1 +1,0 @@
-- Updated ordering of setup experience software to take display names into account.

--- a/changes/41742-fix-my-device-500-fleet-free
+++ b/changes/41742-fix-my-device-500-fleet-free
@@ -1,1 +1,0 @@
-- Fixed a crash on the "My device" page for Fleet Free instances. The page returned a 402 error when the host was assigned to a team because the device endpoint called a premium-only API, and also crashed when accessing undefined policies data.

--- a/changes/41778-fix-enqueue-setup-experience-items-for-arch-linux
+++ b/changes/41778-fix-enqueue-setup-experience-items-for-arch-linux
@@ -1,1 +1,0 @@
-- Fixed an issue where setup experience items (software to install) were not enqueued for Linux distributions that did not report a "platform-like" value, e.g. Arch Linux and Omarchy.

--- a/changes/41815-override-patch-policy-query
+++ b/changes/41815-override-patch-policy-query
@@ -1,1 +1,0 @@
-- Added ability to specify custom patch policy query in an FMA manifest

--- a/changes/41888-otel-service-name
+++ b/changes/41888-otel-service-name
@@ -1,1 +1,0 @@
-* Allow OTEL service name to be overridden with standard OTEL_SERVICE_NAME env var.

--- a/changes/42017-host-details-reports-tab
+++ b/changes/42017-host-details-reports-tab
@@ -1,1 +1,0 @@
-* Added Reports tab to Host details page.

--- a/changes/42047-android-web-app-banner
+++ b/changes/42047-android-web-app-banner
@@ -1,1 +1,0 @@
-Added banner to Add software page to inform users that Android web apps require Google Chrome.

--- a/changes/42185-add-flatcar-coreos-linux-platforms
+++ b/changes/42185-add-flatcar-coreos-linux-platforms
@@ -1,1 +1,0 @@
-* Added Flatcar Container Linux and CoreOS to the list of recognized Linux platforms, fixing host detail queries (IP address, disk space, etc.) not being sent to hosts running these distributions.

--- a/changes/42327-apple-profile-retries
+++ b/changes/42327-apple-profile-retries
@@ -1,1 +1,0 @@
-- Increased automatic retry limit for failed Apple (macOS, iOS, iPadOS) configuration profiles from 1 to 3. Windows profiles remain at 1 retry.

--- a/changes/42383-android-display-name
+++ b/changes/42383-android-display-name
@@ -1,1 +1,0 @@
-* Fixed success message on Android software configuration to reference software display name when applicable.

--- a/changes/42399-support-vpp-policy-automations-in-generate-gitops
+++ b/changes/42399-support-vpp-policy-automations-in-generate-gitops
@@ -1,1 +1,0 @@
-- Support outputting VPP policy automations in `fleetctl generate-gitops`

--- a/changes/42402-fix-query-results-deduplication
+++ b/changes/42402-fix-query-results-deduplication
@@ -1,1 +1,0 @@
-* Fixed query results table deduplicating rows when query data contains an `id` column, and fixed `id` column header and cell styling.

--- a/changes/42443-fix-show-disk-encryption-key-modal
+++ b/changes/42443-fix-show-disk-encryption-key-modal
@@ -1,1 +1,0 @@
-* Fixed disk encryption key modal to not show stale key when switching between hosts.

--- a/changes/42545-windows-mdm-profile-summary-performance
+++ b/changes/42545-windows-mdm-profile-summary-performance
@@ -1,1 +1,0 @@
-- Improved Fleet server performance for the Windows MDM profiles summary and host OS settings filter queries by replacing correlated subqueries with a single aggregation pass.

--- a/changes/42572-fix-duplicate-text
+++ b/changes/42572-fix-duplicate-text
@@ -1,1 +1,0 @@
-- Fixed duplicate text in error message when script validation fails when adding a custom package

--- a/changes/42600-android-cert-templates-cleared-on-reenroll
+++ b/changes/42600-android-cert-templates-cleared-on-reenroll
@@ -1,1 +1,0 @@
-- Fixed a bug where Android host certificate template records were not cleared when a device unenrolled, causing stale certificate statuses after re-enrollment.

--- a/changes/42799-option-to-unlock-not-available-afler-lock
+++ b/changes/42799-option-to-unlock-not-available-afler-lock
@@ -1,1 +1,0 @@
-* Fixed bug that cleared the MDM lock state if an "idle" message was received right after the lock ACK.

--- a/changes/42808-rwmutex-jitter-shouldupdate
+++ b/changes/42808-rwmutex-jitter-shouldupdate
@@ -1,1 +1,0 @@
-- Improved performance of distributed read endpoint by reducing mutex contention in shouldUpdate using sync.RWMutex instead of sync.Mutex.

--- a/changes/42814-sso-learn-more-link
+++ b/changes/42814-sso-learn-more-link
@@ -1,1 +1,0 @@
-- Added "Learn more" link on End User Authentication section.

--- a/changes/42836-deduplicate-flipping-policies-queries
+++ b/changes/42836-deduplicate-flipping-policies-queries
@@ -1,1 +1,0 @@
-- Reduced redundant database queries during policy result submission by computing flipping policies once per host check-in instead of multiple times.

--- a/changes/42991-patch-policy-gitops-bug
+++ b/changes/42991-patch-policy-gitops-bug
@@ -1,1 +1,0 @@
-- Fixed bug where adding a patch policy for a new installer in the UI caused gitops runs that didn't include that installer to fail.

--- a/changes/43034-optimize-policy-queries-for-host
+++ b/changes/43034-optimize-policy-queries-for-host
@@ -1,1 +1,0 @@
-* Optimized `PolicyQueriesForHost` and `ListPoliciesForHost` SQL queries by replacing correlated subqueries with a single aggregated LEFT JOIN for label-based policy scoping, reducing query time by ~77% at scale.

--- a/changes/43125-reports-nav-underline
+++ b/changes/43125-reports-nav-underline
@@ -1,1 +1,0 @@
-* Fixed missing underline on "Reports" nav item when active in top navigation.

--- a/changes/43786-recovery-lock-reenroll-desync
+++ b/changes/43786-recovery-lock-reenroll-desync
@@ -1,1 +1,0 @@
-- Fixed a bug where Fleet continued to show a stale Recovery Lock password after a macOS host left MDM, by soft-deleting the stored password whenever the host leaves MDM (re-enrollment, CheckOut, admin unenroll, or a periodic sweep of hosts osquery reports as unenrolled) and hiding the password on the host details page until the host is enrolled again.

--- a/changes/43875-windows-mdm-pending-commands-flood
+++ b/changes/43875-windows-mdm-pending-commands-flood
@@ -1,1 +1,0 @@
-* Improved Windows MDM server performance at scale by reducing redundant database queries during device check-ins.

--- a/changes/43977-fix-chg-mgmt-focus-issue
+++ b/changes/43977-fix-chg-mgmt-focus-issue
@@ -1,1 +1,0 @@
-- Fixed issue where the "Change Management" form would reset when the page lost and regained focus.

--- a/changes/add-api-time-on-gitops-errors
+++ b/changes/add-api-time-on-gitops-errors
@@ -1,1 +1,0 @@
-* Added "API time" to GitOps output on API errors.

--- a/changes/allow-clearing-windows-update-settings
+++ b/changes/allow-clearing-windows-update-settings
@@ -1,1 +1,0 @@
-- Allowed clearing Windows OS update deadline and grace period fields to remove enforcement.

--- a/changes/bump-mysql-8.0.42
+++ b/changes/bump-mysql-8.0.42
@@ -1,1 +1,0 @@
-* Revised which versions Fleet tests MySQL against to remove 8.0.39 and add 8.0.42.

--- a/changes/issue-40076-clear-enrolled-from-migration
+++ b/changes/issue-40076-clear-enrolled-from-migration
@@ -1,1 +1,0 @@
-- Fixed an issue where silent migration status would persist even after re-enrolling the device normally, causing SCEP renewal to fail.

--- a/changes/refactor-named-functions-nil-checks
+++ b/changes/refactor-named-functions-nil-checks
@@ -1,1 +1,0 @@
-* Refactored large anonymous functions into named functions to improve nil-safety static analysis coverage.

--- a/changes/up-default-software-batch
+++ b/changes/up-default-software-batch
@@ -1,1 +1,0 @@
-- Upped the default limit for the software batch endpoint, from 1MiB to 25MiB

--- a/changes/update-go-1.26.1
+++ b/changes/update-go-1.26.1
@@ -1,1 +1,0 @@
-* Updated go to 1.26.1

--- a/charts/fleet/Chart.yaml
+++ b/charts/fleet/Chart.yaml
@@ -4,11 +4,11 @@ name: fleet
 keywords:
   - fleet
   - osquery
-version: v6.9.0
+version: v6.9.1
 home: https://github.com/fleetdm/fleet
 sources:
   - https://github.com/fleetdm/fleet.git
-appVersion: v4.83.2
+appVersion: v4.84.0
 dependencies:
   - name: mysql
     condition: mysql.enabled

--- a/charts/fleet/values.yaml
+++ b/charts/fleet/values.yaml
@@ -4,7 +4,7 @@ hostName: fleet.localhost
 replicas: 3 # The number of Fleet instances to deploy
 revisionHistoryLimit: 10 # Number of old ReplicaSets for Fleet deployment to retain for rollback (set to 0 for unlimited)
 imageRepository: fleetdm/fleet
-imageTag: v4.83.2 # Version of Fleet to deploy
+imageTag: v4.84.0 # Version of Fleet to deploy
 # imagePullSecrets is optional.
 # imagePullSecrets:
 #   - name: docker

--- a/infrastructure/dogfood/terraform/aws/variables.tf
+++ b/infrastructure/dogfood/terraform/aws/variables.tf
@@ -56,7 +56,7 @@ variable "database_name" {
 
 variable "fleet_image" {
   description = "the name of the container image to run"
-  default     = "fleetdm/fleet:v4.83.2"
+  default     = "fleetdm/fleet:v4.84.0"
 }
 
 variable "software_inventory" {

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -68,8 +68,7 @@ variable "redis_mem" {
 }
 
 variable "image" {
-  default = "fleetdm/fleet:v4.83.2"
-}
+  default = "fleetdm/fleet:v4.84.0"
 
 variable "software_installers_bucket_name" {
   default = "fleet-software-installers"

--- a/infrastructure/dogfood/terraform/gcp/variables.tf
+++ b/infrastructure/dogfood/terraform/gcp/variables.tf
@@ -69,6 +69,7 @@ variable "redis_mem" {
 
 variable "image" {
   default = "fleetdm/fleet:v4.84.0"
+}
 
 variable "software_installers_bucket_name" {
   default = "fleet-software-installers"

--- a/tools/fleetctl-npm/package.json
+++ b/tools/fleetctl-npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fleetctl",
-  "version": "v4.83.2",
+  "version": "v4.84.0",
   "description": "Installer for the fleetctl CLI tool",
   "bin": {
     "fleetctl": "./run.js"

--- a/tools/github-manage/cmd/gm/releases.go
+++ b/tools/github-manage/cmd/gm/releases.go
@@ -207,7 +207,7 @@ Size mapping (low-high):
   XL:  75-100
 
 Usage:
-  gm releases forecast --milestone "Fleet 4.83.0"`,
+  gm releases forecast --milestone "Fleet 4.84.0"`,
 	Run: func(cmd *cobra.Command, args []string) {
 		releasesProjectID := 87 // fleet Releases project
 		milestoneTitle, _ := cmd.Flags().GetString("milestone")
@@ -319,5 +319,5 @@ func init() {
 	releasesSyncEstimatesCmd.Flags().BoolP("overwrite", "o", false, "Overwrite existing Releases estimates (by default, issues with estimates are skipped)")
 	releasesSyncEstimatesCmd.Flags().StringP("milestone", "m", "", "Only process issues in this milestone, e.g., Fleet 4.77.0")
 
-	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.83.0 (required)")
+	releasesForecastCmd.Flags().StringP("milestone", "m", "", "Milestone to forecast, e.g., Fleet 4.84.0 (required)")
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped Fleet release version to v4.84.0 across deployment charts, infrastructure defaults, and tooling.
* **Documentation**
  * Cleaned up release notes by removing numerous outdated or redundant changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->