### PR TITLE
Fix script-only packages not setting install script file

### DIFF
--- a/changes/43659-script-only-hash-ref-preserves-install-script
+++ b/changes/43659-script-only-hash-ref-preserves-install-script
@@ -1,0 +1,1 @@
+- Fixed a bug where applying GitOps to a script-only package by `hash_sha256` reference would wipe the install script, causing self-service installs to silently no-op.

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2539,10 +2539,14 @@ func (svc *Service) softwareBatchUpload(
 				// make a copy of the installer without filled fields in case we add
 				// extra installers
 				extraInstallerBase := *installer
-				fillSoftwareInstallerPayloadFromExisting(installer, foundInstaller, p.SHA256)
+				if err := svc.fillSoftwareInstallerPayloadFromExisting(ctx, installer, foundInstaller, p.SHA256); err != nil {
+					return err
+				}
 				for _, extraInstaller := range foundInstallers[1:] {
 					extraPayload := extraInstallerBase
-					fillSoftwareInstallerPayloadFromExisting(&extraPayload, extraInstaller, p.SHA256)
+					if err := svc.fillSoftwareInstallerPayloadFromExisting(ctx, &extraPayload, extraInstaller, p.SHA256); err != nil {
+						return err
+					}
 					extraInstallers = append(extraInstallers, &extraPayload)
 				}
 
@@ -2583,10 +2587,14 @@ func (svc *Service) softwareBatchUpload(
 					// make a copy of the installer without filled fields in case we add
 					// extra installers
 					extraInstallerBase := *installer
-					fillSoftwareInstallerPayloadFromExisting(installer, teamInstaller, p.SHA256)
+					if err := svc.fillSoftwareInstallerPayloadFromExisting(ctx, installer, teamInstaller, p.SHA256); err != nil {
+						return err
+					}
 					for _, extraInstaller := range teamInstallers[1:] {
 						extraPayload := extraInstallerBase
-						fillSoftwareInstallerPayloadFromExisting(&extraPayload, extraInstaller, p.SHA256)
+						if err := svc.fillSoftwareInstallerPayloadFromExisting(ctx, &extraPayload, extraInstaller, p.SHA256); err != nil {
+							return err
+						}
 						extraInstallers = append(extraInstallers, &extraPayload)
 					}
 
@@ -2690,7 +2698,9 @@ func (svc *Service) softwareBatchUpload(
 					if resp != nil && resp.StatusCode == http.StatusNotModified && existingForCache != nil {
 						bytesExist, existErr := svc.softwareInstallStore.Exists(ctx, existingForCache.StorageID)
 						if existErr == nil && bytesExist {
-							fillSoftwareInstallerPayloadFromExisting(installer, existingForCache, existingForCache.StorageID)
+							if err := svc.fillSoftwareInstallerPayloadFromExisting(ctx, installer, existingForCache, existingForCache.StorageID); err != nil {
+								return err
+							}
 							installer.HTTPETag = existingForCache.HTTPETag
 							// Propagate the existing hash so FMA hydration below
 							// doesn't try to recompute it from the (nil) file
@@ -2975,7 +2985,7 @@ func (svc *Service) softwareBatchUpload(
 	// anymore, so that's intentionally skipped.
 }
 
-func fillSoftwareInstallerPayloadFromExisting(payload *fleet.UploadSoftwareInstallerPayload, existing *fleet.ExistingSoftwareInstaller, sha256Hash string) {
+func (svc *Service) fillSoftwareInstallerPayloadFromExisting(ctx context.Context, payload *fleet.UploadSoftwareInstallerPayload, existing *fleet.ExistingSoftwareInstaller, sha256Hash string) error {
 	payload.Extension = existing.Extension
 	payload.Filename = existing.Filename
 	payload.Version = existing.Version
@@ -2987,6 +2997,21 @@ func fillSoftwareInstallerPayloadFromExisting(payload *fleet.UploadSoftwareInsta
 	payload.Title = existing.Title
 	payload.StorageID = sha256Hash
 	payload.PackageIDs = existing.PackageIDs
+
+	// For script-only packages, the install_script row IS the package data.
+	// Gitops payloads that reference an installer by hash_sha256 (no path:)
+	// carry no script bytes, so without this hydration the upsert in
+	// BatchSetSoftwareInstallers would point install_script_content_id at
+	// an empty content row and silently break self-service installs.
+	if fleet.IsScriptPackage(existing.Extension) {
+		contents, err := svc.ds.GetAnyScriptContents(ctx, existing.InstallScriptContentID)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "fetch install script for hash-matched script-only package")
+		}
+		payload.InstallScript = string(contents)
+	}
+
+	return nil
 }
 
 // validETag checks if an ETag value is a strong ETag per RFC 7232

--- a/ee/server/service/software_installers.go
+++ b/ee/server/service/software_installers.go
@@ -2998,15 +2998,10 @@ func (svc *Service) fillSoftwareInstallerPayloadFromExisting(ctx context.Context
 	payload.StorageID = sha256Hash
 	payload.PackageIDs = existing.PackageIDs
 
-	// For script-only packages, the install_script row IS the package data.
-	// Gitops payloads that reference an installer by hash_sha256 (no path:)
-	// carry no script bytes, so without this hydration the upsert in
-	// BatchSetSoftwareInstallers would point install_script_content_id at
-	// an empty content row and silently break self-service installs.
 	if fleet.IsScriptPackage(existing.Extension) {
 		contents, err := svc.ds.GetAnyScriptContents(ctx, existing.InstallScriptContentID)
 		if err != nil {
-			return ctxerr.Wrap(ctx, err, "fetch install script for hash-matched script-only package")
+			return ctxerr.Wrap(ctx, err, "fetch install script for hash-matched script package")
 		}
 		payload.InstallScript = string(contents)
 	}

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3590,7 +3590,8 @@ SELECT
 	st.source,
 	st.bundle_identifier,
 	st.name AS title,
-	si.package_ids
+	si.package_ids,
+	si.install_script_content_id
 FROM
 	software_installers si
 	JOIN software_titles st ON si.title_id = st.id
@@ -3611,7 +3612,8 @@ SELECT
 	st.source,
 	st.bundle_identifier,
 	st.name AS title,
-	'' AS package_ids
+	'' AS package_ids,
+	0 AS install_script_content_id
 FROM
 	in_house_apps iha
 	JOIN software_titles st ON iha.title_id = st.id

--- a/server/datastore/mysql/software_installers.go
+++ b/server/datastore/mysql/software_installers.go
@@ -3668,7 +3668,8 @@ SELECT
 	st.bundle_identifier AS bundle_identifier,
 	st.name AS title,
 	si.package_ids AS package_ids,
-	si.http_etag AS http_etag
+	si.http_etag AS http_etag,
+	si.install_script_content_id AS install_script_content_id
 FROM
 	software_installers si
 	JOIN software_titles st ON si.title_id = st.id

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -595,6 +595,12 @@ type ExistingSoftwareInstaller struct {
 	PackageIDs       []string
 	StorageID        string  `db:"storage_id"`
 	HTTPETag         *string `db:"http_etag"`
+	// InstallScriptContentID points to the script_contents row holding this
+	// installer's install_script. Used to lazily fetch script bytes for
+	// script-only packages (.sh/.ps1) when matching by hash, so the caller
+	// can preserve them across an upsert that would otherwise wipe the row.
+	// Zero for in-house apps (no install script in this table).
+	InstallScriptContentID uint `db:"install_script_content_id"`
 }
 
 type UpdateSoftwareInstallerPayload struct {

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -595,11 +595,6 @@ type ExistingSoftwareInstaller struct {
 	PackageIDs       []string
 	StorageID        string  `db:"storage_id"`
 	HTTPETag         *string `db:"http_etag"`
-	// InstallScriptContentID points to the script_contents row holding this
-	// installer's install_script. Used to lazily fetch script bytes for
-	// script-only packages (.sh/.ps1) when matching by hash, so the caller
-	// can preserve them across an upsert that would otherwise wipe the row.
-	// Zero for in-house apps (no install script in this table).
 	InstallScriptContentID uint `db:"install_script_content_id"`
 }
 

--- a/server/fleet/software_installer.go
+++ b/server/fleet/software_installer.go
@@ -582,20 +582,20 @@ func (p UploadSoftwareInstallerPayload) GetUpgradeCodeForDB() *string {
 }
 
 type ExistingSoftwareInstaller struct {
-	InstallerID      uint    `db:"installer_id"`
-	TeamID           *uint   `db:"team_id"`
-	Filename         string  `db:"filename"`
-	Extension        string  `db:"extension"`
-	Version          string  `db:"version"`
-	Platform         string  `db:"platform"`
-	Source           string  `db:"source"`
-	BundleIdentifier *string `db:"bundle_identifier"`
-	Title            string  `db:"title"`
-	PackageIDList    string  `db:"package_ids"`
-	PackageIDs       []string
-	StorageID        string  `db:"storage_id"`
-	HTTPETag         *string `db:"http_etag"`
-	InstallScriptContentID uint `db:"install_script_content_id"`
+	InstallerID            uint    `db:"installer_id"`
+	TeamID                 *uint   `db:"team_id"`
+	Filename               string  `db:"filename"`
+	Extension              string  `db:"extension"`
+	Version                string  `db:"version"`
+	Platform               string  `db:"platform"`
+	Source                 string  `db:"source"`
+	BundleIdentifier       *string `db:"bundle_identifier"`
+	Title                  string  `db:"title"`
+	PackageIDList          string  `db:"package_ids"`
+	PackageIDs             []string
+	StorageID              string  `db:"storage_id"`
+	HTTPETag               *string `db:"http_etag"`
+	InstallScriptContentID uint    `db:"install_script_content_id"`
 }
 
 type UpdateSoftwareInstallerPayload struct {

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29133,22 +29133,14 @@ func (s *integrationEnterpriseTestSuite) TestAPIOnlyUserEndpointMiddleware() {
 	})
 }
 
-// TestBatchSetSoftwareInstallersScriptPackageHashRefPreservesScript covers
-// fleet#43659: when a script-only package (.sh/.ps1) uploaded via the UI is
-// then re-applied through the batch installers endpoint by hash_sha256 only
-// (no install script in the payload), the existing install_script must be
-// preserved. The pre-fix bug pointed install_script_content_id at an empty
-// content row, silently breaking self-service installs.
-func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersScriptPackageHashRefPreservesScript() {
+// Regression test for fleet#43659.
+func (s *integrationEnterpriseTestSuite) TestBatchSetInstallersScriptByHash() {
 	t := s.T()
 	ctx := context.Background()
 
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name(), Description: "desc"})
 	require.NoError(t, err)
 
-	// Upload a .sh script-only package via the UI endpoint to mirror the
-	// reporter's setup: the script bytes get stored in object storage AND
-	// in script_contents, linked via install_script_content_id.
 	scriptPath := filepath.Join("testdata", "software-installers", "script.sh")
 	scriptBytes, err := os.ReadFile(scriptPath)
 	require.NoError(t, err)
@@ -29164,8 +29156,6 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersScriptPac
 		SelfService:   true,
 	}, http.StatusOK, "")
 
-	// Find the title and capture pre-batch state: install_script_content_id
-	// and the actual contents from script_contents.
 	var listResp listSoftwareTitlesResponse
 	s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, http.StatusOK, &listResp,
 		"team_id", fmt.Sprintf("%d", tm.ID), "available_for_install", "true")
@@ -29177,59 +29167,30 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersScriptPac
 			break
 		}
 	}
-	require.NotZero(t, titleID, "script.sh title not found after upload")
+	require.NotZero(t, titleID)
 
-	type installerRow struct {
-		StorageID              string `db:"storage_id"`
-		InstallScriptContentID uint   `db:"install_script_content_id"`
-	}
-	var before installerRow
+	var storageID string
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &before,
-			"SELECT storage_id, install_script_content_id FROM software_installers WHERE title_id = ? AND global_or_team_id = ?",
+		return sqlx.GetContext(ctx, q, &storageID,
+			"SELECT storage_id FROM software_installers WHERE title_id = ? AND global_or_team_id = ?",
 			titleID, tm.ID)
 	})
-	require.NotEmpty(t, before.StorageID)
-	require.NotZero(t, before.InstallScriptContentID)
+	require.NotEmpty(t, storageID)
 
-	var beforeContents string
-	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &beforeContents,
-			"SELECT contents FROM script_contents WHERE id = ?", before.InstallScriptContentID)
-	})
-	require.Equal(t, string(scriptBytes), beforeContents)
-
-	// Now run the batch endpoint with a hash-only payload (no URL, no
-	// InstallScript) — the shape gitops generates when a per-package yaml
-	// references the installer by hash_sha256 with no path:.
-	softwareToInstall := []*fleet.SoftwareInstallerPayload{
-		{SHA256: before.StorageID},
-	}
 	var batchResponse batchSetSoftwareInstallersResponse
 	s.DoJSON("POST", "/api/latest/fleet/software/batch",
-		batchSetSoftwareInstallersRequest{Software: softwareToInstall},
+		batchSetSoftwareInstallersRequest{Software: []*fleet.SoftwareInstallerPayload{{SHA256: storageID}}},
 		http.StatusAccepted, &batchResponse, "team_name", tm.Name)
-	packages := waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, tm.Name, batchResponse.RequestUUID)
-	require.Len(t, packages, 1)
-	require.NotNil(t, packages[0].TitleID)
-	require.Equal(t, titleID, *packages[0].TitleID)
+	waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, tm.Name, batchResponse.RequestUUID)
 
-	// Capture post-batch state. The fix preserves install_script_content_id
-	// (or upserts in place to a row with the same contents). Either way,
-	// dereferencing via script_contents must still give us the original bytes.
-	var after installerRow
+	var installScript string
 	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &after,
-			"SELECT storage_id, install_script_content_id FROM software_installers WHERE title_id = ? AND global_or_team_id = ?",
+		return sqlx.GetContext(ctx, q, &installScript, `
+			SELECT sc.contents
+			FROM software_installers si
+			JOIN script_contents sc ON sc.id = si.install_script_content_id
+			WHERE si.title_id = ? AND si.global_or_team_id = ?`,
 			titleID, tm.ID)
 	})
-	require.Equal(t, before.StorageID, after.StorageID, "storage_id must not change for a same-hash batch")
-
-	var afterContents string
-	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
-		return sqlx.GetContext(ctx, q, &afterContents,
-			"SELECT contents FROM script_contents WHERE id = ?", after.InstallScriptContentID)
-	})
-	require.Equal(t, string(scriptBytes), afterContents,
-		"install_script must be preserved after hash-only batch upsert (regression: fleet#43659)")
+	require.Equal(t, string(scriptBytes), installScript)
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29141,19 +29141,13 @@ func (s *integrationEnterpriseTestSuite) TestBatchSetInstallersScriptByHash() {
 	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name(), Description: "desc"})
 	require.NoError(t, err)
 
-	scriptPath := filepath.Join("testdata", "software-installers", "script.sh")
-	scriptBytes, err := os.ReadFile(scriptPath)
+	scriptBytes, err := os.ReadFile(filepath.Join("testdata", "software-installers", "script.sh"))
 	require.NoError(t, err)
-
-	installerFile, err := fleet.NewKeepFileReader(scriptPath)
-	require.NoError(t, err)
-	defer installerFile.Close()
 
 	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
-		TeamID:        &tm.ID,
-		Filename:      "script.sh",
-		InstallerFile: installerFile,
-		SelfService:   true,
+		TeamID:      &tm.ID,
+		Filename:    "script.sh",
+		SelfService: true,
 	}, http.StatusOK, "")
 
 	var listResp listSoftwareTitlesResponse

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -29132,3 +29132,104 @@ func (s *integrationEnterpriseTestSuite) TestAPIOnlyUserEndpointMiddleware() {
 		s.Do("GET", "/api/latest/fleet/hosts", nil, http.StatusOK)
 	})
 }
+
+// TestBatchSetSoftwareInstallersScriptPackageHashRefPreservesScript covers
+// fleet#43659: when a script-only package (.sh/.ps1) uploaded via the UI is
+// then re-applied through the batch installers endpoint by hash_sha256 only
+// (no install script in the payload), the existing install_script must be
+// preserved. The pre-fix bug pointed install_script_content_id at an empty
+// content row, silently breaking self-service installs.
+func (s *integrationEnterpriseTestSuite) TestBatchSetSoftwareInstallersScriptPackageHashRefPreservesScript() {
+	t := s.T()
+	ctx := context.Background()
+
+	tm, err := s.ds.NewTeam(ctx, &fleet.Team{Name: t.Name(), Description: "desc"})
+	require.NoError(t, err)
+
+	// Upload a .sh script-only package via the UI endpoint to mirror the
+	// reporter's setup: the script bytes get stored in object storage AND
+	// in script_contents, linked via install_script_content_id.
+	scriptPath := filepath.Join("testdata", "software-installers", "script.sh")
+	scriptBytes, err := os.ReadFile(scriptPath)
+	require.NoError(t, err)
+
+	installerFile, err := fleet.NewKeepFileReader(scriptPath)
+	require.NoError(t, err)
+	defer installerFile.Close()
+
+	s.uploadSoftwareInstaller(t, &fleet.UploadSoftwareInstallerPayload{
+		TeamID:        &tm.ID,
+		Filename:      "script.sh",
+		InstallerFile: installerFile,
+		SelfService:   true,
+	}, http.StatusOK, "")
+
+	// Find the title and capture pre-batch state: install_script_content_id
+	// and the actual contents from script_contents.
+	var listResp listSoftwareTitlesResponse
+	s.DoJSON("GET", "/api/latest/fleet/software/titles", nil, http.StatusOK, &listResp,
+		"team_id", fmt.Sprintf("%d", tm.ID), "available_for_install", "true")
+
+	var titleID uint
+	for _, sw := range listResp.SoftwareTitles {
+		if sw.SoftwarePackage != nil && sw.SoftwarePackage.Name == "script.sh" {
+			titleID = sw.ID
+			break
+		}
+	}
+	require.NotZero(t, titleID, "script.sh title not found after upload")
+
+	type installerRow struct {
+		StorageID              string `db:"storage_id"`
+		InstallScriptContentID uint   `db:"install_script_content_id"`
+	}
+	var before installerRow
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &before,
+			"SELECT storage_id, install_script_content_id FROM software_installers WHERE title_id = ? AND global_or_team_id = ?",
+			titleID, tm.ID)
+	})
+	require.NotEmpty(t, before.StorageID)
+	require.NotZero(t, before.InstallScriptContentID)
+
+	var beforeContents string
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &beforeContents,
+			"SELECT contents FROM script_contents WHERE id = ?", before.InstallScriptContentID)
+	})
+	require.Equal(t, string(scriptBytes), beforeContents)
+
+	// Now run the batch endpoint with a hash-only payload (no URL, no
+	// InstallScript) — the shape gitops generates when a per-package yaml
+	// references the installer by hash_sha256 with no path:.
+	softwareToInstall := []*fleet.SoftwareInstallerPayload{
+		{SHA256: before.StorageID},
+	}
+	var batchResponse batchSetSoftwareInstallersResponse
+	s.DoJSON("POST", "/api/latest/fleet/software/batch",
+		batchSetSoftwareInstallersRequest{Software: softwareToInstall},
+		http.StatusAccepted, &batchResponse, "team_name", tm.Name)
+	packages := waitBatchSetSoftwareInstallersCompleted(t, &s.withServer, tm.Name, batchResponse.RequestUUID)
+	require.Len(t, packages, 1)
+	require.NotNil(t, packages[0].TitleID)
+	require.Equal(t, titleID, *packages[0].TitleID)
+
+	// Capture post-batch state. The fix preserves install_script_content_id
+	// (or upserts in place to a row with the same contents). Either way,
+	// dereferencing via script_contents must still give us the original bytes.
+	var after installerRow
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &after,
+			"SELECT storage_id, install_script_content_id FROM software_installers WHERE title_id = ? AND global_or_team_id = ?",
+			titleID, tm.ID)
+	})
+	require.Equal(t, before.StorageID, after.StorageID, "storage_id must not change for a same-hash batch")
+
+	var afterContents string
+	mysql.ExecAdhocSQL(t, s.ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &afterContents,
+			"SELECT contents FROM script_contents WHERE id = ?", after.InstallScriptContentID)
+	})
+	require.Equal(t, string(scriptBytes), afterContents,
+		"install_script must be preserved after hash-only batch upsert (regression: fleet#43659)")
+}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43659

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [ ] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [ ] Timeouts are implemented and retries are limited to avoid infinite loops
- [ ] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves install scripts for script-only software installers when using hash-based references in GitOps, preventing self-service installs from silently no‑opping.
* **Tests**
  * Added an integration regression test to verify batch installer resolution by hash preserves uploaded install script contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->