### PR TITLE
do not clear the queue on Authenticate if enrollment renewal is ongoing

### DIFF
--- a/changes/do-not-clear-mdm-queue-on-renewal
+++ b/changes/do-not-clear-mdm-queue-on-renewal
@@ -1,0 +1,1 @@
+- Fixed an issue that clear pending MDM commands if queued when doing an enrollment renewal.

--- a/changes/do-not-clear-mdm-queue-on-renewal
+++ b/changes/do-not-clear-mdm-queue-on-renewal
@@ -1,1 +1,1 @@
-- Fixed an issue that clear pending MDM commands if queued when doing an enrollment renewal.
+- Fixed an issue that would clear pending MDM commands if they were queued during an enrollment renewal.

--- a/server/datastore/mysql/nanomdm_storage_test.go
+++ b/server/datastore/mysql/nanomdm_storage_test.go
@@ -29,6 +29,7 @@ func TestNanoMDMStorage(t *testing.T) {
 		{"TestEnqueueDeviceLockCommandRaceCondition", testEnqueueDeviceLockCommandRaceCondition},
 		{"TestEnqueueDeviceUnlockCommand", testEnqueueDeviceUnlockCommand},
 		{"TestStoreAuthenticatePreservesBootstrapTokenDuringSCEPRenewal", testStoreAuthenticatePreservesBootstrapTokenDuringSCEPRenewal},
+		{"TestClearQueuePreservedDuringSCEPRenewal", testClearQueuePreservedDuringSCEPRenewal},
 	}
 
 	for _, c := range cases {
@@ -357,6 +358,104 @@ func testStoreAuthenticatePreservesBootstrapTokenDuringSCEPRenewal(t *testing.T,
 
 	token = getBootstrapToken()
 	require.False(t, token.Valid, "bootstrap token should be cleared after SCEP renewal completes")
+}
+
+// testClearQueuePreservedDuringSCEPRenewal verifies that ClearQueue does NOT
+// deactivate queued commands while a SCEP renewal is in progress
+// (renew_command_uuid is set in nano_cert_auth_associations), and DOES clear
+// them when no renewal is in progress.
+func testClearQueuePreservedDuringSCEPRenewal(t *testing.T, ds *Datastore) {
+	ctx := t.Context()
+	ns, err := ds.NewMDMAppleMDMStorage()
+	require.NoError(t, err)
+
+	deviceUUID := uuid.NewString()
+
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO nano_devices (id, serial_number, authenticate, authenticate_at)
+		 VALUES (?, 'SERIAL1', 'auth-raw', CURRENT_TIMESTAMP)`,
+		deviceUUID)
+	require.NoError(t, err)
+
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO nano_enrollments (id, device_id, type, topic, push_magic, token_hex, token_update_tally, last_seen_at)
+		 VALUES (?, ?, 'Device', 'topic', 'magic', 'deadbeef', 1, NOW())`,
+		deviceUUID, deviceUUID)
+	require.NoError(t, err)
+
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO nano_cert_auth_associations (id, sha256)
+		 VALUES (?, '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef')`,
+		deviceUUID)
+	require.NoError(t, err)
+
+	// Helper to enqueue a fresh command and return its UUID.
+	enqueueCommand := func() string {
+		cmdUUID := uuid.NewString()
+		_, err := ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO nano_commands (command_uuid, request_type, command)
+			 VALUES (?, 'InstallProfile', '<?xml version="1.0"?>')`,
+			cmdUUID)
+		require.NoError(t, err)
+		_, err = ds.writer(ctx).ExecContext(ctx,
+			`INSERT INTO nano_enrollment_queue (id, command_uuid) VALUES (?, ?)`,
+			deviceUUID, cmdUUID)
+		require.NoError(t, err)
+		return cmdUUID
+	}
+
+	// Helper to read the active flag for a queued command.
+	isActive := func(cmdUUID string) bool {
+		var active bool
+		err := ds.writer(ctx).QueryRowContext(ctx,
+			`SELECT active FROM nano_enrollment_queue WHERE id = ? AND command_uuid = ?`,
+			deviceUUID, cmdUUID,
+		).Scan(&active)
+		require.NoError(t, err)
+		return active
+	}
+
+	req := &mdm.Request{
+		EnrollID: &mdm.EnrollID{ID: deviceUUID, Type: mdm.Device},
+		Context:  ctx,
+	}
+
+	// --- Case 1: No renewal in progress → queue is cleared ---
+
+	cmdUUID1 := enqueueCommand()
+	require.True(t, isActive(cmdUUID1))
+
+	require.NoError(t, ns.ClearQueue(req))
+	require.False(t, isActive(cmdUUID1), "queue should be cleared when no renewal is in progress")
+
+	// --- Case 2: SCEP renewal in progress → queue is preserved ---
+
+	renewCmdUUID := uuid.NewString()
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`INSERT INTO nano_commands (command_uuid, request_type, command)
+		 VALUES (?, 'InstallProfile', '<?xml version="1.0"?>')`,
+		renewCmdUUID)
+	require.NoError(t, err)
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE nano_cert_auth_associations SET renew_command_uuid = ? WHERE id = ?`,
+		renewCmdUUID, deviceUUID)
+	require.NoError(t, err)
+
+	cmdUUID2 := enqueueCommand()
+	require.True(t, isActive(cmdUUID2))
+
+	require.NoError(t, ns.ClearQueue(req))
+	require.True(t, isActive(cmdUUID2), "queue should be preserved while SCEP renewal is in progress")
+
+	// --- Case 3: Renewal completes (renew_command_uuid cleared) → queue is cleared ---
+
+	_, err = ds.writer(ctx).ExecContext(ctx,
+		`UPDATE nano_cert_auth_associations SET renew_command_uuid = NULL WHERE id = ?`,
+		deviceUUID)
+	require.NoError(t, err)
+
+	require.NoError(t, ns.ClearQueue(req))
+	require.False(t, isActive(cmdUUID2), "queue should be cleared after SCEP renewal completes")
 }
 
 func testEnqueueDeviceLockCommandRaceCondition(t *testing.T, ds *Datastore) {

--- a/server/mdm/nanomdm/storage/mysql/queue.go
+++ b/server/mdm/nanomdm/storage/mysql/queue.go
@@ -61,7 +61,8 @@ func enqueue(ctx context.Context, tx sqlx.ExtContext, ids []string, cmd *mdm.Com
 }
 
 func (m *MySQLStorage) EnqueueCommand(ctx context.Context, ids []string, cmd *mdm.CommandWithSubtype) (map[string]error,
-	error) {
+	error,
+) {
 	// We need to retry because this transaction may deadlock with updates to nano_enrollment.last_seen_at
 	// Deadlock seen in 2024/12/12 loadtest: https://docs.google.com/document/d/1-Q6qFTd7CDm-lh7MVRgpNlNNJijk6JZ4KO49R1fp80U
 	err := common_mysql.WithRetryTxx(ctx, sqlx.NewDb(m.db, ""), func(tx sqlx.ExtContext) error {
@@ -254,7 +255,11 @@ SET
 WHERE
     e.device_id = ? AND
     active = 1 AND
-    (r.status IS NULL OR r.status = 'NotNow');`,
+    (r.status IS NULL OR r.status = 'NotNow') AND
+	NOT EXISTS (
+		SELECT 1 FROM nano_cert_auth_associations nca
+		WHERE nca.id = e.id AND nca.renew_command_uuid IS NOT NULL
+	);`,
 		r.ID,
 	)
 	return err
@@ -272,7 +277,8 @@ func (m *MySQLStorage) BulkDeleteHostUserCommandsWithoutResults(ctx context.Cont
 }
 
 func (m *MySQLStorage) bulkDeleteHostUserCommandsWithoutResults(ctx context.Context, tx sqlx.ExtContext,
-	commandToIDs map[string][]string) error {
+	commandToIDs map[string][]string,
+) error {
 	stmt := `
 DELETE
     eq


### PR DESCRIPTION
Found as part of another ticket, that we have a bug that does not surface the result of the enrollment renewal command, and could potentially disrupt other pending commands in certain timing scenarios.

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

- [x] Input data is properly validated, `SELECT *` is avoided, SQL injection is prevented (using placeholders for values in statements), JS inline code is prevented especially for url redirects, and untrusted data interpolated into shell scripts/commands is validated against shell metacharacters.
- [x] Timeouts are implemented and retries are limited to avoid infinite loops
- [x] If paths of existing endpoints are modified without backwards compatibility, checked the frontend/CLI for any necessary changes

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where pending MDM commands queued during an enrollment certificate renewal could be cleared; such commands are now preserved until renewal completes.
* **Tests**
  * Added automated tests verifying queued commands are retained during renewal and cleared appropriately otherwise.
* **Documentation**
  * Added a changelog entry documenting the preservation of queued MDM commands during renewal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->