### PR TITLE
Patch Adobe Acrobat automatically on workstation devices

### DIFF
--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -465,7 +465,7 @@ software:
       categories:
         - Developer tools
     - slug: adobe-acrobat-reader/darwin # Adobe Acrobat Reader for macOS
-      self_service: true
+      self_service: false
       categories:
         - Productivity
     # Windows apps
@@ -515,6 +515,6 @@ software:
       categories:
         - Developer tools
     - slug: adobe-acrobat-reader/windows # Adobe Acrobat Reader for Windows
-      self_service: true
+      self_service: false
       categories:
         - Productivity

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -464,6 +464,10 @@ software:
         - Macs with Cursor installed
       categories:
         - Developer tools
+    - slug: adobe-acrobat-reader/darwin # Adobe Acrobat Reader for macOS
+      self_service: true
+      categories:
+        - Productivity
     # Windows apps
     - slug: 1password/windows # 1Password for Windows
       self_service: true
@@ -510,3 +514,7 @@ software:
         - "x86 Windows hosts with Visual Studio Code installed"
       categories:
         - Developer tools
+    - slug: adobe-acrobat-reader/windows # Adobe Acrobat Reader for Windows
+      self_service: true
+      categories:
+        - Productivity

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -470,6 +470,12 @@ software:
         - Macs with Adobe Acrobat Reader installed
       categories:
         - Productivity
+    - slug: adobe-acrobat-pro/darwin # Adobe Acrobat Pro for macOS
+      self_service: true
+      labels_include_any:
+        - Macs with Adobe Acrobat Pro installed
+      categories:
+        - Productivity
     # Windows apps
     - slug: 1password/windows # 1Password for Windows
       self_service: true

--- a/it-and-security/fleets/workstations.yml
+++ b/it-and-security/fleets/workstations.yml
@@ -465,7 +465,9 @@ software:
       categories:
         - Developer tools
     - slug: adobe-acrobat-reader/darwin # Adobe Acrobat Reader for macOS
-      self_service: false
+      self_service: true
+      labels_include_any:
+        - Macs with Adobe Acrobat Reader installed
       categories:
         - Productivity
     # Windows apps
@@ -515,6 +517,8 @@ software:
       categories:
         - Developer tools
     - slug: adobe-acrobat-reader/windows # Adobe Acrobat Reader for Windows
-      self_service: false
+      self_service: true
+      labels_include_any:
+        - x86 Windows hosts with Adobe Acrobat Reader installed
       categories:
         - Productivity

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -153,3 +153,8 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.github.macadmins.Nudge';
   label_membership_type: dynamic
   platform: darwin
+- name: Macs with Adobe Acrobat Reader installed
+  description: macOS hosts with Adobe Acrobat Reader installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/macs-with-fleet-maintained-apps-installed.yml
@@ -158,3 +158,8 @@
   query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Reader';
   label_membership_type: dynamic
   platform: darwin
+- name: Macs with Adobe Acrobat Pro installed
+  description: macOS hosts with Adobe Acrobat Pro installed
+  query: SELECT 1 FROM apps WHERE bundle_identifier = 'com.adobe.Acrobat.Pro';
+  label_membership_type: dynamic
+  platform: darwin

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -33,3 +33,8 @@
   query: SELECT 1 FROM programs WHERE name LIKE 'Microsoft Visual Studio Code%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows
+- name: x86 Windows hosts with Adobe Acrobat Reader installed
+  description: x86 Windows hosts with Adobe Acrobat Reader installed
+  query: SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  label_membership_type: dynamic
+  platform: windows

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -34,7 +34,7 @@
   label_membership_type: dynamic
   platform: windows
 - name: x86 Windows hosts with Adobe Acrobat Reader installed
-  description: x86 Windows hosts with Adobe Acrobat Reader installed
-  query: SELECT 1 FROM programs WHERE (name = 'Adobe Acrobat (64-bit)' OR name LIKE 'Adobe Acrobat Reader%') AND publisher LIKE 'Adobe%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  description: x86 Windows hosts with Adobe Acrobat Reader installed (excludes Adobe Acrobat Pro, which shares the 'Adobe Acrobat (64-bit)' program name on Windows; differentiated by the Reader install_location).
+  query: SELECT 1 FROM programs WHERE ((name = 'Adobe Acrobat (64-bit)' AND publisher LIKE 'Adobe%' AND install_location LIKE '%\Reader\%') OR (name LIKE 'Adobe Acrobat Reader%' AND publisher LIKE 'Adobe%')) AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows

--- a/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
+++ b/it-and-security/lib/all/labels/windows-with-fleet-maintained-apps-installed.yml
@@ -35,6 +35,6 @@
   platform: windows
 - name: x86 Windows hosts with Adobe Acrobat Reader installed
   description: x86 Windows hosts with Adobe Acrobat Reader installed
-  query: SELECT 1 FROM programs WHERE name = 'Adobe Acrobat (64-bit)' AND publisher = 'Adobe' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
+  query: SELECT 1 FROM programs WHERE (name = 'Adobe Acrobat (64-bit)' OR name LIKE 'Adobe Acrobat Reader%') AND publisher LIKE 'Adobe%' AND EXISTS (SELECT 1 FROM os_version WHERE arch NOT LIKE 'ARM%');
   label_membership_type: dynamic
   platform: windows

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -248,3 +248,10 @@
   install_software: true
   labels_include_any:
     - Macs with Nudge installed
+- name: macOS - Adobe Acrobat Reader up to date
+  description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
+  resolution: "Adobe Acrobat Reader is managed by IT and will be updated automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
+  critical: true
+  type: patch
+  fleet_maintained_app_slug: adobe-acrobat-reader/darwin
+  install_software: true

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -250,8 +250,10 @@
     - Macs with Nudge installed
 - name: macOS - Adobe Acrobat Reader up to date
   description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
-  resolution: "Adobe Acrobat Reader is managed by IT and will be updated automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
+  resolution: "Adobe Acrobat Reader is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   critical: true
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/darwin
   install_software: true
+  labels_include_any:
+    - Macs with Adobe Acrobat Reader installed

--- a/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/macos/policies/patch-fleet-maintained-apps.yml
@@ -257,3 +257,12 @@
   install_software: true
   labels_include_any:
     - Macs with Adobe Acrobat Reader installed
+- name: macOS - Adobe Acrobat Pro up to date
+  description: This device may have an outdated version of Adobe Acrobat Pro, posing a critical security risk. Adobe Acrobat is a frequent target for exploits and must be kept up to date at all times.
+  resolution: "Adobe Acrobat Pro is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
+  critical: true
+  type: patch
+  fleet_maintained_app_slug: adobe-acrobat-pro/darwin
+  install_software: true
+  labels_include_any:
+    - Macs with Adobe Acrobat Pro installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -57,8 +57,10 @@
     - x86 Windows hosts with Visual Studio Code installed
 - name: Windows - Adobe Acrobat Reader up to date
   description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
-  resolution: "Adobe Acrobat Reader is managed by IT and will be updated automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
+  resolution: "Adobe Acrobat Reader is managed by IT and should be updated automatically. If you are failing this policy, install the latest version from Self-service. If you are still failing after Refetch completes, drop a note in #help-it."
   critical: true
   type: patch
   fleet_maintained_app_slug: adobe-acrobat-reader/windows
   install_software: true
+  labels_include_any:
+    - x86 Windows hosts with Adobe Acrobat Reader installed

--- a/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
+++ b/it-and-security/lib/windows/policies/patch-fleet-maintained-apps.yml
@@ -55,3 +55,10 @@
   install_software: false
   labels_include_any:
     - x86 Windows hosts with Visual Studio Code installed
+- name: Windows - Adobe Acrobat Reader up to date
+  description: This device may have an outdated version of Adobe Acrobat Reader, posing a critical security risk. Adobe Reader is a frequent target for exploits and must be kept up to date at all times.
+  resolution: "Adobe Acrobat Reader is managed by IT and will be updated automatically. If you are failing this policy, click Refetch. If you are still failing after Refetch completes, drop a note in #help-it."
+  critical: true
+  type: patch
+  fleet_maintained_app_slug: adobe-acrobat-reader/windows
+  install_software: true


### PR DESCRIPTION
Add forceful Adobe Acrobat Reader patch policy for all devices

Add critical patch policies for Adobe Acrobat Reader on macOS and Windows that enforce immediate automatic updates via install_software: true. This ensures all devices running Adobe Reader are patched without user intervention, addressing the high-risk security profile of PDF readers.

Changes:
- Add macOS patch policy (adobe-acrobat-reader/darwin) with critical flag
- Add Windows patch policy (adobe-acrobat-reader/windows) with critical flag
- Register Adobe Acrobat Reader as a fleet_maintained_app for both platforms
  in workstations.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adobe Acrobat Reader added as self-service software for macOS and x86 Windows; categorized under Productivity.
  * Adobe Acrobat Pro added as self-service software for macOS; categorized under Productivity.
  * Automatic device targeting now surfaces these apps only to hosts that already have them installed.
  * New critical patch policies for macOS and Windows enable automatic updates with self-service fallback on install failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->