### PR TITLE
DevX: Seed premium users, fleets, reports, and queries 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,7 @@ fleet_tables_*.ext
 
 # Local dev files
 .env
+tools/seed/DO_NOT_COMMIT_ENV_FILE
 .tool-versions
 .zed/
 third_party/vuln-check/go.sum

--- a/tools/seed/DO_NOT_COMMIT_ENV_FILE.example
+++ b/tools/seed/DO_NOT_COMMIT_ENV_FILE.example
@@ -1,0 +1,5 @@
+# Copy this file and fill in your values. Do not commit with real credentials.
+export SERVER_URL=https://localhost:8080 #update if needed
+export CURL_FLAGS='-k -s'
+export TOKEN=<your-api-token-here>
+export SEED_PASSWORD=<your-password-here>

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -68,23 +68,23 @@ Re-running is safe — existing users are skipped and policies/reports are upser
 
 Creates 15 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
 
-| User | Email | Role |
-|------|-------|------|
-| Anna G. Admin | anna@organization.com | Global admin |
-| Mary G. Maintainer | mary@organization.com | Global maintainer |
-| Oliver G. Observer | oliver@organization.com | Global observer |
-| Opal G. Observer+ | opal@organization.com | Global observer+ |
-| Tessa G. Technician | tessa@organization.com | Global technician |
-| Gina G. GitOps | gina@organization.com | Global gitops |
-| Marco Mixed Roles | marco@organization.com | Observer (Workstations), Maintainer (Mobile devices) |
-| Anita T. Admin | anita@organization.com | Admin (Workstations) |
-| Manny T. Maintainer | manny@organization.com | Maintainer (Workstations) |
-| Toni T. Observer | toni@organization.com | Observer (Workstations) |
-| Topanga T. Observer+ | topanga@organization.com | Observer+ (Workstations) |
-| Terry T. Technician | terry@organization.com | Technician (Workstations) |
-| Gordon T. GitOps | gordon@organization.com | GitOps (Workstations) |
-| Apollo G. API-only (full access) | apollo@organization.com | Global maintainer, API-only (full access) |
-| Reggie G. API-only (restricted) | auto-generated | Global admin, API-only (restricted to GET hosts) |
+| User | Email | Role | Persona |
+|------|-------|------|---------|
+| Anna G. Admin | anna@organization.com | Global admin | IT Director. Owns the Fleet instance org-wide. Manages users, sets global policies, approves fleet-level admin access. Her priority is consistent security posture across every device. |
+| Mary G. Maintainer | mary@organization.com | Global maintainer | Senior security engineer. Writes and maintains policies and reports across all fleets. Doesn't need user management — Anna handles that. Cares about detection coverage and keeping reports accurate. |
+| Oliver G. Observer | oliver@organization.com | Global observer | Compliance manager. Read-only visibility into everything for audits and executive reporting. Never changes configuration — just needs to verify the org is meeting its compliance commitments. |
+| Opal G. Observer+ | opal@organization.com | Global observer+ | Security analyst on the incident response team. Needs everything Oliver has, plus the ability to run live queries during investigations. Can't change policies or configuration — just investigates. |
+| Tessa G. Technician | tessa@organization.com | Global technician | IT support lead. Helps end users across every fleet — locks lost devices, pushes software, troubleshoots MDM enrollment. Works across all fleets because the helpdesk isn't organized by device type. |
+| Gina G. GitOps | gina@organization.com | Global gitops | Platform engineer who manages Fleet's global configuration as code. Pushes policy and report changes via CI/CD, rarely touches the UI. Owns the GitOps repo and reviews PRs to it. |
+| Marco Mixed Roles | marco@organization.com | Observer (Workstations), Maintainer (Mobile devices) | IT contractor who was brought in to stand up the mobile device program. Full maintainer access on Mobile devices (his project), but only observer on Workstations so he can reference existing policies without changing them. |
+| Anita T. Admin | anita@organization.com | Admin (Workstations) | Workstations fleet owner. A senior IT manager who runs the corporate Mac program. Manages her fleet's users and settings, but has no access to Mobile devices — that's Marco's domain. |
+| Manny T. Maintainer | manny@organization.com | Maintainer (Workstations) | Mac sysadmin on Anita's team. Writes fleet-specific policies, manages software deployments, maintains Workstations reports. Day-to-day hands on the corporate Mac fleet. |
+| Toni T. Observer | toni@organization.com | Observer (Workstations) | Finance team lead. Has read-only access to the Workstations fleet so she can pull asset inventory numbers for quarterly hardware budgeting. Doesn't need to touch anything else. |
+| Topanga T. Observer+ | topanga@organization.com | Observer+ (Workstations) | Senior engineer who occasionally troubleshoots deep macOS issues. Needs to run ad-hoc queries against the Workstations fleet to diagnose problems, but shouldn't change policies or configuration — that's Manny's job. |
+| Terry T. Technician | terry@organization.com | Technician (Workstations) | Helpdesk technician dedicated to the Workstations fleet. Handles end-user requests — reinstalls software, wipes machines for offboarding, resets MDM profiles. No access to Mobile devices. |
+| Gordon T. GitOps | gordon@organization.com | GitOps (Workstations) | The CI/CD service account identity for the Workstations fleet repo. Gordon is the human who maintains that repo, but this account is what the pipeline authenticates as. Scoped only to Workstations. |
+| Apollo G. API-only (full access) | apollo@organization.com | Global maintainer, API-only | Service account for the SIEM integration. Pulls host data, vulnerability info, and policy results into Splunk on a scheduled sync. Full read/write API access but no human ever logs into the UI with it. |
+| Reggie G. API-only (restricted) | auto-generated | Global admin, API-only (restricted to GET hosts) | Service account for an internal asset dashboard. Only needs to list hosts and get host details — nothing else. Locked down to two endpoints so a compromised token has minimal blast radius. |
 
 API-only users created via `/users/api_only` have their API token printed once at creation. Save it — it cannot be retrieved later.
 

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -66,7 +66,7 @@ Re-running is safe — existing users are skipped and policies/reports are upser
 
 ### Users (`seed-users-and-fleets.sh`)
 
-Creates 12 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
+Creates 15 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
 
 | User | Email | Role |
 |------|-------|------|
@@ -75,13 +75,16 @@ Creates 12 users across global, fleet-scoped, and API-only roles. Regular users 
 | Oliver G. Observer | oliver@organization.com | Global observer |
 | Opal G. Observer+ | opal@organization.com | Global observer+ |
 | Tessa G. Technician | tessa@organization.com | Global technician |
+| Gina G. GitOps | gina@organization.com | Global gitops |
 | Marco Mixed Roles | marco@organization.com | Observer (Workstations), Maintainer (Mobile devices) |
 | Anita T. Admin | anita@organization.com | Admin (Workstations) |
 | Manny T. Maintainer | manny@organization.com | Maintainer (Workstations) |
 | Toni T. Observer | toni@organization.com | Observer (Workstations) |
 | Topanga T. Observer+ | topanga@organization.com | Observer+ (Workstations) |
-| Apollo G. API-only | apollo@organization.com | Global maintainer, API-only (full access) |
-| Rosie Restricted (API only) | auto-generated | Global admin, API-only (restricted to GET hosts) |
+| Terry T. Technician | terry@organization.com | Technician (Workstations) |
+| Gordon T. GitOps | gordon@organization.com | GitOps (Workstations) |
+| Apollo G. API-only (full access) | apollo@organization.com | Global maintainer, API-only (full access) |
+| Reggie G. API-only (restricted) | auto-generated | Global admin, API-only (restricted to GET hosts) |
 
 API-only users created via `/users/api_only` have their API token printed once at creation. Save it — it cannot be retrieved later.
 
@@ -97,12 +100,12 @@ Reports extracted from `docs/queries.yml`. Covers inventory, detection, and info
 
 Applied automatically by `seed-users-and-fleets.sh` using `--policies-fleet`:
 
-- **`fleet-workstations-policies.yml`** — 5 macOS policies (Gatekeeper, FileVault, SIP, Firewall, Screen lock)
-- **`fleet-mobile-policies.yml`** — 5 personal laptop policies (SSH keys, Linux FDE, Linux antivirus, 1Password emergency kit, Docker up to date)
+- **`fleet-workstations-policies.yml`** — 5 managed corporate macOS policies (MDM enrolled, automatic login disabled, guest account disabled, iCloud sync disabled, password length)
+- **`fleet-mobile-policies.yml`** — 5 personal laptop/BYOD policies (suspicious autostart, SMBv1 disabled, secure keyboard entry, ad tracking limited, LLMNR disabled)
 
 ### Fleet-scoped reports
 
 Applied automatically by `seed-users-and-fleets.sh`:
 
-- **`fleet-workstations-reports.yml`** — 4 macOS reports (Apple Intelligence, crashes, battery health, installed software)
-- **`fleet-mobile-reports.yml`** — 4 personal laptop reports (Chrome extensions, memory hogs, unencrypted SSH keys, VS Code extensions)
+- **`fleet-workstations-reports.yml`** — 4 corporate macOS reports (Safari extensions, Crowdstrike Falcon status, Apple dev secrets, local admin accounts)
+- **`fleet-mobile-reports.yml`** — 4 personal laptop/BYOD reports (running Docker containers, apps outside /Applications, TLS certificates, fileless processes)

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -100,12 +100,12 @@ Reports extracted from `docs/queries.yml`. Covers inventory, detection, and info
 
 Applied automatically by `seed-users-and-fleets.sh` using `--policies-fleet`:
 
-- **`fleet-workstations-policies.yml`** — 5 managed corporate macOS policies (MDM enrolled, automatic login disabled, guest account disabled, iCloud sync disabled, password length)
-- **`fleet-mobile-policies.yml`** — 5 personal laptop/BYOD policies (suspicious autostart, SMBv1 disabled, secure keyboard entry, ad tracking limited, LLMNR disabled)
+- **`fleet-workstations-policies.yml`** — 5 managed corporate macOS policies (SSH disabled, AirDrop disabled, Bluetooth sharing disabled, login window config, Time Machine encrypted)
+- **`fleet-mobile-policies.yml`** — 5 personal laptop/BYOD policies (no plaintext passwords in dotfiles, screen saver password, Find My Mac, automatic OS updates, no world-writable files)
 
 ### Fleet-scoped reports
 
 Applied automatically by `seed-users-and-fleets.sh`:
 
-- **`fleet-workstations-reports.yml`** — 4 corporate macOS reports (Safari extensions, Crowdstrike Falcon status, Apple dev secrets, local admin accounts)
-- **`fleet-mobile-reports.yml`** — 4 personal laptop/BYOD reports (running Docker containers, apps outside /Applications, TLS certificates, fileless processes)
+- **`fleet-workstations-reports.yml`** — 4 corporate macOS reports (FileVault status, MDM enrollment details, Gatekeeper config, managed profiles)
+- **`fleet-mobile-reports.yml`** — 4 personal laptop/BYOD reports (Homebrew packages, disk space usage, SSH agent keys, browser extensions by user)

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -7,6 +7,7 @@ Scripts and YAML files to populate a local Fleet instance with realistic users, 
 - A running Fleet dev server (`make serve` or equivalent)
 - A premium license (required for fleets)
 - `fleetctl` built (`make build` or set `FLEETCTL` to your binary path)
+- `python3` (used for JSON parsing in the scripts)
 
 ## Quick start
 
@@ -47,15 +48,11 @@ bash tools/seed/clean-seed-data.sh
 
 ### 3. Run the seeds
 
-Log in to `fleetctl` first, then run the seed script:
-
 ```bash
-./build/fleetctl login
-
 bash tools/seed/seed-users-and-fleets.sh
 ```
 
-This seeds everything in one shot: users, fleets, global policies, global reports, fleet-scoped policies, and fleet-scoped reports.
+This seeds everything in one shot: users, fleets, global policies, global reports, fleet-scoped policies, and fleet-scoped reports. The script configures `fleetctl` with your API token automatically — no separate `fleetctl login` needed.
 
 The script expects `fleetctl` at `./build/fleetctl`. If yours is elsewhere:
 
@@ -69,7 +66,7 @@ Re-running is safe — existing users are skipped and policies/reports are upser
 
 ### Users (`seed-users-and-fleets.sh`)
 
-Creates 11 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
+Creates 12 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
 
 | User | Email | Role |
 |------|-------|------|
@@ -77,12 +74,13 @@ Creates 11 users across global, fleet-scoped, and API-only roles. Regular users 
 | Mary G. Maintainer | mary@organization.com | Global maintainer |
 | Oliver G. Observer | oliver@organization.com | Global observer |
 | Opal G. Observer+ | opal@organization.com | Global observer+ |
+| Tessa G. Technician | tessa@organization.com | Global technician |
 | Marco Mixed Roles | marco@organization.com | Observer (Workstations), Maintainer (Mobile devices) |
 | Anita T. Admin | anita@organization.com | Admin (Workstations) |
 | Manny T. Maintainer | manny@organization.com | Maintainer (Workstations) |
 | Toni T. Observer | toni@organization.com | Observer (Workstations) |
 | Topanga T. Observer+ | topanga@organization.com | Observer+ (Workstations) |
-| Robbie Robot (API only) | robbie@organization.com | Global maintainer, API-only (full access) |
+| Apollo G. API-only | apollo@organization.com | Global maintainer, API-only (full access) |
 | Rosie Restricted (API only) | auto-generated | Global admin, API-only (restricted to GET hosts) |
 
 API-only users created via `/users/api_only` have their API token printed once at creation. Save it — it cannot be retrieved later.

--- a/tools/seed/README.md
+++ b/tools/seed/README.md
@@ -1,0 +1,110 @@
+# Seed data for local development
+
+Scripts and YAML files to populate a local Fleet instance with realistic users, policies, and reports for testing. Especially useful after a `make db-reset` to quickly get back to a working state.
+
+## Prerequisites
+
+- A running Fleet dev server (`make serve` or equivalent)
+- A premium license (required for fleets)
+- `fleetctl` built (`make build` or set `FLEETCTL` to your binary path)
+
+## Quick start
+
+### 1. Set up your env file
+
+If you just reset your database, create your admin account first by completing Fleet setup at https://localhost:8080.
+
+Copy the example env file and fill in your values:
+
+```bash
+cp tools/seed/DO_NOT_COMMIT_ENV_FILE.example tools/seed/DO_NOT_COMMIT_ENV_FILE
+```
+
+Edit `tools/seed/DO_NOT_COMMIT_ENV_FILE` with your local server details:
+
+```bash
+export SERVER_URL=https://localhost:8080
+export CURL_FLAGS='-k -s'
+export TOKEN=<your-api-token>
+export SEED_PASSWORD=<password-for-all-seed-users>
+```
+
+Get your API token from **My account** in the Fleet UI.
+
+Then export the path:
+
+```bash
+export FLEET_ENV_PATH=tools/seed/DO_NOT_COMMIT_ENV_FILE
+```
+
+### 2. Clean up existing data (optional)
+
+If you already have manually created users, policies, or reports and want a clean slate, run this first. It deletes all policies, reports, and users except your admin account (ID 1). Requires the env file from step 1.
+
+```bash
+bash tools/seed/clean-seed-data.sh
+```
+
+### 3. Run the seeds
+
+Log in to `fleetctl` first, then run the seed script:
+
+```bash
+./build/fleetctl login
+
+bash tools/seed/seed-users-and-fleets.sh
+```
+
+This seeds everything in one shot: users, fleets, global policies, global reports, fleet-scoped policies, and fleet-scoped reports.
+
+The script expects `fleetctl` at `./build/fleetctl`. If yours is elsewhere:
+
+```bash
+FLEETCTL=/usr/local/bin/fleetctl bash tools/seed/seed-users-and-fleets.sh
+```
+
+Re-running is safe — existing users are skipped and policies/reports are upserted.
+
+## What gets created
+
+### Users (`seed-users-and-fleets.sh`)
+
+Creates 11 users across global, fleet-scoped, and API-only roles. Regular users use `$SEED_PASSWORD`.
+
+| User | Email | Role |
+|------|-------|------|
+| Anna G. Admin | anna@organization.com | Global admin |
+| Mary G. Maintainer | mary@organization.com | Global maintainer |
+| Oliver G. Observer | oliver@organization.com | Global observer |
+| Opal G. Observer+ | opal@organization.com | Global observer+ |
+| Marco Mixed Roles | marco@organization.com | Observer (Workstations), Maintainer (Mobile devices) |
+| Anita T. Admin | anita@organization.com | Admin (Workstations) |
+| Manny T. Maintainer | manny@organization.com | Maintainer (Workstations) |
+| Toni T. Observer | toni@organization.com | Observer (Workstations) |
+| Topanga T. Observer+ | topanga@organization.com | Observer+ (Workstations) |
+| Robbie Robot (API only) | robbie@organization.com | Global maintainer, API-only (full access) |
+| Rosie Restricted (API only) | auto-generated | Global admin, API-only (restricted to GET hosts) |
+
+API-only users created via `/users/api_only` have their API token printed once at creation. Save it — it cannot be retrieved later.
+
+### Global policies (`standard-policies.yml`)
+
+41 policies extracted from the standard query library (`docs/01-Using-Fleet/standard-query-library/standard-query-library.yml`). Covers macOS, Windows, and Linux.
+
+### Global reports (`standard-reports.yml`)
+
+Reports extracted from `docs/queries.yml`. Covers inventory, detection, and informational queries across platforms.
+
+### Fleet-scoped policies
+
+Applied automatically by `seed-users-and-fleets.sh` using `--policies-fleet`:
+
+- **`fleet-workstations-policies.yml`** — 5 macOS policies (Gatekeeper, FileVault, SIP, Firewall, Screen lock)
+- **`fleet-mobile-policies.yml`** — 5 personal laptop policies (SSH keys, Linux FDE, Linux antivirus, 1Password emergency kit, Docker up to date)
+
+### Fleet-scoped reports
+
+Applied automatically by `seed-users-and-fleets.sh`:
+
+- **`fleet-workstations-reports.yml`** — 4 macOS reports (Apple Intelligence, crashes, battery health, installed software)
+- **`fleet-mobile-reports.yml`** — 4 personal laptop reports (Chrome extensions, memory hogs, unencrypted SSH keys, VS Code extensions)

--- a/tools/seed/clean-seed-data.sh
+++ b/tools/seed/clean-seed-data.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Clean up seeded data for local development
+#
+# Deletes all policies, reports, and non-admin users (preserves user ID 1).
+# Useful before re-running the seed scripts on a fresh slate without
+# doing a full database reset.
+#
+# Prerequisites: same env file as seed-users-and-fleets.sh
+#
+# Usage:
+#   export FLEET_ENV_PATH=tools/seed/DO_NOT_COMMIT_ENV_FILE
+#   bash tools/seed/clean-seed-data.sh
+
+set -e
+
+source "$FLEET_ENV_PATH"
+
+API="$SERVER_URL/api/latest/fleet"
+AUTH="Authorization: Bearer $TOKEN"
+
+# Helper: extract IDs from a JSON array
+extract_ids() {
+  python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+key = sys.argv[1]
+exclude_id = int(sys.argv[2]) if len(sys.argv) > 2 else 0
+items = data.get(key, [])
+ids = [item['id'] for item in items if item['id'] != exclude_id]
+print(json.dumps(ids))
+" "$@"
+}
+
+echo "==> Deleting all policies..."
+
+# Delete global policies
+global_policy_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/policies" --insecure | extract_ids "policies")
+if [ "$global_policy_ids" != "[]" ]; then
+  curl -X POST $CURL_FLAGS -H "$AUTH" "$API/policies/delete" --insecure \
+    -d "{\"ids\": $global_policy_ids}" > /dev/null
+  echo "[+] deleted global policies"
+else
+  echo "[+] no global policies to delete"
+fi
+
+# Delete fleet policies
+fleet_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/teams" --insecure \
+  | python3 -c "import sys,json; [print(t['id']) for t in json.load(sys.stdin).get('teams',[])]" 2>/dev/null)
+for fid in $fleet_ids; do
+  fleet_policy_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/teams/$fid/policies" --insecure | extract_ids "policies")
+  if [ "$fleet_policy_ids" != "[]" ]; then
+    curl -X POST $CURL_FLAGS -H "$AUTH" "$API/teams/$fid/policies/delete" --insecure \
+      -d "{\"ids\": $fleet_policy_ids}" > /dev/null
+    echo "[+] deleted policies for fleet $fid"
+  fi
+done
+
+echo ""
+echo "==> Deleting all reports..."
+
+# Delete global reports
+report_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/reports" --insecure | extract_ids "queries")
+if [ "$report_ids" != "[]" ]; then
+  curl -X POST $CURL_FLAGS -H "$AUTH" "$API/reports/delete" --insecure \
+    -d "{\"ids\": $report_ids}" > /dev/null
+  echo "[+] deleted global reports"
+else
+  echo "[+] no global reports to delete"
+fi
+
+# Delete fleet-scoped reports
+for fid in $fleet_ids; do
+  fleet_report_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/reports?team_id=$fid" --insecure | extract_ids "queries")
+  if [ "$fleet_report_ids" != "[]" ]; then
+    curl -X POST $CURL_FLAGS -H "$AUTH" "$API/reports/delete" --insecure \
+      -d "{\"ids\": $fleet_report_ids}" > /dev/null
+    echo "[+] deleted reports for fleet $fid"
+  fi
+done
+
+echo ""
+echo "==> Deleting all users (except ID 1)..."
+
+user_ids=$(curl $CURL_FLAGS -H "$AUTH" "$API/users" --insecure | extract_ids "users" 1)
+for user_id in $(echo "$user_ids" | python3 -c "import sys,json; [print(i) for i in json.load(sys.stdin)]"); do
+  curl -X DELETE $CURL_FLAGS -H "$AUTH" "$API/users/$user_id" --insecure > /dev/null
+  echo "[+] deleted user $user_id"
+done
+
+if [ "$user_ids" = "[]" ]; then
+  echo "[+] no users to delete"
+fi
+
+echo ""
+echo "==> Done! All seed data cleaned up (admin user preserved)."

--- a/tools/seed/clean-seed-data.sh
+++ b/tools/seed/clean-seed-data.sh
@@ -12,9 +12,18 @@
 #   export FLEET_ENV_PATH=tools/seed/DO_NOT_COMMIT_ENV_FILE
 #   bash tools/seed/clean-seed-data.sh
 
-set -e
+set -euo pipefail
 
 source "$FLEET_ENV_PATH"
+
+# Validate required env vars
+missing=""
+[ -z "${TOKEN:-}" ] && missing="$missing TOKEN"
+[ -z "${SERVER_URL:-}" ] && missing="$missing SERVER_URL"
+if [ -n "$missing" ]; then
+  echo "ERROR: Missing required env vars:$missing. Check your env file." >&2
+  exit 1
+fi
 
 API="$SERVER_URL/api/latest/fleet"
 AUTH="Authorization: Bearer $TOKEN"

--- a/tools/seed/fleet-mobile-policies.yml
+++ b/tools/seed/fleet-mobile-policies.yml
@@ -8,44 +8,44 @@
 apiVersion: v1
 kind: policy
 spec:
-  name: Suspicious autostart (Windows)
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM startup_items WHERE path = "regsvr32" AND args LIKE "%http%");
-  description: "Checks for an autostart that is attempting to load a dynamic link library (DLL) from the internet."
-  resolution: "Remove the suspicious startup entry."
-  platform: windows
+  name: Personal devices - No plaintext passwords in common dotfiles
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path LIKE '/Users/%/.bashrc' OR path LIKE '/Users/%/.zshrc' OR path LIKE '/Users/%/.bash_profile' OR path LIKE '/Users/%/.profile' OR path LIKE '/home/%/.bashrc' OR path LIKE '/home/%/.zshrc') AND size > 0);
+  description: "Checks that common shell dotfiles exist. This is a lightweight proxy to encourage auditing dotfiles on personal devices — manual review of contents is still recommended."
+  resolution: "Review your shell configuration files for any hardcoded passwords or secrets."
+  platform: darwin,linux
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: SMBv1 client driver disabled (Windows)
-  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Client' AND state != 1;
-  description: "Checks that the SMBv1 client is disabled."
-  resolution: "Contact your IT administrator to discuss disabling SMBv1 on your system."
-  platform: windows
----
-apiVersion: v1
-kind: policy
-spec:
-  name: Secure keyboard entry for Terminal application enabled (macOS)
-  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable secure keyboard entry for the Terminal application."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables secure keyboard entry for the Terminal application."
+  name: Personal devices - Screen saver password enabled
+  query: SELECT 1 FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.screensaver.plist' AND key = 'askForPassword' AND value = '1' LIMIT 1;
+  description: "Checks that at least one user has screen saver password protection enabled on personal macOS devices."
+  resolution: "Go to System Settings > Lock Screen and enable 'Require password after screen saver begins.'"
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Ad tracking is limited (macOS)
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.AdLib' AND name='forceLimitAdTracking' AND value='1' LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to limit advertisement tracking."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables advertisement tracking."
+  name: Personal devices - Find My Mac enabled
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.icloud.managed' AND name = 'DisableFMMiCloudSetting' AND value = '0' LIMIT 1;
+  description: "Checks that Find My Mac is not disabled by MDM policy on personal devices."
+  resolution: "Go to System Settings > Apple ID > iCloud and enable Find My Mac."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Link-Local Multicast Name Resolution (LLMNR) disabled (Windows)
-  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMulticast' AND CAST(data as integer) = 0;
-  description: "Checks if a Group Policy configures the computer to disable LLMNR. Disabling LLMNR can prevent malicious actors from gaining access to the computer's credentials."
-  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that disables LLMNR on your system."
-  platform: windows
+  name: Personal devices - Automatic OS updates enabled
+  query: SELECT 1 FROM plist WHERE path = '/Library/Preferences/com.apple.SoftwareUpdate.plist' AND key = 'AutomaticallyInstallMacOSUpdates' AND value = '1';
+  description: "Checks that automatic macOS updates are enabled on personal devices via the local preference (not MDM-managed)."
+  resolution: "Go to System Settings > General > Software Update > Automatic Updates and enable 'Install macOS updates.'"
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Personal devices - No world-writable files in home directory
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path LIKE '/Users/%/Desktop/%%' OR path LIKE '/Users/%/Documents/%%' OR path LIKE '/Users/%/Downloads/%%') AND mode LIKE '%7' AND type = 'regular' LIMIT 1);
+  description: "Checks that there are no world-writable files in common user directories on personal devices."
+  resolution: "Fix file permissions with: chmod o-w <file>"
+  platform: darwin

--- a/tools/seed/fleet-mobile-policies.yml
+++ b/tools/seed/fleet-mobile-policies.yml
@@ -10,7 +10,7 @@ kind: policy
 spec:
   name: Personal devices - No plaintext passwords in common dotfiles
   query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path LIKE '/Users/%/.bashrc' OR path LIKE '/Users/%/.zshrc' OR path LIKE '/Users/%/.bash_profile' OR path LIKE '/Users/%/.profile' OR path LIKE '/home/%/.bashrc' OR path LIKE '/home/%/.zshrc') AND size > 0);
-  description: "Checks that common shell dotfiles exist. This is a lightweight proxy to encourage auditing dotfiles on personal devices — manual review of contents is still recommended."
+  description: "Checks that no common shell dotfiles with content exist on personal devices. This is a lightweight proxy to flag dotfiles that may contain hardcoded passwords or secrets — manual review is still recommended."
   resolution: "Review your shell configuration files for any hardcoded passwords or secrets."
   platform: darwin,linux
 ---
@@ -45,7 +45,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: Personal devices - No world-writable files in home directory
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path LIKE '/Users/%/Desktop/%%' OR path LIKE '/Users/%/Documents/%%' OR path LIKE '/Users/%/Downloads/%%') AND mode LIKE '%7' AND type = 'regular' LIMIT 1);
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE (path LIKE '/Users/%/Desktop/%%' OR path LIKE '/Users/%/Documents/%%' OR path LIKE '/Users/%/Downloads/%%') AND (mode LIKE '%2' OR mode LIKE '%3' OR mode LIKE '%6' OR mode LIKE '%7') AND type = 'regular' LIMIT 1);
   description: "Checks that there are no world-writable files in common user directories on personal devices."
   resolution: "Fix file permissions with: chmod o-w <file>"
   platform: darwin

--- a/tools/seed/fleet-mobile-policies.yml
+++ b/tools/seed/fleet-mobile-policies.yml
@@ -1,0 +1,49 @@
+---
+# Policies for the Personal mobile devices fleet (personal laptops)
+#
+# Usage:
+#   fleetctl apply -f tools/seed/fleet-mobile-policies.yml --policies-fleet "Personal mobile devices"
+apiVersion: v1
+kind: policy
+spec:
+  name: SSH keys encrypted
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
+  description: "Required: osquery must have Full Disk Access. Policy passes if all keys are encrypted, including if no keys are present."
+  resolution: "Use this command to encrypt existing SSH keys by providing the path to the file: ssh-keygen -o -p -f /path/to/file"
+  platform: darwin,linux,windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Full disk encryption enabled (Linux)
+  query: SELECT 1 FROM mounts m, disk_encryption d WHERE m.device_alias = d.name AND d.encrypted = 1 AND m.path = '/';
+  description: Checks if the root drive is encrypted. There are many ways to encrypt Linux systems. This is the default on distributions such as Ubuntu.
+  resolution: "Ensure the image deployed to your Linux workstation includes full disk encryption."
+  platform: linux
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Antivirus healthy (Linux)
+  query: SELECT score FROM (SELECT case when COUNT(*) = 2 then 1 ELSE 0 END AS score FROM processes WHERE (name = 'clamd') OR (name = 'freshclam')) WHERE score == 1;
+  description: Checks that both ClamAV's daemon and its updater service (freshclam) are running.
+  resolution: "Ensure ClamAV and Freshclam are installed and running."
+  platform: linux
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: No 1Password emergency kit stored in desktop, documents, or downloads folders (macOS)
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%'));
+  description: "Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders."
+  resolution: "Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Docker application is up to date or not present (macOS)
+  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
+  description: "Checks if Docker Desktop is installed and up to date, or not installed. Fails if installed on a lower version."
+  resolution: "Update Docker or remove it if not used."
+  platform: darwin

--- a/tools/seed/fleet-mobile-policies.yml
+++ b/tools/seed/fleet-mobile-policies.yml
@@ -1,49 +1,51 @@
 ---
-# Policies for the Personal mobile devices fleet (personal laptops)
+# Policies for the Personal mobile devices fleet (personal laptops / BYOD)
 #
 # Usage:
 #   fleetctl apply -f tools/seed/fleet-mobile-policies.yml --policies-fleet "Personal mobile devices"
+#
+# These are unique to this fleet — not duplicates of global policies.
 apiVersion: v1
 kind: policy
 spec:
-  name: SSH keys encrypted
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
-  description: "Required: osquery must have Full Disk Access. Policy passes if all keys are encrypted, including if no keys are present."
-  resolution: "Use this command to encrypt existing SSH keys by providing the path to the file: ssh-keygen -o -p -f /path/to/file"
-  platform: darwin,linux,windows
+  name: Suspicious autostart (Windows)
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM startup_items WHERE path = "regsvr32" AND args LIKE "%http%");
+  description: "Checks for an autostart that is attempting to load a dynamic link library (DLL) from the internet."
+  resolution: "Remove the suspicious startup entry."
+  platform: windows
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Full disk encryption enabled (Linux)
-  query: SELECT 1 FROM mounts m, disk_encryption d WHERE m.device_alias = d.name AND d.encrypted = 1 AND m.path = '/';
-  description: Checks if the root drive is encrypted. There are many ways to encrypt Linux systems. This is the default on distributions such as Ubuntu.
-  resolution: "Ensure the image deployed to your Linux workstation includes full disk encryption."
-  platform: linux
+  name: SMBv1 client driver disabled (Windows)
+  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Client' AND state != 1;
+  description: "Checks that the SMBv1 client is disabled."
+  resolution: "Contact your IT administrator to discuss disabling SMBv1 on your system."
+  platform: windows
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Antivirus healthy (Linux)
-  query: SELECT score FROM (SELECT case when COUNT(*) = 2 then 1 ELSE 0 END AS score FROM processes WHERE (name = 'clamd') OR (name = 'freshclam')) WHERE score == 1;
-  description: Checks that both ClamAV's daemon and its updater service (freshclam) are running.
-  resolution: "Ensure ClamAV and Freshclam are installed and running."
-  platform: linux
----
-apiVersion: v1
-kind: policy
-spec:
-  name: No 1Password emergency kit stored in desktop, documents, or downloads folders (macOS)
-  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%'));
-  description: "Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders."
-  resolution: "Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location."
+  name: Secure keyboard entry for Terminal application enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable secure keyboard entry for the Terminal application."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables secure keyboard entry for the Terminal application."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Docker application is up to date or not present (macOS)
-  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
-  description: "Checks if Docker Desktop is installed and up to date, or not installed. Fails if installed on a lower version."
-  resolution: "Update Docker or remove it if not used."
+  name: Ad tracking is limited (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.AdLib' AND name='forceLimitAdTracking' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to limit advertisement tracking."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables advertisement tracking."
   platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Link-Local Multicast Name Resolution (LLMNR) disabled (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMulticast' AND CAST(data as integer) = 0;
+  description: "Checks if a Group Policy configures the computer to disable LLMNR. Disabling LLMNR can prevent malicious actors from gaining access to the computer's credentials."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that disables LLMNR on your system."
+  platform: windows

--- a/tools/seed/fleet-mobile-reports.yml
+++ b/tools/seed/fleet-mobile-reports.yml
@@ -1,54 +1,55 @@
 ---
-# Reports for the Personal mobile devices fleet (personal laptops)
+# Reports for the Personal mobile devices fleet (personal laptops / BYOD)
 #
 # Note: The "fleet" field must match the exact fleet name. The seed script
 # substitutes FLEET_NAME automatically. To apply manually, replace FLEET_NAME
 # with your fleet's exact name.
+#
+# These are unique to this fleet — not duplicates of global reports.
 apiVersion: v1
 kind: report
 spec:
-  name: Get installed Chrome Extensions
-  platform: darwin, linux, windows
+  name: Get running docker containers
+  platform: darwin, linux
   fleet: FLEET_NAME
-  description: List installed Chrome Extensions for all users.
-  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
+  description: Returns the running Docker containers
+  query: SELECT id, name, image, image_id, state, status FROM docker_containers WHERE state = "running";
   purpose: Informational
-  tags: browser, built-in, inventory
-  contributors: zwass
----
-apiVersion: v1
-kind: report
-spec:
-  name: Get applications hogging memory
-  platform: darwin, linux, windows
-  fleet: FLEET_NAME
-  description: Returns top 10 applications or processes hogging memory the most.
-  query: SELECT pid, name, ROUND((total_size * '10e-7'), 2) AS memory_used FROM processes ORDER BY total_size DESC LIMIT 10;
-  purpose: Informational
-  tags: troubleshooting
+  tags: containers, inventory
   contributors: DominusKelvin
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get unencrypted SSH keys for local accounts
-  platform: darwin, linux, windows
+  name: Get applications that are not in the Applications directory
+  platform: darwin
   fleet: FLEET_NAME
-  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
-  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;
+  description: Returns applications that are not in the `/Applications` directory
+  query: SELECT * FROM apps WHERE path NOT LIKE '/Applications/%';
   purpose: Informational
-  tags: inventory, compliance, ssh, built-in
-  remediation: First, make the user aware about the impact of SSH keys. Then rotate the unencrypted keys detected.
-  contributors: anelshaer
+  tags: hunting, inventory
+  contributors: DominusKelvin
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get a list of Visual Studio Code extensions
-  platform: darwin, linux, windows
+  name: Discover TLS certificates
+  platform: linux, windows, darwin
   fleet: FLEET_NAME
-  description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).
-  query: SELECT u.username, vs.* FROM users u JOIN vscode_extensions vs ON u.uid = vs.uid;
+  description: Retrieves metadata about TLS certificates for servers listening on the local machine. Enables mTLS adoption analysis and cert expiration notifications.
+  query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
   purpose: Informational
-  tags: inventory
-  contributors: lucasmrod,sharon-fdm,zwass
+  tags: network, tls
+  contributors: nabilschear
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get processes that no longer exist on disk
+  platform: linux, darwin, windows
+  fleet: FLEET_NAME
+  description: Lists all processes of which the binary which launched them no longer exists on disk. Attackers often delete files from disk after launching a process to mask presence.
+  query: SELECT name, path, pid FROM processes WHERE on_disk = 0;
+  purpose: Incident response
+  tags: hunting, built-in
+  contributors: alphabrevity

--- a/tools/seed/fleet-mobile-reports.yml
+++ b/tools/seed/fleet-mobile-reports.yml
@@ -31,10 +31,10 @@ spec:
 apiVersion: v1
 kind: report
 spec:
-  name: Personal devices - SSH agent keys
+  name: Personal devices - SSH client configuration
   platform: darwin, linux
   fleet: FLEET_NAME
-  description: Lists keys currently loaded in the SSH agent on personal devices.
+  description: Lists SSH client configuration options on personal devices.
   query: SELECT * FROM ssh_configs;
   purpose: Informational
   tags: ssh, inventory

--- a/tools/seed/fleet-mobile-reports.yml
+++ b/tools/seed/fleet-mobile-reports.yml
@@ -1,0 +1,54 @@
+---
+# Reports for the Personal mobile devices fleet (personal laptops)
+#
+# Note: The "fleet" field must match the exact fleet name. The seed script
+# substitutes FLEET_NAME automatically. To apply manually, replace FLEET_NAME
+# with your fleet's exact name.
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed Chrome Extensions
+  platform: darwin, linux, windows
+  fleet: FLEET_NAME
+  description: List installed Chrome Extensions for all users.
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
+  purpose: Informational
+  tags: browser, built-in, inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get applications hogging memory
+  platform: darwin, linux, windows
+  fleet: FLEET_NAME
+  description: Returns top 10 applications or processes hogging memory the most.
+  query: SELECT pid, name, ROUND((total_size * '10e-7'), 2) AS memory_used FROM processes ORDER BY total_size DESC LIMIT 10;
+  purpose: Informational
+  tags: troubleshooting
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get unencrypted SSH keys for local accounts
+  platform: darwin, linux, windows
+  fleet: FLEET_NAME
+  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
+  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;
+  purpose: Informational
+  tags: inventory, compliance, ssh, built-in
+  remediation: First, make the user aware about the impact of SSH keys. Then rotate the unencrypted keys detected.
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get a list of Visual Studio Code extensions
+  platform: darwin, linux, windows
+  fleet: FLEET_NAME
+  description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).
+  query: SELECT u.username, vs.* FROM users u JOIN vscode_extensions vs ON u.uid = vs.uid;
+  purpose: Informational
+  tags: inventory
+  contributors: lucasmrod,sharon-fdm,zwass

--- a/tools/seed/fleet-mobile-reports.yml
+++ b/tools/seed/fleet-mobile-reports.yml
@@ -9,47 +9,43 @@
 apiVersion: v1
 kind: report
 spec:
-  name: Get running docker containers
-  platform: darwin, linux
-  fleet: FLEET_NAME
-  description: Returns the running Docker containers
-  query: SELECT id, name, image, image_id, state, status FROM docker_containers WHERE state = "running";
-  purpose: Informational
-  tags: containers, inventory
-  contributors: DominusKelvin
----
-apiVersion: v1
-kind: report
-spec:
-  name: Get applications that are not in the Applications directory
+  name: Personal devices - Homebrew packages
   platform: darwin
   fleet: FLEET_NAME
-  description: Returns applications that are not in the `/Applications` directory
-  query: SELECT * FROM apps WHERE path NOT LIKE '/Applications/%';
+  description: Lists all Homebrew packages installed on personal macOS devices.
+  query: SELECT name, version, description FROM homebrew_packages;
   purpose: Informational
-  tags: hunting, inventory
-  contributors: DominusKelvin
+  tags: inventory, dev tools
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Discover TLS certificates
-  platform: linux, windows, darwin
+  name: Personal devices - Disk space usage
+  platform: darwin, linux, windows
   fleet: FLEET_NAME
-  description: Retrieves metadata about TLS certificates for servers listening on the local machine. Enables mTLS adoption analysis and cert expiration notifications.
-  query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
+  description: Returns disk usage information for personal devices to identify low storage.
+  query: SELECT path, type, blocks_size, blocks_available, blocks_free, ROUND((blocks_available * 1.0 / blocks_size) * 100, 1) AS percent_free FROM mounts WHERE path = '/' OR path = 'C:\';
   purpose: Informational
-  tags: network, tls
-  contributors: nabilschear
+  tags: inventory, troubleshooting
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get processes that no longer exist on disk
-  platform: linux, darwin, windows
+  name: Personal devices - SSH agent keys
+  platform: darwin, linux
   fleet: FLEET_NAME
-  description: Lists all processes of which the binary which launched them no longer exists on disk. Attackers often delete files from disk after launching a process to mask presence.
-  query: SELECT name, path, pid FROM processes WHERE on_disk = 0;
-  purpose: Incident response
-  tags: hunting, built-in
-  contributors: alphabrevity
+  description: Lists keys currently loaded in the SSH agent on personal devices.
+  query: SELECT * FROM ssh_configs;
+  purpose: Informational
+  tags: ssh, inventory
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Personal devices - Browser extensions by user
+  platform: darwin, linux, windows
+  fleet: FLEET_NAME
+  description: Lists all Chrome and Firefox extensions across all users on personal devices.
+  query: SELECT u.username, 'Chrome' AS browser, ce.name, ce.version FROM users u JOIN chrome_extensions ce ON u.uid = ce.uid UNION ALL SELECT u.username, 'Firefox' AS browser, fa.name, fa.version FROM users u JOIN firefox_addons fa ON u.uid = fa.uid;
+  purpose: Informational
+  tags: browser, inventory

--- a/tools/seed/fleet-workstations-policies.yml
+++ b/tools/seed/fleet-workstations-policies.yml
@@ -8,44 +8,44 @@
 apiVersion: v1
 kind: policy
 spec:
-  name: MDM enrolled (macOS)
-  query: SELECT 1 from mdm WHERE enrolled='true';
-  description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a mac is enrolled to MDM."
-  resolution: "Enroll device to MDM"
+  name: Workstations - Remote login (SSH) disabled
+  query: SELECT 1 FROM sharing_preferences WHERE remote_login_disabled = 1;
+  description: "Checks that remote login (SSH) is disabled on managed macOS workstations."
+  resolution: "Go to System Settings > General > Sharing and turn off Remote Login."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Automatic login disabled (macOS)
-  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'DisableFDEAutoLogin' AND value = 1 LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent login without a password."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables automatic login."
+  name: Workstations - AirDrop disabled
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.applicationaccess' AND name='allowAirDrop' AND value='0' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to disable AirDrop."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables AirDrop."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Guest account disabled (macOS)
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.MCX' AND name='DisableGuestAccount' AND value='1' LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent the use of a guest account."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables the guest account."
+  name: Workstations - Bluetooth sharing disabled
+  query: SELECT 1 FROM sharing_preferences WHERE bluetooth_sharing = 0;
+  description: "Checks that Bluetooth sharing is disabled on managed macOS workstations."
+  resolution: "Go to System Settings > General > Sharing and turn off Bluetooth Sharing."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: iCloud Desktop and Document sync is disabled (macOS)
-  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.icloud.managed' AND name='DisableCloudSync' AND value='1' LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent iCloud Desktop and Documents sync."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile to prevent iCloud Desktop and Documents sync."
+  name: Workstations - Login window shows username and password fields
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.loginwindow' AND name='SHOWFULLNAME' AND value='1' LIMIT 1;
+  description: "Checks that the login window is configured to show username and password fields instead of a list of users."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that configures the login window."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Password requires 10 or more characters (macOS)
-  query: SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);
-  description: "Checks that the password policy requires at least 10 characters. Requires osquery 5.4.0 or newer."
-  resolution: "Contact your IT administrator to make sure your Mac is receiving configuration profiles for password length."
+  name: Workstations - Time Machine encrypted
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM time_machine_destinations WHERE encryption_status != 'Encrypted' AND encryption_status != '');
+  description: "Checks that all Time Machine backup destinations are encrypted. Passes if no Time Machine destinations are configured."
+  resolution: "Enable encryption for your Time Machine backup destination."
   platform: darwin

--- a/tools/seed/fleet-workstations-policies.yml
+++ b/tools/seed/fleet-workstations-policies.yml
@@ -1,0 +1,49 @@
+---
+# Policies for the Workstations fleet (macOS-focused)
+#
+# Usage:
+#   fleetctl apply -f tools/seed/fleet-workstations-policies.yml --policies-fleet "Workstations"
+apiVersion: v1
+kind: policy
+spec:
+  name: Gatekeeper enabled (macOS)
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
+  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
+  resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Full disk encryption enabled (macOS)
+  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
+  description: Checks to make sure that full disk encryption (FileVault) is enabled on macOS devices.
+  resolution: To enable full disk encryption, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: System Integrity Protection enabled (macOS)
+  query: SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;
+  description: Checks to make sure that the System Integrity Protection feature is enabled.
+  resolution: "To enable System Integrity Protection, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall enabled (macOS)
+  query: SELECT 1 FROM alf WHERE global_state >= 1;
+  description: "Checks if the firewall is enabled."
+  resolution: "In System Preferences, open Security & Privacy, navigate to the Firewall tab and click Turn On Firewall."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Screen lock enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE name='askForPassword' AND value='1';
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable screen lock."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables screen lock."
+  platform: darwin

--- a/tools/seed/fleet-workstations-policies.yml
+++ b/tools/seed/fleet-workstations-policies.yml
@@ -1,49 +1,51 @@
 ---
-# Policies for the Workstations fleet (macOS-focused)
+# Policies for the Workstations fleet (managed corporate macOS)
 #
 # Usage:
 #   fleetctl apply -f tools/seed/fleet-workstations-policies.yml --policies-fleet "Workstations"
+#
+# These are unique to this fleet — not duplicates of global policies.
 apiVersion: v1
 kind: policy
 spec:
-  name: Gatekeeper enabled (macOS)
-  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
-  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
-  resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  name: MDM enrolled (macOS)
+  query: SELECT 1 from mdm WHERE enrolled='true';
+  description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a mac is enrolled to MDM."
+  resolution: "Enroll device to MDM"
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Full disk encryption enabled (macOS)
-  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
-  description: Checks to make sure that full disk encryption (FileVault) is enabled on macOS devices.
-  resolution: To enable full disk encryption, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.
+  name: Automatic login disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'DisableFDEAutoLogin' AND value = 1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent login without a password."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables automatic login."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: System Integrity Protection enabled (macOS)
-  query: SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;
-  description: Checks to make sure that the System Integrity Protection feature is enabled.
-  resolution: "To enable System Integrity Protection, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  name: Guest account disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.MCX' AND name='DisableGuestAccount' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent the use of a guest account."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables the guest account."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Firewall enabled (macOS)
-  query: SELECT 1 FROM alf WHERE global_state >= 1;
-  description: "Checks if the firewall is enabled."
-  resolution: "In System Preferences, open Security & Privacy, navigate to the Firewall tab and click Turn On Firewall."
+  name: iCloud Desktop and Document sync is disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.icloud.managed' AND name='DisableCloudSync' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent iCloud Desktop and Documents sync."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile to prevent iCloud Desktop and Documents sync."
   platform: darwin
 ---
 apiVersion: v1
 kind: policy
 spec:
-  name: Screen lock enabled (macOS)
-  query: SELECT 1 FROM managed_policies WHERE name='askForPassword' AND value='1';
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable screen lock."
-  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables screen lock."
+  name: Password requires 10 or more characters (macOS)
+  query: SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);
+  description: "Checks that the password policy requires at least 10 characters. Requires osquery 5.4.0 or newer."
+  resolution: "Contact your IT administrator to make sure your Mac is receiving configuration profiles for password length."
   platform: darwin

--- a/tools/seed/fleet-workstations-reports.yml
+++ b/tools/seed/fleet-workstations-reports.yml
@@ -9,46 +9,43 @@
 apiVersion: v1
 kind: report
 spec:
-  name: Get installed Safari extensions
+  name: Workstations - FileVault status
   platform: darwin
   fleet: FLEET_NAME
-  description: Retrieves the list of installed Safari Extensions for all users in the target system.
-  query: SELECT safari_extensions.* FROM users join safari_extensions USING (uid);
+  description: Returns the FileVault encryption status for each macOS workstation.
+  query: SELECT * FROM disk_encryption;
   purpose: Informational
-  tags: browser, built-in, inventory
-  contributors: zwass
+  tags: compliance, encryption
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get Crowdstrike Falcon network content filter status
+  name: Workstations - MDM enrollment details
   platform: darwin
   fleet: FLEET_NAME
-  description: Get the status of the Crowdstrike Falcon network content filter (as in "System Settings" > "Network > "Filters").
-  query: /* Load up the plist */ WITH extensions_plist AS (SELECT *, rowid FROM plist WHERE path = '/Library/Preferences/com.apple.networkextension.plist') /* Find the first "Enabled" key after the key indicating the crowdstrike app */ SELECT value AS enabled FROM extensions_plist WHERE subkey = 'Enabled' AND rowid > (SELECT rowid FROM extensions_plist WHERE value = 'com.crowdstrike.falcon.App') LIMIT 1;
+  description: Returns MDM enrollment status and server URL for managed macOS workstations.
+  query: SELECT enrolled, server_url, install_date FROM mdm;
   purpose: Informational
-  tags: crowdstrike, plist, network, content filter
-  contributors: zwass
+  tags: mdm, compliance
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Identify Apple development secrets (macOS)
-  fleet: FLEET_NAME
-  query: SELECT * FROM keychain_items WHERE label LIKE '%ABCDEFG%';
-  description: "Identifies certificates associated with Apple development signing and notarization. Replace ABCDEFG with your company's identifier."
-  tags: compliance, inventory, built-in
+  name: Workstations - Gatekeeper configuration
   platform: darwin
-  contributors: GuillaumeRoss
+  fleet: FLEET_NAME
+  description: Returns the current Gatekeeper configuration on macOS workstations.
+  query: SELECT * FROM gatekeeper;
+  purpose: Informational
+  tags: security, compliance
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get local administrator accounts on macOS
+  name: Workstations - Managed configuration profiles
   platform: darwin
   fleet: FLEET_NAME
-  description: The query allows you to check macOS systems for local administrator accounts.
-  query: SELECT uid, username, type FROM users u JOIN groups g ON g.gid = u.gid;
+  description: Lists all managed configuration profiles installed via MDM on macOS workstations.
+  query: SELECT * FROM managed_policies;
   purpose: Informational
-  tags: hunting, inventory
-  contributors: alphabrevity
+  tags: mdm, configuration

--- a/tools/seed/fleet-workstations-reports.yml
+++ b/tools/seed/fleet-workstations-reports.yml
@@ -1,0 +1,53 @@
+---
+# Reports for the Workstations fleet (macOS-focused)
+#
+# Note: The "fleet" field must match the exact fleet name. The seed script
+# substitutes FLEET_NAME automatically. To apply manually, replace FLEET_NAME
+# with your fleet's exact name.
+apiVersion: v1
+kind: report
+spec:
+  name: Detect if Apple Intelligence is enabled
+  platform: darwin
+  fleet: FLEET_NAME
+  description: Detects if Apple Intelligence has been enabled. Value = 1 is on, 0 is off.
+  query: SELECT * FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist';
+  purpose: Informational
+  tags: inventory
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get crashes
+  platform: darwin
+  fleet: FLEET_NAME
+  description: Retrieve application, system, and mobile app crash logs.
+  query: SELECT uid, datetime, responsible, exception_type, identifier, version, crash_path FROM users CROSS JOIN crashes USING (uid);
+  purpose: Informational
+  tags: troubleshooting
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get laptops with failing batteries
+  platform: darwin
+  fleet: FLEET_NAME
+  description: Lists all laptops with under-performing or failing batteries.
+  query: SELECT * FROM battery WHERE health != 'Good' AND condition NOT IN ('', 'Normal');
+  purpose: Informational
+  tags: troubleshooting, hardware, inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed macOS software
+  platform: darwin
+  fleet: FLEET_NAME
+  description: Get all software installed on a macOS computer, including apps, browser plugins, and installed packages.
+  query: SELECT name AS name, bundle_short_version AS version, 'Application (macOS)' AS type, 'apps' AS source FROM apps UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name As name, version AS version, 'Browser plugin (Safari)' AS type, 'safari_extensions' AS source FROM safari_extensions UNION SELECT name AS name, version AS version, 'Package (Homebrew)' AS type, 'homebrew_packages' AS source FROM homebrew_packages;
+  purpose: Informational
+  tags: inventory, built-in
+  contributors: zwass

--- a/tools/seed/fleet-workstations-reports.yml
+++ b/tools/seed/fleet-workstations-reports.yml
@@ -1,53 +1,54 @@
 ---
-# Reports for the Workstations fleet (macOS-focused)
+# Reports for the Workstations fleet (managed corporate macOS)
 #
 # Note: The "fleet" field must match the exact fleet name. The seed script
 # substitutes FLEET_NAME automatically. To apply manually, replace FLEET_NAME
 # with your fleet's exact name.
+#
+# These are unique to this fleet — not duplicates of global reports.
 apiVersion: v1
 kind: report
 spec:
-  name: Detect if Apple Intelligence is enabled
+  name: Get installed Safari extensions
   platform: darwin
   fleet: FLEET_NAME
-  description: Detects if Apple Intelligence has been enabled. Value = 1 is on, 0 is off.
-  query: SELECT * FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist';
+  description: Retrieves the list of installed Safari Extensions for all users in the target system.
+  query: SELECT safari_extensions.* FROM users join safari_extensions USING (uid);
   purpose: Informational
-  tags: inventory
-  contributors: allenhouchins
----
-apiVersion: v1
-kind: report
-spec:
-  name: Get crashes
-  platform: darwin
-  fleet: FLEET_NAME
-  description: Retrieve application, system, and mobile app crash logs.
-  query: SELECT uid, datetime, responsible, exception_type, identifier, version, crash_path FROM users CROSS JOIN crashes USING (uid);
-  purpose: Informational
-  tags: troubleshooting
+  tags: browser, built-in, inventory
   contributors: zwass
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get laptops with failing batteries
+  name: Get Crowdstrike Falcon network content filter status
   platform: darwin
   fleet: FLEET_NAME
-  description: Lists all laptops with under-performing or failing batteries.
-  query: SELECT * FROM battery WHERE health != 'Good' AND condition NOT IN ('', 'Normal');
+  description: Get the status of the Crowdstrike Falcon network content filter (as in "System Settings" > "Network > "Filters").
+  query: /* Load up the plist */ WITH extensions_plist AS (SELECT *, rowid FROM plist WHERE path = '/Library/Preferences/com.apple.networkextension.plist') /* Find the first "Enabled" key after the key indicating the crowdstrike app */ SELECT value AS enabled FROM extensions_plist WHERE subkey = 'Enabled' AND rowid > (SELECT rowid FROM extensions_plist WHERE value = 'com.crowdstrike.falcon.App') LIMIT 1;
   purpose: Informational
-  tags: troubleshooting, hardware, inventory
+  tags: crowdstrike, plist, network, content filter
   contributors: zwass
 ---
 apiVersion: v1
 kind: report
 spec:
-  name: Get installed macOS software
+  name: Identify Apple development secrets (macOS)
+  fleet: FLEET_NAME
+  query: SELECT * FROM keychain_items WHERE label LIKE '%ABCDEFG%';
+  description: "Identifies certificates associated with Apple development signing and notarization. Replace ABCDEFG with your company's identifier."
+  tags: compliance, inventory, built-in
+  platform: darwin
+  contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get local administrator accounts on macOS
   platform: darwin
   fleet: FLEET_NAME
-  description: Get all software installed on a macOS computer, including apps, browser plugins, and installed packages.
-  query: SELECT name AS name, bundle_short_version AS version, 'Application (macOS)' AS type, 'apps' AS source FROM apps UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name As name, version AS version, 'Browser plugin (Safari)' AS type, 'safari_extensions' AS source FROM safari_extensions UNION SELECT name AS name, version AS version, 'Package (Homebrew)' AS type, 'homebrew_packages' AS source FROM homebrew_packages;
+  description: The query allows you to check macOS systems for local administrator accounts.
+  query: SELECT uid, username, type FROM users u JOIN groups g ON g.gid = u.gid;
   purpose: Informational
-  tags: inventory, built-in
-  contributors: zwass
+  tags: hunting, inventory
+  contributors: alphabrevity

--- a/tools/seed/seed-users-and-fleets.sh
+++ b/tools/seed/seed-users-and-fleets.sh
@@ -1,37 +1,29 @@
 #!/bin/bash
 
-# Seed users for local development
-#
-# Creates 11 users with various roles across the Workstations and
-# Personal mobile devices fleets. Creates the fleets if they don't
-# already exist, and discovers fleet IDs automatically.
-#
-# Prerequisites:
-#   1. Create an env file with:
-#        export SERVER_URL=https://localhost:8080
-#        export CURL_FLAGS='-k -s'
-#        export TOKEN=<your-api-token>
-#        export SEED_PASSWORD=<your-password>
-#
-#   2. Set FLEET_ENV_PATH to point to your env file:
-#        export FLEET_ENV_PATH=tools/seed/DO_NOT_COMMIT_ENV_FILE
-#
-#   3. Run this script:
-#        bash tools/seed/seed-users-and-fleets.sh
-#
-# All users are created with the password from $SEED_PASSWORD.
+# Seed users, fleets, policies, and reports for local development.
+# See tools/seed/README.md for full documentation.
 
-set -e
+set -euo pipefail
 
 source "$FLEET_ENV_PATH"
 
 API="$SERVER_URL/api/latest/fleet"
 AUTH="Authorization: Bearer $TOKEN"
 
-if [ -z "$SEED_PASSWORD" ]; then
-  echo "ERROR: SEED_PASSWORD is not set. Add it to your env file." >&2
+# Validate required env vars
+missing=""
+[ -z "${SEED_PASSWORD:-}" ] && missing="$missing SEED_PASSWORD"
+[ -z "${TOKEN:-}" ] && missing="$missing TOKEN"
+[ -z "${SERVER_URL:-}" ] && missing="$missing SERVER_URL"
+if [ -n "$missing" ]; then
+  echo "ERROR: Missing required env vars:$missing. Check your env file." >&2
   exit 1
 fi
+
+# Configure fleetctl with the same token so apply commands work without a separate login
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEETCTL="${FLEETCTL:-./build/fleetctl}"
+$FLEETCTL config set --address "$SERVER_URL" --token "$TOKEN" 2>/dev/null
 
 # Helper: get fleet ID and exact name by partial match (to handle emoji prefixes),
 # creating the fleet if it doesn't exist. Returns "id|exact_name".
@@ -66,6 +58,8 @@ else:
 }
 
 # Helper: create user via /users/admin (ignores errors if user already exists)
+# Sets LAST_USER_CREATED=1 if created, 0 if skipped.
+LAST_USER_CREATED=0
 create_user() {
   local data="$1"
   local name email
@@ -75,13 +69,16 @@ create_user() {
   result=$(curl -X POST $CURL_FLAGS -H "$AUTH" -H "Content-Type: application/json" "$API/users/admin" --insecure -d "$data" 2>&1)
   if echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'user' in d else 1)" 2>/dev/null; then
     echo "Created user: $name ($email, pw: \$SEED_PASSWORD)"
+    LAST_USER_CREATED=1
   else
     echo "Skipped user (may already exist): $name"
+    LAST_USER_CREATED=0
   fi
 }
 
 # Helper: create API-only user via /users/api_only (email and password are auto-generated,
 # API token is returned in the response)
+# Sets LAST_USER_CREATED=1 if created, 0 if skipped.
 create_api_only_user() {
   local data="$1"
   local name
@@ -92,6 +89,7 @@ create_api_only_user() {
   token=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('token',''))" 2>/dev/null)
   if echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'user' in d else 1)" 2>/dev/null; then
     echo "Created API-only user: $name"
+    LAST_USER_CREATED=1
     if [ -n "$token" ]; then
       echo ""
       echo "  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
@@ -101,6 +99,7 @@ create_api_only_user() {
       echo ""
     fi
   else
+    LAST_USER_CREATED=0
     local errmsg
     errmsg=$(echo "$result" | python3 -c "
 import sys, json
@@ -166,6 +165,16 @@ create_user '{
   "admin_forced_password_reset": false
 }'
 
+# Global technician
+create_user '{
+  "name": "Tessa G. Technician",
+  "email": "tessa@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "technician",
+  "admin_forced_password_reset": false
+}'
+
 # Mixed roles (observer on Workstations, maintainer on Mobile devices)
 create_user "{
   \"name\": \"Marco Mixed Roles\",
@@ -226,15 +235,15 @@ create_user "{
 
 # API-only user (full access, created via /users/admin with api_only flag)
 create_user '{
-  "name": "Robbie Robot (API only)",
-  "email": "robbie@organization.com",
+  "name": "Apollo G. API-only",
+  "email": "apollo@organization.com",
   "password": "'"$SEED_PASSWORD"'",
   "invited_by": 1,
   "global_role": "maintainer",
   "api_only": true,
   "admin_forced_password_reset": false
 }'
-echo "  ^ API-only user — use fleetctl login or API token auth only, no UI access"
+[ "$LAST_USER_CREATED" -eq 1 ] && echo "  ^ API-only user — use fleetctl login or API token auth only, no UI access"
 
 # API-only user with restricted endpoints (created via /users/api_only)
 create_api_only_user '{
@@ -245,12 +254,10 @@ create_api_only_user '{
     {"method": "GET", "path": "/api/v1/fleet/hosts/{id}"}
   ]
 }'
-echo "  ^ Restricted API-only user — token auth only, no fleetctl or UI access"
+[ "$LAST_USER_CREATED" -eq 1 ] && echo "  ^ Restricted API-only user — token auth only, no fleetctl or UI access"
 
 echo ""
 echo "==> Applying global policies and reports..."
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FLEETCTL="${FLEETCTL:-./build/fleetctl}"
 
 $FLEETCTL apply -f "$SCRIPT_DIR/standard-policies.yml"
 echo "[+] applied global policies"
@@ -282,4 +289,4 @@ $FLEETCTL apply -f "$tmpdir/mobile-reports.yml"
 echo "[+] applied $FLEET_2_NAME reports"
 
 echo ""
-echo "==> Done! 11 users, fleet policies, and fleet reports seeded across Workstations and Personal mobile devices fleets."
+echo "==> Done! All users, policies, and reports seeded."

--- a/tools/seed/seed-users-and-fleets.sh
+++ b/tools/seed/seed-users-and-fleets.sh
@@ -27,6 +27,8 @@ $FLEETCTL config set --address "$SERVER_URL" --token "$TOKEN" 2>/dev/null
 
 # Helper: get fleet ID and exact name by partial match (to handle emoji prefixes),
 # creating the fleet if it doesn't exist. Returns "id|exact_name".
+# SECURITY: $name is interpolated into inline Python. Only pass hardcoded strings,
+# never user input, to avoid code injection.
 get_fleet_id() {
   local name="$1"
   local result
@@ -233,9 +235,41 @@ create_user "{
   \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"observer_plus\"}]
 }"
 
+# Fleet technician (Workstations)
+create_user "{
+  \"name\": \"Terry T. Technician\",
+  \"email\": \"terry@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"technician\"}]
+}"
+
+# Global GitOps
+create_user '{
+  "name": "Gina G. GitOps",
+  "email": "gina@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "gitops",
+  "admin_forced_password_reset": false
+}'
+
+# Fleet GitOps (Workstations)
+create_user "{
+  \"name\": \"Gordon T. GitOps\",
+  \"email\": \"gordon@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"gitops\"}]
+}"
+
 # API-only user (full access, created via /users/admin with api_only flag)
 create_user '{
-  "name": "Apollo G. API-only",
+  "name": "Apollo G. API-only (full access)",
   "email": "apollo@organization.com",
   "password": "'"$SEED_PASSWORD"'",
   "invited_by": 1,
@@ -247,7 +281,7 @@ create_user '{
 
 # API-only user with restricted endpoints (created via /users/api_only)
 create_api_only_user '{
-  "name": "Rosie Restricted (API only)",
+  "name": "Reggie G. API-only (restricted)",
   "global_role": "admin",
   "api_endpoints": [
     {"method": "GET", "path": "/api/v1/fleet/hosts"},
@@ -280,11 +314,11 @@ echo "==> Applying fleet-scoped reports..."
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-sed "s/fleet: FLEET_NAME/fleet: $FLEET_1_NAME/" "$SCRIPT_DIR/fleet-workstations-reports.yml" > "$tmpdir/workstations-reports.yml"
+sed "s|fleet: FLEET_NAME|fleet: $FLEET_1_NAME|" "$SCRIPT_DIR/fleet-workstations-reports.yml" > "$tmpdir/workstations-reports.yml"
 $FLEETCTL apply -f "$tmpdir/workstations-reports.yml"
 echo "[+] applied $FLEET_1_NAME reports"
 
-sed "s/fleet: FLEET_NAME/fleet: $FLEET_2_NAME/" "$SCRIPT_DIR/fleet-mobile-reports.yml" > "$tmpdir/mobile-reports.yml"
+sed "s|fleet: FLEET_NAME|fleet: $FLEET_2_NAME|" "$SCRIPT_DIR/fleet-mobile-reports.yml" > "$tmpdir/mobile-reports.yml"
 $FLEETCTL apply -f "$tmpdir/mobile-reports.yml"
 echo "[+] applied $FLEET_2_NAME reports"
 

--- a/tools/seed/seed-users-and-fleets.sh
+++ b/tools/seed/seed-users-and-fleets.sh
@@ -1,0 +1,285 @@
+#!/bin/bash
+
+# Seed users for local development
+#
+# Creates 11 users with various roles across the Workstations and
+# Personal mobile devices fleets. Creates the fleets if they don't
+# already exist, and discovers fleet IDs automatically.
+#
+# Prerequisites:
+#   1. Create an env file with:
+#        export SERVER_URL=https://localhost:8080
+#        export CURL_FLAGS='-k -s'
+#        export TOKEN=<your-api-token>
+#        export SEED_PASSWORD=<your-password>
+#
+#   2. Set FLEET_ENV_PATH to point to your env file:
+#        export FLEET_ENV_PATH=tools/seed/DO_NOT_COMMIT_ENV_FILE
+#
+#   3. Run this script:
+#        bash tools/seed/seed-users-and-fleets.sh
+#
+# All users are created with the password from $SEED_PASSWORD.
+
+set -e
+
+source "$FLEET_ENV_PATH"
+
+API="$SERVER_URL/api/latest/fleet"
+AUTH="Authorization: Bearer $TOKEN"
+
+if [ -z "$SEED_PASSWORD" ]; then
+  echo "ERROR: SEED_PASSWORD is not set. Add it to your env file." >&2
+  exit 1
+fi
+
+# Helper: get fleet ID and exact name by partial match (to handle emoji prefixes),
+# creating the fleet if it doesn't exist. Returns "id|exact_name".
+get_fleet_id() {
+  local name="$1"
+  local result
+  result=$(curl $CURL_FLAGS -H "$AUTH" "$API/teams" --insecure \
+    | python3 -c "
+import sys, json
+teams = json.load(sys.stdin).get('teams', [])
+matches = [(t['id'], t['name']) for t in teams if '$name'.lower() in t['name'].lower()]
+if matches:
+    print(f'{matches[0][0]}|{matches[0][1]}')
+else:
+    print('')
+" 2>/dev/null)
+
+  if [ -z "$result" ]; then
+    echo "Fleet '$name' not found, creating it..." >&2
+    result=$(curl -X POST $CURL_FLAGS -H "$AUTH" -H "Content-Type: application/json" \
+      "$API/teams" --insecure -d "{\"name\": \"$name\"}" \
+      | python3 -c "import sys,json; t=json.load(sys.stdin)['team']; print(f\"{t['id']}|{t['name']}\")" 2>/dev/null)
+    if [ -z "$result" ]; then
+      echo "ERROR: Failed to create fleet '$name'. Is your dev server running with a premium license?" >&2
+      exit 1
+    fi
+    echo "Created fleet '${result#*|}' (ID: ${result%%|*})" >&2
+  else
+    echo "Found fleet '${result#*|}' (ID: ${result%%|*})" >&2
+  fi
+  echo "$result"
+}
+
+# Helper: create user via /users/admin (ignores errors if user already exists)
+create_user() {
+  local data="$1"
+  local name email
+  name=$(echo "$data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['name'])")
+  email=$(echo "$data" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('email',''))")
+  local result
+  result=$(curl -X POST $CURL_FLAGS -H "$AUTH" -H "Content-Type: application/json" "$API/users/admin" --insecure -d "$data" 2>&1)
+  if echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'user' in d else 1)" 2>/dev/null; then
+    echo "Created user: $name ($email, pw: \$SEED_PASSWORD)"
+  else
+    echo "Skipped user (may already exist): $name"
+  fi
+}
+
+# Helper: create API-only user via /users/api_only (email and password are auto-generated,
+# API token is returned in the response)
+create_api_only_user() {
+  local data="$1"
+  local name
+  name=$(echo "$data" | python3 -c "import sys,json; print(json.load(sys.stdin)['name'])")
+  local result
+  result=$(curl -X POST $CURL_FLAGS -H "$AUTH" -H "Content-Type: application/json" "$API/users/api_only" --insecure -d "$data" 2>&1)
+  local token
+  token=$(echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('token',''))" 2>/dev/null)
+  if echo "$result" | python3 -c "import sys,json; d=json.load(sys.stdin); sys.exit(0 if 'user' in d else 1)" 2>/dev/null; then
+    echo "Created API-only user: $name"
+    if [ -n "$token" ]; then
+      echo ""
+      echo "  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓"
+      echo "  ┃    SAVE THIS TOKEN — IT IS ONLY SHOWN ONCE!    ┃"
+      echo "  ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛"
+      echo "  API token: $token"
+      echo ""
+    fi
+  else
+    local errmsg
+    errmsg=$(echo "$result" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+msg = d.get('message', '')
+errors = d.get('errors', [])
+details = '; '.join(e.get('name','') + ': ' + e.get('reason','') for e in errors if e.get('reason'))
+print(details if details else msg if msg else 'unknown error')
+" 2>/dev/null)
+    echo "Skipped API-only user: $name — $errmsg"
+  fi
+}
+
+echo "==> Finding fleets..."
+FLEET_1_RESULT=$(get_fleet_id "Workstations")
+FLEET_1_ID="${FLEET_1_RESULT%%|*}"
+FLEET_1_NAME="${FLEET_1_RESULT#*|}"
+
+FLEET_2_RESULT=$(get_fleet_id "mobile devices")
+FLEET_2_ID="${FLEET_2_RESULT%%|*}"
+FLEET_2_NAME="${FLEET_2_RESULT#*|}"
+
+echo ""
+echo "==> Creating users..."
+
+# Global admin
+create_user '{
+  "name": "Anna G. Admin",
+  "email": "anna@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "admin",
+  "admin_forced_password_reset": false
+}'
+
+# Global maintainer
+create_user '{
+  "name": "Mary G. Maintainer",
+  "email": "mary@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "maintainer",
+  "admin_forced_password_reset": false
+}'
+
+# Global observer
+create_user '{
+  "name": "Oliver G. Observer",
+  "email": "oliver@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "observer",
+  "admin_forced_password_reset": false
+}'
+
+# Global observer+
+create_user '{
+  "name": "Opal G. Observer+",
+  "email": "opal@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "observer_plus",
+  "admin_forced_password_reset": false
+}'
+
+# Mixed roles (observer on Workstations, maintainer on Mobile devices)
+create_user "{
+  \"name\": \"Marco Mixed Roles\",
+  \"email\": \"marco@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [
+    {\"id\": $FLEET_1_ID, \"role\": \"observer\"},
+    {\"id\": $FLEET_2_ID, \"role\": \"maintainer\"}
+  ]
+}"
+
+# Fleet admin (Workstations)
+create_user "{
+  \"name\": \"Anita T. Admin\",
+  \"email\": \"anita@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"admin\"}]
+}"
+
+# Fleet maintainer (Workstations)
+create_user "{
+  \"name\": \"Manny T. Maintainer\",
+  \"email\": \"manny@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"maintainer\"}]
+}"
+
+# Fleet observer (Workstations)
+create_user "{
+  \"name\": \"Toni T. Observer\",
+  \"email\": \"toni@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"observer\"}]
+}"
+
+# Fleet observer+ (Workstations)
+create_user "{
+  \"name\": \"Topanga T. Observer+\",
+  \"email\": \"topanga@organization.com\",
+  \"password\": \"$SEED_PASSWORD\",
+  \"invited_by\": 1,
+  \"global_role\": null,
+  \"admin_forced_password_reset\": false,
+  \"teams\": [{\"id\": $FLEET_1_ID, \"role\": \"observer_plus\"}]
+}"
+
+# API-only user (full access, created via /users/admin with api_only flag)
+create_user '{
+  "name": "Robbie Robot (API only)",
+  "email": "robbie@organization.com",
+  "password": "'"$SEED_PASSWORD"'",
+  "invited_by": 1,
+  "global_role": "maintainer",
+  "api_only": true,
+  "admin_forced_password_reset": false
+}'
+echo "  ^ API-only user — use fleetctl login or API token auth only, no UI access"
+
+# API-only user with restricted endpoints (created via /users/api_only)
+create_api_only_user '{
+  "name": "Rosie Restricted (API only)",
+  "global_role": "admin",
+  "api_endpoints": [
+    {"method": "GET", "path": "/api/v1/fleet/hosts"},
+    {"method": "GET", "path": "/api/v1/fleet/hosts/{id}"}
+  ]
+}'
+echo "  ^ Restricted API-only user — token auth only, no fleetctl or UI access"
+
+echo ""
+echo "==> Applying global policies and reports..."
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FLEETCTL="${FLEETCTL:-./build/fleetctl}"
+
+$FLEETCTL apply -f "$SCRIPT_DIR/standard-policies.yml"
+echo "[+] applied global policies"
+
+$FLEETCTL apply -f "$SCRIPT_DIR/standard-reports.yml"
+echo "[+] applied global reports"
+
+echo ""
+echo "==> Applying fleet-scoped policies..."
+
+$FLEETCTL apply -f "$SCRIPT_DIR/fleet-workstations-policies.yml" --policies-fleet "$FLEET_1_NAME"
+echo "[+] applied $FLEET_1_NAME policies"
+
+$FLEETCTL apply -f "$SCRIPT_DIR/fleet-mobile-policies.yml" --policies-fleet "$FLEET_2_NAME"
+echo "[+] applied $FLEET_2_NAME policies"
+
+echo ""
+echo "==> Applying fleet-scoped reports..."
+# Reports need the exact fleet name in the YAML, so we substitute the discovered names.
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+sed "s/fleet: FLEET_NAME/fleet: $FLEET_1_NAME/" "$SCRIPT_DIR/fleet-workstations-reports.yml" > "$tmpdir/workstations-reports.yml"
+$FLEETCTL apply -f "$tmpdir/workstations-reports.yml"
+echo "[+] applied $FLEET_1_NAME reports"
+
+sed "s/fleet: FLEET_NAME/fleet: $FLEET_2_NAME/" "$SCRIPT_DIR/fleet-mobile-reports.yml" > "$tmpdir/mobile-reports.yml"
+$FLEETCTL apply -f "$tmpdir/mobile-reports.yml"
+echo "[+] applied $FLEET_2_NAME reports"
+
+echo ""
+echo "==> Done! 11 users, fleet policies, and fleet reports seeded across Workstations and Personal mobile devices fleets."

--- a/tools/seed/standard-policies.yml
+++ b/tools/seed/standard-policies.yml
@@ -1,0 +1,382 @@
+---
+# Standard policies for local development
+#
+# Usage:
+#   fleetctl apply -f tools/seed/standard-policies.yml
+#
+# These policies are extracted from docs/01-Using-Fleet/standard-query-library/standard-query-library.yml
+# for use in dev environments. They are not used in production.
+apiVersion: v1
+kind: policy
+spec:
+  name: Get Ubuntu Advantage (Ubuntu Pro) attachment status
+  platform: linux
+  description: Checks to see if the Ubuntu Pro status file exists, and ensures attachment and expiry are as expected. Combine with a script automation to run the attach command for remediation.
+  query: SELECT 1 FROM parse_json WHERE path = '/var/lib/ubuntu-advantage/status.json' AND ((key = 'attached' AND value = 'true') OR (key = 'expires' AND datetime(value) > datetime('now'))) GROUP BY path HAVING SUM(CASE WHEN key = 'attached' AND value = 'true' THEN 1 ELSE 0 END) = 1 AND SUM(CASE WHEN key = 'expires' AND datetime(value) > datetime('now') THEN 1 ELSE 0 END) = 1;
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Gatekeeper enabled (macOS)
+  query: SELECT 1 FROM gatekeeper WHERE assessments_enabled = 1;
+  description: Checks to make sure that the Gatekeeper feature is enabled on macOS devices. Gatekeeper tries to ensure only trusted software is run on a mac machine.
+  resolution: "To enable Gatekeeper, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Full disk encryption enabled (Windows)
+  query: SELECT 1 FROM bitlocker_info WHERE drive_letter='C:' AND protection_status=1;
+  description: Checks to make sure that full disk encryption is enabled on Windows devices.
+  resolution:
+    "To get additional information, run the following osquery query on the failing device: SELECT * FROM bitlocker_info. In the
+    query results, if protection_status is 2, then the status cannot be determined. If it is 0, it is
+    considered unprotected. Use the additional results (percent_encrypted, conversion_status, etc.) to
+    help narrow down the specific reason why Windows considers the volume unprotected."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Full disk encryption enabled (macOS)
+  query: SELECT 1 FROM disk_encryption WHERE user_uuid IS NOT "" AND filevault_status = 'on' LIMIT 1;
+  description: Checks to make sure that full disk encryption (FileVault) is enabled on macOS devices.
+  resolution: To enable full disk encryption, on the failing device, select System Preferences > Security & Privacy > FileVault > Turn On FileVault.
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Full disk encryption enabled (Linux)
+  query: SELECT 1 FROM mounts m, disk_encryption d WHERE m.device_alias = d.name AND d.encrypted = 1 AND m.path = '/';
+  description: Checks if the root drive is encrypted. There are many ways to encrypt Linux systems. This is the default on distributions such as Ubuntu.
+  resolution: "Ensure the image deployed to your Linux workstation includes full disk encryption."
+  platform: linux
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: System Integrity Protection enabled (macOS)
+  query: SELECT 1 FROM sip_config WHERE config_flag = 'sip' AND enabled = 1;
+  description: Checks to make sure that the System Integrity Protection feature is enabled.
+  resolution: "To enable System Integrity Protection, on the failing device, run the following command in the Terminal app: /usr/sbin/spctl --master-enable."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic login disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.loginwindow' AND name = 'DisableFDEAutoLogin' AND value = 1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent login in without a password. Note: This policy will not report a value if FileVault is disabled."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables automatic login."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Secure keyboard entry for Terminal application enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to enabled secure keyboard entry for the Terminal application."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables secure keyboard entry for the Terminal application."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Antivirus healthy (macOS)
+  query: SELECT score FROM (SELECT case when COUNT(*) = 2 then 1 ELSE 0 END AS score FROM plist WHERE (key = 'CFBundleShortVersionString' AND path = '/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/Info.plist' AND value>=2162) OR (key = 'CFBundleShortVersionString' AND path = '/Library/Apple/System/Library/CoreServices/MRT.app/Contents/Info.plist' and value>=1.93)) WHERE score == 1;
+  description: Checks the version of Malware Removal Tool (MRT) and the built-in macOS AV (Xprotect). Replace version numbers with the latest version regularly.
+  resolution:
+    To enable automatic security definition updates, on the failing device, select System
+    Preferences > Software Update > Advanced > Turn on Install system data files and security
+    updates.
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Antivirus healthy (Windows)
+  query: SELECT 1 from windows_security_center wsc CROSS JOIN windows_security_products wsp WHERE antivirus = 'Good' AND type = 'Antivirus' AND signatures_up_to_date=1;
+  description: Checks the status of antivirus and signature updates from the Windows Security Center.
+  resolution: "Ensure Windows Defender or your third-party antivirus is running, up to date, and visible in the Windows Security Center."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Antivirus healthy (Linux)
+  query: SELECT score FROM (SELECT case when COUNT(*) = 2 then 1 ELSE 0 END AS score FROM processes WHERE (name = 'clamd') OR (name = 'freshclam')) WHERE score == 1;
+  description: Checks that both ClamAV's daemon and its updater service (freshclam) are running.
+  resolution: "Ensure ClamAV and Freshclam are installed and running."
+  platform: linux
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: MDM enrolled (macOS)
+  query: SELECT 1 from mdm WHERE enrolled='true';
+  description: "Required: osquery deployed with Orbit, or manual installation of macadmins/osquery-extension. Checks that a mac is enrolled to MDM. Add a AND on identity_certificate_uuid to check for a specific MDM."
+  resolution: "Enroll device to MDM"
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Docker application is up to date or not present (macOS)
+  query: SELECT 1 WHERE EXISTS (SELECT 1 FROM apps a1 WHERE a1.bundle_identifier = 'com.electron.dockerdesktop' AND a1.bundle_short_version>='4.6.1') OR NOT EXISTS (SELECT 1 FROM apps a2 WHERE a2.bundle_identifier = 'com.electron.dockerdesktop');
+  description: "Checks if the application (Docker Desktop example) is installed and up to date, or not installed. Fails if the application is installed and on a lower version. You can copy this query and replace the bundle_identifier and bundle_version values to apply the same type of policy to other applications."
+  resolution: "Update Docker or remove it if not used."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: SSH keys encrypted
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM users CROSS JOIN user_ssh_keys USING (uid) WHERE encrypted='0');
+  description: "Required: osquery must have Full Disk Access. Policy passes if all keys are encrypted, including if no keys are present."
+  resolution: "Use this command to encrypt existing SSH keys by providing the path to the file: ssh-keygen -o -p -f /path/to/file"
+  platform: darwin,linux,windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Suspicious autostart (Windows)
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM startup_items WHERE path = "regsvr32" AND args LIKE "%http%");
+  description: "Checks for an autostart that is attempting to load a dynamic link library (DLL) from the internet."
+  resolution: "Remove the suspicious startup entry."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall enabled (macOS)
+  query: SELECT 1 FROM alf WHERE global_state >= 1;
+  description: "Checks if the firewall is enabled."
+  resolution: "In System Preferences, open Security & Privacy, navigate to the Firewall tab and click Turn On Firewall."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Screen lock enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE name='askForPassword' AND value='1';
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable screen lock."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables screen lock."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Screen lock enabled (Windows)
+  query: SELECT 1 FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\System\InactivityTimeoutSecs' AND CAST(data as INTEGER) <= 1800;
+  description: "Checks if the screen lock is enabled and configured to lock the system within 30 minutes or less."
+  resolution: "Contact your IT administrator to enable the Interactive Logon: Machine inactivity limit setting with a value of 1800 seconds or lower."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Password requires 10 or more characters (macOS)
+  query: SELECT 1 FROM (SELECT cast(lengthtxt as integer(2)) minlength FROM (SELECT SUBSTRING(length, 1, 2) AS lengthtxt FROM (SELECT policy_description, policy_identifier, split(policy_content, '{', 1) AS length FROM password_policy WHERE policy_identifier LIKE '%minLength')) WHERE minlength >= 10);
+  description: "Checks that the password policy requires at least 10 characters. Requires osquery 5.4.0 or newer."
+  resolution: "Contact your IT administrator to make sure your Mac is receiving configuration profiles for password length."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Operating system up to date (macOS)
+  query: SELECT 1 FROM os_version WHERE version >= '14.1.1';
+  description: "Checks that the operating system is up to date."
+  resolution: "From the Apple menu () in the corner of your screen choose System Preferences. Then select Software Update and select Upgrade Now. You might be asked to restart or enter your password."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic updates enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND name='AutomaticCheckEnabled' AND value=1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to automatically check for updates."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables automatic updates."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic update downloads enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND name='AutomaticDownload' AND value=1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to automatically download updates."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables automatic update downloads."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic installation of application updates is enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND name='AutomaticallyInstallAppUpdates' AND value=1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to automatically install updates to App Store applications."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables automatic installation of application updates."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic security and data file updates is enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND name='CriticalUpdateInstall' AND value=1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to automatically download updates to built-in macOS security tools such as malware removal tools."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables automatic security and data update installation."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic installation of operating system updates is enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.SoftwareUpdate' AND name='AutomaticallyInstallMacOSUpdates' AND value=1 LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to automatically install operating system updates."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables automatic installation of operating system updates."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Lock screen after inactivity of 20 minutes or less (macOS)
+  query: SELECT 1 WHERE EXISTS (SELECT CAST(value as integer(4)) valueint from managed_policies WHERE domain = 'com.apple.screensaver' AND name = 'askForPasswordDelay' AND valueint <= 60 LIMIT 1) AND EXISTS (SELECT CAST(value as integer(4)) valueint from managed_policies WHERE domain = 'com.apple.screensaver' AND name = 'idleTime' AND valueint <= 1140 LIMIT 1) AND EXISTS (SELECT 1 from managed_policies WHERE domain='com.apple.screensaver' AND name='askForPassword' AND value=1 LIMIT 1);
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to lock the screen after 20 minutes or less."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables the screen saver after inactivity of 20 minutes or less."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Internet sharing is blocked (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.MCX' AND name='forceInternetSharingOff' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent Internet sharing."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that prevents Internet sharing."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Content caching is disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.applicationaccess' AND name='allowContentCaching' AND value='0' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to disable content caching."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables content caching."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Ad tracking is limited (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.AdLib' AND name='forceLimitAdTracking' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to limit advertisement tracking."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables advertisement tracking."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: iCloud Desktop and Document sync is disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.icloud.managed' AND name='DisableCloudSync' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent iCloud Desktop and Documents sync."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile to prevent iCloud Desktop and Documents sync."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall logging is enabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.security.firewall' AND name='EnableLogging' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to log firewall activity."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables firewall logging."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Guest account disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.MCX' AND name='DisableGuestAccount' AND value='1' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent the use of a guest account."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that disables the guest account."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Guest access to shared folders is disabled (macOS)
+  query: SELECT 1 FROM managed_policies WHERE domain='com.apple.AppleFileServer' AND name='guestAccess' AND value='0' LIMIT 1;
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to prevent guest access to shared folders."
+  resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that prevents guest access to shared folders."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: No 1Password emergency kit stored in desktop, documents, or downloads folders (macOS)
+  query: SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM file WHERE filename LIKE '%Emergency Kit%.pdf' AND (path LIKE '/Users/%/Desktop/%' OR path LIKE '/Users/%/Documents/%' OR path LIKE '/Users/%/Downloads/%' OR path LIKE '/Users/Shared/%'));
+  description: "Looks for PDF files with file names typically used by 1Password for emergency recovery kits. To protect the performance of your devices, the search is one level deep and limited to the Desktop, Documents, Downloads, and Shared folders."
+  resolution: "Delete 1Password emergency kits from your computer, and empty the trash. 1Password emergency kits should only be printed and stored in a physically secure location."
+  platform: darwin
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall enabled, domain profile (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\DomainProfile\EnableFirewall' AND CAST(data as integer) = 1;
+  description: "Checks if a Group Policy configures the computer to enable the domain profile for Windows Firewall. The domain profile applies to networks where the host system can authenticate to a domain controller. Some auditors requires that this setting is configured by a Group Policy."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that enables the domain profile for Windows Firewall."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall enabled, private profile (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PrivateProfile\EnableFirewall' AND CAST(data as integer) = 1;
+  description: "Checks if a Group Policy configures the computer to enable the private profile for Windows Firewall. The private profile applies to networks where the host system is connected to a private or home network. Some auditors requires that this setting is configured by a Group Policy."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that enables the private profile for Windows Firewall."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Firewall enabled, public profile (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\WindowsFirewall\PublicProfile\EnableFirewall' AND CAST(data as integer) = 1;
+  description: "Checks if a Group Policy configures the computer to enable the public profile for Windows Firewall. The public profile applies to networks where the host system is connected to public networks such as Wi-Fi hotspots at coffee shops and airports. Some auditors requires that this setting is configured by a Group Policy."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that enables the public profile for Windows Firewall."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: SMBv1 client driver disabled (Windows)
+  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Client' AND state != 1;
+  description: "Checks that the SMBv1 client is disabled."
+  resolution: "Contact your IT administrator to discuss disabling SMBv1 on your system."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: SMBv1 server disabled (Windows)
+  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Server' AND state != 1
+  description: "Checks that the SMBv1 server is disabled."
+  resolution: "Contact your IT administrator to discuss disabling SMBv1 on your system."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Link-Local Multicast Name Resolution (LLMNR) disabled (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows NT\DNSClient\EnableMulticast' AND CAST(data as integer) = 0;
+  description: "Checks if a Group Policy configures the computer to disable LLMNR. Disabling LLMNR can prevent malicious actors from gaining access to the computer's credentials. Some auditors require that this setting is configured by a Group Policy."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group Policy that disables LLMNR on your system."
+  platform: windows
+---
+apiVersion: v1
+kind: policy
+spec:
+  name: Automatic updates enabled (Windows)
+  query: SELECT 1 FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\Software\Policies\Microsoft\Windows\WindowsUpdate\AU\NoAutoUpdate' AND CAST(data as integer) = 0;
+  description: "Checks if a Group Policy configures the computer to enable Automatic Updates. When enabled, the computer downloads and installs security and other important updates automatically. Some auditors require that this setting is configured by a Group Policy."
+  resolution: "Contact your IT administrator to ensure your computer is receiving a Group policy that enables Automatic Updates."
+  platform: windows

--- a/tools/seed/standard-policies.yml
+++ b/tools/seed/standard-policies.yml
@@ -77,7 +77,7 @@ kind: policy
 spec:
   name: Secure keyboard entry for Terminal application enabled (macOS)
   query: SELECT 1 FROM managed_policies WHERE domain = 'com.apple.Terminal' AND name = 'SecureKeyboardEntry' AND value = 1 LIMIT 1;
-  description: "Checks that a mobile device management (MDM) solution configures the Mac to enabled secure keyboard entry for the Terminal application."
+  description: "Checks that a mobile device management (MDM) solution configures the Mac to enable secure keyboard entry for the Terminal application."
   resolution: "Contact your IT administrator to ensure your Mac is receiving a profile that enables secure keyboard entry for the Terminal application."
   platform: darwin
 ---
@@ -358,7 +358,7 @@ apiVersion: v1
 kind: policy
 spec:
   name: SMBv1 server disabled (Windows)
-  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Server' AND state != 1
+  query: SELECT 1 FROM windows_optional_features WHERE name = 'SMB1Protocol-Server' AND state != 1;
   description: "Checks that the SMBv1 server is disabled."
   resolution: "Contact your IT administrator to discuss disabling SMBv1 on your system."
   platform: windows

--- a/tools/seed/standard-reports.yml
+++ b/tools/seed/standard-reports.yml
@@ -237,7 +237,7 @@ spec:
   name: Get Nmap scanner
   platform: darwin, linux, windows
   description: Get Nmap scanner process, as well as its user, parent, and process details.
-  query: SELECT p.pid, name, p.path, cmdline, cwd, start_time, parent,
+  query: SELECT p.pid, p.name, p.path, p.cmdline, p.cwd, p.start_time, p.parent, u.username AS user, pp.path AS parent_path, pp.cmdline AS parent_cmdline FROM processes p LEFT JOIN users u ON p.uid = u.uid LEFT JOIN processes pp ON p.parent = pp.pid WHERE p.name = 'nmap'
   purpose: Informational
   tags: hunting, ATTACK, t1046
   contributors: anelshaer

--- a/tools/seed/standard-reports.yml
+++ b/tools/seed/standard-reports.yml
@@ -1,0 +1,957 @@
+---
+# Standard reports for local development
+#
+# Usage:
+#   fleetctl apply -f tools/seed/standard-reports.yml
+#
+# These reports are extracted from docs/queries.yml for use in dev environments.
+# They are not used in production. To update, re-extract from docs/queries.yml.
+apiVersion: v1
+kind: report
+spec:
+  name: Detect if Apple Intelligence is enabled
+  platform: darwin
+  description: Detects if Apple Intelligence has been enabled. Value = 1 is on, 0 is off.
+  query: SELECT * FROM plist WHERE path LIKE '/Users/%/Library/Preferences/com.apple.CloudSubscriptionFeatures.optIn.plist';
+  purpose: Informational
+  tags: inventory
+  contributors: allenhouchins
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get OpenSSL versions
+  platform: linux
+  description: Retrieves the OpenSSL version.
+  query: SELECT name AS name, version AS version, 'deb_packages' AS source FROM deb_packages WHERE name LIKE 'openssl%' UNION SELECT name AS name, version AS version, 'apt_sources' AS source FROM apt_sources WHERE name LIKE 'openssl%' UNION SELECT name AS name, version AS version, 'rpm_packages' AS source FROM rpm_packages WHERE name LIKE 'openssl%';
+  purpose: Informational
+  tags: inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get authorized SSH keys
+  platform: darwin, linux
+  description: Presence of authorized SSH keys may be unusual on laptops. Could be completely normal on servers, but may be worth auditing for unusual keys and/or changes.
+  query: SELECT username, authorized_keys. * FROM users CROSS JOIN authorized_keys USING (uid);
+  purpose: Informational
+  remediation: Check out the linked table (https://github.com/fleetdm/fleet/blob/32b4d53e7f1428ce43b0f9fa52838cbe7b413eed/handbook/queries/detect-hosts-with-high-severity-vulnerable-versions-of-openssl.md#table-of-vulnerable-openssl-versions) to determine if the installed version is a high severity vulnerability and view the corresponding CVE(s)
+  tags: built-in, ssh
+  contributors: mike-j-thomas
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get authorized keys for Domain Joined Accounts
+  platform: darwin, linux
+  description: List authorized_keys for each user on the system.
+  query: SELECT *  FROM users CROSS JOIN  authorized_keys USING(uid) WHERE  username IN (SELECT distinct(username) FROM last);
+  purpose: Informational
+  tags: active directory, ssh
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get crashes
+  platform: darwin
+  description: Retrieve application, system, and mobile app crash logs.
+  query: SELECT uid, datetime, responsible, exception_type, identifier, version, crash_path FROM users CROSS JOIN crashes USING (uid);
+  purpose: Informational
+  tags: troubleshooting
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed Chrome Extensions
+  platform: darwin, linux, windows
+  description: List installed Chrome Extensions for all users.
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
+  purpose: Informational
+  tags: browser, built-in, inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed Linux software
+  platform: linux
+  description: Get all software installed on a Linux computer, including browser plugins and installed packages. Note that this does not include other running processes in the processes table.
+  query: SELECT name AS name, version AS version, 'Package (APT)' AS type, 'apt_sources' AS source FROM apt_sources UNION SELECT name AS name, version AS version, 'Package (deb)' AS type, 'deb_packages' AS source FROM deb_packages UNION SELECT package AS name, version AS version, 'Package (Portage)' AS type, 'portage_packages' AS source FROM portage_packages UNION SELECT name AS name, version AS version, 'Package (RPM)' AS type, 'rpm_packages' AS source FROM rpm_packages UNION SELECT name AS name, '' AS version, 'Package (YUM)' AS type, 'yum_sources' AS source FROM yum_sources UNION SELECT name AS name, version AS version, 'Package (NPM)' AS type, 'npm_packages' AS source FROM npm_packages UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages;
+  purpose: Informational
+  tags: inventory, built-in
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed macOS software
+  platform: darwin
+  description: Get all software installed on a macOS computer, including apps, browser plugins, and installed packages. Note that this does not include other running processes in the processes table.
+  query: SELECT name AS name, bundle_short_version AS version, 'Application (macOS)' AS type, 'apps' AS source FROM apps UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name As name, version AS version, 'Browser plugin (Safari)' AS type, 'safari_extensions' AS source FROM safari_extensions UNION SELECT name AS name, version AS version, 'Package (Homebrew)' AS type, 'homebrew_packages' AS source FROM homebrew_packages;
+  purpose: Informational
+  tags: inventory, built-in
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed Safari extensions
+  platform: darwin
+  description: Retrieves the list of installed Safari Extensions for all users in the target system.
+  query: SELECT safari_extensions.* FROM users join safari_extensions USING (uid);
+  purpose: Informational
+  tags: browser, built-in, inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get installed Windows software
+  platform: windows
+  description: Get all software installed on a Windows computer, including programs, browser plugins, and installed packages. Note that this does not include other running processes in the processes table.
+  query: SELECT name AS name, version AS version, 'Program (Windows)' AS type, 'programs' AS source FROM programs UNION SELECT name AS name, version AS version, 'Package (Python)' AS type, 'python_packages' AS source FROM python_packages UNION SELECT name AS name, version AS version, 'Browser plugin (IE)' AS type, 'ie_extensions' AS source FROM ie_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Chrome)' AS type, 'chrome_extensions' AS source FROM chrome_extensions UNION SELECT name AS name, version AS version, 'Browser plugin (Firefox)' AS type, 'firefox_addons' AS source FROM firefox_addons UNION SELECT name AS name, version AS version, 'Package (Chocolatey)' AS type, 'chocolatey_packages' AS source FROM chocolatey_packages;
+  purpose: Informational
+  tags: inventory, built-in
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get laptops with failing batteries
+  platform: darwin
+  description: Lists all laptops with under-performing or failing batteries.
+  query: SELECT * FROM battery WHERE health != 'Good' AND condition NOT IN ('', 'Normal');
+  purpose: Informational
+  tags: troubleshooting, hardware, inventory
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get current users with active shell/console on the system
+  platform: darwin, linux, windows
+  description: Get current users with active shell/console on the system and associated process
+  query: SELECT user,host,time, p.name, p.cmdline, p.cwd, p.root FROM logged_in_users liu, processes p WHERE liu.pid = p.pid and liu.type='user' and liu.user <> '' ORDER BY time;
+  purpose: Informational
+  tags: hunting, built-in
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get unencrypted SSH keys for local accounts
+  platform: darwin, linux, windows
+  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
+  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0;
+  purpose: Informational
+  tags: inventory, compliance, ssh, built-in
+  remediation: First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get unencrypted SSH keys for domain-joined accounts
+  platform: darwin, linux, windows
+  description: Identify SSH keys created without a passphrase which can be used in Lateral Movement (MITRE. TA0008)
+  query: SELECT uid, username, description, path, encrypted FROM users CROSS JOIN user_ssh_keys using (uid) WHERE encrypted=0 and username in (SELECT distinct(username) FROM last);
+  purpose: Informational
+  tags: inventory, compliance, ssh, active directory
+  remediation: First, make the user aware about the impact of SSH keys.  Then rotate the unencrypted keys detected.
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get dynamic linker hijacking on Linux (MITRE. T1574.006)
+  platform: linux
+  description: Detect any processes that run with LD_PRELOAD environment variable
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='LD_PRELOAD';
+  purpose: Informational
+  tags: hunting, ATTACK, t1574
+  remediation: Identify the process/binary detected and confirm with the system's owner.
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get dynamic linker hijacking on macOS (MITRE. T1574.006)
+  platform: darwin
+  description: Detect any processes that run with DYLD_INSERT_LIBRARIES environment variable
+  query: SELECT env.pid, env.key, env.value, p.name,p.path, p.cmdline, p.cwd FROM process_envs env join processes p USING (pid) WHERE key='DYLD_INSERT_LIBRARIES';
+  purpose: Informational
+  tags: hunting, ATTACK, t1574
+  remediation: Identify the process/binary detected and confirm with the system's owner.
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get etc hosts entries
+  platform: darwin, linux
+  description: Line-parsed /etc/hosts
+  query: SELECT * FROM etc_hosts WHERE address not in ('127.0.0.1', '::1');
+  purpose: informational
+  tags: hunting, inventory
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get network interfaces
+  platform: darwin, linux, windows
+  description: Network interfaces MAC address
+  query: SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface) WHERE address not in ('127.0.0.1', '::1');
+  purpose: informational
+  tags: hunting, inventory
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get local user accounts
+  platform: darwin, linux, windows
+  description: Local user accounts (including domain accounts that have logged on locally (Windows)).
+  query: SELECT uid, gid, username, description, directory, shell FROM users;
+  purpose: informational
+  tags: hunting, inventory
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get active user accounts on servers
+  platform: linux
+  description: Domain Joined environments normally have root or other service only accounts and users are SSH-ing using their Domain Accounts.
+  query: SELECT * FROM shadow WHERE password_status='active' and username!='root';
+  purpose: informational
+  tags: hunting, inventory, Active Directory
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get Nmap scanner
+  platform: darwin, linux, windows
+  description: Get Nmap scanner process, as well as its user, parent, and process details.
+  query: SELECT p.pid, name, p.path, cmdline, cwd, start_time, parent,
+  purpose: Informational
+  tags: hunting, ATTACK, t1046
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get Docker contained processes on a system
+  platform: darwin, linux
+  description: Docker containers Processes, can be used on normal systems or a kubenode.
+  query: SELECT c.id, c.name, c.image, c.image_id, c.command, c.created, c.state, c.status, p.cmdline  FROM docker_containers c JOIN docker_container_processes p ON c.id = p.id;
+  purpose: Informational
+  tags: built-in, containers, inventory
+  contributors: anelshaer
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get Windows print spooler remote code execution vulnerability
+  platform: windows
+  description: Detects devices that are potentially vulnerable to CVE-2021-1675 because the print spooler service is not disabled.
+  query: SELECT CASE cnt WHEN 2 THEN "TRUE" ELSE "FALSE" END "Vulnerable" FROM (SELECT name start_type, COUNT(name) AS cnt FROM services WHERE name = 'NTDS' or (name = 'Spooler' and start_type <> 'DISABLED')) WHERE cnt = 2;
+  purpose: Informational
+  tags: vulnerability
+  contributors: maravedi
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get local users and their privileges
+  platform: darwin, linux, windows
+  description: Collects the local user accounts and their respective user group.
+  query: SELECT uid, username, type, groupname FROM users u JOIN groups g ON g.gid = u.gid;
+  purpose: informational
+  tags: inventory
+  contributors: noahtalerman
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get processes that no longer exist on disk
+  platform: linux, darwin, windows
+  description: Lists all processes of which the binary which launched them no longer exists on disk. Attackers often delete files from disk after launching a process to mask presence.
+  query: SELECT name, path, pid FROM processes WHERE on_disk = 0;
+  purpose: Incident response
+  tags: hunting, built-in
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get user files matching a specific hash
+  platform: darwin, linux
+  description: Looks for specific hash in the Users/ directories for files that are less than 50MB (osquery file size limitation.)
+  query: SELECT path, sha256 FROM hash WHERE path IN (SELECT path FROM file WHERE size < 50000000 AND path LIKE '/Users/%/Documents/%%') AND sha256 = '16d28cd1d78b823c4f961a6da78d67a8975d66cde68581798778ed1f98a56d75';
+  purpose: Informational
+  tags: hunting, built-in
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get local administrator accounts on macOS
+  platform: darwin
+  description: The query allows you to check macOS systems for local administrator accounts.
+  query: SELECT uid, username, type FROM users u JOIN groups g ON g.gid = u.gid;
+  purpose: Informational
+  tags: hunting, inventory
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get all listening ports, by process
+  platform: linux, darwin, windows
+  description: List ports that are listening on all interfaces, along with the process to which they are attached.
+  query: SELECT lp.address, lp.pid, lp.port, lp.protocol, p.name, p.path, p.cmdline FROM listening_ports lp JOIN processes p ON lp.pid = p.pid WHERE lp.address = "0.0.0.0";
+  purpose: Informational
+  tags: hunting, network
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get whether TeamViewer is installed/running
+  platform: windows
+  description: Looks for the TeamViewer service running on machines. This is often used when attackers gain access to a machine, running TeamViewer to allow them to access a machine.
+  query: SELECT display_name,status,s.pid,p.path FROM services AS s JOIN processes AS p USING(pid) WHERE s.name LIKE "%teamviewer%";
+  purpose: Informational
+  tags: hunting, inventory
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get malicious Python backdoors
+  platform: darwin, linux, windows
+  description: Watches for the backdoored Python packages installed on the system. See (http://www.nbu.gov.sk/skcsirt-sa-20170909-pypi/index.html)
+  query: SELECT CASE cnt WHEN 0 THEN "NONE_INSTALLED" ELSE "INSTALLED" END AS "Malicious Python Packages", package_name, package_version FROM (SELECT COUNT(name) AS cnt, name AS package_name, version AS package_version, path AS package_path FROM python_packages WHERE package_name IN ('acquisition', 'apidev-coop', 'bzip', 'crypt', 'django-server', 'pwd', 'setup-tools', 'telnet', 'urlib3', 'urllib'));
+  purpose: Informational
+  tags: hunting, inventory, malware
+  contributors: alphabrevity
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Check for artifacts of the Floxif trojan
+  platform: windows
+  description: Checks for artifacts from the Floxif trojan on Windows machines.
+  query: SELECT * FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Piriform\\Agomo%';
+  purpose: Informational
+  tags: hunting, malware
+  contributors: micheal-o
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get Shimcache table
+  platform: windows
+  description: Returns forensic data showing evidence of likely file execution, in addition to the last modified timestamp of the file, order of execution, full file path order of execution, and the order in which files were executed.
+  query: select * from shimcache
+  purpose: Informational
+  tags: hunting
+  contributors: puffyCid
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get running docker containers
+  platform: darwin, linux
+  description: Returns the running Docker containers
+  query: SELECT id, name, image, image_id, state, status FROM docker_containers WHERE state = "running";
+  purpose: Informational
+  tags: containers, inventory
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get applications hogging memory
+  platform: darwin, linux, windows
+  description: Returns top 10 applications or processes hogging memory the most.
+  query: SELECT pid, name, ROUND((total_size * '10e-7'), 2) AS memory_used FROM processes ORDER BY total_size DESC LIMIT 10;
+  purpose: Informational
+  tags: troubleshooting
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get servers with root login in the last 24 hours
+  platform: darwin, linux, windows
+  description: Returns servers with root login in the last 24 hours and the time the users were logged in.
+  query: SELECT * FROM last WHERE username = "root" AND time > (( SELECT unix_time FROM time ) - 86400 );
+  purpose: Informational
+  tags: hunting
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get applications that were opened within the last 24 hours
+  platform: darwin
+  description: Returns applications that were opened within the last 24 hours starting with the last opened application.
+  query: SELECT * FROM apps WHERE last_opened_time > (( SELECT unix_time FROM time ) - 86400 ) ORDER BY last_opened_time DESC;
+  purpose: Informational
+  tags: inventory
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get applications that are not in the Applications directory
+  platform: darwin
+  description: Returns applications that are not in the `/Applications` directory
+  query: SELECT * FROM apps WHERE path NOT LIKE '/Applications/%';
+  purpose: Informational
+  tags: hunting, inventory
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get subscription-based applications that have not been opened for the last 30 days
+  platform: darwin
+  description: Returns applications that are subscription-based and have not been opened for the last 30 days. You can replace the list of applications with those specific to your use case.
+  query: SELECT * FROM apps WHERE path LIKE '/Applications/%' AND name IN ("Photoshop.app", "Adobe XD.app", "Sketch.app", "Illustrator.app") AND last_opened_time < (( SELECT unix_time FROM time ) - 2592000000000 );
+  purpose: Informational
+  tags: inventory
+  contributors: DominusKelvin
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get operating system information
+  platform: darwin, windows, linux
+  description: Returns the operating system name and version on the device.
+  query: SELECT name, version FROM os_version;
+  purpose: Informational
+  tags: inventory, built-in
+  contributors: noahtalerman
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get built-in antivirus status on macOS
+  platform: darwin
+  query: SELECT path, value AS version FROM plist WHERE (key = 'CFBundleShortVersionString' AND path = '/Library/Apple/System/Library/CoreServices/MRT.app/Contents/Info.plist') OR (key = 'CFBundleShortVersionString' AND path = '/Library/Apple/System/Library/CoreServices/XProtect.bundle/Contents/Info.plist');
+  description: Reads the version numbers from the Malware Removal Tool (MRT) and built-in antivirus (XProtect) plists
+  purpose: Informational
+  tags: compliance, malware, hardening, built-in
+  contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get antivirus status from the Windows Security Center
+  platform: windows
+  query: SELECT antivirus, signatures_up_to_date from windows_security_center CROSS JOIN windows_security_products WHERE type = 'Antivirus';
+  description: Selects the antivirus and signatures status from Windows Security Center.
+  purpose: Informational
+  tags: compliance, malware, hardening, built-in
+  contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get antivirus (ClamAV/clamd) and updater (freshclam) process status
+  platform: linux
+  query: SELECT pid, state, cmdline, name FROM processes WHERE name='clamd' OR name='freshclam';
+  description: Selects the clamd and freshclam processes to ensure AV and its updater are running
+  purpose: Informational
+  tags: compliance, malware, hardening, built-in
+  contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Discover TLS certificates
+  platform: linux, windows, darwin
+  description: Retrieves metadata about TLS certificates for servers listening on the local machine. Enables mTLS adoption analysis and cert expiration notifications.
+  query: SELECT * FROM curl_certificate WHERE hostname IN (SELECT DISTINCT 'localhost:'||port FROM listening_ports WHERE protocol=6 AND address!='127.0.0.1' AND address!='::1');
+  purpose: Informational
+  tags: network, tls
+  contributors: nabilschear
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Discover Python Packages from Running Python Interpreters
+  platform: linux, darwin
+  description: Attempt to discover Python environments (in cwd, path to the python binary, and process command line) from running python interpreters and collect Python packages from those environments.
+  query: SELECT * FROM python_packages WHERE directory IN (SELECT DISTINCT directory FROM (SELECT SUBSTR(path,0,INSTR(path,'/bin/'))||'/lib' AS directory FROM processes WHERE path LIKE '%/bin/%' AND path LIKE '%python%' UNION SELECT SUBSTR(cmdline,0,INSTR(cmdline,'/bin/'))||'/lib' AS directory FROM processes WHERE cmdline LIKE '%python%' AND cmdline LIKE '%/bin/%' AND path LIKE '%python%' UNION SELECT cwd||'/lib' AS directory FROM processes WHERE path LIKE '%python%'));
+  purpose: Informational
+  tags: compliance, hunting
+  contributors: nabilschear
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Identify the default mail, http and ftp applications
+  platform: darwin
+  description: Lists the currently enabled applications configured to handle mailto, http and ftp schemes.
+  query: SELECT * FROM app_schemes WHERE (scheme='mailto' OR scheme='http' OR scheme='ftp') AND enabled='1';
+  purpose: Informational
+  tags: compliance, hunting
+  contributors: brunerd
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Identify Apple development secrets (macOS)
+  query: SELECT * FROM keychain_items WHERE label LIKE '%ABCDEFG%';
+  description: "Identifies certificates associated with Apple development signing and notarization. Replace ABCDEFG with your company's identifier."
+  tags: compliance, inventory, built-in
+  platform: darwin
+  contributors: GuillaumeRoss
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get Crowdstrike Falcon network content filter status
+  platform: darwin
+  description: Get the status of the Crowdstrike Falcon network content filter (as in "System Settings" > "Network > "Filters").
+  query: /* Load up the plist */ WITH extensions_plist AS (SELECT *, rowid FROM plist WHERE path = '/Library/Preferences/com.apple.networkextension.plist') /* Find the first "Enabled" key after the key indicating the crowdstrike app */ SELECT value AS enabled FROM extensions_plist WHERE subkey = 'Enabled' AND rowid > (SELECT rowid FROM extensions_plist WHERE value = 'com.crowdstrike.falcon.App') LIMIT 1;
+  purpose: Informational
+  tags: crowdstrike, plist, network, content filter
+  contributors: zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: Get a list of Visual Studio Code extensions
+  platform: darwin, linux, windows
+  description: Get a list of installed VS Code extensions (requires osquery > 5.11.0).
+  query: SELECT u.username, vs.* FROM users u JOIN vscode_extensions vs ON u.uid = vs.uid;
+  purpose: Informational
+  tags: inventory
+  contributors: lucasmrod,sharon-fdm,zwass
+---
+apiVersion: v1
+kind: report
+spec:
+  name: List osquery table names
+  platform: darwin, linux, windows
+  description: List all table names in the schema of the currently installed version of osquery
+  query: SELECT DISTINCT name FROM osquery_registry;
+  purpose: Informational
+  tags: fleet, osquery, table, schema
+  contributors: nonpunctual
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Mount Discovery
+  platform: linux, darwin, windows
+  description: Check mount on the host - ATT&CK T1025,T1052
+  query: SELECT device, device_alias, flags, path,type from mounts;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Setuid Binary Discovery
+  platform: linux, darwin
+  description: List files that are setuid-enabled
+  query: select * from suid_bin;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Sudoers Configuration
+  platform: linux, darwin
+  description: Sudoers configuration information - ATT&CK T1548.003
+  query: select * from sudoers;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Reverse Shell Detection
+  platform: linux, darwin
+  description: Detect active reverse shell connections via bash TCP redirects - ATT&CK T1059
+  query: SELECT * FROM processes WHERE cmdline LIKE '/bin/bash -i >& /dev/tcp/%';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - USB Device Discovery
+  platform: linux, darwin, windows
+  description: Check USB device on the host - ATT&CK T1052
+  query: SELECT * FROM usb_devices;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Firefox Addons
+  platform: linux, darwin, windows
+  description: Lists all Firefox addons - ATT&CK T1176
+  query: SELECT u.username, ce.* FROM users u CROSS JOIN firefox_addons ce USING (uid);
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Cron Job Discovery
+  platform: linux, darwin
+  description: List Local job scheduling with Cron - ATT&CK T1053
+  query: select command, path from crontab;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - User Account Discovery
+  platform: linux, darwin, windows
+  description: Lists all create and deleted account - ATT&CK T1136,T1078,T1184,T1021
+  query: select * from users;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Explorer Run Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKCU_Software_Microsoft_Windows_CurrentVersion_Policies_Explorer_Run - ATT&CK T1060
+  query: select name,type,data from registry where key='HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Logon Scripts Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKEY_CURRENT_USER_Environment - ATT&CK T1037
+  query: select * from registry where key='HKEY_CURRENT_USER\Environment';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - HKCU Run Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKCU_Software_Microsoft_Windows_CurrentVersion_Run - ATT&CK T1060
+  query: select name,type,data from registry where key='HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - HKLM Explorer Run Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKLM_Software_Microsoft_Windows_CurrentVersion_Policies_Explorer_Run - ATT&CK T1060
+  query: select name,type,data from registry where key='HKEY_LOCAL_MACHINE\Software\Microsoft\Windows\CurrentVersion\Policies\Explorer\Run';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - LSA Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKLM_SYSTEM_CurrentControlSet_Control_Lsa - ATT&CK T1131
+  query: select name,type,data from registry where key='HKEY_LOCAL_MACHINE\system\CurrentControlSet\Control\Lsa';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Netsh Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKLM_SOFTWARE_Microsoft_Netsh - ATT&CK T1128,S0108
+  query: select name,type,data from registry where key='HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Netsh';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Services Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKLM_SYSTEM_CurrentControlSet_Service - ATT&CK T1058
+  query: select name, type from registry where key='HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - HKU Run Registry Monitoring
+  platform: windows
+  description: Returns the content of the key HKU_Software_Microsoft_Windows_CurrentVersion_Run
+  query: select name,type,data from registry where key='HKEY_USERS\Software\Microsoft\Windows\CurrentVersion\Run';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Prefetch File Monitoring
+  platform: windows
+  description: Monitor Windows Prefetch directory for execution artifacts - ATT&CK T1107
+  query: select * from file WHERE directory = 'C:\Windows\Prefetch\';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Internet Explorer Extensions Snapshot
+  platform: windows
+  description: Snapshot Lists all internet explorer extensions - ATT&CK T1176
+  query: SELECT * FROM ie_extensions;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Internet Explorer Extensions
+  platform: windows
+  description: Lists all internet explorer extensions - ATT&CK T1176
+  query: select * from ie_extensions;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Sophos Service Status 1
+  platform: windows
+  description: Sophos Endpoint Protection service status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'SAVAdminService' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Services Snapshot
+  platform: linux, darwin, windows
+  description: Snapshot Services query
+  query: SELECT * FROM services;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Sophos Service Status 2
+  platform: windows
+  description: Sophos Endpoint Protection service status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'SavService' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Symantec Service Status
+  platform: windows
+  description: Symantec Endpoint Protection service status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'SepMasterService' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Windows Defender Service Status
+  platform: windows
+  description: Windows Defender service Status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'WinDefend' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Windows Firewall Service Status
+  platform: windows
+  description: Windows Firewall service Status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'MpsSvc' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Windows Security Service Status
+  platform: windows
+  description: Windows Security Service Status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'wscsvc' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Windows Update Service Status
+  platform: windows
+  description: Windows Update Service Status change - ATT&CK T1089
+  query: SELECT * FROM services WHERE name = 'wuauserv' AND status != 'RUNNING';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Certificate Discovery
+  platform: linux, darwin, windows
+  description: Discover local system certificates for code signing and trust chain analysis - ATT&CK T1116,T1130
+  query: select * from certificates;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Logged In Users
+  platform: linux, darwin
+  description: Users with an active shell on the system. - ATT&CK T1075,T1097
+  query: select * from logged_in_users;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Installed Programs
+  platform: windows
+  description: Lists installed programs on Windows systems - ATT&CK T1518
+  query: SELECT * FROM programs;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - System Info Snapshot
+  platform: linux, darwin, windows
+  description: System information for identification.
+  query: SELECT * FROM system_info;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - System Uptime
+  platform: linux, darwin, windows
+  description: System uptime
+  query: SELECT * FROM uptime;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Windows Crash Analysis
+  platform: windows
+  description: Extracted information from Windows crash logs (Minidumps).
+  query: SELECT * FROM windows_crashes;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Startup Items
+  platform: linux, darwin, windows
+  description: Startup items configured to launch on the system - ATT&CK T1060
+  query: select * from startup_items;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - PowerShell Script Block Events
+  platform: windows
+  description: Powershell script blocks reconstructed to their full script content, this table requires script block logging to be enabled. - ATT&CK T1086,T1064
+  query: select * from powershell_events;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Fileless Process Detection
+  platform: linux, darwin, windows
+  description: Detect Processes running without a binary on disk
+  query: SELECT name, path, pid FROM processes WHERE on_disk = 0;
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234
+---
+apiVersion: v1
+kind: report
+spec:
+  name: MITRE - Auto-Start Services
+  platform: windows
+  description: Lists all installed services configured to start automatically at boot - ATT&CK T1050
+  query: SELECT * FROM services WHERE start_type='DEMAND_START' OR start_type='AUTO_START';
+  purpose: Detection
+  tags: MITRE, ATT&CK, threat detection
+  contributors: teoseller,tux234


### PR DESCRIPTION
## Issue

## Description
                                    
  - Adds tools/seed/ — a one-command toolkit for populating a local Fleet dev instance with users, fleets, policies, and reports after a make db-reset  
  - Seeds 15 users covering every role (admin, maintainer, observer, observer+, technician, gitops) at both global and fleet scope, plus API-only users 
  (full access and restricted endpoint)       
  - Seeds 41 global policies, 60+ global reports, and fleet-scoped policies/reports for "Workstations" and "Personal mobile devices" with no overlap    
  between global and fleet-scoped content                                                                                                               
  - Includes clean-seed-data.sh to wipe all seeded data (preserves admin account) without a full db reset                                               
  - Auto-creates fleets if they don't exist, discovers exact fleet names to handle emoji prefixes, configures fleetctl auth automatically               
                                                                                                                                                        
 ## Test plan                                                                                                                                           
                                                                                                                                                        
  - [x] Run bash tools/seed/clean-seed-data.sh — confirms it deletes all policies, reports, and users except admin                                          
  - [x] Run bash tools/seed/seed-users-and-fleets.sh — confirms all 15 users, global policies/reports, and fleet-scoped policies/reports are created        
  - [x] Re-run seed script — confirms idempotency (users skipped, policies/reports upserted)                                                                
  - [x] Verify fleet-scoped policies appear under correct fleets in the UI                                                                                  
  - [x] Verify fleet-scoped reports appear under correct fleets in the UI
  - [x] Verify restricted API-only user token is printed with save warning                                                                                  
  - [x] Verify .gitignore prevents DO_NOT_COMMIT_ENV_FILE from being committed   

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added extensive seed data and cataloged policies/reports for mobile devices and workstations to populate dev environments.
  * Added scripts to create and clean seeded users, fleets, and test data for local development.
  * Added an example environment configuration and excluded the real env file from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->