### PR TITLE
Fix `fleetctl vulnerability-data-stream` to download OSV data

### DIFF
--- a/changes/44242-fleetctl-vuln-data-stream-osv
+++ b/changes/44242-fleetctl-vuln-data-stream-osv
@@ -1,0 +1,1 @@
+- Fixed `fleetctl vulnerability-data-stream` to also download OSV (Ubuntu and RHEL) artifacts.

--- a/cmd/fleetctl/fleetctl/vulnerability_data_stream.go
+++ b/cmd/fleetctl/fleetctl/vulnerability_data_stream.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/macoffice"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/msrc"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/nvd"
+	"github.com/fleetdm/fleet/v4/server/vulnerabilities/osv"
 	"github.com/fleetdm/fleet/v4/server/vulnerabilities/oval"
 	"github.com/urfave/cli/v2"
 )
@@ -99,6 +100,13 @@ Downloads (if needed) the data streams that can be used by the Fleet server to p
 			err = macoffice.SyncFromGithub(ctx, dir)
 			if err != nil {
 				return fmt.Errorf("Error downloading MacOffice release notes: %v", err)
+			}
+			log(c, " Done\n")
+
+			log(c, "[-] Downloading OSV artifacts...")
+			_, err = osv.RefreshAll(ctx, dir)
+			if err != nil {
+				return fmt.Errorf("Error downloading OSV artifacts: %v", err)
 			}
 			log(c, " Done\n")
 

--- a/cmd/fleetctl/integrationtest/vuln/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/integrationtest/vuln/vulnerability_data_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl"
@@ -59,4 +60,13 @@ func TestIntegrationsVulnerabilityDataStream(t *testing.T) {
 	for _, file := range files {
 		assert.FileExists(t, path.Join(vulnPath, file))
 	}
+
+	// Verify OSV artifacts were actually written to disk, not just logged.
+	ubuntuMatches, err := filepath.Glob(filepath.Join(vulnPath, "osv-ubuntu-*.json.gz"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, ubuntuMatches, "expected at least one Ubuntu OSV artifact in %s", vulnPath)
+
+	rhelMatches, err := filepath.Glob(filepath.Join(vulnPath, "osv-rhel-*.json.gz"))
+	require.NoError(t, err)
+	assert.NotEmpty(t, rhelMatches, "expected at least one RHEL OSV artifact in %s", vulnPath)
 }

--- a/cmd/fleetctl/integrationtest/vuln/vulnerability_data_stream_test.go
+++ b/cmd/fleetctl/integrationtest/vuln/vulnerability_data_stream_test.go
@@ -26,6 +26,7 @@ func TestIntegrationsVulnerabilityDataStream(t *testing.T) {
 [-] Downloading Oval definitions... Done
 [-] Downloading MSRC artifacts... Done
 [-] Downloading MacOffice release notes... Done
+[-] Downloading OSV artifacts... Done
 [+] Data streams successfully downloaded!
 `
 

--- a/server/vulnerabilities/osv/sync.go
+++ b/server/vulnerabilities/osv/sync.go
@@ -141,6 +141,103 @@ func rhelOSVFilename(rhelVersion string, date time.Time) string {
 		OSVRHELFilePrefix, rhelVersion, date.Year(), date.Month(), date.Day())
 }
 
+// RefreshAll downloads every Ubuntu and RHEL OSV artifact present in the latest
+// release, without filtering by host inventory. It is intended for use by tools
+// that pre-seed a vulnerability directory without DB access (e.g.
+// `fleetctl vulnerability-data-stream`). Unlike Refresh / RefreshRHEL, it does
+// not delete older artifacts — that responsibility stays with the server's
+// vulnerability cron once the directory is in use.
+func RefreshAll(ctx context.Context, vulnPath string) ([]string, error) {
+	release, err := getLatestRelease(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting latest release: %w", err)
+	}
+
+	releaseDate, ok := releaseDateFromAssets(release)
+	if !ok {
+		return nil, fmt.Errorf("no OSV artifacts found in latest release %q", release.TagName)
+	}
+
+	ubuntuVers, rhelVers := versionsFromRelease(release)
+
+	var downloaded []string
+	if len(ubuntuVers) > 0 {
+		result, err := SyncOSV(ctx, vulnPath, ubuntuVers, releaseDate, release)
+		if err != nil {
+			return downloaded, fmt.Errorf("syncing Ubuntu OSV artifacts: %w", err)
+		}
+		downloaded = append(downloaded, result.Downloaded...)
+	}
+
+	if len(rhelVers) > 0 {
+		result, err := syncRHELOSV(ctx, vulnPath, rhelVers, releaseDate, release)
+		if err != nil {
+			return downloaded, fmt.Errorf("syncing RHEL OSV artifacts: %w", err)
+		}
+		downloaded = append(downloaded, result.Downloaded...)
+	}
+
+	return downloaded, nil
+}
+
+// versionsFromRelease returns the Ubuntu and RHEL versions present in a
+// release's OSV assets. Asset names look like `osv-ubuntu-2204-2026-04-27.json.gz`
+// or `osv-rhel-9-2026-04-27.json.gz`.
+func versionsFromRelease(release *ReleaseInfo) (ubuntu []string, rhel []string) {
+	for assetName := range release.Assets {
+		switch {
+		case strings.HasPrefix(assetName, OSVFilePrefix):
+			if v := versionFromAssetName(assetName, OSVFilePrefix); v != "" {
+				ubuntu = append(ubuntu, v)
+			}
+		case strings.HasPrefix(assetName, OSVRHELFilePrefix):
+			if v := versionFromAssetName(assetName, OSVRHELFilePrefix); v != "" {
+				rhel = append(rhel, v)
+			}
+		}
+	}
+	return ubuntu, rhel
+}
+
+// versionFromAssetName extracts the version segment from an OSV asset filename.
+// e.g. ("osv-ubuntu-2204-2026-04-27.json.gz", "osv-ubuntu-") -> "2204".
+func versionFromAssetName(name, prefix string) string {
+	if !strings.HasPrefix(name, prefix) {
+		return ""
+	}
+	rest := name[len(prefix):]
+	idx := strings.Index(rest, "-")
+	if idx <= 0 {
+		return ""
+	}
+	return rest[:idx]
+}
+
+// releaseDateFromAssets returns the date encoded in any OSV asset filename in
+// the release. All assets in a given release share the same date.
+func releaseDateFromAssets(release *ReleaseInfo) (time.Time, bool) {
+	for name := range release.Assets {
+		if d, ok := dateFromAssetName(name); ok {
+			return d, true
+		}
+	}
+	return time.Time{}, false
+}
+
+// dateFromAssetName extracts the YYYY-MM-DD date suffix from an OSV asset filename.
+func dateFromAssetName(name string) (time.Time, bool) {
+	const layout = "2006-01-02"
+	s := strings.TrimSuffix(name, ".json.gz")
+	if len(s) < len(layout) {
+		return time.Time{}, false
+	}
+	t, err := time.Parse(layout, s[len(s)-len(layout):])
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
 // RefreshRHEL checks local RHEL OSV artifacts, deleting outdated ones and downloading the latest.
 func RefreshRHEL(
 	ctx context.Context,

--- a/server/vulnerabilities/osv/sync.go
+++ b/server/vulnerabilities/osv/sync.go
@@ -167,6 +167,9 @@ func RefreshAll(ctx context.Context, vulnPath string) ([]string, error) {
 			return downloaded, fmt.Errorf("syncing Ubuntu OSV artifacts: %w", err)
 		}
 		downloaded = append(downloaded, result.Downloaded...)
+		if len(result.Failed) > 0 {
+			return downloaded, fmt.Errorf("failed to download OSV for Ubuntu versions: %v", result.Failed)
+		}
 	}
 
 	if len(rhelVers) > 0 {
@@ -175,6 +178,9 @@ func RefreshAll(ctx context.Context, vulnPath string) ([]string, error) {
 			return downloaded, fmt.Errorf("syncing RHEL OSV artifacts: %w", err)
 		}
 		downloaded = append(downloaded, result.Downloaded...)
+		if len(result.Failed) > 0 {
+			return downloaded, fmt.Errorf("failed to download OSV for RHEL versions: %v", result.Failed)
+		}
 	}
 
 	return downloaded, nil

--- a/server/vulnerabilities/osv/sync_test.go
+++ b/server/vulnerabilities/osv/sync_test.go
@@ -444,3 +444,84 @@ func TestSyncOSVChecksumMatch(t *testing.T) {
 	require.Empty(t, result.Downloaded)
 	require.Empty(t, result.Failed)
 }
+
+func TestVersionsFromRelease(t *testing.T) {
+	release := &ReleaseInfo{
+		TagName: "cve-202604270000",
+		Assets: map[string]*AssetInfo{
+			"osv-ubuntu-2204-2026-04-27.json.gz": {Name: "osv-ubuntu-2204-2026-04-27.json.gz"},
+			"osv-ubuntu-2404-2026-04-27.json.gz": {Name: "osv-ubuntu-2404-2026-04-27.json.gz"},
+			"osv-rhel-8-2026-04-27.json.gz":      {Name: "osv-rhel-8-2026-04-27.json.gz"},
+			"osv-rhel-9-2026-04-27.json.gz":      {Name: "osv-rhel-9-2026-04-27.json.gz"},
+		},
+	}
+
+	ubuntu, rhel := versionsFromRelease(release)
+	require.ElementsMatch(t, []string{"2204", "2404"}, ubuntu)
+	require.ElementsMatch(t, []string{"8", "9"}, rhel)
+}
+
+func TestVersionsFromReleaseEmpty(t *testing.T) {
+	release := &ReleaseInfo{TagName: "cve-202604270000", Assets: map[string]*AssetInfo{}}
+	ubuntu, rhel := versionsFromRelease(release)
+	require.Empty(t, ubuntu)
+	require.Empty(t, rhel)
+}
+
+func TestVersionFromAssetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		prefix   string
+		expected string
+	}{
+		{"osv-ubuntu-2204-2026-04-27.json.gz", OSVFilePrefix, "2204"},
+		{"osv-rhel-9-2026-04-27.json.gz", OSVRHELFilePrefix, "9"},
+		{"osv-rhel-10-2026-04-27.json.gz", OSVRHELFilePrefix, "10"},
+		{"osv-ubuntu-.json.gz", OSVFilePrefix, ""},
+		{"osv-ubuntu", OSVFilePrefix, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, versionFromAssetName(tt.name, tt.prefix))
+		})
+	}
+}
+
+func TestReleaseDateFromAssets(t *testing.T) {
+	release := &ReleaseInfo{
+		Assets: map[string]*AssetInfo{
+			"osv-ubuntu-2204-2026-04-27.json.gz": {Name: "osv-ubuntu-2204-2026-04-27.json.gz"},
+		},
+	}
+
+	d, ok := releaseDateFromAssets(release)
+	require.True(t, ok)
+	require.Equal(t, time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC), d)
+
+	emptyRelease := &ReleaseInfo{Assets: map[string]*AssetInfo{}}
+	_, ok = releaseDateFromAssets(emptyRelease)
+	require.False(t, ok)
+}
+
+func TestDateFromAssetName(t *testing.T) {
+	tests := []struct {
+		name     string
+		expected time.Time
+		ok       bool
+	}{
+		{"osv-ubuntu-2204-2026-04-27.json.gz", time.Date(2026, 4, 27, 0, 0, 0, 0, time.UTC), true},
+		{"osv-rhel-9-2026-04-08.json.gz", time.Date(2026, 4, 8, 0, 0, 0, 0, time.UTC), true},
+		{"osv-ubuntu-2204.json.gz", time.Time{}, false},
+		{"some-other-file.json", time.Time{}, false},
+		{"short", time.Time{}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d, ok := dateFromAssetName(tt.name)
+			require.Equal(t, tt.ok, ok)
+			require.Equal(t, tt.expected, d)
+		})
+	}
+}

--- a/server/vulnerabilities/osv/sync_test.go
+++ b/server/vulnerabilities/osv/sync_test.go
@@ -445,6 +445,37 @@ func TestSyncOSVChecksumMatch(t *testing.T) {
 	require.Empty(t, result.Failed)
 }
 
+func TestSyncOSVPartialFailureNotReturnedAsError(t *testing.T) {
+	// Documents the behavior RefreshAll guards against: SyncOSV reports per-
+	// version failures via SyncResult.Failed but does NOT return an error when
+	// some downloads succeed.
+	tmpDir := t.TempDir()
+	date := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+
+	good := "osv-ubuntu-2204-2026-04-01.json.gz"
+	bad := "osv-ubuntu-2404-2026-04-01.json.gz"
+
+	release := &ReleaseInfo{
+		TagName: "cve-202604010000",
+		Assets: map[string]*AssetInfo{
+			good: {Name: good, ID: 1},
+			bad:  {Name: bad, ID: 2},
+		},
+	}
+
+	mockDownload := func(ctx context.Context, assetID int64, dstPath string) error {
+		if assetID == 2 {
+			return errors.New("simulated download failure")
+		}
+		return os.WriteFile(dstPath, []byte("ok"), 0o644)
+	}
+
+	result, err := syncOSVWithDownloader(context.Background(), tmpDir, []string{"2204", "2404"}, date, release, mockDownload, osvFilename)
+	require.NoError(t, err, "SyncOSV does not return error on partial failure")
+	require.Contains(t, result.Downloaded, "2204")
+	require.Contains(t, result.Failed, "2404")
+}
+
 func TestVersionsFromRelease(t *testing.T) {
 	release := &ReleaseInfo{
 		TagName: "cve-202604270000",


### PR DESCRIPTION
**Related issue:** Resolves #44242

## Summary

`fleetctl vulnerability-data-stream` is documented as the way to pre-seed a Fleet server's vulnerability directory (common in air-gapped or restricted-egress deployments). It already downloads CPE, NVD, EPSS, CISA, OVAL, MSRC, and MacOffice feeds, but it never downloaded OSV (Ubuntu / RHEL) artifacts even though the server's vulnerability cron uses them. Operators ended up with a directory that was missing the artifacts powering Ubuntu (and, with `RHELOSVForVulnerabilities`, RHEL) vulnerability scanning.

# Checklist for submitter

- [x] Changes file added for user-visible changes in `changes/`.
- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented, JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops — reuses `fleethttp.NewClient` and the existing `SyncOSV` flow which already handles per-asset failure isolation.
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes — N/A, no API surface changed; the CLI command flag set is unchanged.

## Testing

- [x] Added/updated automated tests — unit tests in `server/vulnerabilities/osv/sync_test.go` cover the new helpers across happy-path, empty, and malformed-input cases.
- [ ] Where appropriate, automated tests simulate multiple hosts and test for host isolation — N/A, the command is host-agnostic and runs without DB access.
- [ ] QA'd all new/changed functionality manually — TODO before flipping out of draft: run `fleetctl vulnerability-data-stream --dir /tmp/fleet-vuln` against a clean dir and confirm `osv-ubuntu-*.json.gz` and `osv-rhel-*.json.gz` files appear alongside the existing CPE/NVD/OVAL/MSRC/MacOffice artifacts.

For unreleased bug fixes in a release candidate, one of:

- [x] Confirmed that the fix is not expected to adversely impact load test results — change is to a one-shot CLI download path, not the request hot path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced fleetctl vulnerability-data-stream to download OSV vulnerability artifacts for Ubuntu and RHEL, and show a dedicated OSV download step.

* **Tests**
  * Added and expanded tests covering OSV sync, version/date parsing, and integration checks to ensure OSV artifacts are written to disk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->