### PR TITLE
[Pricing table] Add debug logging during setup experience to pricing features table

### DIFF
--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -276,9 +276,23 @@
     - description: Connect end users to Wi-Fi by adding your SCEP server.
       moreInfoUrl: https://youtu.be/secV4NCGYPg
 #
-#  ╔╗ ╦ ╦╔═╗╔╦╗  ╔═╗╔╗╔╦═╗╔═╗╦  ╦  ╔╦╗╔═╗╔╗╔╔╦╗
-#  ╠╩╗╚╦╝║ ║ ║║  ║╣ ║║║╠╦╝║ ║║  ║  ║║║║╣ ║║║ ║ 
-#  ╚═╝ ╩ ╚═╝═╩╝  ╚═╝╝╚╝╩╚═╚═╝╩═╝╩═╝╩ ╩╚═╝╝╚╝ ╩ 
+#  ╔╦╗ ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗╔╦╗  ╔╦╗╔═╗╔═╗╦  ╔═╗╦ ╦╔╦╗╔═╗╔╗╔╔╦╗
+#   ║║║ ║╣ ╠╦╝║  ║╣  ║║║╣  ║║   ║║║╣ ╠═╝║  ║ ║╚╦╝║║║║╣ ║║║ ║
+#  ╩ ╩ ╚═╝╩╚═╚═╝╚═╝ ╩ ╩╚═╝═╩╝  ═╩╝╚═╝╩  ╩═╝╚═╝ ╩ ╩ ╩╚═╝╝╚╝ ╩ 
+- industryName: Debug logging during setup experience
+  description: Enable debug logging for fleetd during device enrollment to troubleshoot setup issues.
+  documentationUrl: https://fleetdm.com/docs/configuration/agent-configuration#debug-logging-on-enroll
+  tier: Premium
+  jamfProHasFeature: no
+  jamfProtectHasFeature: no
+  productCategories: [Device management]
+  pricingTableCategories: [Devices]
+  usualDepartment: IT
+  moreInfoUrl: https://github.com/fleetdm/fleet/issues/43997
+#
+#  ╔╦╗ ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗╔╦╗  ╔╦╗╔═╗╔═╗╦  ╔═╗╦ ╦╔╦╗╔═╗╔╗╔╔╦╗
+#   ║║║ ║╣ ╠╦╝║  ║╣  ║║║╣  ║║   ║║║╣ ╠═╝║  ║ ║╚╦╝║║║║╣ ║║║ ║
+#  ╩ ╩ ╚═╝╩╚═╚═╝╚═╝ ╩ ╩╚═╝═╩╝  ═╩╝╚═╝╩  ╩═╝╚═╝ ╩ ╩ ╩╚═╝╝╚╝ ╩ 
 - industryName: Bring your own device (BYOD) enrollment
   description: BYOD enrollment for macOS, iOS/iPadOS, Windows, and Android devices.
   documentationUrl: https://fleetdm.com/guides/sysadmin-diaries-device-enrollment#byod-enrollment

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -161,7 +161,7 @@
   jamfProHasFeature: yes
   jamfProtectHasFeature: yes
   waysToUse:
-    - description: Enforce two-factor authentication when  in to Fleet for added security.
+    - description: Enforce two-factor authentication when logging in to Fleet for added security.
 #  
 #  ╦═╗╔═╗╦  ╔═╗  ╔╗ ╔═╗╔═╗╔═╗╔╦╗  ╔═╗╔═╗╔═╗╔═╗╔═╗╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╦═╗╔═╗╦  
 #  ╠╦╝║ ║║  ║╣───╠╩╗╠═╣╚═╗║╣  ║║  ╠═╣║  ║  ║╣ ╚═╗╚═╗  ║  ║ ║║║║ ║ ╠╦╝║ ║║  
@@ -178,7 +178,7 @@
 #  ╔═╗╦ ╦╔╦╗╦╔╦╗  ╦  ╔═╗╔═╗╔═╗╦╔╗╔╔═╗
 #  ╠═╣║ ║ ║║║ ║   ║  ║ ║║ ╦║ ╦║║║║║ ╦
 #  ╩ ╩╚═╝═╩╝╩ ╩   ╩═╝╚═╝╚═╝╚═╝╩╝╚╝╚═╝
-- industryName: Audit 
+- industryName: Audit logging
   description: Log all activity, including queries, scripts, access, etc.
   demos:
     - description: See activities for enabling/disabling the activities webhook and editing the destination URL so that I can know when the activities webhook was modified and by who.

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -276,9 +276,9 @@
     - description: Connect end users to Wi-Fi by adding your SCEP server.
       moreInfoUrl: https://youtu.be/secV4NCGYPg
 #
-#  ╔╦╗ ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗╔╦╗  ╔╦╗╔═╗╔═╗╦  ╔═╗╦ ╦╔╦╗╔═╗╔╗╔╔╦╗
-#   ║║║ ║╣ ╠╦╝║  ║╣  ║║║╣  ║║   ║║║╣ ╠═╝║  ║ ║╚╦╝║║║║╣ ║║║ ║
-#  ╩ ╩ ╚═╝╩╚═╚═╝╚═╝ ╩ ╩╚═╝═╩╝  ═╩╝╚═╝╩  ╩═╝╚═╝ ╩ ╩ ╩╚═╝╝╚╝ ╩ 
+#  ╔╦╗╔═╗╔╗ ╦ ╦╔═╗  ╦  ╔═╗╔═╗╔═╗╦╔╗╔╔═╗
+#   ║║║╣ ╠╩╗║ ║║ ╦  ║  ║ ║║ ╦║ ╦║║║║║ ╦
+#  ═╩╝╚═╝╚═╝╚═╝╚═╝  ╩═╝╚═╝╚═╝╚═╝╩╝╚╝╚═╝
 - industryName: Debug logging during setup experience
   description: Enable debug logging for fleetd during device enrollment to troubleshoot setup issues.
   documentationUrl: https://fleetdm.com/docs/configuration/agent-configuration#debug-logging-on-enroll
@@ -290,9 +290,9 @@
   usualDepartment: IT
   moreInfoUrl: https://github.com/fleetdm/fleet/issues/43997
 #
-#  ╔╦╗ ╔═╗╦═╗╔═╗╔═╗╔╦╗╔═╗╔╦╗  ╔╦╗╔═╗╔═╗╦  ╔═╗╦ ╦╔╦╗╔═╗╔╗╔╔╦╗
-#   ║║║ ║╣ ╠╦╝║  ║╣  ║║║╣  ║║   ║║║╣ ╠═╝║  ║ ║╚╦╝║║║║╣ ║║║ ║
-#  ╩ ╩ ╚═╝╩╚═╚═╝╚═╝ ╩ ╩╚═╝═╩╝  ═╩╝╚═╝╩  ╩═╝╚═╝ ╩ ╩ ╩╚═╝╝╚╝ ╩ 
+#  ╔╗ ╦ ╦╔═╗╔╦╗  ╔═╗╔╗╔╦═╗╔═╗╦  ╦  ╔╦╗╔═╗╔╗╔╔╦╗
+#  ╠╩╗╚╦╝║ ║ ║║  ║╣ ║║║╠╦╝║ ║║  ║  ║║║║╣ ║║║ ║ 
+#  ╚═╝ ╩ ╚═╝═╩╝  ╚═╝╝╚╝╩╚═╚═╝╩═╝╩═╝╩ ╩╚═╝╝╚╝ ╩ 
 - industryName: Bring your own device (BYOD) enrollment
   description: BYOD enrollment for macOS, iOS/iPadOS, Windows, and Android devices.
   documentationUrl: https://fleetdm.com/guides/sysadmin-diaries-device-enrollment#byod-enrollment

--- a/handbook/company/pricing-features-table.yml
+++ b/handbook/company/pricing-features-table.yml
@@ -161,7 +161,7 @@
   jamfProHasFeature: yes
   jamfProtectHasFeature: yes
   waysToUse:
-    - description: Enforce two-factor authentication when logging in to Fleet for added security.
+    - description: Enforce two-factor authentication when  in to Fleet for added security.
 #  
 #  ╦═╗╔═╗╦  ╔═╗  ╔╗ ╔═╗╔═╗╔═╗╔╦╗  ╔═╗╔═╗╔═╗╔═╗╔═╗╔═╗  ╔═╗╔═╗╔╗╔╔╦╗╦═╗╔═╗╦  
 #  ╠╦╝║ ║║  ║╣───╠╩╗╠═╣╚═╗║╣  ║║  ╠═╣║  ║  ║╣ ╚═╗╚═╗  ║  ║ ║║║║ ║ ╠╦╝║ ║║  
@@ -178,7 +178,7 @@
 #  ╔═╗╦ ╦╔╦╗╦╔╦╗  ╦  ╔═╗╔═╗╔═╗╦╔╗╔╔═╗
 #  ╠═╣║ ║ ║║║ ║   ║  ║ ║║ ╦║ ╦║║║║║ ╦
 #  ╩ ╩╚═╝═╩╝╩ ╩   ╩═╝╚═╝╚═╝╚═╝╩╝╚╝╚═╝
-- industryName: Audit logging
+- industryName: Audit 
   description: Log all activity, including queries, scripts, access, etc.
   demos:
     - description: See activities for enabling/disabling the activities webhook and editing the destination URL so that I can know when the activities webhook was modified and by who.
@@ -282,7 +282,7 @@
 - industryName: Debug logging during setup experience
   description: Enable debug logging for fleetd during device enrollment to troubleshoot setup issues.
   documentationUrl: https://fleetdm.com/docs/configuration/agent-configuration#debug-logging-on-enroll
-  tier: Premium
+  tier: Free
   jamfProHasFeature: no
   jamfProtectHasFeature: no
   productCategories: [Device management]


### PR DESCRIPTION
Feature: Enable fleetd debug logging at runtime during setup experience
- Adds agent option to configure debug_logging_on_enroll_duration
- Premium feature under Devices category

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** #43997
