### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/notepad++/windows.json
+++ b/ee/maintained-apps/outputs/notepad++/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.9.3",
+      "version": "8.9.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Notepad++' AND publisher = 'Notepad++ Team';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Notepad++' AND publisher = 'Notepad++ Team' AND version_compare(version, '8.9.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Notepad++' AND publisher = 'Notepad++ Team' AND version_compare(version, '8.9.4') < 0);"
       },
-      "installer_url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.3/npp.8.9.3.Installer.x64.exe",
+      "installer_url": "https://github.com/notepad-plus-plus/notepad-plus-plus/releases/download/v8.9.4/npp.8.9.4.Installer.x64.exe",
       "install_script_ref": "46c6fee6",
       "uninstall_script_ref": "642b4036",
-      "sha256": "8db87a458551371e911bea5243840c783b5e7d41b7f867a2a6f74971881fb1e4",
+      "sha256": "f3629f500d0754d8e870255fff0e00384a37f5402d6f3ad8dd1f4f67d707b593",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/signal/darwin.json
+++ b/ee/maintained-apps/outputs/signal/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "8.7.0",
+      "version": "8.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.7.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.whispersystems.signal-desktop' AND version_compare(bundle_short_version, '8.8.0') < 0);"
       },
-      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.7.0.zip",
+      "installer_url": "https://updates.signal.org/desktop/signal-desktop-mac-arm64-8.8.0.zip",
       "install_script_ref": "80dd2c27",
       "uninstall_script_ref": "3902de16",
-      "sha256": "df795bf1ab0b7c4e775e8193d874a4838a5a5c97e243b3723a91afba6ff3968b",
+      "sha256": "8ffa773d8275230c0a64ffa1ff20ebd8872b27adfb1c747f013b0fd2d5b316e5",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/stats/darwin.json
+++ b/ee/maintained-apps/outputs/stats/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2.12.11",
+      "version": "2.12.12",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.11') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'eu.exelban.Stats' AND version_compare(bundle_short_version, '2.12.12') < 0);"
       },
-      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.11/Stats.dmg",
+      "installer_url": "https://github.com/exelban/stats/releases/download/v2.12.12/Stats.dmg",
       "install_script_ref": "06b599e5",
       "uninstall_script_ref": "9c854aeb",
-      "sha256": "41edc5bc9c6a4503f9b48826ea1040ea3b94f76221f0801788c8714d18924093",
+      "sha256": "4acaf32dde402016fa390cfcfd7afd162c309cd46480528d28915041b4451ffd",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version support for Notepad++ (8.9.4), Signal for macOS (8.8.0), and Stats for macOS (2.12.12).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->