### PR TITLE
Ignore `fleetdm/fleet` and `fleetdm/fleetctl` vulnerabilities

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -268,6 +268,14 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Justification:** `vulnerable_code_not_in_execute_path`
 - **Timestamp:** 2026-03-23 16:44:57
 
+### [CVE-2026-40962](https://nvd.nist.gov/vuln/detail/CVE-2026-40962)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleetctl functionality does not make use of ffmpeg.
+- **Products:** `fleetctl`,`pkg:deb/debian/libavcodec61`,`pkg:deb/debian/libavformat61`,`pkg:deb/debian/libavutil59`,`pkg:deb/debian/libswresample5`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 17:38:09
+
 ### [CVE-2026-34875](https://nvd.nist.gov/vuln/detail/CVE-2026-34875)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`

--- a/security/status.md
+++ b/security/status.md
@@ -5,6 +5,30 @@ Following is the vulnerability report of Fleet and its dependencies.
 
 ## `fleetdm/fleet` docker image
 
+### [CVE-2026-40200](https://nvd.nist.gov/vuln/detail/CVE-2026-40200)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet runs on 64-bit. The 64-bit trigger is ~23 trillion elements — that requires petabytes of contiguous memory in a single sort call. It is not reachable from any Fleet code path under any real workload. Also, the only way Fleet would touch musl's qsort is through a cgo dependency (SQLite via fts5, the only meaningful cgo path). Even SQLite's internal qsort calls are nowhere near the trigger threshold.
+- **Products:** `fleet`,`pkg:apk/alpine/musl`,`pkg:apk/alpine/musl-utils`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:51:37
+
+### [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating).
+- **Products:** `fleet`,`pkg:golang/go.opentelemetry.io/otel/sdk`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 15:03:59
+
+### [CVE-2026-33487](https://nvd.nist.gov/vuln/detail/CVE-2026-33487)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** The loop variable capture is a real code defect, but its practical exploitability as a signature bypass (without possession of the IdP private key in the first place) appears overstated by the CVSS 7.5 / High rating.
+- **Products:** `fleet`,`pkg:golang/github.com/russellhaering/goxmldsig`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 15:00:17
+
 ### [CVE-2026-33186](https://nvd.nist.gov/vuln/detail/CVE-2026-33186)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
@@ -12,6 +36,78 @@ Following is the vulnerability report of Fleet and its dependencies.
 - **Products:** `fleet`,`pkg:golang/google.golang.org/grpc`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-03-24 12:38:53
+
+### [CVE-2026-32283](https://nvd.nist.gov/vuln/detail/CVE-2026-32283)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.
+- **Products:** `fleet`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 15:37:36
+
+### [CVE-2026-32281](https://nvd.nist.gov/vuln/detail/CVE-2026-32281)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.
+- **Products:** `fleet`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 15:37:25
+
+### [CVE-2026-32280](https://nvd.nist.gov/vuln/detail/CVE-2026-32280)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.
+- **Products:** `fleet`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 15:37:12
+
+### [CVE-2026-31789](https://nvd.nist.gov/vuln/detail/CVE-2026-31789)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleet uses Go TLS to connect to servers.
+- **Products:** `fleet`,`pkg:apk/alpine/libcrypto3`,`pkg:apk/alpine/libssl3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:42:11
+
+### [CVE-2026-28390](https://nvd.nist.gov/vuln/detail/CVE-2026-28390)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleet uses Go TLS to connect to servers.
+- **Products:** `fleet`,`pkg:apk/alpine/libcrypto3`,`pkg:apk/alpine/libssl3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:41:44
+
+### [CVE-2026-28389](https://nvd.nist.gov/vuln/detail/CVE-2026-28389)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleet uses Go TLS to connect to servers.
+- **Products:** `fleet`,`pkg:apk/alpine/libcrypto3`,`pkg:apk/alpine/libssl3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:41:34
+
+### [CVE-2026-28388](https://nvd.nist.gov/vuln/detail/CVE-2026-28388)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleet uses Go TLS to connect to servers.
+- **Products:** `fleet`,`pkg:apk/alpine/libcrypto3`,`pkg:apk/alpine/libssl3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:41:22
+
+### [CVE-2026-28387](https://nvd.nist.gov/vuln/detail/CVE-2026-28387)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** fleetdm/fleet uses Go TLS to connect to servers.
+- **Products:** `fleet`,`pkg:apk/alpine/libcrypto3`,`pkg:apk/alpine/libssl3`
+- **Justification:** `vulnerable_code_not_in_execute_path`
+- **Timestamp:** 2026-04-27 14:41:09
+
+### [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-25679)
+- **Author:** @lucasmrod
+- **Status:** `not_affected`
+- **Status notes:** All url.Parse inputs reachable in Fleet are admin-trusted configuration, not attacker-controlled. Nonetheless, we advise upgrading to v4.84.0 when possible.
+- **Products:** `fleet`,`pkg:golang/stdlib`
+- **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
+- **Timestamp:** 2026-04-27 17:05:55
 
 ### [CVE-2026-22184](https://nvd.nist.gov/vuln/detail/CVE-2026-22184)
 - **Author:** @lucasmrod

--- a/security/vex/fleet/CVE-2026-25679.vex.json
+++ b/security/vex/fleet/CVE-2026-25679.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-158adaa5164ea891ed3983242a7e5f651f74e7ff7ef40283b5312715db00a861",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T17:05:55.156014-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-25679"
+      },
+      "timestamp": "2026-04-27T17:05:55.156015-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "All url.Parse inputs reachable in Fleet are admin-trusted configuration, not attacker-controlled. Nonetheless, we advise upgrading to v4.84.0 when possible.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-28387.vex.json
+++ b/security/vex/fleet/CVE-2026-28387.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-c912b84e6e9bcc2a24ab8256eee542e7a619e2e507079becd0d5510531ee824d",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:41:09.913019-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28387"
+      },
+      "timestamp": "2026-04-27T14:41:09.91302-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleet uses Go TLS to connect to servers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-28388.vex.json
+++ b/security/vex/fleet/CVE-2026-28388.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-5cd3cfea757e530e420b3d9a75a9f6c1ee5e1b8bc181977c69e69ae5d940058a",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:41:22.335457-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28388"
+      },
+      "timestamp": "2026-04-27T14:41:22.335458-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleet uses Go TLS to connect to servers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-28389.vex.json
+++ b/security/vex/fleet/CVE-2026-28389.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-75818ff168776bca89036161672e4a9a85077d1795929b7980e05bc8969d6a22",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:41:34.498456-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28389"
+      },
+      "timestamp": "2026-04-27T14:41:34.498457-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleet uses Go TLS to connect to servers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-28390.vex.json
+++ b/security/vex/fleet/CVE-2026-28390.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-317890a6804bf360310948cc10beca4456951aac21710738fe4da3e045a19bac",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:41:44.10623-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-28390"
+      },
+      "timestamp": "2026-04-27T14:41:44.10623-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleet uses Go TLS to connect to servers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-31789.vex.json
+++ b/security/vex/fleet/CVE-2026-31789.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b625b36a4eea8cb55239608ea727778a6da3665878f49dcb3f201a71214a4b57",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:42:11.08649-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-31789"
+      },
+      "timestamp": "2026-04-27T14:42:11.08649-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/libcrypto3"
+        },
+        {
+          "@id": "pkg:apk/alpine/libssl3"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleet uses Go TLS to connect to servers",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-32280.vex.json
+++ b/security/vex/fleet/CVE-2026-32280.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-3e4e80a6125759252bfc1404ac9d50e6738d76ce2bbbf0b5933ac8bdc910e9fd",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T15:37:12.15943-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32280"
+      },
+      "timestamp": "2026-04-27T15:37:12.159433-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-32281.vex.json
+++ b/security/vex/fleet/CVE-2026-32281.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9bd709c8f7c05e852a8c96d1dc0cdd64d34aa1d6bd07275f15701582c1ac7751",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T15:37:25.970767-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32281"
+      },
+      "timestamp": "2026-04-27T15:37:25.970768-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-32283.vex.json
+++ b/security/vex/fleet/CVE-2026-32283.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-0e94ea09dfa2bdbf702070b86095ea36fa4ccf7c864605e716aa6966e495c608",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T15:37:36.02109-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-32283"
+      },
+      "timestamp": "2026-04-27T15:37:36.02109-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/stdlib"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-33487.vex.json
+++ b/security/vex/fleet/CVE-2026-33487.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-9b6719e09d5e2dd15a7da0a4286adef90baec813482459de59c90c79395744a6",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T15:00:17.543328-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-33487"
+      },
+      "timestamp": "2026-04-27T15:00:17.543329-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/github.com/russellhaering/goxmldsig"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "The loop variable capture is a real code defect, but its practical exploitability as a signature bypass (without possession of the IdP private key in the first place) appears overstated by the CVSS 7.5 / High rating.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-39883.vex.json
+++ b/security/vex/fleet/CVE-2026-39883.vex.json
@@ -1,0 +1,26 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-1cdb875d657df36fb8899c6ef4f455aecf52a6b3fede2dd5fe1c0c0149ff0590",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T15:03:59.468784-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-39883"
+      },
+      "timestamp": "2026-04-27T15:03:59.468784-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:golang/go.opentelemetry.io/otel/sdk"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating).",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}

--- a/security/vex/fleet/CVE-2026-40200.vex.json
+++ b/security/vex/fleet/CVE-2026-40200.vex.json
@@ -1,0 +1,29 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-193ab7a0e4eb4ef36ac8760adc2dcbffd81090fa574046c4efc6bf3563aa717e",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T14:51:37.743583-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40200"
+      },
+      "timestamp": "2026-04-27T14:51:37.743584-03:00",
+      "products": [
+        {
+          "@id": "fleet"
+        },
+        {
+          "@id": "pkg:apk/alpine/musl"
+        },
+        {
+          "@id": "pkg:apk/alpine/musl-utils"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "Fleet runs on 64-bit. The 64-bit trigger is ~23 trillion elements — that requires petabytes of contiguous memory in a single sort call. It is not reachable from any Fleet code path under any real workload. Also, the only way Fleet would touch musl's qsort is through a cgo dependency (SQLite via fts5, the only meaningful cgo path). Even SQLite's internal qsort calls are nowhere near the trigger threshold",
+      "justification": "vulnerable_code_not_in_execute_path"
+    }
+  ]
+}

--- a/security/vex/fleetctl/CVE-2026-40962.vex.json
+++ b/security/vex/fleetctl/CVE-2026-40962.vex.json
@@ -1,0 +1,35 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-652a13a42f75d8ef379565bc54f8bea6e81e9f61452072c6887b717ea69f9e94",
+  "author": "@lucasmrod",
+  "timestamp": "2026-04-27T17:38:09.812786-03:00",
+  "version": 1,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "CVE-2026-40962"
+      },
+      "timestamp": "2026-04-27T17:38:09.812786-03:00",
+      "products": [
+        {
+          "@id": "fleetctl"
+        },
+        {
+          "@id": "pkg:deb/debian/libavcodec61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavformat61"
+        },
+        {
+          "@id": "pkg:deb/debian/libavutil59"
+        },
+        {
+          "@id": "pkg:deb/debian/libswresample5"
+        }
+      ],
+      "status": "not_affected",
+      "status_notes": "fleetdm/fleetctl functionality does not make use of ffmpeg.",
+      "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: https://github.com/fleetdm/fleet/actions/runs/24980770051/job/73142219314.

Run: https://github.com/fleetdm/fleet/actions/runs/25018399091.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added OpenVEX vulnerability declarations for multiple CVEs, marking them as not affected for Fleet and fleetctl. Each entry includes metadata, human-readable status notes, and justifications addressing exploitability relative to Go runtime, Alpine/musl packages, crypto/SSL libraries, OpenTelemetry, xmldsig, and media libraries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->