### PR TITLE
Add spacing to report description blocks

### DIFF
--- a/it-and-security/lib/all/reports/collect-chromium-browser-extensions.yml
+++ b/it-and-security/lib/all/reports/collect-chromium-browser-extensions.yml
@@ -1,6 +1,7 @@
 - name: Collect Chromium-family browser extensions
   description: |-
     Extension inventory across Chrome, Edge, Brave, and other Chromium-based profiles.
+
     Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
   query: |-
     SELECT

--- a/it-and-security/lib/all/reports/collect-firefox-browser-extensions.yml
+++ b/it-and-security/lib/all/reports/collect-firefox-browser-extensions.yml
@@ -1,6 +1,7 @@
 - name: Collect Firefox browser extensions
   description: |-
     Add-on/extension inventory across Firefox profiles for all users.
+
     Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
   query: |-
     SELECT

--- a/it-and-security/lib/all/reports/collect-listening-ports.yml
+++ b/it-and-security/lib/all/reports/collect-listening-ports.yml
@@ -1,6 +1,7 @@
 - name: Collect listening TCP/UDP ports
   description: |-
     Processes listening on network ports for anomaly detection and firewall reviews.
+
     Maps to **NET-91** / ISO **A.8.20**, **MON-121** / **A.8.16**, and SOC2 **CC 6.6** / **CC 7.2**.
   query: |-
     SELECT

--- a/it-and-security/lib/all/reports/collect-local-user-accounts.yml
+++ b/it-and-security/lib/all/reports/collect-local-user-accounts.yml
@@ -1,6 +1,7 @@
 - name: Collect local user accounts and admin membership
   description: |-
     Inventory of local user accounts with admin-equivalent membership for access reviews.
+
     Maps to Vanta **AST-66** / ISO **A.5.9** (asset inventory), **IAC-200** / **A.5.18** (access rights), and **IAC-201** / **A.8.2** (privileged access).
   query: |-
     SELECT

--- a/it-and-security/lib/all/reports/collect-safari-browser-extensions.yml
+++ b/it-and-security/lib/all/reports/collect-safari-browser-extensions.yml
@@ -1,7 +1,9 @@
 - name: Collect Safari browser extensions
   description: |-
     Extension inventory across Safari profiles for all macOS users.
+
     Supports **NET-94** / ISO **A.8.23** (web/content exposure), **VPM-75** / **A.8.8** (vulnerability management), and SOC2 **CC 7.1**.
+
     Note: Safari data is isolated per macOS user, so osquery requires Full Disk Access to read it. See https://fleetdm.com/guides/enroll-hosts#grant-full-disk-access-to-osquery-on-macos.
   query: |-
     SELECT

--- a/it-and-security/lib/all/reports/collect-usb-devices.yml
+++ b/it-and-security/lib/all/reports/collect-usb-devices.yml
@@ -1,7 +1,9 @@
 - name: Collect connected USB devices
   description: |-
     USB devices currently attached to the host (useful for removable media and exfiltration visibility).
+
     Maps to Vanta **AST-70** / ISO **A.7.10** (storage media), **CRY-3** / SOC2 **CC 6.7**, and **DCH-112** / **A.8.12** (data leakage prevention).
+
     Note: `usb_devices` is available on macOS and Linux only in Fleet’s schema.
   query: |-
     SELECT


### PR DESCRIPTION
Insert blank lines in the description sections of several it-and-security reports to improve readability. Files updated: collect-chromium-browser-extensions.yml, collect-firefox-browser-extensions.yml, collect-listening-ports.yml, collect-local-user-accounts.yml, collect-safari-browser-extensions.yml, collect-usb-devices.yml. No query or functional changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting and readability of description text in security report configurations by adding spacing between paragraphs for better visual organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->