### PR TITLE
Fleet UI: Per team ADE check for managed local account setting

### DIFF
--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tests.tsx
@@ -1,0 +1,72 @@
+import { IMdmAbmToken } from "interfaces/mdm";
+
+import { isAdeConfiguredForTeam } from "./Users";
+
+const createAbmToken = (
+  overrides: Partial<{
+    macosTeamId: number;
+    iosTeamId: number;
+    ipadosTeamId: number;
+  }> = {}
+): IMdmAbmToken => ({
+  id: 1,
+  apple_id: "test@example.com",
+  org_name: "Test Org",
+  mdm_server_url: "https://mdm.example.com",
+  renew_date: "2027-01-01T00:00:00Z",
+  terms_expired: false,
+  macos_team: { team_id: overrides.macosTeamId ?? 1, name: "Workstations" },
+  ios_team: { team_id: overrides.iosTeamId ?? 2, name: "iOS devices" },
+  ipados_team: {
+    team_id: overrides.ipadosTeamId ?? 2,
+    name: "iPadOS devices",
+  },
+});
+
+describe("isAdeConfiguredForTeam", () => {
+  it("returns false when abmTokens is undefined", () => {
+    expect(isAdeConfiguredForTeam(1, undefined)).toBe(false);
+  });
+
+  it("returns false when abmTokens is empty", () => {
+    expect(isAdeConfiguredForTeam(1, [])).toBe(false);
+  });
+
+  it("returns true when team matches a macos_team", () => {
+    const tokens = [createAbmToken({ macosTeamId: 5 })];
+    expect(isAdeConfiguredForTeam(5, tokens)).toBe(true);
+  });
+
+  it("returns true when team matches an ios_team", () => {
+    const tokens = [createAbmToken({ iosTeamId: 7 })];
+    expect(isAdeConfiguredForTeam(7, tokens)).toBe(true);
+  });
+
+  it("returns true when team matches an ipados_team", () => {
+    const tokens = [createAbmToken({ ipadosTeamId: 9 })];
+    expect(isAdeConfiguredForTeam(9, tokens)).toBe(true);
+  });
+
+  it("returns false when team does not match any token", () => {
+    const tokens = [createAbmToken()];
+    expect(isAdeConfiguredForTeam(999, tokens)).toBe(false);
+  });
+
+  it("returns true when team matches in one of multiple tokens", () => {
+    const tokens = [
+      createAbmToken({ macosTeamId: 1 }),
+      createAbmToken({ macosTeamId: 10 }),
+    ];
+    expect(isAdeConfiguredForTeam(10, tokens)).toBe(true);
+  });
+
+  it("handles 'No team' (id 0) correctly", () => {
+    const tokens = [createAbmToken({ macosTeamId: 0 })];
+    expect(isAdeConfiguredForTeam(0, tokens)).toBe(true);
+  });
+
+  it("returns false for 'No team' (id 0) when no token assigns it", () => {
+    const tokens = [createAbmToken({ macosTeamId: 1 })];
+    expect(isAdeConfiguredForTeam(0, tokens)).toBe(false);
+  });
+});

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/Users.tsx
@@ -4,7 +4,11 @@ import { useQuery } from "react-query";
 
 import configAPI from "services/entities/config";
 import teamsAPI, { ILoadTeamResponse } from "services/entities/teams";
+import mdmAppleBmAPI, {
+  IGetAbmTokensResponse,
+} from "services/entities/mdm_apple_bm";
 import { IConfig, IMdmConfig } from "interfaces/config";
+import { IMdmAbmToken } from "interfaces/mdm";
 import { ITeamConfig } from "interfaces/team";
 
 import SectionHeader from "components/SectionHeader/SectionHeader";
@@ -87,6 +91,26 @@ const isIdPConfigured = ({
   );
 };
 
+/** Returns true if any ABM token assigns the given team for macOS, iOS, or iPadOS.
+ *  For "No team" (id 0), checks for team_id 0 which represents unassigned hosts.
+ *
+ *  Note: This is a per-team ADE check. Other Setup Experience cards (SetupAssistant,
+ *  BootstrapPackage, RunScript, InstallSoftware) gate on the global
+ *  apple_bm_enabled_and_configured flag instead. Aligning those cards to use
+ *  per-team ADE checking would be a potential improvement for consistency. */
+export const isAdeConfiguredForTeam = (
+  teamId: number,
+  abmTokens?: IMdmAbmToken[]
+) => {
+  if (!abmTokens?.length) return false;
+  return abmTokens.some(
+    (token) =>
+      token.macos_team.team_id === teamId ||
+      token.ios_team.team_id === teamId ||
+      token.ipados_team.team_id === teamId
+  );
+};
+
 const Users = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
   const { data: globalConfig, isLoading: isLoadingGlobalConfig } = useQuery<
     IConfig,
@@ -106,6 +130,21 @@ const Users = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
     enabled: currentTeamId !== 0,
     select: (res) => res.fleet,
   });
+
+  const { data: abmTokensData } = useQuery<IGetAbmTokensResponse>(
+    ["abm_tokens"],
+    () => mdmAppleBmAPI.getTokens(),
+    {
+      refetchOnWindowFocus: false,
+      retry: false,
+      enabled: !!globalConfig?.mdm.apple_bm_enabled_and_configured,
+    }
+  );
+
+  const teamHasAde = isAdeConfiguredForTeam(
+    currentTeamId,
+    abmTokensData?.abm_tokens
+  );
 
   const defaultIsEndUserAuthEnabled = getEnabledEndUserAuth(
     currentTeamId,
@@ -138,6 +177,7 @@ const Users = ({ currentTeamId, router }: ISetupExperienceCardProps) => {
           defaultLockEndUserInfo={defaultLockEndUserInfo}
           defaultEnableManagedLocalAccount={defaultEnableManagedLocalAccount}
           isIdPConfigured={isIdPConfigured(mdmConfig)}
+          teamHasAde={teamHasAde}
         />
       </SetupExperienceContentContainer>
     );

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tests.tsx
@@ -11,6 +11,7 @@ describe("UsersForm", () => {
     defaultLockEndUserInfo: false,
     defaultEnableManagedLocalAccount: false,
     isIdPConfigured: true,
+    teamHasAde: true,
   };
 
   const render = createCustomRenderer({
@@ -163,6 +164,18 @@ describe("UsersForm", () => {
       await user.click(checkbox);
 
       expect(checkbox).not.toBeChecked();
+    });
+
+    it("hides managed local account checkbox when team does not have ADE configured", () => {
+      render(<UsersForm {...defaultProps} teamHasAde={false} />);
+      expect(
+        screen.queryByText("Managed local account")
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows managed local account checkbox when team has ADE configured", () => {
+      render(<UsersForm {...defaultProps} teamHasAde />);
+      expect(screen.getByText("Managed local account")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
+++ b/frontend/pages/ManageControlsPage/SetupExperience/cards/Users/components/UsersForm/UsersForm.tsx
@@ -19,6 +19,7 @@ interface IUsersFormProps {
   defaultLockEndUserInfo: boolean;
   defaultEnableManagedLocalAccount: boolean;
   isIdPConfigured: boolean;
+  teamHasAde: boolean;
 }
 
 const UsersForm = ({
@@ -27,6 +28,7 @@ const UsersForm = ({
   defaultLockEndUserInfo,
   defaultEnableManagedLocalAccount,
   isIdPConfigured,
+  teamHasAde,
 }: IUsersFormProps) => {
   const { renderFlash } = useContext(NotificationContext);
   const { config, isMacMdmEnabledAndConfigured } = useContext(AppContext);
@@ -158,50 +160,52 @@ const UsersForm = ({
             </Checkbox>
           </div>
         )}
-        <TooltipWrapper
-          tipContent={
-            !isMacMdmEnabledAndConfigured ? (
-              <span>
-                To enable, first turn on{" "}
-                <CustomLink
-                  url={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}
-                  text="Apple MDM"
-                  variant="tooltip-link"
-                />
-                .
-              </span>
-            ) : undefined
-          }
-          disableTooltip={!!isMacMdmEnabledAndConfigured}
-          underline={false}
-          position="left"
-          showArrow
-        >
-          <Checkbox
-            disabled={gitOpsModeEnabled || !isMacMdmEnabledAndConfigured}
-            value={enableManagedLocalAccount}
-            onChange={onToggleManagedLocalAccount}
-            helpText={
-              <span>
-                Fleet generates a user (_fleetadmin) and unique password for
-                each host, accessible in <b>Host details</b> &gt;{" "}
-                <b>Show managed account</b>.
-              </span>
+        {teamHasAde && (
+          <TooltipWrapper
+            tipContent={
+              !isMacMdmEnabledAndConfigured ? (
+                <span>
+                  To enable, first turn on{" "}
+                  <CustomLink
+                    url={PATHS.ADMIN_INTEGRATIONS_MDM_APPLE}
+                    text="Apple MDM"
+                    variant="tooltip-link"
+                  />
+                  .
+                </span>
+              ) : undefined
             }
+            disableTooltip={!!isMacMdmEnabledAndConfigured}
+            underline={false}
+            position="left"
+            showArrow
           >
-            <TooltipWrapper
-              tipContent={
-                <>
-                  Creates a hidden managed local admin account for
-                  <br />
-                  remote troubleshooting on macOS hosts.
-                </>
+            <Checkbox
+              disabled={gitOpsModeEnabled || !isMacMdmEnabledAndConfigured}
+              value={enableManagedLocalAccount}
+              onChange={onToggleManagedLocalAccount}
+              helpText={
+                <span>
+                  Fleet generates a user (_fleetadmin) and unique password for
+                  each host, accessible in <b>Host details</b> &gt;{" "}
+                  <b>Show managed account</b>.
+                </span>
               }
             >
-              Managed local account
-            </TooltipWrapper>
-          </Checkbox>
-        </TooltipWrapper>
+              <TooltipWrapper
+                tipContent={
+                  <>
+                    Creates a hidden managed local admin account for
+                    <br />
+                    remote troubleshooting on macOS hosts.
+                  </>
+                }
+              >
+                Managed local account
+              </TooltipWrapper>
+            </Checkbox>
+          </TooltipWrapper>
+        )}
         <GitOpsModeTooltipWrapper
           renderChildren={(disableChildren) => (
             <Button


### PR DESCRIPTION
## Issue
Closes #42945

## Description
- Followup for the Managed local account checkbox to show conditionally based on if ADE is configured for the team selected in the UI

## More
- Waiting on Product to confirm this decision https://fleetdm.slack.com/archives/C086V2QK76X/p1777470745514829
  - maybe we should file a ticket to also gate the rest of the UI based on team's ADE configuration to be consistent? Or maybe this checkbox shouldn't be conditionally rendered to allow pre-configuration just like the rest of setup experience


## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually
