### PR TITLE
Setup experience: status jitter fix

### DIFF
--- a/frontend/components/IconStatusMessage/_styles.scss
+++ b/frontend/components/IconStatusMessage/_styles.scss
@@ -1,7 +1,7 @@
 .icon-status-message {
   display: flex;
   align-items: flex-start;
-  gap: $pad-small;
+  gap: $gap-icon-text;
   font-size: $x-small;
 }
 

--- a/frontend/components/StatusIndicatorWithIcon/_styles.scss
+++ b/frontend/components/StatusIndicatorWithIcon/_styles.scss
@@ -4,10 +4,7 @@
     display: inline-flex;
     align-items: center;
     vertical-align: middle;
-
-    .icon {
-      margin-right: $pad-xsmall;
-    }
+    gap: $gap-icon-text;
 
     span {
       white-space: nowrap;

--- a/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/HostMdmStatusCell/_styles.scss
@@ -2,6 +2,6 @@
   display: inline-flex;
   flex-direction: row;
   text-wrap: nowrap;
-  gap: $pad-small;
+  gap: $gap-icon-text;
   align-items: center;
 }

--- a/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptProcessCell/_styles.scss
@@ -4,7 +4,7 @@
   gap: $pad-small;
 
   .graphic {
-      width: $pad-xlarge;
-      scale: 60%;
+    width: $pad-xlarge;
+    scale: 60%;
   }
 }

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.stories.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import SetupScriptStatusCell from "./SetupScriptStatusCell";
+
+const meta: Meta<typeof SetupScriptStatusCell> = {
+  title: "Components/TableContainer/SetupScriptStatusCell",
+  component: SetupScriptStatusCell,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SetupScriptStatusCell>;
+
+export const Pending: Story = {
+  args: { status: "pending" },
+};
+
+export const Running: Story = {
+  args: { status: "running" },
+};
+
+export const Success: Story = {
+  args: { status: "success" },
+};
+
+export const Failure: Story = {
+  args: { status: "failure" },
+};
+
+export const Cancelled: Story = {
+  args: { status: "cancelled" },
+};

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.stories.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.stories.tsx
@@ -26,7 +26,3 @@ export const Success: Story = {
 export const Failure: Story = {
   args: { status: "failure" },
 };
-
-export const Cancelled: Story = {
-  args: { status: "cancelled" },
-};

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
@@ -34,8 +34,14 @@ const SetupScriptStatusCell = ({ status }: ISetupScriptStatusCell) => {
   const { label, icon } = serverToUiStatus(status);
   return (
     <div className={baseClass}>
-      {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
-      {label}
+      <div className={`${baseClass}__icon`}>
+        {icon === "spinner" ? (
+          <Spinner size="x-small" />
+        ) : (
+          <Icon name={icon} />
+        )}
+      </div>
+      <span className={`${baseClass}__label`}>{label}</span>
     </div>
   );
 };

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
@@ -35,7 +35,11 @@ const SetupScriptStatusCell = ({ status }: ISetupScriptStatusCell) => {
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
-        {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
+        {icon === "spinner" ? (
+          <Spinner size="x-small" includeContainer={false} delay={0} />
+        ) : (
+          <Icon name={icon} />
+        )}
       </div>
       <span className={`${baseClass}__label`}>{label}</span>
     </div>

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/SetupScriptStatusCell.tsx
@@ -35,11 +35,7 @@ const SetupScriptStatusCell = ({ status }: ISetupScriptStatusCell) => {
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
-        {icon === "spinner" ? (
-          <Spinner size="x-small" />
-        ) : (
-          <Icon name={icon} />
-        )}
+        {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
       </div>
       <span className={`${baseClass}__label`}>{label}</span>
     </div>

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
@@ -1,7 +1,7 @@
 .setup-script-status-cell {
   display: flex;
   align-items: center;
-  gap: $pad-small;
+  gap: $gap-icon-text;
   font-size: $x-small; // Already applied but on component level for storybook
 
   &__icon {

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
@@ -1,11 +1,24 @@
 .setup-script-status-cell {
   display: flex;
   align-items: center;
-  gap: $pad-xsmall;
+  gap: $pad-small;
+  font-size: $x-small; // Already applied but on component level for storybook
 
-  .loading-spinner {
-    margin: 0;
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: $pad-medium;
     height: $pad-medium;
+
+    .loading-spinner {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  &__label {
+    min-width: 14ch; // 14 characters — Prevents jitter, fits longest label ("Installing")
   }
 }

--- a/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupScriptStatusCell/_styles.scss
@@ -10,12 +10,6 @@
     justify-content: center;
     width: $pad-medium;
     height: $pad-medium;
-
-    .loading-spinner {
-      margin: 0;
-      width: 100%;
-      height: 100%;
-    }
   }
 
   &__label {

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.stories.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.stories.tsx
@@ -26,7 +26,3 @@ export const Installed: Story = {
 export const Failure: Story = {
   args: { status: "failure" },
 };
-
-export const Cancelled: Story = {
-  args: { status: "cancelled" },
-};

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.stories.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from "@storybook/react";
+
+import SetupSoftwareStatusCell from "./SetupSoftwareStatusCell";
+
+const meta: Meta<typeof SetupSoftwareStatusCell> = {
+  title: "Components/TableContainer/SetupSoftwareStatusCell",
+  component: SetupSoftwareStatusCell,
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SetupSoftwareStatusCell>;
+
+export const Pending: Story = {
+  args: { status: "pending" },
+};
+
+export const Installing: Story = {
+  args: { status: "running" },
+};
+
+export const Installed: Story = {
+  args: { status: "success" },
+};
+
+export const Failure: Story = {
+  args: { status: "failure" },
+};
+
+export const Cancelled: Story = {
+  args: { status: "cancelled" },
+};

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -35,11 +35,7 @@ const SetupSoftwareStatusCell = ({ status }: ISetupSoftwareStatusCell) => {
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
-        {icon === "spinner" ? (
-          <Spinner size="x-small" />
-        ) : (
-          <Icon name={icon} />
-        )}
+        {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
       </div>
       <span className={`${baseClass}__label`}>{label}</span>
     </div>

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -34,8 +34,14 @@ const SetupSoftwareStatusCell = ({ status }: ISetupSoftwareStatusCell) => {
   const { label, icon } = serverToUiStatus(status);
   return (
     <div className={baseClass}>
-      {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
-      {label}
+      <div className={`${baseClass}__icon`}>
+        {icon === "spinner" ? (
+          <Spinner size="x-small" />
+        ) : (
+          <Icon name={icon} />
+        )}
+      </div>
+      <span className={`${baseClass}__label`}>{label}</span>
     </div>
   );
 };

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/SetupSoftwareStatusCell.tsx
@@ -35,7 +35,11 @@ const SetupSoftwareStatusCell = ({ status }: ISetupSoftwareStatusCell) => {
   return (
     <div className={baseClass}>
       <div className={`${baseClass}__icon`}>
-        {icon === "spinner" ? <Spinner size="x-small" /> : <Icon name={icon} />}
+        {icon === "spinner" ? (
+          <Spinner size="x-small" includeContainer={false} delay={0} />
+        ) : (
+          <Icon name={icon} />
+        )}
       </div>
       <span className={`${baseClass}__label`}>{label}</span>
     </div>

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
@@ -1,7 +1,7 @@
 .setup-software-status-cell {
   display: flex;
   align-items: center;
-  gap: $pad-small;
+  gap: $gap-icon-text;
   font-size: $x-small; // Already applied but on component level for storybook
 
   &__icon {

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
@@ -1,11 +1,24 @@
 .setup-software-status-cell {
   display: flex;
   align-items: center;
-  gap: $pad-xsmall;
+  gap: $pad-small;
+  font-size: $x-small; // Already applied but on component level for storybook
 
-  .loading-spinner {
-    margin: 0;
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     width: $pad-medium;
     height: $pad-medium;
+
+    .loading-spinner {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+    }
+  }
+
+  &__label {
+    min-width: 14ch; // 14 characters — Prevents jitter, fits longest label ("Installing")
   }
 }

--- a/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/SetupSoftwareStatusCell/_styles.scss
@@ -10,12 +10,6 @@
     justify-content: center;
     width: $pad-medium;
     height: $pad-medium;
-
-    .loading-spinner {
-      margin: 0;
-      width: 100%;
-      height: 100%;
-    }
   }
 
   &__label {

--- a/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/TooltipTruncatedTextCell/_styles.scss
@@ -1,7 +1,7 @@
 .tooltip-truncated-cell {
   display: flex;
   align-items: center; // For badges, etc
-  gap: $pad-small;
+  gap: $gap-icon-text;
   max-width: 100%;
 
   .text-muted {
@@ -55,7 +55,7 @@
   .data-table__suffix,
   .data-table__prefix {
     display: flex;
-    gap: $pad-small;
+    gap: $gap-icon-text;
     height: 24px;
     align-items: center;
     flex-shrink: 0; /* Prevent suffix from shrinking */

--- a/frontend/components/TableContainer/DataTable/_styles.scss
+++ b/frontend/components/TableContainer/DataTable/_styles.scss
@@ -149,7 +149,7 @@ $shadow-transition-width: 16px;
           span {
             display: flex;
             align-items: center;
-            gap: 3px;
+            gap: $gap-icon-text;
           }
         }
 

--- a/frontend/components/side_panels/QuerySidePanel/EventedTableTag/_styles.scss
+++ b/frontend/components/side_panels/QuerySidePanel/EventedTableTag/_styles.scss
@@ -7,5 +7,5 @@
   border-radius: 6px;
   font-size: $xxx-small;
   font-weight: $bold;
-  gap: $pad-small
+  gap: $gap-icon-text;
 }

--- a/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/_styles.scss
+++ b/frontend/pages/ManageControlsPage/OSUpdates/components/OSTypeCell/_styles.scss
@@ -5,7 +5,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   align-items: center;
-  gap: $pad-small;
+  gap: $gap-icon-text;
 
   &__tooltip-wrapper {
     display: flex;

--- a/frontend/pages/hosts/components/IssuesIndicator/_styles.scss
+++ b/frontend/pages/hosts/components/IssuesIndicator/_styles.scss
@@ -2,6 +2,6 @@
   .component__tooltip-wrapper__element {
     display: inline-flex;
     align-items: center;
-    gap: $pad-small;
+    gap: $gap-icon-text;
   }
 }

--- a/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/InstallStatusCell/_styles.scss
@@ -10,7 +10,7 @@
     .component__tooltip-wrapper__element {
       display: flex;
       align-items: center;
-      gap: $pad-small;
+      gap: $gap-icon-text;
     }
 
     .component__tooltip-wrapper__tip-text {

--- a/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/_styles.scss
+++ b/frontend/pages/hosts/details/cards/Software/SelfService/components/TileActionStatus/_styles.scss
@@ -1,7 +1,7 @@
 .tile-action-status {
   display: flex;
   align-items: center;
-  gap: $pad-small;
+  gap: $gap-icon-text;
   font-size: $x-small;
   height: 36px; // Min height of button to keep height the same when switching to active action "Installing..."
 }

--- a/frontend/styles/var/padding.scss
+++ b/frontend/styles/var/padding.scss
@@ -21,4 +21,5 @@ $gap-form-component: $pad-small;
 $gap-data-sets: $pad-medium;
 $gap-table-elements: $pad-medium;
 $gap-modal-component: $pad-large;
+$gap-icon-text: $pad-small;
 $table-cell-padding: $pad-large;


### PR DESCRIPTION
## Issue
#44606 

## Description
- Give the icon space and the text space a fixed width to avoid any column or cell jitters
- Changed the space between the icon and text to 8px instead of 4px to match other icon text gaps

## Screenrecording of fix

✅ E2E tested by @jkatz01 <3 


https://github.com/user-attachments/assets/5ae3bc62-8339-4929-aa16-ea914f7fb84a



## Testing

- [x] Added to storybook
- [x] QA'd all new/changed functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Unified icon-to-text spacing across many UI tables, cells, indicators and tooltips by introducing a dedicated spacing token and applying it consistently.
* **Documentation**
  * Added component library stories/examples for Setup Script and Setup Software status cells to showcase pending, running, success, and failure states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->