### PR TITLE
Disable 1Password auto-install and patch checks

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -244,11 +244,11 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
-    - slug: 1password/darwin # 1Password for macOS
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
+    # - slug: 1password/darwin # 1Password for macOS
+    #   self_service: true
+    #   setup_experience: true
+    #   categories:
+    #     - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
       self_service: true
       labels_include_any:
@@ -419,11 +419,11 @@ software:
       categories:
         - Developer tools
     # Windows apps
-    - slug: 1password/windows # 1Password for Windows
-      self_service: true
-      setup_experience: true
-      categories:
-        - Security
+    # - slug: 1password/windows # 1Password for Windows
+    #   self_service: true
+    #   setup_experience: true
+    #   categories:
+    #     - Security
     - slug: slack/windows # Slack for Windows
       self_service: true
       setup_experience: true

--- a/it-and-security/lib/macos/policies/1password-installed.yml
+++ b/it-and-security/lib/macos/policies/1password-installed.yml
@@ -1,7 +1,7 @@
 - name: macOS - 1Password installed
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.1password.1password';
-  install_software:
-    fleet_maintained_app_slug: 1password/darwin
+  # install_software:
+  #   fleet_maintained_app_slug: 1password/darwin
   critical: false
   description: Our SOC 2 policies require a password manager to be installed on all workstations.
   resolution: 1Password should be automatically installed. If it is missing, install it from self-service. 

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
-- name: macOS - 1Password up to date
-  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-  type: patch
-  fleet_maintained_app_slug: 1password/darwin
-  install_software: false
-  calendar_events_enabled: true
-  labels_include_any:
-    - Macs with 1Password installed
+# - name: macOS - 1Password up to date
+#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+#   type: patch
+#   fleet_maintained_app_slug: 1password/darwin
+#   install_software: false
+#   calendar_events_enabled: true
+#   labels_include_any:
+#     - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."

--- a/it-and-security/lib/windows/policies/1password-installed.yml
+++ b/it-and-security/lib/windows/policies/1password-installed.yml
@@ -1,7 +1,7 @@
 - name: Windows - 1Password installed
   query: SELECT 1 FROM programs WHERE name = "1Password";
-  install_software:
-    fleet_maintained_app_slug: 1password/windows
+  # install_software:
+  #   fleet_maintained_app_slug: 1password/windows
   critical: false
   description: Our SOC 2 policies require a password manager to be installed on all workstations.
   resolution: 1Password should be automatically installed. If it is missing, install it from self-service. 

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Slack installed
-- name: Windows - 1Password up to date
-  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-  type: patch
-  fleet_maintained_app_slug: 1password/windows
-  install_software: false
-  calendar_events_enabled: true
-  labels_include_any:
-    - x86 Windows hosts with 1Password installed
+# - name: Windows - 1Password up to date
+#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+#   type: patch
+#   fleet_maintained_app_slug: 1password/windows
+#   install_software: false
+#   calendar_events_enabled: true
+#   labels_include_any:
+#     - x86 Windows hosts with 1Password installed
 - name: Windows - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."


### PR DESCRIPTION
Comment out 1Password fleet-maintained app entries and related install/patch policies for macOS and Windows. Updates remove/disable the fleet_maintained_app references in it-and-security/fleets/workstations.yml and comment out install_software and patch entries in the macOS and Windows policy files to temporarily stop automatic installation and patch enforcement for 1Password.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * 1Password management has been disabled across fleet workstations for both macOS and Windows platforms. Automatic installation and patching policies have been deactivated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->