### PR TITLE
Improvements for Redis stress testing tool

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -220,7 +220,7 @@ go run ./tools/run-scripts -scripts-disabled -content 'echo "Test"'
 | `dbutils/` | Database schema generator | `go run ./tools/dbutils/schema_generator.go <dumpfile>` |
 | `mysql-replica-testing/` | MySQL replica testing | See [mysql-replica-testing/README.md](mysql-replica-testing/README.md) |
 | `mysql-tests/` | MySQL testing configs | Docker configs for MySQL testing |
-| `redis-stress/` | Redis stress testing | `go run` tools in directory |
+| `redis-stress/` | Redis stress testing — cluster-aware `write` (steady SET load) and `race` (SET-then-GET visibility race detection) modes | `go run ./tools/redis-stress write -addr 127.0.0.1:7001 -workers 5 -duration 1m` or `race -addr 127.0.0.1:7001 -workers 50 -iterations 2000` — see [redis-stress/README.md](redis-stress/README.md) |
 | `redis-tests/` | Redis testing configs | ElastiCache and general Redis test configs |
 | `snapshot/` | Database snapshot/restore tool | `go run ./tools/snapshot s` or `go run ./tools/snapshot r` |
 | **Development Tools** | | |

--- a/tools/README.md
+++ b/tools/README.md
@@ -220,7 +220,7 @@ go run ./tools/run-scripts -scripts-disabled -content 'echo "Test"'
 | `dbutils/` | Database schema generator | `go run ./tools/dbutils/schema_generator.go <dumpfile>` |
 | `mysql-replica-testing/` | MySQL replica testing | See [mysql-replica-testing/README.md](mysql-replica-testing/README.md) |
 | `mysql-tests/` | MySQL testing configs | Docker configs for MySQL testing |
-| `redis-stress/` | Redis stress testing — cluster-aware `write` (steady SET load) and `race` (SET-then-GET visibility race detection) modes | `go run ./tools/redis-stress write -addr 127.0.0.1:7001 -workers 5 -duration 1m` or `race -addr 127.0.0.1:7001 -workers 50 -iterations 2000` — see [redis-stress/README.md](redis-stress/README.md) |
+| `redis-stress/` | Redis stress testing — cluster-aware `write` (steady SET load) and `race` (SET-then-GET visibility race detection) modes | `go run ./tools/redis-stress write -addr 127.0.0.1:7001 -workers 5 -duration 1m` or `go run ./tools/redis-stress race -addr 127.0.0.1:7001 -workers 50 -iterations 2000` — see [redis-stress/README.md](redis-stress/README.md) |
 | `redis-tests/` | Redis testing configs | ElastiCache and general Redis test configs |
 | `snapshot/` | Database snapshot/restore tool | `go run ./tools/snapshot s` or `go run ./tools/snapshot r` |
 | **Development Tools** | | |

--- a/tools/redis-stress/README.md
+++ b/tools/redis-stress/README.md
@@ -1,0 +1,146 @@
+# redis-stress
+
+Cluster-aware Redis stress tool with two modes.
+
+Both modes use Fleet's own `redis.NewPool` (`server/datastore/redis`), so
+cluster topology, redirection handling, and connection routing match what the
+real Fleet server does in production.
+
+## Modes
+
+### `write` — steady SET-only load
+
+Fill a Redis instance (standalone or cluster) at a configurable rate. Each
+worker writes keys on its own ticker; useful for "occupy the cluster with
+ongoing writes while I observe something else" or seeding a dataset.
+
+This mode is the cluster-aware successor to the original `tools/redis-stress`
+tool. The old subcommand-less invocation (`redis-stress -addr=X -wait=10m`)
+still works — when the first arg starts with `-`, the dispatcher routes to
+`write`. The legacy flags `-wait`, `-debug`, and `-index-start` are kept for
+backward compatibility.
+
+```sh
+go run ./tools/redis-stress write \
+  -addr 127.0.0.1:7001 \
+  -workers 5 \
+  -rate 100 \
+  -duration 1m
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-addr` | `127.0.0.1:6379` | Redis address (cluster startup node OK; cluster auto-detected) |
+| `-workers` | `1` | Concurrent SET workers |
+| `-rate` | `1` | SETs per worker per second (fractional OK) |
+| `-duration` | `10m` | Total run time |
+| `-key-prefix` | `stress_write_` | Key prefix |
+| `-key-ttl` | `10m` | Per-key expiration |
+| `-index-start` | `0` | Starting value of each worker's per-key counter (legacy) |
+| `-debug` | `false` | Log every SET (legacy) |
+| `-wait` | — | Alias for `-duration` (legacy) |
+| `-cluster-follow-redirects` | `true` | `ClusterFollowRedirections` (cluster only) |
+| `-cluster-read-from-replica` | `false` | `ClusterReadFromReplica` (cluster only) |
+
+### `race` — SET-then-GET race detection
+
+Each worker repeatedly does, on fresh pool connections:
+
+```
+conn1 := pool.Get(); conn1.Do("SET", k, v, "PX", ttl); conn1.Close()
+conn2 := pool.Get(); conn2.Do("GET", k);                conn2.Close()
+```
+
+and counts any `GET` that returns `nil` immediately after a successful `SET`
+on the same key. This mirrors how Fleet's
+`server/service/redis_key_value.RedisKeyValue` does its `Set` / `Get` —
+fresh connection per call.
+
+```sh
+# default — cluster mode, reads through ConfigureDoer (i.e., not explicitly
+# routed to replicas; same path Fleet uses today)
+go run ./tools/redis-stress race -addr 127.0.0.1:7001 -workers 50 -iterations 2000
+
+# explicit replica reads — useful for testing what a deployment with an
+# external read-from-replica router (proxy, ElastiCache reader endpoint,
+# Redis-Enterprise R/W split) would expose
+go run ./tools/redis-stress race -addr 127.0.0.1:7001 \
+  -cluster-read-from-replica \
+  -explicit-readonly
+```
+
+| Flag | Default | Purpose |
+|---|---|---|
+| `-addr` | `127.0.0.1:7001` | Redis cluster startup node |
+| `-workers` | `50` | Concurrent SET-then-GET workers |
+| `-iterations` | `1000` | Iterations per worker |
+| `-ttl` | `4m` | PX expiration on SET |
+| `-key-prefix` | `stress_race_` | Key prefix |
+| `-explicit-readonly` | `false` | Wrap the GET conn with `redis.ReadOnlyConn` so it's routed to a replica when the pool has `ClusterReadFromReplica=true`. Without this flag, both SET and GET go to primary. |
+| `-cluster-follow-redirects` | `true` | `ClusterFollowRedirections` |
+| `-cluster-read-from-replica` | `true` | `ClusterReadFromReplica` |
+
+#### Output
+
+```
+================ summary ================
+elapsed:           11.2s
+sets:              100000 (errors 0)
+gets:              100000 (errors 0)
+nil-after-set:     0  ← the bug
+stale-after-set:   0
+ops/sec:           17858.2
+```
+
+`nil-after-set` is the metric to watch. Any non-zero value means the cluster
+served a `GET` for a key the same code had just `SET` and gotten an OK
+acknowledgement for. The tool exits with status 1 when this happens.
+
+`stale-after-set` should be zero in normal operation (the key namespace is
+worker-and-iteration-specific) and is included as a defense against
+unexpected key collisions.
+
+## Bringing up a local Redis cluster
+
+The repo includes a 6-node Redis Cluster compose file. From the repo root:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose-redis-cluster.yml up -d \
+  redis-cluster-1 redis-cluster-2 redis-cluster-3 \
+  redis-cluster-4 redis-cluster-5 redis-cluster-6 \
+  redis-cluster-setup
+```
+
+Verify the cluster came up:
+
+```sh
+docker exec fleet-redis-cluster-1-1 redis-cli -p 7001 cluster info | grep cluster_state
+# cluster_state:ok
+```
+
+On macOS, host-to-cluster networking requires
+[`docker-mac-net-connect`](https://github.com/chipmk/docker-mac-net-connect):
+
+```sh
+brew install chipmk/tap/docker-mac-net-connect
+sudo brew services start chipmk/tap/docker-mac-net-connect
+```
+
+Without it, only port-forwarded nodes are reachable and any cluster redirect
+times out.
+
+## Forcing a replica to lag
+
+To verify the race detector works mechanically (or to simulate a customer
+deployment where reads can fall behind writes), pause one of the replica
+nodes mid-test:
+
+```sh
+docker pause fleet-redis-cluster-4-1
+go run ./tools/redis-stress race \
+  -addr 127.0.0.1:7001 -explicit-readonly -workers 20 -iterations 500
+docker unpause fleet-redis-cluster-4-1
+```
+
+With `-explicit-readonly` *and* a paused replica, you should see non-zero
+`nil-after-set` events for keys whose slot's replica was the paused one.

--- a/tools/redis-stress/race.go
+++ b/tools/redis-stress/race.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	"github.com/fleetdm/fleet/v4/server/fleet"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+// raceStats accumulates per-run counts for the race-detection mode.
+type raceStats struct {
+	sets       atomic.Int64
+	setErrs    atomic.Int64
+	gets       atomic.Int64
+	getErrs    atomic.Int64
+	getNilRace atomic.Int64 // GET returned nil after a successful SET — the bug we're chasing.
+	getStale   atomic.Int64 // GET returned a value, but not the one we just set (would be very odd).
+}
+
+func runRace(args []string) {
+	fs := flag.NewFlagSet("race", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "redis-stress race — tight SET-then-GET race detection.\n\n")
+		fmt.Fprintf(fs.Output(), "Each worker repeatedly does:\n")
+		fmt.Fprintf(fs.Output(), "  conn1 := pool.Get(); conn1.Do(\"SET\", k, v, \"PX\", ttl); conn1.Close()\n")
+		fmt.Fprintf(fs.Output(), "  conn2 := pool.Get(); conn2.Do(\"GET\", k);                conn2.Close()\n")
+		fmt.Fprintf(fs.Output(), "and reports any GET that returns nil immediately after a successful SET.\n")
+		fmt.Fprintf(fs.Output(), "This mirrors how Fleet's RedisKeyValue.Set/.Get use the connection pool.\n\n")
+		fmt.Fprintf(fs.Output(), "FLAGS:\n")
+		fs.PrintDefaults()
+	}
+	addr := fs.String("addr", "127.0.0.1:7001", "Redis cluster startup node")
+	workers := fs.Int("workers", 50, "Concurrent SET-then-GET workers")
+	iterations := fs.Int("iterations", 1000, "Iterations per worker")
+	ttl := fs.Duration("ttl", 4*time.Minute, "PX expiration on SET")
+	keyPrefix := fs.String("key-prefix", "stress_race_", "Key prefix")
+	explicitReadOnly := fs.Bool("explicit-readonly", false,
+		"Call redis.ReadOnlyConn on the GET conn (routes reads to replicas in cluster mode); "+
+			"set this together with -cluster-read-from-replica to test replica-lag scenarios")
+	followRedirs := fs.Bool("cluster-follow-redirects", true, "ClusterFollowRedirections")
+	readReplica := fs.Bool("cluster-read-from-replica", true, "ClusterReadFromReplica")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if *workers < 1 {
+		log.Fatalf("workers must be >= 1, got %d", *workers)
+	}
+	if *iterations < 1 {
+		log.Fatalf("iterations must be >= 1, got %d", *iterations)
+	}
+
+	pool, err := redis.NewPool(redis.PoolConfig{
+		Server:                    *addr,
+		UseTLS:                    false,
+		ClusterFollowRedirections: *followRedirs,
+		ClusterReadFromReplica:    *readReplica,
+		ConnTimeout:               5 * time.Second,
+		ReadTimeout:               5 * time.Second,
+		WriteTimeout:              5 * time.Second,
+		MaxIdleConns:              *workers * 2,
+		MaxOpenConns:              *workers * 4,
+	})
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	log.Printf("race mode: addr=%s read_from_replica=%v follow_redirects=%v explicit_readonly=%v",
+		*addr, *readReplica, *followRedirs, *explicitReadOnly)
+	log.Printf("workers=%d iterations=%d ttl=%s", *workers, *iterations, *ttl)
+
+	var s raceStats
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	for w := 0; w < *workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < *iterations; i++ {
+				key := fmt.Sprintf("%sw%d_i%d", *keyPrefix, id, i)
+				expected := fmt.Sprintf("v_%d_%d", id, i)
+				if err := raceOnce(pool, key, expected, ttl.Milliseconds(), *explicitReadOnly, &s); err != nil {
+					log.Printf("[w%d.i%d] %v", id, i, err)
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	elapsed := time.Since(start)
+	total := s.sets.Load() + s.gets.Load()
+
+	fmt.Println()
+	fmt.Println("================ summary ================")
+	fmt.Printf("elapsed:           %s\n", elapsed)
+	fmt.Printf("sets:              %d (errors %d)\n", s.sets.Load(), s.setErrs.Load())
+	fmt.Printf("gets:              %d (errors %d)\n", s.gets.Load(), s.getErrs.Load())
+	fmt.Printf("nil-after-set:     %d  ← the bug\n", s.getNilRace.Load())
+	fmt.Printf("stale-after-set:   %d\n", s.getStale.Load())
+	fmt.Printf("ops/sec:           %.1f\n", float64(total)/elapsed.Seconds())
+
+	if s.getNilRace.Load() > 0 {
+		fmt.Println()
+		fmt.Println("RESULT: SET-visibility race observed.")
+		os.Exit(1)
+	}
+	fmt.Println()
+	fmt.Println("RESULT: no race observed under these conditions.")
+}
+
+// raceOnce mimics RedisKeyValue.Set immediately followed by RedisKeyValue.Get,
+// each on a fresh pool connection. If explicitReadOnly is true, the GET conn
+// is converted via redis.ReadOnlyConn — only effective in cluster mode with
+// ClusterReadFromReplica=true on the pool.
+func raceOnce(pool fleet.RedisPool, key, expected string, ttlMs int64, explicitReadOnly bool, s *raceStats) error {
+	// SET
+	{
+		conn := redis.ConfigureDoer(pool, pool.Get())
+		_, err := redigo.String(conn.Do("SET", key, expected, "PX", ttlMs))
+		conn.Close()
+		if err != nil {
+			s.setErrs.Add(1)
+			return fmt.Errorf("set: %w", err)
+		}
+		s.sets.Add(1)
+	}
+
+	// GET (optionally via a read-only conn that may land on a replica)
+	{
+		conn := redis.ConfigureDoer(pool, pool.Get())
+		if explicitReadOnly {
+			conn = redis.ReadOnlyConn(pool, conn)
+		}
+		got, err := redigo.String(conn.Do("GET", key))
+		conn.Close()
+		if errors.Is(err, redigo.ErrNil) {
+			s.getNilRace.Add(1)
+			s.gets.Add(1)
+			fmt.Printf("RACE key=%s expected=%s got=<nil>\n", key, expected)
+			return nil
+		}
+		if err != nil {
+			s.getErrs.Add(1)
+			return fmt.Errorf("get: %w", err)
+		}
+		s.gets.Add(1)
+		if got != expected {
+			s.getStale.Add(1)
+			fmt.Printf("STALE key=%s expected=%s got=%s\n", key, expected, got)
+		}
+	}
+
+	// Best-effort cleanup so we don't pile up keys with the TTL.
+	{
+		conn := redis.ConfigureDoer(pool, pool.Get())
+		_, _ = conn.Do("DEL", key)
+		conn.Close()
+	}
+	return nil
+}

--- a/tools/redis-stress/race.go
+++ b/tools/redis-stress/race.go
@@ -71,7 +71,6 @@ func runRace(args []string) {
 	if err != nil {
 		log.Fatalf("connect: %v", err)
 	}
-	defer pool.Close()
 
 	log.Printf("race mode: addr=%s read_from_replica=%v follow_redirects=%v explicit_readonly=%v",
 		*addr, *readReplica, *followRedirs, *explicitReadOnly)
@@ -107,6 +106,11 @@ func runRace(args []string) {
 	fmt.Printf("nil-after-set:     %d  ← the bug\n", s.getNilRace.Load())
 	fmt.Printf("stale-after-set:   %d\n", s.getStale.Load())
 	fmt.Printf("ops/sec:           %.1f\n", float64(total)/elapsed.Seconds())
+
+	// Close the pool explicitly rather than via defer so that any subsequent
+	// os.Exit doesn't skip cleanup. (gocritic exitAfterDefer flags the defer
+	// + os.Exit pattern.)
+	pool.Close()
 
 	if s.getNilRace.Load() > 0 {
 		fmt.Println()

--- a/tools/redis-stress/race.go
+++ b/tools/redis-stress/race.go
@@ -51,18 +51,8 @@ func runRace(args []string) {
 	// post-Parse error path to handle here.
 	_ = fs.Parse(args)
 
-	if *workers < 1 {
-		log.Fatalf("workers must be >= 1, got %d", *workers)
-	}
-	if *iterations < 1 {
-		log.Fatalf("iterations must be >= 1, got %d", *iterations)
-	}
-	// Redis PX requires a positive integer count of milliseconds; sub-ms
-	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
-	// "ERR invalid expire time in set" which would inflate set-error counts
-	// rather than test what we want.
-	if *ttl < time.Millisecond {
-		log.Fatalf("ttl must be >= 1ms, got %s", *ttl)
+	if err := validateRaceFlags(*workers, *iterations, *ttl); err != nil {
+		log.Fatal(err)
 	}
 
 	pool, err := redis.NewPool(redis.PoolConfig{
@@ -127,6 +117,26 @@ func runRace(args []string) {
 	}
 	fmt.Println()
 	fmt.Println("RESULT: no race observed under these conditions.")
+}
+
+// validateRaceFlags returns a non-nil error if any of the input bounds are
+// out of range. Pulled out of runRace so the validation can be unit-tested
+// without spinning up a Redis pool.
+func validateRaceFlags(workers, iterations int, ttl time.Duration) error {
+	if workers < 1 {
+		return fmt.Errorf("workers must be >= 1, got %d", workers)
+	}
+	if iterations < 1 {
+		return fmt.Errorf("iterations must be >= 1, got %d", iterations)
+	}
+	// Redis PX requires a positive integer count of milliseconds; sub-ms
+	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
+	// "ERR invalid expire time in set" which would inflate set-error counts
+	// rather than test what we want.
+	if ttl < time.Millisecond {
+		return fmt.Errorf("ttl must be >= 1ms, got %s", ttl)
+	}
+	return nil
 }
 
 // raceOnce mimics RedisKeyValue.Set immediately followed by RedisKeyValue.Get,

--- a/tools/redis-stress/race.go
+++ b/tools/redis-stress/race.go
@@ -47,14 +47,22 @@ func runRace(args []string) {
 			"set this together with -cluster-read-from-replica to test replica-lag scenarios")
 	followRedirs := fs.Bool("cluster-follow-redirects", true, "ClusterFollowRedirections")
 	readReplica := fs.Bool("cluster-read-from-replica", true, "ClusterReadFromReplica")
-	if err := fs.Parse(args); err != nil {
-		os.Exit(2)
-	}
+	// flag.ExitOnError handles parse errors itself (calls os.Exit(2)); no
+	// post-Parse error path to handle here.
+	_ = fs.Parse(args)
+
 	if *workers < 1 {
 		log.Fatalf("workers must be >= 1, got %d", *workers)
 	}
 	if *iterations < 1 {
 		log.Fatalf("iterations must be >= 1, got %d", *iterations)
+	}
+	// Redis PX requires a positive integer count of milliseconds; sub-ms
+	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
+	// "ERR invalid expire time in set" which would inflate set-error counts
+	// rather than test what we want.
+	if *ttl < time.Millisecond {
+		log.Fatalf("ttl must be >= 1ms, got %s", *ttl)
 	}
 
 	pool, err := redis.NewPool(redis.PoolConfig{
@@ -123,51 +131,56 @@ func runRace(args []string) {
 
 // raceOnce mimics RedisKeyValue.Set immediately followed by RedisKeyValue.Get,
 // each on a fresh pool connection. If explicitReadOnly is true, the GET conn
-// is converted via redis.ReadOnlyConn — only effective in cluster mode with
-// ClusterReadFromReplica=true on the pool.
+// is marked read-only before ConfigureDoer wraps it — only effective in
+// cluster mode with ClusterReadFromReplica=true on the pool.
 func raceOnce(pool fleet.RedisPool, key, expected string, ttlMs int64, explicitReadOnly bool, s *raceStats) error {
-	// SET
-	{
-		conn := redis.ConfigureDoer(pool, pool.Get())
-		_, err := redigo.String(conn.Do("SET", key, expected, "PX", ttlMs))
-		conn.Close()
-		if err != nil {
-			s.setErrs.Add(1)
-			return fmt.Errorf("set: %w", err)
-		}
-		s.sets.Add(1)
+	// SET via the standard connection routing.
+	conn := redis.ConfigureDoer(pool, pool.Get())
+	_, err := redigo.String(conn.Do("SET", key, expected, "PX", ttlMs))
+	conn.Close()
+	if err != nil {
+		s.setErrs.Add(1)
+		return fmt.Errorf("set: %w", err)
 	}
+	s.sets.Add(1)
 
-	// GET (optionally via a read-only conn that may land on a replica)
-	{
-		conn := redis.ConfigureDoer(pool, pool.Get())
-		if explicitReadOnly {
-			conn = redis.ReadOnlyConn(pool, conn)
-		}
-		got, err := redigo.String(conn.Do("GET", key))
-		conn.Close()
-		if errors.Is(err, redigo.ErrNil) {
-			s.getNilRace.Add(1)
-			s.gets.Add(1)
-			fmt.Printf("RACE key=%s expected=%s got=<nil>\n", key, expected)
-			return nil
-		}
-		if err != nil {
-			s.getErrs.Add(1)
-			return fmt.Errorf("get: %w", err)
-		}
-		s.gets.Add(1)
-		if got != expected {
-			s.getStale.Add(1)
-			fmt.Printf("STALE key=%s expected=%s got=%s\n", key, expected, got)
-		}
-	}
-
-	// Best-effort cleanup so we don't pile up keys with the TTL.
-	{
+	// SET succeeded; ensure DEL runs no matter how the GET branch returns.
+	// Without this defer, ErrNil and GET-error early-returns leave keys to
+	// expire only by TTL, inflating memory pressure during a noisy run.
+	defer func() {
 		conn := redis.ConfigureDoer(pool, pool.Get())
 		_, _ = conn.Do("DEL", key)
 		conn.Close()
+	}()
+
+	// GET. ReadOnlyConn must be applied to the raw *redisc.Conn before
+	// ConfigureDoer wraps it: ConfigureDoer wraps in *redisc.retryConn (in
+	// cluster mode with follow-redirects), which does not implement
+	// ReadOnly() error. Calling ReadOnlyConn after ConfigureDoer would
+	// silently no-op via the type-assertion-fail path in
+	// redisc.ReadOnlyConn (whose error Fleet's wrapper discards), and the
+	// GET would still go to the primary.
+	getConn := pool.Get()
+	if explicitReadOnly {
+		getConn = redis.ReadOnlyConn(pool, getConn)
+	}
+	getConn = redis.ConfigureDoer(pool, getConn)
+	got, err := redigo.String(getConn.Do("GET", key))
+	getConn.Close()
+	if errors.Is(err, redigo.ErrNil) {
+		s.getNilRace.Add(1)
+		s.gets.Add(1)
+		fmt.Printf("RACE key=%s expected=%s got=<nil>\n", key, expected)
+		return nil
+	}
+	if err != nil {
+		s.getErrs.Add(1)
+		return fmt.Errorf("get: %w", err)
+	}
+	s.gets.Add(1)
+	if got != expected {
+		s.getStale.Add(1)
+		fmt.Printf("STALE key=%s expected=%s got=%s\n", key, expected, got)
 	}
 	return nil
 }

--- a/tools/redis-stress/stress.go
+++ b/tools/redis-stress/stress.go
@@ -1,61 +1,52 @@
+// redis-stress: cluster-aware Redis stress tool with multiple modes.
+//
+// See ./README.md for full docs.
 package main
 
 import (
-	"flag"
 	"fmt"
-	"log"
-	"time"
-
-	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	"os"
 )
 
-var (
-	addrFlag       = flag.String("addr", "", "Redis address, including port")
-	indexStartFlag = flag.Int("index-start", 1, "Index to start from when inserting keys")
-	debugFlag      = flag.Bool("debug", false, "Print debug logs")
-	waitFlag       = flag.Duration("wait", 10*time.Minute, "Amount of time to do SETs")
-)
+const usage = `redis-stress: cluster-aware Redis stress tool with multiple modes.
+
+USAGE:
+  redis-stress <command> [flags]
+
+COMMANDS:
+  write   Steady SET-only load (fill the cluster at a configurable rate).
+  race    Tight SET-then-GET race detection (chase SET-visibility issues
+          like Redis cluster replica-read lag, MOVED redirect blips, etc).
+
+For per-command help:
+  redis-stress <command> -h
+`
 
 func main() {
-	flag.Parse()
-
-	pool, err := redis.NewPool(redis.PoolConfig{Server: *addrFlag, UseTLS: false})
-	if err != nil {
-		log.Fatal(err)
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
 	}
-	defer pool.Close()
-
-	log.Println("pool created successfully")
-
-	conn := pool.Get()
-	defer conn.Close()
-
-	ticker := time.NewTicker(1 * time.Second)
-	quit := make(chan struct{})
-	go func() {
-		i := 0
-		if indexStartFlag != nil {
-			i = *indexStartFlag
+	// Backward-compat with the original (subcommand-less) tool: if the first arg
+	// starts with `-`, treat it as flags for write mode. Lets old invocations
+	// like `redis-stress -addr=X -wait=10m` keep working.
+	if len(os.Args[1]) > 0 && os.Args[1][0] == '-' {
+		if os.Args[1] == "-h" || os.Args[1] == "--help" {
+			fmt.Fprint(os.Stdout, usage)
+			return
 		}
-		for {
-			select {
-			case <-ticker.C:
-				_, err := conn.Do("SET", fmt.Sprintf("error:%d", i), 1, "EX", (10 * time.Minute).Seconds())
-				if debugFlag != nil && *debugFlag {
-					log.Println("SET", i)
-					if err != nil {
-						log.Println("err", err)
-					}
-				}
-			case <-quit:
-				ticker.Stop()
-				return
-			}
-			i++
-		}
-	}()
-
-	time.Sleep(*waitFlag)
-	close(quit)
-	log.Println("done")
+		runWrite(os.Args[1:])
+		return
+	}
+	switch os.Args[1] {
+	case "write":
+		runWrite(os.Args[2:])
+	case "race":
+		runRace(os.Args[2:])
+	case "help":
+		fmt.Fprint(os.Stdout, usage)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n%s", os.Args[1], usage)
+		os.Exit(2)
+	}
 }

--- a/tools/redis-stress/stress_test.go
+++ b/tools/redis-stress/stress_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateWriteFlags(t *testing.T) {
+	t.Parallel()
+	const validRate = 1.0
+	validDur := 10 * time.Minute
+	validTTL := 10 * time.Minute
+
+	cases := []struct {
+		name     string
+		workers  int
+		rate     float64
+		duration time.Duration
+		keyTTL   time.Duration
+		wantErr  string // substring; "" means expect success
+	}{
+		{"happy path", 1, validRate, validDur, validTTL, ""},
+		{"workers=0", 0, validRate, validDur, validTTL, "workers must be >= 1"},
+		{"workers=-1", -1, validRate, validDur, validTTL, "workers must be >= 1"},
+		{"rate=0", 1, 0, validDur, validTTL, "rate must be > 0"},
+		{"rate=-1", 1, -1, validDur, validTTL, "rate must be > 0"},
+		{"rate=1e10 (period truncates to 0)", 1, 1e10, validDur, validTTL, "non-positive ticker period"},
+		{"duration=0", 1, validRate, 0, validTTL, "duration must be > 0"},
+		{"duration=-1s", 1, validRate, -1 * time.Second, validTTL, "duration must be > 0"},
+		{"keyTTL=0", 1, validRate, validDur, 0, "key-ttl must be >= 1ms"},
+		{"keyTTL=-1ms", 1, validRate, validDur, -time.Millisecond, "key-ttl must be >= 1ms"},
+		{"keyTTL=500us (sub-ms)", 1, validRate, validDur, 500 * time.Microsecond, "key-ttl must be >= 1ms"},
+		{"keyTTL=1ms (boundary)", 1, validRate, validDur, time.Millisecond, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			period, err := validateWriteFlags(c.workers, c.rate, c.duration, c.keyTTL)
+			if c.wantErr == "" {
+				require.NoError(t, err)
+				require.Greater(t, period, time.Duration(0))
+			} else {
+				require.ErrorContains(t, err, c.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRaceFlags(t *testing.T) {
+	t.Parallel()
+	validIters := 100
+	validTTL := 4 * time.Minute
+
+	cases := []struct {
+		name       string
+		workers    int
+		iterations int
+		ttl        time.Duration
+		wantErr    string
+	}{
+		{"happy path", 1, validIters, validTTL, ""},
+		{"workers=0", 0, validIters, validTTL, "workers must be >= 1"},
+		{"workers=-1", -1, validIters, validTTL, "workers must be >= 1"},
+		{"iterations=0", 1, 0, validTTL, "iterations must be >= 1"},
+		{"iterations=-1", 1, -1, validTTL, "iterations must be >= 1"},
+		{"ttl=0", 1, validIters, 0, "ttl must be >= 1ms"},
+		{"ttl=-1ms", 1, validIters, -time.Millisecond, "ttl must be >= 1ms"},
+		{"ttl=500us (sub-ms)", 1, validIters, 500 * time.Microsecond, "ttl must be >= 1ms"},
+		{"ttl=1ms (boundary)", 1, validIters, time.Millisecond, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateRaceFlags(c.workers, c.iterations, c.ttl)
+			if c.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, c.wantErr)
+			}
+		})
+	}
+}

--- a/tools/redis-stress/write.go
+++ b/tools/redis-stress/write.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/fleetdm/fleet/v4/server/datastore/redis"
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+func runWrite(args []string) {
+	fs := flag.NewFlagSet("write", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "redis-stress write — steady SET-only load against Redis or a Redis cluster.\n\n")
+		fmt.Fprintf(fs.Output(), "FLAGS:\n")
+		fs.PrintDefaults()
+	}
+	addr := fs.String("addr", "127.0.0.1:6379", "Redis address (cluster startup node OK; cluster mode is auto-detected)")
+	workers := fs.Int("workers", 1, "Concurrent SET workers")
+	rate := fs.Float64("rate", 1.0, "SETs per worker per second")
+	duration := fs.Duration("duration", 10*time.Minute, "Total run time")
+	wait := fs.Duration("wait", 0, "Alias for -duration (legacy; kept for backward compatibility with the original tool)")
+	keyPrefix := fs.String("key-prefix", "stress_write_", "Key prefix")
+	keyTTL := fs.Duration("key-ttl", 10*time.Minute, "Per-key expiration")
+	indexStart := fs.Int("index-start", 0, "Starting value of each worker's per-key counter")
+	debug := fs.Bool("debug", false, "Log every SET")
+	followRedirs := fs.Bool("cluster-follow-redirects", true, "ClusterFollowRedirections (cluster only)")
+	readReplica := fs.Bool("cluster-read-from-replica", false, "ClusterReadFromReplica (cluster only)")
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if *wait > 0 {
+		duration = wait
+	}
+	if *workers < 1 {
+		log.Fatalf("workers must be >= 1, got %d", *workers)
+	}
+	if *rate <= 0 {
+		log.Fatalf("rate must be > 0, got %f", *rate)
+	}
+
+	pool, err := redis.NewPool(redis.PoolConfig{
+		Server:                    *addr,
+		UseTLS:                    false,
+		ClusterFollowRedirections: *followRedirs,
+		ClusterReadFromReplica:    *readReplica,
+		MaxIdleConns:              *workers * 2,
+		MaxOpenConns:              *workers * 4,
+		ConnTimeout:               5 * time.Second,
+		ReadTimeout:               5 * time.Second,
+		WriteTimeout:              5 * time.Second,
+	})
+	if err != nil {
+		log.Fatalf("connect: %v", err)
+	}
+	defer pool.Close()
+
+	log.Printf("write mode: addr=%s workers=%d rate=%.2f/s duration=%s",
+		*addr, *workers, *rate, *duration)
+
+	var sets, errs atomic.Int64
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), *duration)
+	defer cancel()
+
+	period := time.Duration(float64(time.Second) / *rate)
+	start := time.Now()
+
+	for w := 0; w < *workers; w++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			ticker := time.NewTicker(period)
+			defer ticker.Stop()
+			i := *indexStart
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					key := fmt.Sprintf("%sw%d_%d", *keyPrefix, id, i)
+					conn := redis.ConfigureDoer(pool, pool.Get())
+					_, err := redigo.String(conn.Do("SET", key, "1", "PX", keyTTL.Milliseconds()))
+					conn.Close()
+					if err != nil {
+						errs.Add(1)
+						if *debug {
+							log.Printf("SET %s err=%v", key, err)
+						}
+					} else {
+						sets.Add(1)
+						if *debug {
+							log.Printf("SET %s", key)
+						}
+					}
+					i++
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	elapsed := time.Since(start)
+	fmt.Println()
+	fmt.Println("================ summary ================")
+	fmt.Printf("elapsed:     %s\n", elapsed)
+	fmt.Printf("sets:        %d\n", sets.Load())
+	fmt.Printf("errors:      %d\n", errs.Load())
+	fmt.Printf("ops/sec:     %.1f\n", float64(sets.Load())/elapsed.Seconds())
+}

--- a/tools/redis-stress/write.go
+++ b/tools/redis-stress/write.go
@@ -35,29 +35,18 @@ func runWrite(args []string) {
 	// post-Parse error path to handle here.
 	_ = fs.Parse(args)
 
+	// -wait is a legacy alias for -duration; copy its value rather than
+	// rebinding the pointer so the validation below sees the effective value.
 	if *wait > 0 {
-		duration = wait
-	}
-	if *workers < 1 {
-		log.Fatalf("workers must be >= 1, got %d", *workers)
-	}
-	if *rate <= 0 {
-		log.Fatalf("rate must be > 0, got %f", *rate)
-	}
-	// Redis PX requires a positive integer count of milliseconds; sub-ms
-	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
-	// "ERR invalid expire time in set" which would silently inflate the
-	// errors counter.
-	if *keyTTL < time.Millisecond {
-		log.Fatalf("key-ttl must be >= 1ms, got %s", *keyTTL)
-	}
-	// Guard against time.NewTicker(0) panic for very large rates.
-	period := time.Duration(float64(time.Second) / *rate)
-	if period <= 0 {
-		log.Fatalf("rate %.2f/s produces a non-positive ticker period (%s); choose a smaller rate", *rate, period)
+		*duration = *wait
 	}
 
-	pool, err := redis.NewPool(redis.PoolConfig{
+	period, err := validateWriteFlags(*workers, *rate, *duration, *keyTTL)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	pool, poolErr := redis.NewPool(redis.PoolConfig{
 		Server:                    *addr,
 		UseTLS:                    false,
 		ClusterFollowRedirections: *followRedirs,
@@ -68,8 +57,8 @@ func runWrite(args []string) {
 		ReadTimeout:               5 * time.Second,
 		WriteTimeout:              5 * time.Second,
 	})
-	if err != nil {
-		log.Fatalf("connect: %v", err)
+	if poolErr != nil {
+		log.Fatalf("connect: %v", poolErr)
 	}
 	defer pool.Close()
 
@@ -124,4 +113,32 @@ func runWrite(args []string) {
 	fmt.Printf("sets:        %d\n", sets.Load())
 	fmt.Printf("errors:      %d\n", errs.Load())
 	fmt.Printf("ops/sec:     %.1f\n", float64(sets.Load())/elapsed.Seconds())
+}
+
+// validateWriteFlags returns the per-worker ticker period and a non-nil error
+// if any of the input bounds are out of range. Pulled out of runWrite so the
+// validation can be unit-tested without spinning up a Redis pool.
+func validateWriteFlags(workers int, rate float64, duration, keyTTL time.Duration) (time.Duration, error) {
+	if workers < 1 {
+		return 0, fmt.Errorf("workers must be >= 1, got %d", workers)
+	}
+	if rate <= 0 {
+		return 0, fmt.Errorf("rate must be > 0, got %f", rate)
+	}
+	if duration <= 0 {
+		return 0, fmt.Errorf("duration must be > 0, got %s", duration)
+	}
+	// Redis PX requires a positive integer count of milliseconds; sub-ms
+	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
+	// "ERR invalid expire time in set" which would silently inflate the
+	// errors counter.
+	if keyTTL < time.Millisecond {
+		return 0, fmt.Errorf("key-ttl must be >= 1ms, got %s", keyTTL)
+	}
+	// Guard against time.NewTicker(0) panic for very large rates.
+	period := time.Duration(float64(time.Second) / rate)
+	if period <= 0 {
+		return 0, fmt.Errorf("rate %.2f/s produces a non-positive ticker period (%s); choose a smaller rate", rate, period)
+	}
+	return period, nil
 }

--- a/tools/redis-stress/write.go
+++ b/tools/redis-stress/write.go
@@ -5,7 +5,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"os"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -32,9 +31,10 @@ func runWrite(args []string) {
 	debug := fs.Bool("debug", false, "Log every SET")
 	followRedirs := fs.Bool("cluster-follow-redirects", true, "ClusterFollowRedirections (cluster only)")
 	readReplica := fs.Bool("cluster-read-from-replica", false, "ClusterReadFromReplica (cluster only)")
-	if err := fs.Parse(args); err != nil {
-		os.Exit(2)
-	}
+	// flag.ExitOnError handles parse errors itself (calls os.Exit(2)); no
+	// post-Parse error path to handle here.
+	_ = fs.Parse(args)
+
 	if *wait > 0 {
 		duration = wait
 	}
@@ -43,6 +43,18 @@ func runWrite(args []string) {
 	}
 	if *rate <= 0 {
 		log.Fatalf("rate must be > 0, got %f", *rate)
+	}
+	// Redis PX requires a positive integer count of milliseconds; sub-ms
+	// durations truncate to 0 via .Milliseconds(), and SET ... PX 0 returns
+	// "ERR invalid expire time in set" which would silently inflate the
+	// errors counter.
+	if *keyTTL < time.Millisecond {
+		log.Fatalf("key-ttl must be >= 1ms, got %s", *keyTTL)
+	}
+	// Guard against time.NewTicker(0) panic for very large rates.
+	period := time.Duration(float64(time.Second) / *rate)
+	if period <= 0 {
+		log.Fatalf("rate %.2f/s produces a non-positive ticker period (%s); choose a smaller rate", *rate, period)
 	}
 
 	pool, err := redis.NewPool(redis.PoolConfig{
@@ -69,7 +81,6 @@ func runWrite(args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), *duration)
 	defer cancel()
 
-	period := time.Duration(float64(time.Second) / *rate)
 	start := time.Now()
 
 	for w := 0; w < *workers; w++ {


### PR DESCRIPTION
# Summary

Refresh `tools/redis-stress` with cluster-aware modes. The original tool was a 1 key per second single-goroutine SET-only loop that couldn't exercise cluster routing or observe reads. 

While investigating #42607 I needed something that could stress a Redis Cluster and detect SET-then-GET visibility races, so extracted this out into the tool itself instead of leaving it as throwaway scaffolding.

## Two modes via subcommands:

  - **write** — steady SET-only load, now cluster-aware and multi-worker. Configurable rate, workers, duration, key prefix/TTL, cluster flags. Successor to the original tool.
  - **race** — tight SET-then-GET race detector with N concurrent workers. Each worker uses fresh pool connections per call (mirroring how RedisKeyValue.Set/.Get actually behave), and the tool reports any nil-after-set it observes. Optional -explicit-readonly flag wraps the GET conn with redis.ReadOnlyConn to test deployments where reads route to replicas.

Both modes use Fleet's own `redis.NewPool` (auto-detects cluster vs. standalone) so they exercise the same connection routing the real Fleet server does in production.

## Backward compatibility

Preserved end-to-end. The old subcommand-less invocation (`redis-stress -addr=X -wait=10m`) still works (the dispatcher detects a leading `-`) and routes to write mode. All original flags kept: `-addr`, `-wait` (alias for `-duration`), `-debug`, `-index-start`. Default rate, worker count, and TTL all match the original tool.

## Test plan

Tested against the in-tree `docker-compose-redis-cluster.yml` (3 primaries + 3 replicas) plus the standalone redis service:

  - Dispatcher: no-args, `help`, `-h`, `--help`, unknown command — usage text + exit codes correct
  - write against cluster (multi-worker, custom rate, -debug, -index-start, -key-prefix); keys verified via `redis-cli`
  - write against standalone Redis (cluster auto-detection working)
  - Legacy invocation `redis-stress -addr -wait -debug` (no subcommand) — routes to write, all old flags work
  - race against healthy cluster — 2,000–30,000 `SET`/`GET` pairs, 0 races, exit `0`
  - race with `-explicit-readonly` — same, 0 races on healthy cluster
  - race cleanup — no leftover keys after run
  - Detection path proven: `race -ttl 1ms` forces keys to expire between `SET` and `GET`, tool correctly emits `RACE` lines, increments nil-after-set counter, exits `1`
  - `make lint-go-incremental` — 0 issues

## Docs

- Updated tool's README and the `/tools` README.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a write subcommand for Redis stress testing with configurable concurrency, rate, TTL, duration, and debug logging.
  * Added a race subcommand to detect visibility anomalies between SET and GET and fail when races are observed.

* **Refactor**
  * CLI switched to a command-based structure while preserving legacy flag-style invocations and unified usage/help handling.

* **Tests**
  * Added table-driven tests validating flag input validation for both write and race modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->