### PR TITLE
Empty state followup

### DIFF
--- a/frontend/components/queries/LiveResults/AwaitingResults/AwaitingResults.tsx
+++ b/frontend/components/queries/LiveResults/AwaitingResults/AwaitingResults.tsx
@@ -8,8 +8,13 @@ const AwaitingResults = () => {
   return (
     <EmptyState
       header="Phoning home..."
-      info=" There are currently no results to your report. Please wait while we talk
-        to more hosts."
+      info={
+        <>
+          There are currently no results to your report.
+          <br />
+          Please wait while we talk to more hosts.
+        </>
+      }
       className={baseClass}
     />
   );

--- a/frontend/components/queries/LiveResults/AwaitingResults/AwaitingResults.tsx
+++ b/frontend/components/queries/LiveResults/AwaitingResults/AwaitingResults.tsx
@@ -7,12 +7,12 @@ const baseClass = "awaiting-results";
 const AwaitingResults = () => {
   return (
     <EmptyState
-      header="Phoning home..."
+      header="Waiting for results"
       info={
         <>
-          There are currently no results to your report.
+          No hosts have responded yet.
           <br />
-          Please wait while we talk to more hosts.
+          Results will appear as hosts check in.
         </>
       }
       className={baseClass}

--- a/frontend/components/queries/LiveResults/AwaitingResults/_styles.scss
+++ b/frontend/components/queries/LiveResults/AwaitingResults/_styles.scss
@@ -1,8 +1,3 @@
 .awaiting-results {
   margin: 120px auto;
-  width: 275px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
 }

--- a/frontend/components/queries/LiveResults/AwaitingResults/_styles.scss
+++ b/frontend/components/queries/LiveResults/AwaitingResults/_styles.scss
@@ -1,3 +1,0 @@
-.awaiting-results {
-  margin: 120px auto;
-}


### PR DESCRIPTION
## Issue
Closes #35483

## Description
- Fix styling for awaiting results of a live query/policy
- Unreleased bug found by Allen
- Updated copies because 1) released bug says report instead of policy in the empty description also used by awaiting results of a policy and 2) it was defined in the Figma for #35483 so quick update

## BEFORE

<img width="3806" height="3042" alt="Screenshot 2026-04-29 at 12 18 43 PM (1)" src="https://github.com/user-attachments/assets/9d4c9afd-4bfc-410d-a1f5-f71f664500ab" />


## Screenshot of fix

<img width="1467" height="739" alt="Screenshot 2026-04-29 at 2 51 48 PM" src="https://github.com/user-attachments/assets/c31c80ff-8f92-4747-86c3-3c2fc18fe354" />
<img width="1474" height="740" alt="Screenshot 2026-04-29 at 2 51 35 PM" src="https://github.com/user-attachments/assets/6b3ef9c4-0753-46f3-b34c-c7a5f52e13d6" />

## Testing

- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated awaiting-results messaging with a clearer header and explicit line breaks so it's easier to read and understand that hosts haven't responded yet.
  * Simplified the awaiting-results presentation by removing fixed width, flexbox column layout, and centered alignment, resulting in a more streamlined layout and reduced spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->