### PR TITLE
Update santa-configuration.mobileconfig

### DIFF
--- a/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
+++ b/it-and-security/lib/macos/configuration-profiles/santa-configuration.mobileconfig
@@ -43,6 +43,8 @@
 								<string>This application has been blocked by a security policy.</string>
 								<key>ClientMode</key>
 								<integer>1</integer>
+								<key>EnableMenuItem</key>
+								<false/>
 								<key>FileChangesRegex</key>
 								<string>^/(?!(?:private/tmp|Library/(?:Caches|Managed Installs/Logs|(?:Managed )?Preferences))/)</string>
 								<key>MachineIDKey</key>


### PR DESCRIPTION
Change menubar app to be hidden by default. User can override this setting if they prefer. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS security tool configuration by disabling a menu item setting, enforcing policy adjustments while preserving all other existing configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->