### PR TITLE
For 4.84.1 RC - Fleet UI: Disable gitops mode if in gitops mode

### DIFF
--- a/changes/44245-fix-gitops-variable-bug
+++ b/changes/44245-fix-gitops-variable-bug
@@ -1,0 +1,1 @@
+Fleet UI > Settings > Variables: Fixed access to not allow adding custom variable while in gitops mode both in the empty state and when a variable already exists

--- a/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
@@ -204,14 +204,16 @@ const Secrets = () => {
             {canEdit && (
               <GitOpsModeTooltipWrapper
                 renderChildren={(disableChildren) => (
-                  <Button
-                    variant="inverse"
-                    onClick={onClickAddSecret}
-                    disabled={disableChildren}
-                  >
-                    <Icon name="plus" />
-                    <span>Add custom variable</span>
-                  </Button>
+                  <span>
+                    <Button
+                      variant="inverse"
+                      onClick={onClickAddSecret}
+                      disabled={disableChildren}
+                    >
+                      <Icon name="plus" />
+                      <span>Add custom variable</span>
+                    </Button>
+                  </span>
                 )}
               />
             )}

--- a/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
+++ b/frontend/pages/ManageControlsPage/Secrets/Secrets.tsx
@@ -160,7 +160,13 @@ const Secrets = () => {
           info="Add a custom variable to make it available in scripts and profiles."
           primaryButton={
             canEdit ? (
-              <Button onClick={onClickAddSecret}>Add custom variable</Button>
+              <GitOpsModeTooltipWrapper
+                renderChildren={(disableChildren) => (
+                  <Button onClick={onClickAddSecret} disabled={disableChildren}>
+                    Add custom variable
+                  </Button>
+                )}
+              />
             ) : undefined
           }
         />
@@ -197,18 +203,15 @@ const Secrets = () => {
             <span>Custom variables</span>
             {canEdit && (
               <GitOpsModeTooltipWrapper
-                entityType="secrets"
                 renderChildren={(disableChildren) => (
-                  <span>
-                    <Button
-                      variant="inverse"
-                      onClick={onClickAddSecret}
-                      disabled={disableChildren}
-                    >
-                      <Icon name="plus" />
-                      <span>Add custom variable</span>
-                    </Button>
-                  </span>
+                  <Button
+                    variant="inverse"
+                    onClick={onClickAddSecret}
+                    disabled={disableChildren}
+                  >
+                    <Icon name="plus" />
+                    <span>Add custom variable</span>
+                  </Button>
                 )}
               />
             )}


### PR DESCRIPTION
## NOTE: DRAFT ONLY until merge can be redirected to 4.84.1 branch once 4.84.1 branch is made, cannot cherry-pick as these files have been renamed since 4.84.x

## Issue
Closes #44245 

## Description
- Previously merged into `main` with #44237 
- Previously merged into `4.85.0 RC` with #44241 
- Cannot be cherry picked as changes on 4.85 on are on file renamed to `Variables.tsx`
- 4.84.1 Fix is on file named `Secrets.tsx` prior to the rename to `Variables.tsx` on 4.85.0

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] QA'd all new/changed functionality manually