### PR TITLE
Fleet UI: Disable gitops mode if in gitops mode

### DIFF
--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -222,7 +222,6 @@ const Variables = () => {
         {renderPageDescription()}
         {canEdit && (
           <GitOpsModeTooltipWrapper
-            entityType="secrets"
             renderChildren={(disableChildren) => (
               <Button
                 variant="inverse"

--- a/frontend/pages/ManageControlsPage/Variables/Variables.tsx
+++ b/frontend/pages/ManageControlsPage/Variables/Variables.tsx
@@ -202,7 +202,13 @@ const Variables = () => {
           info="Add a custom variable to make it available in scripts and profiles."
           primaryButton={
             canEdit ? (
-              <Button onClick={onClickAddSecret}>Add custom variable</Button>
+              <GitOpsModeTooltipWrapper
+                renderChildren={(disableChildren) => (
+                  <Button onClick={onClickAddSecret} disabled={disableChildren}>
+                    Add custom variable
+                  </Button>
+                )}
+              />
             ) : undefined
           }
         />


### PR DESCRIPTION
## Issue
Followup to #36661 (4.85.0)

## Description
- Found during QA of #36661 but turns out it's a 4.84.0 released bug due to file naming confusions
- Still needs to be fixed in main and RC of 4.85.0
- Will file a separate issue to cherry-pick onto 4.84.1 

## Screenshots of both fixes
<img width="1415" height="504" alt="Screenshot 2026-04-27 at 4 14 09 PM" src="https://github.com/user-attachments/assets/273fa515-6319-49da-8f57-8fe8c426647c" />
<img width="1418" height="586" alt="Screenshot 2026-04-27 at 4 14 45 PM" src="https://github.com/user-attachments/assets/567a7ad4-1384-4231-a8c6-6a13b82b873f" />


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The "Add custom variable" button in empty-state now correctly respects GitOps mode and will be disabled when appropriate.

* **Refactor**
  * Updated internal wrapping for add-buttons in the Variables management area to centralize enable/disable behavior.

---

Note: No other visible changes to end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->