### PR TITLE
Fix: Label shows outdated manually selected host after navigating back to the Edit page

### DIFF
--- a/changes/43135-fix-stale-label-hosts
+++ b/changes/43135-fix-stale-label-hosts
@@ -1,0 +1,2 @@
+* Fixed stale "Selected hosts" on the edit label page after a previous edit by invalidating the related query caches on success.
+* Fixed stale "Selected hosts" on the edit label page when navigating between manual labels by scoping the hosts cache per label and keying the form on the actual host set.

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -152,7 +152,10 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       />
     ) : (
       <ManualLabelForm
-        key={targetedHosts?.map((h) => h.id).join(",")}
+        key={`${labelId}-${(targetedHosts || [])
+          .map((h) => h.id)
+          .sort((a, b) => a - b)
+          .join(",")}`}
         defaultName={label.name}
         defaultDescription={label.description}
         defaultTargetedHosts={targetedHosts}

--- a/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
+++ b/frontend/pages/labels/EditLabelPage/EditLabelPage.tsx
@@ -79,7 +79,7 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
     isLoading: isLoadingHosts,
     isError: isErrorHosts,
   } = useQuery<IGetHostsInLabelResponse, AxiosError, IHost[]>(
-    ["hosts"],
+    ["hosts", labelId],
     () => {
       return labelsAPI.getHostsInLabel(labelId);
     },
@@ -101,6 +101,8 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       await labelsAPI.update(labelId, formData);
       renderFlash("success", "Label updated successfully.");
       queryClient.invalidateQueries(["label", labelId, currentUser]);
+      queryClient.invalidateQueries(["hosts", labelId]);
+      queryClient.invalidateQueries(["labels"]);
     } catch (error) {
       const status = (error as { status: number }).status;
       let errorMessage = "Couldn't edit label. Please try again.";
@@ -150,7 +152,7 @@ const EditLabelPage = ({ routeParams, router }: IEditLabelPageProps) => {
       />
     ) : (
       <ManualLabelForm
-        key={targetedHosts?.toString()}
+        key={targetedHosts?.map((h) => h.id).join(",")}
         defaultName={label.name}
         defaultDescription={label.description}
         defaultTargetedHosts={targetedHosts}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43135

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale "Selected hosts" display on the edit label page by ensuring host data refreshes after successful label edits, so the UI reflects the updated host set immediately.
  * Fixed stale host selections when navigating between manual labels by scoping and resetting the form to the correct current host set, preventing selections from carrying over between labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->