### PR TITLE
Enable osquery eventing and macOS FIM config

### DIFF
--- a/it-and-security/fleets/testing-and-qa.yml
+++ b/it-and-security/fleets/testing-and-qa.yml
@@ -10,18 +10,55 @@ settings:
     - secret: $DOGFOOD_TESTING_AND_QA_ENROLL_SECRET
 agent_options:
   config:
+    options:
+      pack_delimiter: /
+      logger_tls_period: 10
+      distributed_plugin: tls
+      disable_distributed: false
+      logger_tls_endpoint: /api/osquery/log
+      distributed_interval: 10
+      distributed_tls_max_attempts: 3
     decorators:
       load:
         - SELECT uuid AS host_uuid FROM system_info;
         - SELECT hostname AS hostname FROM system_info;
-    options:
-      disable_distributed: false
-      distributed_interval: 10
-      distributed_plugin: tls
-      distributed_tls_max_attempts: 3
-      logger_tls_endpoint: /api/osquery/log
-      logger_tls_period: 10
-      pack_delimiter: /
+    # macOS FIM scope
+    file_paths:
+      system_binaries:
+        - /usr/bin/%%
+        - /usr/sbin/%%
+        - /bin/%%
+        - /sbin/%%
+      launch_items:
+        - /Library/LaunchAgents/%%
+        - /Library/LaunchDaemons/%%
+        - /Users/%/Library/LaunchAgents/%%
+      etc:
+        - /etc/%%
+        - /private/etc/%%
+    exclude_paths:
+      etc:
+        - /private/etc/cups/%%
+        - /private/etc/newsyslog.d/%%
+  command_line_flags:
+    # Primary switch for the eventing system
+    disable_events: false
+    # Buffer / retention
+    events_max: 50000
+    events_expiry: 86400
+    events_optimize: true
+    # Watchdog headroom so evented workloads don't get killed
+    watchdog_memory_limit: 350
+    watchdog_utilization_limit: 130
+    # --- macOS FIM ---
+    enable_file_events: true
+    # --- Linux process + socket auditing via the audit framework ---
+    disable_audit: false
+    audit_allow_process_events: true
+    audit_allow_sockets: true
+    audit_persist: true
+    # --- Windows process auditing via ETW ---
+    enable_process_etw_events: true
   update_channels:
     osqueryd: edge
     orbit: edge

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -20,18 +20,55 @@ settings:
       webhook_url: $DOGFOOD_CALENDAR_WEBHOOK_URL
 agent_options:
   config:
+    options:
+      pack_delimiter: /
+      logger_tls_period: 10
+      distributed_plugin: tls
+      disable_distributed: false
+      logger_tls_endpoint: /api/osquery/log
+      distributed_interval: 10
+      distributed_tls_max_attempts: 3
     decorators:
       load:
         - SELECT uuid AS host_uuid FROM system_info;
         - SELECT hostname AS hostname FROM system_info;
-    options:
-      disable_distributed: false
-      distributed_interval: 10
-      distributed_plugin: tls
-      distributed_tls_max_attempts: 3
-      logger_tls_endpoint: /api/osquery/log
-      logger_tls_period: 10
-      pack_delimiter: /
+    # macOS FIM scope
+    file_paths:
+      system_binaries:
+        - /usr/bin/%%
+        - /usr/sbin/%%
+        - /bin/%%
+        - /sbin/%%
+      launch_items:
+        - /Library/LaunchAgents/%%
+        - /Library/LaunchDaemons/%%
+        - /Users/%/Library/LaunchAgents/%%
+      etc:
+        - /etc/%%
+        - /private/etc/%%
+    exclude_paths:
+      etc:
+        - /private/etc/cups/%%
+        - /private/etc/newsyslog.d/%%
+  command_line_flags:
+    # Primary switch for the eventing system
+    disable_events: false
+    # Buffer / retention
+    events_max: 50000
+    events_expiry: 86400
+    events_optimize: true
+    # Watchdog headroom so evented workloads don't get killed
+    watchdog_memory_limit: 350
+    watchdog_utilization_limit: 130
+    # --- macOS FIM ---
+    enable_file_events: true
+    # --- Linux process + socket auditing via the audit framework ---
+    disable_audit: false
+    audit_allow_process_events: true
+    audit_allow_sockets: true
+    audit_persist: true
+    # --- Windows process auditing via ETW ---
+    enable_process_etw_events: true
   update_channels:
     osqueryd: stable
     orbit: stable


### PR DESCRIPTION
Update testing-and-qa and workstations fleet configs to enable osquery eventing and file-integrity monitoring. Reorder and add agent_options.config options (pack_delimiter, logger settings, distributed plugin/endpoint, tls attempts), move decorators under config, and add macOS FIM file_paths/exclude_paths. Add command_line_flags to tune eventing, audit, ETW and watchdog settings for better event collection and retention.

Related: https://github.com/fleetdm/confidential/issues/11768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced platform-specific security monitoring across macOS, Linux, and Windows fleets
  * Added file integrity monitoring capabilities for macOS systems
  * Expanded audit framework and event collection for Linux environments
  * Improved process event auditing for Windows systems
  * Added configurable event retention and optimization controls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->