### PR TITLE
Revert "Comment out 1Password fleet policy and app"

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -110,13 +110,13 @@ controls:
     - path: ../lib/linux/scripts/install-fleet-desktop-required-extension.sh
 policies:
   # macOS policies
-  # - path: ../lib/macos/policies/1password-emergency-kit-check.yml
+  - path: ../lib/macos/policies/1password-emergency-kit-check.yml
   - path: ../lib/macos/policies/latest-macos.yml
   - path: ../lib/macos/policies/all-software-updates-installed.yml
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
-  # - path: ../lib/macos/policies/1password-installed.yml
+  - path: ../lib/macos/policies/1password-installed.yml
   - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -244,11 +244,11 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
-    # - slug: 1password/darwin # 1Password for macOS
-    #   self_service: true
-    #   setup_experience: true
-    #   categories:
-    #     - Security
+    - slug: 1password/darwin # 1Password for macOS
+      self_service: true
+      setup_experience: true
+      categories:
+        - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
       self_service: true
       labels_include_any:

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -116,7 +116,7 @@ policies:
   - path: ../lib/macos/policies/enrollment-profile-up-to-date.yml
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
-  - path: ../lib/macos/policies/1password-installed.yml
+  # - path: ../lib/macos/policies/1password-installed.yml https://github.com/fleetdm/fleet/pull/44179
   - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
-# - name: macOS - 1Password up to date
-#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-#   type: patch
-#   fleet_maintained_app_slug: 1password/darwin
-#   install_software: false
-#   calendar_events_enabled: true
-#   labels_include_any:
-#     - Macs with 1Password installed
+- name: macOS - 1Password up to date
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  type: patch
+  fleet_maintained_app_slug: 1password/darwin
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."


### PR DESCRIPTION
Reverts fleetdm/fleet#44178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled 1Password emergency kit verification for macOS devices
  * Made 1Password available as a self-service application with automated setup on macOS
  * Activated maintenance and patch management for 1Password

<!-- end of auto-generated comment: release notes by coderabbit.ai -->