### PR TITLE
Fix some bugs in charts UI

### DIFF
--- a/frontend/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/pages/DashboardPage/DashboardPage.tsx
@@ -18,7 +18,7 @@ import {
   IEnrollSecret,
   IEnrollSecretsResponse,
 } from "interfaces/enroll_secret";
-import { IHostSummary, IHostSummaryPlatforms } from "interfaces/host_summary";
+import { IHostSummary } from "interfaces/host_summary";
 import { ILabelSummary } from "interfaces/label";
 import { IMacadminAggregate } from "interfaces/macadmins";
 import {
@@ -68,7 +68,6 @@ import {
   PLATFORM_NAME_TO_LABEL_NAME,
 } from "./helpers";
 import useInfoCard from "./components/InfoCard";
-import PlatformHostCounts from "./sections/PlatformHostCounts";
 import MetricsHostCounts from "./sections/MetricsHostCounts";
 import ActivityFeed from "./cards/ActivityFeed";
 import Software from "./cards/Software";
@@ -137,13 +136,6 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
     setSelectedPlatformLabelId,
   ] = useState<number>();
   const [labels, setLabels] = useState<ILabelSummary[]>();
-  const [macCount, setMacCount] = useState(0);
-  const [windowsCount, setWindowsCount] = useState(0);
-  const [linuxCount, setLinuxCount] = useState(0);
-  const [chromeCount, setChromeCount] = useState(0);
-  const [iosCount, setIosCount] = useState(0);
-  const [ipadosCount, setIpadosCount] = useState(0);
-  const [androidCount, setAndroidCount] = useState(0);
   const [missingCount, setMissingCount] = useState(0);
   const [lowDiskSpaceCount, setLowDiskSpaceCount] = useState(0);
   const [abmIssueCount, setAbmIssueCount] = useState(0);
@@ -231,37 +223,6 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
           setLowDiskSpaceCount(data.low_disk_space_count || 0);
           setAbmIssueCount(data.dep_assign_error_count || 0);
         }
-        const macHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "darwin"
-        ) || { platform: "darwin", hosts_count: 0 };
-
-        const windowsHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "windows"
-        ) || { platform: "windows", hosts_count: 0 };
-
-        const chomeOSHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "chrome"
-        ) || { platform: "chrome", hosts_count: 0 };
-
-        const iOSHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "ios"
-        ) || { platform: "ios", hosts_count: 0 };
-
-        const iPadOSHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "ipados"
-        ) || { platform: "ipados", hosts_count: 0 };
-
-        const androidHosts = data.platforms?.find(
-          (platform: IHostSummaryPlatforms) => platform.platform === "android"
-        ) || { platform: "android", hosts_count: 0 };
-
-        setMacCount(macHosts.hosts_count);
-        setWindowsCount(windowsHosts.hosts_count);
-        setLinuxCount(data.all_linux_count);
-        setChromeCount(chomeOSHosts.hosts_count);
-        setIosCount(iOSHosts.hosts_count);
-        setIpadosCount(iPadOSHosts.hosts_count);
-        setAndroidCount(androidHosts.hosts_count);
         setShowHostsUI(true);
       },
     }
@@ -615,39 +576,20 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
       <DataError verticalPaddingSize="pad-large" />
     </Card>
   ) : (
-    <>
-      <PlatformHostCounts
-        currentTeamId={teamIdForApi}
-        macCount={macCount}
-        windowsCount={windowsCount}
-        linuxCount={linuxCount}
-        chromeCount={chromeCount}
-        iosCount={iosCount}
-        ipadosCount={ipadosCount}
-        androidCount={androidCount}
-        builtInLabels={labels}
-        selectedPlatform={selectedPlatform}
-        totalHostCount={
-          !isHostSummaryFetching && !errorHosts
-            ? hostSummaryData?.totals_hosts_count
-            : undefined
-        }
-      />
-      <MetricsHostCounts
-        currentTeamId={teamIdForApi}
-        selectedPlatform={selectedPlatform}
-        totalHostCount={
-          !isHostSummaryFetching && !errorHosts
-            ? hostSummaryData?.totals_hosts_count
-            : undefined
-        }
-        isPremiumTier={isPremiumTier}
-        missingCount={missingCount}
-        lowDiskSpaceCount={lowDiskSpaceCount}
-        abmIssueCount={abmIssueCount}
-        selectedPlatformLabelId={selectedPlatformLabelId}
-      />
-    </>
+    <MetricsHostCounts
+      currentTeamId={teamIdForApi}
+      selectedPlatform={selectedPlatform}
+      totalHostCount={
+        !isHostSummaryFetching && !errorHosts
+          ? hostSummaryData?.totals_hosts_count
+          : undefined
+      }
+      isPremiumTier={isPremiumTier}
+      missingCount={missingCount}
+      lowDiskSpaceCount={lowDiskSpaceCount}
+      abmIssueCount={abmIssueCount}
+      selectedPlatformLabelId={selectedPlatformLabelId}
+    />
   );
 
   const WelcomeHostCard = useInfoCard({
@@ -943,7 +885,12 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
         </div>
         <div className={`${baseClass}__charts-row`}>
           <Card paddingSize="xlarge" borderRadiusSize="large">
-            <HostsEnrolledCard counts={totalCounts} />
+            <HostsEnrolledCard
+              counts={totalCounts}
+              builtInLabels={labels}
+              currentTeamId={teamIdForApi}
+              router={router}
+            />
           </Card>
           <Card paddingSize="xlarge" borderRadiusSize="large">
             <ChartCard currentTeamId={teamIdForApi} />
@@ -967,6 +914,15 @@ const DashboardPage = ({ router, location }: IDashboardProps): JSX.Element => {
               );
             }}
           />
+        </div>
+        <div className={`${baseClass}__host-sections`}>
+          {isHostSummaryFetching ? (
+            <Card paddingSize="medium">
+              <Spinner includeContainer={false} verticalPadding="small" />
+            </Card>
+          ) : (
+            HostCountCards
+          )}
         </div>
         {renderCards()}
         {showAddHostsModal && renderAddHostsModal()}

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -17,8 +17,8 @@ import { PLATFORM_NAME_TO_LABEL_NAME } from "pages/DashboardPage/helpers";
 
 const baseClass = "hosts-enrolled-card";
 
-// Use design-system color token via CSS custom property so recharts picks
-// up the themed value for the bar fill.
+// Use the design-system color token via CSS custom property so recharts
+// picks up the themed value for the SVG fill.
 const BAR_COLOR = "var(--core-fleet-green)";
 
 export interface IHostPlatformCounts {
@@ -46,6 +46,8 @@ interface IPlatformDatum {
   platform: PlatformKey;
 }
 
+// Make a map of platform to label for use in linking to the correct hosts list
+// when clicked.
 const PLATFORM_ROWS: { platform: PlatformKey; label: string }[] = [
   { platform: "darwin", label: "macOS" },
   { platform: "windows", label: "Windows" },
@@ -68,6 +70,7 @@ interface IYAxisTickProps {
   x?: number;
   y?: number;
   payload?: { value: string; index: number };
+  isClickable: (index: number) => boolean;
   onLabelClick: (index: number) => void;
 }
 
@@ -75,15 +78,24 @@ const ClickableYAxisTick = ({
   x = 0,
   y = 0,
   payload,
+  isClickable,
   onLabelClick,
 }: IYAxisTickProps): JSX.Element => {
   if (!payload) return <g />;
+  const clickable = isClickable(payload.index);
   return (
     <g
       transform={`translate(${x},${y})`}
-      onClick={() => onLabelClick(payload.index)}
+      onClick={clickable ? () => onLabelClick(payload.index) : undefined}
     >
-      <text x={0} y={0} dy={4} textAnchor="end" fontSize={14}>
+      <text
+        x={0}
+        y={0}
+        dy={4}
+        textAnchor="end"
+        fontSize={14}
+        className={clickable ? `${baseClass}__tick--clickable` : undefined}
+      >
         {payload.value}
       </text>
     </g>
@@ -127,6 +139,12 @@ const HostsEnrolledCard = ({
     if (datum) navigateToPlatform(datum.platform, datum.count);
   };
 
+  const isTickClickable = (index: number) => {
+    const datum = data[index];
+    if (!datum || !datum.count) return false;
+    return getLabelId(datum.platform) !== undefined;
+  };
+
   return (
     <div className={baseClass}>
       <h2 className={`${baseClass}__title`}>Hosts enrolled</h2>
@@ -152,16 +170,27 @@ const HostsEnrolledCard = ({
             axisLine={false}
             tickLine={false}
             width={80}
-            tick={<ClickableYAxisTick onLabelClick={handleTickClick} />}
+            tick={
+              <ClickableYAxisTick
+                isClickable={isTickClickable}
+                onLabelClick={handleTickClick}
+              />
+            }
           />
           <Bar
             dataKey="count"
             radius={[0, 4, 4, 0]}
             barSize={16}
-            onClick={(d) => handleBarClick(d as IPlatformDatum)}
+            onClick={(d) => handleBarClick(d.payload as IPlatformDatum)}
           >
             {data.map((entry) => (
-              <Cell key={entry.label} fill={BAR_COLOR} />
+              <Cell
+                key={entry.label}
+                fill={BAR_COLOR}
+                className={
+                  entry.count > 0 ? `${baseClass}__bar--clickable` : undefined
+                }
+              />
             ))}
           </Bar>
         </BarChart>

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -8,6 +8,7 @@ import {
   CartesianGrid,
   ResponsiveContainer,
   Cell,
+  Tooltip,
 } from "recharts";
 
 import PATHS from "router/paths";
@@ -17,9 +18,10 @@ import { PLATFORM_NAME_TO_LABEL_NAME } from "pages/DashboardPage/helpers";
 
 const baseClass = "hosts-enrolled-card";
 
-// Use the design-system color token via CSS custom property so recharts
-// picks up the themed value for the SVG fill.
+// Use design-system color tokens via CSS custom properties so recharts picks
+// up the themed values for the SVG fills.
 const BAR_COLOR = "var(--core-fleet-green)";
+const BAR_HOVER_COLOR = "var(--core-fleet-green-over)";
 
 export interface IHostPlatformCounts {
   darwin: number;
@@ -64,6 +66,27 @@ const formatTick = (value: number): string => {
     return Number.isInteger(k) ? `${k}k` : `${k.toFixed(1)}k`;
   }
   return `${value}`;
+};
+
+interface ITooltipProps {
+  active?: boolean;
+  payload?: { payload: IPlatformDatum }[];
+}
+
+const HostsEnrolledTooltip = ({
+  active,
+  payload,
+}: ITooltipProps): JSX.Element | null => {
+  if (!active || !payload?.length) return null;
+  const datum = payload[0].payload;
+  return (
+    <div className={`${baseClass}__tooltip`}>
+      <div className={`${baseClass}__tooltip-label`}>{datum.label}</div>
+      <div className={`${baseClass}__tooltip-value`}>
+        {datum.count.toLocaleString()} hosts
+      </div>
+    </div>
+  );
 };
 
 interface IYAxisTickProps {
@@ -179,10 +202,17 @@ const HostsEnrolledCard = ({
               />
             }
           />
+          <Tooltip
+            content={<HostsEnrolledTooltip />}
+            cursor={false}
+            isAnimationActive={false}
+          />
           <Bar
             dataKey="count"
             radius={[0, 4, 4, 0]}
             barSize={16}
+            isAnimationActive={false}
+            activeBar={{ fill: BAR_HOVER_COLOR }}
             onClick={(d) => handleBarClick(d.payload as IPlatformDatum)}
           >
             {data.map((entry) => (

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -17,10 +17,9 @@ import { PLATFORM_NAME_TO_LABEL_NAME } from "pages/DashboardPage/helpers";
 
 const baseClass = "hosts-enrolled-card";
 
-// Use design-system color tokens via CSS custom properties so recharts picks
-// up the themed value for SVG fill / text colors.
+// Use design-system color token via CSS custom property so recharts picks
+// up the themed value for the bar fill.
 const BAR_COLOR = "var(--core-fleet-green)";
-const TICK_COLOR = "var(--ui-fleet-black-75)";
 
 export interface IHostPlatformCounts {
   darwin: number;
@@ -82,10 +81,9 @@ const ClickableYAxisTick = ({
   return (
     <g
       transform={`translate(${x},${y})`}
-      style={{ cursor: "pointer", outline: "none" }}
       onClick={() => onLabelClick(payload.index)}
     >
-      <text x={0} y={0} dy={4} textAnchor="end" fill={TICK_COLOR} fontSize={14}>
+      <text x={0} y={0} dy={4} textAnchor="end" fontSize={14}>
         {payload.value}
       </text>
     </g>
@@ -146,7 +144,7 @@ const HostsEnrolledCard = ({
             tickFormatter={formatTick}
             axisLine={false}
             tickLine={false}
-            tick={{ fontSize: 14, fill: TICK_COLOR }}
+            tick={{ fontSize: 14 }}
           />
           <YAxis
             type="category"
@@ -161,7 +159,6 @@ const HostsEnrolledCard = ({
             radius={[0, 4, 4, 0]}
             barSize={16}
             onClick={(d) => handleBarClick(d as IPlatformDatum)}
-            style={{ cursor: "pointer", outline: "none" }}
           >
             {data.map((entry) => (
               <Cell key={entry.label} fill={BAR_COLOR} />

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { InjectedRouter } from "react-router";
 import {
   BarChart,
   Bar,
@@ -9,11 +10,17 @@ import {
   Cell,
 } from "recharts";
 
+import PATHS from "router/paths";
+import { ILabelSummary } from "interfaces/label";
+import { getPathWithQueryParams } from "utilities/url";
+import { PLATFORM_NAME_TO_LABEL_NAME } from "pages/DashboardPage/helpers";
+
 const baseClass = "hosts-enrolled-card";
 
-// Use the design-system color token via CSS custom property so recharts
-// picks up the themed value for the SVG fill.
+// Use design-system color tokens via CSS custom properties so recharts picks
+// up the themed value for SVG fill / text colors.
 const BAR_COLOR = "var(--core-fleet-green)";
+const TICK_COLOR = "var(--ui-fleet-black-75)";
 
 export interface IHostPlatformCounts {
   darwin: number;
@@ -25,14 +32,30 @@ export interface IHostPlatformCounts {
   android: number;
 }
 
+type PlatformKey = keyof IHostPlatformCounts;
+
 interface IHostsEnrolledCardProps {
   counts: IHostPlatformCounts;
+  builtInLabels?: ILabelSummary[];
+  currentTeamId?: number;
+  router: InjectedRouter;
 }
 
 interface IPlatformDatum {
   label: string;
   count: number;
+  platform: PlatformKey;
 }
+
+const PLATFORM_ROWS: { platform: PlatformKey; label: string }[] = [
+  { platform: "darwin", label: "macOS" },
+  { platform: "windows", label: "Windows" },
+  { platform: "linux", label: "Linux" },
+  { platform: "chrome", label: "ChromeOS" },
+  { platform: "ios", label: "iOS" },
+  { platform: "ipados", label: "iPadOS" },
+  { platform: "android", label: "Android" },
+];
 
 const formatTick = (value: number): string => {
   if (value >= 1000) {
@@ -42,18 +65,69 @@ const formatTick = (value: number): string => {
   return `${value}`;
 };
 
+interface IYAxisTickProps {
+  x?: number;
+  y?: number;
+  payload?: { value: string; index: number };
+  onLabelClick: (index: number) => void;
+}
+
+const ClickableYAxisTick = ({
+  x = 0,
+  y = 0,
+  payload,
+  onLabelClick,
+}: IYAxisTickProps): JSX.Element => {
+  if (!payload) return <g />;
+  return (
+    <g
+      transform={`translate(${x},${y})`}
+      style={{ cursor: "pointer", outline: "none" }}
+      onClick={() => onLabelClick(payload.index)}
+    >
+      <text x={0} y={0} dy={4} textAnchor="end" fill={TICK_COLOR} fontSize={14}>
+        {payload.value}
+      </text>
+    </g>
+  );
+};
+
 const HostsEnrolledCard = ({
   counts,
+  builtInLabels,
+  currentTeamId,
+  router,
 }: IHostsEnrolledCardProps): JSX.Element => {
-  const data: IPlatformDatum[] = [
-    { label: "macOS", count: counts.darwin },
-    { label: "Windows", count: counts.windows },
-    { label: "Linux", count: counts.linux },
-    { label: "ChromeOS", count: counts.chrome },
-    { label: "iOS", count: counts.ios },
-    { label: "iPadOS", count: counts.ipados },
-    { label: "Android", count: counts.android },
-  ];
+  const data: IPlatformDatum[] = PLATFORM_ROWS.map(({ platform, label }) => ({
+    platform,
+    label,
+    count: counts[platform],
+  }));
+
+  const getLabelId = (platform: PlatformKey): number | undefined => {
+    const labelName = PLATFORM_NAME_TO_LABEL_NAME[platform];
+    return builtInLabels?.find((l) => l.name === labelName)?.id;
+  };
+
+  const navigateToPlatform = (platform: PlatformKey, count: number) => {
+    if (!count) return;
+    const labelId = getLabelId(platform);
+    if (labelId === undefined) return;
+    router.push(
+      getPathWithQueryParams(PATHS.MANAGE_HOSTS_LABEL(labelId), {
+        fleet_id: currentTeamId,
+      })
+    );
+  };
+
+  const handleBarClick = (datum: IPlatformDatum) => {
+    navigateToPlatform(datum.platform, datum.count);
+  };
+
+  const handleTickClick = (index: number) => {
+    const datum = data[index];
+    if (datum) navigateToPlatform(datum.platform, datum.count);
+  };
 
   return (
     <div className={baseClass}>
@@ -72,7 +146,7 @@ const HostsEnrolledCard = ({
             tickFormatter={formatTick}
             axisLine={false}
             tickLine={false}
-            tick={{ fontSize: 14 }}
+            tick={{ fontSize: 14, fill: TICK_COLOR }}
           />
           <YAxis
             type="category"
@@ -80,9 +154,15 @@ const HostsEnrolledCard = ({
             axisLine={false}
             tickLine={false}
             width={80}
-            tick={{ fontSize: 14 }}
+            tick={<ClickableYAxisTick onLabelClick={handleTickClick} />}
           />
-          <Bar dataKey="count" radius={[0, 4, 4, 0]} barSize={16}>
+          <Bar
+            dataKey="count"
+            radius={[0, 4, 4, 0]}
+            barSize={16}
+            onClick={(d) => handleBarClick(d as IPlatformDatum)}
+            style={{ cursor: "pointer", outline: "none" }}
+          >
             {data.map((entry) => (
               <Cell key={entry.label} fill={BAR_COLOR} />
             ))}

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/HostsEnrolledCard.tsx
@@ -114,6 +114,8 @@ const HostsEnrolledCard = ({
     count: counts[platform],
   }));
 
+  // Given a platform, find the corresponding built-in label ID for linking to the
+  // hosts list.
   const getLabelId = (platform: PlatformKey): number | undefined => {
     const labelName = PLATFORM_NAME_TO_LABEL_NAME[platform];
     return builtInLabels?.find((l) => l.name === labelName)?.id;

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -4,4 +4,16 @@
     font-weight: $bold;
     margin: 0 0 $pad-medium !important;
   }
+
+  // Suppress browser focus/click outlines on the chart wrapper, SVG surface,
+  // and individual bar rectangles. Recharts wraps each bar in a focusable
+  // <rect> and the chart surface itself is focusable when interactive.
+  .recharts-wrapper,
+  .recharts-surface,
+  .recharts-bar-rectangle,
+  .recharts-rectangle,
+  .recharts-wrapper *:focus,
+  .recharts-wrapper *:focus-visible {
+    outline: none !important;
+  }
 }

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -5,6 +5,19 @@
     margin: 0 0 $pad-medium !important;
   }
 
+  // Theme-aware axis tick text. CSS fill overrides the inline fill attribute
+  // recharts adds to its default <text> elements. Font size stays inline
+  // (recharts measures it via getComputedStyle to lay out the axis).
+  .recharts-cartesian-axis text {
+    fill: $ui-fleet-black-75;
+  }
+
+  // Y-axis labels and bars are clickable.
+  .recharts-yAxis .recharts-cartesian-axis-tick,
+  .recharts-bar-rectangle {
+    cursor: pointer;
+  }
+
   // Suppress browser focus/click outlines on the chart wrapper, SVG surface,
   // and individual bar rectangles. Recharts wraps each bar in a focusable
   // <rect> and the chart surface itself is focusable when interactive.

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -12,9 +12,10 @@
     fill: $ui-fleet-black-75;
   }
 
-  // Y-axis labels and bars are clickable.
-  .recharts-yAxis .recharts-cartesian-axis-tick,
-  .recharts-bar-rectangle {
+  // Pointer cursor only on rows with hosts. The component adds these classes
+  // to the y-axis <text> and <Cell> elements when count > 0.
+  &__tick--clickable,
+  &__bar--clickable {
     cursor: pointer;
   }
 

--- a/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
+++ b/frontend/pages/DashboardPage/cards/HostsEnrolledCard/_styles.scss
@@ -8,7 +8,9 @@
   // Theme-aware axis tick text. CSS fill overrides the inline fill attribute
   // recharts adds to its default <text> elements. Font size stays inline
   // (recharts measures it via getComputedStyle to lay out the axis).
-  .recharts-cartesian-axis text {
+  // Note: recharts portals tick labels out of .recharts-cartesian-axis into a
+  // .recharts-zIndex-layer_* group, so we target via .recharts-wrapper.
+  .recharts-wrapper text {
     fill: $ui-fleet-black-75;
   }
 
@@ -17,6 +19,25 @@
   &__tick--clickable,
   &__bar--clickable {
     cursor: pointer;
+  }
+
+  &__tooltip {
+    background: $core-fleet-black;
+    color: $core-fleet-white;
+    padding: $pad-small $pad-medium;
+    border-radius: $border-radius;
+    font-size: $xx-small;
+    box-shadow: 0px 2px 6px rgba(0, 0, 0, 0.1);
+    white-space: nowrap;
+  }
+
+  &__tooltip-label {
+    margin-bottom: $pad-xsmall;
+    opacity: 0.8;
+  }
+
+  &__tooltip-value {
+    font-weight: $bold;
   }
 
   // Suppress browser focus/click outlines on the chart wrapper, SVG surface,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44249

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.
n/a, unreleased

## Testing

- [ ] Added/updated automated tests
not worth it for style fixes and accidental content removal
- [ ] Where appropriate, [automated tests simulate multiple hosts and test for host isolation](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/reference/patterns-backend.md#unit-testing) (updates to one hosts's records do not affect another)

- [X] QA'd all new/changed functionality manually
  - [X] can click on hosts enrolled labels and bars to go to the appropriate hosts list
  - [X] no more weird focus rectangles on hosts enrolled chart
  - [X] hosts enrolled chart y-axis respects dark mode
  - [X] metrics cards returned to dashboard
  - [X] hovering over a bar on the hosts enrolled chart shows a tooltip with the # of hosts in that platform

For unreleased bug fixes in a release candidate, one of:

- [X] Confirmed that the fix is not expected to adversely impact load test results


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosts Enrolled card: click platform bars or Y-axis labels to navigate to platform-specific host lists; interactive tooltips show platform and host count.

* **UI Improvements**
  * Streamlined dashboard host-count display with a small loading spinner while summaries load.
  * Improved interactivity cues: hover styles, pointer cursor, and refined tooltip visuals for chart elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->