### PR TITLE
Vulnerability dashboard: Update `update-reports` script to use software version API

### DIFF
--- a/ee/vulnerability-dashboard/scripts/update-reports.js
+++ b/ee/vulnerability-dashboard/scripts/update-reports.js
@@ -274,12 +274,12 @@ module.exports = {
     await sails.helpers.flow.until(async ()=>{
       // * * *
       // Load a page of vulnerable software versions.
-      // [?] https://fleetdm.com/docs/using-fleet/rest-api#list-all-software
+      // [?] https://fleetdm.com/docs/rest-api/rest-api#list-software-versions
       // # requests == O(vulnerableSoftware / SOFTWARE_VERSIONS_PAGE_SIZE)
       let vulnerableWares;
       {
         let responseData = await sails.helpers.http.get.with({
-          url: '/api/v1/fleet/software',
+          url: '/api/v1/fleet/software/versions',
           data: { vulnerable: true, page: page, per_page: SOFTWARE_VERSIONS_PAGE_SIZE, order_key: 'name', order_direction: 'asc' },//eslint-disable-line camelcase
           baseUrl: fleetBaseUrl,
           headers
@@ -309,7 +309,7 @@ module.exports = {
           await sails.helpers.flow.until( async()=>{
             let responseData = await sails.helpers.http.get.with({
               url: '/api/v1/fleet/hosts',
-              data: { software_id: ware.id, page: hostsPage, per_page: HOSTS_PAGE_SIZE, order_key: 'hostname', order_direction: 'asc' },//eslint-disable-line camelcase
+              data: { software_version_id: ware.id, page: hostsPage, per_page: HOSTS_PAGE_SIZE, order_key: 'hostname', order_direction: 'asc' },//eslint-disable-line camelcase
               baseUrl: fleetBaseUrl,
               headers
             })
@@ -317,7 +317,7 @@ module.exports = {
             .retry(['requestFailed', {name: 'TimeoutError'}])
             .tolerate({raw:{statusCode: 404}} , ()=>{
               // If the hosts API returns a 404 response for a software item that was returned from in the list of vulnerable software, we'll log a warning and remove this software from the list of software.
-              loggedWarningsFromThisScriptRun.push(`When processing vulnerable software, a request to the '/hosts' endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Impact: If this vulnerable software was previously processed, the database record(s) for it will be marked as uninstalled. If it shows up in a future run of this script, a new database record will be created.`);
+              loggedWarningsFromThisScriptRun.push(`When processing vulnerable software, a request to the '/hosts' endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software version ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Impact: If this vulnerable software was previously processed, the database record(s) for it will be marked as uninstalled. If it shows up in a future run of this script, a new database record will be created.`);
               vulnerableWaresWithNoHostInformation.push(ware);// Add this software to the vulnerableWaresWithNoHostInformation array, these will be removed before we create and update database records.
               return {};// Return an empty object. This will let the script continue without information about this software.
             });
@@ -576,7 +576,7 @@ module.exports = {
       let criticalWares;
       {
         let responseData = await sails.helpers.http.get.with({
-          url: '/api/v1/fleet/software',
+          url: '/api/v1/fleet/software/versions',
           data: { query: softwareQuery.query },
           baseUrl: fleetBaseUrl,
           headers
@@ -621,7 +621,7 @@ module.exports = {
             // sails.log(`sending request for page ${hostsPage} for ${ware.name}.`)
             let responseData = await sails.helpers.http.get.with({
               url: '/api/v1/fleet/hosts',
-              data: { software_id: ware.id, page: hostsPage, per_page: HOSTS_PAGE_SIZE, order_key: 'hostname', order_direction: 'asc' },//eslint-disable-line camelcase
+              data: { software_version_id: ware.id, page: hostsPage, per_page: HOSTS_PAGE_SIZE, order_key: 'hostname', order_direction: 'asc' },//eslint-disable-line camelcase
               baseUrl: fleetBaseUrl,
               headers
             })
@@ -629,7 +629,7 @@ module.exports = {
             .retry(['requestFailed', {name: 'TimeoutError'}])
             .tolerate({raw:{statusCode: 404}} , ()=>{
               // If the hosts API returns a 404 response for a software item that was returned from in the list of critical software, we'll log a warning and remove this software from the list of software.
-              loggedWarningsFromThisScriptRun.push(`When processing critical software, a request to the '/hosts' endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Impact: This software will be marked as uninstalled, and a new database record will be created if it shows up in a future run of this script.`);
+              loggedWarningsFromThisScriptRun.push(`When processing critical software, a request to the '/hosts' endpoint to get a filtered array of hosts with ${ware.name} ${ware.version} installed (software version ID: ${ware.id}), the Fleet instance returned a 404 response when we expected it to return an array of ${ware.hosts_count} host(s).\n Impact: This software will be marked as uninstalled, and a new database record will be created if it shows up in a future run of this script.`);
               criticalWaresWithNoHostInformation.push(ware);// Add this software to the criticalWaresWithNoHostInformation array, these will be removed before we create and update database records.
               return {};// Return an empty object. This will let the script continue without information about this software.
             });


### PR DESCRIPTION
Changes:
- Updated the vulnerability dashboard's `update-reports` script to use the list software versions API endpoint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved vulnerability report accuracy by updating the system to identify affected hosts using software version-specific identifiers instead of general software IDs, enabling more precise tracking and impact analysis across vulnerable and critical software categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->