### PR TITLE
Exclude orphaned windows profiles

### DIFF
--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -407,16 +407,16 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 			resetBatch()
 		}
 
-		batchCount++
-		queueHostUUIDs = append(queueHostUUIDs, hostUUID)
-
 		// Host profile entry.
 		p := payloadByHostUUID[hostUUID]
 
 		if p == nil {
-			ds.logger.WarnContext(ctx, "windows MDM profile command enqueued without corresponding host profile", "host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
+			ds.logger.WarnContext(ctx, "skipping host with no corresponding profile payload", "host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
 			continue
 		}
+
+		batchCount++
+		queueHostUUIDs = append(queueHostUUIDs, hostUUID)
 		profileSB.WriteString("(?, ?, ?, ?, ?, ?, ?, ?),")
 		profileArgs = append(profileArgs, p.ProfileUUID, p.HostUUID, p.Status, p.OperationType, p.Detail, p.CommandUUID, p.ProfileName, p.Checksum)
 

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -324,11 +324,9 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 		payloadByHostUUID[p.HostUUID] = p
 	}
 
-	// Insert command queue entries and host profile entries in batches, each
-	// batch in its own transaction to limit lock contention. Each host gets
-	// one command queue row and one host_mdm_windows_profiles row, inserted
-	// together so they stay consistent within the batch and so we don't end
-	// up with queued commands that don't have corresponding host profile entries.
+	// Insert command queue entries and host profile entries in batches.
+	// The queue INSERT ... SELECT silently skips hosts without an
+	// enrollment; profile rows are upserted for all hosts in the batch.
 	var (
 		queueHostUUIDs []string
 		profileArgs    []any

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -289,6 +289,42 @@ func (ds *Datastore) MDMWindowsDeleteEnrolledDeviceWithDeviceID(ctx context.Cont
 	})
 }
 
+// resolveWindowsEnrollmentIDs returns a map of host_uuid -> enrollment_id for
+// the given host UUIDs. Hosts without a current enrollment are omitted from the map.
+func (ds *Datastore) resolveWindowsEnrollmentIDs(ctx context.Context, hostUUIDs []string) (map[string]uint, error) {
+	if len(hostUUIDs) == 0 {
+		return nil, nil
+	}
+
+	const query = `
+		SELECT host_uuid, MAX(id) as id
+		FROM mdm_windows_enrollments
+		WHERE host_uuid IN (?)
+		GROUP BY host_uuid`
+
+	result := make(map[string]uint, len(hostUUIDs))
+	err := common_mysql.BatchProcessSimple(hostUUIDs, windowsMDMProfileDeleteBatchSize, func(batch []string) error {
+		stmt, args, err := sqlx.In(query, batch)
+		if err != nil {
+			return ctxerr.Wrap(ctx, err, "building IN for resolveWindowsEnrollmentIDs")
+		}
+
+		var rows []struct {
+			HostUUID string `db:"host_uuid"`
+			ID       uint   `db:"id"`
+		}
+		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &rows, stmt, args...); err != nil {
+			return ctxerr.Wrap(ctx, err, "selecting Windows enrollment IDs")
+		}
+
+		for _, r := range rows {
+			result[r.HostUUID] = r.ID
+		}
+		return nil
+	})
+	return result, err
+}
+
 // this function inserts both the host_mdm_windows_profile entries and the actual mdm_windows_command_queue entries for a given command and list of hosts.
 // We do the host-targeting pieces in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries,
 // which would previously cause issues when processing responses from the device if there was a long delay between enqueing the command and the host profile
@@ -322,6 +358,12 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 	payloadByHostUUID := make(map[string]*fleet.MDMWindowsBulkUpsertHostProfilePayload, len(payload))
 	for _, p := range payload {
 		payloadByHostUUID[p.HostUUID] = p
+	}
+
+	// Resolve enrollment IDs up front; hosts without a valid enrollment are skipped
+	enrollmentIDs, err := ds.resolveWindowsEnrollmentIDs(ctx, hostUUIDs)
+	if err != nil {
+		return ctxerr.Wrap(ctx, err, "resolving Windows enrollment IDs")
 	}
 
 	// Insert command queue entries and host profile entries in batches, each
@@ -399,12 +441,17 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 			resetBatch()
 		}
 
+		// Skip hosts without a valid enrollment — they can't receive MDM commands
+		enrollmentID, ok := enrollmentIDs[hostUUID]
+		if !ok {
+			ds.logger.WarnContext(ctx, "skipping Windows MDM command for host without enrollment",
+				"host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
+			continue
+		}
+
 		batchCount++
-		// Command queue entry: resolve enrollment_id via subquery.
-		queueSB.WriteString(
-			"((SELECT id FROM mdm_windows_enrollments WHERE host_uuid = ? ORDER BY created_at DESC, id DESC LIMIT 1), ?),",
-		)
-		queueArgs = append(queueArgs, hostUUID, cmd.CommandUUID)
+		queueSB.WriteString("(?, ?),")
+		queueArgs = append(queueArgs, enrollmentID, cmd.CommandUUID)
 
 		// Host profile entry.
 		p := payloadByHostUUID[hostUUID]
@@ -2458,6 +2505,13 @@ const windowsProfilesToRemoveQuery = `
 	WHERE
 		-- profiles that are in B but not in A
 		ds.profile_uuid IS NULL AND ds.host_uuid IS NULL AND
+		-- only target hosts that still have a valid Windows MDM enrollment;
+		-- orphaned host_mdm_windows_profiles rows (where the enrollment was
+		-- deleted) cannot receive MDM commands and must be skipped.
+		EXISTS (
+			SELECT 1 FROM mdm_windows_enrollments mwe
+			WHERE mwe.host_uuid = hmwp.host_uuid
+		) AND
 		-- exclude remove operations with non-NULL status (already processed;
 		-- matches the pattern used by Fleet's Apple MDM profile removal)
 		(hmwp.operation_type != 'remove' OR hmwp.status IS NULL) AND

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -369,32 +369,40 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 	// Insert command queue entries and host profile entries in batches, each
 	// batch in its own transaction to limit lock contention. Each host gets
 	// one command queue row and one host_mdm_windows_profiles row, inserted
-	// together so they stay consistent within the batch and so we don't end\
+	// together so they stay consistent within the batch and so we don't end
 	// up with queued commands that don't have corresponding host profile entries.
 	var (
-		queueArgs   []any
-		queueSB     strings.Builder
-		profileArgs []any
-		profileSB   strings.Builder
-		batchCount  int
+		batchHostUUIDs []string
+		profileArgs    []any
+		profileSB      strings.Builder
+		batchCount     int
 	)
 
 	executeBatch := func() error {
 		return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
-			// Insert command queue entries.
-			queueStmt := fmt.Sprintf(`
-				INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid)
-				VALUES %s`,
-				strings.TrimSuffix(queueSB.String(), ","),
-			)
-			if _, err := tx.ExecContext(ctx, queueStmt, queueArgs...); err != nil {
-				if IsDuplicate(err) {
-					return ctxerr.Wrap(ctx, alreadyExists("MDMWindowsCommandQueue", cmd.CommandUUID))
+			// Insert command queue entries via INSERT ... SELECT so that
+			// enrollments deleted after the pre-check are silently skipped.
+			if len(batchHostUUIDs) > 0 {
+				queueQuery, queueArgs, err := sqlx.In(`
+					INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid)
+					SELECT MAX(mwe.id), ?
+					FROM mdm_windows_enrollments mwe
+					WHERE mwe.host_uuid IN (?)
+					GROUP BY mwe.host_uuid`,
+					cmd.CommandUUID, batchHostUUIDs,
+				)
+				if err != nil {
+					return ctxerr.Wrap(ctx, err, "building IN for MDMWindowsCommandQueue insert")
 				}
-				return ctxerr.Wrap(ctx, err, "batch inserting MDMWindowsCommandQueue")
+				if _, err := tx.ExecContext(ctx, queueQuery, queueArgs...); err != nil {
+					if IsDuplicate(err) {
+						return ctxerr.Wrap(ctx, alreadyExists("MDMWindowsCommandQueue", cmd.CommandUUID))
+					}
+					return ctxerr.Wrap(ctx, err, "batch inserting MDMWindowsCommandQueue")
+				}
 			}
 
-			// Should never happen but could in the case of a bug in the batching logic or if the caller supplied bad args(we warn in the logs for this case)
+			// Should never happen
 			if len(profileArgs) == 0 {
 				return nil
 			}
@@ -425,8 +433,7 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 
 	resetBatch := func() {
 		batchCount = 0
-		queueArgs = queueArgs[:0]
-		queueSB.Reset()
+		batchHostUUIDs = batchHostUUIDs[:0]
 		profileArgs = profileArgs[:0]
 		profileSB.Reset()
 	}
@@ -441,17 +448,15 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 			resetBatch()
 		}
 
-		// Skip hosts without a valid enrollment — they can't receive MDM commands
-		enrollmentID, ok := enrollmentIDs[hostUUID]
-		if !ok {
-			ds.logger.WarnContext(ctx, "skipping Windows MDM command for host without enrollment",
+		// Skip hosts without a valid enrollment — they can't receive MDM command.
+		if _, ok := enrollmentIDs[hostUUID]; !ok {
+			ds.logger.DebugContext(ctx, "skipping Windows MDM command for host without enrollment",
 				"host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
 			continue
 		}
 
 		batchCount++
-		queueSB.WriteString("(?, ?),")
-		queueArgs = append(queueArgs, enrollmentID, cmd.CommandUUID)
+		batchHostUUIDs = append(batchHostUUIDs, hostUUID)
 
 		// Host profile entry.
 		p := payloadByHostUUID[hostUUID]

--- a/server/datastore/mysql/microsoft_mdm.go
+++ b/server/datastore/mysql/microsoft_mdm.go
@@ -289,42 +289,6 @@ func (ds *Datastore) MDMWindowsDeleteEnrolledDeviceWithDeviceID(ctx context.Cont
 	})
 }
 
-// resolveWindowsEnrollmentIDs returns a map of host_uuid -> enrollment_id for
-// the given host UUIDs. Hosts without a current enrollment are omitted from the map.
-func (ds *Datastore) resolveWindowsEnrollmentIDs(ctx context.Context, hostUUIDs []string) (map[string]uint, error) {
-	if len(hostUUIDs) == 0 {
-		return nil, nil
-	}
-
-	const query = `
-		SELECT host_uuid, MAX(id) as id
-		FROM mdm_windows_enrollments
-		WHERE host_uuid IN (?)
-		GROUP BY host_uuid`
-
-	result := make(map[string]uint, len(hostUUIDs))
-	err := common_mysql.BatchProcessSimple(hostUUIDs, windowsMDMProfileDeleteBatchSize, func(batch []string) error {
-		stmt, args, err := sqlx.In(query, batch)
-		if err != nil {
-			return ctxerr.Wrap(ctx, err, "building IN for resolveWindowsEnrollmentIDs")
-		}
-
-		var rows []struct {
-			HostUUID string `db:"host_uuid"`
-			ID       uint   `db:"id"`
-		}
-		if err := sqlx.SelectContext(ctx, ds.writer(ctx), &rows, stmt, args...); err != nil {
-			return ctxerr.Wrap(ctx, err, "selecting Windows enrollment IDs")
-		}
-
-		for _, r := range rows {
-			result[r.HostUUID] = r.ID
-		}
-		return nil
-	})
-	return result, err
-}
-
 // this function inserts both the host_mdm_windows_profile entries and the actual mdm_windows_command_queue entries for a given command and list of hosts.
 // We do the host-targeting pieces in a transaction to ensure that we don't end up with queued commands that don't have corresponding host profile entries,
 // which would previously cause issues when processing responses from the device if there was a long delay between enqueing the command and the host profile
@@ -360,19 +324,13 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 		payloadByHostUUID[p.HostUUID] = p
 	}
 
-	// Resolve enrollment IDs up front; hosts without a valid enrollment are skipped
-	enrollmentIDs, err := ds.resolveWindowsEnrollmentIDs(ctx, hostUUIDs)
-	if err != nil {
-		return ctxerr.Wrap(ctx, err, "resolving Windows enrollment IDs")
-	}
-
 	// Insert command queue entries and host profile entries in batches, each
 	// batch in its own transaction to limit lock contention. Each host gets
 	// one command queue row and one host_mdm_windows_profiles row, inserted
 	// together so they stay consistent within the batch and so we don't end
 	// up with queued commands that don't have corresponding host profile entries.
 	var (
-		batchHostUUIDs []string
+		queueHostUUIDs []string
 		profileArgs    []any
 		profileSB      strings.Builder
 		batchCount     int
@@ -381,15 +339,16 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 	executeBatch := func() error {
 		return ds.withRetryTxx(ctx, func(tx sqlx.ExtContext) error {
 			// Insert command queue entries via INSERT ... SELECT so that
-			// enrollments deleted after the pre-check are silently skipped.
-			if len(batchHostUUIDs) > 0 {
+			// hosts whose enrollment was deleted produce 0 rows instead
+			// of a NULL enrollment_id / FK error.
+			if len(queueHostUUIDs) > 0 {
 				queueQuery, queueArgs, err := sqlx.In(`
 					INSERT INTO windows_mdm_command_queue (enrollment_id, command_uuid)
 					SELECT MAX(mwe.id), ?
 					FROM mdm_windows_enrollments mwe
 					WHERE mwe.host_uuid IN (?)
 					GROUP BY mwe.host_uuid`,
-					cmd.CommandUUID, batchHostUUIDs,
+					cmd.CommandUUID, queueHostUUIDs,
 				)
 				if err != nil {
 					return ctxerr.Wrap(ctx, err, "building IN for MDMWindowsCommandQueue insert")
@@ -433,7 +392,7 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 
 	resetBatch := func() {
 		batchCount = 0
-		batchHostUUIDs = batchHostUUIDs[:0]
+		queueHostUUIDs = queueHostUUIDs[:0]
 		profileArgs = profileArgs[:0]
 		profileSB.Reset()
 	}
@@ -448,21 +407,14 @@ func (ds *Datastore) MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx co
 			resetBatch()
 		}
 
-		// Skip hosts without a valid enrollment — they can't receive MDM command.
-		if _, ok := enrollmentIDs[hostUUID]; !ok {
-			ds.logger.DebugContext(ctx, "skipping Windows MDM command for host without enrollment",
-				"host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
-			continue
-		}
-
 		batchCount++
-		batchHostUUIDs = append(batchHostUUIDs, hostUUID)
+		queueHostUUIDs = append(queueHostUUIDs, hostUUID)
 
 		// Host profile entry.
 		p := payloadByHostUUID[hostUUID]
 
 		if p == nil {
-			ds.logger.WarnContext(ctx, "windows MDM profile Command enqueued without corresponding host profile", "host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
+			ds.logger.WarnContext(ctx, "windows MDM profile command enqueued without corresponding host profile", "host_uuid", hostUUID, "command_uuid", cmd.CommandUUID)
 			continue
 		}
 		profileSB.WriteString("(?, ?, ?, ?, ?, ?, ?, ?),")

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -5213,6 +5213,17 @@ func testMDMWindowsInsertCommandSkipsUnenrolledHosts(t *testing.T, ds *Datastore
 			`SELECT COUNT(*) FROM windows_mdm_command_queue WHERE command_uuid = ?`, cmdUUID)
 	})
 	require.Equal(t, 1, queueCount)
+
+	// Both hosts get profile rows upserted — d2's profile row is
+	// intentionally kept. It's harmless dead data: the EXISTS check in
+	// windowsProfilesToRemoveQuery prevents it from being selected for
+	// removal on the next cron cycle.
+	var profileCount int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &profileCount,
+			`SELECT COUNT(*) FROM host_mdm_windows_profiles WHERE command_uuid = ?`, cmdUUID)
+	})
+	require.Equal(t, 2, profileCount)
 }
 
 // testMDMWindowsProfilesSummaryEnumeration exhaustively enumerates every

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -5204,16 +5204,9 @@ func testMDMWindowsInsertCommandSkipsUnenrolledHosts(t *testing.T, ds *Datastore
 	require.NoError(t, err)
 	require.Len(t, cmds, 1)
 
-	// d1 should have a host profile row.
-	var hostProfiles []*fleet.MDMWindowsProfilePayload
-	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
-		return sqlx.SelectContext(ctx, q, &hostProfiles,
-			`SELECT profile_uuid, host_uuid, status, operation_type, command_uuid, profile_name
-			 FROM host_mdm_windows_profiles ORDER BY host_uuid`)
-	})
-	require.Len(t, hostProfiles, 1)
-	require.Equal(t, d1.HostUUID, hostProfiles[0].HostUUID)
-
+	// There should be exactly 1 command queue entry (d1 only); d2 was
+	// silently skipped by the INSERT ... SELECT because its enrollment
+	// no longer exists.
 	var queueCount int
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.GetContext(ctx, q, &queueCount,

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -5214,15 +5214,12 @@ func testMDMWindowsInsertCommandSkipsUnenrolledHosts(t *testing.T, ds *Datastore
 	require.Len(t, hostProfiles, 1)
 	require.Equal(t, d1.HostUUID, hostProfiles[0].HostUUID)
 
-	// d2 (unenrolled) should have no command queue entry.
 	var queueCount int
 	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
 		return sqlx.GetContext(ctx, q, &queueCount,
-			`SELECT COUNT(*) FROM windows_mdm_command_queue wq
-			 JOIN mdm_windows_enrollments mwe ON mwe.id = wq.enrollment_id
-			 WHERE mwe.host_uuid = ?`, d2.HostUUID)
+			`SELECT COUNT(*) FROM windows_mdm_command_queue WHERE command_uuid = ?`, cmdUUID)
 	})
-	require.Zero(t, queueCount)
+	require.Equal(t, 1, queueCount)
 }
 
 // testMDMWindowsProfilesSummaryEnumeration exhaustively enumerates every

--- a/server/datastore/mysql/microsoft_mdm_test.go
+++ b/server/datastore/mysql/microsoft_mdm_test.go
@@ -59,6 +59,8 @@ func TestMDMWindows(t *testing.T) {
 		{"TestEditProfileDeletesRemovedLocURIs", testEditProfileDeletesRemovedLocURIs},
 		{"TestBatchDeleteMultipleWindowsProfiles", testBatchDeleteMultipleWindowsProfiles},
 		{"TestMDMWindowsUnenrollCleansUpProfiles", testMDMWindowsUnenrollCleansUpProfiles},
+		{"TestMDMWindowsProfilesToRemoveSkipsOrphanedHosts", testMDMWindowsProfilesToRemoveSkipsOrphanedHosts},
+		{"TestMDMWindowsInsertCommandSkipsUnenrolledHosts", testMDMWindowsInsertCommandSkipsUnenrolledHosts},
 	}
 
 	for _, c := range cases {
@@ -5072,6 +5074,155 @@ func testMDMWindowsUnenrollCleansUpProfiles(t *testing.T, ds *Datastore) {
 	winProfs, err = ds.GetHostMDMWindowsProfiles(ctx, host.UUID)
 	require.NoError(t, err)
 	require.Empty(t, winProfs)
+}
+
+// testMDMWindowsProfilesToRemoveSkipsOrphanedHosts verifies that
+// ListMDMWindowsProfilesToRemoveForHosts does not return profiles for hosts
+// whose mdm_windows_enrollments row has been deleted (issue #44369).
+func testMDMWindowsProfilesToRemoveSkipsOrphanedHosts(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Create two Windows hosts and enroll both.
+	host1 := test.NewHost(t, ds, "win-orphan1", "10.0.0.1", "k1", "uuid-orphan1", time.Now())
+	host1.Platform = "windows"
+	require.NoError(t, ds.UpdateHost(ctx, host1))
+	windowsEnroll(t, ds, host1)
+
+	host2 := test.NewHost(t, ds, "win-orphan2", "10.0.0.2", "k2", "uuid-orphan2", time.Now())
+	host2.Platform = "windows"
+	require.NoError(t, ds.UpdateHost(ctx, host2))
+	windowsEnroll(t, ds, host2)
+
+	// Create a global profile and mark it as installed+verified on both hosts.
+	profUUID := InsertWindowsProfileForTest(t, ds, 0)
+	installWindowsProfilesAsVerified(t, ds, []string{host1.UUID, host2.UUID}, []string{profUUID})
+
+	// Delete the profile definition via raw SQL so that host_mdm_windows_profiles
+	// rows become orphaned removal candidates (bypassing the cascade cleanup in
+	// DeleteMDMWindowsConfigProfile).
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM mdm_windows_configuration_profiles WHERE profile_uuid = ?`, profUUID)
+		return err
+	})
+
+	// Sanity check: both hosts should be removal candidates while enrolled.
+	toRemove, err := ds.ListMDMWindowsProfilesToRemoveForHosts(ctx, []string{host1.UUID, host2.UUID})
+	require.NoError(t, err)
+	require.Len(t, toRemove, 2)
+
+	// Now delete host1's enrollment to simulate the orphan condition.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM mdm_windows_enrollments WHERE host_uuid = ?`, host1.UUID)
+		return err
+	})
+
+	// Only host2 (still enrolled) should be returned; host1 is orphaned.
+	toRemove, err = ds.ListMDMWindowsProfilesToRemoveForHosts(ctx, []string{host1.UUID, host2.UUID})
+	require.NoError(t, err)
+	require.Len(t, toRemove, 1)
+	require.Equal(t, host2.UUID, toRemove[0].HostUUID)
+}
+
+// testMDMWindowsInsertCommandSkipsUnenrolledHosts verifies that
+// MDMWindowsInsertCommandAndUpsertHostProfilesForHosts gracefully skips hosts
+// without an enrollment instead of failing the batch (issue #44369).
+func testMDMWindowsInsertCommandSkipsUnenrolledHosts(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+
+	// Create and enroll two devices.
+	d1 := &fleet.MDMWindowsEnrolledDevice{
+		MDMDeviceID:            uuid.New().String(),
+		MDMHardwareID:          uuid.New().String() + uuid.New().String(),
+		MDMDeviceState:         microsoft_mdm.MDMDeviceStateEnrolled,
+		MDMDeviceType:          "CIMClient_Windows",
+		MDMDeviceName:          "DESKTOP-1C3ARC1",
+		MDMEnrollType:          "ProgrammaticEnrollment",
+		MDMEnrollUserID:        "",
+		MDMEnrollProtoVersion:  "5.0",
+		MDMEnrollClientVersion: "10.0.19045.2965",
+		MDMNotInOOBE:           false,
+		HostUUID:               uuid.NewString(),
+	}
+	d2 := &fleet.MDMWindowsEnrolledDevice{
+		MDMDeviceID:            uuid.New().String(),
+		MDMHardwareID:          uuid.New().String() + uuid.New().String(),
+		MDMDeviceState:         microsoft_mdm.MDMDeviceStateEnrolled,
+		MDMDeviceType:          "CIMClient_Windows",
+		MDMDeviceName:          "DESKTOP-2C3ARC2",
+		MDMEnrollType:          "ProgrammaticEnrollment",
+		MDMEnrollUserID:        "",
+		MDMEnrollProtoVersion:  "5.0",
+		MDMEnrollClientVersion: "10.0.19045.2965",
+		MDMNotInOOBE:           false,
+		HostUUID:               uuid.NewString(),
+	}
+	require.NoError(t, ds.MDMWindowsInsertEnrolledDevice(ctx, d1))
+	require.NoError(t, ds.MDMWindowsInsertEnrolledDevice(ctx, d2))
+
+	d1EnrollID := mdmWindowsEnrollmentIDByHardwareID(ctx, t, ds, d1.MDMHardwareID)
+
+	// Delete d2's enrollment to simulate an orphan.
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		_, err := q.ExecContext(ctx, `DELETE FROM mdm_windows_enrollments WHERE host_uuid = ?`, d2.HostUUID)
+		return err
+	})
+
+	profUUID := InsertWindowsProfileForTest(t, ds, 0)
+	cmdUUID := uuid.NewString()
+	cmd := &fleet.MDMWindowsCommand{
+		CommandUUID:  cmdUUID,
+		RawCommand:   []byte("<Exec></Exec>"),
+		TargetLocURI: "./test/uri",
+	}
+	payload := []*fleet.MDMWindowsBulkUpsertHostProfilePayload{
+		{
+			ProfileUUID:   profUUID,
+			ProfileName:   "prof1",
+			HostUUID:      d1.HostUUID,
+			CommandUUID:   cmdUUID,
+			OperationType: fleet.MDMOperationTypeInstall,
+			Status:        &fleet.MDMDeliveryPending,
+			Checksum:      []byte("checksum1"),
+		},
+		{
+			ProfileUUID:   profUUID,
+			ProfileName:   "prof1",
+			HostUUID:      d2.HostUUID,
+			CommandUUID:   cmdUUID,
+			OperationType: fleet.MDMOperationTypeInstall,
+			Status:        &fleet.MDMDeliveryPending,
+			Checksum:      []byte("checksum2"),
+		},
+	}
+
+	// Should succeed — d2 is skipped, d1 is processed.
+	err := ds.MDMWindowsInsertCommandAndUpsertHostProfilesForHosts(ctx, []string{d1.HostUUID, d2.HostUUID}, cmd, payload)
+	require.NoError(t, err)
+
+	// d1 (enrolled) should have a queued command.
+	cmds, err := ds.MDMWindowsGetPendingCommands(ctx, d1EnrollID)
+	require.NoError(t, err)
+	require.Len(t, cmds, 1)
+
+	// d1 should have a host profile row.
+	var hostProfiles []*fleet.MDMWindowsProfilePayload
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.SelectContext(ctx, q, &hostProfiles,
+			`SELECT profile_uuid, host_uuid, status, operation_type, command_uuid, profile_name
+			 FROM host_mdm_windows_profiles ORDER BY host_uuid`)
+	})
+	require.Len(t, hostProfiles, 1)
+	require.Equal(t, d1.HostUUID, hostProfiles[0].HostUUID)
+
+	// d2 (unenrolled) should have no command queue entry.
+	var queueCount int
+	ExecAdhocSQL(t, ds, func(q sqlx.ExtContext) error {
+		return sqlx.GetContext(ctx, q, &queueCount,
+			`SELECT COUNT(*) FROM windows_mdm_command_queue wq
+			 JOIN mdm_windows_enrollments mwe ON mwe.id = wq.enrollment_id
+			 WHERE mwe.host_uuid = ?`, d2.HostUUID)
+	})
+	require.Zero(t, queueCount)
 }
 
 // testMDMWindowsProfilesSummaryEnumeration exhaustively enumerates every


### PR DESCRIPTION
**Related issue:** Resolves #44369


- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented operations on Windows MDM profiles for hosts without active enrollments.
  * Batch processing now skips hosts lacking current enrollments so only enrolled hosts receive queued commands.
  * Strengthened profile-removal checks to avoid acting on orphaned profile rows.

* **Tests**
  * Added regression tests covering orphaned enrollment/profile scenarios and mixed-host batch processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->