### PR TITLE
restrict unbouded goroutine spawning, fix panic on nil pushInfo for multi push

### DIFF
--- a/server/mdm/nanomdm/push/nanopush/nanopush.go
+++ b/server/mdm/nanomdm/push/nanopush/nanopush.go
@@ -69,6 +69,9 @@ func WithExpiration(expiration time.Duration) Option {
 // WithWorkers sets how many worker goroutines to use when sending pushes.
 func WithWorkers(workers int) Option {
 	return func(f *Factory) {
+		if workers < 1 {
+			workers = 1
+		}
 		f.workers = workers
 	}
 }

--- a/server/mdm/nanomdm/push/nanopush/nanopush.go
+++ b/server/mdm/nanomdm/push/nanopush/nanopush.go
@@ -67,6 +67,7 @@ func WithExpiration(expiration time.Duration) Option {
 }
 
 // WithWorkers sets how many worker goroutines to use when sending pushes.
+// If not set, the default is 5. If set to less than 1, it will be set to 1.
 func WithWorkers(workers int) Option {
 	return func(f *Factory) {
 		if workers < 1 {

--- a/server/mdm/nanomdm/push/nanopush/provider.go
+++ b/server/mdm/nanomdm/push/nanopush/provider.go
@@ -72,7 +72,6 @@ func (p *Provider) do(ctx context.Context, pushInfo *mdm.Push) *push.Response {
 
 	url := p.baseURL + "/3/device/" + pushInfo.Token.String()
 	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(jsonPayload))
-
 	if err != nil {
 		return &push.Response{Err: err}
 	}
@@ -116,7 +115,7 @@ func (p *Provider) pushSerial(ctx context.Context, pushInfos []*mdm.Push) (map[s
 func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (map[string]*push.Response, error) {
 	// don't start more workers than we have pushes to send
 	workers := p.workers
-	if len(pushInfos) > workers {
+	if len(pushInfos) < workers {
 		workers = len(pushInfos)
 	}
 
@@ -147,6 +146,10 @@ func (p *Provider) pushConcurrent(ctx context.Context, pushInfos []*mdm.Push) (m
 	// start the "feeder" (queue source)
 	go func() {
 		for _, pushInfo := range pushInfos {
+			if pushInfo == nil {
+				continue
+			}
+
 			jobs <- pushInfo
 		}
 		close(jobs)

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -38,6 +38,26 @@ func TestPush(t *testing.T) {
 	t.Run("multiple-push", func(t *testing.T) {
 		testPushDevices(t, devicePushInfoStrings)
 	})
+
+	// test nil push info does not panic
+	t.Run("nil-concurrent-push-info", func(t *testing.T) {
+		prov := &Provider{
+			baseURL: "https://example.com",
+			client:  http.DefaultClient,
+			workers: 2,
+		}
+
+		resp, err := prov.Push(context.Background(), []*mdm.Push{nil, nil})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp == nil {
+			t.Fatal("expected non-nil response")
+		}
+		if len(resp) != 0 {
+			t.Fatalf("expected empty response, got %d", len(resp))
+		}
+	})
 }
 
 func testPushDevices(t *testing.T, input [][]string) {
@@ -93,6 +113,7 @@ func testPushDevices(t *testing.T, input [][]string) {
 	prov := &Provider{
 		baseURL: server.URL,
 		client:  http.DefaultClient,
+		workers: 2,
 	}
 
 	resp, err := prov.Push(context.Background(), pushInfos)
@@ -109,7 +130,6 @@ func testPushDevices(t *testing.T, input [][]string) {
 			}
 		}
 	}
-
 }
 
 // goAwayDoer is a mock http.RoundTripper that returns an http2.GoAwayError,

--- a/server/mdm/nanomdm/push/nanopush/provider_test.go
+++ b/server/mdm/nanomdm/push/nanopush/provider_test.go
@@ -3,6 +3,7 @@ package nanopush
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -43,7 +44,7 @@ func TestPush(t *testing.T) {
 	t.Run("nil-concurrent-push-info", func(t *testing.T) {
 		prov := &Provider{
 			baseURL: "https://example.com",
-			client:  http.DefaultClient,
+			client:  &errorDoer{},
 			workers: 2,
 		}
 
@@ -130,6 +131,12 @@ func testPushDevices(t *testing.T, input [][]string) {
 			}
 		}
 	}
+}
+
+type errorDoer struct{}
+
+func (d *errorDoer) Do(*http.Request) (*http.Response, error) {
+	return nil, errors.New("error from Do")
 }
 
 // goAwayDoer is a mock http.RoundTripper that returns an http2.GoAwayError,


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #42898

I was waiting for my [upstream PR](https://github.com/micromdm/nanomdm/pull/250) to be merged, but I've waited for 2+ weeks now, so I'll go ahead and do the same change here, and then if the maintainer requests change I can update this fix retrospectively

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [ ] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information. **None, since it's unused in our codebase at this point**

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [ ] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented nil push entries from causing panics during concurrent push processing
  * Adjusted worker allocation so concurrency scales down when batch sizes are smaller
  * Clamped configured worker count to a minimum of 1 (documented default behavior)

* **Tests**
  * Added regression test ensuring safe handling of nil entries in concurrent push inputs and updated test harness to exercise reduced-worker scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->