### PR TITLE
Enable 1Password in fleets and patch policies

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -127,7 +127,7 @@ policies:
   - path: ../lib/windows/policies/all-windows-updates-installed.yml
   - path: ../lib/windows/policies/disk-encryption-check.yml
   - path: ../lib/windows/policies/disk-space-check.yml
-  - path: ../lib/windows/policies/1password-installed.yml
+  # - path: ../lib/windows/policies/1password-installed.yml
   - path: ../lib/windows/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/windows/policies/battery-health-check.yml
   - path: ../lib/windows/policies/windows-defender-compliance-check.yml
@@ -244,11 +244,11 @@ software:
         - Productivity
   fleet_maintained_apps:
     # macOS apps
-    # - slug: 1password/darwin # 1Password for macOS
-    #   self_service: true
-    #   setup_experience: true
-    #   categories:
-    #     - Security
+    - slug: 1password/darwin # 1Password for macOS
+      self_service: true
+      setup_experience: true
+      categories:
+        - Security
     - slug: aws-vpn-client/darwin # AWS VPN Client for macOS
       self_service: true
       labels_include_any:
@@ -419,11 +419,11 @@ software:
       categories:
         - Developer tools
     # Windows apps
-    # - slug: 1password/windows # 1Password for Windows
-    #   self_service: true
-    #   setup_experience: true
-    #   categories:
-    #     - Security
+    - slug: 1password/windows # 1Password for Windows
+      self_service: true
+      setup_experience: true
+      categories:
+        - Security
     - slug: slack/windows # Slack for Windows
       self_service: true
       setup_experience: true

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - Macs with Google Chrome installed
-# - name: macOS - 1Password up to date
-#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-#   type: patch
-#   fleet_maintained_app_slug: 1password/darwin
-#   install_software: false
-#   calendar_events_enabled: true
-#   labels_include_any:
-#     - Macs with 1Password installed
+- name: macOS - 1Password up to date
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  type: patch
+  fleet_maintained_app_slug: 1password/darwin
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - Macs with 1Password installed
 - name: macOS - Brave Browser up to date
   description: The host may have an outdated version of Brave Browser, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Brave Browser's built-in update functionality. You can also delete Brave Browser if you are no longer using it."

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -6,15 +6,15 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Slack installed
-# - name: Windows - 1Password up to date
-#   description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
-#   resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
-#   type: patch
-#   fleet_maintained_app_slug: 1password/windows
-#   install_software: false
-#   calendar_events_enabled: true
-#   labels_include_any:
-#     - x86 Windows hosts with 1Password installed
+- name: Windows - 1Password up to date
+  description: This device may have an outdated version of 1Password, potentially risking security vulnerabilities or compatibility issues.
+  resolution: "Download the latest version from Self-service, otherwise the update will automatically install during an upcoming scheduled maintenance window. Check your calendar for details."
+  type: patch
+  fleet_maintained_app_slug: 1password/windows
+  install_software: false
+  calendar_events_enabled: true
+  labels_include_any:
+    - x86 Windows hosts with 1Password installed
 - name: Windows - Claude up to date
   description: The host may have an outdated version of Claude, potentially risking security vulnerabilities or compatibility issues.
   resolution: "Download the latest version from Self-service or check for updates using Claude's built-in update functionality. You can also uninstall Claude if you are no longer using it."


### PR DESCRIPTION
Uncomment 1Password entries in workstations.yml so 1Password is managed as a fleet_maintained_app for both macOS and Windows. Commented out the separate Windows 1Password installed policy path and enabled the corresponding patch checks in macos/windows/patch-fleet-maintained-apps.yml to surface/update out-of-date 1Password installations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 1Password is now available as a self-service application for installation on macOS and Windows with guided setup experience.

* **Chores**
  * Activated automatic patch update policies for 1Password on both platforms with calendar-driven event scheduling to keep installations current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->