### PR TITLE
Enable Nudge auto-install and comment policy

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -117,7 +117,7 @@ policies:
   - path: ../lib/macos/policies/disk-encryption-check.yml
   - path: ../lib/macos/policies/disk-space-check.yml
   # - path: ../lib/macos/policies/1password-installed.yml https://github.com/fleetdm/fleet/pull/44179
-  - path: ../lib/macos/policies/nudge-installed.yml
+  # - path: ../lib/macos/policies/nudge-installed.yml
   - path: ../lib/macos/policies/install-nudge-assets.yml
   - path: ../lib/macos/policies/patch-fleet-maintained-apps.yml
   - path: ../lib/macos/policies/update-fleet-desktop.yml

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -237,6 +237,6 @@
   resolution: "Nudge is an app managed by IT and should be kept up to date automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
   type: patch
   fleet_maintained_app_slug: nudge/darwin
-  install_software: false
+  install_software: true
   labels_include_any:
     - Macs with Nudge installed


### PR DESCRIPTION
Comment out the nudge-installed policy in it-and-security/fleets/workstations.yml and set install_software: true for the Nudge fleet-maintained app in it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml. This ensures Fleet will automatically install/patch Nudge on matching Macs (using the existing install-nudge-assets policy) rather than relying on the nudge-installed enforcement entry.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled a macOS policy for workstations, removing it from policy evaluation.
  * Enabled software installation in the macOS update policy, allowing updates to proceed instead of being blocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->