### PR TITLE
Vulnerability exposure chart front-end

### DIFF
--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -41,6 +41,38 @@ const DATASETS: IDataSet[] = [
         during a given hour.
       </>
     ),
+    tooltipFormatter: ({
+      value,
+      total,
+      percentage,
+    }: {
+      value: number;
+      total?: number;
+      percentage?: number;
+    }) => (
+      <>
+        {percentage}% active
+        <br />({value} / {total} hosts)
+      </>
+    ),
+  },
+  {
+    name: "cve",
+    label: "Vulnerability exposure",
+    defaultChartType: "checkerboard",
+    description: (
+      <>
+        Shows the number of hosts with{" "}
+        <a
+          target="vulncode-link"
+          href="https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138"
+        >
+          certain critical vulnerabilities
+        </a>{" "}
+        during a given hour.
+      </>
+    ),
+    theme: "red",
   },
 ];
 
@@ -157,6 +189,8 @@ const ChartCard = ({ currentTeamId }: IChartCardProps): JSX.Element => {
     const vizProps = {
       data: formattedData,
       selectedDays: CHART_DAYS,
+      theme: currentDataset.theme,
+      tooltipFormatter: currentDataset.tooltipFormatter,
     };
 
     switch (currentDataset.defaultChartType) {

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -52,7 +52,7 @@ const DATASETS: IDataSet[] = [
     }) => (
       <>
         {percentage}% active
-        <br />({value} / {total} hosts)
+        <br />({total ? `${value} / ${total}` : 0} hosts)
       </>
     ),
   },
@@ -64,7 +64,8 @@ const DATASETS: IDataSet[] = [
       <>
         Shows the number of hosts with{" "}
         <a
-          target="vulncode-link"
+          target="_blank"
+          rel="noopener noreferrer"
           href="https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138"
         >
           certain critical
@@ -85,7 +86,7 @@ const DATASETS: IDataSet[] = [
     }) => (
       <>
         {percentage}% exposed
-        <br />({value} / {total} hosts)
+        <br />({total ? `${value} / ${total}` : 0} hosts)
       </>
     ),
     theme: "red",
@@ -175,14 +176,16 @@ const ChartCard = ({ currentTeamId }: IChartCardProps): JSX.Element => {
 
   const formattedData: IFormattedDataPoint[] = useMemo(() => {
     if (!chartData?.data) return [];
-    const totalHosts = chartData.total_hosts || 1;
+    const totalHosts = chartData.total_hosts;
     return chartData.data.map((point) => {
       const date = parseISO(point.timestamp);
       return {
         timestamp: point.timestamp,
         label: format(date, "MMM d, h:mm a"),
         value: point.value,
-        percentage: Math.round((point.value / totalHosts) * 100),
+        percentage: totalHosts
+          ? Math.round((point.value / totalHosts) * 100)
+          : 0,
         total: totalHosts,
       };
     });

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -72,6 +72,20 @@ const DATASETS: IDataSet[] = [
         during a given hour.
       </>
     ),
+    tooltipFormatter: ({
+      value,
+      total,
+      percentage,
+    }: {
+      value: number;
+      total?: number;
+      percentage?: number;
+    }) => (
+      <>
+        {percentage}% exposed
+        <br />({value} / {total} hosts)
+      </>
+    ),
     theme: "red",
   },
 ];
@@ -167,6 +181,7 @@ const ChartCard = ({ currentTeamId }: IChartCardProps): JSX.Element => {
         label: format(date, "MMM d, h:mm a"),
         value: point.value,
         percentage: Math.round((point.value / totalHosts) * 100),
+        total: totalHosts,
       };
     });
   }, [chartData]);

--- a/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/ChartCard.tsx
@@ -67,7 +67,9 @@ const DATASETS: IDataSet[] = [
           target="vulncode-link"
           href="https://github.com/fleetdm/fleet/blob/1ea1fddfd62f66fd14de65cbeceb4f7a9d0167ec/server/chart/internal/mysql/charts.go#L111-L138"
         >
-          certain critical vulnerabilities
+          certain critical
+          <br />
+          vulnerabilities
         </a>{" "}
         during a given hour.
       </>

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tests.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function, class-methods-use-this */
 import React from "react";
-import { screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { renderWithSetup } from "test/test-utils";
 
 import CheckerboardViz from "./CheckerboardViz";
@@ -176,6 +176,230 @@ describe("CheckerboardViz", () => {
     expect(screen.getByText("No data")).toBeInTheDocument();
     expect(screen.getByText("Less")).toBeInTheDocument();
     expect(screen.getByText("More")).toBeInTheDocument();
+  });
+
+  it("applies the default green theme class when no theme prop is passed", async () => {
+    const data = generateData(1);
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={data} selectedDays={30} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    expect(
+      container.querySelector(".checkerboard-viz--theme-green")
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".checkerboard-viz--theme-red")
+    ).not.toBeInTheDocument();
+  });
+
+  it("applies the red theme class when theme='red' is passed", async () => {
+    const data = generateData(1);
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={data} selectedDays={30} theme="red" />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    expect(
+      container.querySelector(".checkerboard-viz--theme-red")
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".checkerboard-viz--theme-green")
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the default '<percentage>% of hosts' tooltip when no formatter is provided", async () => {
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 42,
+        percentage: 70,
+        total: 60,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz data={points} selectedDays={14} />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    // The first cell (slot 0) is the one populated by the data point above.
+    fireEvent.mouseEnter(container.querySelector("rect") as SVGRectElement);
+
+    expect(await screen.findByText("70% of hosts")).toBeInTheDocument();
+  });
+
+  it("invokes tooltipFormatter with the cell's value, percentage, and total", async () => {
+    const formatter = jest.fn(({ value, total, percentage }) => (
+      <span data-testid="custom-tooltip">
+        {percentage}% exposed ({value} / {total} hosts)
+      </span>
+    ));
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 12,
+        percentage: 20,
+        total: 60,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz
+        data={points}
+        selectedDays={14}
+        tooltipFormatter={formatter}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.mouseEnter(container.querySelector("rect") as SVGRectElement);
+
+    const tooltip = await screen.findByTestId("custom-tooltip");
+    expect(tooltip).toHaveTextContent("20% exposed (12 / 60 hosts)");
+    expect(formatter).toHaveBeenCalledWith({
+      value: 12,
+      total: 60,
+      percentage: 20,
+    });
+  });
+
+  it("passes total=0 through to tooltipFormatter when the dataset reports zero hosts", async () => {
+    const formatter = jest.fn(({ value, total, percentage }) => (
+      <span data-testid="custom-tooltip">
+        {percentage}% ({value} / {total} hosts)
+      </span>
+    ));
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 0,
+        percentage: 0,
+        total: 0,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz
+        data={points}
+        selectedDays={14}
+        tooltipFormatter={formatter}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.mouseEnter(container.querySelector("rect") as SVGRectElement);
+
+    const tooltip = await screen.findByTestId("custom-tooltip");
+    expect(tooltip).toHaveTextContent("0% (0 / 0 hosts)");
+    expect(formatter).toHaveBeenCalledWith({
+      value: 0,
+      total: 0,
+      percentage: 0,
+    });
+  });
+
+  it("passes total=undefined through to tooltipFormatter when the data point omits it", async () => {
+    const formatter = jest.fn(({ value, total, percentage }) => (
+      <span data-testid="custom-tooltip">
+        {percentage}% / value={value} / total=
+        {total === undefined ? "n/a" : total}
+      </span>
+    ));
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 5,
+        percentage: 50,
+        // total intentionally omitted
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz
+        data={points}
+        selectedDays={14}
+        tooltipFormatter={formatter}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    fireEvent.mouseEnter(container.querySelector("rect") as SVGRectElement);
+
+    const tooltip = await screen.findByTestId("custom-tooltip");
+    expect(tooltip).toHaveTextContent("50% / value=5 / total=n/a");
+    expect(formatter).toHaveBeenCalledWith({
+      value: 5,
+      total: undefined,
+      percentage: 50,
+    });
+  });
+
+  it("falls back to value=0 when hovering a cell with no underlying data point", async () => {
+    const formatter = jest.fn(({ value, total, percentage }) => (
+      <span data-testid="custom-tooltip">
+        v={value}/p={percentage}/t={total === undefined ? "n/a" : total}
+      </span>
+    ));
+    // Single data point at slot 0; remaining 11 slots in the day are filled
+    // with synthetic level-0 cells whose value/total fall back to 0/undefined.
+    const points: IFormattedDataPoint[] = [
+      {
+        timestamp: "2026-03-01T00:00:00",
+        label: "Mar 1, 12am",
+        value: 80,
+        percentage: 80,
+        total: 100,
+      },
+    ];
+
+    const { container } = renderWithSetup(
+      <CheckerboardViz
+        data={points}
+        selectedDays={14}
+        tooltipFormatter={formatter}
+      />
+    );
+
+    await waitFor(() => {
+      expect(container.querySelectorAll("rect").length).toBeGreaterThan(0);
+    });
+
+    const emptyCell = Array.from(container.querySelectorAll("rect")).find((r) =>
+      (r.getAttribute("class") || "").includes("--level-0")
+    );
+    expect(emptyCell).toBeDefined();
+    fireEvent.mouseEnter(emptyCell as Element);
+
+    const tooltip = await screen.findByTestId("custom-tooltip");
+    expect(tooltip).toHaveTextContent("v=0/p=0/t=n/a");
+    expect(formatter).toHaveBeenCalledWith({
+      value: 0,
+      total: undefined,
+      percentage: 0,
+    });
   });
 
   it("fills empty hour slots with level-0 cells", async () => {

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -231,9 +231,7 @@ const CheckerboardViz = ({
 
   return (
     <div
-      className={classnames(baseClass, {
-        [`${baseClass}--theme-${theme}`]: theme !== "green",
-      })}
+      className={classnames(baseClass, `${baseClass}--theme-${theme}`)}
       ref={containerRef}
     >
       <div className={`${baseClass}__chart-row`}>

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import classnames from "classnames";
 import { format, parseISO } from "date-fns";
 
-import { IFormattedDataPoint } from "./types";
+import { ChartTheme, IFormattedDataPoint } from "./types";
 
 const baseClass = "checkerboard-viz";
 
@@ -34,6 +35,16 @@ interface ICellData {
 interface ICheckerboardVizProps {
   data: IFormattedDataPoint[];
   selectedDays: number;
+  theme?: ChartTheme;
+  tooltipFormatter?: ({
+    value,
+    total,
+    percentage,
+  }: {
+    value: number;
+    total?: number;
+    percentage?: number;
+  }) => string | React.ReactNode;
 }
 
 // These are calculated at a chart width of 580px and columns.
@@ -49,6 +60,8 @@ const WIDE_MULTIPLIER = 1.5;
 const CheckerboardViz = ({
   data,
   selectedDays,
+  theme = "green",
+  tooltipFormatter,
 }: ICheckerboardVizProps): JSX.Element => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [isWide, setIsWide] = useState(false);
@@ -199,7 +212,12 @@ const CheckerboardViz = ({
   const leftMargin = showYAxis ? Y_AXIS_WIDTH : 0;
 
   return (
-    <div className={baseClass} ref={containerRef}>
+    <div
+      className={classnames(baseClass, {
+        [`${baseClass}--theme-${theme}`]: theme !== "green",
+      })}
+      ref={containerRef}
+    >
       <div className={`${baseClass}__chart-row`}>
         {/* Y-axis 6am/6pm labels. Kept outside the scroll-wrapper so they stay
             pinned during horizontal scroll and label text can overflow

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -69,6 +69,9 @@ const CheckerboardViz = ({
   const [isWide, setIsWide] = useState(false);
   const [hoveredCell, setHoveredCell] = useState<ICellData | null>(null);
   const [tooltipPos, setTooltipPos] = useState({ x: 0, y: 0 });
+  const [tooltipAlign, setTooltipAlign] = useState<"left" | "center" | "right">(
+    "center"
+  );
 
   useEffect(() => {
     const node = containerRef.current;
@@ -201,10 +204,21 @@ const CheckerboardViz = ({
     const rect = (e.target as SVGElement).getBoundingClientRect();
     const containerRect = containerRef.current?.getBoundingClientRect();
     if (containerRect) {
+      const cellCenterX = rect.left - containerRect.left + cellW / 2;
       setTooltipPos({
-        x: rect.left - containerRect.left + cellW / 2,
+        x: cellCenterX,
         y: rect.top - containerRect.top - 8,
       });
+      // Near either edge, the default centered tooltip would overflow or
+      // word-wrap. Flip the anchor so the tooltip grows inward instead.
+      const EDGE_ZONE = 100;
+      if (cellCenterX > containerRect.width - EDGE_ZONE) {
+        setTooltipAlign("right");
+      } else if (cellCenterX < EDGE_ZONE) {
+        setTooltipAlign("left");
+      } else {
+        setTooltipAlign("center");
+      }
     }
   };
 
@@ -303,7 +317,7 @@ const CheckerboardViz = ({
 
       {hoveredCell && (
         <div
-          className={`chart-card__tooltip ${baseClass}__floating-tooltip`}
+          className={`chart-card__tooltip ${baseClass}__floating-tooltip ${baseClass}__floating-tooltip--align-${tooltipAlign}`}
           style={{ left: tooltipPos.x, top: tooltipPos.y }}
         >
           <div className="chart-card__tooltip-label">

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import classnames from "classnames";
 import { format, parseISO } from "date-fns";
 
-import { ChartTheme, IFormattedDataPoint } from "./types";
+import { ChartTheme, IFormattedDataPoint, TooltipFormatter } from "./types";
 
 const baseClass = "checkerboard-viz";
 
@@ -38,15 +38,7 @@ interface ICheckerboardVizProps {
   data: IFormattedDataPoint[];
   selectedDays: number;
   theme?: ChartTheme;
-  tooltipFormatter?: ({
-    value,
-    total,
-    percentage,
-  }: {
-    value: number;
-    total?: number;
-    percentage?: number;
-  }) => string | React.ReactNode;
+  tooltipFormatter?: TooltipFormatter;
 }
 
 // These are calculated at a chart width of 580px and columns.

--- a/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
+++ b/frontend/pages/DashboardPage/cards/ChartCard/CheckerboardViz.tsx
@@ -27,6 +27,8 @@ const formatHourLabel = (hourVal: number): string => {
 interface ICellData {
   dayIndex: number;
   hourRow: number;
+  value: number;
+  total?: number;
   percentage: number;
   dayLabel: string;
   hourLabel: string;
@@ -160,6 +162,8 @@ const CheckerboardViz = ({
           dayIndex,
           hourRow: row,
           percentage: point?.percentage ?? 0,
+          value: point?.value ?? 0,
+          total: point?.total,
           dayLabel: format(date, "MMM d"),
           hourLabel: formatHourLabel(hourVal),
         });
@@ -306,7 +310,13 @@ const CheckerboardViz = ({
             {hoveredCell.dayLabel}, {hoveredCell.hourLabel}
           </div>
           <div className="chart-card__tooltip-value">
-            {hoveredCell.percentage}% of hosts
+            {tooltipFormatter
+              ? tooltipFormatter({
+                  value: hoveredCell.value,
+                  percentage: hoveredCell.percentage,
+                  total: hoveredCell.total,
+                })
+              : `${hoveredCell.percentage}% of hosts`}
           </div>
         </div>
       )}

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -231,8 +231,6 @@
   }
 
   // Color levels for cells (SVG fill) and legend swatches (background-color).
-  // Scale colors don't exist in the shared palette, so they stay as literal
-  // hex values; level-4 matches $core-fleet-green and is aliased accordingly.
   // The per-level colors are exposed as custom properties so themes can
   // override them with a single block of overrides below.
   &--theme-green {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -172,6 +172,18 @@
     position: absolute;
     transform: translate(-50%, -100%);
     pointer-events: none;
+    white-space: nowrap;
+
+    // Near the right edge, anchor the tooltip's right side to the cell center
+    // so it grows leftward into the grid instead of overflowing the card.
+    &--align-right {
+      transform: translate(-100%, -100%);
+    }
+
+    // Mirror for the left edge.
+    &--align-left {
+      transform: translate(0, -100%);
+    }
   }
 
   &__x-axis {

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -111,6 +111,7 @@
     border-radius: $border-radius;
     font-size: $xx-small;
     box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
+
   }
 
   &__tooltip-label {
@@ -120,6 +121,14 @@
 
   &__tooltip-value {
     font-weight: $bold;
+  }
+
+  .react-tooltip {
+    a {
+      color: $core-fleet-white;
+      display: inline;
+      font-size: $xx-small;
+    }
   }
 }
 
@@ -212,38 +221,56 @@
   // Color levels for cells (SVG fill) and legend swatches (background-color).
   // Scale colors don't exist in the shared palette, so they stay as literal
   // hex values; level-4 matches $core-fleet-green and is aliased accordingly.
+  // The per-level colors are exposed as custom properties so themes can
+  // override them with a single block of overrides below.
+  --level-0: #ebedf0;
+  --level-1: #e4f1ec;
+  --level-2: #badecf;
+  --level-3: #82d2b9;
+  --level-4: #{$core-fleet-green};
+  --level-5: #005b4a;
+
+  &--theme-red {
+    --level-0: #ebedf0;
+    --level-1: #f1e4e4;
+    --level-2: #debaba;
+    --level-3: #d28282;
+    --level-4: #9a0000;
+    --level-5: #5b0000;
+  }
+
   &__cell {
     stroke: $core-fleet-white;
     stroke-width: 1px;
 
     &--level-0 {
-      fill: #ebedf0;
-      background-color: #ebedf0;
+      fill: var(--level-0);
+      background-color: var(--level-0);
     }
 
     &--level-1 {
-      fill: #e4f1ec;
-      background-color: #e4f1ec;
+      fill: var(--level-1);
+      background-color: var(--level-1);
     }
 
     &--level-2 {
-      fill: #badecf;
-      background-color: #badecf;
+      fill: var(--level-2);
+      background-color: var(--level-2);
     }
 
     &--level-3 {
-      fill: #82d2b9;
-      background-color: #82d2b9;
+      fill: var(--level-3);
+      background-color: var(--level-3);
     }
 
     &--level-4 {
-      fill: $core-fleet-green;
-      background-color: $core-fleet-green;
+      fill: var(--level-4);
+      background-color: var(--level-4);
     }
 
     &--level-5 {
-      fill: #005b4a;
-      background-color: #005b4a;
+      fill: var(--level-5);
+      background-color: var(--level-5);
     }
   }
 }

--- a/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/ChartCard/_styles.scss
@@ -235,12 +235,14 @@
   // hex values; level-4 matches $core-fleet-green and is aliased accordingly.
   // The per-level colors are exposed as custom properties so themes can
   // override them with a single block of overrides below.
-  --level-0: #ebedf0;
-  --level-1: #e4f1ec;
-  --level-2: #badecf;
-  --level-3: #82d2b9;
-  --level-4: #{$core-fleet-green};
-  --level-5: #005b4a;
+  &--theme-green {
+    --level-0: #ebedf0;
+    --level-1: #e4f1ec;
+    --level-2: #badecf;
+    --level-3: #82d2b9;
+    --level-4: #009a7d;
+    --level-5: #005b4a;
+  }
 
   &--theme-red {
     --level-0: #ebedf0;

--- a/frontend/pages/DashboardPage/cards/ChartCard/types.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/types.ts
@@ -2,11 +2,15 @@ import { ReactNode } from "react";
 
 export type ChartType = "line" | "checkerboard";
 
+export type ChartTheme = "green" | "red";
+
 export interface IDataSet {
   name: string;
   label: string;
   defaultChartType: ChartType;
   description?: ReactNode;
+  tooltipFormatter?: TooltipFormatter;
+  theme?: ChartTheme;
 }
 
 export interface IFormattedDataPoint {
@@ -15,3 +19,13 @@ export interface IFormattedDataPoint {
   value: number;
   percentage: number;
 }
+
+export type TooltipFormatter = ({
+  value,
+  total,
+  percentage,
+}: {
+  value: number;
+  total?: number;
+  percentage?: number;
+}) => string | ReactNode;

--- a/frontend/pages/DashboardPage/cards/ChartCard/types.ts
+++ b/frontend/pages/DashboardPage/cards/ChartCard/types.ts
@@ -18,6 +18,7 @@ export interface IFormattedDataPoint {
   label: string;
   value: number;
   percentage: number;
+  total?: number;
 }
 
 export type TooltipFormatter = ({


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** For #44125

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
Added in https://github.com/fleetdm/fleet/pull/44124

## Testing

- [X] Added/updated automated tests
- [X] QA'd all new/changed functionality manually
  - [X] with backend PR and test data:
  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CVE dataset visualization with its own red theme and tailored tooltip copy.
  * Tooltips now show host counts alongside computed percentages.

* **Improvements**
  * Chart theming is customizable per dataset.
  * Checkerboard tooltips align smartly to avoid overflow and support custom tooltip formats.
  * Percentage handling now safely falls back to 0 when totals are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->