### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/docker-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/docker-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.70.0",
+      "version": "4.71.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.70.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.electron.dockerdesktop' AND version_compare(bundle_short_version, '4.71.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/mac/main/arm64/224270/Docker.dmg",
+      "installer_url": "https://desktop.docker.com/mac/main/arm64/225177/Docker.dmg",
       "install_script_ref": "e016f7e9",
       "uninstall_script_ref": "d80afd7a",
-      "sha256": "38a19ac039dee38e0e445118da34962039ef1601b0656dc4d138592efda2caba",
+      "sha256": "56a78b132696b747c40b151af57ecdbd8529b5f4dac4d436cd0d767721a957b4",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/docker/windows.json
+++ b/ee/maintained-apps/outputs/docker/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.70.0",
+      "version": "4.71.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.70.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Docker Desktop' AND publisher = 'Docker Inc.' AND version_compare(version, '4.71.0') < 0);"
       },
-      "installer_url": "https://desktop.docker.com/win/main/amd64/224270/Docker%20Desktop%20Installer.exe",
+      "installer_url": "https://desktop.docker.com/win/main/amd64/225177/Docker%20Desktop%20Installer.exe",
       "install_script_ref": "f938db79",
       "uninstall_script_ref": "000be0a3",
-      "sha256": "b12f554c903c1f1e60ab98eff3d976705b90f3fe39a3815c6c86b7d88ef92577",
+      "sha256": "72f5ae091b90ffda86bbe721b484342b34e347586111e049e7c157d3e37d7e27",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.7.6",
+      "version": "12.8.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.7.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.8.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.7.6/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.0/osx_arm64",
       "install_script_ref": "d27f3112",
       "uninstall_script_ref": "15e9f11c",
-      "sha256": "a1248b74741d96e38bd48443f6d1aec6ace9e988b13bee4752fe2c7e5be12a14",
+      "sha256": "928063304893a510c3e7d801407b7cba979f556952490c033dd8ca004cfd99fa",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.7.6",
+      "version": "12.8.0",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.7.6') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.8.0') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.7.6/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.0/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "939a1412f68b29cf8fab6462421d76c5fe205da0c76be95788232a0e047b2acf",
+      "sha256": "83a0f062359557825a34eb4db543242e603709e9a8bee0a56284b0ea96fe418a",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/rider/darwin.json
+++ b/ee/maintained-apps/outputs/rider/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "2026.1.0.1",
+      "version": "2026.1.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider' AND version_compare(bundle_short_version, '2026.1.0.1') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.jetbrains.rider' AND version_compare(bundle_short_version, '2026.1.1') < 0);"
       },
-      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.0.1-aarch64.dmg",
+      "installer_url": "https://download.jetbrains.com/rider/JetBrains.Rider-2026.1.1-aarch64.dmg",
       "install_script_ref": "ee596313",
       "uninstall_script_ref": "da8aa8fc",
-      "sha256": "0471eb3b80cb7f0e1c75bac9087d6ea97daa766fe28f21678f7d9643cae95612",
+      "sha256": "7919756da703a7870617214dd30ef436642c9e33fa452ae51b9acb31b07f7d68",
       "default_categories": [
         "Developer tools"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker Desktop application support to version 4.71.0 for macOS and Windows platforms.
  * Updated Postman application support to version 12.8.0 for macOS and Windows platforms.
  * Updated Rider application support to version 2026.1.1 for macOS platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->