### PR TITLE
[API] Document API endpoint for host's device URL

### DIFF
--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4530,7 +4530,7 @@ This report includes a subset of host vitals, and simplified policy and vulnerab
 }
 ```
 
-### Get host's My device page URL
+### Get host's device page URL
 
 Retrieves the end user url for the host's **My device** page.
 

--- a/docs/REST API/rest-api.md
+++ b/docs/REST API/rest-api.md
@@ -4530,6 +4530,33 @@ This report includes a subset of host vitals, and simplified policy and vulnerab
 }
 ```
 
+### Get host's My device page URL
+
+Retrieves the end user url for the host's **My device** page.
+
+`GET /api/v1/fleet/hosts/:id/device_url`
+
+#### Parameters
+
+| Name       | Type              | In   | Description                                                                   |
+| ---------- | ----------------- | ---- | ----------------------------------------------------------------------------- |
+| id         | integer           | path | **Required**. The host's `id`.                                                |
+
+#### Example
+
+`GET /api/v1/fleet/hosts/1/device_url`
+
+##### Default response
+
+`Status: 200`
+
+```json
+{
+  "host_id": 1,
+  "device_url": "example.com/device/device_id"
+}
+```
+
 ---
 
 ### Get host's mobile device management (MDM) information


### PR DESCRIPTION
Added documentation for retrieving the host's My device page URL, including parameters and example response.

<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43895 