### PR TITLE
move main customer quote up a section

### DIFF
--- a/website/views/pages/infrastructure-as-code.ejs
+++ b/website/views/pages/infrastructure-as-code.ejs
@@ -50,6 +50,27 @@
       </div>
     </div>
 
+
+    <%# Quote section %>
+    <div purpose="page-section">
+      <div purpose="section-quote">
+        <div purpose="quote-image">
+          <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
+        </div>
+        <p purpose="quote-text">“The shift to infrastructure as code has modernized our operations giving us the agility and change control we needed giving leadership real-time confidence in device health and compliance.”</p>
+        <div purpose="quote-author-info">
+          <div purpose="quote-author-image">
+            <img alt="Dan Jackson" src="/images/testimonial-author-dan-jackson-48x48@2x.png">
+          </div>
+          <div purpose="name-and-title">
+            <p purpose="author-name">Dan Jackson</p>
+            <p purpose="author-title">Sr Manager Systems Engineering, Fastly</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+
     <div purpose="page-section">
       <div purpose="section-title">
         <h2>Less manual work, faster recovery, <br>simpler compliance.</h2>
@@ -75,24 +96,6 @@
       </div>
     </div>
 
-    <%# Quote section %>
-    <div purpose="page-section">
-      <div purpose="section-quote">
-        <div purpose="quote-image">
-          <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
-        </div>
-        <p purpose="quote-text">“The shift to GitOps has modernized our operations giving us the agility and change control we needed giving leadership real-time confidence in device health and compliance.”</p>
-        <div purpose="quote-author-info">
-          <div purpose="quote-author-image">
-            <img alt="Dan Jackson" src="/images/testimonial-author-dan-jackson-48x48@2x.png">
-          </div>
-          <div purpose="name-and-title">
-            <p purpose="author-name">Dan Jackson</p>
-            <p purpose="author-title">Sr Manager Systems Engineering, Fastly</p>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <%# Feature with images sections %>
     <div purpose="page-section">
@@ -206,8 +209,8 @@
               <td>GUI or web console</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Git repository and YAML</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Git repository and YAML</p>
                 </div>
               </td>
             </tr>
@@ -216,8 +219,8 @@
               <td>Spreadsheets or vendor database</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Version-controlled files</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Version-controlled files</p>
                 </div>
               </td>
             </tr>
@@ -226,8 +229,8 @@
               <td>Verbal approval or action logs</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Pull requests with peer review</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Pull requests with peer review</p>
                 </div>
               </td>
             </tr>
@@ -236,8 +239,8 @@
               <td>Manual or periodic reporting</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Continuous self-healing</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Continuous self-healing</p>
                 </div>
               </td>
             </tr>
@@ -246,8 +249,8 @@
               <td>Manual redo or backups/restore</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Revert a Git commit</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Revert a Git commit</p>
                 </div>
               </td>
             </tr>
@@ -256,8 +259,8 @@
               <td>Fragmented or click history</td>
               <td>
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Immutable commit history</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Immutable commit history</p>
                 </div>
               </td>
             </tr>
@@ -277,8 +280,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Git repository and YAML</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Git repository and YAML</p>
                 </div>
               </div>
             </div>
@@ -296,8 +299,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Version-controlled files</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Version-controlled files</p>
                 </div>
               </div>
             </div>
@@ -315,8 +318,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Pull requests with peer review</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Pull requests with peer review</p>
                 </div>
               </div>
             </div>
@@ -334,8 +337,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Continuous self-healing</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Continuous self-healing</p>
                 </div>
               </div>
             </div>
@@ -353,8 +356,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Revert a Git commit</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Revert a Git commit</p>
                 </div>
               </div>
             </div>
@@ -372,8 +375,8 @@
               <div purpose="comparison-name">Fleet GitOps (IaC)</div>
               <div purpose="comparison-status">
                 <div purpose="fleet-cell">
-                <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
-                <p>Immutable commit history</p>
+                  <img alt="checkmark" src="/images/icon-checkmark-green-16x16@2x.png">
+                  <p>Immutable commit history</p>
                 </div>
               </div>
             </div>
@@ -446,7 +449,7 @@
         </div>
 
 
-<%#         <div purpose="card">
+        <%#         <div purpose="card">
           <p><strong>Global social media platform</strong></p>
           <p>Global social media platform migrates to Fleet.</p>
           <a href="/case-study/">Read their story</a>

--- a/website/views/pages/infrastructure-as-code.ejs
+++ b/website/views/pages/infrastructure-as-code.ejs
@@ -57,7 +57,7 @@
         <div purpose="quote-image">
           <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
         </div>
-        <p purpose="quote-text">“The shift to infrastructure as code has modernized our operations giving us the agility and change control we needed giving leadership real-time confidence in device health and compliance.”</p>
+        <p purpose="quote-text">"The shift to infrastructure as code has modernized our operations, giving us the agility and change control we needed, giving leadership real-time confidence in device health and compliance."</p>
         <div purpose="quote-author-info">
           <div purpose="quote-author-image">
             <img alt="Dan Jackson" src="/images/testimonial-author-dan-jackson-48x48@2x.png">


### PR DESCRIPTION
Moved main Fastly quote up so it is after the "ClickOps does not scale" section (closer to fold).
Also changed the quote from "GitOps" to "infrastructure as code" since our lower repeated version of the same quote says IaC, and it aligns more with the page overall, and it is likely the actual quote.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated testimonial on the infrastructure-as-code page to reflect current messaging.

* **Style**
  * Improved layout and alignment in desktop and mobile comparison views for more consistent presentation.
  * Minor markup tidy-up to ensure cleaner page formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->