### PR TITLE
Fleet UI: Creating policy redirects to policy details page

### DIFF
--- a/frontend/pages/policies/edit/screens/QueryEditor.tsx
+++ b/frontend/pages/policies/edit/screens/QueryEditor.tsx
@@ -169,7 +169,7 @@ const QueryEditor = ({
       );
       setIsUpdatingPolicy(false);
       router.push(
-        getPathWithQueryParams(PATHS.EDIT_POLICY(policy.id), {
+        getPathWithQueryParams(PATHS.POLICY_DETAILS(policy.id), {
           fleet_id: policy.team_id,
         })
       );


### PR DESCRIPTION
## Issue
Closes #44314 

## Description
- Follows report mental model

## Screenrecording


https://github.com/user-attachments/assets/d8beee97-4183-40bb-a1c8-0cc041262932




## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved policy creation workflow: Users are now directed to the policy details page after successfully creating a policy instead of the edit page, allowing immediate review of the new policy configuration while maintaining the current fleet context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->