### PR TITLE
Fleet UI: Improved error message when deleting a label that is for targeting a software installation

### DIFF
--- a/changes/43767-delete-label-error-msg
+++ b/changes/43767-delete-label-error-msg
@@ -1,0 +1,1 @@
+- Fleet UI: Improved error message when deleting a label that is for targeting a software installation

--- a/frontend/interfaces/errors.ts
+++ b/frontend/interfaces/errors.ts
@@ -193,6 +193,15 @@ export const getErrorReason = (
   return "";
 };
 
+export const hasStatusKey = (value: unknown): value is { status: number } => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as any).status === "number"
+  );
+};
+
 export const ignoreAxiosError = (err: AxiosError, ignoreStatuses: number[]) => {
   // TODO - isAxiosError currently not recognizing axios error, fix
   // if (!isAxiosError(err)) {

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -113,7 +113,8 @@ import {
   MANAGE_HOSTS_PAGE_FILTER_KEYS,
   MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS,
 } from "./HostsPageConfig";
-import { getDeleteLabelErrorMessages, isAcceptableStatus } from "./helpers";
+import { isAcceptableStatus } from "./helpers";
+import getDeleteLabelErrorMessages from "pages/labels/helpers";
 
 import DeleteSecretModal from "../../../components/EnrollSecrets/DeleteSecretModal";
 import SecretEditorModal from "../../../components/EnrollSecrets/SecretEditorModal";

--- a/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
+++ b/frontend/pages/hosts/ManageHostsPage/ManageHostsPage.tsx
@@ -81,6 +81,7 @@ import {
   PolicyResponse,
 } from "utilities/constants";
 import { getNextLocationPath } from "utilities/helpers";
+import getDeleteLabelErrorMessages from "pages/labels/helpers";
 import { strToBool } from "utilities/strings/stringUtils";
 
 import Button from "components/buttons/Button";
@@ -114,7 +115,6 @@ import {
   MANAGE_HOSTS_PAGE_LABEL_INCOMPATIBLE_QUERY_PARAMS,
 } from "./HostsPageConfig";
 import { isAcceptableStatus } from "./helpers";
-import getDeleteLabelErrorMessages from "pages/labels/helpers";
 
 import DeleteSecretModal from "../../../components/EnrollSecrets/DeleteSecretModal";
 import SecretEditorModal from "../../../components/EnrollSecrets/SecretEditorModal";

--- a/frontend/pages/hosts/ManageHostsPage/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.ts
@@ -1,5 +1,3 @@
-import { getErrorReason } from "interfaces/errors";
-
 export const isAcceptableStatus = (filter: string): boolean => {
   return (
     filter === "new" ||
@@ -32,17 +30,4 @@ export const hasStatusKey = (value: unknown): value is { status: number } => {
     "status" in value &&
     typeof (value as any).status === "number"
   );
-};
-
-export const getDeleteLabelErrorMessages = (error: unknown): string => {
-  // unprocessable content status. Label is used in a custom profile
-  // or software target. we have to check that status exists on the error object
-  // before we can access it.
-  if (hasStatusKey(error) && error.status === 422) {
-    return getErrorReason(error).includes("built-in")
-      ? "Built-in labels can't be modified or deleted."
-      : "Couldn't delete. Software uses this label as a custom target. Remove the label from the software target and try again.";
-  }
-
-  return "Could not delete label. Please try again.";
 };

--- a/frontend/pages/hosts/ManageHostsPage/helpers.ts
+++ b/frontend/pages/hosts/ManageHostsPage/helpers.ts
@@ -22,12 +22,3 @@ export const isValidPemCertificate = (cert: string): boolean => {
 
   return regexPemHeader.test(cert) && regexPemFooter.test(cert);
 };
-
-export const hasStatusKey = (value: unknown): value is { status: number } => {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "status" in value &&
-    typeof (value as any).status === "number"
-  );
-};

--- a/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
+++ b/frontend/pages/hosts/details/HostDetailsPage/modals/CancelActivityModal/helpers.ts
@@ -1,4 +1,4 @@
-import { hasStatusKey } from "pages/hosts/ManageHostsPage/helpers";
+import { hasStatusKey } from "interfaces/errors";
 
 const DEFAULT_ERR_MESSAGE = "Couldn't cancel activity. Please try again.";
 const LOCK_WIPE_ERR_MESSAGE =

--- a/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
@@ -9,7 +9,7 @@ import { NotificationContext } from "context/notification";
 import useGitOpsMode from "hooks/useGitOpsMode";
 
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
-import { getDeleteLabelErrorMessages } from "pages/hosts/ManageHostsPage/helpers";
+import getDeleteLabelErrorMessages from "pages/labels/helpers";
 
 import { ILabel } from "interfaces/label";
 

--- a/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
+++ b/frontend/pages/labels/ManageLabelsPage/ManageLabelsPage.tsx
@@ -9,6 +9,7 @@ import { NotificationContext } from "context/notification";
 import useGitOpsMode from "hooks/useGitOpsMode";
 
 import labelsAPI, { ILabelsResponse } from "services/entities/labels";
+import { getDeleteLabelErrorMessages } from "pages/hosts/ManageHostsPage/helpers";
 
 import { ILabel } from "interfaces/label";
 
@@ -65,11 +66,8 @@ const ManageLabelsPage = ({ router }: IManageLabelsPageProps): JSX.Element => {
         await labelsAPI.destroy(labelToDelete);
         renderFlash("success", `Successfully deleted ${labelToDelete.name}.`);
         refetch();
-      } catch {
-        renderFlash(
-          "error",
-          `Could not delete ${labelToDelete.name}. Please try again.`
-        );
+      } catch (err) {
+        renderFlash("error", getDeleteLabelErrorMessages(err));
       } finally {
         setLabelToDelete(null);
         setIsUpdating(false);

--- a/frontend/pages/labels/helpers.ts
+++ b/frontend/pages/labels/helpers.ts
@@ -1,13 +1,4 @@
-import { getErrorReason } from "interfaces/errors";
-
-const hasStatusKey = (value: unknown): value is { status: number } => {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "status" in value &&
-    typeof (value as any).status === "number"
-  );
-};
+import { getErrorReason, hasStatusKey } from "interfaces/errors";
 
 const getDeleteLabelErrorMessages = (error: unknown): string => {
   // unprocessable content status. Label is used in a custom profile

--- a/frontend/pages/labels/helpers.ts
+++ b/frontend/pages/labels/helpers.ts
@@ -1,0 +1,25 @@
+import { getErrorReason } from "interfaces/errors";
+
+const hasStatusKey = (value: unknown): value is { status: number } => {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "status" in value &&
+    typeof (value as any).status === "number"
+  );
+};
+
+const getDeleteLabelErrorMessages = (error: unknown): string => {
+  // unprocessable content status. Label is used in a custom profile
+  // or software target. we have to check that status exists on the error object
+  // before we can access it.
+  if (hasStatusKey(error) && error.status === 422) {
+    return getErrorReason(error).includes("built-in")
+      ? "Built-in labels can't be modified or deleted."
+      : "Couldn't delete. Software uses this label as a custom target. Remove the label from the software target and try again.";
+  }
+
+  return "Could not delete label. Please try again.";
+};
+
+export default getDeleteLabelErrorMessages;


### PR DESCRIPTION
## Issue
Closes #43767 

## Description
- See AI description

## Screenshot of fix

<img width="1070" height="356" alt="Screenshot 2026-04-28 at 3 08 02 PM" src="https://github.com/user-attachments/assets/490352b5-84d0-4f82-85c0-47a40f3c4e1d" />


- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.


## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delete-label error messaging: when deleting a label tied to software targeting fails, the UI now shows clearer, context-aware guidance — distinguishing built-in labels from labels attached to a software target — instead of a generic fallback message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->