### PR TITLE
Update user channel error

### DIFF
--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5555,7 +5555,7 @@ func ReconcileAppleProfiles(
 				if fleet.IsAppleMobilePlatform(p.HostPlatform) {
 					errorDetail = "This setting couldn't be enforced because the user channel isn't available on iOS and iPadOS hosts."
 				} else {
-					errorDetail = "This setting couldn't be enforced because the user channel doesn't exist for this host. Currently, Fleet creates the user channel for hosts that automatically enroll."
+					errorDetail = "This setting couldn't be enforced because the user channel doesn't exist for this host."
 					logger.WarnContext(ctx, "host does not have a user enrollment, failing profile installation",
 						"host_uuid", p.HostUUID, "profile_uuid", p.ProfileUUID, "profile_identifier", p.ProfileIdentifier)
 				}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -3151,7 +3151,7 @@ func TestMDMAppleReconcileAppleProfiles(t *testing.T) {
 				ProfileIdentifier: "com.add.profile.five",
 				HostUUID:          hostUUID2,
 				OperationType:     fleet.MDMOperationTypeInstall,
-				Detail:            "This setting couldn't be enforced because the user channel doesn't exist for this host. Currently, Fleet creates the user channel for hosts that automatically enroll.",
+				Detail:            "This setting couldn't be enforced because the user channel doesn't exist for this host.",
 				Status:            &fleet.MDMDeliveryFailed,
 				Scope:             fleet.PayloadScopeUser,
 			},
@@ -3450,7 +3450,7 @@ func TestMDMAppleReconcileAppleProfiles(t *testing.T) {
 				HostUUID:          hostUUID2,
 				OperationType:     fleet.MDMOperationTypeInstall,
 				Status:            &fleet.MDMDeliveryFailed,
-				Detail:            "This setting couldn't be enforced because the user channel doesn't exist for this host. Currently, Fleet creates the user channel for hosts that automatically enroll.",
+				Detail:            "This setting couldn't be enforced because the user channel doesn't exist for this host.",
 				Scope:             fleet.PayloadScopeUser,
 			},
 			{


### PR DESCRIPTION
Fleet now creates the user channel on manually enrolled devices as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging for Apple MDM user-scoped profile installation failures. The error message now accurately reports the absence of user enrollment channels without misleading information about automatic channel creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->