### PR TITLE
Ignore `fleetdm/bomutils` vulnerabilities

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -549,6 +549,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/bomutils` docker image
 
+### [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL.
+- **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:28:25
+
 ### [CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -556,6 +564,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-04-20 11:48:55
+
+### [CVE-2026-28389](https://nvd.nist.gov/vuln/detail/CVE-2026-28389)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL.
+- **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:29:08
+
+### [CVE-2026-28388](https://nvd.nist.gov/vuln/detail/CVE-2026-28388)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL.
+- **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:28:53
+
+### [CVE-2026-28387](https://nvd.nist.gov/vuln/detail/CVE-2026-28387)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL.
+- **Products:** `bomutils`,`pkg:deb/debian/libssl3t64`,`pkg:deb/debian/openssl`,`pkg:deb/debian/openssl-provider-legacy`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:28:43
 
 ### [CVE-2026-0861](https://nvd.nist.gov/vuln/detail/CVE-2026-0861)
 - **Author:** @lucasmrod

--- a/security/vex/bomutils/CVE-2026-28387.vex.json
+++ b/security/vex/bomutils/CVE-2026-28387.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1fcea008c360a3e3947a2989e6a6e1600a6260a1c11cf604be1b41e937d437db",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:28:43.394667-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28387"
+      },
+      "timestamp": "2026-04-27T14:28:43.394668-03:00",
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/bomutils/CVE-2026-28388.vex.json
+++ b/security/vex/bomutils/CVE-2026-28388.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-6e0ac78b8e3db7db626e61826725e6e90a75cc5be8d05c322258288c00fb6d15",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:28:53.338235-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28388"
+      },
+      "timestamp": "2026-04-27T14:28:53.338236-03:00",
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/bomutils/CVE-2026-28389.vex.json
+++ b/security/vex/bomutils/CVE-2026-28389.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-23a02983ac75062c3c8dca96728ff898b592f88a677df2eb38848f78a25086bd",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:29:08.336893-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28389"
+      },
+      "timestamp": "2026-04-27T14:29:08.336894-03:00",
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/bomutils/CVE-2026-31789.vex.json
+++ b/security/vex/bomutils/CVE-2026-31789.vex.json
@@ -1,0 +1,32 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5fcdbd3e0b25b65fb86d25ab5d1ec7c957278a6a5399bc414dbb815f91e13a45",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:28:25.472076-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-31789"
+      },
+      "timestamp": "2026-04-27T14:28:25.472077-03:00",
+      "products": [
+        {
+          "@id": "bomutils"
+        },
+        {
+          "@id": "pkg:deb/debian/libssl3t64"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl"
+        },
+        {
+          "@id": "pkg:deb/debian/openssl-provider-legacy"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetctl does not use fleetdm/bomutils to connect to TLS servers using OpenSSL",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/24981188476. 

Run: https://github.com/fleetdm/fleet/actions/runs/25009852107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added vulnerability impact assessments for four CVEs (CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-31789). Documentation confirms these vulnerabilities do not affect the product.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->