### PR TITLE
Fix deprecation warnings

### DIFF
--- a/it-and-security/default.yml
+++ b/it-and-security/default.yml
@@ -48,8 +48,8 @@ org_settings:
   server_settings:
     deferred_save_host: false
     enable_analytics: true
-    live_query_disabled: false
-    query_reports_disabled: false
+    live_reporting_disabled: false
+    discard_reports_data: false
     scripts_disabled: false
     server_url: https://dogfood.fleetdm.com
   sso_settings:

--- a/it-and-security/fleets/company-owned-mobile-devices.yml
+++ b/it-and-security/fleets/company-owned-mobile-devices.yml
@@ -17,13 +17,13 @@ controls:
   ipados_updates:
     deadline: "2025-06-01"
     minimum_version: "18.5"
-  macos_settings:
-    custom_settings:
+  apple_settings:
+    configuration_profiles:
       - path: ../lib/ios/configuration-profiles/lock-screen-message.mobileconfig
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/declaration-profiles/Software Update settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  macos_setup:
+  setup_experience:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/personal-mobile-devices.yml
+++ b/it-and-security/fleets/personal-mobile-devices.yml
@@ -17,11 +17,11 @@ controls:
   ipados_updates:
     deadline: "2025-06-01"
     minimum_version: "18.5"
-  macos_settings:
-    custom_settings:
+  apple_settings:
+    configuration_profiles:
       - path: ../lib/ios/declaration-profiles/Passcode settings.json
       - path: ../lib/ios/configuration-profiles/self-service.mobileconfig
-  macos_setup:
+  setup_experience:
     enable_end_user_authentication: true
   scripts:
 policies:

--- a/it-and-security/fleets/servers.yml
+++ b/it-and-security/fleets/servers.yml
@@ -12,17 +12,17 @@ agent_options:
   path: ../lib/all/agent-options/servers.agent-options.yml
 controls:
   enable_disk_encryption: false
-  macos_settings:
-    custom_settings:
-  macos_setup:
-    bootstrap_package: null
+  apple_settings:
+    configuration_profiles:
+  setup_experience:
+    macos_bootstrap_package: null
     enable_end_user_authentication: false
-    macos_setup_assistant: null
+    apple_setup_assistant: null
   macos_updates:
     deadline: null
     minimum_version: null
   windows_settings:
-    custom_settings: null
+    configuration_profiles: null
   windows_updates:
     deadline_days: null
     grace_period_days: null

--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -27,10 +27,10 @@ agent_options:
     orbit: edge
     desktop: edge
 controls:
-  macos_setup:
-    bootstrap_package: ""
+  setup_experience:
+    macos_bootstrap_package: ""
     enable_end_user_authentication: true
-    macos_setup_assistant: 
+    apple_setup_assistant: 
   macos_updates:
     deadline:
     minimum_version:

--- a/it-and-security/fleets/unassigned.yml
+++ b/it-and-security/fleets/unassigned.yml
@@ -2,4 +2,4 @@ name: Unassigned
 policies:
 software:
 controls:
-  macos_settings:
+  apple_settings:

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -38,8 +38,8 @@ agent_options:
     desktop: stable
 controls:
   enable_disk_encryption: true
-  macos_settings:
-    custom_settings:
+  apple_settings:
+    configuration_profiles:
       - path: ../lib/macos/configuration-profiles/date-time.mobileconfig
       - path: ../lib/macos/configuration-profiles/automatic-app-store-updates.mobileconfig
       - path: ../lib/macos/configuration-profiles/chrome-enrollment.mobileconfig
@@ -80,17 +80,17 @@ controls:
       - path: ../lib/macos/configuration-profiles/microsoft-autoupdate-settings.mobileconfig
         labels_include_any:
           - "Microsoft AutoUpdate installed"
-  macos_setup:
-    bootstrap_package: ""
+  setup_experience:
+    macos_bootstrap_package: ""
     enable_end_user_authentication: true
     lock_end_user_info: false
-    macos_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
+    apple_setup_assistant: ../lib/macos/enrollment-profiles/automatic-enrollment.dep.json
   macos_updates:
     deadline:
     minimum_version:
     update_new_hosts: true
   windows_settings:
-    custom_settings:
+    configuration_profiles:
       - path: ../lib/windows/configuration-profiles/Enable firewall.xml
       - path: ../lib/windows/configuration-profiles/Password settings.xml
       - path: ../lib/windows/configuration-profiles/Advanced PowerShell logging.xml


### PR DESCRIPTION
Rename and standardize configuration keys across fleet profiles: replace macos_settings -> apple_settings, macos_setup -> setup_experience, and macos_setup_assistant -> apple_setup_assistant. Move/rename bootstrap key to macos_bootstrap_package under setup_experience. Convert per-OS custom_settings to configuration_profiles (including windows_settings.custom_settings -> configuration_profiles). Update server flags: live_query_disabled -> live_reporting_disabled and query_reports_disabled -> discard_reports_data. Changes applied to: it-and-security/default.yml, and fleet files in it-and-security/fleets (company-owned-mobile-devices.yml, personal-mobile-devices.yml, servers.yml, testing-and-qa.yml, unassigned.yml, workstations.yml) to unify naming and align with cross-platform config schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated device fleet configuration schema across company-owned mobile devices, personal mobile devices, servers, and workstations
  * Reorganized Apple device settings delivery and authentication setup configuration structure
  * Standardized configuration key naming conventions across platforms for consistency
  * Updated report configuration flags for device management policies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->