### PR TITLE
Trigger CertificateList on macOS ACME profile install (PR 2/8)

### DIFF
--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1669,17 +1669,6 @@ WHERE
 	return dest, nil
 }
 
-// ProfileHasACMEPayloadForCommand bundles the gates needed to decide whether
-// an InstallProfile ack should trigger a CertificateList refetch on macOS:
-// host platform, profile UUID, whether the delivered profile contains a
-// com.apple.security.acme payload, and whether a CertificateList refetch is
-// already pending for the host. Computed in a single indexed lookup so the
-// per-ack hot path stays cheap.
-//
-// LOCATE on the mobileconfig blob is byte-exact (mediumblob, no collation).
-// False positive risk is bounded — if the substring appears outside an actual
-// payload-type element, the worst case is one redundant CertificateList
-// command queued for that host.
 func (ds *Datastore) ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID, commandUUID string) (fleet.ProfileACMECommandResult, error) {
 	const stmt = `
 SELECT

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1675,13 +1675,7 @@ SELECT
 	h.id              AS host_id,
 	h.platform        AS platform,
 	hmap.profile_uuid AS profile_uuid,
-	LOCATE('com.apple.security.acme', mac.mobileconfig) > 0 AS has_acme_payload,
-	EXISTS(
-		SELECT 1
-		FROM host_mdm_commands hmc
-		WHERE hmc.host_id = h.id
-		  AND hmc.command_type = ?
-	) AS refetch_pending
+	LOCATE('com.apple.security.acme', mac.mobileconfig) > 0 AS has_acme_payload
 FROM host_mdm_apple_profiles hmap
 	JOIN hosts h
 		ON h.uuid = hmap.host_uuid
@@ -1691,8 +1685,7 @@ WHERE hmap.command_uuid = ?
 	AND hmap.host_uuid    = ?`
 
 	var dest fleet.ProfileACMECommandResult
-	err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt,
-		fleet.RefetchCertsCommandUUIDPrefix, commandUUID, hostUUID)
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt, commandUUID, hostUUID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return dest, notFound("HostMDMAppleProfile").WithMessage(fmt.Sprintf("command uuid %s not found for host uuid %s", commandUUID, hostUUID))

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1669,6 +1669,37 @@ WHERE
 	return dest, nil
 }
 
+// GetHostAndProfileByCommandUUID returns identifying details about the host
+// and the Apple configuration profile that produced the given InstallProfile
+// command. Used by post-ack handlers that need to inspect the delivered
+// profile content.
+func (ds *Datastore) GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID, hostUUID string) (uint, string, string, error) {
+	const stmt = `
+SELECT
+	h.id AS host_id,
+	h.platform AS platform,
+	hmap.profile_uuid AS profile_uuid
+FROM
+	host_mdm_apple_profiles hmap
+	JOIN hosts h ON h.uuid = hmap.host_uuid
+WHERE
+	hmap.command_uuid = ?
+	AND hmap.host_uuid = ?`
+
+	var dest struct {
+		HostID      uint   `db:"host_id"`
+		Platform    string `db:"platform"`
+		ProfileUUID string `db:"profile_uuid"`
+	}
+	if err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt, commandUUID, hostUUID); err != nil {
+		if err == sql.ErrNoRows {
+			return 0, "", "", notFound("HostMDMAppleProfile").WithMessage(fmt.Sprintf("command uuid %s not found for host uuid %s", commandUUID, hostUUID))
+		}
+		return 0, "", "", ctxerr.Wrap(ctx, err, "get host and profile by command uuid")
+	}
+	return dest.HostID, dest.Platform, dest.ProfileUUID, nil
+}
+
 func batchSetProfileLabelAssociationsDB(
 	ctx context.Context,
 	tx sqlx.ExtContext,

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1632,7 +1632,7 @@ WHERE
 func (ds *Datastore) GetHostMDMProfileRetryCountByCommandUUID(ctx context.Context, host *fleet.Host, cmdUUID string) (fleet.HostMDMProfileRetryCount, error) {
 	const darwinStmt = `
 SELECT
-	profile_identifier, retries
+	profile_identifier, profile_uuid, retries
 FROM
 	host_mdm_apple_profiles hmap
 WHERE
@@ -1667,37 +1667,6 @@ WHERE
 	}
 
 	return dest, nil
-}
-
-// GetHostAndProfileByCommandUUID returns identifying details about the host
-// and the Apple configuration profile that produced the given InstallProfile
-// command. Used by post-ack handlers that need to inspect the delivered
-// profile content.
-func (ds *Datastore) GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID, hostUUID string) (uint, string, string, error) {
-	const stmt = `
-SELECT
-	h.id AS host_id,
-	h.platform AS platform,
-	hmap.profile_uuid AS profile_uuid
-FROM
-	host_mdm_apple_profiles hmap
-	JOIN hosts h ON h.uuid = hmap.host_uuid
-WHERE
-	hmap.command_uuid = ?
-	AND hmap.host_uuid = ?`
-
-	var dest struct {
-		HostID      uint   `db:"host_id"`
-		Platform    string `db:"platform"`
-		ProfileUUID string `db:"profile_uuid"`
-	}
-	if err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt, commandUUID, hostUUID); err != nil {
-		if err == sql.ErrNoRows {
-			return 0, "", "", notFound("HostMDMAppleProfile").WithMessage(fmt.Sprintf("command uuid %s not found for host uuid %s", commandUUID, hostUUID))
-		}
-		return 0, "", "", ctxerr.Wrap(ctx, err, "get host and profile by command uuid")
-	}
-	return dest.HostID, dest.Platform, dest.ProfileUUID, nil
 }
 
 func batchSetProfileLabelAssociationsDB(

--- a/server/datastore/mysql/mdm.go
+++ b/server/datastore/mysql/mdm.go
@@ -1632,7 +1632,7 @@ WHERE
 func (ds *Datastore) GetHostMDMProfileRetryCountByCommandUUID(ctx context.Context, host *fleet.Host, cmdUUID string) (fleet.HostMDMProfileRetryCount, error) {
 	const darwinStmt = `
 SELECT
-	profile_identifier, profile_uuid, retries
+	profile_identifier, retries
 FROM
 	host_mdm_apple_profiles hmap
 WHERE
@@ -1666,6 +1666,50 @@ WHERE
 		return dest, ctxerr.Wrap(ctx, err, fmt.Sprintf("getting retry count for host %s command uuid %s", host.UUID, cmdUUID))
 	}
 
+	return dest, nil
+}
+
+// ProfileHasACMEPayloadForCommand bundles the gates needed to decide whether
+// an InstallProfile ack should trigger a CertificateList refetch on macOS:
+// host platform, profile UUID, whether the delivered profile contains a
+// com.apple.security.acme payload, and whether a CertificateList refetch is
+// already pending for the host. Computed in a single indexed lookup so the
+// per-ack hot path stays cheap.
+//
+// LOCATE on the mobileconfig blob is byte-exact (mediumblob, no collation).
+// False positive risk is bounded — if the substring appears outside an actual
+// payload-type element, the worst case is one redundant CertificateList
+// command queued for that host.
+func (ds *Datastore) ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID, commandUUID string) (fleet.ProfileACMECommandResult, error) {
+	const stmt = `
+SELECT
+	h.id              AS host_id,
+	h.platform        AS platform,
+	hmap.profile_uuid AS profile_uuid,
+	LOCATE('com.apple.security.acme', mac.mobileconfig) > 0 AS has_acme_payload,
+	EXISTS(
+		SELECT 1
+		FROM host_mdm_commands hmc
+		WHERE hmc.host_id = h.id
+		  AND hmc.command_type = ?
+	) AS refetch_pending
+FROM host_mdm_apple_profiles hmap
+	JOIN hosts h
+		ON h.uuid = hmap.host_uuid
+	JOIN mdm_apple_configuration_profiles mac
+		ON mac.profile_uuid = hmap.profile_uuid
+WHERE hmap.command_uuid = ?
+	AND hmap.host_uuid    = ?`
+
+	var dest fleet.ProfileACMECommandResult
+	err := sqlx.GetContext(ctx, ds.reader(ctx), &dest, stmt,
+		fleet.RefetchCertsCommandUUIDPrefix, commandUUID, hostUUID)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return dest, notFound("HostMDMAppleProfile").WithMessage(fmt.Sprintf("command uuid %s not found for host uuid %s", commandUUID, hostUUID))
+		}
+		return dest, ctxerr.Wrap(ctx, err, "probe profile for ACME payload")
+	}
 	return dest, nil
 }
 

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -65,7 +65,6 @@ func TestMDMShared(t *testing.T) {
 		{"TestListNextPendingMDMWindowsHostUUIDsCursor", testListNextPendingMDMWindowsHostUUIDsCursor},
 		{"TestCleanUpMDMManagedCertificates", testCleanUpMDMManagedCertificates},
 		{"TestEnqueueCommandWithName", testEnqueueCommandWithName},
-		{"TestGetHostAndProfileByCommandUUID", testGetHostAndProfileByCommandUUID},
 	}
 
 	for _, c := range cases {
@@ -10441,49 +10440,4 @@ func testCleanUpMDMManagedCertificates(t *testing.T, ds *Datastore) {
 		})
 		require.Equal(t, appleProfileUUID, uid)
 	})
-}
-
-func testGetHostAndProfileByCommandUUID(t *testing.T, ds *Datastore) {
-	ctx := t.Context()
-
-	host, err := ds.NewHost(ctx, &fleet.Host{
-		DetailUpdatedAt: time.Now(),
-		LabelUpdatedAt:  time.Now(),
-		PolicyUpdatedAt: time.Now(),
-		SeenTime:        time.Now(),
-		OsqueryHostID:   ptr.String("hp-osq-id"),
-		NodeKey:         ptr.String("hp-node-key"),
-		UUID:            "hp-host-uuid",
-		Hostname:        "hp-host",
-		Platform:        "darwin",
-	})
-	require.NoError(t, err)
-
-	profileUUID := uuid.NewString()
-	commandUUID := uuid.NewString()
-
-	require.NoError(t, ds.BulkUpsertMDMAppleHostProfiles(ctx, []*fleet.MDMAppleBulkUpsertHostProfilePayload{{
-		ProfileUUID:   profileUUID,
-		HostUUID:      host.UUID,
-		Checksum:      []byte("checksum"),
-		Scope:         fleet.PayloadScopeSystem,
-		OperationType: fleet.MDMOperationTypeInstall,
-		CommandUUID:   commandUUID,
-	}}))
-
-	gotHostID, gotPlatform, gotProfileUUID, err := ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, host.UUID)
-	require.NoError(t, err)
-	require.Equal(t, host.ID, gotHostID)
-	require.Equal(t, "darwin", gotPlatform)
-	require.Equal(t, profileUUID, gotProfileUUID)
-
-	// Mismatched host UUID returns not found.
-	_, _, _, err = ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, "no-such-host")
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
-
-	// Unknown command UUID returns not found.
-	_, _, _, err = ds.GetHostAndProfileByCommandUUID(ctx, "no-such-command", host.UUID)
-	require.Error(t, err)
-	require.True(t, fleet.IsNotFound(err))
 }

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -10501,7 +10501,6 @@ func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
 		require.Equal(t, "darwin", got.Platform)
 		require.Equal(t, profUUID, got.ProfileUUID)
 		require.True(t, got.HasACMEPayload)
-		require.False(t, got.RefetchPending)
 	})
 
 	t.Run("darwin host with non-ACME profile reports has_acme_payload=false", func(t *testing.T) {
@@ -10513,28 +10512,6 @@ func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
 		require.NoError(t, err)
 		require.Equal(t, "darwin", got.Platform)
 		require.False(t, got.HasACMEPayload)
-	})
-
-	t.Run("refetch already pending reports refetch_pending=true", func(t *testing.T) {
-		profUUID := mkProfile(t, "acme-pending", acmeXML)
-		cmdUUID := uuid.NewString()
-		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
-
-		require.NoError(t, ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
-			HostID:      host.ID,
-			CommandType: fleet.RefetchCertsCommandUUIDPrefix,
-		}}))
-		t.Cleanup(func() {
-			require.NoError(t, ds.RemoveHostMDMCommand(ctx, fleet.HostMDMCommand{
-				HostID:      host.ID,
-				CommandType: fleet.RefetchCertsCommandUUIDPrefix,
-			}))
-		})
-
-		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
-		require.NoError(t, err)
-		require.True(t, got.HasACMEPayload)
-		require.True(t, got.RefetchPending)
 	})
 
 	t.Run("unknown command returns not found", func(t *testing.T) {

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -65,6 +65,7 @@ func TestMDMShared(t *testing.T) {
 		{"TestListNextPendingMDMWindowsHostUUIDsCursor", testListNextPendingMDMWindowsHostUUIDsCursor},
 		{"TestCleanUpMDMManagedCertificates", testCleanUpMDMManagedCertificates},
 		{"TestEnqueueCommandWithName", testEnqueueCommandWithName},
+		{"TestProfileHasACMEPayloadForCommand", testProfileHasACMEPayloadForCommand},
 	}
 
 	for _, c := range cases {
@@ -10439,5 +10440,116 @@ func testCleanUpMDMManagedCertificates(t *testing.T, ds *Datastore) {
 				appleProfileUUID)
 		})
 		require.Equal(t, appleProfileUUID, uid)
+	})
+}
+
+func testProfileHasACMEPayloadForCommand(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		OsqueryHostID:   ptr.String("acme-probe-osq"),
+		NodeKey:         ptr.String("acme-probe-nk"),
+		UUID:            "acme-probe-host-uuid",
+		Hostname:        "acme-probe-host",
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	mkProfile := func(t *testing.T, name string, mobileconfig []byte) string {
+		t.Helper()
+		teamID := uint(0)
+		profileUUID := uuid.NewString()
+		stmt := `
+			INSERT INTO mdm_apple_configuration_profiles
+				(profile_uuid, team_id, identifier, name, mobileconfig, checksum, uploaded_at)
+			VALUES (?, ?, ?, ?, ?, ?, NOW())`
+		ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+			_, err := q.ExecContext(ctx, stmt,
+				profileUUID, teamID, name, name, mobileconfig, []byte("0123456789abcdef"))
+			return err
+		})
+		return profileUUID
+	}
+
+	mkHostProfileLink := func(t *testing.T, hostUUID, profileUUID, commandUUID string) {
+		t.Helper()
+		require.NoError(t, ds.BulkUpsertMDMAppleHostProfiles(ctx, []*fleet.MDMAppleBulkUpsertHostProfilePayload{{
+			ProfileUUID:   profileUUID,
+			HostUUID:      hostUUID,
+			Checksum:      []byte("0123456789abcdef"),
+			Scope:         fleet.PayloadScopeSystem,
+			OperationType: fleet.MDMOperationTypeInstall,
+			CommandUUID:   commandUUID,
+		}}))
+	}
+
+	acmeXML := []byte(`<?xml version="1.0"?><plist><dict><key>PayloadContent</key><array><dict><key>PayloadType</key><string>com.apple.security.acme</string></dict></array></dict></plist>`)
+	scepXML := []byte(`<?xml version="1.0"?><plist><dict><key>PayloadContent</key><array><dict><key>PayloadType</key><string>com.apple.security.scep</string></dict></array></dict></plist>`)
+
+	t.Run("darwin host with ACME profile, no pending refetch", func(t *testing.T) {
+		profUUID := mkProfile(t, "acme-darwin", acmeXML)
+		cmdUUID := uuid.NewString()
+		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
+
+		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
+		require.NoError(t, err)
+		require.Equal(t, host.ID, got.HostID)
+		require.Equal(t, "darwin", got.Platform)
+		require.Equal(t, profUUID, got.ProfileUUID)
+		require.True(t, got.HasACMEPayload)
+		require.False(t, got.RefetchPending)
+	})
+
+	t.Run("darwin host with non-ACME profile reports has_acme_payload=false", func(t *testing.T) {
+		profUUID := mkProfile(t, "scep-darwin", scepXML)
+		cmdUUID := uuid.NewString()
+		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
+
+		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
+		require.NoError(t, err)
+		require.Equal(t, "darwin", got.Platform)
+		require.False(t, got.HasACMEPayload)
+	})
+
+	t.Run("refetch already pending reports refetch_pending=true", func(t *testing.T) {
+		profUUID := mkProfile(t, "acme-pending", acmeXML)
+		cmdUUID := uuid.NewString()
+		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
+
+		require.NoError(t, ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
+			HostID:      host.ID,
+			CommandType: fleet.RefetchCertsCommandUUIDPrefix,
+		}}))
+		t.Cleanup(func() {
+			require.NoError(t, ds.RemoveHostMDMCommand(ctx, fleet.HostMDMCommand{
+				HostID:      host.ID,
+				CommandType: fleet.RefetchCertsCommandUUIDPrefix,
+			}))
+		})
+
+		got, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, cmdUUID)
+		require.NoError(t, err)
+		require.True(t, got.HasACMEPayload)
+		require.True(t, got.RefetchPending)
+	})
+
+	t.Run("unknown command returns not found", func(t *testing.T) {
+		_, err := ds.ProfileHasACMEPayloadForCommand(ctx, host.UUID, "no-such-command")
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
+	})
+
+	t.Run("unknown host returns not found", func(t *testing.T) {
+		profUUID := mkProfile(t, "acme-unknown-host", acmeXML)
+		cmdUUID := uuid.NewString()
+		mkHostProfileLink(t, host.UUID, profUUID, cmdUUID)
+
+		_, err := ds.ProfileHasACMEPayloadForCommand(ctx, "no-such-host", cmdUUID)
+		require.Error(t, err)
+		require.True(t, fleet.IsNotFound(err))
 	})
 }

--- a/server/datastore/mysql/mdm_test.go
+++ b/server/datastore/mysql/mdm_test.go
@@ -65,6 +65,7 @@ func TestMDMShared(t *testing.T) {
 		{"TestListNextPendingMDMWindowsHostUUIDsCursor", testListNextPendingMDMWindowsHostUUIDsCursor},
 		{"TestCleanUpMDMManagedCertificates", testCleanUpMDMManagedCertificates},
 		{"TestEnqueueCommandWithName", testEnqueueCommandWithName},
+		{"TestGetHostAndProfileByCommandUUID", testGetHostAndProfileByCommandUUID},
 	}
 
 	for _, c := range cases {
@@ -10440,4 +10441,49 @@ func testCleanUpMDMManagedCertificates(t *testing.T, ds *Datastore) {
 		})
 		require.Equal(t, appleProfileUUID, uid)
 	})
+}
+
+func testGetHostAndProfileByCommandUUID(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	host, err := ds.NewHost(ctx, &fleet.Host{
+		DetailUpdatedAt: time.Now(),
+		LabelUpdatedAt:  time.Now(),
+		PolicyUpdatedAt: time.Now(),
+		SeenTime:        time.Now(),
+		OsqueryHostID:   ptr.String("hp-osq-id"),
+		NodeKey:         ptr.String("hp-node-key"),
+		UUID:            "hp-host-uuid",
+		Hostname:        "hp-host",
+		Platform:        "darwin",
+	})
+	require.NoError(t, err)
+
+	profileUUID := uuid.NewString()
+	commandUUID := uuid.NewString()
+
+	require.NoError(t, ds.BulkUpsertMDMAppleHostProfiles(ctx, []*fleet.MDMAppleBulkUpsertHostProfilePayload{{
+		ProfileUUID:   profileUUID,
+		HostUUID:      host.UUID,
+		Checksum:      []byte("checksum"),
+		Scope:         fleet.PayloadScopeSystem,
+		OperationType: fleet.MDMOperationTypeInstall,
+		CommandUUID:   commandUUID,
+	}}))
+
+	gotHostID, gotPlatform, gotProfileUUID, err := ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, host.UUID)
+	require.NoError(t, err)
+	require.Equal(t, host.ID, gotHostID)
+	require.Equal(t, "darwin", gotPlatform)
+	require.Equal(t, profileUUID, gotProfileUUID)
+
+	// Mismatched host UUID returns not found.
+	_, _, _, err = ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, "no-such-host")
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err))
+
+	// Unknown command UUID returns not found.
+	_, _, _, err = ds.GetHostAndProfileByCommandUUID(ctx, "no-such-command", host.UUID)
+	require.Error(t, err)
+	require.True(t, fleet.IsNotFound(err))
 }

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -450,11 +450,6 @@ type Datastore interface {
 	// ingestion don't clobber each other's view.
 	UpdateHostCertificates(ctx context.Context, hostID uint, hostUUID string, certs []*HostCertificateRecord, origin HostCertificateOrigin) error
 
-	// GetHostAndProfileByCommandUUID returns the host ID, host platform, and
-	// profile UUID associated with the given InstallProfile command. Used by
-	// post-ack handlers that need to inspect the delivered profile.
-	GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID, hostUUID string) (hostID uint, platform, profileUUID string, err error)
-
 	// AreHostsConnectedToFleetMDM checks each host MDM enrollment with
 	// this server and returns a map indexed by the host uuid and a boolean
 	// indicating if the enrollment is active.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -450,6 +450,16 @@ type Datastore interface {
 	// ingestion don't clobber each other's view.
 	UpdateHostCertificates(ctx context.Context, hostID uint, hostUUID string, certs []*HostCertificateRecord, origin HostCertificateOrigin) error
 
+	// ProfileHasACMEPayloadForCommand returns the host/profile gating data
+	// needed to decide whether an InstallProfile ack should trigger a
+	// CertificateList refetch: host platform, profile UUID, whether the
+	// delivered profile contains a com.apple.security.acme payload, and
+	// whether a refetch is already pending. All gates are computed
+	// server-side in a single indexed lookup so the per-ack hot path stays
+	// cheap. Substring-matched on the mobileconfig blob; bounded false-
+	// positive risk (one redundant CertificateList per false match).
+	ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID, commandUUID string) (ProfileACMECommandResult, error)
+
 	// AreHostsConnectedToFleetMDM checks each host MDM enrollment with
 	// this server and returns a map indexed by the host uuid and a boolean
 	// indicating if the enrollment is active.

--- a/server/fleet/datastore.go
+++ b/server/fleet/datastore.go
@@ -450,6 +450,11 @@ type Datastore interface {
 	// ingestion don't clobber each other's view.
 	UpdateHostCertificates(ctx context.Context, hostID uint, hostUUID string, certs []*HostCertificateRecord, origin HostCertificateOrigin) error
 
+	// GetHostAndProfileByCommandUUID returns the host ID, host platform, and
+	// profile UUID associated with the given InstallProfile command. Used by
+	// post-ack handlers that need to inspect the delivered profile.
+	GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID, hostUUID string) (hostID uint, platform, profileUUID string, err error)
+
 	// AreHostsConnectedToFleetMDM checks each host MDM enrollment with
 	// this server and returns a map indexed by the host uuid and a boolean
 	// indicating if the enrollment is active.

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -311,6 +311,9 @@ type HostMDMProfileRetryCount struct {
 	ProfileIdentifier string `db:"profile_identifier"`
 	// ProfileName is the unique name used by Windows profiles
 	ProfileName string `db:"profile_name"`
+	// ProfileUUID is the Fleet-internal profile UUID; populated for both Apple and
+	// Windows profiles so callers can look up profile content by UUID.
+	ProfileUUID string `db:"profile_uuid"`
 	Retries     uint   `db:"retries"`
 }
 

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -311,10 +311,21 @@ type HostMDMProfileRetryCount struct {
 	ProfileIdentifier string `db:"profile_identifier"`
 	// ProfileName is the unique name used by Windows profiles
 	ProfileName string `db:"profile_name"`
-	// ProfileUUID is the Fleet-internal profile UUID; populated for both Apple and
-	// Windows profiles so callers can look up profile content by UUID.
-	ProfileUUID string `db:"profile_uuid"`
 	Retries     uint   `db:"retries"`
+}
+
+// ProfileACMECommandResult bundles the gates needed to decide whether an
+// InstallProfile ack should trigger a CertificateList refetch on macOS:
+// host platform, profile UUID, whether the delivered profile contains a
+// com.apple.security.acme payload, and whether a CertificateList refetch is
+// already pending for the host. All fields are computed in a single query
+// keyed on (host_uuid, command_uuid).
+type ProfileACMECommandResult struct {
+	HostID         uint   `db:"host_id"`
+	Platform       string `db:"platform"`
+	ProfileUUID    string `db:"profile_uuid"`
+	HasACMEPayload bool   `db:"has_acme_payload"`
+	RefetchPending bool   `db:"refetch_pending"`
 }
 
 // TeamIDSetter defines the method to set a TeamID value on a struct,

--- a/server/fleet/mdm.go
+++ b/server/fleet/mdm.go
@@ -316,16 +316,14 @@ type HostMDMProfileRetryCount struct {
 
 // ProfileACMECommandResult bundles the gates needed to decide whether an
 // InstallProfile ack should trigger a CertificateList refetch on macOS:
-// host platform, profile UUID, whether the delivered profile contains a
-// com.apple.security.acme payload, and whether a CertificateList refetch is
-// already pending for the host. All fields are computed in a single query
-// keyed on (host_uuid, command_uuid).
+// host platform, profile UUID, and whether the delivered profile contains a
+// com.apple.security.acme payload. Computed in a single query keyed on
+// (host_uuid, command_uuid).
 type ProfileACMECommandResult struct {
 	HostID         uint   `db:"host_id"`
 	Platform       string `db:"platform"`
 	ProfileUUID    string `db:"profile_uuid"`
 	HasACMEPayload bool   `db:"has_acme_payload"`
-	RefetchPending bool   `db:"refetch_pending"`
 }
 
 // TeamIDSetter defines the method to set a TeamID value on a struct,

--- a/server/mdm/apple/mobileconfig/mobileconfig.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig.go
@@ -16,10 +16,17 @@ import (
 const (
 	// FleetFileVaultPayloadIdentifier is the value for the PayloadIdentifier
 	// used by Fleet to configure FileVault and FileVault Escrow.
-	FleetFileVaultPayloadIdentifier        = "com.fleetdm.fleet.mdm.filevault"
-	FleetFileVaultPayloadType              = "com.apple.MCX.FileVault2"
-	FleetCustomSettingsPayloadType         = "com.apple.MCX"
-	FleetRecoveryKeyEscrowPayloadType      = "com.apple.security.FDERecoveryKeyEscrow"
+	FleetFileVaultPayloadIdentifier   = "com.fleetdm.fleet.mdm.filevault"
+	FleetFileVaultPayloadType         = "com.apple.MCX.FileVault2"
+	FleetCustomSettingsPayloadType    = "com.apple.MCX"
+	FleetRecoveryKeyEscrowPayloadType = "com.apple.security.FDERecoveryKeyEscrow"
+
+	// ACMEPayloadType is the Apple-defined PayloadType for ACME certificate
+	// payloads (com.apple.security.acme).
+	ACMEPayloadType = "com.apple.security.acme"
+	// SCEPPayloadType is the Apple-defined PayloadType for SCEP certificate
+	// payloads (com.apple.security.scep).
+	SCEPPayloadType                        = "com.apple.security.scep"
 	DiskEncryptionProfileRestrictionErrMsg = "Couldn't add. The configuration profile can't include FileVault settings."
 
 	// FleetdConfigPayloadIdentifier is the value for the PayloadIdentifier used
@@ -206,6 +213,22 @@ func (mc Mobileconfig) payloadSummary() ([]payloadSummary, error) {
 	}
 
 	return result, nil
+}
+
+// HasPayloadType reports whether the profile contains at least one payload
+// content item with the given PayloadType. Returns an error if the profile
+// cannot be parsed.
+func (mc Mobileconfig) HasPayloadType(payloadType string) (bool, error) {
+	summaries, err := mc.payloadSummary()
+	if err != nil {
+		return false, err
+	}
+	for _, s := range summaries {
+		if s.Type == payloadType {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (mc *Mobileconfig) ScreenPayloads(allowCustomOSUpdatesAndFileVault bool) error {

--- a/server/mdm/apple/mobileconfig/mobileconfig_test.go
+++ b/server/mdm/apple/mobileconfig/mobileconfig_test.go
@@ -34,3 +34,57 @@ func TestXMLEscapeString(t *testing.T) {
 		})
 	}
 }
+
+func TestHasPayloadType(t *testing.T) {
+	build := func(payloadType string) Mobileconfig {
+		return Mobileconfig(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key>
+			<string>` + payloadType + `</string>
+			<key>PayloadIdentifier</key>
+			<string>com.example.profile.cert</string>
+			<key>PayloadDisplayName</key>
+			<string>Test Cert</string>
+			<key>PayloadUUID</key>
+			<string>00000000-0000-0000-0000-000000000001</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key>
+	<string>Test Profile</string>
+	<key>PayloadIdentifier</key>
+	<string>com.example.profile</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>00000000-0000-0000-0000-000000000002</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>`)
+	}
+
+	t.Run("ACME profile reports ACME payload", func(t *testing.T) {
+		got, err := build(ACMEPayloadType).HasPayloadType(ACMEPayloadType)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+
+	t.Run("SCEP profile does not report ACME payload", func(t *testing.T) {
+		got, err := build(SCEPPayloadType).HasPayloadType(ACMEPayloadType)
+		require.NoError(t, err)
+		require.False(t, got)
+	})
+
+	t.Run("SCEP profile reports SCEP payload", func(t *testing.T) {
+		got, err := build(SCEPPayloadType).HasPayloadType(SCEPPayloadType)
+		require.NoError(t, err)
+		require.True(t, got)
+	})
+}

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -343,6 +343,8 @@ type ListHostCertificatesFunc func(ctx context.Context, hostID uint, opts fleet.
 
 type UpdateHostCertificatesFunc func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord, origin fleet.HostCertificateOrigin) error
 
+type ProfileHasACMEPayloadForCommandFunc func(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileACMECommandResult, error)
+
 type AreHostsConnectedToFleetMDMFunc func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error)
 
 type AggregatedMunkiVersionFunc func(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error)
@@ -2387,6 +2389,9 @@ type DataStore struct {
 
 	UpdateHostCertificatesFunc        UpdateHostCertificatesFunc
 	UpdateHostCertificatesFuncInvoked bool
+
+	ProfileHasACMEPayloadForCommandFunc        ProfileHasACMEPayloadForCommandFunc
+	ProfileHasACMEPayloadForCommandFuncInvoked bool
 
 	AreHostsConnectedToFleetMDMFunc        AreHostsConnectedToFleetMDMFunc
 	AreHostsConnectedToFleetMDMFuncInvoked bool
@@ -5855,6 +5860,13 @@ func (s *DataStore) UpdateHostCertificates(ctx context.Context, hostID uint, hos
 	s.UpdateHostCertificatesFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostCertificatesFunc(ctx, hostID, hostUUID, certs, origin)
+}
+
+func (s *DataStore) ProfileHasACMEPayloadForCommand(ctx context.Context, hostUUID string, commandUUID string) (fleet.ProfileACMECommandResult, error) {
+	s.mu.Lock()
+	s.ProfileHasACMEPayloadForCommandFuncInvoked = true
+	s.mu.Unlock()
+	return s.ProfileHasACMEPayloadForCommandFunc(ctx, hostUUID, commandUUID)
 }
 
 func (s *DataStore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -343,8 +343,6 @@ type ListHostCertificatesFunc func(ctx context.Context, hostID uint, opts fleet.
 
 type UpdateHostCertificatesFunc func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord, origin fleet.HostCertificateOrigin) error
 
-type GetHostAndProfileByCommandUUIDFunc func(ctx context.Context, commandUUID string, hostUUID string) (hostID uint, platform string, profileUUID string, err error)
-
 type AreHostsConnectedToFleetMDMFunc func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error)
 
 type AggregatedMunkiVersionFunc func(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error)
@@ -2389,9 +2387,6 @@ type DataStore struct {
 
 	UpdateHostCertificatesFunc        UpdateHostCertificatesFunc
 	UpdateHostCertificatesFuncInvoked bool
-
-	GetHostAndProfileByCommandUUIDFunc        GetHostAndProfileByCommandUUIDFunc
-	GetHostAndProfileByCommandUUIDFuncInvoked bool
 
 	AreHostsConnectedToFleetMDMFunc        AreHostsConnectedToFleetMDMFunc
 	AreHostsConnectedToFleetMDMFuncInvoked bool
@@ -5860,13 +5855,6 @@ func (s *DataStore) UpdateHostCertificates(ctx context.Context, hostID uint, hos
 	s.UpdateHostCertificatesFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostCertificatesFunc(ctx, hostID, hostUUID, certs, origin)
-}
-
-func (s *DataStore) GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID string, hostUUID string) (hostID uint, platform string, profileUUID string, err error) {
-	s.mu.Lock()
-	s.GetHostAndProfileByCommandUUIDFuncInvoked = true
-	s.mu.Unlock()
-	return s.GetHostAndProfileByCommandUUIDFunc(ctx, commandUUID, hostUUID)
 }
 
 func (s *DataStore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {

--- a/server/mock/datastore_mock.go
+++ b/server/mock/datastore_mock.go
@@ -343,6 +343,8 @@ type ListHostCertificatesFunc func(ctx context.Context, hostID uint, opts fleet.
 
 type UpdateHostCertificatesFunc func(ctx context.Context, hostID uint, hostUUID string, certs []*fleet.HostCertificateRecord, origin fleet.HostCertificateOrigin) error
 
+type GetHostAndProfileByCommandUUIDFunc func(ctx context.Context, commandUUID string, hostUUID string) (hostID uint, platform string, profileUUID string, err error)
+
 type AreHostsConnectedToFleetMDMFunc func(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error)
 
 type AggregatedMunkiVersionFunc func(ctx context.Context, teamID *uint) ([]fleet.AggregatedMunkiVersion, time.Time, error)
@@ -2387,6 +2389,9 @@ type DataStore struct {
 
 	UpdateHostCertificatesFunc        UpdateHostCertificatesFunc
 	UpdateHostCertificatesFuncInvoked bool
+
+	GetHostAndProfileByCommandUUIDFunc        GetHostAndProfileByCommandUUIDFunc
+	GetHostAndProfileByCommandUUIDFuncInvoked bool
 
 	AreHostsConnectedToFleetMDMFunc        AreHostsConnectedToFleetMDMFunc
 	AreHostsConnectedToFleetMDMFuncInvoked bool
@@ -5855,6 +5860,13 @@ func (s *DataStore) UpdateHostCertificates(ctx context.Context, hostID uint, hos
 	s.UpdateHostCertificatesFuncInvoked = true
 	s.mu.Unlock()
 	return s.UpdateHostCertificatesFunc(ctx, hostID, hostUUID, certs, origin)
+}
+
+func (s *DataStore) GetHostAndProfileByCommandUUID(ctx context.Context, commandUUID string, hostUUID string) (hostID uint, platform string, profileUUID string, err error) {
+	s.mu.Lock()
+	s.GetHostAndProfileByCommandUUIDFuncInvoked = true
+	s.mu.Unlock()
+	return s.GetHostAndProfileByCommandUUIDFunc(ctx, commandUUID, hostUUID)
 }
 
 func (s *DataStore) AreHostsConnectedToFleetMDM(ctx context.Context, hosts []*fleet.Host) (map[string]bool, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5008,11 +5008,19 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 // hardware-bound ACME certs that osquery cannot see. iOS/iPadOS do not need
 // this hook because IOSiPadOSRefetch already runs CertificateList on a cron.
 //
-// All gating happens server-side in a single query
-// (ProfileHasACMEPayloadForCommand): host platform, ACME payload presence,
-// and pending-refetch dedup. The hot path early-returns for the common
-// non-ACME / non-darwin cases without parsing the profile or making
-// additional roundtrips.
+// Gating happens server-side in a single indexed query
+// (ProfileHasACMEPayloadForCommand): host platform and ACME payload presence.
+// The hot path early-returns for the common non-ACME / non-darwin cases
+// without parsing the profile or making additional roundtrips.
+//
+// We deliberately do NOT dedupe against an in-flight CertificateList: if a
+// previous refetch is still pending when this trigger fires, that earlier
+// refetch can capture state that predates the new ACME exchange completing
+// on-device. Letting the new install queue its own refetch ensures the new
+// cert is captured even if the earlier refetch was already in flight.
+// host_mdm_commands has a (host_id, command_type) PK so duplicate INSERTs
+// collapse via ON DUPLICATE KEY UPDATE, and handleRefetchCertsResults is
+// safe to call on an already-removed row.
 func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEProfile(ctx context.Context, hostUUID, commandUUID string) error {
 	res, err := svc.ds.ProfileHasACMEPayloadForCommand(ctx, hostUUID, commandUUID)
 	if err != nil {
@@ -5021,7 +5029,7 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 		}
 		return ctxerr.Wrap(ctx, err, "probe profile for ACME payload")
 	}
-	if res.Platform != "darwin" || !res.HasACMEPayload || res.RefetchPending {
+	if res.Platform != "darwin" || !res.HasACMEPayload {
 		return nil
 	}
 

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4074,15 +4074,29 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 
 	switch requestType {
 	case "InstallProfile":
-		return nil, apple_mdm.HandleHostMDMProfileInstallResult(
+		status := mdmAppleDeliveryStatusFromCommandStatus(cmdResult.Status)
+		if err := apple_mdm.HandleHostMDMProfileInstallResult(
 			r.Context,
 			svc.ds,
 			cmdResult.Identifier(),
 			cmdResult.CommandUUID,
-			mdmAppleDeliveryStatusFromCommandStatus(cmdResult.Status),
+			status,
 			apple_mdm.FmtErrorChain(cmdResult.ErrorChain),
 			svc.newActivityFn,
-		)
+		); err != nil {
+			return nil, err
+		}
+		// Best-effort: when an ACME profile is acknowledged on macOS, queue
+		// CertificateList so hardware-bound certs (invisible to osquery) get
+		// ingested into host_certificates. Failures here are logged but don't
+		// affect the ack.
+		if status != nil && (*status == fleet.MDMDeliveryVerifying || *status == fleet.MDMDeliveryVerified) {
+			if err := svc.maybeQueueCertificateListForACMEProfile(r.Context, cmdResult.Identifier(), cmdResult.CommandUUID); err != nil {
+				svc.logger.WarnContext(r.Context, "queue CertificateList after ACME profile install",
+					"err", err, "host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)
+			}
+		}
+		return nil, nil
 	case "RemoveProfile":
 		status := mdmAppleDeliveryStatusFromCommandStatus(cmdResult.Status)
 		detail := apple_mdm.FmtErrorChain(cmdResult.ErrorChain)
@@ -4986,6 +5000,64 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 	}
 
 	return nil, nil
+}
+
+// maybeQueueCertificateListForACMEProfile fires a CertificateList MDM command
+// after a successful InstallProfile ack on a macOS host whose profile contains
+// a com.apple.security.acme payload. This populates host_certificates with
+// hardware-bound ACME certs that osquery cannot see. iOS/iPadOS do not need
+// this hook because IOSiPadOSRefetch already runs CertificateList on a cron.
+//
+// Dedups via host_mdm_commands so multiple ACME profile installs on the same
+// host do not enqueue duplicate commands while one is in flight.
+func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEProfile(ctx context.Context, hostUUID, commandUUID string) error {
+	hostID, platform, profileUUID, err := svc.ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, hostUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "look up host and profile")
+	}
+	if platform != "darwin" {
+		return nil
+	}
+
+	contents, err := svc.ds.GetMDMAppleProfilesContents(ctx, []string{profileUUID})
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get profile contents")
+	}
+	mc, ok := contents[profileUUID]
+	if !ok {
+		return nil
+	}
+	hasACME, err := mc.HasPayloadType(mobileconfig.ACMEPayloadType)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "check ACME payload")
+	}
+	if !hasACME {
+		return nil
+	}
+
+	// Skip if a CertificateList is already pending for this host.
+	pending, err := svc.ds.GetHostMDMCommands(ctx, hostID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get pending mdm commands")
+	}
+	for _, cmd := range pending {
+		if cmd.CommandType == fleet.RefetchCertsCommandUUIDPrefix {
+			return nil
+		}
+	}
+
+	if err := svc.ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
+		HostID:      hostID,
+		CommandType: fleet.RefetchCertsCommandUUIDPrefix,
+	}}); err != nil {
+		return ctxerr.Wrap(ctx, err, "track refetch certs command")
+	}
+
+	cmdUUID := uuid.NewString()
+	if err := svc.commander.CertificateList(ctx, []string{hostUUID}, fleet.RefetchCertsCommandUUIDPrefix+cmdUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "enqueue CertificateList")
+	}
+	return nil
 }
 
 func (svc *MDMAppleCheckinAndCommandService) handleRefetchDeviceResults(ctx context.Context, host *fleet.Host, cmdResult *mdm.CommandResults) (*mdm.Command, error) {

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5008,56 +5008,25 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 // hardware-bound ACME certs that osquery cannot see. iOS/iPadOS do not need
 // this hook because IOSiPadOSRefetch already runs CertificateList on a cron.
 //
-// Dedups via host_mdm_commands so multiple ACME profile installs on the same
-// host do not enqueue duplicate commands while one is in flight.
+// All gating happens server-side in a single query
+// (ProfileHasACMEPayloadForCommand): host platform, ACME payload presence,
+// and pending-refetch dedup. The hot path early-returns for the common
+// non-ACME / non-darwin cases without parsing the profile or making
+// additional roundtrips.
 func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEProfile(ctx context.Context, hostUUID, commandUUID string) error {
-	checkin, err := svc.ds.GetHostMDMCheckinInfo(ctx, hostUUID)
+	res, err := svc.ds.ProfileHasACMEPayloadForCommand(ctx, hostUUID, commandUUID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get host checkin info")
-	}
-	if checkin.Platform != "darwin" {
-		return nil
-	}
-
-	retry, err := svc.ds.GetHostMDMProfileRetryCountByCommandUUID(ctx, &fleet.Host{UUID: hostUUID, Platform: checkin.Platform}, commandUUID)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get profile by command uuid")
-	}
-	if retry.ProfileUUID == "" {
-		return nil
-	}
-
-	contents, err := svc.ds.GetMDMAppleProfilesContents(ctx, []string{retry.ProfileUUID})
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get profile contents")
-	}
-	profileUUID := retry.ProfileUUID
-	hostID := checkin.HostID
-	mc, ok := contents[profileUUID]
-	if !ok {
-		return nil
-	}
-	hasACME, err := mc.HasPayloadType(mobileconfig.ACMEPayloadType)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "check ACME payload")
-	}
-	if !hasACME {
-		return nil
-	}
-
-	// Skip if a CertificateList is already pending for this host.
-	pending, err := svc.ds.GetHostMDMCommands(ctx, hostID)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "get pending mdm commands")
-	}
-	for _, cmd := range pending {
-		if cmd.CommandType == fleet.RefetchCertsCommandUUIDPrefix {
+		if fleet.IsNotFound(err) {
 			return nil
 		}
+		return ctxerr.Wrap(ctx, err, "probe profile for ACME payload")
+	}
+	if res.Platform != "darwin" || !res.HasACMEPayload || res.RefetchPending {
+		return nil
 	}
 
 	if err := svc.ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
-		HostID:      hostID,
+		HostID:      res.HostID,
 		CommandType: fleet.RefetchCertsCommandUUIDPrefix,
 	}}); err != nil {
 		return ctxerr.Wrap(ctx, err, "track refetch certs command")

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4090,8 +4090,6 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		// CertificateList so hardware-bound certs (invisible to osquery) get
 		// ingested into host_certificates. Failures here are logged but don't
 		// affect the ack.
-		// MDMDeliveryVerifying is the only success state produced here by
-		// mdmAppleDeliveryStatusFromCommandStatus on Acknowledged ack.
 		if status != nil && *status == fleet.MDMDeliveryVerifying {
 			if err := svc.maybeQueueCertificateListForACMEProfile(r.Context, cmdResult.Identifier(), cmdResult.CommandUUID); err != nil {
 				svc.logger.WarnContext(r.Context, "queue CertificateList after ACME profile install",

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -4090,7 +4090,9 @@ func (svc *MDMAppleCheckinAndCommandService) CommandAndReportResults(r *mdm.Requ
 		// CertificateList so hardware-bound certs (invisible to osquery) get
 		// ingested into host_certificates. Failures here are logged but don't
 		// affect the ack.
-		if status != nil && (*status == fleet.MDMDeliveryVerifying || *status == fleet.MDMDeliveryVerified) {
+		// MDMDeliveryVerifying is the only success state produced here by
+		// mdmAppleDeliveryStatusFromCommandStatus on Acknowledged ack.
+		if status != nil && *status == fleet.MDMDeliveryVerifying {
 			if err := svc.maybeQueueCertificateListForACMEProfile(r.Context, cmdResult.Identifier(), cmdResult.CommandUUID); err != nil {
 				svc.logger.WarnContext(r.Context, "queue CertificateList after ACME profile install",
 					"err", err, "host_uuid", cmdResult.Identifier(), "command_uuid", cmdResult.CommandUUID)

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5025,16 +5025,19 @@ func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEPro
 		return nil
 	}
 
+	cmdUUID := uuid.NewString()
+	if err := svc.commander.CertificateList(ctx, []string{hostUUID}, fleet.RefetchCertsCommandUUIDPrefix+cmdUUID); err != nil {
+		return ctxerr.Wrap(ctx, err, "enqueue CertificateList")
+	}
+
+	// Track after the commander call so a CertificateList enqueue failure
+	// doesn't leave a stale tracking row that would suppress future
+	// triggers. Matches the iOS/iPadOS pattern in IOSiPadOSRefetch.
 	if err := svc.ds.AddHostMDMCommands(ctx, []fleet.HostMDMCommand{{
 		HostID:      res.HostID,
 		CommandType: fleet.RefetchCertsCommandUUIDPrefix,
 	}}); err != nil {
 		return ctxerr.Wrap(ctx, err, "track refetch certs command")
-	}
-
-	cmdUUID := uuid.NewString()
-	if err := svc.commander.CertificateList(ctx, []string{hostUUID}, fleet.RefetchCertsCommandUUIDPrefix+cmdUUID); err != nil {
-		return ctxerr.Wrap(ctx, err, "enqueue CertificateList")
 	}
 	return nil
 }

--- a/server/service/apple_mdm.go
+++ b/server/service/apple_mdm.go
@@ -5011,18 +5011,28 @@ func (svc *MDMAppleCheckinAndCommandService) handleRefetchCertsResults(ctx conte
 // Dedups via host_mdm_commands so multiple ACME profile installs on the same
 // host do not enqueue duplicate commands while one is in flight.
 func (svc *MDMAppleCheckinAndCommandService) maybeQueueCertificateListForACMEProfile(ctx context.Context, hostUUID, commandUUID string) error {
-	hostID, platform, profileUUID, err := svc.ds.GetHostAndProfileByCommandUUID(ctx, commandUUID, hostUUID)
+	checkin, err := svc.ds.GetHostMDMCheckinInfo(ctx, hostUUID)
 	if err != nil {
-		return ctxerr.Wrap(ctx, err, "look up host and profile")
+		return ctxerr.Wrap(ctx, err, "get host checkin info")
 	}
-	if platform != "darwin" {
+	if checkin.Platform != "darwin" {
 		return nil
 	}
 
-	contents, err := svc.ds.GetMDMAppleProfilesContents(ctx, []string{profileUUID})
+	retry, err := svc.ds.GetHostMDMProfileRetryCountByCommandUUID(ctx, &fleet.Host{UUID: hostUUID, Platform: checkin.Platform}, commandUUID)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "get profile by command uuid")
+	}
+	if retry.ProfileUUID == "" {
+		return nil
+	}
+
+	contents, err := svc.ds.GetMDMAppleProfilesContents(ctx, []string{retry.ProfileUUID})
 	if err != nil {
 		return ctxerr.Wrap(ctx, err, "get profile contents")
 	}
+	profileUUID := retry.ProfileUUID
+	hostID := checkin.HostID
 	mc, ok := contents[profileUUID]
 	if !ok {
 		return nil

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2145,11 +2145,10 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 				return nil
 			}
 			// Best-effort ACME-cert-list trigger fires on successful InstallProfile
-			// acks; stub the lookup to no-op so this test stays focused on the
-			// retry/status logic. Returning a non-darwin platform short-circuits
-			// the trigger before any other datastore calls.
-			ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, hUUID string) (*fleet.HostMDMCheckinInfo, error) {
-				return &fleet.HostMDMCheckinInfo{Platform: "ios"}, nil
+			// acks; stub the probe to a non-darwin platform so the trigger
+			// short-circuits without doing any further work.
+			ds.ProfileHasACMEPayloadForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileACMECommandResult, error) {
+				return fleet.ProfileACMECommandResult{Platform: "ios"}, nil
 			}
 
 			_, err := svc.CommandAndReportResults(
@@ -2192,86 +2191,52 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 		hostID      = uint(42)
 	)
 
-	acmeProfile := mobileconfig.Mobileconfig(`<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key><string>com.apple.security.acme</string>
-			<key>PayloadIdentifier</key><string>com.example.acme</string>
-			<key>PayloadDisplayName</key><string>ACME</string>
-			<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000001</string>
-			<key>PayloadVersion</key><integer>1</integer>
-		</dict>
-	</array>
-	<key>PayloadDisplayName</key><string>ACME Profile</string>
-	<key>PayloadIdentifier</key><string>com.example.profile</string>
-	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000002</string>
-	<key>PayloadVersion</key><integer>1</integer>
-</dict>
-</plist>`)
-
-	scepProfile := mobileconfig.Mobileconfig(`<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>PayloadContent</key>
-	<array>
-		<dict>
-			<key>PayloadType</key><string>com.apple.security.scep</string>
-			<key>PayloadIdentifier</key><string>com.example.scep</string>
-			<key>PayloadDisplayName</key><string>SCEP</string>
-			<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000003</string>
-			<key>PayloadVersion</key><integer>1</integer>
-		</dict>
-	</array>
-	<key>PayloadDisplayName</key><string>SCEP Profile</string>
-	<key>PayloadIdentifier</key><string>com.example.profile</string>
-	<key>PayloadType</key><string>Configuration</string>
-	<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000004</string>
-	<key>PayloadVersion</key><integer>1</integer>
-</dict>
-</plist>`)
-
 	cases := []struct {
 		name             string
-		platform         string
-		profileContent   mobileconfig.Mobileconfig
-		pendingCommands  []fleet.HostMDMCommand
+		probeResult      fleet.ProfileACMECommandResult
+		probeErr         error
 		expectAddCommand bool
 		expectEnqueue    bool
 	}{
 		{
-			name:             "macOS + ACME profile: enqueues CertificateList",
-			platform:         "darwin",
-			profileContent:   acmeProfile,
+			name: "macOS + ACME profile: enqueues CertificateList",
+			probeResult: fleet.ProfileACMECommandResult{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+				HasACMEPayload: true, RefetchPending: false,
+			},
 			expectAddCommand: true,
 			expectEnqueue:    true,
 		},
 		{
-			name:             "iOS host: skipped (existing refetch cron handles it)",
-			platform:         "ios",
-			profileContent:   acmeProfile,
-			expectAddCommand: false,
-			expectEnqueue:    false,
-		},
-		{
-			name:             "macOS + non-ACME profile: no trigger",
-			platform:         "darwin",
-			profileContent:   scepProfile,
-			expectAddCommand: false,
-			expectEnqueue:    false,
-		},
-		{
-			name:           "macOS + ACME but refetch already pending: dedups",
-			platform:       "darwin",
-			profileContent: acmeProfile,
-			pendingCommands: []fleet.HostMDMCommand{
-				{HostID: hostID, CommandType: fleet.RefetchCertsCommandUUIDPrefix},
+			name: "iOS host: skipped (existing refetch cron handles it)",
+			probeResult: fleet.ProfileACMECommandResult{
+				HostID: hostID, Platform: "ios", ProfileUUID: profileUUID,
+				HasACMEPayload: true,
 			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name: "macOS + non-ACME profile: no trigger",
+			probeResult: fleet.ProfileACMECommandResult{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+				HasACMEPayload: false,
+			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name: "macOS + ACME but refetch already pending: dedups",
+			probeResult: fleet.ProfileACMECommandResult{
+				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
+				HasACMEPayload: true, RefetchPending: true,
+			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name:             "command not found: no error, no trigger",
+			probeErr:         &notFoundError{},
 			expectAddCommand: false,
 			expectEnqueue:    false,
 		},
@@ -2280,17 +2245,10 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ds := new(mock.Store)
-			ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, hUUID string) (*fleet.HostMDMCheckinInfo, error) {
-				return &fleet.HostMDMCheckinInfo{HostID: hostID, Platform: c.platform}, nil
-			}
-			ds.GetHostMDMProfileRetryCountByCommandUUIDFunc = func(ctx context.Context, host *fleet.Host, cmdUUID string) (fleet.HostMDMProfileRetryCount, error) {
-				return fleet.HostMDMProfileRetryCount{ProfileUUID: profileUUID}, nil
-			}
-			ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, uuids []string) (map[string]mobileconfig.Mobileconfig, error) {
-				return map[string]mobileconfig.Mobileconfig{profileUUID: c.profileContent}, nil
-			}
-			ds.GetHostMDMCommandsFunc = func(ctx context.Context, hID uint) ([]fleet.HostMDMCommand, error) {
-				return c.pendingCommands, nil
+			ds.ProfileHasACMEPayloadForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileACMECommandResult, error) {
+				require.Equal(t, hostUUID, hUUID)
+				require.Equal(t, commandUUID, cmdUUID)
+				return c.probeResult, c.probeErr
 			}
 			var addedCommands []fleet.HostMDMCommand
 			ds.AddHostMDMCommandsFunc = func(ctx context.Context, cmds []fleet.HostMDMCommand) error {

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2144,6 +2144,12 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 				require.ElementsMatch(t, toRetry, []string{profileIdentifier})
 				return nil
 			}
+			// Best-effort ACME-cert-list trigger fires on successful InstallProfile
+			// acks; stub the lookup to no-op so this test stays focused on the
+			// retry/status logic.
+			ds.GetHostAndProfileByCommandUUIDFunc = func(ctx context.Context, cmdUUID, hostUUID string) (uint, string, string, error) {
+				return 0, "", "", &notFoundError{}
+			}
 
 			_, err := svc.CommandAndReportResults(
 				&mdm.Request{Context: ctx},
@@ -2169,6 +2175,167 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 			require.Equal(t, shouldCheckCount, ds.GetHostMDMProfileRetryCountByCommandUUIDFuncInvoked)
 			require.Equal(t, shouldRetry, ds.UpdateHostMDMProfilesVerificationFuncInvoked)
 			require.Equal(t, shouldUpdateOrDelete, ds.UpdateOrDeleteHostMDMAppleProfileFuncInvoked)
+		})
+	}
+}
+
+// TestMaybeQueueCertificateListForACMEProfile verifies the on-demand
+// CertificateList trigger fires only on macOS hosts whose acked profile
+// contains an ACME payload, and that it dedups against pending refetches.
+func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
+	ctx := context.Background()
+	const (
+		hostUUID    = "host-uuid"
+		commandUUID = "cmd-uuid"
+		profileUUID = "profile-uuid"
+		hostID      = uint(42)
+	)
+
+	acmeProfile := mobileconfig.Mobileconfig(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key><string>com.apple.security.acme</string>
+			<key>PayloadIdentifier</key><string>com.example.acme</string>
+			<key>PayloadDisplayName</key><string>ACME</string>
+			<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000001</string>
+			<key>PayloadVersion</key><integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key><string>ACME Profile</string>
+	<key>PayloadIdentifier</key><string>com.example.profile</string>
+	<key>PayloadType</key><string>Configuration</string>
+	<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000002</string>
+	<key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>`)
+
+	scepProfile := mobileconfig.Mobileconfig(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>PayloadType</key><string>com.apple.security.scep</string>
+			<key>PayloadIdentifier</key><string>com.example.scep</string>
+			<key>PayloadDisplayName</key><string>SCEP</string>
+			<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000003</string>
+			<key>PayloadVersion</key><integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDisplayName</key><string>SCEP Profile</string>
+	<key>PayloadIdentifier</key><string>com.example.profile</string>
+	<key>PayloadType</key><string>Configuration</string>
+	<key>PayloadUUID</key><string>00000000-0000-0000-0000-000000000004</string>
+	<key>PayloadVersion</key><integer>1</integer>
+</dict>
+</plist>`)
+
+	cases := []struct {
+		name             string
+		platform         string
+		profileContent   mobileconfig.Mobileconfig
+		pendingCommands  []fleet.HostMDMCommand
+		expectAddCommand bool
+		expectEnqueue    bool
+	}{
+		{
+			name:             "macOS + ACME profile: enqueues CertificateList",
+			platform:         "darwin",
+			profileContent:   acmeProfile,
+			expectAddCommand: true,
+			expectEnqueue:    true,
+		},
+		{
+			name:             "iOS host: skipped (existing refetch cron handles it)",
+			platform:         "ios",
+			profileContent:   acmeProfile,
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name:             "macOS + non-ACME profile: no trigger",
+			platform:         "darwin",
+			profileContent:   scepProfile,
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+		{
+			name:           "macOS + ACME but refetch already pending: dedups",
+			platform:       "darwin",
+			profileContent: acmeProfile,
+			pendingCommands: []fleet.HostMDMCommand{
+				{HostID: hostID, CommandType: fleet.RefetchCertsCommandUUIDPrefix},
+			},
+			expectAddCommand: false,
+			expectEnqueue:    false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.GetHostAndProfileByCommandUUIDFunc = func(ctx context.Context, cmdUUID, hUUID string) (uint, string, string, error) {
+				return hostID, c.platform, profileUUID, nil
+			}
+			ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, uuids []string) (map[string]mobileconfig.Mobileconfig, error) {
+				return map[string]mobileconfig.Mobileconfig{profileUUID: c.profileContent}, nil
+			}
+			ds.GetHostMDMCommandsFunc = func(ctx context.Context, hID uint) ([]fleet.HostMDMCommand, error) {
+				return c.pendingCommands, nil
+			}
+			var addedCommands []fleet.HostMDMCommand
+			ds.AddHostMDMCommandsFunc = func(ctx context.Context, cmds []fleet.HostMDMCommand) error {
+				addedCommands = append(addedCommands, cmds...)
+				return nil
+			}
+
+			mdmStorage := &mdmmock.MDMAppleStore{}
+			pushFactory, _ := newMockAPNSPushProviderFactory()
+			pusher := nanomdm_pushsvc.New(mdmStorage, mdmStorage, pushFactory, NewNanoMDMLogger(slog.New(slog.DiscardHandler)))
+			cmdr := apple_mdm.NewMDMAppleCommander(mdmStorage, pusher)
+			var enqueued bool
+			mdmStorage.EnqueueCommandFunc = func(ctx context.Context, id []string, cmd *mdm.CommandWithSubtype) (map[string]error, error) {
+				enqueued = true
+				require.Equal(t, []string{hostUUID}, id)
+				require.Equal(t, "CertificateList", cmd.Command.Command.RequestType)
+				return nil, nil
+			}
+			mdmStorage.RetrievePushInfoFunc = func(ctx context.Context, ids []string) (map[string]*mdm.Push, error) {
+				res := make(map[string]*mdm.Push, len(ids))
+				for _, id := range ids {
+					res[id] = &mdm.Push{Token: []byte(id), Topic: "topic", PushMagic: "magic"}
+				}
+				return res, nil
+			}
+			mdmStorage.RetrievePushCertFunc = func(ctx context.Context, topic string) (*tls.Certificate, string, error) {
+				cert, err := tls.LoadX509KeyPair("testdata/server.pem", "testdata/server.key")
+				return &cert, "", err
+			}
+			mdmStorage.IsPushCertStaleFunc = func(ctx context.Context, topic string, staleToken string) (bool, error) {
+				return false, nil
+			}
+
+			svc := &MDMAppleCheckinAndCommandService{
+				ds:        ds,
+				logger:    slog.New(slog.DiscardHandler),
+				commander: cmdr,
+			}
+			err := svc.maybeQueueCertificateListForACMEProfile(ctx, hostUUID, commandUUID)
+			require.NoError(t, err)
+
+			if c.expectAddCommand {
+				require.Len(t, addedCommands, 1)
+				require.Equal(t, fleet.RefetchCertsCommandUUIDPrefix, addedCommands[0].CommandType)
+				require.Equal(t, hostID, addedCommands[0].HostID)
+			} else {
+				require.Empty(t, addedCommands)
+			}
+			require.Equal(t, c.expectEnqueue, enqueued)
 		})
 	}
 }

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2144,9 +2144,6 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 				require.ElementsMatch(t, toRetry, []string{profileIdentifier})
 				return nil
 			}
-			// Best-effort ACME-cert-list trigger fires on successful InstallProfile
-			// acks; stub the probe to a non-darwin platform so the trigger
-			// short-circuits without doing any further work.
 			ds.ProfileHasACMEPayloadForCommandFunc = func(ctx context.Context, hUUID, cmdUUID string) (fleet.ProfileACMECommandResult, error) {
 				return fleet.ProfileACMECommandResult{Platform: "ios"}, nil
 			}

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2199,7 +2199,7 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 			name: "macOS + ACME profile: enqueues CertificateList",
 			probeResult: fleet.ProfileACMECommandResult{
 				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
-				HasACMEPayload: true, RefetchPending: false,
+				HasACMEPayload: true,
 			},
 			expectAddCommand: true,
 			expectEnqueue:    true,
@@ -2218,15 +2218,6 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 			probeResult: fleet.ProfileACMECommandResult{
 				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
 				HasACMEPayload: false,
-			},
-			expectAddCommand: false,
-			expectEnqueue:    false,
-		},
-		{
-			name: "macOS + ACME but refetch already pending: dedups",
-			probeResult: fleet.ProfileACMECommandResult{
-				HostID: hostID, Platform: "darwin", ProfileUUID: profileUUID,
-				HasACMEPayload: true, RefetchPending: true,
 			},
 			expectAddCommand: false,
 			expectEnqueue:    false,

--- a/server/service/apple_mdm_test.go
+++ b/server/service/apple_mdm_test.go
@@ -2146,9 +2146,10 @@ func TestMDMCommandAndReportResultsProfileHandling(t *testing.T) {
 			}
 			// Best-effort ACME-cert-list trigger fires on successful InstallProfile
 			// acks; stub the lookup to no-op so this test stays focused on the
-			// retry/status logic.
-			ds.GetHostAndProfileByCommandUUIDFunc = func(ctx context.Context, cmdUUID, hostUUID string) (uint, string, string, error) {
-				return 0, "", "", &notFoundError{}
+			// retry/status logic. Returning a non-darwin platform short-circuits
+			// the trigger before any other datastore calls.
+			ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, hUUID string) (*fleet.HostMDMCheckinInfo, error) {
+				return &fleet.HostMDMCheckinInfo{Platform: "ios"}, nil
 			}
 
 			_, err := svc.CommandAndReportResults(
@@ -2279,8 +2280,11 @@ func TestMaybeQueueCertificateListForACMEProfile(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			ds := new(mock.Store)
-			ds.GetHostAndProfileByCommandUUIDFunc = func(ctx context.Context, cmdUUID, hUUID string) (uint, string, string, error) {
-				return hostID, c.platform, profileUUID, nil
+			ds.GetHostMDMCheckinInfoFunc = func(ctx context.Context, hUUID string) (*fleet.HostMDMCheckinInfo, error) {
+				return &fleet.HostMDMCheckinInfo{HostID: hostID, Platform: c.platform}, nil
+			}
+			ds.GetHostMDMProfileRetryCountByCommandUUIDFunc = func(ctx context.Context, host *fleet.Host, cmdUUID string) (fleet.HostMDMProfileRetryCount, error) {
+				return fleet.HostMDMProfileRetryCount{ProfileUUID: profileUUID}, nil
 			}
 			ds.GetMDMAppleProfilesContentsFunc = func(ctx context.Context, uuids []string) (map[string]mobileconfig.Mobileconfig, error) {
 				return map[string]mobileconfig.Mobileconfig{profileUUID: c.profileContent}, nil


### PR DESCRIPTION
Resolves #44342.

Fires a one-shot `CertificateList` MDM command when a macOS host acknowledges an `InstallProfile` containing a `com.apple.security.acme` payload, so hardware-bound ACME certs (invisible to osquery) land in `host_certificates` with `origin=mdm`. Dedups against pending refetches; iOS/iPadOS skipped (existing `IOSiPadOSRefetch` cron handles them).

# Checklist for submitter

- [x] Input data validated, parameterized SQL, no `SELECT *`
- [x] Timeouts and retry limits in place — best-effort trigger; failures logged, ack still succeeds
- [x] No backwards-compat issues — additive trigger, dedupes against existing refetch tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic certificate list refresh for ACME-backed mobile profiles on macOS devices following successful profile installation, improving certificate management workflows.
  * Enhanced profile payload detection to identify specific payload types within mobile configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->