### PR TITLE
Update CVE notes in `security/status.md`

### DIFF
--- a/security/status.md
+++ b/security/status.md
@@ -16,7 +16,7 @@ Following is the vulnerability report of Fleet and its dependencies.
 ### [CVE-2026-39883](https://nvd.nist.gov/vuln/detail/CVE-2026-39883)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
-- **Status notes:** Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating).
+- **Status notes:** Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating). Also the vulnerability affects BSD and Solaris platforms (which are not supported).
 - **Products:** `fleet`,`pkg:golang/go.opentelemetry.io/otel/sdk`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-04-27 15:03:59
@@ -40,7 +40,7 @@ Following is the vulnerability report of Fleet and its dependencies.
 ### [CVE-2026-32283](https://nvd.nist.gov/vuln/detail/CVE-2026-32283)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
-- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.
+- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.84.1 when it's available.
 - **Products:** `fleet`,`pkg:golang/stdlib`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-04-27 15:37:36
@@ -48,7 +48,7 @@ Following is the vulnerability report of Fleet and its dependencies.
 ### [CVE-2026-32281](https://nvd.nist.gov/vuln/detail/CVE-2026-32281)
 - **Author:** @lucasmrod
 - **Status:** `not_affected`
-- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.
+- **Status notes:** Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.84.1+ when it's available.
 - **Products:** `fleet`,`pkg:golang/stdlib`
 - **Justification:** `vulnerable_code_cannot_be_controlled_by_adversary`
 - **Timestamp:** 2026-04-27 15:37:25

--- a/security/vex/fleet/CVE-2026-32281.vex.json
+++ b/security/vex/fleet/CVE-2026-32281.vex.json
@@ -19,7 +19,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.",
+      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.84.1+ when it's available.",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
     }
   ]

--- a/security/vex/fleet/CVE-2026-32283.vex.json
+++ b/security/vex/fleet/CVE-2026-32283.vex.json
@@ -19,7 +19,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.85.0 when it's available.",
+      "status_notes": "Fleet connects using TLS to a strict set of URLs (e.g. for vulnerability scanning, Apple VPP features, Google/Android APIs, etc.). Exploiting this vulnerability requires a Fleet administrator to control URLs Fleet connects to (e.g. webhook URLs). This, combined with the fact that the vulnerabilities are DoS (do not affect data confidentiality) we consider this report to be MEDIUM instead of HIGH impact. Nonetheless, we advise upgrading to v4.84.1 when it's available.",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
     }
   ]

--- a/security/vex/fleet/CVE-2026-39883.vex.json
+++ b/security/vex/fleet/CVE-2026-39883.vex.json
@@ -19,7 +19,7 @@
         }
       ],
       "status": "not_affected",
-      "status_notes": "Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating).",
+      "status_notes": "Exploiting this vulnerability already requires access to the host running the Fleet server (so its practical exploitability appears overstated by the CVSS score / High rating). Also the vulnerability affects BSD and Solaris platforms (which are not supported).",
       "justification": "vulnerable_code_cannot_be_controlled_by_adversary"
     }
   ]


### PR DESCRIPTION
Updating CVE notes with new information for:
- CVE-2026-39883 (only affects BSD and Solaris).
- CVE-2026-32281, CVE-2026-32283: To be fixed in [v4.84.1](https://github.com/fleetdm/fleet/milestone/246).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Updates**
  * Updated Fleet vulnerability advisories and remediation guidance with corrected upgrade recommendations to ensure users receive accurate information for addressing security issues
  * Enhanced vulnerability assessments with additional platform compatibility information to help users better evaluate applicable risks to their environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->