### PR TITLE
Fix issue with fleet's docker image in k8s environments

### DIFF
--- a/changes/44298-fix-goquery-dependency-side-effects
+++ b/changes/44298-fix-goquery-dependency-side-effects
@@ -1,0 +1,1 @@
+* Fixed Fleet's Docker image failing to start in Kubernetes with an `unknown userid` error, triggered by a fleetctl dependency side effect.

--- a/cmd/fleetctl/fleetctl/goquery.go
+++ b/cmd/fleetctl/fleetctl/goquery.go
@@ -2,112 +2,22 @@ package fleetctl
 
 import (
 	"errors"
-	"fmt"
-	"strconv"
 
-	"github.com/AbGuthrie/goquery/v2"
-	gqconfig "github.com/AbGuthrie/goquery/v2/config"
-	gqhosts "github.com/AbGuthrie/goquery/v2/hosts"
-	gqmodels "github.com/AbGuthrie/goquery/v2/models"
-	"github.com/fleetdm/fleet/v4/server/fleet"
 	"github.com/fleetdm/fleet/v4/server/service"
 	"github.com/urfave/cli/v2"
 )
 
-type activeQuery struct {
-	status  string
-	results []map[string]string
-}
+// goqueryRunner is set by the fleetctl binary's main package via
+// SetGoqueryRunner. Keeping the github.com/AbGuthrie/goquery/v2 import out of
+// this package prevents its init function from being linked into binaries
+// (e.g. fleet server) that transitively import the fleetctl package without
+// needing the goquery subcommand.
+var goqueryRunner func(*service.Client) error
 
-type goqueryClient struct {
-	client       *service.Client
-	queryCounter int
-	queries      map[string]activeQuery
-	// goquery passes the UUID, while we need the hostname (or ID) to
-	// query against Fleet. Keep a mapping so that we know how to target
-	// the host.
-	hostnameByUUID map[string]string
-}
-
-func newGoqueryClient(fleetClient *service.Client) *goqueryClient {
-	return &goqueryClient{
-		client:         fleetClient,
-		queryCounter:   0,
-		queries:        make(map[string]activeQuery),
-		hostnameByUUID: make(map[string]string),
-	}
-}
-
-func (c *goqueryClient) CheckHost(query string) (gqhosts.Host, error) {
-	res, err := c.client.SearchTargets(query, nil, nil)
-	if err != nil {
-		return gqhosts.Host{}, err
-	}
-
-	var host *fleet.Host
-	for _, h := range res.Hosts {
-		// We allow hosts to be looked up by hostname in addition to UUID
-		if query == h.UUID || query == h.Hostname || query == h.ComputerName {
-			host = h
-			break
-		}
-	}
-
-	if host == nil {
-		return gqhosts.Host{}, fmt.Errorf("host %s not found", query)
-	}
-
-	c.hostnameByUUID[host.UUID] = host.Hostname
-
-	return gqhosts.Host{
-		UUID:         host.UUID,
-		ComputerName: host.ComputerName,
-		Platform:     host.Platform,
-		Version:      host.OsqueryVersion,
-	}, nil
-}
-
-func (c *goqueryClient) ScheduleQuery(uuid, query string) (string, error) {
-	c.queryCounter++
-	queryName := strconv.Itoa(c.queryCounter)
-
-	hostname, ok := c.hostnameByUUID[uuid]
-	if !ok {
-		return "", errors.New("could not lookup host")
-	}
-
-	res, err := c.client.LiveQuery(query, nil, []string{}, []string{hostname})
-	if err != nil {
-		return "", err
-	}
-
-	c.queries[queryName] = activeQuery{status: "Pending"}
-
-	// We need to start a separate thread due to goquery expecting
-	// scheduling a query and retrieving results to be separate
-	// operations.
-	go func() {
-		select {
-		case hostResult := <-res.Results():
-			c.queries[queryName] = activeQuery{status: "Completed", results: hostResult.Rows}
-
-			// Print an error
-		case err := <-res.Errors():
-			c.queries[queryName] = activeQuery{status: "error: " + err.Error()}
-		}
-	}()
-
-	gqhosts.AddQueryToHost(uuid, gqhosts.Query{Name: queryName, SQL: query})
-	return queryName, nil
-}
-
-func (c *goqueryClient) FetchResults(queryName string) (gqmodels.Rows, string, error) {
-	res, ok := c.queries[queryName]
-	if !ok {
-		return nil, "", fmt.Errorf("Unknown query %s", queryName)
-	}
-
-	return res.results, res.status, nil
+// SetGoqueryRunner registers the implementation of the `fleetctl goquery`
+// subcommand. Call from package main before CreateApp.
+func SetGoqueryRunner(runner func(*service.Client) error) {
+	goqueryRunner = runner
 }
 
 func goqueryCommand() *cli.Command {
@@ -121,13 +31,14 @@ func goqueryCommand() *cli.Command {
 			debugFlag(),
 		},
 		Action: func(c *cli.Context) error {
-			fleet, err := clientFromCLI(c)
+			if goqueryRunner == nil {
+				return errors.New("goquery support is not built into this binary")
+			}
+			fleetClient, err := clientFromCLI(c)
 			if err != nil {
 				return err
 			}
-
-			goquery.Run(newGoqueryClient(fleet), gqconfig.Config{})
-			return nil
+			return goqueryRunner(fleetClient)
 		},
 	}
 }

--- a/cmd/fleetctl/fleetctl/goquerycmd/goquery.go
+++ b/cmd/fleetctl/fleetctl/goquerycmd/goquery.go
@@ -1,0 +1,124 @@
+// Package goquerycmd implements the `fleetctl goquery` interactive REPL.
+//
+// The github.com/AbGuthrie/goquery/v2 dependency is isolated in this
+// sub-package so its init-time side effects are only linked into the
+// fleetctl binary, not into other binaries (such as fleet server) that
+// transitively import the parent fleetctl package.
+package goquerycmd
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/AbGuthrie/goquery/v2"
+	gqconfig "github.com/AbGuthrie/goquery/v2/config"
+	gqhosts "github.com/AbGuthrie/goquery/v2/hosts"
+	gqmodels "github.com/AbGuthrie/goquery/v2/models"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	"github.com/fleetdm/fleet/v4/server/service"
+)
+
+type activeQuery struct {
+	status  string
+	results []map[string]string
+}
+
+type goqueryClient struct {
+	client       *service.Client
+	queryCounter int
+	queries      map[string]activeQuery
+	// goquery passes the UUID, while we need the hostname (or ID) to
+	// query against Fleet. Keep a mapping so that we know how to target
+	// the host.
+	hostnameByUUID map[string]string
+}
+
+func newGoqueryClient(fleetClient *service.Client) *goqueryClient {
+	return &goqueryClient{
+		client:         fleetClient,
+		queryCounter:   0,
+		queries:        make(map[string]activeQuery),
+		hostnameByUUID: make(map[string]string),
+	}
+}
+
+func (c *goqueryClient) CheckHost(query string) (gqhosts.Host, error) {
+	res, err := c.client.SearchTargets(query, nil, nil)
+	if err != nil {
+		return gqhosts.Host{}, err
+	}
+
+	var host *fleet.Host
+	for _, h := range res.Hosts {
+		// We allow hosts to be looked up by hostname in addition to UUID
+		if query == h.UUID || query == h.Hostname || query == h.ComputerName {
+			host = h
+			break
+		}
+	}
+
+	if host == nil {
+		return gqhosts.Host{}, fmt.Errorf("host %s not found", query)
+	}
+
+	c.hostnameByUUID[host.UUID] = host.Hostname
+
+	return gqhosts.Host{
+		UUID:         host.UUID,
+		ComputerName: host.ComputerName,
+		Platform:     host.Platform,
+		Version:      host.OsqueryVersion,
+	}, nil
+}
+
+func (c *goqueryClient) ScheduleQuery(uuid, query string) (string, error) {
+	c.queryCounter++
+	queryName := strconv.Itoa(c.queryCounter)
+
+	hostname, ok := c.hostnameByUUID[uuid]
+	if !ok {
+		return "", errors.New("could not lookup host")
+	}
+
+	res, err := c.client.LiveQuery(query, nil, []string{}, []string{hostname})
+	if err != nil {
+		return "", err
+	}
+
+	c.queries[queryName] = activeQuery{status: "Pending"}
+
+	// We need to start a separate thread due to goquery expecting
+	// scheduling a query and retrieving results to be separate
+	// operations.
+	go func() {
+		select {
+		case hostResult := <-res.Results():
+			c.queries[queryName] = activeQuery{status: "Completed", results: hostResult.Rows}
+
+			// Print an error
+		case err := <-res.Errors():
+			c.queries[queryName] = activeQuery{status: "error: " + err.Error()}
+		}
+	}()
+
+	gqhosts.AddQueryToHost(uuid, gqhosts.Query{Name: queryName, SQL: query})
+	return queryName, nil
+}
+
+func (c *goqueryClient) FetchResults(queryName string) (gqmodels.Rows, string, error) {
+	res, ok := c.queries[queryName]
+	if !ok {
+		return nil, "", fmt.Errorf("Unknown query %s", queryName)
+	}
+
+	return res.results, res.status, nil
+}
+
+// Run starts the interactive goquery REPL using the provided Fleet client.
+// It is registered with the fleetctl package via fleetctl.SetGoqueryRunner
+// from the fleetctl binary's main package.
+func Run(fleetClient *service.Client) error {
+	goquery.Run(newGoqueryClient(fleetClient), gqconfig.Config{})
+	return nil
+}

--- a/cmd/fleetctl/main.go
+++ b/cmd/fleetctl/main.go
@@ -9,10 +9,17 @@ import (
 	"runtime"
 
 	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl"
+	"github.com/fleetdm/fleet/v4/cmd/fleetctl/fleetctl/goquerycmd"
 	"github.com/urfave/cli/v2"
 )
 
 func main() {
+	// Register the goquery subcommand here so that the
+	// github.com/AbGuthrie/goquery/v2 dependency (and its init function) are
+	// only linked into the fleetctl binary, not into other binaries that
+	// import the fleetctl package (e.g. fleet server).
+	fleetctl.SetGoqueryRunner(goquerycmd.Run)
+
 	app := fleetctl.CreateApp(os.Stdin, os.Stdout, os.Stderr, exitErrHandler)
 	fleetctl.StashRawArgs(app, os.Args)
 	if err := app.Run(os.Args); err != nil {


### PR DESCRIPTION
Resolves #44298

- [X] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.

## Testing

- [X] QA'd all new/changed functionality manually

1. Running the docker image pushed by this PR with the user 3333 doesn't fail anymore:
```sh
docker run --platform linux/amd64 -it --user 3333:3333 fleetdm/fleet@sha256:1a06bcae25e13e37f871378c7c156f5a2cdf67bc3c3e3bcdc95b6afc0c6decbb
[...]
ts=2026-04-29T13:25:56Z level=warn msg="could not connect to db" err="dial tcp [::1]:3306: connect: connection refused" sleep_interval=0s
[...]
```
4.84.0 fails with:
```sh
docker run --platform linux/amd64 -it --user 3333:3333 fleetdm/fleet:v4.84.0@sha256:51b56ad59a840b28e074ff9b06d6d5b232b0ca2f0d999bb164820da69c7cbe15

Failed to fetch user info for home directory: user: unknown userid 33332026/04/29 13:28:08 71 <nil>
```
2. `strings ./build/fleet | rg github.com/AbGuthrie/goquery/v2` returns nothing in this branch and returns plenty of matches in `main`.
3. Smoke tested `fleetctl goquery` functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Docker image startup failures in Kubernetes environments caused by a dependency side effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->