### PR TITLE
Website: Add two redirects for comparison article

### DIFF
--- a/website/config/routes.js
+++ b/website/config/routes.js
@@ -958,6 +958,8 @@ module.exports.routes = {
   'GET /compare/jamf': '/compare/jamf-vs-fleet',
   'GET /compare/fleet-vs-workspace-one': '/compare/workspace-one-vs-fleet',
   'GET /compare/fleet-vs-jamf-vs-intune': '/compare/jamf-vs-intune-vs-fleet',
+  'GET /articles/fleet-vs-jamf-vs-iru-mdm-comparison': '/compare/jamf-vs-iru-vs-fleet',
+  'GET /articles/fleet-vs-jamf-vs-iru-kandji-mdm-comparison': '/compare/jamf-vs-iru-vs-fleet',
 
   // Software catalog redirects
   'GET /software-catalog/abstract': '/software-catalog/abstract-darwin',


### PR DESCRIPTION
Changes:
- Added two redirects for a comparison article

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added URL redirects for legacy MDM comparison article endpoints, ensuring existing external links and bookmarks to older URLs continue to function properly and direct to the current comparison page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->