### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/inputs/homebrew/google-gemini.json
+++ b/ee/maintained-apps/inputs/homebrew/google-gemini.json
@@ -3,6 +3,7 @@
   "unique_identifier": "com.google.GeminiMacOS",
   "token": "google-gemini",
   "installer_format": "dmg",
+  "frozen": true,
   "slug": "google-gemini/darwin",
   "default_categories": ["Productivity"]
 }

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.51.0.245",
+      "version": "1.49.2.233",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.51.0.245') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.49.2.233') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "6e7ec188",

--- a/ee/maintained-apps/outputs/google-gemini/darwin.json
+++ b/ee/maintained-apps/outputs/google-gemini/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "1.49.2.233",
+      "version": "1.51.0.245",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.49.2.233') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.google.GeminiMacOS' AND version_compare(bundle_short_version, '1.51.0.245') < 0);"
       },
       "installer_url": "https://dl.google.com/release2/j33ro/release/Gemini.dmg",
       "install_script_ref": "6e7ec188",

--- a/ee/maintained-apps/outputs/slack/darwin.json
+++ b/ee/maintained-apps/outputs/slack/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "4.49.81",
+      "version": "4.49.89",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap' AND version_compare(bundle_short_version, '4.49.81') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.tinyspeck.slackmacgap' AND version_compare(bundle_short_version, '4.49.89') < 0);"
       },
       "installer_url": "https://slack.com/api/desktop.latestRelease?redirect=1&variant=pkg&arch=universal",
       "install_script_ref": "17356f4e",


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Slack macOS app version metadata for patch tracking.
  * Marked Google Gemini app as frozen to pause automatic updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->