### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
+++ b/ee/maintained-apps/outputs/grammarly-desktop/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "1.162.2",
+      "version": "1.163.0",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.162.2') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.grammarly.ProjectLlama' AND version_compare(bundle_short_version, '1.163.0') < 0);"
       },
-      "installer_url": "https://download-mac.grammarly.com/versions/1.162.2.0/Grammarly.dmg",
+      "installer_url": "https://download-mac.grammarly.com/versions/1.163.0.0/Grammarly.dmg",
       "install_script_ref": "962d8d13",
       "uninstall_script_ref": "7b5a67c7",
-      "sha256": "2c8171d340819c76a92b53987cef4ae73eeb0cd96848e8967932eab5c6a35402",
+      "sha256": "f3413e6e7f7a78108953fabfde221e5009f7f1e124e394508ee0685a7db5f0ee",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/loom/darwin.json
+++ b/ee/maintained-apps/outputs/loom/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "0.345.3",
+      "version": "0.346.3",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.345.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.loom.desktop' AND version_compare(bundle_short_version, '0.346.3') < 0);"
       },
-      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.345.3-arm64.dmg",
+      "installer_url": "https://packages.loom.com/desktop-packages/Loom-0.346.3-arm64.dmg",
       "install_script_ref": "aa484c07",
       "uninstall_script_ref": "393b959f",
-      "sha256": "28a85f0afd48353d0ac8763f336e8354be207454fbc8b46a34824c549cb7d34d",
+      "sha256": "50808dcb8284e48da706911c9b1d4ac7e7eb4f4c7bb4cb346f2d12b2bc1daff3",
       "default_categories": [
         "Productivity"
       ]

--- a/ee/maintained-apps/outputs/microsoft-edge/windows.json
+++ b/ee/maintained-apps/outputs/microsoft-edge/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "147.0.3912.72",
+      "version": "147.0.3912.86",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '147.0.3912.72') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Microsoft Edge' AND publisher = 'Microsoft Corporation' AND version_compare(version, '147.0.3912.86') < 0);"
       },
-      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/a7793e3c-0595-419c-bfc9-a891c92c6e53/MicrosoftEdgeEnterpriseX64.msi",
+      "installer_url": "https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2d48f894-08d6-4212-99bc-319200435457/MicrosoftEdgeEnterpriseX64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "a173cfc1",
-      "sha256": "f38cde736a1b9a538d85832ebba099e67f76c8c3ef781c559967c6ab95e1b130",
+      "sha256": "b1dcc651ac4f168ee658285293119e47c95a79391c5ae560a977d63bf8518ef5",
       "default_categories": [
         "Browsers"
       ],

--- a/ee/maintained-apps/outputs/nordpass/darwin.json
+++ b/ee/maintained-apps/outputs/nordpass/darwin.json
@@ -1,10 +1,10 @@
 {
   "versions": [
     {
-      "version": "7.6.14",
+      "version": "7.6.18",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.6.14') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.nordsec.nordpass' AND version_compare(bundle_short_version, '7.6.18') < 0);"
       },
       "installer_url": "https://downloads.npass.app/mac/arm/NordPass.dmg",
       "install_script_ref": "1c8f6193",

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.8.0",
+      "version": "12.8.1",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.8.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.8.1') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.8.0/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.1/osx_arm64",
       "install_script_ref": "d27f3112",
       "uninstall_script_ref": "15e9f11c",
-      "sha256": "928063304893a510c3e7d801407b7cba979f556952490c033dd8ca004cfd99fa",
+      "sha256": "9551adae42ac97cb956f1d493d583d94761a9934e19b68757cd2894759b119b5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.8.0",
+      "version": "12.8.1",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.8.0') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.8.1') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.8.0/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.1/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "83a0f062359557825a34eb4db543242e603709e9a8bee0a56284b0ea96fe418a",
+      "sha256": "5b8b3e4ee421eac33ba76db13fb7976dc168398343ddd4ecf0a8ce23a1af8b47",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/slack/windows.json
+++ b/ee/maintained-apps/outputs/slack/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.49.81",
+      "version": "4.49.89",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.49.81') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Slack' AND publisher = 'Slack Technologies Inc.' AND version_compare(version, '4.49.89') < 0);"
       },
-      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.49.81/Slack.msix",
+      "installer_url": "https://downloads.slack-edge.com/desktop-releases/windows/x64/4.49.89/Slack.msix",
       "install_script_ref": "1d82bbc6",
       "uninstall_script_ref": "ae79ce28",
-      "sha256": "e0470d9217e34bf7375b991895f4ae77e6b33650aba2f6c7870397eab7820847",
+      "sha256": "f2ae0041b05f919e19a660dc9e83f9857b483f3eabbdbbfbd1a29b0e80095d24",
       "default_categories": [
         "Communication"
       ]

--- a/ee/maintained-apps/outputs/tor-browser/darwin.json
+++ b/ee/maintained-apps/outputs/tor-browser/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "15.0.10",
+      "version": "15.0.11",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser' AND version_compare(bundle_short_version, '15.0.10') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.torproject.torbrowser' AND version_compare(bundle_short_version, '15.0.11') < 0);"
       },
-      "installer_url": "https://www.torproject.org/dist/torbrowser/15.0.10/tor-browser-macos-15.0.10.dmg",
+      "installer_url": "https://www.torproject.org/dist/torbrowser/15.0.11/tor-browser-macos-15.0.11.dmg",
       "install_script_ref": "eefe49d7",
       "uninstall_script_ref": "1d588638",
-      "sha256": "6d093809bfd6e8a90ee9f0d60dfe5d3a211709399447477cb432422ab304a0c1",
+      "sha256": "d7699b4e134cbaaae4f09c3d06d20d248bff443baff45eec3b0d4d0a1f32408d",
       "default_categories": [
         "Browsers"
       ]

--- a/ee/maintained-apps/outputs/transmit/darwin.json
+++ b/ee/maintained-apps/outputs/transmit/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "5.11.5",
+      "version": "5.11.6",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit' AND version_compare(bundle_short_version, '5.11.5') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.panic.Transmit' AND version_compare(bundle_short_version, '5.11.6') < 0);"
       },
-      "installer_url": "https://download-cdn.panic.com/transmit/Transmit%205.11.5.zip",
+      "installer_url": "https://download-cdn.panic.com/transmit/Transmit%205.11.6.zip",
       "install_script_ref": "638a918e",
       "uninstall_script_ref": "098dc5d4",
-      "sha256": "9557a8dceb9af8d9f031fdff6f7ca351e02c18180816c77d542f8caa11550366",
+      "sha256": "6761097e3ec7141058f0fa67815ff2244e2ca68f9fcdce06edeaf04279a10208",
       "default_categories": [
         "Productivity"
       ]


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release version metadata and associated installer integrity checksums for maintained applications. Updated apps include: Grammarly macOS (1.163.0), Loom macOS (0.346.3), Microsoft Edge Windows (147.0.3912.86), NordPass macOS (7.6.18), Postman macOS and Windows (12.8.1), Slack Windows (4.49.89), Tor Browser macOS (15.0.11), and Transmit macOS (5.11.6).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->