### PR TITLE
Enable disk encryption when only Windows MDM is configured.

### DIFF
--- a/changes/44194-team-bitlocker-windows-only
+++ b/changes/44194-team-bitlocker-windows-only
@@ -1,1 +1,1 @@
-- Fixed `PATCH /api/v1/fleet/teams/:id` rejecting `mdm.enable_disk_encryption` on Fleet deployments where only Windows MDM is configured. Team-level BitLocker enforcement can now be toggled when either Apple MDM or Windows MDM is configured.
+- Fixed the team PATCH endpoint rejecting `mdm.enable_disk_encryption` on Fleet deployments where only Windows MDM is configured. Team-level BitLocker enforcement can now be toggled when either Apple MDM or Windows MDM is configured.

--- a/changes/44194-team-bitlocker-windows-only
+++ b/changes/44194-team-bitlocker-windows-only
@@ -1,0 +1,1 @@
+- Fixed `PATCH /api/v1/fleet/teams/:id` rejecting `mdm.enable_disk_encryption` on Fleet deployments where only Windows MDM is configured. Team-level BitLocker enforcement can now be toggled when either Apple MDM or Windows MDM is configured.

--- a/ee/server/service/teams.go
+++ b/ee/server/service/teams.go
@@ -272,11 +272,14 @@ func (svc *Service) ModifyTeam(ctx context.Context, teamID uint, payload fleet.T
 		}
 
 		if payload.MDM.EnableDiskEncryption.Valid {
-			macOSDiskEncryptionUpdated = team.Config.MDM.EnableDiskEncryption != payload.MDM.EnableDiskEncryption.Value
-			if macOSDiskEncryptionUpdated && !appCfg.MDM.EnabledAndConfigured {
-				return nil, fleet.NewInvalidArgumentError("apple_settings.enable_disk_encryption",
-					`Couldn't update apple_settings because MDM features aren't turned on in Fleet. Use fleetctl generate mdm-apple and then fleet serve with mdm configuration to turn on MDM features.`)
+			diskEncryptionUpdated := team.Config.MDM.EnableDiskEncryption != payload.MDM.EnableDiskEncryption.Value
+			if diskEncryptionUpdated && !appCfg.MDM.EnabledAndConfigured && !appCfg.MDM.WindowsEnabledAndConfigured {
+				return nil, fleet.NewInvalidArgumentError("mdm.enable_disk_encryption",
+					"Couldn't update mdm.enable_disk_encryption because neither Apple MDM nor Windows MDM is turned on in Fleet.")
 			}
+			// The Apple FileVault profile and macOS-named activity only apply when Apple MDM is configured.
+			// On Windows-only deployments the flag still controls BitLocker enforcement via the Windows MDM path.
+			macOSDiskEncryptionUpdated = diskEncryptionUpdated && appCfg.MDM.EnabledAndConfigured
 			team.Config.MDM.EnableDiskEncryption = payload.MDM.EnableDiskEncryption.Value
 		}
 

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -14,6 +14,7 @@ import (
 	svcmock "github.com/fleetdm/fleet/v4/server/mock/service"
 	"github.com/fleetdm/fleet/v4/server/ptr"
 	"github.com/fleetdm/fleet/v4/server/test"
+	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
 )
 
@@ -675,6 +676,132 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 		require.Equal(t, "Workstations", savedTeam.Name,
 			"no-filename spec must preserve the DB's canonical name, not silently case-rename it")
 	})
+}
+
+// TestModifyTeamMDMEnableDiskEncryption covers the team-level PATCH endpoint
+// validation for `mdm.enable_disk_encryption`. The flag governs both FileVault
+// (Apple) and BitLocker (Windows) enforcement, so the change must be allowed
+// when either platform's MDM is configured. Issue #44194 reported that the
+// previous validation gated solely on Apple MDM and rejected Windows-only
+// deployments.
+func TestModifyTeamMDMEnableDiskEncryption(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		appleEnabled         bool
+		windowsEnabled       bool
+		wantErr              string
+		wantFileVaultProfile bool
+	}{
+		{
+			name:                 "windows MDM only succeeds without invoking FileVault (issue #44194)",
+			appleEnabled:         false,
+			windowsEnabled:       true,
+			wantFileVaultProfile: false,
+		},
+		{
+			name:           "neither MDM platform configured rejects the change",
+			appleEnabled:   false,
+			windowsEnabled: false,
+			wantErr:        "mdm.enable_disk_encryption",
+		},
+		{
+			name:                 "apple MDM only invokes FileVault profile creation",
+			appleEnabled:         true,
+			windowsEnabled:       false,
+			wantFileVaultProfile: true,
+		},
+		{
+			name:                 "both MDM platforms configured invokes FileVault profile creation",
+			appleEnabled:         true,
+			windowsEnabled:       true,
+			wantFileVaultProfile: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ds := new(mock.Store)
+			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{
+					MDM: fleet.MDM{
+						EnabledAndConfigured:        tc.appleEnabled,
+						WindowsEnabledAndConfigured: tc.windowsEnabled,
+					},
+				}, nil
+			}
+			ds.TeamWithExtrasFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
+				return &fleet.Team{
+					ID:     tid,
+					Name:   "team-1",
+					Config: fleet.TeamConfig{MDM: fleet.TeamMDM{EnableDiskEncryption: false}},
+				}, nil
+			}
+			var savedTeam *fleet.Team
+			ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+				savedTeam = team
+				return team, nil
+			}
+			// CA cert + profile mocks are exercised by the FileVault path when
+			// Apple MDM is configured. Both are wired regardless because the
+			// invocation flag is what we assert against.
+			ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, _ []fleet.MDMAssetName,
+				_ sqlx.QueryerContext,
+			) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+				return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+					fleet.MDMAssetCACert: {Value: []byte(testCert)},
+				}, nil
+			}
+			ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, p fleet.MDMAppleConfigProfile,
+				_ []fleet.FleetVarName,
+			) (*fleet.MDMAppleConfigProfile, error) {
+				return &p, nil
+			}
+
+			authorizer, err := authz.NewAuthorizer()
+			require.NoError(t, err)
+
+			mockSvc := &svcmock.Service{}
+			mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
+				return nil
+			}
+
+			svc := &Service{
+				Service: mockSvc,
+				ds:      ds,
+				config: config.FleetConfig{
+					Server: config.ServerConfig{PrivateKey: "something"},
+				},
+				authz: authorizer,
+			}
+
+			adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
+			ctx := test.UserContext(context.Background(), adminUser)
+
+			payload := fleet.TeamPayload{
+				MDM: &fleet.TeamPayloadMDM{
+					EnableDiskEncryption: optjson.SetBool(true),
+				},
+			}
+			team, err := svc.ModifyTeam(ctx, 1, payload)
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tc.wantErr)
+				require.Nil(t, team)
+				require.False(t, ds.SaveTeamFuncInvoked, "team should not have been saved")
+				require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked, "FileVault profile should not have been created")
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, team)
+			require.True(t, team.Config.MDM.EnableDiskEncryption, "team payload should reflect EnableDiskEncryption=true")
+			require.NotNil(t, savedTeam)
+			require.True(t, savedTeam.Config.MDM.EnableDiskEncryption, "EnableDiskEncryption must be persisted")
+			require.Equal(t, tc.wantFileVaultProfile, ds.NewMDMAppleConfigProfileFuncInvoked,
+				"FileVault profile creation should match Apple MDM configuration")
+		})
+	}
 }
 
 func TestUpdateTeamMDMDiskEncryption(t *testing.T) {

--- a/ee/server/service/teams_test.go
+++ b/ee/server/service/teams_test.go
@@ -680,108 +680,84 @@ func TestApplyTeamSpecsCollationEqualConflict(t *testing.T) {
 
 // TestModifyTeamMDMEnableDiskEncryption covers the team-level PATCH endpoint
 // validation for `mdm.enable_disk_encryption`. The flag governs both FileVault
-// (Apple) and BitLocker (Windows) enforcement, so the change must be allowed
-// when either platform's MDM is configured. Issue #44194 reported that the
-// previous validation gated solely on Apple MDM and rejected Windows-only
-// deployments.
+// (Apple) and BitLocker (Windows), so the change must be allowed when either
+// platform's MDM is configured. The Apple FileVault profile is created only
+// when Apple MDM is configured.
 func TestModifyTeamMDMEnableDiskEncryption(t *testing.T) {
 	testCases := []struct {
-		name                 string
-		appleEnabled         bool
-		windowsEnabled       bool
-		wantErr              string
-		wantFileVaultProfile bool
+		name           string
+		appleEnabled   bool
+		windowsEnabled bool
+		wantErr        string
 	}{
 		{
-			name:                 "windows MDM only succeeds without invoking FileVault (issue #44194)",
-			appleEnabled:         false,
-			windowsEnabled:       true,
-			wantFileVaultProfile: false,
+			name:           "windows MDM only succeeds without invoking FileVault (issue #44194)",
+			windowsEnabled: true,
 		},
 		{
-			name:           "neither MDM platform configured rejects the change",
-			appleEnabled:   false,
-			windowsEnabled: false,
-			wantErr:        "mdm.enable_disk_encryption",
+			name:    "neither MDM platform configured rejects the change",
+			wantErr: "mdm.enable_disk_encryption",
 		},
 		{
-			name:                 "apple MDM only invokes FileVault profile creation",
-			appleEnabled:         true,
-			windowsEnabled:       false,
-			wantFileVaultProfile: true,
-		},
-		{
-			name:                 "both MDM platforms configured invokes FileVault profile creation",
-			appleEnabled:         true,
-			windowsEnabled:       true,
-			wantFileVaultProfile: true,
+			name:         "apple MDM configured invokes FileVault profile creation",
+			appleEnabled: true,
 		},
 	}
+
+	authorizer, err := authz.NewAuthorizer()
+	require.NoError(t, err)
+	mockSvc := &svcmock.Service{}
+	mockSvc.NewActivityFunc = func(context.Context, *fleet.User, fleet.ActivityDetails) error {
+		return nil
+	}
+	ctx := test.UserContext(context.Background(),
+		&fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)})
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ds := new(mock.Store)
-			ds.AppConfigFunc = func(ctx context.Context) (*fleet.AppConfig, error) {
-				return &fleet.AppConfig{
-					MDM: fleet.MDM{
-						EnabledAndConfigured:        tc.appleEnabled,
-						WindowsEnabledAndConfigured: tc.windowsEnabled,
-					},
-				}, nil
+			ds.AppConfigFunc = func(context.Context) (*fleet.AppConfig, error) {
+				return &fleet.AppConfig{MDM: fleet.MDM{
+					EnabledAndConfigured:        tc.appleEnabled,
+					WindowsEnabledAndConfigured: tc.windowsEnabled,
+				}}, nil
 			}
-			ds.TeamWithExtrasFunc = func(ctx context.Context, tid uint) (*fleet.Team, error) {
-				return &fleet.Team{
-					ID:     tid,
-					Name:   "team-1",
-					Config: fleet.TeamConfig{MDM: fleet.TeamMDM{EnableDiskEncryption: false}},
-				}, nil
+			ds.TeamWithExtrasFunc = func(_ context.Context, tid uint) (*fleet.Team, error) {
+				return &fleet.Team{ID: tid, Name: "team-1"}, nil
 			}
 			var savedTeam *fleet.Team
-			ds.SaveTeamFunc = func(ctx context.Context, team *fleet.Team) (*fleet.Team, error) {
+			ds.SaveTeamFunc = func(_ context.Context, team *fleet.Team) (*fleet.Team, error) {
 				savedTeam = team
 				return team, nil
 			}
-			// CA cert + profile mocks are exercised by the FileVault path when
-			// Apple MDM is configured. Both are wired regardless because the
-			// invocation flag is what we assert against.
-			ds.GetAllMDMConfigAssetsByNameFunc = func(ctx context.Context, _ []fleet.MDMAssetName,
-				_ sqlx.QueryerContext,
-			) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
-				return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
-					fleet.MDMAssetCACert: {Value: []byte(testCert)},
-				}, nil
-			}
-			ds.NewMDMAppleConfigProfileFunc = func(ctx context.Context, p fleet.MDMAppleConfigProfile,
-				_ []fleet.FleetVarName,
-			) (*fleet.MDMAppleConfigProfile, error) {
-				return &p, nil
-			}
-
-			authorizer, err := authz.NewAuthorizer()
-			require.NoError(t, err)
-
-			mockSvc := &svcmock.Service{}
-			mockSvc.NewActivityFunc = func(ctx context.Context, user *fleet.User, activity fleet.ActivityDetails) error {
-				return nil
+			// Wire the Apple FileVault mocks only when Apple MDM is configured;
+			// a regression that drops the gate would call into them on a
+			// Windows-only deployment and panic on the nil mock function.
+			if tc.appleEnabled {
+				ds.GetAllMDMConfigAssetsByNameFunc = func(_ context.Context, _ []fleet.MDMAssetName,
+					_ sqlx.QueryerContext,
+				) (map[fleet.MDMAssetName]fleet.MDMConfigAsset, error) {
+					return map[fleet.MDMAssetName]fleet.MDMConfigAsset{
+						fleet.MDMAssetCACert: {Value: []byte(testCert)},
+					}, nil
+				}
+				ds.NewMDMAppleConfigProfileFunc = func(_ context.Context, p fleet.MDMAppleConfigProfile,
+					_ []fleet.FleetVarName,
+				) (*fleet.MDMAppleConfigProfile, error) {
+					return &p, nil
+				}
 			}
 
 			svc := &Service{
 				Service: mockSvc,
 				ds:      ds,
-				config: config.FleetConfig{
-					Server: config.ServerConfig{PrivateKey: "something"},
-				},
-				authz: authorizer,
+				config:  config.FleetConfig{Server: config.ServerConfig{PrivateKey: "something"}},
+				authz:   authorizer,
 			}
 
-			adminUser := &fleet.User{ID: 1, GlobalRole: ptr.String(fleet.RoleAdmin)}
-			ctx := test.UserContext(context.Background(), adminUser)
-
-			payload := fleet.TeamPayload{
-				MDM: &fleet.TeamPayloadMDM{
-					EnableDiskEncryption: optjson.SetBool(true),
-				},
-			}
+			payload := fleet.TeamPayload{MDM: &fleet.TeamPayloadMDM{
+				EnableDiskEncryption: optjson.SetBool(true),
+			}}
 			team, err := svc.ModifyTeam(ctx, 1, payload)
 
 			if tc.wantErr != "" {
@@ -789,17 +765,15 @@ func TestModifyTeamMDMEnableDiskEncryption(t *testing.T) {
 				require.Contains(t, err.Error(), tc.wantErr)
 				require.Nil(t, team)
 				require.False(t, ds.SaveTeamFuncInvoked, "team should not have been saved")
-				require.False(t, ds.NewMDMAppleConfigProfileFuncInvoked, "FileVault profile should not have been created")
 				return
 			}
-
 			require.NoError(t, err)
 			require.NotNil(t, team)
-			require.True(t, team.Config.MDM.EnableDiskEncryption, "team payload should reflect EnableDiskEncryption=true")
+			require.True(t, team.Config.MDM.EnableDiskEncryption)
 			require.NotNil(t, savedTeam)
-			require.True(t, savedTeam.Config.MDM.EnableDiskEncryption, "EnableDiskEncryption must be persisted")
-			require.Equal(t, tc.wantFileVaultProfile, ds.NewMDMAppleConfigProfileFuncInvoked,
-				"FileVault profile creation should match Apple MDM configuration")
+			require.True(t, savedTeam.Config.MDM.EnableDiskEncryption)
+			require.Equal(t, tc.appleEnabled, ds.NewMDMAppleConfigProfileFuncInvoked,
+				"FileVault profile creation must match Apple MDM configuration")
 		})
 	}
 }

--- a/server/service/integration_enterprise_test.go
+++ b/server/service/integration_enterprise_test.go
@@ -1899,14 +1899,14 @@ func (s *integrationEnterpriseTestSuite) TestTeamEndpoints() {
 	s.DoJSON("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), team, http.StatusOK, &tmResp)
 	assert.Contains(t, tmResp.Team.Description, "Alt ")
 
-	// modify team's disk encryption, impossible without mdm enabled
+	// modify team's disk encryption, impossible without either Apple or Windows MDM enabled
 	res := s.Do("PATCH", fmt.Sprintf("/api/latest/fleet/teams/%d", tm1ID), fleet.TeamPayload{
 		MDM: &fleet.TeamPayloadMDM{
 			EnableDiskEncryption: optjson.SetBool(true),
 		},
 	}, http.StatusUnprocessableEntity)
 	errMsg := extractServerErrorText(res.Body)
-	assert.Contains(t, errMsg, `Couldn't update apple_settings because MDM features aren't turned on in Fleet.`)
+	assert.Contains(t, errMsg, `Couldn't update mdm.enable_disk_encryption because neither Apple MDM nor Windows MDM is turned on in Fleet.`)
 
 	// modify a team with a NULL config
 	defaultFeatures := fleet.Features{}


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #44194 

# Checklist for submitter

If some of the following don't apply, delete the relevant line.

- [x] Changes file added for user-visible changes in `changes/`, `orbit/changes/` or `ee/fleetd-chrome/changes`.
  See [Changes files](https://github.com/fleetdm/fleet/blob/main/docs/Contributing/guides/committing-changes.md#changes-files) for more information.

## Testing

- [x] Added/updated automated tests
- [x] QA'd all new/changed functionality manually

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team-level disk encryption can be toggled when at least one MDM platform (Windows or Apple) is configured, enabling BitLocker control for Windows-only deployments.

* **Bug Fixes**
  * Updates validation to reject disk-encryption changes only when no MDM platforms are configured.

* **Tests**
  * Added coverage for platform combinations and expected behavior, including Apple-specific profile creation when applicable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->