### PR TITLE
Release osqueryd 5.23.0

### DIFF
--- a/.github/workflows/generate-osqueryd-targets.yml
+++ b/.github/workflows/generate-osqueryd-targets.yml
@@ -24,7 +24,7 @@ defaults:
     shell: bash
 
 env:
-  OSQUERY_VERSION: 5.22.1
+  OSQUERY_VERSION: 5.23.0
 
 permissions:
   id-token: write

--- a/tools/tuf/releaser.sh
+++ b/tools/tuf/releaser.sh
@@ -236,9 +236,9 @@ create_fleetd_release_pr () {
 
 release_osqueryd_to_edge () {
     echo "Releasing osqueryd to edge..."
-    prompt "A branch and PR for bumping the osquery version will be created."
     BRANCH_NAME=release-osqueryd-v$VERSION
     if [[ "$SKIP_PR_AND_TAG_PUSH" != "1" ]]; then
+        prompt "A branch and PR for bumping the osquery version will be created."
         pushd "$GIT_REPOSITORY_DIRECTORY"
         git checkout -b "$BRANCH_NAME"
         # Update the version used to build osqueryd targets.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated osqueryd version to 5.23.0 across macOS, Linux, and Windows build processes.
  * Adjusted release tooling behavior so the confirmation prompt only appears when the corresponding branch/PR creation step will actually run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->