### PR TITLE
CLAUDE.md guidance on branch-name sanitization for Docker

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -42,6 +42,15 @@ The following terms were recently renamed. Use the new terms in conversation and
 - **Pointers**: Use Go 1.26 `new(expression)` for pointer values (e.g., `new("value")`, `new(true)`, `new(42)`). Do NOT use the legacy `server/ptr` package in new code — it exists throughout the codebase but is superseded by `new(expr)`.
 - **Reference example**: `server/service/vulnerabilities.go`
 
+## CI and Docker
+
+When interpolating a git branch name into a Docker/registry identifier in a workflow or script:
+- Branch names can be up to ~250 chars and may contain `/`, uppercase, `+`, `@`, etc. None of these are valid in all Docker contexts.
+- **Docker tags**: max 128 chars, must match `[a-zA-Z0-9_][a-zA-Z0-9_.-]*` (no `/`, no `+`).
+- **Docker image / repo names**: must be lowercase.
+- Sanitize with `${BRANCH//\//-}`, also replace `+`, `@`, spaces, lowercase the result, then truncate to 128 chars before use.
+- Existing sanitization lives in `.github/workflows/goreleaser-snapshot-fleet.yaml` and `.github/workflows/docker-cleanup-branch.yaml` — follow the same pattern when adding new interpolations.
+
 ## Before writing a fix
 
 - Identify WHERE in the request lifecycle the problem manifests (creation vs team-addition vs sync vs query). Fix it there, not at the reproduction step.


### PR DESCRIPTION
**Related issue:** N/A — docs-only change for `.claude/CLAUDE.md`

## Summary

Adds a short "CI and Docker" section to `.claude/CLAUDE.md` so future Claude Code sessions know how to sanitize branch names before they get interpolated into Docker tags, image names, or other registry identifiers.

## Why

While auditing CI workflows, I noticed the existing branch-name sanitization in `.github/workflows/goreleaser-snapshot-fleet.yaml` and `.github/workflows/docker-cleanup-branch.yaml` only handles `/` → `-`. It doesn't:

- Truncate to the Docker tag max of 128 chars
- Strip `+`, `@`, or spaces (all invalid in Docker tags)
- Lowercase the result (Docker image/repo names must be lowercase)

A long or unusual branch name (e.g. `feature/MyBugFix`, `feat+exp`, or anything > 128 chars after slash-replacement) can produce an invalid Docker tag and break the snapshot push or branch-cleanup jobs.

This PR doesn't fix the workflows themselves — it just documents the constraints in `CLAUDE.md` so the next time someone (or Claude) adds a branch-name → identifier interpolation, they'll follow the right pattern. The actual workflow fixes can be a follow-up.

## What changed

- `.claude/CLAUDE.md`: new "CI and Docker" section listing the Docker tag/image/repo constraints, the recommended sanitization (`${BRANCH//\//-}` + replace `+`/`@`/space, lowercase, truncate to 128), and a pointer to the two existing workflows that already do part of this.

# Checklist for submitter

- [x] Docs-only change. No code, no migrations, no settings, no tests.