### PR TITLE
Update ee/fleet-agent-downloader app configuration

### DIFF
--- a/ee/fleet-agent-downloader/.sailsrc
+++ b/ee/fleet-agent-downloader/.sailsrc
@@ -2,6 +2,9 @@
   "generators": {
     "modules": {}
   },
+  "hooks": {
+    "sockets": false
+  },
   "_generatedWith": {
     "sails": "1.5.17",
     "sails-generate": "2.0.13"

--- a/ee/fleet-agent-downloader/config/env/production.js
+++ b/ee/fleet-agent-downloader/config/env/production.js
@@ -189,7 +189,7 @@ module.exports = {
     *                                                                          *
     ***************************************************************************/
     adapter: '@sailshq/connect-redis',
-    url: process.env.REDIS_TLS_URL,
+    url: process.env.REDIS_URL,
     tls: {
       rejectUnauthorized: false
     },

--- a/ee/fleet-agent-downloader/config/env/production.js
+++ b/ee/fleet-agent-downloader/config/env/production.js
@@ -47,8 +47,12 @@ module.exports = {
     *                                                                          *
     ***************************************************************************/
     default: {
-      // adapter: 'sails-mysql',
-      // url: 'mysql://user:password@host:port/database',
+      adapter: 'sails-postgresql',
+      url: process.env.DATABASE_URL,
+      ssl: {
+        sslmode: 'require',
+        rejectUnauthorized: false,
+      }
       //--------------------------------------------------------------------------
       //  /\   To avoid checking it in to version control, you might opt to set
       //  ||   sensitive credentials like `url` using an environment variable.
@@ -184,8 +188,11 @@ module.exports = {
     * > (For a full list, see https://sailsjs.com/plugins/sessions)            *
     *                                                                          *
     ***************************************************************************/
-    // adapter: '@sailshq/connect-redis',
-    // url: 'redis://user:password@localhost:6379/databasenumber',
+    adapter: '@sailshq/connect-redis',
+    url: process.env.REDIS_TLS_URL,
+    tls: {
+      rejectUnauthorized: false
+    },
     //--------------------------------------------------------------------------
     // /\   OR, to avoid checking it in to version control, you might opt to
     // ||   set sensitive credentials like this using an environment variable.


### PR DESCRIPTION
Changes:
- Updated the configuration in the ee/fleet-agent-downloader app to disable the sockets hook and to use environment variables set by Heroku add-ons (`DATABASE_URL` and `REDIS_URL`) in production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured database setup with PostgreSQL and SSL/TLS support.
  * Enabled Redis-backed session storage with TLS security configuration.
  * Disabled sockets hook in core configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->