### PR TITLE
fix fastly customer quote on iac page

### DIFF
--- a/website/views/pages/infrastructure-as-code.ejs
+++ b/website/views/pages/infrastructure-as-code.ejs
@@ -57,7 +57,7 @@
         <div purpose="quote-image">
           <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
         </div>
-        <p purpose="quote-text">"The shift to infrastructure as code has modernized our operations, giving us the agility and change control we needed, giving leadership real-time confidence in device health and compliance."</p>
+        <p purpose="quote-text">"The shift to GitOps has modernized our operations, giving us the agility and change control we needed, giving leadership real-time confidence in device health and compliance."</p>
         <div purpose="quote-author-info">
           <div purpose="quote-author-image">
             <img alt="Dan Jackson" src="/images/testimonial-author-dan-jackson-48x48@2x.png">
@@ -484,7 +484,7 @@
             <img alt="Fastly logo" src="/images/fastly-logo-104x40@2x.png">
           </div>
           <p purpose="quote">
-            The shift to infrastructure as code has modernized our operations, giving us the agility and change control we needed, giving leadership real-time confidence in device health and compliance.
+            The shift to GitOps has modernized our operations, giving us the agility and change control we needed, giving leadership real-time confidence in device health and compliance.
           </p>
           <div purpose="quote-author-info" class="d-flex flex-row align-items-center">
             <div purpose="profile-picture">


### PR DESCRIPTION
Apparently they actually said "GitOps" and not "infrastructure as code". The quote at the bottom of the page was incorrect. Now they are both right.

Thanks for the catch @eashaw 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated website testimonials and case study quotes with refreshed terminology and messaging to better reflect current positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->