### PR TITLE
[Guide] Document MDM turn-off on SCEP renewal failure

### DIFF
--- a/articles/apple-mdm-setup.md
+++ b/articles/apple-mdm-setup.md
@@ -185,6 +185,8 @@ The acquisitions's VPP token will be assigned to the above fleets.
 Fleet uses SCEP certificates (1 year expiry) to authenticate the requests hosts make to Fleet. Fleet
 renews each host's SCEP certificates automatically every 180 days.
 
+For manually enrolled devices, if SCEP certificate renewal fails, MDM will be turned off on the host. The user will need to re-enroll the device to restore MDM management.
+
 ## Troubleshooting failed enrollments
 
 If a host is turned off due to user action or a low battery during the Setup Assistant, it may fail to enroll. This can also happen if your Fleet instance is down for maintenance when a host tries to enroll automatically during the Setup Assistant. In these cases, hosts usually restart after the user attempts to get past the “Welcome to Mac" screen. The best practice in this situation is to wipe the host with Fleet if it has network connectivity or to [reinstall macOS from Recovery](https://support.apple.com/en-us/102655).


### PR DESCRIPTION
## Summary
- Adds a note under the SCEP section of the Apple MDM setup guide clarifying that, for manually enrolled devices, MDM is turned off on the host if SCEP certificate renewal fails, and the user must re-enroll to restore MDM management.
- This documents already-released behavior.

## Test plan
- [ ] Verify the SCEP section in `articles/apple-mdm-setup.md` reads correctly and renders properly on the docs site.

Replaces #44512 (which targeted `docs-v4.86.0` and had merge conflicts when rebased to main).

https://claude.ai/code/session_01WacVBQENufY9uWfb1Aj48W

---
_Generated by [Claude Code](https://claude.ai/code/session_01WacVBQENufY9uWfb1Aj48W)_