### PR TITLE
Transition 1Password to Fleet-maintained app version

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -113,7 +113,6 @@ policies:
   - path: ../lib/macos/policies/1password-emergency-kit-check.yml
   - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/macos/policies/all-software-updates-installed.yml
-  - path: ../lib/macos/policies/update-1password.yml
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
@@ -129,7 +128,6 @@ policies:
   - path: ../lib/windows/policies/disk-encryption-check.yml
   - path: ../lib/windows/policies/disk-space-check.yml
   - path: ../lib/windows/policies/1password-installed.yml
-  - path: ../lib/windows/policies/update-1password.yml
   - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml
@@ -146,11 +144,6 @@ reports:
 software:
   packages:
     # macOS apps
-    - path: ../lib/macos/software/1password.yml # 1Password for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
     - path: ../lib/macos/software/santa.yml # Santa for macOS
       self_service: true
       categories:
@@ -235,11 +228,6 @@ software:
     #     - Browsers
     #   labels_include_any:
     #     - "ARM-based Windows hosts"
-    - path: ../lib/windows/software/1password.yml # 1Password for Windows
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
     - path: ../lib/windows/software/okta-verify.yml # Okta Verify for Windows (x86)
       self_service: true
       setup_experience: true
@@ -256,6 +244,11 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
+    - slug: 1password/darwin # 1Password for macOS
+      self_service: true
+      setup_experience: true
+      categories:
+        - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
       self_service: true
       labels_include_any:
@@ -426,6 +419,11 @@ software:
       categories:
         - Developer tools
     # Windows apps
+    - slug: 1password/windows # 1Password for Windows
+      self_service: true
+      setup_experience: true
+      categories:
+        - Security
     - slug: slack/windows # Slack for Windows
       self_service: true
       setup_experience: true

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -3,6 +3,11 @@
   query: SELECT 1 FROM programs WHERE name = 'Slack' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
+- name: x86 Windows hosts with 1Password installed
+  description: x86 Windows hosts with 1Password installed
+  query: SELECT 1 FROM programs WHERE name = '1Password' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows
 - name: x86 Windows hosts with Claude installed
   description: x86 Windows hosts with Claude installed
   query: SELECT 1 FROM programs WHERE name = 'Claude' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');

--- a/it-and-security/lib/macos/policies/1password-installed.yml
+++ b/it-and-security/lib/macos/policies/1password-installed.yml
@@ -1,7 +1,7 @@
 - name: macOS - 1Password installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';
   install_software:
-    package_path: ../software/1password.yml
+    fleet_maintained_app_slug: 1password/darwin
   critical: false
   description: Our SOC 2 policies require a password manager to be installed on all workstations.
   resolution: 1Password should be automatically installed. If it is missing, install it from self-service. 

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -6,6 +6,15 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
+- name: macOS - 1Password up to date
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  type: patch
+  fleet_maintained_app_slug: 1password/darwin
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."

--- a/it-and-security/lib/macos/policies/update-1password.yml
+++ b/it-and-security/lib/macos/policies/update-1password.yml
@@ -1,7 +1,0 @@
-- name: macOS - 1Password up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE name = '1Password.app' AND version_compare(bundle_short_version, '8.12.12') < 0);
-  critical: false
-  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-  platform: darwin
-  calendar_events_enabled: true

--- a/it-and-security/lib/windows/policies/1password-installed.yml
+++ b/it-and-security/lib/windows/policies/1password-installed.yml
@@ -1,7 +1,7 @@
 - name: Windows - 1Password installed
   query: SELECT 1 FROM programs WHERE name = "1Password";
   install_software:
-    package_path: ../software/1password.yml
+    fleet_maintained_app_slug: 1password/windows
   critical: false
   description: Our SOC 2 policies require a password manager to be installed on all workstations.
   resolution: 1Password should be automatically installed. If it is missing, install it from self-service. 

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -6,6 +6,15 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Slack installed
+- name: Windows - 1Password up to date
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  type: patch
+  fleet_maintained_app_slug: 1password/windows
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - x86 Windows hosts with 1Password installed
 - name: Windows - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."

--- a/it-and-security/lib/windows/policies/update-1password.yml
+++ b/it-and-security/lib/windows/policies/update-1password.yml
@@ -1,7 +1,0 @@
-- name: Windows - 1Password up to date
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = '1Password') OR EXISTS (SELECT 1 FROM programs WHERE name = '1Password' AND version_compare(version, '8.10.75') >= 0);
-  critical: false
-  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details.
-  platform: windows
-  calendar_events_enabled: true


### PR DESCRIPTION
Replace ad-hoc 1Password update flow with fleet_maintained app handling: remove the macOS updater script and platform-specific update policy files; switch install_software refs in macOS/Windows 1Password policies to fleet_maintained_app_slug; add fleet_maintained_apps entries for 1Password in the workstation fleet manifest; add dynamic labels and patch policies to track/upkeep 1Password on macOS and Windows. Also remove references to the removed update step from the dogfood CI workflow and simplify PR title/branch generation logic accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated 1Password installation from locally managed packages to Fleet-maintained applications on macOS and Windows.
  * Updated 1Password patch policies with calendar-driven scheduling for automatic updates.
  * Removed legacy 1Password version check policies.

* **New Features**
  * Added dynamic label for Windows x86 hosts with 1Password installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->