### PR TITLE
Update Fleet-maintained apps

### DIFF
--- a/ee/maintained-apps/outputs/p4v/darwin.json
+++ b/ee/maintained-apps/outputs/p4v/darwin.json
@@ -9,7 +9,7 @@
       "installer_url": "https://filehost.perforce.com/perforce/r26.1/bin.macosx12u/P4V.dmg",
       "install_script_ref": "804d7fe0",
       "uninstall_script_ref": "6f04fef2",
-      "sha256": "f0c04b4ba1103957a7c59d54bfbe643f353c68ed8095d9b19303b3f897014696",
+      "sha256": "b4ce469dcbdb3dbdc63b40f9c0510ea996e45ac000b5b1908d5502ab952937e5",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/darwin.json
+++ b/ee/maintained-apps/outputs/postman/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.8.3",
+      "version": "12.8.4",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.8.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'com.postmanlabs.mac' AND version_compare(bundle_short_version, '12.8.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.8.3/osx_arm64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.4/osx_arm64",
       "install_script_ref": "98946078",
       "uninstall_script_ref": "15e9f11c",
-      "sha256": "76b836c20140f075beaac567e901df437cafe5552b0ae98574ae0aec9c6ad61d",
+      "sha256": "ba5012df42c1ea87328b6c3bfbe5f9a80806302614a4c8e5ff7abea9b8e78492",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/postman/windows.json
+++ b/ee/maintained-apps/outputs/postman/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "12.8.3",
+      "version": "12.8.4",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.8.3') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name LIKE 'Postman x64 %' AND publisher = 'Postman' AND version_compare(version, '12.8.4') < 0);"
       },
-      "installer_url": "https://dl.pstmn.io/download/version/12.8.3/windows_64",
+      "installer_url": "https://dl.pstmn.io/download/version/12.8.4/windows_64",
       "install_script_ref": "538f63bf",
       "uninstall_script_ref": "cd01b68f",
-      "sha256": "d84240aa468516843a891db64e1bc56d19d6e413ca2db507ff92e580085b21c0",
+      "sha256": "bc174612ebf20295fefafd7ae5f8e2d47ea8fc46476336cfc83edb3b7d8ed8a3",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/warp/darwin.json
+++ b/ee/maintained-apps/outputs/warp/darwin.json
@@ -1,12 +1,12 @@
 {
   "versions": [
     {
-      "version": "0.2026.04.27.15.32.02",
+      "version": "0.2026.04.27.15.32.03",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.27.15.32.02') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'dev.warp.Warp-Stable' AND version_compare(bundle_short_version, '0.2026.04.27.15.32.03') < 0);"
       },
-      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.27.15.32.stable_02/Warp.dmg",
+      "installer_url": "https://releases.warp.dev/stable/v0.2026.04.27.15.32.stable_03/Warp.dmg",
       "install_script_ref": "ec5da61d",
       "uninstall_script_ref": "54d05203",
       "sha256": "no_check",

--- a/ee/maintained-apps/outputs/wireshark-app/darwin.json
+++ b/ee/maintained-apps/outputs/wireshark-app/darwin.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.4",
+      "version": "4.6.5",
       "queries": {
         "exists": "SELECT 1 FROM apps WHERE bundle_identifier = 'org.wireshark.Wireshark';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.wireshark.Wireshark' AND version_compare(bundle_short_version, '4.6.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM apps WHERE bundle_identifier = 'org.wireshark.Wireshark' AND version_compare(bundle_short_version, '4.6.5') < 0);"
       },
-      "installer_url": "https://www.wireshark.org/download/osx/all-versions/Wireshark%204.6.4.dmg",
+      "installer_url": "https://www.wireshark.org/download/osx/all-versions/Wireshark%204.6.5.dmg",
       "install_script_ref": "c90c4535",
       "uninstall_script_ref": "0d1bc605",
-      "sha256": "08150f79cfc5828820f991b6d944c68536db9595b1c3052982bbde79fb2053df",
+      "sha256": "9e83253bc59ffee2d7050a4e4b7bd390d216d38042ef7740305eea7ce59eee48",
       "default_categories": [
         "Developer tools"
       ]

--- a/ee/maintained-apps/outputs/wireshark/windows.json
+++ b/ee/maintained-apps/outputs/wireshark/windows.json
@@ -1,15 +1,15 @@
 {
   "versions": [
     {
-      "version": "4.6.4",
+      "version": "4.6.5",
       "queries": {
         "exists": "SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org';",
-        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org' AND version_compare(version, '4.6.4') < 0);"
+        "patched": "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM programs WHERE name = 'Wireshark' AND publisher = 'The Wireshark developer community, https://www.wireshark.org' AND version_compare(version, '4.6.5') < 0);"
       },
-      "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.4-x64.msi",
+      "installer_url": "https://2.na.dl.wireshark.org/win64/all-versions/Wireshark-4.6.5-x64.msi",
       "install_script_ref": "8959087b",
       "uninstall_script_ref": "e23b6565",
-      "sha256": "e233387deeac2693cd9edc73a9a1578338ae211669f01f5dfb99a119a4f5ff9a",
+      "sha256": "4e10774e14132a8507163d43fad98a61aa52d8eada00fa85ae717b3494623cbe",
       "default_categories": [
         "Developer tools"
       ],


### PR DESCRIPTION
Automated ingestion of latest Fleet-maintained app data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for Postman 12.8.4 on macOS and Windows
  * Added support for Wireshark 4.6.5 on macOS and Windows
  * Added support for Warp build 0.2026.04.27.15.32.03 on macOS
  * Updated P4V installer validation on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->