### PR TITLE
UDAE: fetch and allow download default setup assistant profile

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
@@ -8,6 +8,7 @@ import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
 import mdmAPI, {
   IAppleSetupEnrollmentProfileResponse,
+  IDefaultAppleSetupEnrollmentProfileResponse,
 } from "services/entities/mdm";
 import { DEFAULT_USE_QUERY_OPTIONS } from "utilities/constants";
 import PATHS from "router/paths";
@@ -66,6 +67,20 @@ const SetupAssistant = ({
       retry: false,
     }
   );
+  const enrollmentProfileNotFound = enrollmentProfileError?.status === 404;
+
+  const {
+    data: defaultEnrollmentProfileData,
+    isLoading: isLoadingDefaultEnrollmentProfile,
+  } = useQuery<IDefaultAppleSetupEnrollmentProfileResponse, AxiosError>(
+    ["default_enrollment_profile", currentTeamId],
+    () => mdmAPI.getDefaultSetupEnrollmentProfile(),
+    {
+      ...DEFAULT_USE_QUERY_OPTIONS,
+      retry: false,
+      enabled: enrollmentProfileNotFound, // only fetch the default profile if there is no team enrollment profile
+    }
+  );
 
   const getReleaseDeviceSetting = () => {
     if (currentTeamId === API_NO_TEAM_ID) {
@@ -92,21 +107,36 @@ const SetupAssistant = ({
   const defaultReleaseDeviceSetting = getReleaseDeviceSetting();
 
   const isLoading =
-    isLoadingGlobalConfig || isLoadingTeamConfig || isLoadingEnrollmentProfile;
-  const enrollmentProfileNotFound = enrollmentProfileError?.status === 404;
+    isLoadingGlobalConfig ||
+    isLoadingTeamConfig ||
+    isLoadingEnrollmentProfile ||
+    isLoadingDefaultEnrollmentProfile;
 
   const renderSetupAssistantView = () => {
     return (
       <SetupExperienceContentContainer>
         <div className={`${baseClass}__upload-container`}>
           <p className={`${baseClass}__section-description`}>
-            Add an automatic enrollment profile to customize Setup Assistant.
+            Add an automatic enrollment profile to customize Setup Assistant.{" "}
+            <CustomLink
+              url="https://fleetdm.com/learn-more-about/enrollment-profiles"
+              text="Learn more"
+              newTab
+            />
           </p>
           {enrollmentProfileNotFound || !enrollmentProfileData ? (
-            <SetupAssistantProfileUploader
-              currentTeamId={currentTeamId}
-              onUpload={onUpload}
-            />
+            <>
+              <SetupAssistantProfileCard
+                profile={
+                  defaultEnrollmentProfileData as IAppleSetupEnrollmentProfileResponse
+                }
+                defaultProfile
+              />
+              <SetupAssistantProfileUploader
+                currentTeamId={currentTeamId}
+                onUpload={onUpload}
+              />
+            </>
           ) : (
             <SetupAssistantProfileCard
               profile={enrollmentProfileData}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/SetupAssistant.tsx
@@ -126,12 +126,14 @@ const SetupAssistant = ({
           </p>
           {enrollmentProfileNotFound || !enrollmentProfileData ? (
             <>
-              <SetupAssistantProfileCard
-                profile={
-                  defaultEnrollmentProfileData as IAppleSetupEnrollmentProfileResponse
-                }
-                defaultProfile
-              />
+              {defaultEnrollmentProfileData && (
+                <SetupAssistantProfileCard
+                  profile={
+                    defaultEnrollmentProfileData as IAppleSetupEnrollmentProfileResponse
+                  }
+                  defaultProfile
+                />
+              )}
               <SetupAssistantProfileUploader
                 currentTeamId={currentTeamId}
                 onUpload={onUpload}

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
@@ -9,23 +9,27 @@ import Graphic from "components/Graphic";
 import Button from "components/buttons/Button";
 import { IAppleSetupEnrollmentProfileResponse } from "services/entities/mdm";
 
-const baseClass = "setup-assistant-profile-card";
 interface ISetupAssistantProfileCardProps {
   profile: IAppleSetupEnrollmentProfileResponse;
-  onDelete: () => void;
+  onDelete?: () => void;
+  defaultProfile?: boolean;
 }
 
 const SetupAssistantProfileCard = ({
   profile,
   onDelete,
+  defaultProfile = false,
 }: ISetupAssistantProfileCardProps) => {
+  const baseClass = `setup-assistant-profile-card${
+    defaultProfile ? "-default-profile" : ""
+  }`;
   const onDownload = () => {
     const date = new Date();
-    const filename = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}_${
-      profile.name
+    const filename = `${date.toISOString().split("T")[0]}_${
+      defaultProfile ? "default-automatic-enrollment.json" : profile.name
     }`;
     const file = new global.window.File(
-      [JSON.stringify(profile.enrollment_profile)],
+      [JSON.stringify(profile.enrollment_profile, null, 2)],
       filename
     );
 
@@ -36,10 +40,23 @@ const SetupAssistantProfileCard = ({
     <Card paddingSize="medium" className={baseClass}>
       <Graphic name="file-configuration-profile" />
       <div className={`${baseClass}__info`}>
-        <span className={`${baseClass}__profile-name`}>{profile.name}</span>
-        <span className={`${baseClass}__uploaded-at`}>
-          {uploadedFromNow(profile.uploaded_at)}
-        </span>
+        {defaultProfile ? (
+          <>
+            <span className={`${baseClass}__profile-name`}>
+              Default profile
+            </span>
+            <span className={`${baseClass}__description`}>
+              Hosts use this profile, unless you add your own.
+            </span>
+          </>
+        ) : (
+          <>
+            <span className={`${baseClass}__profile-name`}>{profile.name}</span>
+            <span className={`${baseClass}__uploaded-at`}>
+              {uploadedFromNow(profile.uploaded_at)}
+            </span>
+          </>
+        )}
       </div>
       <div className={`${baseClass}__actions`}>
         <Button
@@ -49,13 +66,15 @@ const SetupAssistantProfileCard = ({
         >
           <Icon name="download" />
         </Button>
-        <Button
-          className={`${baseClass}__delete-button`}
-          variant="icon"
-          onClick={onDelete}
-        >
-          <Icon name="trash" />
-        </Button>
+        {!defaultProfile && (
+          <Button
+            className={`${baseClass}__delete-button`}
+            variant="icon"
+            onClick={onDelete}
+          >
+            <Icon name="trash" />
+          </Button>
+        )}
       </div>
     </Card>
   );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/SetupAssistantProfileCard.tsx
@@ -7,29 +7,43 @@ import Icon from "components/Icon";
 import Card from "components/Card";
 import Graphic from "components/Graphic";
 import Button from "components/buttons/Button";
-import { IAppleSetupEnrollmentProfileResponse } from "services/entities/mdm";
+import {
+  IAppleSetupEnrollmentProfileResponse,
+  IDefaultAppleSetupEnrollmentProfileResponse,
+} from "services/entities/mdm";
 
-interface ISetupAssistantProfileCardProps {
-  profile: IAppleSetupEnrollmentProfileResponse;
-  onDelete?: () => void;
-  defaultProfile?: boolean;
+interface IBaseProps<TProfile> {
+  profile: TProfile;
 }
 
-const SetupAssistantProfileCard = ({
-  profile,
-  onDelete,
-  defaultProfile = false,
-}: ISetupAssistantProfileCardProps) => {
+interface IDefaultProfileProps
+  extends IBaseProps<IDefaultAppleSetupEnrollmentProfileResponse> {
+  defaultProfile: true;
+}
+
+interface ICustomProfileProps
+  extends IBaseProps<IAppleSetupEnrollmentProfileResponse> {
+  defaultProfile?: false;
+  onDelete: () => void;
+}
+
+type ISetupAssistantProfileCardProps =
+  | IDefaultProfileProps
+  | ICustomProfileProps;
+
+const SetupAssistantProfileCard = (props: ISetupAssistantProfileCardProps) => {
   const baseClass = `setup-assistant-profile-card${
-    defaultProfile ? "-default-profile" : ""
+    props.defaultProfile ? "-default-profile" : ""
   }`;
   const onDownload = () => {
     const date = new Date();
     const filename = `${date.toISOString().split("T")[0]}_${
-      defaultProfile ? "default-automatic-enrollment.json" : profile.name
+      props.defaultProfile
+        ? "default-automatic-enrollment.json"
+        : props.profile.name
     }`;
     const file = new global.window.File(
-      [JSON.stringify(profile.enrollment_profile, null, 2)],
+      [JSON.stringify(props.profile.enrollment_profile, null, 2)],
       filename
     );
 
@@ -40,7 +54,7 @@ const SetupAssistantProfileCard = ({
     <Card paddingSize="medium" className={baseClass}>
       <Graphic name="file-configuration-profile" />
       <div className={`${baseClass}__info`}>
-        {defaultProfile ? (
+        {props.defaultProfile ? (
           <>
             <span className={`${baseClass}__profile-name`}>
               Default profile
@@ -51,9 +65,11 @@ const SetupAssistantProfileCard = ({
           </>
         ) : (
           <>
-            <span className={`${baseClass}__profile-name`}>{profile.name}</span>
+            <span className={`${baseClass}__profile-name`}>
+              {props.profile.name}
+            </span>
             <span className={`${baseClass}__uploaded-at`}>
-              {uploadedFromNow(profile.uploaded_at)}
+              {uploadedFromNow(props.profile.uploaded_at)}
             </span>
           </>
         )}
@@ -66,11 +82,11 @@ const SetupAssistantProfileCard = ({
         >
           <Icon name="download" />
         </Button>
-        {!defaultProfile && (
+        {!props.defaultProfile && (
           <Button
             className={`${baseClass}__delete-button`}
             variant="icon"
-            onClick={onDelete}
+            onClick={props.onDelete}
           >
             <Icon name="trash" />
           </Button>

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/_styles.scss
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/SetupAssistant/components/SetupAssistantProfileCard/_styles.scss
@@ -1,4 +1,4 @@
-.setup-assistant-profile-card {
+.setup-assistant-profile-card, .setup-assistant-profile-card-default-profile {
   display: flex;
   gap: $pad-medium;
   align-items: center;
@@ -16,6 +16,9 @@
   &__uploaded-at {
     font-size: $xx-small;
   }
+  &__description {
+    font-size: $x-small;
+  }
 
   &__actions {
     display: flex;
@@ -27,4 +30,8 @@
   &__download-button, &__delete-button {
     padding: 11px; // TODO: use a padding value from existing variables. talk to design.
   }
+}
+
+.setup-assistant-profile-card-default-profile {
+  background-color: $ui-off-white;
 }

--- a/frontend/services/entities/mdm.ts
+++ b/frontend/services/entities/mdm.ts
@@ -68,6 +68,12 @@ export interface IAppleSetupEnrollmentProfileResponse {
   enrollment_profile: Record<string, unknown>;
 }
 
+export interface IDefaultAppleSetupEnrollmentProfileResponse {
+  updated_at?: string;
+  // enrollment profile is an object with keys found here https://developer.apple.com/documentation/devicemanagement/profile.
+  enrollment_profile: Record<string, unknown>;
+}
+
 export interface IMDMSSOParams {
   deviceinfo: string;
   initiator: string;
@@ -300,6 +306,11 @@ const mdmService = {
       { fleet_id: teamId }
     )}`;
     return sendRequest("GET", path);
+  },
+
+  getDefaultSetupEnrollmentProfile: (): Promise<IDefaultAppleSetupEnrollmentProfileResponse> => {
+    const { MDM_APPLE_DEFAULT_SETUP_ENROLLMENT_PROFILE } = endpoints;
+    return sendRequest("GET", MDM_APPLE_DEFAULT_SETUP_ENROLLMENT_PROFILE);
   },
 
   uploadSetupEnrollmentProfile: (file: File, teamId: number) => {

--- a/frontend/utilities/endpoints.ts
+++ b/frontend/utilities/endpoints.ts
@@ -184,7 +184,8 @@ export default {
 
     return `/api/mdm/apple/enroll?${query}`;
   },
-  MDM_APPLE_SETUP_ENROLLMENT_PROFILE: `/${API_VERSION}/fleet/mdm/apple/enrollment_profile`,
+  MDM_APPLE_SETUP_ENROLLMENT_PROFILE: `/${API_VERSION}/fleet/enrollment_profiles/automatic`,
+  MDM_APPLE_DEFAULT_SETUP_ENROLLMENT_PROFILE: `/${API_VERSION}/fleet/enrollment_profiles/automatic/default`,
   MDM_BOOTSTRAP_PACKAGE_METADATA: (teamId: number) =>
     `/${API_VERSION}/fleet/mdm/bootstrap/${teamId}/metadata`,
   MDM_BOOTSTRAP_PACKAGE: `/${API_VERSION}/fleet/bootstrap`,


### PR DESCRIPTION
### Needs #44236

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43790

<img width="1109" height="511" alt="image" src="https://github.com/user-attachments/assets/256560ee-0d70-4fff-b553-37e46224a54a" />


# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. Added in backend PR

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [ ] Added/updated automated tests
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup Assistant now fetches and shows a default Apple enrollment profile when a team profile is missing, including its loading state before showing the uploader.

* **User-facing behavior**
  * Default profile can be viewed and downloaded immediately; download uses a fixed filename and formatted JSON.

* **Documentation**
  * Added a "Learn more" link to the Setup Assistant section.

* **Style**
  * Default profile card uses a distinct background, smaller description text, and hides the delete action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->