### PR TITLE
Set Redis explicitly to 6.2 for clarity (it was already aliased to latest 6.2)

### DIFF
--- a/docker-compose-redis-cluster.yml
+++ b/docker-compose-redis-cluster.yml
@@ -2,7 +2,7 @@
 version: "2"
 services:
   redis-cluster-setup:
-    image: redis:6
+    image: redis:6.2
     command: redis-cli --cluster create 172.20.0.31:7001 172.20.0.32:7002 172.20.0.33:7003 172.20.0.34:7004 172.20.0.35:7005 172.20.0.36:7006 --cluster-yes --cluster-replicas 1
     networks:
       cluster_network:
@@ -16,7 +16,7 @@ services:
       - redis-cluster-6
 
   redis-cluster-1:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7001:7001"
@@ -27,7 +27,7 @@ services:
         ipv4_address: 172.20.0.31
 
   redis-cluster-2:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7002:7002"
@@ -38,7 +38,7 @@ services:
         ipv4_address: 172.20.0.32
 
   redis-cluster-3:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7003:7003"
@@ -49,7 +49,7 @@ services:
         ipv4_address: 172.20.0.33
 
   redis-cluster-4:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7004:7004"
@@ -60,7 +60,7 @@ services:
         ipv4_address: 172.20.0.34
 
   redis-cluster-5:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7005:7005"
@@ -71,7 +71,7 @@ services:
         ipv4_address: 172.20.0.35
 
   redis-cluster-6:
-    image: redis:6
+    image: redis:6.2
     command: redis-server /usr/local/etc/redis/redis.conf
     ports:
       - "127.0.0.1:7006:7006"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,7 +118,7 @@ services:
       - ServerOptions__TlsCertificatePrivateKey=/certs/fleet.key
 
   redis:
-    image: redis:6
+    image: redis:6.2
     ports:
       - "127.0.0.1:${FLEET_REDIS_PORT:-6379}:6379"
 

--- a/tools/osquery/in-a-box/docker-compose.yml
+++ b/tools/osquery/in-a-box/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - fleet-preview
 
   redis01:
-    image: redis:6
+    image: redis:6.2
     networks:
       - fleet-preview
 


### PR DESCRIPTION
<!-- Add the related story/sub-task/bug number, like Resolves #123, or remove if NA -->
**Related issue:** Resolves #43928 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Redis image version to 6.2 across Docker Compose configurations for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->