### PR TITLE
Bound orbit retries on missing installer details to 5 mins

### DIFF
--- a/changes/44084-fix-install-loop-on-deleted-installer
+++ b/changes/44084-fix-install-loop-on-deleted-installer
@@ -1,0 +1,1 @@
+- Fixed a bug where setup experience could remain stuck for up to 90 minutes after a software installer was edited or deleted while a host was installing it.

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/docker/go-units"
+	"github.com/fleetdm/fleet/v4/client"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/constant"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/scripts"
 	"github.com/fleetdm/fleet/v4/orbit/pkg/update"
@@ -77,6 +78,8 @@ type Runner struct {
 	// the script's temporary directory after execution.
 	removeAllFn func(string) error
 
+	nowFn func() time.Time
+
 	connectOsquery func(*Runner) error
 
 	scriptsEnabled func() bool
@@ -88,19 +91,31 @@ type Runner struct {
 	retryOpts []retry.Option
 
 	logger zerolog.Logger
+
+	// installerNotFoundFirstSeen records, per execution_id, when we first saw
+	// a "not found" response from GetInstallerDetails (#44084). Guarded by
+	// installerNotFoundMu.
+	installerNotFoundFirstSeen map[string]time.Time
+	installerNotFoundMu        sync.Mutex
 }
 
 const extractionDirectoryName = "extracted"
 
+// installerNotFoundRetryWindow bounds how long orbit silently retries a 404
+// from GetInstallerDetails before it reports a synthetic failure (#44084).
+var installerNotFoundRetryWindow = 5 * time.Minute
+
 func NewRunner(client Client, socketPath string, scriptsEnabled func() bool, rootDirPath string) *Runner {
 	r := &Runner{
-		OrbitClient:               client,
-		osquerySocketPath:         socketPath,
-		scriptsEnabled:            scriptsEnabled,
-		installerExecutionTimeout: pkgscripts.MaxHostSoftwareInstallExecutionTime,
-		rootDirPath:               rootDirPath,
-		retryOpts:                 []retry.Option{retry.WithMaxAttempts(5)},
-		logger:                    log.With().Str("runner", "installer").Logger(),
+		OrbitClient:                client,
+		osquerySocketPath:          socketPath,
+		scriptsEnabled:             scriptsEnabled,
+		installerExecutionTimeout:  pkgscripts.MaxHostSoftwareInstallExecutionTime,
+		rootDirPath:                rootDirPath,
+		retryOpts:                  []retry.Option{retry.WithMaxAttempts(5)},
+		logger:                     log.With().Str("runner", "installer").Logger(),
+		nowFn:                      time.Now,
+		installerNotFoundFirstSeen: make(map[string]time.Time),
 	}
 
 	return r
@@ -161,9 +176,9 @@ func (r *Runner) run(ctx context.Context, config *fleet.OrbitConfig) error {
 		payload, err := r.installSoftware(ctx, installerID, logger)
 		if err != nil {
 			errs = append(errs, err)
-			if payload == nil {
-				continue
-			}
+		}
+		if payload == nil {
+			continue
 		}
 		attemptNum := 1
 		err = retry.Do(func() error {
@@ -185,6 +200,40 @@ func (r *Runner) run(ctx context.Context, config *fleet.OrbitConfig) error {
 	}
 
 	return nil
+}
+
+// handleInstallerNotFound returns a synthetic failure payload once
+// installerNotFoundRetryWindow has elapsed for execID, nil otherwise (#44084).
+func (r *Runner) handleInstallerNotFound(execID string, logger zerolog.Logger) *fleet.HostSoftwareInstallResultPayload {
+	r.installerNotFoundMu.Lock()
+	defer r.installerNotFoundMu.Unlock()
+
+	now := r.nowFn()
+	firstSeen, ok := r.installerNotFoundFirstSeen[execID]
+	if !ok {
+		r.installerNotFoundFirstSeen[execID] = now
+		return nil
+	}
+	if now.Sub(firstSeen) < installerNotFoundRetryWindow {
+		return nil
+	}
+
+	logger.Warn().
+		Dur("retry_window", installerNotFoundRetryWindow).
+		Msg("installer not found for longer than retry window; reporting failure to server")
+
+	delete(r.installerNotFoundFirstSeen, execID)
+	return &fleet.HostSoftwareInstallResultPayload{
+		InstallUUID:           execID,
+		InstallScriptExitCode: ptr.Int(fleet.ExitCodeInstallerNotFound),
+		InstallScriptOutput:   ptr.String("Installer no longer exists on the server. Abandoning install after retry window."),
+	}
+}
+
+func (r *Runner) clearInstallerNotFound(execID string) {
+	r.installerNotFoundMu.Lock()
+	defer r.installerNotFoundMu.Unlock()
+	delete(r.installerNotFoundFirstSeen, execID)
 }
 
 func (r *Runner) preConditionCheck(ctx context.Context, query string) (bool, string, error) {
@@ -221,9 +270,20 @@ func (r *Runner) installSoftware(ctx context.Context, installID string, logger z
 	logger.Info().Msg("fetching installer details")
 	installer, err := r.OrbitClient.GetInstallerDetails(installID)
 	if err != nil {
+		if client.IsNotFoundErr(err) {
+			if payload := r.handleInstallerNotFound(installID, logger); payload != nil {
+				logger.Err(err).Msg("fetch installer details")
+				return payload, nil
+			}
+			logger.Debug().Err(err).Msg("installer not found, within retry window")
+			return nil, nil
+		}
 		logger.Err(err).Msg("fetch installer details")
+		r.clearInstallerNotFound(installID)
 		return nil, fmt.Errorf("fetching software installer details: %w", err)
 	}
+
+	r.clearInstallerNotFound(installID)
 
 	payload := &fleet.HostSoftwareInstallResultPayload{}
 	payload.InstallUUID = installID

--- a/orbit/pkg/installer/installer.go
+++ b/orbit/pkg/installer/installer.go
@@ -208,7 +208,15 @@ func (r *Runner) handleInstallerNotFound(execID string, logger zerolog.Logger) *
 	r.installerNotFoundMu.Lock()
 	defer r.installerNotFoundMu.Unlock()
 
-	now := r.nowFn()
+	nowFn := r.nowFn
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	if r.installerNotFoundFirstSeen == nil {
+		r.installerNotFoundFirstSeen = make(map[string]time.Time)
+	}
+
+	now := nowFn()
 	firstSeen, ok := r.installerNotFoundFirstSeen[execID]
 	if !ok {
 		r.installerNotFoundFirstSeen[execID] = now

--- a/orbit/pkg/installer/installer_test.go
+++ b/orbit/pkg/installer/installer_test.go
@@ -1255,10 +1255,9 @@ func tempDirFn(t *testing.T) func(string, string) (string, error) {
 }
 
 // TestInstallSoftwareNotFoundRetryWindow covers the retry-window behavior for
-// orphaned installer 404s (#44084).
+// orphaned installer 404s (#44084). Not parallel: it mutates the package-level
+// installerNotFoundRetryWindow.
 func TestInstallSoftwareNotFoundRetryWindow(t *testing.T) {
-	t.Parallel()
-
 	prevWindow := installerNotFoundRetryWindow
 	installerNotFoundRetryWindow = time.Minute
 	t.Cleanup(func() { installerNotFoundRetryWindow = prevWindow })

--- a/orbit/pkg/installer/installer_test.go
+++ b/orbit/pkg/installer/installer_test.go
@@ -15,6 +15,7 @@ import (
 	"testing/synctest"
 	"time"
 
+	"github.com/fleetdm/fleet/v4/client"
 	"github.com/fleetdm/fleet/v4/pkg/retry"
 	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/ptr"
@@ -1251,4 +1252,164 @@ func tempDirFn(t *testing.T) func(string, string) (string, error) {
 	return func(dir, pattern string) (string, error) {
 		return t.TempDir(), nil
 	}
+}
+
+// TestInstallSoftwareNotFoundRetryWindow covers the retry-window behavior for
+// orphaned installer 404s (#44084).
+func TestInstallSoftwareNotFoundRetryWindow(t *testing.T) {
+	t.Parallel()
+
+	prevWindow := installerNotFoundRetryWindow
+	installerNotFoundRetryWindow = time.Minute
+	t.Cleanup(func() { installerNotFoundRetryWindow = prevWindow })
+
+	const execID = "exec-uuid-1"
+
+	notFoundErr := &client.NotFoundErr{Msg: "SoftwareInstallerDetails was not found in the datastore"}
+
+	t.Run("first failure records timestamp and returns nil payload", func(t *testing.T) {
+		oc := &TestOrbitClient{
+			getInstallerDetailsFn: func(string) (*fleet.SoftwareInstallDetails, error) {
+				return nil, notFoundErr
+			},
+		}
+		now := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		r := &Runner{
+			OrbitClient:                oc,
+			scriptsEnabled:             func() bool { return true },
+			nowFn:                      func() time.Time { return now },
+			installerNotFoundFirstSeen: make(map[string]time.Time),
+			logger:                     log.With().Logger(),
+		}
+
+		payload, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.Nil(t, payload)
+		require.NoError(t, err, "in-window 404 must not surface an error so run() doesn't log ERR every cycle (#44084)")
+		require.Equal(t, now, r.installerNotFoundFirstSeen[execID])
+	})
+
+	t.Run("subsequent failures within window keep returning nil payload", func(t *testing.T) {
+		oc := &TestOrbitClient{
+			getInstallerDetailsFn: func(string) (*fleet.SoftwareInstallDetails, error) {
+				return nil, notFoundErr
+			},
+		}
+		start := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		now := start
+		r := &Runner{
+			OrbitClient:                oc,
+			scriptsEnabled:             func() bool { return true },
+			nowFn:                      func() time.Time { return now },
+			installerNotFoundFirstSeen: make(map[string]time.Time),
+			logger:                     log.With().Logger(),
+		}
+
+		_, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.NoError(t, err)
+
+		now = start.Add(installerNotFoundRetryWindow - time.Second)
+		payload, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.Nil(t, payload)
+		require.NoError(t, err)
+		require.Equal(t, start, r.installerNotFoundFirstSeen[execID], "tracker should not be reset within window")
+	})
+
+	t.Run("after window elapses returns synthetic failure payload", func(t *testing.T) {
+		oc := &TestOrbitClient{
+			getInstallerDetailsFn: func(string) (*fleet.SoftwareInstallDetails, error) {
+				return nil, notFoundErr
+			},
+		}
+		start := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		now := start
+		r := &Runner{
+			OrbitClient:                oc,
+			scriptsEnabled:             func() bool { return true },
+			nowFn:                      func() time.Time { return now },
+			installerNotFoundFirstSeen: make(map[string]time.Time),
+			logger:                     log.With().Logger(),
+		}
+
+		_, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.NoError(t, err)
+
+		now = start.Add(installerNotFoundRetryWindow + time.Second)
+		payload, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.NoError(t, err, "synthetic failure should be returned without error so caller reports it")
+		require.NotNil(t, payload)
+		require.Equal(t, execID, payload.InstallUUID)
+		require.NotNil(t, payload.InstallScriptExitCode)
+		require.Equal(t, fleet.ExitCodeInstallerNotFound, *payload.InstallScriptExitCode)
+		require.Equal(t, fleet.SoftwareInstallFailed, payload.Status())
+		_, stillTracked := r.installerNotFoundFirstSeen[execID]
+		require.False(t, stillTracked, "tracker should be cleared after firing")
+	})
+
+	t.Run("successful fetch clears tracker", func(t *testing.T) {
+		var callCount int
+		oc := &TestOrbitClient{
+			getInstallerDetailsFn: func(string) (*fleet.SoftwareInstallDetails, error) {
+				callCount++
+				if callCount == 1 {
+					return nil, notFoundErr
+				}
+				return &fleet.SoftwareInstallDetails{
+					InstallerID:   1,
+					ExecutionID:   execID,
+					InstallScript: "echo hi",
+				}, nil
+			},
+		}
+		start := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		now := start
+		r := &Runner{
+			OrbitClient:                oc,
+			scriptsEnabled:             func() bool { return true },
+			nowFn:                      func() time.Time { return now },
+			installerNotFoundFirstSeen: make(map[string]time.Time),
+			logger:                     log.With().Logger(),
+			// stop-here error short-circuits attemptInstall after GetInstallerDetails.
+			tempDirFn: func(string, string) (string, error) { return "", errors.New("stop here") },
+		}
+
+		_, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.NoError(t, err)
+		require.Equal(t, start, r.installerNotFoundFirstSeen[execID])
+
+		_, _ = r.installSoftware(context.Background(), execID, r.logger)
+		_, stillTracked := r.installerNotFoundFirstSeen[execID]
+		require.False(t, stillTracked, "successful fetch must clear tracker so future 404s start a fresh window")
+	})
+
+	t.Run("non-404 error clears tracker so unrelated transient errors don't leak into window", func(t *testing.T) {
+		var returnNotFound bool
+		oc := &TestOrbitClient{
+			getInstallerDetailsFn: func(string) (*fleet.SoftwareInstallDetails, error) {
+				if returnNotFound {
+					return nil, notFoundErr
+				}
+				return nil, errors.New("some other transport error")
+			},
+		}
+		start := time.Date(2026, 4, 28, 12, 0, 0, 0, time.UTC)
+		now := start
+		r := &Runner{
+			OrbitClient:                oc,
+			scriptsEnabled:             func() bool { return true },
+			nowFn:                      func() time.Time { return now },
+			installerNotFoundFirstSeen: make(map[string]time.Time),
+			logger:                     log.With().Logger(),
+		}
+
+		returnNotFound = true
+		_, err := r.installSoftware(context.Background(), execID, r.logger)
+		require.NoError(t, err)
+		require.Contains(t, r.installerNotFoundFirstSeen, execID)
+
+		returnNotFound = false
+		_, err = r.installSoftware(context.Background(), execID, r.logger)
+		require.Error(t, err)
+		_, stillTracked := r.installerNotFoundFirstSeen[execID]
+		require.False(t, stillTracked, "non-404 error path must clear tracker")
+	})
 }

--- a/server/datastore/mysql/software_installers_test.go
+++ b/server/datastore/mysql/software_installers_test.go
@@ -62,6 +62,7 @@ func TestSoftwareInstallers(t *testing.T) {
 		{"GetInstallerByTeamAndURL", testGetInstallerByTeamAndURL},
 		{"BatchSetFMACancelsPendingOnActiveRow", testBatchSetFMACancelsPendingOnActiveRow},
 		{"MatchOrCreateSoftwareInstallerDuplicateConflicts", testMatchOrCreateSoftwareInstallerDuplicateConflicts},
+		{"SetHostSoftwareInstallResultResolvesOrphanedActivity", testSetHostSoftwareInstallResultResolvesOrphanedActivity},
 	}
 
 	for _, c := range cases {
@@ -297,6 +298,81 @@ func testListPendingSoftwareInstalls(t *testing.T, ds *Datastore) {
 	require.Equal(t, host1.ID, setupExperienceInstallDetails.HostID)
 	require.Equal(t, setupExperienceInstallID, setupExperienceInstallDetails.ExecutionID)
 	require.Equal(t, setupExperienceSoftwareInstallsRetries, setupExperienceInstallDetails.MaxRetries, "Setup experience install should have MaxRetries = %d", setupExperienceSoftwareInstallsRetries)
+}
+
+// testSetHostSoftwareInstallResultResolvesOrphanedActivity covers #44084: an
+// install whose software_installer_id was nulled by FK SET NULL must still be
+// resolvable by SetHostSoftwareInstallResult so the install loop stops.
+func testSetHostSoftwareInstallResultResolvesOrphanedActivity(t *testing.T, ds *Datastore) {
+	ctx := context.Background()
+
+	host := test.NewHost(t, ds, "host-orphan", "1", "host-orphan-key", "host-orphan-uuid", time.Now())
+	user := test.NewUser(t, ds, "Alice", "alice-orphan@example.com", true)
+
+	tfr, err := fleet.NewTempFileReader(strings.NewReader("hello"), t.TempDir)
+	require.NoError(t, err)
+	installerID, _, err := ds.MatchOrCreateSoftwareInstaller(ctx, &fleet.UploadSoftwareInstallerPayload{
+		InstallScript:   "echo install",
+		InstallerFile:   tfr,
+		StorageID:       "storage-orphan",
+		Filename:        "orphan.pkg",
+		Title:           "orphan",
+		Version:         "1.0",
+		Source:          "apps",
+		UserID:          user.ID,
+		ValidatedLabels: &fleet.LabelIdentsWithScope{},
+	})
+	require.NoError(t, err)
+
+	executionID, err := ds.InsertSoftwareInstallRequest(ctx, host.ID, installerID, fleet.HostSoftwareInstallOptions{})
+	require.NoError(t, err)
+
+	_, err = ds.GetSoftwareInstallDetails(ctx, executionID)
+	require.NoError(t, err)
+
+	// Simulate the FK SET NULL outcome directly so the test isn't coupled to
+	// DeleteSoftwareInstaller's own cleanup side-effects.
+	_, err = ds.writer(ctx).ExecContext(ctx, `
+		UPDATE host_software_installs
+		SET software_installer_id = NULL
+		WHERE execution_id = ?`, executionID)
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx, `
+		UPDATE software_install_upcoming_activities siua
+		JOIN upcoming_activities ua ON ua.id = siua.upcoming_activity_id
+		SET siua.software_installer_id = NULL
+		WHERE ua.execution_id = ?`, executionID)
+	require.NoError(t, err)
+
+	_, err = ds.GetSoftwareInstallDetails(ctx, executionID)
+	require.Error(t, err)
+	var nfe fleet.NotFoundError
+	require.ErrorAs(t, err, &nfe)
+
+	_, err = ds.SetHostSoftwareInstallResult(ctx, &fleet.HostSoftwareInstallResultPayload{
+		HostID:                host.ID,
+		InstallUUID:           executionID,
+		InstallScriptExitCode: ptr.Int(fleet.ExitCodeInstallerNotFound),
+		InstallScriptOutput:   ptr.String("Installer no longer exists on the server. Abandoning install after retry window."),
+	}, nil)
+	require.NoError(t, err)
+
+	var exitCode sql.NullInt64
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &exitCode, `
+		SELECT install_script_exit_code
+		FROM host_software_installs
+		WHERE execution_id = ?`, executionID)
+	require.NoError(t, err)
+	require.True(t, exitCode.Valid)
+	require.EqualValues(t, fleet.ExitCodeInstallerNotFound, exitCode.Int64)
+
+	var remaining int
+	err = sqlx.GetContext(ctx, ds.reader(ctx), &remaining, `
+		SELECT COUNT(*)
+		FROM upcoming_activities
+		WHERE host_id = ? AND execution_id = ?`, host.ID, executionID)
+	require.NoError(t, err)
+	require.Zero(t, remaining, "stale upcoming_activities row should be deleted so orbit's loop stops")
 }
 
 func testSoftwareInstallRequests(t *testing.T, ds *Datastore) {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -442,6 +442,7 @@ Exit code: %d (Failed)
 %s
 `
 	SoftwareInstallerDownloadFailedCopy = "Installing software...\nError: Software installer download failed."
+	SoftwareInstallerNotFoundCopy       = "Installing software...\nError: The software installer no longer exists on the server. fleetd abandoned the install after retrying for 5 minutes."
 )
 
 // EnhanceOutputDetails is used to add extra boilerplate/information to the
@@ -471,6 +472,9 @@ func (h *HostSoftwareInstallerResult) EnhanceOutputDetails() {
 		return
 	case ExitCodeInstallerDownloadFailed:
 		*h.Output = SoftwareInstallerDownloadFailedCopy
+		return
+	case ExitCodeInstallerNotFound:
+		*h.Output = SoftwareInstallerNotFoundCopy
 		return
 	default:
 		h.Output = ptr.String(fmt.Sprintf(SoftwareInstallerInstallFailCopy, *h.Output))
@@ -1022,6 +1026,11 @@ const (
 	// ExitCodeInstallerDownloadFailed is a special exit code returned by fleetd in the
 	// HostSoftwareInstallResultPayload when fleetd failed to download the installer.
 	ExitCodeInstallerDownloadFailed = -3
+	// ExitCodeInstallerNotFound is a special exit code returned by fleetd in the
+	// HostSoftwareInstallResultPayload when fleetd has been unable to fetch installer
+	// details from the server for longer than the retry window (e.g. because the
+	// installer was deleted/replaced while a setup-experience install was in flight).
+	ExitCodeInstallerNotFound = -4
 )
 
 // SoftwareInstallerTokenMetadata is the metadata stored in Redis for a software installer token.

--- a/server/fleet/software_test.go
+++ b/server/fleet/software_test.go
@@ -139,6 +139,17 @@ func TestEnhanceOutputDetails(t *testing.T) {
 			expectedPostInstallScriptOutput: nil,
 		},
 		{
+			name: "non-pending status with installer not found exit code",
+			initial: HostSoftwareInstallerResult{
+				Status:                SoftwareInstallFailed,
+				InstallScriptExitCode: new(ExitCodeInstallerNotFound),
+				Output:                ptr.String(""),
+			},
+			expectedPreInstallQueryOutput:   nil,
+			expectedOutput:                  ptr.String(SoftwareInstallerNotFoundCopy),
+			expectedPostInstallScriptOutput: nil,
+		},
+		{
 			name: "non-pending status with failed install script",
 			initial: HostSoftwareInstallerResult{
 				Status:                SoftwareInstallFailed,


### PR DESCRIPTION
Fixes #44084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install processes no longer hang if an installer is edited or deleted mid-install: the system retries for 5 minutes then marks the install as failed with a clear "installer no longer exists" outcome and message.
* **Tests**
  * Added tests covering orphaned installer scenarios, retry-window behavior, and datastore handling of removed installers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->