### PR TITLE
Comment out 1Password fleet policy and app

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -110,13 +110,13 @@ controls:
     - path: ../lib/linux/scripts/install-fleet-desktop-required-extension.sh
 policies:
   # macOS policies
-  - path: ../lib/macos/policies/1password-emergency-kit-check.yml
+  # - path: ../lib/macos/policies/1password-emergency-kit-check.yml
   - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/macos/policies/all-software-updates-installed.yml
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
-  - path: ../lib/macos/policies/1password-installed.yml
+  # - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -244,11 +244,11 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
-    - slug: 1password/darwin # 1Password for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
+    # - slug: 1password/darwin # 1Password for macOS
+    #   self_service: true
+    #   setup_experience: true
+    #   categories:
+    #     - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
       self_service: true
       labels_include_any:

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
-- name: macOS - 1Password up to date
-  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-  type: patch
-  fleet_maintained_app_slug: 1password/darwin
-  install_software: false
-  calendar_events_enabled: true
-  labels_include_any:
-    - Macs with 1Password installed
+# - name: macOS - 1Password up to date
+#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+#   type: patch
+#   fleet_maintained_app_slug: 1password/darwin
+#   install_software: false
+#   calendar_events_enabled: true
+#   labels_include_any:
+#     - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."


### PR DESCRIPTION
Temporarily disable 1Password-related Fleet checks and app entry. workstations.yml: commented out the macOS policies 1password-emergency-kit-check.yml and 1password-installed.yml and the fleet_maintained_apps entry for 1password/darwin. lib/macos/policies/patch-fleet-maintained-apps.yml: commented out the patch rule for 1password/darwin. This stops 1Password health checks and automatic patching until re-enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled 1Password management and automatic patching controls across macOS fleet configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->